### PR TITLE
MGMT-1669 / MGMT-1637: Add image presigned URL, size, and expire time

### DIFF
--- a/client/installer/download_cluster_i_s_o_responses.go
+++ b/client/installer/download_cluster_i_s_o_responses.go
@@ -60,6 +60,12 @@ func (o *DownloadClusterISOReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return nil, result
+	case 409:
+		result := NewDownloadClusterISOConflict()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewDownloadClusterISOInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -247,18 +253,39 @@ func NewDownloadClusterISOMethodNotAllowed() *DownloadClusterISOMethodNotAllowed
 Method Not Allowed.
 */
 type DownloadClusterISOMethodNotAllowed struct {
-	Payload *models.Error
 }
 
 func (o *DownloadClusterISOMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOMethodNotAllowed  %+v", 405, o.Payload)
-}
-
-func (o *DownloadClusterISOMethodNotAllowed) GetPayload() *models.Error {
-	return o.Payload
+	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOMethodNotAllowed ", 405)
 }
 
 func (o *DownloadClusterISOMethodNotAllowed) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDownloadClusterISOConflict creates a DownloadClusterISOConflict with default headers values
+func NewDownloadClusterISOConflict() *DownloadClusterISOConflict {
+	return &DownloadClusterISOConflict{}
+}
+
+/*DownloadClusterISOConflict handles this case with default header values.
+
+Error.
+*/
+type DownloadClusterISOConflict struct {
+	Payload *models.Error
+}
+
+func (o *DownloadClusterISOConflict) Error() string {
+	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOConflict  %+v", 409, o.Payload)
+}
+
+func (o *DownloadClusterISOConflict) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *DownloadClusterISOConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Error)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,7 +59,6 @@ var Options struct {
 	Versions                    versions.Versions
 	CreateS3Bucket              bool          `envconfig:"CREATE_S3_BUCKET" default:"false"`
 	ImageExpirationInterval     time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
-	ImageExpirationTime         time.Duration `envconfig:"IMAGE_EXPIRATION_TIME" default:"60m"`
 	ClusterConfig               cluster.Config
 	DeployTarget                string `envconfig:"DEPLOY_TARGET" default:"k8s"`
 }
@@ -154,7 +153,7 @@ func main() {
 	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"))
 
 	if Options.DeployTarget == "k8s" {
-		expirer := imgexpirer.NewManager(log, s3Client.Client, Options.S3Config.S3Bucket, Options.ImageExpirationTime, eventsHandler)
+		expirer := imgexpirer.NewManager(log, s3Client.Client, Options.S3Config.S3Bucket, Options.BMConfig.ImageExpirationTime, eventsHandler)
 		imageExpirationMonitor := thread.New(
 			log.WithField("pkg", "image-expiration-monitor"), "Image Expiration Monitor", Options.ImageExpirationInterval, expirer.ExpirationTask)
 		imageExpirationMonitor.Start()

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -75,6 +75,7 @@ type Config struct {
 	ServiceBaseURL      string            `envconfig:"SERVICE_BASE_URL"`
 	S3EndpointURL       string            `envconfig:"S3_ENDPOINT_URL" default:"http://10.35.59.36:30925"`
 	S3Bucket            string            `envconfig:"S3_BUCKET" default:"test"`
+	ImageExpirationTime time.Duration     `envconfig:"IMAGE_EXPIRATION_TIME" default:"60m"`
 	AwsAccessKeyID      string            `envconfig:"AWS_ACCESS_KEY_ID" default:"accessKey1"`
 	AwsSecretAccessKey  string            `envconfig:"AWS_SECRET_ACCESS_KEY" default:"verySecretKey1"`
 	DeployTarget        string            `envconfig:"DEPLOY_TARGET" default:"k8s"`
@@ -318,18 +319,23 @@ func (b *bareMetalInventory) DeregisterCluster(ctx context.Context, params insta
 
 func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params installer.DownloadClusterISOParams) middleware.Responder {
 	log := logutil.FromContext(ctx, b.log)
-	if err := b.db.First(&common.Cluster{}, "id = ?", params.ClusterID).Error; err != nil {
+	var cluster common.Cluster
+
+	if err := b.db.First(&cluster, "id = ?", params.ClusterID).Error; err != nil {
 		log.WithError(err).Errorf("failed to get cluster %s", params.ClusterID)
 		return installer.NewDownloadClusterISONotFound().
 			WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
-	imgName := getImageName(params.ClusterID)
-	imageURL := fmt.Sprintf("%s/%s/%s", b.S3EndpointURL, b.S3Bucket, imgName)
+	if cluster.ImageInfo.DownloadURL == "" {
+		log.Errorf("no download URL set for cluster %s", params.ClusterID)
+		return installer.NewDownloadClusterISOConflict().
+			WithPayload(common.GenerateError(http.StatusConflict, errors.New("No download URL set for cluster")))
+	}
 
-	log.Info("Image URL: ", imageURL)
-	resp, err := http.Get(imageURL)
+	log.Info("Image URL: ", cluster.ImageInfo.DownloadURL)
+	resp, err := http.Get(cluster.ImageInfo.DownloadURL)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to get ISO: %s", imgName)
+		log.WithError(err).Errorf("Failed to get ISO for cluster %s", cluster.ID.String())
 		msg := "Failed to download image: error fetching from storage backend"
 		b.eventsHandler.AddEvent(ctx, params.ClusterID.String(), models.EventSeverityError, msg, time.Now())
 		return installer.NewDownloadClusterISOInternalServerError().
@@ -339,7 +345,7 @@ func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params inst
 		defer resp.Body.Close()
 		body, _ := ioutil.ReadAll(resp.Body)
 		log.WithError(fmt.Errorf("%d - %s", resp.StatusCode, string(body))).
-			Errorf("Failed to get ISO: %s", imgName)
+			Errorf("Failed to get ISO for cluster %s", cluster.ID.String())
 		if resp.StatusCode == http.StatusNotFound {
 			msg := "Failed to download image: the image was not found (perhaps it expired) - please generate the image and try again"
 			b.eventsHandler.AddEvent(ctx, params.ClusterID.String(), models.EventSeverityError, msg, time.Now())
@@ -357,6 +363,30 @@ func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params inst
 	return filemiddleware.NewResponder(installer.NewDownloadClusterISOOK().WithPayload(resp.Body),
 		fmt.Sprintf("cluster-%s-discovery.iso", params.ClusterID.String()),
 		resp.ContentLength)
+}
+
+func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, cluster *common.Cluster) error {
+	imgName := getImageName(*cluster.ID)
+	imgSize, err := b.s3Client.GetObjectSizeBytes(ctx, imgName)
+	if err != nil {
+		return errors.New("Failed to generate image: error fetching size")
+	}
+
+	signedURL, err := b.s3Client.GeneratePresignedDownloadURL(ctx, imgName, b.Config.ImageExpirationTime)
+	if err != nil {
+		return errors.New("Failed to generate image: error generating URL")
+	}
+
+	updates := map[string]interface{}{}
+	updates["image_size_bytes"] = imgSize
+	updates["image_download_url"] = signedURL
+	dbReply := b.db.Model(&models.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
+	if dbReply.Error != nil {
+		return errors.New("Failed to generate image: error updating image record")
+	}
+	cluster.ImageInfo.SizeBytes = &imgSize
+	cluster.ImageInfo.DownloadURL = signedURL
+	return nil
 }
 
 func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params installer.GenerateClusterISOParams) middleware.Responder {
@@ -435,7 +465,9 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 	updates["image_proxy_url"] = params.ImageCreateParams.ProxyURL
 	updates["image_ssh_public_key"] = params.ImageCreateParams.SSHPublicKey
 	updates["image_created_at"] = strfmt.DateTime(now)
+	updates["image_expires_at"] = strfmt.DateTime(now.Add(b.Config.ImageExpirationTime))
 	updates["image_generator_version"] = b.Config.ImageBuilder
+	updates["image_download_url"] = ""
 	dbReply := tx.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
 	if dbReply.Error != nil {
 		log.WithError(dbReply.Error).Errorf("failed to update cluster: %s", params.ClusterID)
@@ -460,6 +492,11 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 	}
 
 	if imageExists {
+		if err := b.updateImageInfoPostUpload(ctx, &cluster); err != nil {
+			return installer.NewGenerateClusterISOInternalServerError().
+				WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+		}
+
 		log.Infof("Re-used existing cluster <%s> image", params.ClusterID)
 		b.eventsHandler.AddEvent(ctx, cluster.ID.String(), models.EventSeverityInfo, "Re-used existing image rather than generating a new one", time.Now())
 		return installer.NewGenerateClusterISOCreated().WithPayload(&cluster.Cluster)
@@ -481,6 +518,11 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 		msg := "Failed to generate image: error in generator.GenerateISO"
 		b.eventsHandler.AddEvent(ctx, params.ClusterID.String(), models.EventSeverityError, msg, time.Now())
 		return installer.NewGenerateClusterISOInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+	}
+
+	if err := b.updateImageInfoPostUpload(ctx, &cluster); err != nil {
+		return installer.NewGenerateClusterISOInternalServerError().
+			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
 	log.Infof("Generated cluster <%s> image with ignition config %s", params.ClusterID, ignitionConfig)

--- a/models/image_info.go
+++ b/models/image_info.go
@@ -21,6 +21,13 @@ type ImageInfo struct {
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// download url
+	DownloadURL string `json:"download_url,omitempty"`
+
+	// expires at
+	// Format: date-time
+	ExpiresAt strfmt.DateTime `json:"expires_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// Image generator version
 	GeneratorVersion string `json:"generator_version,omitempty"`
 
@@ -28,6 +35,10 @@ type ImageInfo struct {
 	// http://\<user\>:\<password\>@\<server\>:\<port\>/
 	//
 	ProxyURL string `json:"proxy_url,omitempty"`
+
+	// size bytes
+	// Minimum: 0
+	SizeBytes *int64 `json:"size_bytes,omitempty"`
 
 	// SSH public key for debugging the installation
 	SSHPublicKey string `json:"ssh_public_key,omitempty" gorm:"type:varchar(1024)"`
@@ -38,6 +49,14 @@ func (m *ImageInfo) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateCreatedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateExpiresAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSizeBytes(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -54,6 +73,32 @@ func (m *ImageInfo) validateCreatedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("created_at", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ImageInfo) validateExpiresAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ExpiresAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("expires_at", "body", "date-time", m.ExpiresAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ImageInfo) validateSizeBytes(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SizeBytes) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("size_bytes", "body", int64(*m.SizeBytes), 0, false); err != nil {
 		return err
 	}
 

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -31,6 +31,8 @@ type API interface {
 	DoesObjectExist(ctx context.Context, objectName string) (bool, error)
 	DeleteObject(ctx context.Context, objectName string) error
 	UpdateObjectTag(ctx context.Context, objectName, key, value string) (bool, error)
+	GetObjectSizeBytes(ctx context.Context, objectName string) (int64, error)
+	GeneratePresignedDownloadURL(ctx context.Context, objectName string, duration time.Duration) (string, error)
 }
 
 var _ API = &S3Client{}
@@ -128,16 +130,13 @@ func (c *S3Client) Upload(ctx context.Context, data []byte, objectName string) e
 func (c *S3Client) Download(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
 	log := logutil.FromContext(ctx, c.log)
 	log.Infof("Downloading %s from bucket %s", objectName, c.cfg.S3Bucket)
-	headResp, err := c.Client.HeadObject(&s3.HeadObjectInput{
-		Bucket: aws.String(c.cfg.S3Bucket),
-		Key:    aws.String(objectName),
-	})
+
+	contentLength, err := c.GetObjectSizeBytes(ctx, objectName)
 	if err != nil {
 		err = errors.Wrapf(err, "Failed to fetch metadata for object %s in bucket %s", objectName, c.cfg.S3Bucket)
 		log.Error(err)
 		return nil, 0, err
 	}
-	contentLength := *headResp.ContentLength
 
 	getResp, err := c.Client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(c.cfg.S3Bucket),
@@ -216,4 +215,33 @@ func (c *S3Client) UpdateObjectTag(ctx context.Context, objectName, key, value s
 		}
 	}
 	return true, nil
+}
+
+func (c *S3Client) GetObjectSizeBytes(ctx context.Context, objectName string) (int64, error) {
+	log := logutil.FromContext(ctx, c.log)
+	headResp, err := c.Client.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(c.cfg.S3Bucket),
+		Key:    aws.String(objectName),
+	})
+	if err != nil {
+		err = errors.Wrapf(err, "Failed to fetch metadata for object %s in bucket %s", objectName, c.cfg.S3Bucket)
+		log.Error(err)
+		return 0, err
+	}
+	return *headResp.ContentLength, nil
+}
+
+func (c *S3Client) GeneratePresignedDownloadURL(ctx context.Context, objectName string, duration time.Duration) (string, error) {
+	log := logutil.FromContext(ctx, c.log)
+	req, _ := c.Client.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(c.cfg.S3Bucket),
+		Key:    aws.String(objectName),
+	})
+	urlStr, err := req.Presign(duration)
+	if err != nil {
+		err = errors.Wrapf(err, "Failed to create presigned download URL for object %s in bucket %s", objectName, c.cfg.S3Bucket)
+		log.Error(err)
+		return "", err
+	}
+	return urlStr, nil
 }

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -9,6 +9,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
+	time "time"
 )
 
 // MockAPI is a mock of API interface
@@ -120,4 +121,34 @@ func (m *MockAPI) UpdateObjectTag(ctx context.Context, objectName, key, value st
 func (mr *MockAPIMockRecorder) UpdateObjectTag(ctx, objectName, key, value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateObjectTag", reflect.TypeOf((*MockAPI)(nil).UpdateObjectTag), ctx, objectName, key, value)
+}
+
+// GetObjectSizeBytes mocks base method
+func (m *MockAPI) GetObjectSizeBytes(ctx context.Context, objectName string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectSizeBytes", ctx, objectName)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetObjectSizeBytes indicates an expected call of GetObjectSizeBytes
+func (mr *MockAPIMockRecorder) GetObjectSizeBytes(ctx, objectName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectSizeBytes", reflect.TypeOf((*MockAPI)(nil).GetObjectSizeBytes), ctx, objectName)
+}
+
+// GeneratePresignedDownloadURL mocks base method
+func (m *MockAPI) GeneratePresignedDownloadURL(ctx context.Context, objectName string, duration time.Duration) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GeneratePresignedDownloadURL", ctx, objectName, duration)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GeneratePresignedDownloadURL indicates an expected call of GeneratePresignedDownloadURL
+func (mr *MockAPIMockRecorder) GeneratePresignedDownloadURL(ctx, objectName, duration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GeneratePresignedDownloadURL", reflect.TypeOf((*MockAPI)(nil).GeneratePresignedDownloadURL), ctx, objectName, duration)
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -784,7 +784,10 @@ func init() {
             }
           },
           "405": {
-            "description": "Method Not Allowed.",
+            "description": "Method Not Allowed."
+          },
+          "409": {
+            "description": "Error.",
             "schema": {
               "$ref": "#/definitions/error"
             }
@@ -2817,6 +2820,14 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "download_url": {
+          "type": "string"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
         "generator_version": {
           "description": "Image generator version",
           "type": "string"
@@ -2824,6 +2835,9 @@ func init() {
         "proxy_url": {
           "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
           "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer"
         },
         "ssh_public_key": {
           "description": "SSH public key for debugging the installation",
@@ -3883,7 +3897,10 @@ func init() {
             }
           },
           "405": {
-            "description": "Method Not Allowed.",
+            "description": "Method Not Allowed."
+          },
+          "409": {
+            "description": "Error.",
             "schema": {
               "$ref": "#/definitions/error"
             }
@@ -5922,6 +5939,14 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "download_url": {
+          "type": "string"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
         "generator_version": {
           "description": "Image generator version",
           "type": "string"
@@ -5929,6 +5954,10 @@ func init() {
         "proxy_url": {
           "description": "The URL of the HTTP/S proxy that agents should use to access the discovery service\nhttp://\\\u003cuser\\\u003e:\\\u003cpassword\\\u003e@\\\u003cserver\\\u003e:\\\u003cport\\\u003e/\n",
           "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
         },
         "ssh_public_key": {
           "description": "SSH public key for debugging the installation",

--- a/restapi/operations/installer/download_cluster_i_s_o_responses.go
+++ b/restapi/operations/installer/download_cluster_i_s_o_responses.go
@@ -240,11 +240,6 @@ const DownloadClusterISOMethodNotAllowedCode int = 405
 swagger:response downloadClusterISOMethodNotAllowed
 */
 type DownloadClusterISOMethodNotAllowed struct {
-
-	/*
-	  In: Body
-	*/
-	Payload *models.Error `json:"body,omitempty"`
 }
 
 // NewDownloadClusterISOMethodNotAllowed creates DownloadClusterISOMethodNotAllowed with default headers values
@@ -253,21 +248,50 @@ func NewDownloadClusterISOMethodNotAllowed() *DownloadClusterISOMethodNotAllowed
 	return &DownloadClusterISOMethodNotAllowed{}
 }
 
-// WithPayload adds the payload to the download cluster i s o method not allowed response
-func (o *DownloadClusterISOMethodNotAllowed) WithPayload(payload *models.Error) *DownloadClusterISOMethodNotAllowed {
+// WriteResponse to the client
+func (o *DownloadClusterISOMethodNotAllowed) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(405)
+}
+
+// DownloadClusterISOConflictCode is the HTTP code returned for type DownloadClusterISOConflict
+const DownloadClusterISOConflictCode int = 409
+
+/*DownloadClusterISOConflict Error.
+
+swagger:response downloadClusterISOConflict
+*/
+type DownloadClusterISOConflict struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewDownloadClusterISOConflict creates DownloadClusterISOConflict with default headers values
+func NewDownloadClusterISOConflict() *DownloadClusterISOConflict {
+
+	return &DownloadClusterISOConflict{}
+}
+
+// WithPayload adds the payload to the download cluster i s o conflict response
+func (o *DownloadClusterISOConflict) WithPayload(payload *models.Error) *DownloadClusterISOConflict {
 	o.Payload = payload
 	return o
 }
 
-// SetPayload sets the payload to the download cluster i s o method not allowed response
-func (o *DownloadClusterISOMethodNotAllowed) SetPayload(payload *models.Error) {
+// SetPayload sets the payload to the download cluster i s o conflict response
+func (o *DownloadClusterISOConflict) SetPayload(payload *models.Error) {
 	o.Payload = payload
 }
 
 // WriteResponse to the client
-func (o *DownloadClusterISOMethodNotAllowed) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+func (o *DownloadClusterISOConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.WriteHeader(405)
+	rw.WriteHeader(409)
 	if o.Payload != nil {
 		payload := o.Payload
 		if err := producer.Produce(rw, payload); err != nil {

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -109,6 +109,6 @@ var _ = Describe("image tests", func() {
 		_, err = userBMClient.Installer.DownloadClusterISO(ctx, &installer.DownloadClusterISOParams{
 			ClusterID: *cluster.GetPayload().ID,
 		}, file)
-		Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewDownloadClusterISONotFound())))
+		Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewDownloadClusterISOConflict())))
 	})
 })

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -311,6 +311,8 @@ paths:
             $ref: '#/definitions/error'
         405:
           description: Method Not Allowed.
+        409:
+          description: Error.
           schema:
             $ref: '#/definitions/error'
         500:
@@ -1802,10 +1804,19 @@ definitions:
         type: string
         x-go-custom-tag: gorm:"type:varchar(1024)"
         description: SSH public key for debugging the installation
+      size_bytes:
+        type: integer
+        minimum: 0
+      download_url:
+        type: string
       generator_version:
         type: string
         description: Image generator version
       created_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone"
+      expires_at:
         type: string
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"


### PR DESCRIPTION
1. Upon generating image, create a presigned S3 URL and store it in download_url.  If S3 isn't exposed, DownloadClusterISO can still be used and it will download from the presigned URL.  The UI should show either the presigned URL or the assisted-service URL depending on the deployment.
2. Added image size and expiration time.