### PR TITLE
Consuming route53-creds secret as a volume in openshift/template.yaml.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -119,11 +119,6 @@ objects:
                 path: /ready
                 port: 8090
             env:
-              - name: ROUTE53_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    key: route53_secret
-                    name: route53-creds
               - name: AWS_SECRET_ACCESS_KEY
                 valueFrom:
                   secretKeyRef:
@@ -238,7 +233,15 @@ objects:
                 value: ${FREE_ADDRESSES_IMAGE}
               - name: DHCP_LEASE_ALLOCATOR_IMAGE
                 value: ${DHCP_LEASE_ALLOCATOR_IMAGE}
-
+            volumeMounts:
+              - name: route53-creds
+                mountPath: "/etc/.aws"
+                readOnly: true
+        volumes:
+          - name: route53-creds
+            secret:
+              secretName: route53-creds
+              optional: true
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
No one is making use of ROUTE53_SECRET variable in the code so
apparently the credentials are expected to be red from a file.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>