### PR TITLE
MGMT-2249 Add the old default as the default for the parameter

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -91,7 +91,7 @@ parameters:
 - name: RELEASE_TAG
   value: ''
 - name: AGENT_TIMEOUT_START
-  value: ''
+  value: '3m'
 apiVersion: v1
 kind: Template
 metadata:


### PR DESCRIPTION
If the parameter is not provided then we get the following error:

`envconfig.Process: assigning MYAPP_BMCONFIG_AGENT_TIMEOUT_START to AgentTimeoutStart: converting '' to type time.Duration. details: time: invalid duration " func=main.main file="/go/src/github.com/openshift/origin/cmd/main.go:110`