### PR TITLE
MGMT=1918 Validate hostname validity on the backend

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/thoas/go-funk"
@@ -74,11 +76,11 @@ func updateHostStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, 
 	}
 
 	if newStatus != srcStatus {
-		msg := fmt.Sprintf("Host %s: updated status from \"%s\" to \"%s\"", common.GetHostnameForMsg(host), srcStatus, newStatus)
+		msg := fmt.Sprintf("Host %s: updated status from \"%s\" to \"%s\"", hostutil.GetHostnameForMsg(host), srcStatus, newStatus)
 		if statusInfo != "" {
 			msg += fmt.Sprintf(" (%s)", statusInfo)
 		}
-		eventsHandler.AddEvent(ctx, clusterId, &hostId, common.GetEventSeverityFromHostStatus(newStatus), msg, time.Now())
+		eventsHandler.AddEvent(ctx, clusterId, &hostId, hostutil.GetEventSeverityFromHostStatus(newStatus), msg, time.Now())
 		log.Infof("host %s from cluster %s has been updated with the following updates %+v", hostId, clusterId, extra)
 	}
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/go-openapi/strfmt"
 
 	"github.com/filanov/stateswitch"
@@ -333,7 +335,7 @@ func (m *Manager) UpdateHostname(ctx context.Context, h *models.Host, hostname s
 
 func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason string, db *gorm.DB) *common.ApiErrorResponse {
 	eventSeverity := models.EventSeverityInfo
-	eventInfo := fmt.Sprintf("Installation canceled for host %s", common.GetHostnameForMsg(h))
+	eventInfo := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(h))
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
@@ -348,7 +350,7 @@ func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason
 	})
 	if err != nil {
 		eventSeverity = models.EventSeverityError
-		eventInfo = fmt.Sprintf("Failed to cancel installation of host %s: %s", common.GetHostnameForMsg(h), err.Error())
+		eventInfo = fmt.Sprintf("Failed to cancel installation of host %s: %s", hostutil.GetHostnameForMsg(h), err.Error())
 		return common.NewApiError(http.StatusConflict, err)
 	} else if swag.StringValue(h.Status) == models.HostStatusDisabled {
 		shouldAddEvent = false
@@ -375,7 +377,7 @@ func (m *Manager) IsRequireUserActionReset(h *models.Host) bool {
 
 func (m *Manager) ResetHost(ctx context.Context, h *models.Host, reason string, db *gorm.DB) *common.ApiErrorResponse {
 	eventSeverity := models.EventSeverityInfo
-	eventInfo := fmt.Sprintf("Installation reset for host %s", common.GetHostnameForMsg(h))
+	eventInfo := fmt.Sprintf("Installation reset for host %s", hostutil.GetHostnameForMsg(h))
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
@@ -390,7 +392,7 @@ func (m *Manager) ResetHost(ctx context.Context, h *models.Host, reason string, 
 	})
 	if err != nil {
 		eventSeverity = models.EventSeverityError
-		eventInfo = fmt.Sprintf("Failed to reset installation of host %s. Error: %s", common.GetHostnameForMsg(h), err.Error())
+		eventInfo = fmt.Sprintf("Failed to reset installation of host %s. Error: %s", hostutil.GetHostnameForMsg(h), err.Error())
 		return common.NewApiError(http.StatusConflict, err)
 	} else if swag.StringValue(h.Status) == models.HostStatusDisabled {
 		shouldAddEvent = false
@@ -400,7 +402,7 @@ func (m *Manager) ResetHost(ctx context.Context, h *models.Host, reason string, 
 
 func (m *Manager) ResetPendingUserAction(ctx context.Context, h *models.Host, db *gorm.DB) error {
 	eventSeverity := models.EventSeverityInfo
-	eventInfo := fmt.Sprintf("User action is required in order to complete installation reset for host %s", common.GetHostnameForMsg(h))
+	eventInfo := fmt.Sprintf("User action is required in order to complete installation reset for host %s", hostutil.GetHostnameForMsg(h))
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
@@ -414,7 +416,7 @@ func (m *Manager) ResetPendingUserAction(ctx context.Context, h *models.Host, db
 	})
 	if err != nil {
 		eventSeverity = models.EventSeverityError
-		eventInfo = fmt.Sprintf("Failed to set status of host %s to reset-pending-user-action. Error: %s", common.GetHostnameForMsg(h), err.Error())
+		eventInfo = fmt.Sprintf("Failed to set status of host %s to reset-pending-user-action. Error: %s", hostutil.GetHostnameForMsg(h), err.Error())
 		return err
 	} else if swag.StringValue(h.Status) == models.HostStatusDisabled {
 		shouldAddEvent = false

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
@@ -476,7 +478,7 @@ var _ = Describe("cancel installation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("Installation canceled for host %s", common.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*cancelEvent.Message).Should(Equal(eventMessage))
 		})
 
@@ -489,7 +491,7 @@ var _ = Describe("cancel installation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("Installation canceled for host %s", common.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*cancelEvent.Message).Should(Equal(eventMessage))
 		})
 
@@ -558,7 +560,7 @@ var _ = Describe("reset host", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			resetEvent := events[len(events)-1]
 			Expect(*resetEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("Installation reset for host %s", common.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("Installation reset for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*resetEvent.Message).Should(Equal(eventMessage))
 		})
 
@@ -588,7 +590,7 @@ var _ = Describe("reset host", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			resetEvent := events[len(events)-1]
 			Expect(*resetEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("User action is required in order to complete installation reset for host %s", common.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("User action is required in order to complete installation reset for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*resetEvent.Message).Should(Equal(eventMessage))
 		})
 
@@ -607,7 +609,7 @@ var _ = Describe("reset host", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			resetEvent := events[len(events)-1]
 			Expect(*resetEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("User action is required in order to complete installation reset for host %s", common.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("User action is required in order to complete installation reset for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*resetEvent.Message).Should(Equal(eventMessage))
 		})
 

--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/jinzhu/gorm"
@@ -67,7 +69,7 @@ func (i *installCmd) GetStep(ctx context.Context, host *models.Host) (*models.St
 		"AGENT_IMAGE":            i.instructionConfig.InventoryImage,
 	}
 
-	hostname, _ := common.GetCurrentHostName(host)
+	hostname, _ := hostutil.GetCurrentHostName(host)
 	if hostname != "" {
 		cmdArgsTmpl = cmdArgsTmpl + " --host-name {{.HOST_NAME}}"
 		data["HOST_NAME"] = hostname

--- a/internal/host/instructionmanager_test.go
+++ b/internal/host/instructionmanager_test.go
@@ -3,6 +3,8 @@ package host
 import (
 	"context"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
@@ -153,7 +155,7 @@ var _ = Describe("instructionmanager", func() {
 
 func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents *events.MockHandler, instMng *InstructionManager, mockValidator *hardware.MockValidator, ctx context.Context,
 	expectedStepTypes []models.StepType) {
-	mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, host.ID, common.GetEventSeverityFromHostStatus(state), gomock.Any(), gomock.Any())
+	mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, host.ID, hostutil.GetEventSeverityFromHostStatus(state), gomock.Any(), gomock.Any())
 	updateReply, updateErr := updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, state, "")
 	ExpectWithOffset(1, updateErr).ShouldNot(HaveOccurred())
 	ExpectWithOffset(1, updateReply).ShouldNot(BeNil())

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/hostutil"
+
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/events"
 	"github.com/openshift/assisted-service/internal/hardware"
@@ -895,7 +897,7 @@ var _ = Describe("Enable", func() {
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				if t.sendEvent {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, &hostId, models.EventSeverityInfo,
-						fmt.Sprintf("Host %s: updated status from \"%s\" to \"discovering\" (Waiting for host to send hardware details)", common.GetHostnameForMsg(&host), srcState),
+						fmt.Sprintf("Host %s: updated status from \"%s\" to \"discovering\" (Waiting for host to send hardware details)", hostutil.GetHostnameForMsg(&host), srcState),
 						gomock.Any())
 				}
 				t.validation(hapi.EnableHost(ctx, &host))
@@ -1550,7 +1552,7 @@ var _ = Describe("Refresh Host", func() {
 				cluster = getTestCluster(clusterId, t.machineNetworkCidr)
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 				if srcState != t.dstState {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, &hostId, common.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -1601,7 +1603,7 @@ var _ = Describe("Refresh Host", func() {
 				cluster.Status = &t.clusterStatus
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 				if *host.Status != t.dstState {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, &hostId, common.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)

--- a/internal/hostutil/host_utils.go
+++ b/internal/hostutil/host_utils.go
@@ -1,9 +1,19 @@
-package common
+package hostutil
 
 import (
 	"encoding/json"
+	"net/http"
+	"regexp"
+
+	"github.com/openshift/assisted-service/internal/common"
+
+	"github.com/pkg/errors"
 
 	"github.com/openshift/assisted-service/models"
+)
+
+const (
+	MaxHostnameLength = 253
 )
 
 func GetCurrentHostName(host *models.Host) (string, error) {
@@ -40,4 +50,19 @@ func GetEventSeverityFromHostStatus(status string) string {
 	default:
 		return models.EventSeverityInfo
 	}
+}
+
+func ValidateHostname(hostname string) error {
+	if len(hostname) > MaxHostnameLength {
+		return common.NewApiError(http.StatusBadRequest, errors.New("hostname is too long"))
+	}
+	pattern := "^[a-z0-9][a-z0-9-]{0,62}(?:[.][a-z0-9-]{1,63})*$"
+	b, err := regexp.MatchString(pattern, hostname)
+	if err != nil {
+		return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "Matching hostname"))
+	}
+	if !b {
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("Hostname does not pass required regex validation: %s. Hostname: %s", pattern, hostname))
+	}
+	return nil
 }


### PR DESCRIPTION
Followed linux hostname rules:
Each element of the hostname must be from 1 to 63 characters long and the entire hostname, including the dots, can be at most 253 characters long.
Valid characters for hostnames are ASCII(7) letters from a to z, the digits from 0  to 9, and the hyphen (-). A hostname may not start with a hyphen.