### PR TITLE
Revert "MGMT-1849: Delete PVCs on clear-deplyment by flag (#161)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ subsystem-clean:
 	-$(KUBECTL) get pod -o name | grep ignition-generator | xargs $(KUBECTL) delete 1> /dev/null || true
 
 clear-deployment:
-	-python3 ./tools/clear_deployment.py --delete-namespace $(APPLY_NAMESPACE) --delete-pvc $(DELETE_PVC) --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)" || true
+	-python3 ./tools/clear_deployment.py --delete-namespace $(APPLY_NAMESPACE) --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)" || true
 
 clean-onprem:
 	podman pod rm -f -i assisted-installer

--- a/tools/clear_deployment.py
+++ b/tools/clear_deployment.py
@@ -5,7 +5,6 @@ import deployment_options
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--delete-namespace", type=lambda x: (str(x).lower() == 'true'), default=True)
-    parser.add_argument("--delete-pvc", type=lambda x: (str(x).lower() == 'true'), default=False)
     deploy_options = deployment_options.load_deployment_options(parser)
 
     utils.set_profile(deploy_options.target, deploy_options.profile)
@@ -14,10 +13,6 @@ def main():
     # configmaps are not deleted with `delete all`
     print(utils.check_output(f"kubectl get configmap -o name -n {deploy_options.namespace} | " +
                              f"xargs kubectl delete -n {deploy_options.namespace} 1> /dev/null ; true"))
-
-    if deploy_options.delete_pvc:
-        print(utils.check_output(f"kubectl delete pvc --all -n {deploy_options.namespace} 1> /dev/null ; true"))
-
     if deploy_options.delete_namespace is True:
         print(utils.check_output(f"kubectl delete namespace {deploy_options.namespace} 1> /dev/null ; true"))
 


### PR DESCRIPTION
This reverts commit 3f53620644be27b21deedde4c50e26b178f08bfc.
no defult value to added arg, failes jenkins ci

```
20:29:03  python3 ./tools/clear_deployment.py --delete-namespace True --delete-pvc  --namespace "assisted-installer" --profile "minikube" --target "minikube" || true
20:29:03  usage: clear_deployment.py [-h] [--delete-namespace DELETE_NAMESPACE]
20:29:03                             [--delete-pvc DELETE_PVC] [--namespace NAMESPACE]
20:29:03                             [--profile PROFILE]
20:29:03                             [--target {minikube,oc,oc-ingress}]
20:29:03                             [--domain DOMAIN]
20:29:03                             [--deploy-tag DEPLOY_TAG | --deploy-manifest-tag DEPLOY_MANIFEST_TAG | --deploy-manifest-path DEPLOY_MANIFEST_PATH | --disable-tls]
20:29:03  clear_deployment.py: error: argument --delete-pvc: expected one argument
20:29:03  [Pipeline] }
```