### PR TITLE
MGMT-1723 Run UI yaml generation directly

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -2,7 +2,7 @@ FROM golang:1.14.3
 
 ENV GO111MODULE=on
 
-RUN apt-get update && apt-get install -y docker.io libvirt-clients awscli python3-pip postgresql \
+RUN apt-get update && apt-get install -y libvirt-clients awscli python3-pip postgresql \
  && rm -rf /var/lib/apt/lists/*
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.12.2 \

--- a/tools/deploy_ui.py
+++ b/tools/deploy_ui.py
@@ -3,23 +3,38 @@ import os
 import utils
 import deployment_options
 
+UI_REPOSITORY = "https://github.com/openshift-metal3/facet"
+
 
 def main():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--subsystem-test", help='deploy in subsystem mode', action='store_true')
+    parser.add_argument("--subsystem-test", help="deploy in subsystem mode", action="store_true")
     deploy_options = deployment_options.load_deployment_options(parser)
 
     utils.set_profile(deploy_options.target, deploy_options.profile)
 
     dst_file = os.path.join(os.getcwd(), "build/deploy_ui.yaml")
     image_fqdn = deployment_options.get_image_override(deploy_options, "ocp-metal-ui", "UI_IMAGE")
-    runtime_cmd = utils.get_runtime_command()
-    utils.check_output(f'{runtime_cmd} pull {image_fqdn}')
-    cmd = f'{runtime_cmd} run {image_fqdn} /deploy/deploy_config.sh -i {image_fqdn} -n {deploy_options.namespace}'
-    cmd += ' > {}'.format(dst_file)
+
+    tag = deployment_options.get_tag(image_fqdn)
+    clone_directory = os.path.join(os.getcwd(), "build/assisted-installer-ui")
+
+    if not os.path.exists(clone_directory):
+        utils.check_output(f"git clone --branch master {UI_REPOSITORY} {clone_directory}")
+
+    cmd = f"cd {clone_directory} && git pull"
+
+    if tag == "latest":
+        print("WARNING: No hash specified, will run the deployment generation script from the top of master branch")
+    else:
+        cmd += f" && git reset --hard {tag}"
+
+    cmd += f" && deploy/deploy_config.sh -t {clone_directory}/deploy/ocp-metal-ui-template.yaml " \
+           f"-i {image_fqdn} -n {deploy_options.namespace} > {dst_file}"
+
     utils.check_output(cmd)
-    print("Deploying {}".format(dst_file))
+    print(f"Deploying {dst_file}")
     utils.apply(dst_file)
 
     # in case of openshift deploy ingress as well

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -189,6 +189,7 @@ def get_yaml_field(field, yaml_path):
 
     return _field
 
+
 def check_if_exists(k8s_object, k8s_object_name, namespace="assisted-installer"):
     try:
         cmd = "{} -n {} get {} {} --no-headers".format(KUBECTL_CMD, namespace, k8s_object, k8s_object_name)
@@ -198,17 +199,3 @@ def check_if_exists(k8s_object, k8s_object_name, namespace="assisted-installer")
         output = False
 
     return output
-
-def is_tool(name):
-    """Check whether `name` is on PATH and marked as executable."""
-    return find_executable(name) is not None
-
-
-def get_runtime_command():
-    if is_tool(DOCKER):
-        cmd = DOCKER
-    elif is_tool(PODMAN):
-        cmd = PODMAN
-    else:
-        raise Exception("Nor %s nor %s are installed" % (PODMAN, DOCKER))
-    return cmd


### PR DESCRIPTION
Replace using Docker to generate a UI deployment descriptor with running the generation script directly from a repository clone. The Docker method effectively requires a container to run within a container, which not always works and does not work with Podman.