### PR TITLE
change name to assisted-service for oc ingress

### DIFF
--- a/tools/deploy_inventory_service.py
+++ b/tools/deploy_inventory_service.py
@@ -26,7 +26,7 @@ def main():
 
     # in case of OpenShift deploy ingress as well
     if deploy_options.target == "oc-ingress":
-        hostname = utils.get_service_host("assisted-installer", deploy_options.target, deploy_options.domain,
+        hostname = utils.get_service_host("assisted-service", deploy_options.target, deploy_options.domain,
                                           deploy_options.namespace)
 
         if deploy_options.enable_tls:


### PR DESCRIPTION
oc-ingress is checking for assisted-installer instead of the updated assisted-service

```
[root@rh8-tools assisted-install-vsphere]# oc get svc -n assisted-installer
NAME                TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
assisted-service    LoadBalancer   172.30.90.108    <pending>     8090:30333/TCP   27m
cloudserver-front   ClusterIP      None             <none>        8000/TCP         27m
ocp-metal-ui        LoadBalancer   172.30.61.239    <pending>     80:31959/TCP     25m
postgres            LoadBalancer   172.30.174.165   <pending>     5432:30702/TCP   27m
```

This change allowed me to complete an install. 