### PR TITLE
Renamed image name on quay.io/app-sre/.

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -7,10 +7,10 @@ export LANG="en_US.UTF-8"
 
 TAG=$(git rev-parse --short=7 HEAD)
 ASSISTED_SERVICE_IMAGE=quay.io/app-sre/assisted-service
-ASSISTED_ISO_GENERATOR_IMAGE=quay.io/app-sre/assisted-iso-generator
+ASSISTED_ISO_CREATE_IMAGE=quay.io/app-sre/assisted-iso-create
 
 SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make update-minimal
 docker tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
 
-ISO_CREATION="${ASSISTED_ISO_GENERATOR_IMAGE}:latest" skipper make build-minimal-assisted-iso-generator-image
-docker tag "${ASSISTED_ISO_GENERATOR_IMAGE}:latest" "${ASSISTED_ISO_GENERATOR_IMAGE}:${TAG}"
+ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:latest" skipper make build-minimal-assisted-iso-generator-image
+docker tag "${ASSISTED_ISO_CREATE_IMAGE}:latest" "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"


### PR DESCRIPTION
Renamed:
    * from:     quay.io/app-sre/assisted-iso-generator
    * to:       quay.io/app-sre/assisted-iso-create
in build_images.sh.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

We are waiting for https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8566 to be merged first.