### PR TITLE
fixes error when re-generating an ISO for the same cluster on-prem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ test-onprem:
 	INVENTORY=127.0.0.1:8090 \
 	DB_HOST=127.0.0.1 \
 	DB_PORT=5432 \
-	go test -v ./subsystem/... -count=1 -ginkgo.focus=${FOCUS} -ginkgo.v
+	go test -v ./subsystem/... -count=1 -ginkgo.focus=${FOCUS} -ginkgo.v -timeout 30m
 
 #########
 # Clean #
@@ -240,7 +240,7 @@ clear-deployment:
 	-python3 ./tools/clear_deployment.py --delete-namespace $(APPLY_NAMESPACE) --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)" || true
 
 clean-onprem:
-	podman pod rm -f assisted-installer
+	podman pod rm -f -i assisted-installer
 	podman volume rm s3-volume
 
 delete-minikube-profile:

--- a/pkg/job/local_job.go
+++ b/pkg/job/local_job.go
@@ -92,6 +92,7 @@ func (j *localJob) GenerateISO(ctx context.Context, cluster common.Cluster, jobN
 
 	var out bytes.Buffer
 	cmd.Stdout = &out
+	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
 		log.Errorf("assisted-iso-create failed: %s", out.String())
 		return err

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -162,6 +163,9 @@ var _ = Describe("system-test proxy update tests", func() {
 
 		// Verify proxy settings changed event emitted
 		verifyEventExistence(clusterID, "Proxy settings changed")
+
+		// at least 10s must elapse between requests to generate the same ISO
+		time.Sleep(time.Second * 10)
 
 		// Generate ISO of registered cluster with proxy configured
 		_, err = userBMClient.Installer.GenerateClusterISO(ctx, &installer.GenerateClusterISOParams{


### PR DESCRIPTION
If the ISO already existed on disk, the coreos-installer command would error out. This
PR ensures that when coreos-installer runs, any previous ISO has been deleted first.

This change also:
- adds a 10s sleep to a test because the API requires 10s to elapse between ISO
  create requests
- captures stderr output when running coreos-installer
- specifies a 30m timeout for onprem subsystem tests, matching the k8s test
  suite. The default 10m was not enough
- enables `make clean-onprem` to work even if the pod does not exist