### PR TITLE
Making app-sre-jenkins job fail if the scripts fails.

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source build_images.sh
 
 DOCKER_CONF="${PWD}/.docker"

--- a/build_images.sh
+++ b/build_images.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # required for `skipper` according to
 # https://github.com/Stratoscale/skipper/blob/upstream/README.md#python3-environment
 export LC_ALL="en_US.UTF-8"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 IMAGE_TEST=assisted-service-test
 
 # run some 'assisted-service' checks inside a golang container


### PR DESCRIPTION
Before the fix the scripts `pr_check.sh` and `build_deploy.sh` will fail
only if the last command of each one of them fails, after the fix
each failure in the scripts will make it exit with error code
immediately.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>