### PR TITLE
Raz/mgmt 1685 installcmd installation timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ OCM_CLIENT_SECRET := ${OCM_CLIENT_SECRET}
 ENABLE_AUTH := $(or ${ENABLE_AUTH},False)
 DELETE_PVC := $(or ${DELETE_PVC},False)
 
+ifdef INSTALLATION_TIMEOUT
+        INSTALLATION_TIMEOUT_FLAG = --installation-timeout $(INSTALLATION_TIMEOUT)
+endif
+
+
 all: build
 
 lint:
@@ -163,7 +168,7 @@ deploy-inventory-service-file: deploy-namespace
 deploy-service-requirements: deploy-namespace deploy-inventory-service-file
 	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" \
 		--base-dns-domains "$(BASE_DNS_DOMAINS)" --namespace "$(NAMESPACE)" --profile "$(PROFILE)" \
-		$(DEPLOY_TAG_OPTION) --enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS)
+		$(INSTALLATION_TIMEOUT_FLAG) $(DEPLOY_TAG_OPTION) --enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS)
 
 deploy-service: deploy-namespace deploy-service-requirements deploy-role
 	python3 ./tools/deploy_assisted_installer.py $(DEPLOY_TAG_OPTION) --namespace "$(NAMESPACE)" \

--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -73,6 +73,11 @@ func (i *installCmd) GetStep(ctx context.Context, host *models.Host) (*models.St
 		data["HOST_NAME"] = hostname
 	}
 
+	if i.instructionConfig.InstallationTimeout != 0 {
+		cmdArgsTmpl = cmdArgsTmpl + " --installation-timeout {{.INSTALLATION_TIMEOUT}}"
+		data["INSTALLATION_TIMEOUT"] = strconv.Itoa(int(i.instructionConfig.InstallationTimeout))
+	}
+
 	// added to run upload logs if install command fails
 	// will return same exit code as installer command
 	logsCommand, err := CreateUploadLogsCmd(host, i.instructionConfig.ServiceBaseURL,

--- a/internal/host/installcmd_test.go
+++ b/internal/host/installcmd_test.go
@@ -21,10 +21,11 @@ import (
 )
 
 var DefaultInstructionConfig = InstructionConfig{
-	ServiceBaseURL:  "http://10.35.59.36:30485",
-	InstallerImage:  "quay.io/ocpmetal/assisted-installer:latest",
-	ControllerImage: "quay.io/ocpmetal/assisted-installer-controller:latest",
-	InventoryImage:  "quay.io/ocpmetal/assisted-installer-agent:latest",
+	ServiceBaseURL:      "http://10.35.59.36:30485",
+	InstallerImage:      "quay.io/ocpmetal/assisted-installer:latest",
+	ControllerImage:     "quay.io/ocpmetal/assisted-installer-controller:latest",
+	InventoryImage:      "quay.io/ocpmetal/assisted-installer-agent:latest",
+	InstallationTimeout: 120,
 }
 
 var _ = Describe("installcmd", func() {
@@ -239,15 +240,15 @@ func validateInstallCommand(reply *models.Step, role models.HostRole, clusterId 
 			"--name assisted-installer quay.io/ocpmetal/assisted-installer:latest --role %s " +
 			"--cluster-id %s " +
 			"--boot-device /dev/sdb --host-id %s --openshift-version 4.5 " +
-			"--controller-image %s --url %s --insecure=false --agent-image %s --host-name %s " +
+			"--controller-image %s --url %s --insecure=false --agent-image %s --host-name %s --installation-timeout %s " +
 			"|| ( returnCode=$?; podman run --rm --privileged " +
 			"-v /run/systemd/journal/socket:/run/systemd/journal/socket -v /var/log:/var/log " +
 			"--env PULL_SECRET_TOKEN --name logs-sender %s logs_sender " +
 			"-url %s -cluster-id %s -host-id %s --insecure=false -bootstrap %s; exit $returnCode; )"
 		ExpectWithOffset(1, reply.Args[1]).Should(Equal(fmt.Sprintf(installCommand, role, clusterId,
 			hostId, DefaultInstructionConfig.ControllerImage, DefaultInstructionConfig.ServiceBaseURL, DefaultInstructionConfig.InventoryImage, hostname,
-			DefaultInstructionConfig.InventoryImage, DefaultInstructionConfig.ServiceBaseURL, clusterId, hostId,
-			strconv.FormatBool(role == models.HostRoleBootstrap))))
+			strconv.Itoa(int(DefaultInstructionConfig.InstallationTimeout)), DefaultInstructionConfig.InventoryImage, DefaultInstructionConfig.ServiceBaseURL,
+			clusterId, hostId, strconv.FormatBool(role == models.HostRoleBootstrap))))
 	} else {
 		installCommand := "podman run -v /dev:/dev:rw -v /opt:/opt:rw -v /run/systemd/journal/socket:/run/systemd/journal/socket " +
 			"--privileged --pid=host " +
@@ -255,13 +256,13 @@ func validateInstallCommand(reply *models.Step, role models.HostRole, clusterId 
 			"--name assisted-installer quay.io/ocpmetal/assisted-installer:latest --role %s " +
 			"--cluster-id %s " +
 			"--boot-device /dev/sdb --host-id %s --openshift-version 4.5 " +
-			"--controller-image %s --url %s --insecure=false --agent-image %s " +
+			"--controller-image %s --url %s --insecure=false --agent-image %s --installation-timeout %s " +
 			"|| ( returnCode=$?; podman run --rm --privileged " +
 			"-v /run/systemd/journal/socket:/run/systemd/journal/socket -v /var/log:/var/log " +
 			"--env PULL_SECRET_TOKEN --name logs-sender %s logs_sender " +
 			"-url %s -cluster-id %s -host-id %s --insecure=false -bootstrap %s; exit $returnCode; )"
 		ExpectWithOffset(1, reply.Args[1]).Should(Equal(fmt.Sprintf(installCommand, role, clusterId,
-			hostId, DefaultInstructionConfig.ControllerImage, DefaultInstructionConfig.ServiceBaseURL, DefaultInstructionConfig.InventoryImage,
+			hostId, DefaultInstructionConfig.ControllerImage, DefaultInstructionConfig.ServiceBaseURL, DefaultInstructionConfig.InventoryImage, strconv.Itoa(int(DefaultInstructionConfig.InstallationTimeout)),
 			DefaultInstructionConfig.InventoryImage, DefaultInstructionConfig.ServiceBaseURL, clusterId, hostId,
 			strconv.FormatBool(role == models.HostRoleBootstrap))))
 	}

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -39,6 +39,7 @@ type InstructionManager struct {
 	db           *gorm.DB
 	stateToSteps stateToStepsMap
 }
+
 type InstructionConfig struct {
 	ServiceBaseURL          string `envconfig:"SERVICE_BASE_URL"`
 	InstallerImage          string `envconfig:"INSTALLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer:latest"`
@@ -48,6 +49,7 @@ type InstructionConfig struct {
 	FreeAddressesImage      string `envconfig:"FREE_ADDRESSES_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
 	DhcpLeaseAllocatorImage string `envconfig:"DHCP_LEASE_ALLOCATOR_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
 	SkipCertVerification    bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	InstallationTimeout     uint   `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
 }
 
 func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, instructionConfig InstructionConfig, connectivityValidator connectivity.Validator) *InstructionManager {


### PR DESCRIPTION
New flag installation-timeout will be provided from env and
passed to installcmd. Represent timeout in minutes to wait for
control plane.