### PR TITLE
[BZ1872302] Exposing grafana and prometheus as NodePort instead of clusterIP on Minikube

### DIFF
--- a/deploy/monitoring/grafana/assisted-installer-k8s-grafana.yaml
+++ b/deploy/monitoring/grafana/assisted-installer-k8s-grafana.yaml
@@ -82,4 +82,4 @@ spec:
     targetPort: grafana
   selector:
     app: grafana
-  type: ClusterIP
+  type: NodePort

--- a/deploy/monitoring/prometheus/assisted-installer-k8s-prometheus-svc.yaml
+++ b/deploy/monitoring/prometheus/assisted-installer-k8s-prometheus-svc.yaml
@@ -14,4 +14,4 @@ spec:
   selector:
     app: prometheus
     prometheus: assisted-installer-prometheus
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
- Fixing [BZ1872302](https://bugzilla.redhat.com/show_bug.cgi?id=1872302)