### PR TITLE
MGMT-1867: set user_name as 'admin' when auth is disabled

### DIFF
--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -9,10 +9,6 @@ import (
 
 func IsAdmin(ctx context.Context) bool {
 	authPayload := auth.PayloadFromContext(ctx)
-	if authPayload == nil {
-		return false
-	}
-
 	return authPayload.IsAdmin
 }
 

--- a/pkg/auth/auth_handler.go
+++ b/pkg/auth/auth_handler.go
@@ -86,7 +86,7 @@ func (a *AuthHandler) getValidationToken(token *jwt.Token) (interface{}, error) 
 func (a *AuthHandler) AuthAgentAuth(token string) (interface{}, error) {
 	if !a.EnableAuthAgent {
 		// return a fake user for subsystem
-		return &ocm.AuthPayload{Username: ocm.FakePayloadUsername, IsAdmin: true}, nil
+		return &ocm.AuthPayload{Username: AdminUsername, IsAdmin: true}, nil
 	}
 	if a.client == nil {
 		a.log.Error("OCM client unavailable")
@@ -223,7 +223,8 @@ func (a *AuthHandler) CreateAuthenticator() func(name, in string, authenticate s
 			if !a.EnableAuth {
 				a.log.Debug("API Key Authentication Disabled")
 				return true, &ocm.AuthPayload{
-					IsAdmin: true, // auth disabled - behave as system-admin
+					IsAdmin:  true, // auth disabled - behave as system-admin
+					Username: AdminUsername,
 				}, nil
 			}
 			token := getToken(r)

--- a/pkg/auth/authz_handler.go
+++ b/pkg/auth/authz_handler.go
@@ -16,6 +16,9 @@ const (
 	amsActionCreate          string = "create"
 	capabilityName           string = "bare_metal_installer_admin"
 	capabilityType           string = "Account"
+
+	// AdminUsername for disabled auth
+	AdminUsername string = "admin"
 )
 
 type AuthzHandler struct {
@@ -90,7 +93,8 @@ func (a *AuthzHandler) allowedToUseAssistedInstaller(username string) (bool, err
 func PayloadFromContext(ctx context.Context) *ocm.AuthPayload {
 	payload := ctx.Value(restapi.AuthKey)
 	if payload == nil {
-		return nil
+		// fallback to system-admin
+		return &ocm.AuthPayload{IsAdmin: true, Username: AdminUsername}
 	}
 	return payload.(*ocm.AuthPayload)
 }
@@ -98,17 +102,11 @@ func PayloadFromContext(ctx context.Context) *ocm.AuthPayload {
 // UserNameFromContext returns username from the specified context
 func UserNameFromContext(ctx context.Context) string {
 	payload := PayloadFromContext(ctx)
-	if payload == nil {
-		return ""
-	}
 	return payload.Username
 }
 
 // OrgIDFromContext returns org ID from the specified context
 func OrgIDFromContext(ctx context.Context) string {
 	payload := PayloadFromContext(ctx)
-	if payload == nil {
-		return ""
-	}
 	return payload.Organization
 }

--- a/pkg/ocm/pullsecret_auth.go
+++ b/pkg/ocm/pullsecret_auth.go
@@ -8,11 +8,6 @@ import (
 	"github.com/patrickmn/go-cache"
 )
 
-const (
-	// FakePayloadUsername for AuthAgentAuth return value
-	FakePayloadUsername string = "jdoe123@example.com"
-)
-
 type OCMAuthentication interface {
 	AuthenticatePullSecret(ctx context.Context, pullSecret string) (user *AuthPayload, err error)
 }


### PR DESCRIPTION
When authentication is disabled, new clusters should be created with 'admin' as user_name.