### PR TITLE
NO-JIRA improves commit message checking

### DIFF
--- a/tools/check-commit-message.sh
+++ b/tools/check-commit-message.sh
@@ -6,9 +6,11 @@ commit_file=${1}
 commit_message="$(cat ${commit_file})"
 valid_commit_regex='^([A-Z]+-[0-9]+|merge|no-jira)'
 
-error_msg="""Aborting commit with message: '${commit_message}'
-Your commit message is missing either a JIRA Issue ('JIRA-1111') or 'Merge'.
+error_msg="""Aborting commit.
+Your commit message is missing a prefix of either a JIRA Issue ('JIRA-1111') or 'Merge'.
 You can ignore the JIRA ticket by prefixing with 'NO-JIRA'.
+
+Your message is preserved at '${commit_file}'
 """
 
 status=$(echo "${commit_message}" | grep -iqE "${valid_commit_regex}")

--- a/tools/check-commits.sh
+++ b/tools/check-commits.sh
@@ -6,7 +6,12 @@ set -o nounset
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-master_branch="origin/master"
+remote=$(git remote -v | (grep "github\.com.openshift/assisted-service.git" || true) | head -n 1 | awk '{ print $1 }')
+if [ -z $remote ]; then
+    echo "could not find remote for github.com/openshift/assisted-service"
+    exit 1
+fi
+master_branch="$remote/master"
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 revs=$(git rev-list "${master_branch}".."${current_branch}")


### PR DESCRIPTION
Instead of assuming "origin" is the remote that corresponds to
github.com/openshift/assisted-service, the script now finds the remote
corresponding to that location. This works better for devs who use "origin" as
the name for their fork's remote.

If the commit is rejected, a message is shown citing the location of the file
where the commit message is preserved. Previously, it looked to the dev like
their commit message had just been thrown away.

In the interest of ensuring the dev reads the error message in case of commit
rejection, the script no longer prints the entire commit message before
displaying the helpful error message. By not throwing a wall of text at the dev,
they'll be more likely to see the error info itself.