### PR TITLE
Pass proxy settings to install command

### DIFF
--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -80,6 +80,21 @@ func (i *installCmd) GetStep(ctx context.Context, host *models.Host) (*models.St
 		data["INSTALLATION_TIMEOUT"] = strconv.Itoa(int(i.instructionConfig.InstallationTimeout))
 	}
 
+	if cluster.HTTPProxy != "" || cluster.HTTPSProxy != "" {
+		if cluster.HTTPProxy != "" {
+			cmdArgsTmpl = cmdArgsTmpl + " --http-proxy {{.HTTP_PROXY}}"
+			data["HTTP_PROXY"] = cluster.HTTPProxy
+		}
+		if cluster.HTTPSProxy != "" {
+			cmdArgsTmpl = cmdArgsTmpl + " --https-proxy {{.HTTPS_PROXY}}"
+			data["HTTPS_PROXY"] = cluster.HTTPSProxy
+		}
+		if cluster.NoProxy != "" {
+			cmdArgsTmpl = cmdArgsTmpl + " --no-proxy {{.NO_PROXY}}"
+			data["NO_PROXY"] = cluster.NoProxy
+		}
+	}
+
 	// added to run upload logs if install command fails
 	// will return same exit code as installer command
 	logsCommand, err := CreateUploadLogsCmd(host, i.instructionConfig.ServiceBaseURL,


### PR DESCRIPTION
On D/S image, nsenter is being executed without environment variables,
therefore no proxy configuration are enabled to 'coreos-installer'
command which attempt to download a resource.

While the issue isn't happened to commands running on 'bash' image used
for U/S assisted-installer image, D/S image uses ubi8-minimal which
behaves differently and requires the env-vars to be provided explicitly
(assuming we'd like to avoid hacking the process id of the agent in
order to inherit the already-provided env-vars for proxy from it).

Depends on https://github.com/openshift/assisted-installer/pull/35

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1877
Signed-off-by: Moti Asayag <masayag@redhat.com>