### PR TITLE
MGMT-1940 Fix token parsing error format

### DIFF
--- a/pkg/auth/auth_handler.go
+++ b/pkg/auth/auth_handler.go
@@ -158,7 +158,7 @@ func (a *AuthHandler) AuthUserAuth(token string) (interface{}, error) {
 
 	// Check if there was an error in parsing...
 	if err != nil {
-		a.log.Errorf("Error parsing token: %e", err)
+		a.log.Errorf("Error parsing token: %s", err.Error())
 		return nil, fmt.Errorf("Error parsing token: %v", err)
 	}
 


### PR DESCRIPTION
Fix log and print the error string, not the obj.

**Example:**
```level=error msg="Error parsing token: Token is expired" pkg=auth```

**Used to be:**
```
) %!e(uint32=16) %!e(string=)}" func="github.com/openshift/assisted-service/pkg/auth.(*AuthHandler).AuthUserAuth" file="/go/src/github.com/openshift/origin/pkg/auth/auth_handler.go:161" pkg=auth
```