### PR TITLE
fix subsystem test - cancel installation with a disabled host

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -899,6 +899,8 @@ var _ = Describe("cluster install", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				waitForHostState(ctx, clusterID, *disabledHost.ID, models.HostStatusDisabled,
 					defaultWaitForHostStateTimeout)
+				waitForClusterState(ctx, clusterID, models.ClusterStatusReady, defaultWaitForClusterStateTimeout,
+					clusterReadyStateInfo)
 
 				By("install cluster")
 				_, err = userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
@@ -1172,6 +1174,8 @@ var _ = Describe("cluster install", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				waitForHostState(ctx, clusterID, *disabledHost.ID, models.HostStatusDisabled,
 					defaultWaitForHostStateTimeout)
+				waitForClusterState(ctx, clusterID, models.ClusterStatusReady, defaultWaitForClusterStateTimeout,
+					clusterReadyStateInfo)
 
 				By("install cluster")
 				_, err = userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})


### PR DESCRIPTION
fix failed tests: cancel installation with a disabled host and reset cluster with a disabled host
fix failed test: http://10.46.10.2:8080/job/assisted-service-subsystem-test/1195/consoleFull
http://10.46.10.2:8080/job/assisted-service-subsystem-test/1198/consoleFull

@RazRegev @filanov please review
