### PR TITLE
Add Agent Auth to Hosts list API

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1016,6 +1016,14 @@ func init() {
     },
     "/clusters/{cluster_id}/hosts": {
       "get": {
+        "security": [
+          {
+            "userAuth": []
+          },
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],
@@ -4055,6 +4063,14 @@ func init() {
     },
     "/clusters/{cluster_id}/hosts": {
       "get": {
+        "security": [
+          {
+            "userAuth": []
+          },
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -134,6 +134,14 @@ func init() {
     },
     "/clusters/{cluster_id}": {
       "get": {
+        "security": [
+          {
+            "userAuth": []
+          },
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],
@@ -3181,6 +3189,14 @@ func init() {
     },
     "/clusters/{cluster_id}": {
       "get": {
+        "security": [
+          {
+            "userAuth": []
+          },
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -391,6 +391,11 @@ func init() {
     },
     "/clusters/{cluster_id}/actions/complete_installation": {
       "post": {
+        "security": [
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],
@@ -3446,6 +3451,11 @@ func init() {
     },
     "/clusters/{cluster_id}/actions/complete_installation": {
       "post": {
+        "security": [
+          {
+            "agentAuth": []
+          }
+        ],
         "tags": [
           "installer"
         ],

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -217,7 +217,7 @@ func installCluster(clusterID strfmt.UUID) {
 	waitForClusterState(ctx, clusterID, "finalizing", defaultWaitForClusterStateTimeout, "Finalizing cluster installation")
 
 	success := true
-	_, err = userBMClient.Installer.CompleteInstallation(ctx,
+	_, err = agentBMClient.Installer.CompleteInstallation(ctx,
 		&installer.CompleteInstallationParams{ClusterID: clusterID, CompletionParams: &models.CompletionParams{IsSuccess: &success, ErrorInfo: ""}})
 	Expect(err).NotTo(HaveOccurred())
 
@@ -435,7 +435,7 @@ var _ = Describe("cluster install", func() {
 			waitForClusterState(ctx, clusterID, "finalizing", defaultWaitForClusterStateTimeout, "Finalizing cluster installation")
 			By("Completing installation installation")
 			success := true
-			_, err = userBMClient.Installer.CompleteInstallation(ctx,
+			_, err = agentBMClient.Installer.CompleteInstallation(ctx,
 				&installer.CompleteInstallationParams{ClusterID: clusterID, CompletionParams: &models.CompletionParams{IsSuccess: &success, ErrorInfo: ""}})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -466,7 +466,7 @@ var _ = Describe("cluster install", func() {
 			waitForClusterState(ctx, clusterID, "finalizing", defaultWaitForClusterStateTimeout, "Finalizing cluster installation")
 			By("Failing installation")
 			success := false
-			_, err = userBMClient.Installer.CompleteInstallation(ctx,
+			_, err = agentBMClient.Installer.CompleteInstallation(ctx,
 				&installer.CompleteInstallationParams{ClusterID: clusterID, CompletionParams: &models.CompletionParams{IsSuccess: &success, ErrorInfo: "failed"}})
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying installation failed")
@@ -1732,7 +1732,7 @@ var _ = Describe("cluster install, with default network params", func() {
 
 		waitForClusterState(ctx, clusterID, "finalizing", defaultWaitForClusterStateTimeout, "Finalizing cluster installation")
 		success := true
-		_, err = userBMClient.Installer.CompleteInstallation(ctx,
+		_, err = agentBMClient.Installer.CompleteInstallation(ctx,
 			&installer.CompleteInstallationParams{ClusterID: clusterID, CompletionParams: &models.CompletionParams{IsSuccess: &success, ErrorInfo: ""}})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -98,7 +98,10 @@ var _ = Describe("Cluster tests", func() {
 
 		getReply, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
+		Expect(getReply.GetPayload().Hosts[0].ClusterID.String()).Should(Equal(clusterID.String()))
 
+		getReply, err = agentBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
+		Expect(err).NotTo(HaveOccurred())
 		Expect(getReply.GetPayload().Hosts[0].ClusterID.String()).Should(Equal(clusterID.String()))
 
 		list, err := userBMClient.Installer.ListClusters(ctx, &installer.ListClustersParams{})

--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -51,6 +51,10 @@ var _ = Describe("Host tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(list.GetPayload())).Should(Equal(1))
 
+		list, err = agentBMClient.Installer.ListHosts(ctx, &installer.ListHostsParams{ClusterID: clusterID})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(list.GetPayload())).Should(Equal(1))
+
 		_, err = userBMClient.Installer.DeregisterHost(ctx, &installer.DeregisterHostParams{
 			ClusterID: clusterID,
 			HostID:    *host.ID,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -640,6 +640,8 @@ paths:
     post:
       tags:
         - installer
+      security:
+        - agentAuth: []
       summary: Agent API to mark a finalizing installation as complete.
       operationId: CompleteInstallation
       parameters:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -732,6 +732,9 @@ paths:
     get:
       tags:
         - installer
+      security:
+        - userAuth: []
+        - agentAuth: []
       summary: Retrieves the list of OpenShift bare metal hosts.
       operationId: ListHosts
       parameters:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -99,6 +99,9 @@ paths:
     get:
       tags:
         - installer
+      security:
+        - userAuth: []
+        - agentAuth: []
       summary: Retrieves the details of the OpenShift bare metal cluster.
       operationId: GetCluster
       parameters:


### PR DESCRIPTION
In https://github.com/oshercc/ignition-manifests-and-kubeconfig-generate, there is call to assisted-service for Hosts List API.

In this PR, I enable the API to be able to be called it as a Agent authenticated in addition to User.

This is needed for :
https://github.com/oshercc/ignition-manifests-and-kubeconfig-generate/pull/19