### PR TITLE
Added livecd iso creation files

### DIFF
--- a/Dockerfile.assisted-iso-create
+++ b/Dockerfile.assisted-iso-create
@@ -1,21 +1,20 @@
-#This image contains the RHCOS livecd.iso
-# FROM quay.io/ocpmetal/livecd-iso:rhcos-livecd AS livecd-build
-FROM quay.io/yshnaidm/livecd-iso:v4.6 AS livecd-build
-RUN chmod 644 /root/image/livecd.iso
-
 FROM quay.io/coreos/coreos-installer:release AS installer-image
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ARG WORK_DIR=/data
 ARG NAMESPACE=assisted-installer
+ARG OS_IMAGE
 ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
 ENV WORK_DIR=$WORK_DIR
+ENV BASE_OS_IMAGE=$OS_IMAGE
 
 RUN mkdir $WORK_DIR
 RUN chmod 775 $WORK_DIR
 
-COPY --from=livecd-build /root/image/livecd.iso $WORK_DIR
+RUN curl -L -k ${BASE_OS_IMAGE} -o $WORK_DIR/livecd.iso
+RUN chmod 644 $WORK_DIR/livecd.iso
+
 COPY --from=installer-image /usr/sbin/coreos-installer $WORK_DIR
 
 COPY build/$NAMESPACE/assisted-iso-create $WORK_DIR

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ endif # TARGET
 SERVICE := $(or ${SERVICE},quay.io/ocpmetal/assisted-service:latest)
 ISO_CREATION := $(or ${ISO_CREATION},quay.io/ocpmetal/assisted-iso-create:latest)
 DUMMY_IGNITION := $(or ${DUMMY_IGNITION},minikube-local-registry/ignition-dummy-generator:minikube-test)
+BASE_OS_IMAGE ?= https://releases-rhcos.cloud.privileged.psi.redhat.com/storage/releases/4.6-devel/46.82.202008261306-0/x86_64/rhcos-46.82.202008261306-0-live.x86_64.iso
 GIT_REVISION := $(shell git rev-parse HEAD)
 APPLY_NAMESPACE := $(or ${APPLY_NAMESPACE},True)
 ROUTE53_SECRET := ${ROUTE53_SECRET}
@@ -108,7 +109,7 @@ build-image: build
 build-assisted-iso-generator-image: lint unit-test build-minimal build-minimal-assisted-iso-generator-image
 
 build-minimal-assisted-iso-generator-image: build-iso-generator
-	GIT_REVISION=${GIT_REVISION} docker build --network=host --build-arg GIT_REVISION --build-arg NAMESPACE=$(NAMESPACE) \
+	GIT_REVISION=${GIT_REVISION} docker build --network=host --build-arg GIT_REVISION --build-arg NAMESPACE=$(NAMESPACE) --build-arg OS_IMAGE=${BASE_OS_IMAGE} \
  		-f Dockerfile.assisted-iso-create . -t $(ISO_CREATION)
 
 update: build-image

--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ skipper make update && kubectl get pod --namespace assisted-installer -o name | 
 
 It will build and push a new image of the service to your Docker registry, then delete the service pod from minikube, the deployment will handle the update and pull the new image to start the service again.
 
+## Update Discovery Image base OS
+￼
+￼If you want to update the underlying operating system image used by the discovery iso, follow these steps:
+￼
+￼1. Choose the base os image you want to use
+￼
+￼    1. RHCOS: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/
+￼    2. Fedora CoreOS: https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable
+￼2. Build the new iso generator image
+￼
+￼    ```sh
+￼    # Example with RHCOS
+￼    BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-4.6.0-0.nightly-2020-08-26-093617-x86_64-live.x86_64.iso make build-assisted-iso-generator-image
+￼    ```
+
 ## Deployment
 
 ### Deploy to minikube


### PR DESCRIPTION
This PR adds the required files to build the image builder service with a given RHCOS or Fedora CoreOS base OS image. 