### PR TITLE
Removing `namespace` field from all resources in openshift/template.yaml

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -35,7 +35,6 @@ objects:
   kind: Deployment
   metadata:
     name: assisted-service
-    namespace: assisted-installer
   spec:
     selector:
       matchLabels:
@@ -132,7 +131,6 @@ objects:
     labels:
       app: assisted-service
     name: assisted-service
-    namespace: assisted-installer
   spec:
     ports:
       - name: assisted-svc
@@ -145,7 +143,6 @@ objects:
   kind: ConfigMap
   metadata:
     name: assisted-service-config
-    namespace: assisted-installer
     labels:
       app: assisted-service
   data:


### PR DESCRIPTION
This namespace is overwritten in app-sre according to the env so it is
not in use and just creating confusion.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>