### PR TITLE
MGMT-1859: use CapabilityReview via SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/openshift-online/ocm-sdk-go v0.1.116
+	github.com/openshift-online/ocm-sdk-go v0.1.118
 	github.com/ory/dockertest/v3 v3.6.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pborman/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.0-rc9 h1:/k06BMULKF5hidyoZymkoDCzdJzltZpz/UU4LguQVtc=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
-github.com/openshift-online/ocm-sdk-go v0.1.116 h1:/OGBuoLZA4DELtawpbIVX58Rn9n9S2iFCgdBJy2KTEw=
-github.com/openshift-online/ocm-sdk-go v0.1.116/go.mod h1:BBF7bNkfHkkVwKolft9AsbYXJBsFiSOFQ6bLSedQby0=
+github.com/openshift-online/ocm-sdk-go v0.1.118 h1:CxdUb9FMtmVc36JGkWwLXdeC48XV+efpwd15XkHtr1I=
+github.com/openshift-online/ocm-sdk-go v0.1.118/go.mod h1:BBF7bNkfHkkVwKolft9AsbYXJBsFiSOFQ6bLSedQby0=
 github.com/ory/dockertest/v3 v3.6.0 h1:I6KNJ6izxGduLACQii2SP/g7GN0JM9Xfaik6aAVaw6Y=
 github.com/ory/dockertest/v3 v3.6.0/go.mod h1:4ZOpj8qBUmh8fcBSVzkH2bws2s91JdGvHUqan4GHEuQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=

--- a/pkg/ocm/authorization.go
+++ b/pkg/ocm/authorization.go
@@ -2,7 +2,6 @@ package ocm
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
@@ -51,46 +50,39 @@ func (a authorization) AccessReview(ctx context.Context, username, action, resou
 }
 
 func (a authorization) CapabilityReview(ctx context.Context, username, capabilityName, capabilityType string) (allowed bool, err error) {
-	// CapabilityReview is not available yet in ocm-sdk-go:
-	// https://github.com/openshift-online/ocm-sdk-go/blob/master/authorizations/v1/root_client.go
-	// Sending a simple POST request for now.
 	connection, err := a.client.NewConnection()
 	if err != nil {
 		return false, err
 	}
 	defer connection.Close()
 
-	request := connection.Post()
-	request.Path("/api/authorizations/v1/capability_review")
+	capabilityReview := connection.Authorizations().V1().CapabilityReview()
 
-	type CapabilityRequest struct {
-		Name     string `json:"capability"`
-		Type     string `json:"type"`
-		Username string `json:"account_username"`
-	}
-
-	capabilityRequest := CapabilityRequest{
-		Name:     capabilityName,
-		Type:     capabilityType,
-		Username: username,
-	}
-
-	var jsonData []byte
-	jsonData, err = json.Marshal(capabilityRequest)
-	if err != nil {
-		return false, err
-	}
-	request.Bytes(jsonData)
-
-	postResp, err := request.SendContext(ctx)
+	request, err := azv1.NewCapabilityReviewRequest().
+		AccountUsername(username).
+		Capability(capabilityName).
+		Type(capabilityType).
+		Build()
 	if err != nil {
 		return false, err
 	}
 
-	var respJSON map[string]interface{}
-	if err := json.Unmarshal(postResp.Bytes(), &respJSON); err != nil {
+	postResp, err := capabilityReview.Post().
+		Request(request).
+		SendContext(ctx)
+	if err != nil {
 		return false, err
 	}
 
-	return respJSON["result"] == "true", nil
+	response, ok := postResp.GetResponse()
+	if !ok {
+		return false, fmt.Errorf("Empty response from authorization post request")
+	}
+
+	result, ok := response.GetResult()
+	if !ok {
+		return false, fmt.Errorf("Failed to fetch result from the response")
+	}
+
+	return result == "true", nil
 }


### PR DESCRIPTION
Use CapabilityReview API from ocm-sdk-go instead of a manually generated request.