### PR TITLE
Fixing build_deploy.sh and pr_check.sh.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./build_images.sh
+source build_images.sh
 
 DOCKER_CONF="${PWD}/.docker"
 mkdir -p "${DOCKER_CONF}"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,5 +7,5 @@ docker build -t ${IMAGE_TEST} -f Dockerfile.test .
 docker run --rm ${IMAGE_TEST}
 
 # build app-sre image to make sure they are build without errors before merging to master
-./build_images.sh
+source build_images.sh
 


### PR DESCRIPTION
The helper script `build_images.sh` should run in the same process
because the variables between them are shared.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>