### PR TITLE
MGMT-1450: Fix auth.json path in live ISO and FCC

### DIFF
--- a/config/onprem-iso-config.ign
+++ b/config/onprem-iso-config.ign
@@ -56,7 +56,7 @@
         "name": "assisted-service-db.service"
       },
       {
-        "contents": "[Unit]\nAfter=assisted-service-db.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/rwsu/assisted-service:dns\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:dns\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nAfter=assisted-service-db.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/ocpmetal/assisted-service:latest\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/ocpmetal/assisted-service:latest\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "assisted-service-installer.service"
       },

--- a/config/onprem-iso-config.ign
+++ b/config/onprem-iso-config.ign
@@ -37,7 +37,7 @@
         "path": "/etc/assisted-service/auth.json",
         "filesystem": "root",
         "contents": {
-          "source": "data:;base64,replace-with-your-base64-encoded-pull-secret"
+          "source": "data:,replace-with-your-urlencoded-pull-secret"
         },
         "mode": 420
       }
@@ -56,7 +56,7 @@
         "name": "assisted-service-db.service"
       },
       {
-        "contents": "[Unit]\nAfter=assisted-service-db.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/rwsu/assisted-service:test\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:test\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nAfter=assisted-service-db.service\n\n[Service]\nType=forking\nRestart=no\nExecStartPre=podman pull quay.io/rwsu/assisted-service:dns\nExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:dns\nTimeoutStartSec=300\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "assisted-service-installer.service"
       },

--- a/config/onprem-iso-fcc.yaml
+++ b/config/onprem-iso-fcc.yaml
@@ -45,8 +45,8 @@ systemd:
             [Service]
             Type=forking
             Restart=no
-            ExecStartPre=podman pull quay.io/rwsu/assisted-service:dns
-            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:dns
+            ExecStartPre=podman pull quay.io/ocpmetal/assisted-service:latest
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/ocpmetal/assisted-service:latest
             TimeoutStartSec=300
           
             [Install]

--- a/config/onprem-iso-fcc.yaml
+++ b/config/onprem-iso-fcc.yaml
@@ -45,8 +45,8 @@ systemd:
             [Service]
             Type=forking
             Restart=no
-            ExecStartPre=podman pull quay.io/rwsu/assisted-service:test
-            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:test
+            ExecStartPre=podman pull quay.io/rwsu/assisted-service:dns
+            ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --restart always --name installer quay.io/rwsu/assisted-service:dns
             TimeoutStartSec=300
           
             [Install]
@@ -103,9 +103,7 @@ storage:
                         try_files $uri /index.html;
                     }
                 }
-        - path: /etc/assisted-service/auth.conf
+        - path: /etc/assisted-service/auth.json
           mode: 0644
           contents:
-            inline: "data:;base64,replace-with-your-base64-encoded-pull-secret"
-              
-        
+            inline: replace-with-your-urlencoded-pull-secret

--- a/docs/installer-live-iso.md
+++ b/docs/installer-live-iso.md
@@ -16,10 +16,10 @@ Download this ignition config and modify it to include your ssh public key and y
 wget https://raw.githubusercontent.com/openshift/assisted-service/master/config/onprem-iso-config.ign
 
 export SSH_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)
-export PULL_SECRET_BASE64=$(base64 -w 0 auth.json) 
+export PULL_SECRET_ENCODED=$(export PULL_SECRET=$(cat auth.json); urlencode $PULL_SECRET)
 
 sed -i 's#replace-with-your-ssh-public-key#'"${SSH_PUBLIC_KEY}"'#' onprem-iso-config.ign
-sed -i 's#replace-with-your-base64-encoded-pull-secret#'"${PULL_SECRET_BASE64}"'#' onprem-iso-config.ign
+sed -i 's#replace-with-your-urlencoded-pull-secret#'"${PULL_SECRET_ENCODED}"'#' onprem-iso-config.ign
 ````
 
 ### Download the base RHCOS live ISO
@@ -54,7 +54,7 @@ It may take a couple of minutes for the assisted-service and UI to become ready 
 
 ## How to debug
 
-Login to the host using your ssh public key.
+Login to the host using your ssh private key.
 
 The assisted-service components are deployed as systemd services.
 * assisted-service-installer.service

--- a/docs/installer-live-iso.md
+++ b/docs/installer-live-iso.md
@@ -22,6 +22,21 @@ sed -i 's#replace-with-your-ssh-public-key#'"${SSH_PUBLIC_KEY}"'#' onprem-iso-co
 sed -i 's#replace-with-your-urlencoded-pull-secret#'"${PULL_SECRET_ENCODED}"'#' onprem-iso-config.ign
 ````
 
+Currently, the upstream assisted-service container image cannot be used with the live ISO. You will 
+need to build a custom container image and push it to quay.io.
+
+````
+export SERVICE=quay.io/<your-org>/assisted-service:latest
+make build-onprem
+podman push ${SERVICE}
+````
+
+Then update the ignition config file to use your assisted-service container image.
+
+````
+sed -i 's#quay.io/ocpmetal/assisted-service:latest#'"${SERVICE}"'#' onprem-iso-config.ign
+````
+
 ### Download the base RHCOS live ISO
 
 The base live ISO is extracted from a container image. Run the container


### PR DESCRIPTION
The temporary string that represents auth.json needs to be base64
or the transpiler will error.