### PR TITLE
OPCBUGSM-17391: cancel/reset from installing-pending-user-action

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -106,6 +106,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeCancelInstallation,
 		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstallingPendingUserAction),
 			stateswitch.State(models.HostStatusPreparingForInstallation),
 			stateswitch.State(models.HostStatusInstalling),
 			stateswitch.State(models.HostStatusInstallingInProgress),
@@ -129,6 +130,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeResetHost,
 		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstallingPendingUserAction),
 			stateswitch.State(models.HostStatusInstalling),
 			stateswitch.State(models.HostStatusPreparingForInstallation),
 			stateswitch.State(models.HostStatusInstallingInProgress),

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -414,10 +414,10 @@ var _ = Describe("Cancel host installation", func() {
 		{state: models.HostStatusInstalled, success: true},
 		{state: models.HostStatusError, success: true},
 		{state: models.HostStatusDisabled, success: true},
+		{state: models.HostStatusInstallingPendingUserAction, success: true},
 		{state: models.HostStatusDiscovering, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusKnown, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusPendingForInput, success: false, statusCode: http.StatusConflict},
-		{state: models.HostStatusInstallingPendingUserAction, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusResettingPendingUserAction, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusDisconnected, success: false, statusCode: http.StatusConflict},
 	}
@@ -487,10 +487,10 @@ var _ = Describe("Reset host", func() {
 		{state: models.HostStatusInstalled, success: true},
 		{state: models.HostStatusError, success: true},
 		{state: models.HostStatusDisabled, success: true},
+		{state: models.HostStatusInstallingPendingUserAction, success: true},
 		{state: models.HostStatusDiscovering, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusKnown, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusPendingForInput, success: false, statusCode: http.StatusConflict},
-		{state: models.HostStatusInstallingPendingUserAction, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusResettingPendingUserAction, success: false, statusCode: http.StatusConflict},
 		{state: models.HostStatusDisconnected, success: false, statusCode: http.StatusConflict},
 	}


### PR DESCRIPTION
Should be allowed for edge cases where some hosts have this
status and other hosts are in error. In that case we can allow
abort and reset.
https://bugzilla.redhat.com/show_bug.cgi?id=1878154