### PR TITLE
OCPBUGSM-18040 Cluster installation fails with error : the container …

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -1,0 +1,57 @@
+name: image-push
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        sudo pip install strato-skipper
+        mkdir -p ~/.docker
+        echo "{}" > ~/.docker/config.json
+        touch ${HOME}/.gitconfig
+        ln -s Dockerfile.assisted-service Dockerfile
+    - name: build
+      run: |
+        skipper make build
+    - name: Get release version
+      id: get_version
+      run: echo ::set-env name=GIT_REVISION::$(echo ${GITHUB_SHA})
+    - name: create python client
+      run: |
+        skipper make create-python-client
+    - name: Publish assisted-service to Registry
+      if: github.event_name != 'pull_request'
+      uses: elgohr/Publish-Docker-Github-Action@2.15
+      with:
+        name: assisted-service
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        REGISTRY: 'quay.io/ocpmetal'
+        dockerfile: "Dockerfile.assisted-service"
+        buildargs: GIT_REVISION
+        tags: "latest,${{ env.GIT_REVISION }}"
+    - name: Publish assisted-service PR image to Registry
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      uses: elgohr/Publish-Docker-Github-Action@2.15
+      with:
+        name: assisted-service
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        REGISTRY: 'quay.io/ocpmetal'
+        dockerfile: "Dockerfile.assisted-service"
+        buildargs: GIT_REVISION, QUAY_TAG_EXPIRATION
+        tags: "PR_${{ env.GIT_REVISION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        sudo pip install strato-skipper
+        mkdir -p ~/.docker
+        echo "{}" > ~/.docker/config.json
+        touch ${HOME}/.gitconfig
+        ln -s Dockerfile.assisted-service Dockerfile
+    - name: build
+      run: |
+        skipper make build
+    - name: create python client
+      run: |
+        skipper make create-python-client
+    - name: Get release version
+      id: get_version
+      run: echo ::set-env name=GIT_REVISION::$(echo ${GITHUB_SHA})
+    - name: Get tag
+      id: get_tag
+      run: echo ::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
+    - name: Publish assisted-service to Registry
+      uses: elgohr/Publish-Docker-Github-Action@2.15
+      with:
+        name: assisted-service
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        REGISTRY: 'quay.io/ocpmetal'
+        dockerfile: "Dockerfile.assisted-service"
+        buildargs: GIT_REVISION
+        tags: "${{ env.GIT_TAG }},${{ env.GIT_REVISION }}"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,43 @@
+name: unit-test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    # the golanci-lint step publishes annotations on failed lines
+    # It does not, however faile the build. That is why lated, during the test phase we also
+    # invoke the linter from the Makefile
+    - name: golangci-lint
+      uses: reviewdog/action-golangci-lint@v1.1.3
+      with:
+        github_token: ${{ secrets.github_token }}
+        golangci_lint_flags: "--config=.golangci.yml"
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: |
+        sudo pip install strato-skipper
+        mkdir -p ~/.docker
+        echo "{}" > ~/.docker/config.json
+        touch ${HOME}/.gitconfig
+    - name: test
+      run: |
+        skipper make build

--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -26,6 +26,8 @@ RUN cd build && python3 setup.py sdist --dist-dir /assisted-service-client
 
 # Create final image
 FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG GIT_REVISION
+LABEL "git_revision"=${GIT_REVISION}
 COPY --from=builder /build/assisted-service /assisted-service
 COPY --from=builder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
 CMD ["/assisted-service"]

--- a/Dockerfile.assisted-service-onprem
+++ b/Dockerfile.assisted-service-onprem
@@ -4,9 +4,12 @@ FROM quay.io/ocpmetal/assisted-ignition-generator:latest AS config-gen
 
 FROM centos:8
 
+ARG GIT_REVISION
 ARG WORK_DIR=/data
 ARG USER=assisted-installer
 ARG NAMESPACE=assisted-installer
+
+LABEL "git_revision"=${GIT_REVISION}
 
 RUN yum install -y libvirt-libs python3 python3-pip findutils wget && \
     yum clean all && \

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -65,6 +65,9 @@ const (
 const DefaultUser = "kubeadmin"
 const ConsoleUrlPrefix = "https://console-openshift-console.apps"
 
+// 125 is the generic exit code for cases the error is in podman / docker and not the container we tried to run
+const ContainerAlreadyRunningExitCode = 125
+
 var (
 	DefaultClusterNetworkCidr       = "10.128.0.0/14"
 	DefaultClusterNetworkHostPrefix = int64(23)
@@ -1521,7 +1524,7 @@ func (b *bareMetalInventory) PostStepReply(ctx context.Context, params installer
 	if params.Reply.ExitCode != 0 {
 		err = fmt.Errorf(msg)
 		log.WithError(err).Errorf("Exit code is <%d> ", params.Reply.ExitCode)
-		handlingError := handleReplyError(params, b, ctx, &host)
+		handlingError := b.handleReplyError(params, ctx, &host)
 		if handlingError != nil {
 			log.WithError(handlingError).Errorf("Failed handling reply error for host <%s> cluster <%s>", params.HostID, params.ClusterID)
 		}
@@ -1551,9 +1554,14 @@ func (b *bareMetalInventory) PostStepReply(ctx context.Context, params installer
 	return installer.NewPostStepReplyNoContent()
 }
 
-func handleReplyError(params installer.PostStepReplyParams, b *bareMetalInventory, ctx context.Context, h *models.Host) error {
+func (b *bareMetalInventory) handleReplyError(params installer.PostStepReplyParams, ctx context.Context, h *models.Host) error {
 
 	if params.Reply.StepType == models.StepTypeInstall {
+		// Handle case of installation error due to an already running assisted-installer.
+		if params.Reply.ExitCode == ContainerAlreadyRunningExitCode && strings.Contains(params.Reply.Error, "the container name \"assisted-installer\" is already in use") {
+			b.log.Warnf("Install command failed due to an already running installation: %s", params.Reply.Error)
+			return nil
+		}
 		//if it's install step - need to move host to error
 		return b.hostApi.HandleInstallationFailure(ctx, h)
 	}


### PR DESCRIPTION
…name \"assisted-installer\" is already in use.

Failure is caused by executing multiple install commands on the host.
Since only one container with the name "assisted-installer" can be executed just one install command is actually running and the rest return with error setting the host installation to failure
The trigger to this behavior is the time it take to pull the installer image from the downstream registry.
This patch mitigate the error by not moving the host to error in case the install command fail with that specific error code and stderr output (the container name \"assisted-installer\" is already in use) .