### PR TITLE
MGMT-2007: Removed preparing-for-installation cancel/reset subsystem-…

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1264,22 +1264,6 @@ var _ = Describe("cluster install", func() {
 					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusError))
 				}
 			})
-			It("[only_k8s]cancel preparing installation", func() {
-				_, err := userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				waitForClusterState(context.Background(), clusterID, models.ClusterStatusPreparingForInstallation,
-					10*time.Second, IgnoreStateInfo)
-				_, err = userBMClient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				c := rep.GetPayload()
-				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusError))
-				Expect(len(c.Hosts)).Should(Equal(4))
-				for _, host := range c.Hosts {
-					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusError))
-				}
-			})
 		})
 		Context("reset installation", func() {
 			It("[only_k8s]reset cluster and register hosts", func() {
@@ -1539,22 +1523,6 @@ var _ = Describe("cluster install", func() {
 						continue
 					}
 					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusResetting))
-				}
-			})
-			It("[only_k8s]reset preparing installation", func() {
-				_, err := userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				waitForClusterState(context.Background(), clusterID, models.ClusterStatusPreparingForInstallation,
-					10*time.Second, IgnoreStateInfo)
-				_, err = userBMClient.Installer.ResetCluster(ctx, &installer.ResetClusterParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
-				Expect(err).NotTo(HaveOccurred())
-				c := rep.GetPayload()
-				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusInsufficient))
-				Expect(len(c.Hosts)).Should(Equal(4))
-				for _, h := range c.Hosts {
-					Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusResetting))
 				}
 			})
 		})


### PR DESCRIPTION
…test

There are two cluster subsystem tests, one that cancel cluster
from preparing-for-installation and the second reset cluster
from preparing-for-installation.

CI keeps fail because cluster state was change to installing
before  reset/cancel transactions start. We can't be 100% sure
we'll get to send the request before the status is change.
Therefore I removed these test. This functionality is still
tested in the cluster/host transitions tests.