### PR TITLE
MGMT-1841 Increase wait for service timeout

### DIFF
--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -8,7 +8,7 @@ import utils
 import deployment_options
 
 SERVICE = "assisted-service"
-TIMEOUT = 60 * 8
+TIMEOUT = 60 * 15
 REQUEST_TIMEOUT = 2
 SLEEP = 3
 


### PR DESCRIPTION
Service will start reploying to request only after all the components are created.
Durring the creation of the inventory there is a dummy job to pull iso-generation image
Pulling this iso can take a long time