### PR TITLE
Fixing base DNS issue when trying to configure route53 to a cluster.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -238,6 +238,8 @@ objects:
                 value: ${DHCP_LEASE_ALLOCATOR_IMAGE}
               - name: LOG_LEVEL
                 value: ${LOG_LEVEL}
+              - name: AWS_SHARED_CREDENTIALS_FILE
+                value: /etc/.aws/credentials
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
A variable should be set to the path of the credentials file otherwise
the default value will be used and the DNS validation will fail.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>