### PR TITLE
Fixing DB password's env variable in openshift/template.yaml.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -85,7 +85,7 @@ objects:
                   secretKeyRef:
                     key: db.name
                     name: assisted-installer-rds
-              - name: DB_PASSWORD
+              - name: DB_PASS
                 valueFrom:
                   secretKeyRef:
                     key: db.password


### PR DESCRIPTION
`assisted-service` expects an environment variable named DB_PASS
and not DB_PASSWORD.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>