### PR TITLE
Update local job to use assisted-iso-create

### DIFF
--- a/Dockerfile.assisted-service-onprem
+++ b/Dockerfile.assisted-service-onprem
@@ -1,7 +1,6 @@
 # ISO
 FROM quay.io/coreos/coreos-installer:release AS coreos-installer
 FROM quay.io/ocpmetal/livecd-iso:rhcos-livecd AS livecd
-FROM quay.io/ocpmetal/installer-image-build:stable AS installer-image-build
 
 # install config
 # [TODO] - remove this line, once we are ready to use openshift-installer from the release
@@ -26,7 +25,7 @@ RUN chown $USER:$USER $WORK_DIR
 # ISO
 COPY --from=coreos-installer /usr/sbin/coreos-installer $WORK_DIR
 COPY --from=livecd /root/image/livecd.iso $WORK_DIR/livecd.iso
-COPY --from=installer-image-build /data/install_process.py $WORK_DIR
+COPY build/assisted-iso-create $WORK_DIR
 ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
 
 # install config

--- a/pkg/job/local_job.go
+++ b/pkg/job/local_job.go
@@ -70,14 +70,24 @@ func (j *localJob) AbortInstallConfig(ctx context.Context, cluster common.Cluste
 
 func (j *localJob) GenerateISO(ctx context.Context, cluster common.Cluster, jobName string, imageName string, ignitionConfig string, eventsHandler events.Handler) error {
 	log := logutil.FromContext(ctx, j.log)
-	envVars := append(os.Environ(),
+	workDir := "/data"
+	cmd := exec.Command(workDir + "/assisted-iso-create")
+	cmd.Env = append(os.Environ(),
 		"S3_ENDPOINT_URL="+j.Config.S3EndpointURL,
 		"IGNITION_CONFIG="+ignitionConfig,
 		"IMAGE_NAME="+imageName,
+		"COREOS_IMAGE="+workDir+"/livecd.iso",
 		"S3_BUCKET="+j.Config.S3Bucket,
-		"aws_access_key_id="+j.Config.AwsAccessKeyID,
-		"aws_secret_access_key="+j.Config.AwsSecretAccessKey,
-		"WORK_DIR=/data",
+		"AWS_ACCESS_KEY_ID="+j.Config.AwsAccessKeyID,
+		"AWS_SECRET_ACCESS_KEY="+j.Config.AwsSecretAccessKey,
+		"WORK_DIR="+workDir,
 	)
-	return j.Execute("python", "./data/install_process.py", envVars, log)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		log.Errorf("assisted-iso-create failed: %s", out.String())
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Update to use the new assisted-iso-create command. In case of local, there is no k8s job and the assisted-iso-create
runs inside the installer container itself.