### PR TITLE
OPCBUGSM-17520: noop transition for resetting-pending-user-action (disabled host)

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -196,6 +196,14 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostResettingPendingUserAction,
 	})
 
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeResettingPendingUserAction,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusDisabled),
+		},
+		DestinationState: stateswitch.State(models.HostStatusDisabled),
+	})
+
 	// Prepare for installation
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypePrepareForInstallation,


### PR DESCRIPTION
Without this transition, installation will hang on 'resetting' state if some hosts are disabled and
other passed the reboot stage, since the transition failed for the disabled hosts.