### PR TITLE
OCPBUGSM-18121: Flush network interface on reset cmd

### DIFF
--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -57,7 +57,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	installCmd := NewInstallCmd(log, db, hwValidator, instructionConfig)
 	inventoryCmd := NewInventoryCmd(log, instructionConfig.InventoryImage)
 	freeAddressesCmd := NewFreeAddressesCmd(log, instructionConfig.FreeAddressesImage)
-	resetCmd := NewResetInstallationCmd(log)
+	resetCmd := NewResetInstallationCmd(log, connectivityValidator)
 	stopCmd := NewStopInstallationCmd(log)
 	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.DhcpLeaseAllocatorImage, db)
 

--- a/internal/host/resetinstallationcmd_test.go
+++ b/internal/host/resetinstallationcmd_test.go
@@ -3,6 +3,9 @@ package host
 import (
 	"context"
 
+	"github.com/golang/mock/gomock"
+	"github.com/openshift/assisted-service/internal/connectivity"
+
 	"github.com/openshift/assisted-service/internal/common"
 
 	"github.com/go-openapi/strfmt"
@@ -15,17 +18,22 @@ import (
 
 var _ = Describe("reset", func() {
 	ctx := context.Background()
+	var ctrl *gomock.Controller
 	var host models.Host
 	var db *gorm.DB
 	var rstCmd *resetInstallationCmd
+	var mockConnectivityValidator connectivity.Validator
 	var id, clusterId strfmt.UUID
 	var stepReply *models.Step
 	var stepErr error
 	dbName := "reset_cmd"
 
 	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockConnectivityValidator = connectivity.NewMockValidator(ctrl)
+		rstCmd = NewResetInstallationCmd(getTestLog(), mockConnectivityValidator)
+
 		db = common.PrepareTestDB(dbName)
-		rstCmd = NewResetInstallationCmd(getTestLog())
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
Since dhcp was added the virtual ip is not cleared on reset.
Bootstrap should flash the network interfaces and reset network manager for a fresh start.