### PR TITLE
MGMT-1450: Create assisted installer artifact to run on-prem

### DIFF
--- a/config/onprem-iso-config.ign
+++ b/config/onprem-iso-config.ign
@@ -1,0 +1,75 @@
+{
+  "ignition": {
+    "version": "2.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "sudo"
+        ],
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "replace-with-your-ssh-public-key"
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "path": "/etc/assisted-service/environment",
+        "filesystem": "root",
+        "contents": {
+          "source": "data:,S3DATAPATH%3D%2Fmnt%2Fdata%0AS3METADATAPATH%3D%2Fmnt%2Fdata%0AS3_ENDPOINT_URL%3Dhttp%3A%2F%2F127.0.0.1%3A8000%0AS3_REGION%3Dus-east-1%0AS3_BUCKET%3Dtest%0AAWS_ACCESS_KEY_ID%3DaccessKey1%0AAWS_SECRET_ACCESS_KEY%3DverySecretKey1%0APOSTGRESQL_DATABASE%3Dinstaller%0APOSTGRESQL_PASSWORD%3Dadmin%0APOSTGRESQL_USER%3Dadmin%0ADB_HOST%3D127.0.0.1%0ADB_PORT%3D5432%0ADB_USER%3Dadmin%0ADB_PASS%3Dadmin%0ADB_NAME%3Dinstaller%0ASERVICE_BASE_URL%3Dhttp%3A%2F%2Fassisted-api.local.openshift.io%3A8080%0ADEPLOY_TARGET%3Donprem%0ACREATE_S3_BUCKET%3Dtrue%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/assisted-service/nginx.conf",
+        "filesystem": "root",
+        "contents": {
+          "source": "data:,server%20%7B%0A%20%20%20%20listen%208080%3B%0A%20%20%20%20server_name%20_%3B%0A%20%20%20%20root%20%2Fapp%3B%0A%20%20%20%20index%20index.html%3B%0A%20%20%20%20location%20%2Fapi%20%7B%0A%20%20%20%20%20%20%20%20proxy_pass%20http%3A%2F%2Flocalhost%3A8090%3B%0A%20%20%20%20%20%20%20%20proxy_http_version%201.1%3B%0A%20%20%20%20%20%20%20%20proxy_set_header%20Upgrade%20%24http_upgrade%3B%0A%20%20%20%20%20%20%20%20proxy_set_header%20Connection%20'upgrade'%3B%0A%20%20%20%20%20%20%20%20proxy_set_header%20Host%20%24host%3B%0A%20%20%20%20%20%20%20%20proxy_cache_bypass%20%24http_upgrade%3B%0A%20%20%20%20%7D%0A%20%20%20%20location%20%2F%20%7B%0A%20%20%20%20%20%20%20%20try_files%20%24uri%20%2Findex.html%3B%0A%20%20%20%20%7D%0A%7D%0A"
+        },
+        "mode": 420
+      },
+      {
+        "path": "/etc/assisted-service/auth.json",
+        "filesystem": "root",
+        "contents": {
+          "source": "data:;base64,replace-with-your-base64-encoded-pull-secret"
+        },
+        "mode": 420
+      }
+    ]
+  },
+  "systemd": {
+    "units": [
+      {
+        "contents": "[Unit]\nAfter=network-online.target\n\n[Service]\nType=forking\nRestart=no\nExecStart=podman pod create --name assisted-installer -p 5432,8000,8090,8080\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "assisted-service-pod.service"
+      },
+      {
+        "contents": "[Unit]\nAfter=assisted-service-pod.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull --authfile /etc/assisted-service/auth.json rhel8/postgresql-12:latest\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --name db rhel8/postgresql-12:latest\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "assisted-service-db.service"
+      },
+      {
+        "contents": "[Unit]\nAfter=assisted-service-pod.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull docker.io/scality/s3server:latest\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --mount type=tmpfs,destination=/mnt/data --name s3 docker.io/scality/s3server:latest\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "assisted-service-s3.service"
+      },
+      {
+        "contents": "[Unit]\nAfter=assisted-service-db.service\nAfter=assisted-service-s3.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/rwsu/assisted-service:test\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:test\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "assisted-service-installer.service"
+      },
+      {
+        "contents": "[Unit]\nAfter=assisted-service-installer.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/ocpmetal/ocp-metal-ui:latest\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment -v /etc/assisted-service/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "enabled": true,
+        "name": "assisted-service-ui.service"
+      }
+    ]
+  }
+}

--- a/config/onprem-iso-fcc.yaml
+++ b/config/onprem-iso-fcc.yaml
@@ -1,0 +1,135 @@
+variant: fcos
+version: 1.0.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - "replace-with-your-ssh-public-key"
+      groups: [ sudo ]
+systemd:
+    units:
+        - name: assisted-service-pod.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=network-online.target
+          
+            [Service]
+            Type=forking
+            Restart=no
+            ExecStart=podman pod create --name assisted-installer -p 5432,8000,8090,8080
+          
+            [Install]
+            WantedBy=multi-user.target
+        - name: assisted-service-db.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=assisted-service-pod.service
+            
+            [Service]
+            Type=forking
+            Restart=no
+            ExecStartPre=podman pull --authfile /etc/assisted-service/auth.json rhel8/postgresql-12:latest
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --name db rhel8/postgresql-12:latest
+            TimeoutStartSec=300
+          
+            [Install]
+            WantedBy=multi-user.target
+        - name: assisted-service-s3.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=assisted-service-pod.service
+          
+            [Service]
+            Type=forking
+            Restart=no
+            ExecStartPre=podman pull docker.io/scality/s3server:latest
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --mount type=tmpfs,destination=/mnt/data --name s3 docker.io/scality/s3server:latest
+            TimeoutStartSec=300
+          
+            [Install]
+            WantedBy=multi-user.target
+        - name: assisted-service-installer.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=assisted-service-db.service
+            After=assisted-service-s3.service
+          
+            [Service]
+            Type=forking
+            Restart=no
+            ExecStartPre=podman pull quay.io/rwsu/assisted-service:test
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:test
+            TimeoutStartSec=300
+          
+            [Install]
+            WantedBy=multi-user.target
+        - name: assisted-service-ui.service
+          enabled: true
+          contents: |
+            [Unit]
+            After=assisted-service-installer.service
+          
+            [Service]
+            Type=forking
+            Restart=no
+            ExecStartPre=podman pull quay.io/ocpmetal/ocp-metal-ui:latest
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment -v /etc/assisted-service/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest
+            TimeoutStartSec=300
+          
+            [Install]
+            WantedBy=multi-user.target
+storage:
+    files:
+        - path: /etc/assisted-service/environment
+          mode: 0644
+          contents:
+            inline: |
+                S3DATAPATH=/mnt/data
+                S3METADATAPATH=/mnt/data
+                S3_ENDPOINT_URL=http://127.0.0.1:8000
+                S3_REGION=us-east-1
+                S3_BUCKET=test
+                AWS_ACCESS_KEY_ID=accessKey1
+                AWS_SECRET_ACCESS_KEY=verySecretKey1
+                POSTGRESQL_DATABASE=installer
+                POSTGRESQL_PASSWORD=admin
+                POSTGRESQL_USER=admin
+                DB_HOST=127.0.0.1
+                DB_PORT=5432
+                DB_USER=admin
+                DB_PASS=admin
+                DB_NAME=installer
+                SERVICE_BASE_URL=http://assisted-api.local.openshift.io:8080
+                DEPLOY_TARGET=onprem
+                CREATE_S3_BUCKET=true
+        - path: /etc/assisted-service/nginx.conf
+          mode: 0644
+          contents:
+            inline: |
+                server {
+                    listen 8080;
+                    server_name _;
+                    root /app;
+                    index index.html;
+                    location /api {
+                        proxy_pass http://localhost:8090;
+                        proxy_http_version 1.1;
+                        proxy_set_header Upgrade $http_upgrade;
+                        proxy_set_header Connection 'upgrade';
+                        proxy_set_header Host $host;
+                        proxy_cache_bypass $http_upgrade;
+                    }
+                    location / {
+                        try_files $uri /index.html;
+                    }
+                }
+        - path: /etc/assisted-service/auth.conf
+          mode: 0644
+          contents:
+            inline: "data:;base64,replace-with-your-base64-encoded-pull-secret"
+              
+        

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
 ## State machines
   - State machines are defined as Graphviz DOT files
   - The image can be viewed via the online editors [here](https://dreampuf.github.io/GraphvizOnline/) or [here](http://www.webgraphviz.com)
+
+## assisted-service Live ISO
+
+[assisted-service Live ISO](https://github.com/openshift/assisted-service/blob/master/docs/installer-live-iso.md) describes how to create a live ISO to deploy the assisted-service.

--- a/docs/installer-live-iso.md
+++ b/docs/installer-live-iso.md
@@ -1,0 +1,102 @@
+# assisted-service Live ISO
+
+The assisted-service can be deployed using a live ISO. The live ISO deploys the assisted-service
+using containers on RHCOS. The assisted-service live ISO is a RHCOS live ISO that is customized with an ignition config file.
+
+## How to create an assisted-service live ISO
+
+### Create the ignition config
+
+A ignition config that deploys the assisted-service is available at 
+https://raw.githubusercontent.com/openshift/assisted-service/master/config/onprem-iso-config.ign.
+
+Download this ignition config and modify it to include your ssh public key and your registry.redhat.io pull secret. The example below assumes your pull secret is saved into a file called auth.json.
+
+````
+wget https://raw.githubusercontent.com/openshift/assisted-service/master/config/onprem-iso-config.ign
+
+export SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)
+export PULL_SECRET_BASE64=$(base64 -w 0 auth.json) 
+
+sed -i 's#replace-with-your-ssh-public-key#'"${SSH_PUBLIC_KEY}"'#' onprem-iso-config.ign
+sed -i 's#replace-with-your-base64-encoded-pull-secret#'"${PULL_SECRET_BASE64}"'#' onprem-iso-config.ign
+````
+
+### Download the base RHCOS live ISO
+
+The base live ISO is extracted from a container image. Run the container
+image containing the ISO, copy the ISO, and then stop and remove the container. 
+
+````
+podman run -dt --name livecdsrc quay.io/ocpmetal/livecd-iso:rhcos-livecd
+podman cp livecdsrc:/root/image/livecd.iso ./livecd.iso
+podman rm -f livecdsrc
+````
+
+### Create the assisted-service live ISO
+
+Finally, use the ignition config (onprem-iso-config.ign) and the base live ISO (livecd.iso) to
+create the assisted-service live ISO.
+
+````
+podman run --rm --privileged  -v /dev:/dev -v /run/udev:/run/udev -v .:/data  quay.io/coreos/coreos-installer:release iso embed -c /data/onprem-iso-config.ign -o /data/assisted-service.iso /data/livecd.iso
+````
+
+The live ISO, **assisted-service.iso** (not livecd.iso), can then be used to deploy the installer. The live ISO storage system is emphemeral and its size depends on the amount of memory installed on the host. A minimum of 10GB of memory is required to deploy the installer, generate a single discovery ISO, and install an OCP cluster.
+
+After the live ISO boots, the UI should be accessible from the a browser at
+
+````
+http://<hostname-or-ip>:8080. 
+````
+
+It may take a couple of minutes for the assisted-service and UI to become ready after you see the login prompt.
+
+## How to debug
+
+Login to the host using your ssh public key.
+
+The assisted-service components are deployed as systemd services.
+* assisted-service-installer.service
+* assisted-service-db.service
+* assisted-service-s3.service
+* assisted-service-ui.service
+
+Verify that the containers deploy by those services are running.
+
+````
+sudo podman ps -a
+````
+
+Examine the assisted-service-installer.service logs:
+
+````
+sudo journalctl -f -u assisted-service-installer.service
+````
+
+The environment file used to deploy the assisted-service is located at /etc/assisted-service/environment.
+
+Pull secrets are saved to a file located at /etc/assisted-service/auth.json.
+
+## How to use the FCC file to generate the base ignition config file
+
+The ignition file is created using a predefined Fedore CoreOS Config (FCC) file provided in /config/onprem-iso-fcc.yaml. FCC files are easier to read and edit than the machine readable ignition files.
+
+The FCC file transpiles to an ignition config using:
+
+````
+podman run --rm -v ./config/onprem-iso-fcc.yaml:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict /config.fcc > onprem-iso-config.ign
+````
+
+The transpiled ignition config is version 3.0.0. The RHCOS live ISO we are currently using is able to read v2.2.0. To change the ignition file to v2.2.0:
+
+* Change version: from 3.0.0 to 2.2.0
+* For each file in the storage -> files section add 
+
+````
+"filesystem": "root",
+````
+
+These two edits will not be necessary once we move to a RHCOS image that supports
+ignition v3.0.0.
+


### PR DESCRIPTION
Contains documentation and ignition config to create an
assisted-service live ISO.

Requires a follow-up PR that does the correct DNS translation
for SERVICE_BASE_URL=http://assisted-api.local.openshift.io:8080.
The discovery ISO's /etc/hosts will be modified to include the
live ISO host's ip addresses and they will be mapped to
assisted-api.local.openshift.io. This is being worked on in a
separate PR.