### PR TITLE
NO-ISSUE - add to openshift/template a default value for the AGENT_TI…

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -91,7 +91,7 @@ parameters:
 - name: RELEASE_TAG
   value: ''
 - name: AGENT_TIMEOUT_START
-  value: ''
+  value: '5m'
 apiVersion: v1
 kind: Template
 metadata:


### PR DESCRIPTION
…MEOUT_START because empty string is not a valid time.duration