### PR TITLE
MGMT-2283 change unit-tests db into quay.io/ocpmetal/postgresql-12-ce…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,9 +260,11 @@ deploy-monitoring: deploy-olm deploy-prometheus deploy-grafana
 unit-test:
 	docker kill postgres || true
 	sleep 3
-	docker run -d  --rm --name postgres -e POSTGRES_PASSWORD=admin -e POSTGRES_USER=admin -p 127.0.0.1:5432:5432 postgres:12.3-alpine -c 'max_connections=10000'
-	until PGPASSWORD=admin pg_isready -U admin --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done
-	SKIP_UT_DB=1 go test -v $(or ${TEST}, ${TEST}, $(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) -cover -timeout 20m || (docker kill postgres && /bin/false)
+	docker run -d --rm --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 \
+		-p 127.0.0.1:5432:5432 quay.io/ocpmetal/postgresql-12-centos7
+	until PGPASSWORD=admin pg_isready -U postgres --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done
+	SKIP_UT_DB=1 go test -v $(or ${TEST}, ${TEST}, $(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) \
+		-cover -timeout 20m -count=1 || (docker kill postgres && /bin/false)
 	docker kill postgres
 
 test-onprem:

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -13,6 +13,8 @@ import (
 )
 
 const (
+	dbUser        = "postgres"
+	dbPassword    = "admin"
 	dbDockerName  = "ut-postgres"
 	dbDefaultPort = "5432"
 )
@@ -47,10 +49,13 @@ func InitializeDBTest() {
 		oldResource.Close()
 	}
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "postgres",
-		Tag:        "12.3",
-		Env:        []string{"POSTGRES_PASSWORD=admin", "POSTGRES_USER=admin"},
-		Name:       dbDockerName,
+		Repository: "quay.io/ocpmetal/postgresql-12-centos7",
+		Tag:        "latest",
+		Env: []string{
+			fmt.Sprintf("POSTGRESQL_ADMIN_PASSWORD=%s", dbPassword),
+			"POSTGRESQL_MAX_CONNECTION=10000",
+		},
+		Name: dbDockerName,
 	})
 	Expect(err).ShouldNot(HaveOccurred())
 
@@ -60,8 +65,7 @@ func InitializeDBTest() {
 	var dbTemp *gorm.DB
 	err = gDbCtx.pool.Retry(func() error {
 		var er error
-
-		dbTemp, er = gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+		dbTemp, er = dbConnect()
 		return er
 	})
 	Expect(err).ShouldNot(HaveOccurred())
@@ -79,15 +83,14 @@ func TerminateDBTest() {
 }
 
 func PrepareTestDB(dbName string, extrasSchemas ...interface{}) *gorm.DB {
-	dbTemp, err := gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+	dbTemp, err := dbConnect()
 	Expect(err).ShouldNot(HaveOccurred())
 	defer dbTemp.Close()
 
 	dbTemp = dbTemp.Exec(fmt.Sprintf("CREATE DATABASE %s;", strings.ToLower(dbName)))
 	Expect(dbTemp.Error).ShouldNot(HaveOccurred())
 
-	db, err := gorm.Open("postgres",
-		fmt.Sprintf("host=127.0.0.1 port=%s dbname=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort(), strings.ToLower(dbName)))
+	db, err := dbConnectWithDB(dbName)
 	Expect(err).ShouldNot(HaveOccurred())
 	// db = db.Debug()
 	db.AutoMigrate(&models.Host{}, &Cluster{})
@@ -102,12 +105,22 @@ func PrepareTestDB(dbName string, extrasSchemas ...interface{}) *gorm.DB {
 
 func DeleteTestDB(db *gorm.DB, dbName string) {
 	db.Close()
-
-	db, err := gorm.Open("postgres",
-		fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+	db, err := dbConnect()
 	Expect(err).ShouldNot(HaveOccurred())
 	defer db.Close()
 	db = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s;", strings.ToLower(dbName)))
 
 	Expect(db.Error).ShouldNot(HaveOccurred())
+}
+
+func dbConnect() (*gorm.DB, error) {
+	return gorm.Open("postgres",
+		fmt.Sprintf("host=127.0.0.1 port=%s user=%s password=%s sslmode=disable",
+			gDbCtx.GetPort(), dbUser, dbPassword))
+}
+
+func dbConnectWithDB(dbName string) (*gorm.DB, error) {
+	return gorm.Open("postgres",
+		fmt.Sprintf("host=127.0.0.1 port=%s dbname=%s user=%s password=%s sslmode=disable",
+			gDbCtx.GetPort(), strings.ToLower(dbName), dbUser, dbPassword))
 }


### PR DESCRIPTION
…ntos7

Our postgres version act different from the old version
In order to make it work, admin user `postgres` is used otherwise the created user don't have permissions to create a DB
Using single db will prevent from running tests in parallel.