### PR TITLE
The working directory needs group write permissions

### DIFF
--- a/Dockerfile.assisted-iso-create
+++ b/Dockerfile.assisted-iso-create
@@ -11,7 +11,7 @@ ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
 ENV WORK_DIR=$WORK_DIR
 
 RUN mkdir $WORK_DIR
-RUN chmod 755 $WORK_DIR
+RUN chmod 775 $WORK_DIR
 
 COPY --from=livecd-build /root/image/livecd.iso $WORK_DIR
 COPY --from=installer-image /usr/sbin/coreos-installer $WORK_DIR


### PR DESCRIPTION
This allows a user with root group (as we will run on OpenShift) to
write to this directory