### PR TITLE
MGMT-1791 remove disable ssl from s3 client

### DIFF
--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -88,7 +88,6 @@ func newS3Session(cfg *Config) (*session.Session, error) {
 		Region:               aws.String(cfg.Region),
 		Endpoint:             aws.String(cfg.S3EndpointURL),
 		Credentials:          creds,
-		DisableSSL:           aws.Bool(true),
 		S3ForcePathStyle:     aws.Bool(true),
 		S3Disable100Continue: aws.Bool(true),
 		HTTPClient:           &http.Client{Transport: HTTPTransport},


### PR DESCRIPTION
it is not needed for aws s3 or for scality