### PR TITLE
Raz/mgmt 2023 onprem flow fix

### DIFF
--- a/Dockerfile.assisted-service-onprem
+++ b/Dockerfile.assisted-service-onprem
@@ -14,6 +14,7 @@ FROM fedora:31
 ARG GIT_REVISION
 ARG WORK_DIR=/data
 ARG USER=assisted-installer
+ARG NAMESPACE=assisted-installer
 
 LABEL "git_revision"=${GIT_REVISION}
 
@@ -22,8 +23,8 @@ RUN dnf install -y libvirt-libs python3 python3-pip findutils wget && \
    rm -rf /var/cache/yum
 RUN pip3 install boto3 botocore pyyaml ipython
 
-COPY --from=inventory /clients/assisted-service-client-*.tar.gz /build/pip/
-RUN pip3 install /build/pip/*
+COPY --from=inventory /clients/assisted-service-client-*.tar.gz /build/$NAMESPACE/pip/
+RUN pip3 install /build/$NAMESPACE/pip/*
 
 RUN mkdir $WORK_DIR && chmod 755 $WORK_DIR
 RUN useradd $USER
@@ -32,7 +33,7 @@ RUN chown $USER:$USER $WORK_DIR
 # ISO
 COPY --from=coreos-installer /usr/sbin/coreos-installer $WORK_DIR
 COPY --from=livecd /root/image/livecd.iso $WORK_DIR/livecd.iso
-COPY build/assisted-iso-create $WORK_DIR
+COPY build/$NAMESPACE/assisted-iso-create $WORK_DIR
 ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
 
 # install config
@@ -42,5 +43,5 @@ COPY --from=config-gen $WORK_DIR/*.py $WORK_DIR
 
 ENV WORK_DIR=$WORK_DIR
 
-ADD build/assisted-service /assisted-service
+ADD build/$NAMESPACE/assisted-service /assisted-service
 CMD ["/assisted-service"]

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ build-dummy-ignition: $(BUILD_FOLDER)
 	CGO_ENABLED=0 go build -o $(BUILD_FOLDER)/dummy-ignition dummy-ignition/main.go
 
 build-onprem: build-minimal build-iso-generator build-dummy-ignition
-	podman build -f Dockerfile.assisted-service-onprem -t ${SERVICE} .
+	podman build --build-arg NAMESPACE=$(NAMESPACE) -f Dockerfile.assisted-service-onprem -t ${SERVICE} .
 
 build-image: build
 	GIT_REVISION=${GIT_REVISION} docker build --network=host --build-arg GIT_REVISION \


### PR DESCRIPTION
MGMT-2023: openrm flow fix

Namespace was missing from dockerfile build dir path which causes
the flow to get exception:

 [|http://10.46.10.2:8080/blue/organizations/jenkins/assisted-service/detail/osher%2Fonprem_subsystem/51/pipeline/23#step-44-log-265][2020-09-01T15:06:03.526Z] Error: error building at STEP "COPY build/assisted-iso-create $WORK_DIR": no files found matching "/home/workspace/d-service_osher_onprem_subsystem/build/assisted-iso-create": no such file or directory