### PR TITLE
deployment: change aws mountPath

### DIFF
--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -86,9 +86,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: AWS_SHARED_CREDENTIALS_FILE
+              value: /etc/.aws/credentials
           volumeMounts:
             - name: route53-creds
-              mountPath: "/.aws"
+              mountPath: "/etc/.aws"
               readOnly: true
       volumes:
         - name: route53-creds


### PR DESCRIPTION
As assisted-service is based on ubi8 instead of scratch now,
aws credenetials file is expected at /root/.aws/ path.
Hence, set AWS_SHARED_CREDENTIALS_FILE env var to /etc/.aws/credentials