### PR TITLE
Run assisted-service on-prem as non-root

### DIFF
--- a/Dockerfile.assisted-service-onprem
+++ b/Dockerfile.assisted-service-onprem
@@ -12,12 +12,15 @@ FROM fedora:31
 
 ARG GIT_REVISION
 ARG WORK_DIR=/data
+ARG USER=assisted-installer
 
 LABEL "git_revision"=${GIT_REVISION}
 
 RUN dnf install -y python pip libvirt-devel && dnf clean all && pip install boto3 botocore
 
-RUN mkdir $WORK_DIR && chmod 777 $WORK_DIR
+RUN mkdir $WORK_DIR && chmod 755 $WORK_DIR
+RUN useradd $USER
+RUN chown $USER:$USER $WORK_DIR
 
 # ISO
 COPY --from=coreos-installer /usr/sbin/coreos-installer $WORK_DIR

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ deploy-onprem:
 	podman volume create s3-volume
 	podman run -dt --pod assisted-installer --env-file onprem-environment -v s3-volume:/mnt/data:rw --name s3 scality/s3server:latest
 	podman run -dt --pod assisted-installer --env-file onprem-environment --name db centos/postgresql-12-centos7
-	podman run -dt --pod assisted-installer --env-file onprem-environment --restart always --name installer ${SERVICE}
+	podman run -dt --pod assisted-installer --env-file onprem-environment --user assisted-installer  --restart always --name installer ${SERVICE}
 	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always -v $(PWD)/deploy/ui/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest
 
 ########


### PR DESCRIPTION
 The on-prem assisted-service now runs as non-root user and `/data` is not be world-writeable.

```
podman top installer
USER        PID   PPID   %CPU    ELAPSED        TTY     TIME   COMMAND
assisted-installer   1     0      0.000   8.482246148s   pts/0   0s     /assisted-service 

podman exec -it installer ls -ld /data
drwxr-xr-x. 1 assisted-installer assisted-installer 4096 Aug  7 01:49 /data
```
Ref: https://issues.redhat.com/browse/MGMT-1738