### PR TITLE
MGMT-1743 - use smee to proxy requests to run the jenkins job

### DIFF
--- a/openshift/template-post-deploy-job.yaml
+++ b/openshift/template-post-deploy-job.yaml
@@ -27,7 +27,7 @@ objects:
               - POST
               - --user
               - $(USER):$(TOKEN)
-              - $(URL)/job/cloud.redhat.com_assisted-test-infra/buildWithParameters?OFFLINE_TOKEN_CRED=$(OFFLINE_TOKEN_CRED)&PULL_SECRET_CRED=$(PULL_SECRET_CRED)&ASSISTED_SERVICE_URL=$(ASSISTED_SERVICE_URL)
+              - $(URL)?OFFLINE_TOKEN_CRED=$(OFFLINE_TOKEN_CRED)&PULL_SECRET_CRED=$(PULL_SECRET_CRED)&ASSISTED_SERVICE_URL=$(ASSISTED_SERVICE_URL)
             env:
               - name: URL
                 valueFrom:


### PR DESCRIPTION
The smee client will handle routing to the correct path for us,
we just need to post to the url endpoint which is configured in a
secret in the openshift cluster.

cc @YuviGold 