### PR TITLE
MGMT-2052 - Patching OPENSHIFT_RELEASE_IMAGE variable to make that customizable on the Assisted Service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ endif # TARGET
 SERVICE := $(or ${SERVICE},quay.io/ocpmetal/assisted-service:latest)
 SERVICE_ONPREM := $(or ${SERVICE_ONPREM},quay.io/ocpmetal/assisted-service-onprem:latest)
 ISO_CREATION := $(or ${ISO_CREATION},quay.io/ocpmetal/assisted-iso-create:latest)
+OPENSHIFT_INSTALL_RELEASE_IMAGE := $(or ${OPENSHIFT_INSTALL_RELEASE_IMAGE},quay.io/ocpmetal/ocp-release:4.6.0-0.nightly-2020-08-31-220837)
 DUMMY_IGNITION := $(or ${DUMMY_IGNITION},False)
 GIT_REVISION := $(shell git rev-parse HEAD)
 APPLY_NAMESPACE := $(or ${APPLY_NAMESPACE},True)
@@ -195,7 +196,8 @@ deploy-inventory-service-file: deploy-namespace
 deploy-service-requirements: deploy-namespace deploy-inventory-service-file
 	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" \
 		--base-dns-domains "$(BASE_DNS_DOMAINS)" --namespace "$(NAMESPACE)" --profile "$(PROFILE)" \
-		$(INSTALLATION_TIMEOUT_FLAG) $(DEPLOY_TAG_OPTION) --enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS)
+		$(INSTALLATION_TIMEOUT_FLAG) $(DEPLOY_TAG_OPTION) --enable-auth "$(ENABLE_AUTH)" $(TEST_FLAGS) \
+		--ocp-release $(OPENSHIFT_INSTALL_RELEASE_IMAGE)
 
 deploy-service: deploy-namespace deploy-service-requirements deploy-role
 	python3 ./tools/deploy_assisted_installer.py $(DEPLOY_TAG_OPTION) --namespace "$(NAMESPACE)" \

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This deployment option have multiple optional parameters that should be used in 
 1. `APPLY_NAMESPACE` - True by default. Will try to deploy "assisted-installer" namespace, if you are not the Admin of the cluster or maybe you don't have permissions for this operation you may skip namespace deployment.
 1. `INGRESS_DOMAIN` - By default deployment script will try to get the domain prefix from OpenShift ingress controller. If you don't have access to it then you may specify the domain yourself. For example: `apps.ocp.prod.psi.redhat.com`
 
-To set the parameters simply add them in the end of the command, for example
+To set the parameters simply add them in the end of the command, for example:
 ```shell
 skipper make deploy-all TARGET=oc-ingress APPLY_NAMESPACE=False INGRESS_DOMAIN=apps.ocp.prod.psi.redhat.com
 ```

--- a/deploy/assisted-service-configmap.yaml
+++ b/deploy/assisted-service-configmap.yaml
@@ -9,7 +9,7 @@ data:
   SERVICE_BASE_URL: REPLACE_BASE_URL
   NAMESPACE: REPLACE_NAMESPACE
   BASE_DNS_DOMAINS: REPLACE_DOMAINS # example: name1:id1/provider1,name2:id2/provider2
-  OPENSHIFT_INSTALL_RELEASE_IMAGE: "quay.io/ocpmetal/ocp-release:4.6.0-0.nightly-2020-08-31-220837"
+  OPENSHIFT_INSTALL_RELEASE_IMAGE: REPLACE_OPENSHIFT_INSTALL_RELEASE_IMAGE # https://quay.io/repository/ocpmetal/ocp-release 
   CREATE_S3_BUCKET: "true"
   ENABLE_AUTH: REPLACE_AUTH_ENABLED_FLAG
   JWKS_URL: REPLACE_JWKS_URL # example https://example.com/.well-known/jwks.json

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -12,6 +12,7 @@ def handle_arguments():
     parser.add_argument("--subsystem-test", action='store_true')
     parser.add_argument("--jwks-url", default="https://api.openshift.com/.well-known/jwks.json")
     parser.add_argument("--ocm-url", default="https://api-integration.6943.hive-integration.openshiftapps.com")
+    parser.add_argument("--ocp-release")
     parser.add_argument("--installation-timeout", type=int)
 
     return deployment_options.load_deployment_options(parser)
@@ -50,6 +51,7 @@ def main():
             data = data.replace('REPLACE_AUTH_ENABLED_FLAG', '"{}"'.format(deploy_options.enable_auth))
             data = data.replace('REPLACE_JWKS_URL', '"{}"'.format(deploy_options.jwks_url))
             data = data.replace('REPLACE_OCM_BASE_URL', '"{}"'.format(deploy_options.ocm_url))
+            data = data.replace('REPLACE_OPENSHIFT_INSTALL_RELEASE_IMAGE', '"{}"'.format(deploy_options.ocp_release))
 
             subsystem_versions = {"IMAGE_BUILDER": "ISO_CREATION",
                                   "IGNITION_GENERATE_IMAGE": "DUMMY_IGNITION"}

--- a/tools/update_bm_cm.py
+++ b/tools/update_bm_cm.py
@@ -15,6 +15,7 @@ ENVS = [
     ("HW_VALIDATOR_MIN_DISK_SIZE_GIB", "10"),
     ("INSTALLER_IMAGE", ""),
     ("CONTROLLER_IMAGE", ""),
+    ("OPENSHIFT_INSTALL_RELEASE_IMAGE", ""),
     ("SERVICE_URL", ""),
     ("SERVICE_PORT", ""),
     ("AGENT_DOCKER_IMAGE", ""),


### PR DESCRIPTION
This PR will add the capability to customize the deployment of OPENSHIFT_RELEASE_IMAGE used on the different OCP/K8s objetcs.

- This PR is related too with: https://github.com/openshift/assisted-test-infra/pull/156, we need to merge this current PR before this other from assisted-test-infra repo to make it work properly.
- [x] Patched the deployment ConfigMap Python script
- [x] Patched  deployment update script
- [x] Patched YAML ConfigMap
