### PR TITLE
MGMT-1015 Fix date format in Swagger APIs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,7 +52,7 @@ import (
 )
 
 func init() {
-	strfmt.MarshalFormat = strfmt.ISO8601LocalTime
+	strfmt.MarshalFormat = strfmt.RFC3339Millis
 }
 
 const deploymet_type_k8s = "k8s"


### PR DESCRIPTION
This PR is pending UI changes. Otherwise errors invalid format will be shown instead of dates in the UI.