### PR TITLE
OCPBUGSM-17629 Move Agent Auth cache to AuthHandler

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -14,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	auth "github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,6 +48,7 @@ var _ = Describe("Pull secret validation", func() {
 	client := &ocm.Client{
 		Authentication: &mockOCMAuthentication{},
 		Authorization:  &mockOCMAuthorization{},
+		Cache:          cache.New(1*time.Minute, 30*time.Minute),
 	}
 	authHandler := auth.NewAuthHandler(fakeConfig, client, log.WithField("pkg", "auth"))
 

--- a/pkg/ocm/pullsecret_auth.go
+++ b/pkg/ocm/pullsecret_auth.go
@@ -7,7 +7,6 @@ import (
 
 	amgmtv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 )
 
@@ -21,11 +20,6 @@ type authentication struct {
 }
 
 func (a authentication) AuthenticatePullSecret(ctx context.Context, pullSecret string) (user *AuthPayload, err error) {
-	authUser, found := a.client.Cache.Get(pullSecret)
-	if found {
-		return authUser.(*AuthPayload), nil
-	}
-
 	connection, err := a.client.NewConnection()
 	if err != nil {
 		return nil, common.NewApiError(http.StatusInternalServerError,
@@ -64,7 +58,6 @@ func (a authentication) AuthenticatePullSecret(ctx context.Context, pullSecret s
 	payload.FirstName = responseVal.Account().FirstName()
 	payload.LastName = responseVal.Account().LastName()
 	payload.Email = responseVal.Account().Email()
-	a.client.Cache.Set(pullSecret, payload, cache.DefaultExpiration)
 
 	return payload, nil
 }


### PR DESCRIPTION
In order to minimize OCM calls, the cache is now updated after that the Admin Capability is checked.