### PR TITLE
OPCBUGSM-17442-fix-enable-host

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -620,7 +620,7 @@ var _ = Describe("cluster install", func() {
 			registerHostsAndSetRoles(clusterID, 4)
 		})
 
-		It("[only_k8s]disable enable master, monitor cluster status", func() {
+		It("[only_k8s]disable enable master", func() {
 			By("get masters")
 			c, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
@@ -635,13 +635,12 @@ var _ = Describe("cluster install", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(swag.StringValue(disableRet.GetPayload().Status)).Should(Equal(models.ClusterStatusInsufficient))
 
-			By("enable master, expect cluster to become ready")
-			enableRet, err := userBMClient.Installer.EnableHost(ctx, &installer.EnableHostParams{
+			By("enable master")
+			_, err = userBMClient.Installer.EnableHost(ctx, &installer.EnableHostParams{
 				HostID:    *hosts[0].ID,
 				ClusterID: clusterID,
 			})
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(swag.StringValue(enableRet.GetPayload().Status)).Should(Equal(models.ClusterStatusReady))
 		})
 
 		It("[only_k8s]register host while installing", func() {


### PR DESCRIPTION
Since host is loaded before EnableHost transition, we
should load it again before RefreshStatus.
Otherwise, it will skip the discovery part.