### PR TITLE
MGMT-1733 Make multistage production image to support Prow

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -1,10 +1,33 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as certs
+# Generate python client
+FROM swaggerapi/swagger-codegen-cli:2.4.15 as swagger_py
 
-FROM scratch
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-bundle.crt
-COPY --from=certs /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt /etc/ssl/certs/ca-bundle.trust.crt
+COPY swagger.yaml .
+COPY tools/generate_python_client.sh .
+RUN chmod +x ./generate_python_client.sh && SWAGGER_FILE=swagger.yaml OUTPUT=/build ./generate_python_client.sh
+
+# Generate go client
+FROM quay.io/goswagger/swagger:v0.25.0 as swagger_go
+COPY . .
+RUN mkdir /build
+RUN swagger generate server --template=stratoscale -f swagger.yaml --template-dir=/templates/contrib \
+    && mv restapi models /build
+RUN swagger generate client --template=stratoscale -f swagger.yaml --template-dir=/templates/contrib \
+    && mv client /build
+
+# Build binaries
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 as builder
+COPY . .
+COPY --from=swagger_py /build build
+COPY --from=swagger_go /build/client client
+COPY --from=swagger_go /build/models models
+COPY --from=swagger_go /build/restapi restapi
+RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service cmd/main.go
+RUN cd build && python3 setup.py sdist --dist-dir /assisted-service-client
+
+# Create final image
+FROM registry.access.redhat.com/ubi8/ubi:latest
 ARG GIT_REVISION
 LABEL "git_revision"=${GIT_REVISION}
-ADD build/assisted-service /assisted-service
-ADD build/assisted-service-client-1.0.0.tar.gz /clients/assisted-service-client-1.0.0.tar.gz
+COPY --from=builder /build/assisted-service /assisted-service
+COPY --from=builder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
 CMD ["/assisted-service"]

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -3,7 +3,6 @@ build-container-image: assisted-service-build
 
 containers:
     assisted-service-build: Dockerfile.assisted-service-build
-    assisted-service: Dockerfile.assisted-service
 volumes:
     - $HOME/.cache/go-build:/go/pkg/mod
     - $HOME/.cache/golangci-lint:$HOME/.cache/golangci-lint

--- a/tools/generate_python_client.sh
+++ b/tools/generate_python_client.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -o nounset
+
+temp_swagger_file=$(mktemp)
+sed '/pattern:/d' ${SWAGGER_FILE} > ${temp_swagger_file}
+temp_config_file=$(mktemp)
+echo '{"packageName" : "assisted_service_client", "packageVersion": "1.0.0"}' > ${temp_config_file}
+java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate --lang python --config ${temp_config_file} --output ${OUTPUT} --input-spec ${temp_swagger_file}


### PR DESCRIPTION
Matching PR on openshift/release#10715

Made the production image to be a multistage because:
* In assisted-service we depend on a sequence of operations in runtime. In Prow all the images should be built in build time.
* DockerInDocker isn't available. e.g. to run client generation with a swagger container.