### PR TITLE
Adding 'assisted-iso-generator' to app-interface.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,9 +7,13 @@ export LANG="en_US.UTF-8"
 
 TAG=$(git rev-parse --short=7 HEAD)
 ASSISTED_SERVICE_IMAGE="quay.io/app-sre/assisted-service"
+ASSISTED_ISO_GENERATOR_IMAGE="quay.io/app-sre/assisted-iso-generator"
 
 SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make update-minimal
 docker tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+
+ISO_CREATION="${ASSISTED_ISO_GENERATOR_IMAGE}:latest" skipper make build-assisted-iso-generator-image
+docker tag "${ASSISTED_ISO_GENERATOR_IMAGE}:latest" "${ASSISTED_ISO_GENERATOR_IMAGE}:${TAG}"
 
 #ASSISTED_SERVICE_BUILD_IMAGE="quay.io/app-sre/assisted-service-build"
 #
@@ -27,6 +31,9 @@ docker --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay
 
 docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"
 docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+
+docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_GENERATOR_IMAGE}:latest"
+docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_GENERATOR_IMAGE}:${TAG}"
 
 #docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_BUILD_IMAGE}:latest"
 #docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_BUILD_IMAGE}:${TAG}"


### PR DESCRIPTION
Nothing is triggered on PRs, on merges to master the new image will be
built and pushed to quay.io.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>