### PR TITLE
Use an env var to set the s3 url scheme if not present

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,6 +123,10 @@ func main() {
 
 	log.Println("DeployTarget: " + Options.DeployTarget)
 
+	if err = fixS3EndpointURL(&Options.JobConfig); err != nil {
+		log.WithError(err).Fatalf("failed to create valid S3 endpoint URL from %s", Options.JobConfig.S3EndpointURL)
+	}
+
 	var generator generator.ISOInstallConfigGenerator
 
 	switch Options.DeployTarget {
@@ -198,4 +202,13 @@ func createS3Bucket(s3Client *s3wrapper.S3Client) {
 			log.Fatal(err)
 		}
 	}
+}
+
+func fixS3EndpointURL(c *job.Config) error {
+	new_url, err := s3wrapper.FixEndpointURL(c.S3EndpointURL)
+	if err != nil {
+		return err
+	}
+	c.S3EndpointURL = new_url
+	return nil
 }

--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -80,6 +80,8 @@ spec:
                 secretKeyRef:
                   key: endpoint
                   name: assisted-installer-s3
+            - name: S3_USE_SSL
+              value: "false"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -26,6 +26,8 @@ parameters:
 - name: OCM_BASE_URL
   value: ''
   required: true
+- name: S3_USE_SSL
+  value: "true"
 apiVersion: v1
 kind: Template
 metadata:
@@ -94,6 +96,8 @@ objects:
                   secretKeyRef:
                     key: endpoint
                     name: assisted-installer-s3
+              - name: S3_USE_SSL
+                value: ${S3_USE_SSL}
               - name: DB_HOST
                 valueFrom:
                   secretKeyRef:

--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -1,0 +1,25 @@
+package s3wrapper
+
+import (
+	"net/url"
+	"os"
+)
+
+func FixEndpointURL(endpoint string) (string, error) {
+	_, err := url.ParseRequestURI(endpoint)
+	if err == nil {
+		return endpoint, nil
+	}
+
+	prefix := "http://"
+	if os.Getenv("S3_USE_SSL") == "true" {
+		prefix = "https://"
+	}
+
+	new_url := prefix + endpoint
+	_, err = url.ParseRequestURI(new_url)
+	if err != nil {
+		return "", err
+	}
+	return new_url, nil
+}

--- a/pkg/s3wrapper/util_test.go
+++ b/pkg/s3wrapper/util_test.go
@@ -1,0 +1,53 @@
+package s3wrapper
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestJob(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util")
+}
+
+var _ = Describe("Util", func() {
+	It("returns the original string with a valid http URL", func() {
+		endpoint := "http://example.com/stuff"
+		result, err := FixEndpointURL(endpoint)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("http://example.com/stuff"))
+	})
+
+	It("returns the original string with a valid https URL", func() {
+		endpoint := "https://example.com/stuff"
+		result, err := FixEndpointURL(endpoint)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("https://example.com/stuff"))
+	})
+
+	It("prefixes an invalid endpoint with http:// when S3_USE_SSL is not set", func() {
+		endpoint := "example.com"
+		result, err := FixEndpointURL(endpoint)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("http://example.com"))
+	})
+
+	It("prefixes and invalid endpoint with https:// when S3_USE_SSL is \"true\"", func() {
+		endpoint := "example.com"
+		os.Setenv("S3_USE_SSL", "true")
+		defer os.Unsetenv("S3_USE_SSL")
+		result, err := FixEndpointURL(endpoint)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal("https://example.com"))
+	})
+
+	It("returns an error when a prefix does not produce a valid URL", func() {
+		endpoint := ":example.com"
+		result, err := FixEndpointURL(endpoint)
+		Expect(result).To(Equal(""))
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Currently we sometimes are provided an s3 "url" which is just a
hostname. This causes an error when trying to upload the iso file.

This PR will add either http or https to the hostname to create
a valid url.