### PR TITLE
Connected `assisted-service` deployment to its ServiceAccount.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -29,6 +29,7 @@ objects:
         labels:
           app: assisted-service
       spec:
+        serviceAccountName: assisted-service
         containers:
           - name: assisted-service
             image: ${BM_INVENTORY_IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
This ServiceAccount was authorized to create Jobs within the same
namespace, we need it so `assisted-service` can create `dummy-image` job
without errors.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>