### PR TITLE
Make it possible to disable route53.

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -10,7 +10,6 @@ parameters:
   required: true
 - name: BASE_DNS_DOMAINS # example: name1:id1/provider1,name2:id2/provider2
   value: ''
-  required: true
 - name: OPENSHIFT_INSTALL_RELEASE_IMAGE
   value: ''
   required: true


### PR DESCRIPTION
We need to disable route53 on production env, therefore this parameter
needs to be allowed to stay empty.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>