### PR TITLE
[MGMT-766][MGMT-1108] Provide HTTP/S Proxy for OCP cluster installation

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -39,9 +39,16 @@ type platform struct {
 	Baremetal baremetal `yaml:"baremetal"`
 }
 
+type proxy struct {
+	HTTPProxy  string `yaml:"httpProxy,omitempty"`
+	HTTPSProxy string `yaml:"httpsProxy,omitempty"`
+	NoProxy    string `yaml:"noProxy,omitempty"`
+}
+
 type InstallerConfigBaremetal struct {
 	APIVersion string `yaml:"apiVersion"`
 	BaseDomain string `yaml:"baseDomain"`
+	Proxy      *proxy `yaml:"proxy,omitempty"`
 	Networking struct {
 		NetworkType    string `yaml:"networkType"`
 		ClusterNetwork []struct {
@@ -80,7 +87,7 @@ func countHostsByRole(cluster *common.Cluster, role models.HostRole) int {
 }
 
 func getBasicInstallConfig(cluster *common.Cluster) *InstallerConfigBaremetal {
-	return &InstallerConfigBaremetal{
+	cfg := &InstallerConfigBaremetal{
 		APIVersion: "v1",
 		BaseDomain: cluster.BaseDNSDomain,
 		Networking: struct {
@@ -132,6 +139,15 @@ func getBasicInstallConfig(cluster *common.Cluster) *InstallerConfigBaremetal {
 		PullSecret: cluster.PullSecret,
 		SSHKey:     cluster.SSHPublicKey,
 	}
+
+	if cluster.HTTPProxy != "" || cluster.HTTPSProxy != "" {
+		cfg.Proxy = &proxy{
+			HTTPProxy:  cluster.HTTPProxy,
+			HTTPSProxy: cluster.HTTPSProxy,
+			NoProxy:    cluster.NoProxy,
+		}
+	}
+	return cfg
 }
 
 // [TODO] - remove once we decide to use specific values from the hosts of the cluster

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -77,6 +77,20 @@ var _ = Describe("installcfg", func() {
 		err = yaml.Unmarshal(data, &result)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(result.Platform.Baremetal.Hosts)).Should(Equal(2))
+		Expect(result.Proxy).Should(BeNil())
+	})
+
+	It("create_configuration_with_proxy", func() {
+		var result InstallerConfigBaremetal
+		proxyURL := "http://proxyserver:3218"
+		cluster.HTTPProxy = proxyURL
+		cluster.HTTPSProxy = proxyURL
+		data, err := GetInstallConfig(logrus.New(), &cluster)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = yaml.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result.Proxy.HTTPProxy).Should(Equal(proxyURL))
+		Expect(result.Proxy.HTTPSProxy).Should(Equal(proxyURL))
 	})
 
 	AfterEach(func() {

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -50,6 +50,16 @@ type Cluster struct {
 	// Required: true
 	Href *string `json:"href"`
 
+	// A proxy URL to use for creating HTTP connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPProxy string `json:"http_proxy,omitempty"`
+
+	// A proxy URL to use for creating HTTPS connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPSProxy string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
+
 	// Unique identifier of the object.
 	// Required: true
 	// Format: uuid
@@ -85,6 +95,9 @@ type Cluster struct {
 
 	// Name of the OpenShift cluster.
 	Name string `json:"name,omitempty"`
+
+	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
+	NoProxy string `json:"no_proxy,omitempty"`
 
 	// Version of the OpenShift cluster.
 	// Enum: [4.5 4.6]

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -31,6 +31,16 @@ type ClusterCreateParams struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// A proxy URL to use for creating HTTP connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPProxy *string `json:"http_proxy,omitempty"`
+
+	// A proxy URL to use for creating HTTPS connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPSProxy *string `json:"https_proxy,omitempty"`
+
 	// Virtual IP used for cluster ingress traffic.
 	// Pattern: ^(([0-9]{1,3}\.){3}[0-9]{1,3})?$
 	IngressVip string `json:"ingress_vip,omitempty"`
@@ -38,6 +48,9 @@ type ClusterCreateParams struct {
 	// Name of the OpenShift cluster.
 	// Required: true
 	Name *string `json:"name"`
+
+	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
+	NoProxy *string `json:"no_proxy,omitempty"`
 
 	// Version of the OpenShift cluster.
 	// Required: true

--- a/models/cluster_update_params.go
+++ b/models/cluster_update_params.go
@@ -41,12 +41,25 @@ type ClusterUpdateParams struct {
 	// The desired role for hosts associated with the cluster.
 	HostsRoles []*ClusterUpdateParamsHostsRolesItems0 `json:"hosts_roles" gorm:"type:varchar(64)[]"`
 
+	// A proxy URL to use for creating HTTP connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPProxy *string `json:"http_proxy,omitempty"`
+
+	// A proxy URL to use for creating HTTPS connections outside the cluster.
+	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+	//
+	HTTPSProxy *string `json:"https_proxy,omitempty"`
+
 	// Virtual IP used for cluster ingress traffic.
 	// Pattern: ^(([0-9]{1,3}\.){3}[0-9]{1,3})?$
 	IngressVip *string `json:"ingress_vip,omitempty"`
 
 	// OpenShift cluster name
 	Name *string `json:"name,omitempty"`
+
+	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
+	NoProxy *string `json:"no_proxy,omitempty"`
 
 	// The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
 	PullSecret *string `json:"pull_secret,omitempty"`

--- a/models/image_create_params.go
+++ b/models/image_create_params.go
@@ -15,11 +15,6 @@ import (
 // swagger:model image-create-params
 type ImageCreateParams struct {
 
-	// The URL of the HTTP/S proxy that agents should use to access the discovery service
-	// http://\<user\>:\<password\>@\<server\>:\<port\>/
-	//
-	ProxyURL string `json:"proxy_url,omitempty"`
-
 	// SSH public key for debugging the installation.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 }

--- a/models/image_info.go
+++ b/models/image_info.go
@@ -31,11 +31,6 @@ type ImageInfo struct {
 	// Image generator version
 	GeneratorVersion string `json:"generator_version,omitempty"`
 
-	// The URL of the HTTP/S proxy that agents should use to access the discovery service
-	// http://\<user\>:\<password\>@\<server\>:\<port\>/
-	//
-	ProxyURL string `json:"proxy_url,omitempty"`
-
 	// size bytes
 	// Minimum: 0
 	SizeBytes *int64 `json:"size_bytes,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2086,6 +2086,15 @@ func init() {
           "description": "Self link.",
           "type": "string"
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string"
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"column:https_proxy\""
+        },
         "id": {
           "description": "Unique identifier of the object.",
           "type": "string",
@@ -2130,6 +2139,10 @@ func init() {
         },
         "name": {
           "description": "Name of the OpenShift cluster.",
+          "type": "string"
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
           "type": "string"
         },
         "openshift_version": {
@@ -2221,6 +2234,16 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
         "ingress_vip": {
           "description": "Virtual IP used for cluster ingress traffic.",
           "type": "string",
@@ -2229,6 +2252,11 @@ func init() {
         "name": {
           "description": "Name of the OpenShift cluster.",
           "type": "string"
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
+          "type": "string",
+          "x-nullable": true
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
@@ -2329,6 +2357,16 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:varchar(64)[]\"",
           "x-nullable": true
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
         "ingress_vip": {
           "description": "Virtual IP used for cluster ingress traffic.",
           "type": "string",
@@ -2337,6 +2375,11 @@ func init() {
         },
         "name": {
           "description": "OpenShift cluster name",
+          "type": "string",
+          "x-nullable": true
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
           "type": "string",
           "x-nullable": true
         },
@@ -2964,10 +3007,6 @@ func init() {
     "image-create-params": {
       "type": "object",
       "properties": {
-        "proxy_url": {
-          "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
-          "type": "string"
-        },
         "ssh_public_key": {
           "description": "SSH public key for debugging the installation.",
           "type": "string"
@@ -2992,10 +3031,6 @@ func init() {
         },
         "generator_version": {
           "description": "Image generator version",
-          "type": "string"
-        },
-        "proxy_url": {
-          "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
           "type": "string"
         },
         "size_bytes": {
@@ -5396,6 +5431,15 @@ func init() {
           "description": "Self link.",
           "type": "string"
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string"
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"column:https_proxy\""
+        },
         "id": {
           "description": "Unique identifier of the object.",
           "type": "string",
@@ -5440,6 +5484,10 @@ func init() {
         },
         "name": {
           "description": "Name of the OpenShift cluster.",
+          "type": "string"
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
           "type": "string"
         },
         "openshift_version": {
@@ -5531,6 +5579,16 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
         "ingress_vip": {
           "description": "Virtual IP used for cluster ingress traffic.",
           "type": "string",
@@ -5539,6 +5597,11 @@ func init() {
         "name": {
           "description": "Name of the OpenShift cluster.",
           "type": "string"
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
+          "type": "string",
+          "x-nullable": true
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
@@ -5621,6 +5684,16 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:varchar(64)[]\"",
           "x-nullable": true
         },
+        "http_proxy": {
+          "description": "A proxy URL to use for creating HTTP connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
+        "https_proxy": {
+          "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
+          "type": "string",
+          "x-nullable": true
+        },
         "ingress_vip": {
           "description": "Virtual IP used for cluster ingress traffic.",
           "type": "string",
@@ -5629,6 +5702,11 @@ func init() {
         },
         "name": {
           "description": "OpenShift cluster name",
+          "type": "string",
+          "x-nullable": true
+        },
+        "no_proxy": {
+          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.",
           "type": "string",
           "x-nullable": true
         },
@@ -6256,10 +6334,6 @@ func init() {
     "image-create-params": {
       "type": "object",
       "properties": {
-        "proxy_url": {
-          "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
-          "type": "string"
-        },
         "ssh_public_key": {
           "description": "SSH public key for debugging the installation.",
           "type": "string"
@@ -6284,10 +6358,6 @@ func init() {
         },
         "generator_version": {
           "description": "Image generator version",
-          "type": "string"
-        },
-        "proxy_url": {
-          "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
           "type": "string"
         },
         "size_bytes": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1420,11 +1420,6 @@ definitions:
   image-create-params:
     type: object
     properties:
-      proxy_url:
-        type: string
-        description: |
-          The URL of the HTTP/S proxy that agents should use to access the discovery service
-          http://\<user\>:\<password\>@\<server\>:\<port\>/
       ssh_public_key:
         type: string
         description: SSH public key for debugging the installation.
@@ -1685,6 +1680,22 @@ definitions:
         description: Indicate if VIP DHCP allocation mode is enabled.
         x-nullable: true
         default: false
+      http_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTP connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+        x-nullable: true
+      https_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTPS connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+        x-nullable: true
+      no_proxy:
+        type: string
+        description: A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
+        x-nullable: true
 
   cluster-update-params:
     type: object
@@ -1734,6 +1745,22 @@ definitions:
       vip_dhcp_allocation:
         type: boolean
         description: Indicate if VIP DHCP allocation mode is enabled.
+        x-nullable: true
+      http_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTP connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+        x-nullable: true
+      https_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTPS connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+        x-nullable: true
+      no_proxy:
+        type: string
+        description: A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
         x-nullable: true
       hosts_roles:
         type: array
@@ -1830,6 +1857,20 @@ definitions:
         type: string
         x-go-custom-tag: gorm:"type:varchar(1024)"
         description: SSH public key for debugging OpenShift nodes.
+      http_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTP connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+      https_proxy:
+        type: string
+        description: |
+          A proxy URL to use for creating HTTPS connections outside the cluster.
+          http://\<username\>:\<pswd\>@\<ip\>:\<port\>
+        x-go-custom-tag: gorm:"column:https_proxy"
+      no_proxy:
+        type: string
+        description: A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying.
       status:
         type: string
         description: Status of the OpenShift cluster.
@@ -1896,11 +1937,6 @@ definitions:
   image_info:
     type: object
     properties:
-      proxy_url:
-        type: string
-        description: |
-          The URL of the HTTP/S proxy that agents should use to access the discovery service
-          http://\<user\>:\<password\>@\<server\>:\<port\>/
       ssh_public_key:
         type: string
         x-go-custom-tag: gorm:"type:varchar(1024)"


### PR DESCRIPTION
The PR enables the user to set HTTP/S proxy values to be set for the installed cluster.
The values will be reflected in the generated `install-config.yaml`:

```
apiVersion: v1
baseDomain: redhat.com
proxy:
  httpProxy: http://10.46.41.7:3128
  httpsProxy: ""
  noProxy: ""
```
On the installed cluster, the cluster-wide proxy [1] will contain those settings:
```
oc get proxy cluster -o yaml
apiVersion: config.openshift.io/v1
kind: Proxy
...
spec:
  httpProxy: http://10.46.41.7:3128
...
```

[MGMT-1108] The agent runs on the nodes will use the same HTTP Proxy to communication with the assisted service:
```
oc describe pod -n assisted-installer createimage-4cb1cb1a-aa7c-441a-9ecf-7ea58054522b-202008051sfrfk
...
    Environment:
      IGNITION_CONFIG:        {
                              "ignition": { "version": "2.2.0" },
...
"contents": "[Service]\nType=simple\nRestart=always\nRestartSec=3\nStartLimitIntervalSec=0\nEnvironment=HTTPS_PROXY=\nEnvironment=HTTP_PROXY=http://10.46.41.7:3128\nEnvironment=http_proxy=http://10.46.41.7:3128\nEnvironment=https_proxy=\nEnvironment=PULL_SECRET_TOKEN=b3B...==\nExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/ocpmetal/agent:latest cp /usr/bin/agent /hostbin\nExecStart=/usr/local/bin/agent --host 10.46.41.7 --port 6000 --cluster-id 4cb1cb1a-aa7c-441a-9ecf-7ea58054522b --agent-version quay.io/ocpmetal/agent:latest\n\n[Install]\nWantedBy=multi-user.target"
...
```
[1] https://docs.openshift.com/container-platform/4.5/networking/enable-cluster-wide-proxy.html

Signed-off-by: Moti Asayag <masayag@redhat.com>