### PR TITLE
MGMT-1792 add ready api to assisted-service

### DIFF
--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -30,7 +30,7 @@ def main():
     service_url = utils.get_service_url(service=SERVICE, target=deploy_options.target, domain=deploy_options.domain,
                                         namespace=deploy_options.namespace, profile=deploy_options.profile,
                                         disable_tls=deploy_options.disable_tls)
-    health_url = f'{service_url}/health'
+    health_url = f'{service_url}/ready'
 
     print(f'Wait for {health_url}')
     waiting.wait(lambda: wait_for_request(health_url),


### PR DESCRIPTION
health api will indicate the service is started and have all the needed clients
ready will indicate that service is ready to recive API calls and will start to be active only
after dummy iso is generated
Using middleware to enable the api after the dummy iso is generated

Service is health but not ready
```
 mfilanov  …  github.com  openshift  assisted-service  curl -i http://192.168.39.203:30948/health
HTTP/1.1 200 OK
Date: Wed, 26 Aug 2020 14:50:11 GMT
Content-Length: 0
 mfilanov  …  github.com  openshift  assisted-service  curl -i http://192.168.39.203:30948/ready
HTTP/1.1 503 Service Unavailable
Date: Wed, 26 Aug 2020 14:50:12 GMT
Content-Length: 0
```

After the dummy iso job is completed the service is ready:
```
curl -i http://192.168.39.203:30948/ready
HTTP/1.1 200 OK
Date: Wed, 26 Aug 2020 14:56:34 GMT
Content-Length: 0
```