### PR TITLE
MGMT-2175 Enhancing the integration of Assisted Installer with Podman

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -2,7 +2,10 @@ FROM golang:1.14.3
 
 ENV GO111MODULE=on
 
-RUN apt-get update && apt-get install -y docker.io libvirt-clients awscli python3-pip postgresql \
+RUN echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_10/Release.key | apt-key add -
+
+RUN apt-get update && apt-get install -y podman libvirt-clients awscli python3-pip postgresql \
  && rm -rf /var/lib/apt/lists/*
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.12.2 \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
-                sh 'docker system prune -a'
+                sh 'podman system prune -a'
                 sh 'make ci-lint'
             }
         }
@@ -50,7 +50,7 @@ pipeline {
         stage('Publish') {
             when { branch 'master'}
             steps {
-                sh "docker login quay.io -u ${QUAY_IO_CREDS_USR} -p ${QUAY_IO_CREDS_PSW}"
+                sh "podman login quay.io -u ${QUAY_IO_CREDS_USR} -p ${QUAY_IO_CREDS_PSW}"
                 sh "podman login quay.io -u ${QUAY_IO_CREDS_USR} -p ${QUAY_IO_CREDS_PSW}"
                 sh "make publish"
             }

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,13 +4,14 @@ set -e
 
 source build_images.sh
 
+# This folder/authfile is not necessary to be patched, podman will use $HOME/.docker/config.json.
 DOCKER_CONF="${PWD}/.docker"
 mkdir -p "${DOCKER_CONF}"
-docker --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+podman --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
-docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"
-docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+podman --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"
+podman --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${TAG}"
 
-docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:latest"
-docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"
+podman --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:latest"
+podman --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"
 

--- a/build_images.sh
+++ b/build_images.sh
@@ -12,7 +12,7 @@ ASSISTED_SERVICE_IMAGE=quay.io/app-sre/assisted-service
 ASSISTED_ISO_CREATE_IMAGE=quay.io/app-sre/assisted-iso-create
 
 SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make update-minimal
-docker tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+podman tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
 
 ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:latest" skipper make build-minimal-assisted-iso-generator-image
-docker tag "${ASSISTED_ISO_CREATE_IMAGE}:latest" "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"
+podman tag "${ASSISTED_ISO_CREATE_IMAGE}:latest" "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -5,8 +5,8 @@ set -e
 IMAGE_TEST=assisted-service-test
 
 # run some 'assisted-service' checks inside a golang container
-docker build -t ${IMAGE_TEST} -f Dockerfile.test .
-docker run --rm ${IMAGE_TEST}
+podman build -t ${IMAGE_TEST} -f Dockerfile.test .
+podman run --rm ${IMAGE_TEST}
 
 # build app-sre image to make sure they are build without errors before merging to master
 source build_images.sh

--- a/tools/debug/pod_image_labels.sh
+++ b/tools/debug/pod_image_labels.sh
@@ -6,16 +6,13 @@
 function print_usage() {
     [[ -n "$1" ]] && echo "$1" && echo
     echo "usage: pod_image_labels [-p] <pod-name-filter> "
-    echo
-    echo "    -p - Use podman instead of docker"
     exit 1
 }
 
 
-DOCKER_ENGINE="docker"
+DOCKER_ENGINE="podman"
 while getopts ':ph' flag; do
   case "${flag}" in
-    p) DOCKER_ENGINE="podman" ;;
     h) print_usage ;;
     ?) print_usage "invalid flag ${OPTARG}" ;;
   esac

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -13,7 +13,6 @@ INGRESS_REMOTE_TARGET = 'oc-ingress'
 
 MINIKUBE_CMD = 'minikube'
 KUBECTL_CMD = 'kubectl'
-DOCKER = "docker"
 PODMAN = "podman"
 
 
@@ -250,12 +249,10 @@ def is_tool(name):
 
 
 def get_runtime_command():
-    if is_tool(DOCKER):
-        cmd = DOCKER
-    elif is_tool(PODMAN):
+    if is_tool(PODMAN):
         cmd = PODMAN
     else:
-        raise Exception("Nor %s nor %s are installed" % (PODMAN, DOCKER))
+        raise Exception("Nor %s nor %s are installed" % (PODMAN))
     return cmd
 
 


### PR DESCRIPTION
- Patched also the Assisted-Test-Infra repo in this PR: https://github.com/openshift/assisted-test-infra/pull/91
- Modified all Make Targets in order to use podman as a container engine:

```
RT_CMD=podman make generate-go-server
RT_CMD=podman make generate-go-client
RT_CMD=podman make build
RT_CMD=podman make build-image
```

- By default `docker` will be used then if we execute `make build-image` will be the same as `RT_CMD=docker make build-image`. 

**What need to be addressed here?**

- [ ] Delete the Docker supportability from `Makefile`
- [ ] Delete the Docker executions from `Jenkinsfile`
- [ ] Delete the Docker dependencies from Go Unit Testing [here](https://github.com/openshift/assisted-service/blob/master/internal/common/common_unitest_db.go#L12)
- [ ] Delete the Docker references from `pod_image_labels.sh`