### PR TITLE
MGMT-2030 - Add Red Hat IT Root CA to ignition and InstallConfig

### DIFF
--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -102,6 +102,8 @@ spec:
               value: "false"
             - name: LOG_LEVEL
               value: "info"
+            - name: INSTALL_RH_CA
+              value: "false"
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -2,6 +2,7 @@ package installcfg
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strconv"
 
@@ -224,7 +225,7 @@ func applyConfigOverrides(overrides string, cfg *InstallerConfigBaremetal) error
 	return nil
 }
 
-func GetInstallConfig(log logrus.FieldLogger, cluster *common.Cluster) ([]byte, error) {
+func GetInstallConfig(log logrus.FieldLogger, cluster *common.Cluster, addRhCa bool, ca string) ([]byte, error) {
 	cfg := getBasicInstallConfig(cluster)
 	err := setBMPlatformInstallconfig(log, cluster, cfg)
 	if err != nil {
@@ -234,6 +235,9 @@ func GetInstallConfig(log logrus.FieldLogger, cluster *common.Cluster) ([]byte, 
 	err = applyConfigOverrides(cluster.InstallConfigOverrides, cfg)
 	if err != nil {
 		return nil, err
+	}
+	if addRhCa {
+		cfg.AdditionalTrustBundle = fmt.Sprintf(` | %s`, ca)
 	}
 
 	return yaml.Marshal(*cfg)

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -76,6 +76,9 @@ parameters:
 - name: DHCP_LEASE_ALLOCATOR_IMAGE
   value: ''
   required: true
+- name: INSTALL_RH_CA
+  value: "false"
+  required: true
 - name: LOG_LEVEL
   value: "info"
   required: true
@@ -240,6 +243,8 @@ objects:
                 value: ${DHCP_LEASE_ALLOCATOR_IMAGE}
               - name: LOG_LEVEL
                 value: ${LOG_LEVEL}
+              - name: INSTALL_RH_CA
+                value: ${INSTALL_RH_CA}
               - name: AWS_SHARED_CREDENTIALS_FILE
                 value: /etc/.aws/credentials
             volumeMounts:


### PR DESCRIPTION
In order to be able to pull container images from Brew, the root certificate for Red Hat IT needs to be installed on the live ISO.
Also for assisted-install-controller, the cert is added to InstallConfig in `AdditionalTrustBundle`