### PR TITLE
Adding REPLICAS_COUNT parameters to openshift/template.yaml.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -79,6 +79,8 @@ parameters:
 - name: LOG_LEVEL
   value: "info"
   required: true
+- name: REPLICAS_COUNT
+  value: "3"
 apiVersion: v1
 kind: Template
 metadata:
@@ -92,7 +94,7 @@ objects:
     selector:
       matchLabels:
         app: assisted-service
-    replicas: 1
+    replicas: ${{REPLICAS_COUNT}}
     template:
       metadata:
         labels:


### PR DESCRIPTION
`app-sre` contract requires `3` replicas for production env.

`integration` and `staging` envs will run `3` replicas as well.

We need to wait for https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8449 to be merge first and then we can merge this one.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>