### PR TITLE
NO-ISSUE Revert "NO-ISSUE Verify minikube before any Makefile targets…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,6 @@ TARGET := $(or ${TARGET},minikube)
 PROFILE := $(or $(PROFILE),minikube)
 KUBECTL=kubectl -n $(NAMESPACE)
 
-# Verify minikube is running, otherwise abort
-_MINIKUBE := $(shell if [ -x "$(shell command -v minikube)" ];then minikube status; fi)
-ifneq ($(.SHELLSTATUS),0)
-    $(error $(_MINIKUBE))
-endif
-
 ifeq ($(TARGET), minikube)
 define get_service
 minikube -p $(PROFILE) service --url $(1) -n $(NAMESPACE) | sed 's/http:\/\///g'


### PR DESCRIPTION
… (#431)"

This reverts commit 1d23951e9269e59684e2cd9d89a3fe5c9241d27d.
It doesn't worked and it's a bad solution, i don't need minikube to run unit-tests