### PR TITLE
NO-ISSUE: logs the correct error when leader election fails

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,7 +202,7 @@ func main() {
 
 		err = lead.StartLeaderElection(context.Background())
 		if err != nil {
-			log.WithError(cerr).Fatalf("Failed to start leader")
+			log.WithError(err).Fatalf("Failed to start leader")
 		}
 
 	case "onprem":


### PR DESCRIPTION
Previously (I assume due to a typo) the log message when leader election failed
included the wrong error variable, so the message would end with:
`error="<nil>"`