### PR TITLE
OCPBUGSM-16612: Handle MethodNotAllowed when updating tags

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -465,8 +465,8 @@ func (b *bareMetalInventory) GenerateClusterISO(ctx context.Context, params inst
 		imageExists, err = b.objectHandler.UpdateObjectTimestamp(ctx, imgName)
 		if err != nil {
 			log.WithError(err).Errorf("failed to contact storage backend")
-			msg := "Failed to generate image: error contacting storage backend"
-			b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityError, msg, time.Now())
+			b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityError,
+				"Failed to generate image: error contacting storage backend", time.Now())
 			return installer.NewInstallClusterInternalServerError().
 				WithPayload(common.GenerateError(http.StatusInternalServerError, errors.New("failed to contact storage backend")))
 		}

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -250,7 +250,8 @@ func (c *S3Client) UpdateObjectTimestamp(ctx context.Context, objectName string)
 
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == s3.ErrCodeNoSuchKey || aerr.Code() == "NotFound" {
+			// S3 returns MethodNotAllowed if an object existed but was deleted
+			if aerr.Code() == s3.ErrCodeNoSuchKey || aerr.Code() == "NotFound" || aerr.Code() == "MethodNotAllowed" {
 				return false, nil
 			}
 			return false, errors.Wrap(err, fmt.Sprintf("Failed to update tags on object %s from bucket %s (code %s)", objectName, c.cfg.S3Bucket, aerr.Code()))


### PR DESCRIPTION
AWS returns 405 MethodNotAllowed when trying to update tags of an object
that was deleted, rather than the expected 404.