### PR TITLE
OCPBUGSM-17629 Handle failure OCM call for IsAdmin

### DIFF
--- a/internal/common/error_utils.go
+++ b/internal/common/error_utils.go
@@ -116,3 +116,10 @@ func GenerateErrorResponderWithDefault(err error, defaultCode int32) middleware.
 		return NewApiError(defaultCode, err)
 	}
 }
+
+func ApiErrorWithDefaultInfraError(err error, defaultCode int32) error {
+	if IsKnownError(err) {
+		return err
+	}
+	return NewInfraError(defaultCode, err)
+}

--- a/pkg/ocm/authorization.go
+++ b/pkg/ocm/authorization.go
@@ -3,8 +3,11 @@ package ocm
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	azv1 "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/pkg/errors"
 )
 
 type OCMAuthorization interface {
@@ -52,7 +55,8 @@ func (a authorization) AccessReview(ctx context.Context, username, action, resou
 func (a authorization) CapabilityReview(ctx context.Context, username, capabilityName, capabilityType string) (allowed bool, err error) {
 	connection, err := a.client.NewConnection()
 	if err != nil {
-		return false, err
+		return false, common.NewApiError(http.StatusInternalServerError,
+			errors.Wrap(err, "Unable to build OCM connection"))
 	}
 	defer connection.Close()
 
@@ -64,24 +68,35 @@ func (a authorization) CapabilityReview(ctx context.Context, username, capabilit
 		Type(capabilityType).
 		Build()
 	if err != nil {
-		return false, err
+		return false, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
 	postResp, err := capabilityReview.Post().
 		Request(request).
 		SendContext(ctx)
+
 	if err != nil {
-		return false, err
+		a.client.logger.Error(context.Background(), "Fail to send CapabilityReview. Error: %v", err)
+		if postResp != nil {
+			a.client.logger.Error(context.Background(), "Fail to send CapabilityReview. Response: %v", postResp)
+			if postResp.Status() >= 400 && postResp.Status() < 500 {
+				return false, common.NewInfraError(http.StatusUnauthorized, err)
+			}
+			if postResp.Status() >= 500 {
+				return false, common.NewApiError(http.StatusServiceUnavailable, err)
+			}
+		}
+		return false, common.NewApiError(http.StatusServiceUnavailable, err)
 	}
 
 	response, ok := postResp.GetResponse()
 	if !ok {
-		return false, fmt.Errorf("Empty response from authorization post request")
+		return false, fmt.Errorf("Empty response from authorization CapabilityReview post request")
 	}
 
 	result, ok := response.GetResult()
 	if !ok {
-		return false, fmt.Errorf("Failed to fetch result from the response")
+		return false, fmt.Errorf("Failed to fetch result from the response CapabilityReview")
 	}
 
 	return result == "true", nil


### PR DESCRIPTION
In case that OCM fails to retrieve a token from SSO, the return call of the API should be 503 and not 401.