### PR TITLE
Fix installation timeout deployment in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,11 +161,16 @@ deploy-inventory-service-file: deploy-namespace
 	sleep 5;  # wait for service to get an address
 
 deploy-service-requirements: deploy-namespace deploy-inventory-service-file
-	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" --base-dns-domains "$(BASE_DNS_DOMAINS)" --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --installation-timeout $(or "${INSTALLATION_TIMEOUT}","120m") $(DEPLOY_TAG_OPTION) --enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS)
+	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" \
+		--base-dns-domains "$(BASE_DNS_DOMAINS)" --namespace "$(NAMESPACE)" --profile "$(PROFILE)" \
+		--installation-timeout $(or ${INSTALLATION_TIMEOUT},120m) $(DEPLOY_TAG_OPTION) \
+		--enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS)
 
 deploy-service: deploy-namespace deploy-service-requirements deploy-role
-	python3 ./tools/deploy_assisted_installer.py $(DEPLOY_TAG_OPTION) --namespace "$(NAMESPACE)" --profile "$(PROFILE)" $(TEST_FLAGS) --target "$(TARGET)"
-	python3 ./tools/wait_for_assisted_service.py --target $(TARGET) --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --domain "$(INGRESS_DOMAIN)"
+	python3 ./tools/deploy_assisted_installer.py $(DEPLOY_TAG_OPTION) --namespace "$(NAMESPACE)" \
+		--profile "$(PROFILE)" $(TEST_FLAGS) --target "$(TARGET)"
+	python3 ./tools/wait_for_assisted_service.py --target $(TARGET) --namespace "$(NAMESPACE)" \
+		--profile "$(PROFILE)" --domain "$(INGRESS_DOMAIN)"
 
 deploy-role: deploy-namespace
 	python3 ./tools/deploy_role.py --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)"


### PR DESCRIPTION
```
kubectl describe configmaps assisted-service-config  | grep INSTALLATION_TIMEOUT -A 2
INSTALLATION_TIMEOUT:
----
120m
```
```
python3 ./tools/deploy_assisted_installer_configmap.py --target "minikube" --domain "" \
	--base-dns-domains "" --namespace "assisted-installer" --profile "minikube" \
	--installation-timeout 120m  \
	--enable-auth "False" 
```