### PR TITLE
MGMT-2012 Handle DHCP lease allocation timeout

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -1,6 +1,10 @@
 package common
 
-import "github.com/openshift/assisted-service/models"
+import (
+	"time"
+
+	"github.com/openshift/assisted-service/models"
+)
 
 type Cluster struct {
 	models.Cluster
@@ -10,4 +14,7 @@ type Cluster struct {
 	// The compute hash value of the http-proxy, https-proxy and no-proxy attributes, used internally to indicate
 	// if the proxy settings were changed while downloading ISO
 	ProxyHash string `json:"proxy_hash"`
+
+	// Used to detect if DHCP allocation task is timed out
+	MachineNetworkCidrUpdatedAt time.Time
 }


### PR DESCRIPTION
- Change VIPs validation text to indicate if lease allocation has been timed out
- When lease allocation is timed out, cluster status remains insufficient
- Event is triggered when lease timeout occurs