### PR TITLE
[MGMT-1828] Generate new ISO after proxy was changed

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3,6 +3,9 @@ package bminventory
 import (
 	"bytes"
 	"context"
+
+	// #nosec
+	"crypto/md5"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
@@ -275,6 +278,16 @@ func (b *bareMetalInventory) RegisterCluster(ctx context.Context, params install
 		NoProxy:                  swag.StringValue(params.NewClusterParams.NoProxy),
 		VipDhcpAllocation:        swag.Bool(false),
 	}}
+
+	if proxyHash, err := computeClusterProxyHash(params.NewClusterParams.HTTPProxy,
+		params.NewClusterParams.HTTPSProxy,
+		params.NewClusterParams.NoProxy); err != nil {
+		log.Error("Failed to compute cluster proxy hash", err)
+		return installer.NewGenerateClusterISOInternalServerError()
+	} else {
+		cluster.ProxyHash = proxyHash
+	}
+
 	if params.NewClusterParams.PullSecret != "" {
 		err := validations.ValidatePullSecret(params.NewClusterParams.PullSecret)
 		if err != nil {
@@ -363,7 +376,7 @@ func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params inst
 		contentLength)
 }
 
-func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, cluster *common.Cluster) error {
+func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, cluster *common.Cluster, clusterProxyHash string) error {
 	updates := map[string]interface{}{}
 	imgName := getImageName(*cluster.ID)
 	imgSize, err := b.s3Client.GetObjectSizeBytes(ctx, imgName)
@@ -383,7 +396,12 @@ func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, clus
 		cluster.ImageInfo.DownloadURL = signedURL
 	}
 
-	dbReply := b.db.Model(&models.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
+	if cluster.ProxyHash != clusterProxyHash {
+		updates["proxy_hash"] = clusterProxyHash
+		cluster.ProxyHash = clusterProxyHash
+	}
+
+	dbReply := b.db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
 	if dbReply.Error != nil {
 		return errors.New("Failed to generate image: error updating image record")
 	}
@@ -447,9 +465,16 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 	/* If the request has the same parameters as the previous request and the image is still in S3,
 	just refresh the timestamp.
 	*/
+	clusterProxyHash, err := computeClusterProxyHash(&cluster.HTTPProxy, &cluster.HTTPSProxy, &cluster.NoProxy)
+	if err != nil {
+		log.Error("Failed to compute cluster proxy hash", err)
+		return installer.NewGenerateClusterISOInternalServerError()
+	}
+
 	var imageExists bool
 	if cluster.ImageInfo.SSHPublicKey == params.ImageCreateParams.SSHPublicKey &&
-		cluster.ImageInfo.GeneratorVersion == b.Config.ImageBuilder {
+		cluster.ImageInfo.GeneratorVersion == b.Config.ImageBuilder &&
+		cluster.ProxyHash == clusterProxyHash {
 		var err error
 		imgName := getImageName(params.ClusterID)
 		imageExists, err = b.s3Client.UpdateObjectTag(ctx, imgName, "create_sec_since_epoch", strconv.FormatInt(now.Unix(), 10))
@@ -492,7 +517,7 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 	}
 
 	if imageExists {
-		if err := b.updateImageInfoPostUpload(ctx, &cluster); err != nil {
+		if err := b.updateImageInfoPostUpload(ctx, &cluster, clusterProxyHash); err != nil {
 			return installer.NewGenerateClusterISOInternalServerError().
 				WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 		}
@@ -520,7 +545,7 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 		return installer.NewGenerateClusterISOInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
-	if err := b.updateImageInfoPostUpload(ctx, &cluster); err != nil {
+	if err := b.updateImageInfoPostUpload(ctx, &cluster, clusterProxyHash); err != nil {
 		return installer.NewGenerateClusterISOInternalServerError().
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
@@ -2199,4 +2224,27 @@ func proxySettingsChanged(params *models.ClusterUpdateParams, cluster *common.Cl
 		return true
 	}
 	return false
+}
+
+// computes the cluster proxy hash in order to identify if proxy settings were changed which will indicated if
+// new ISO file should be generated to contain new proxy settings
+func computeClusterProxyHash(httpProxy, httpsProxy, noProxy *string) (string, error) {
+	var proxyHash string
+	if httpProxy != nil {
+		proxyHash += *httpProxy
+	}
+	if httpsProxy != nil {
+		proxyHash += *httpsProxy
+	}
+	if noProxy != nil {
+		proxyHash += *noProxy
+	}
+	// #nosec
+	h := md5.New()
+	_, err := h.Write([]byte(proxyHash))
+	if err != nil {
+		return "", err
+	}
+	bs := h.Sum(nil)
+	return fmt.Sprintf("%x", bs), nil
 }

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -6,4 +6,8 @@ type Cluster struct {
 	models.Cluster
 	// The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
 	PullSecret string `json:"pull_secret" gorm:"type:TEXT"`
+
+	// The compute hash value of the http-proxy, https-proxy and no-proxy attributes, used internally to indicate
+	// if the proxy settings were changed while downloading ISO
+	ProxyHash string `json:"proxy_hash"`
 }

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -112,3 +112,83 @@ var _ = Describe("image tests", func() {
 		Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewDownloadClusterISONotFound())))
 	})
 })
+
+var _ = Describe("system-test proxy update tests", func() {
+	ctx := context.Background()
+	var cluster *installer.RegisterClusterCreated
+	var clusterID strfmt.UUID
+	pullSecret := "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}" // #nosec
+
+	AfterEach(func() {
+		clearDB()
+	})
+
+	BeforeEach(func() {
+		var err error
+		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
+			NewClusterParams: &models.ClusterCreateParams{
+				Name:             swag.String("test-cluster"),
+				OpenshiftVersion: swag.String("4.5"),
+				PullSecret:       pullSecret,
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		clusterID = *cluster.GetPayload().ID
+	})
+
+	It("[only_k8s]generate_image_after_proxy_was_set", func() {
+		// Generate ISO of registered cluster without proxy configured
+		_, err := userBMClient.Installer.GenerateClusterISO(ctx, &installer.GenerateClusterISOParams{
+			ClusterID:         clusterID,
+			ImageCreateParams: &models.ImageCreateParams{},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// fetch cluster proxy hash for generated image
+		msg := "Generated image (proxy URL is \"\", SSH public key is not set)"
+		verifyEventExistence(clusterID, msg)
+
+		// Update cluster with proxy settings
+		httpProxy := "http://proxyserver:3128"
+		noProxy := "test.com"
+		_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
+			ClusterUpdateParams: &models.ClusterUpdateParams{
+				HTTPProxy: &httpProxy,
+				NoProxy:   &noProxy,
+			},
+			ClusterID: clusterID,
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Verify proxy settings changed event emitted
+		verifyEventExistence(clusterID, "Proxy settings changed")
+
+		// Generate ISO of registered cluster with proxy configured
+		_, err = userBMClient.Installer.GenerateClusterISO(ctx, &installer.GenerateClusterISOParams{
+			ClusterID:         clusterID,
+			ImageCreateParams: &models.ImageCreateParams{},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// fetch cluster proxy hash for generated image
+		msg = fmt.Sprintf("Generated image (proxy URL is \"%s\", SSH public key is not set)", httpProxy)
+		verifyEventExistence(clusterID, msg)
+	})
+})
+
+func verifyEventExistence(ClusterID strfmt.UUID, message string) {
+	eventsReply, err := userBMClient.Events.ListEvents(context.TODO(), &events.ListEventsParams{
+		ClusterID: ClusterID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(eventsReply.Payload).ShouldNot(HaveLen(0))
+	nEvents := 0
+	for _, ev := range eventsReply.Payload {
+		fmt.Printf("EntityID:%s, Message:%s\n", ev.ClusterID, *ev.Message)
+		Expect(ev.ClusterID.String()).Should(Equal(ClusterID.String()))
+		if strings.Contains(*ev.Message, message) {
+			nEvents++
+		}
+	}
+	Expect(nEvents).ShouldNot(Equal(0))
+}


### PR DESCRIPTION
Image should be generated based on its recent updated properties.
We need to consider proxy settings change in order to generate a
new image.

The PR adds a check when downloading ISO for changed in proxy settings.
If there was a change, a new image will be generated and the new proxy
changes will be computed and saved for next ISO download check.

Signed-off-by: Moti Asayag <masayag@redhat.com>