### PR TITLE
Removed s3-object-expirer from openshift/template.yaml.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -5,10 +5,6 @@ parameters:
 - name: IMAGE_TAG
   value: ''
   required: true
-- name: OBJ_EXPIRER_IMAGE
-  value: quay.io/ocpmetal/s3-object-expirer
-- name: OBJ_EXPIRER_IMAGE_TAG
-  value: latest
 apiVersion: v1
 kind: Template
 metadata:


### PR DESCRIPTION
It was removed at cc3db2a67f0ffd73926ce9396942aaa7f5c01a1f so the
template was needed to be updated.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>