### PR TITLE
Added "---" separator in openshift/template.yaml after adding a service.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -101,6 +101,7 @@ objects:
                     name: assisted-installer-rds
               - name: IMAGE_BUILDER_CMD
                 value: ""
+---
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Without it the new service for `assisted-installer` isn't deployed.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>