### PR TITLE
NO-ISSUE Use gotestsum tool for testing and publish junit on Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 *.out
 
 /vendor
+reports

--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -8,7 +8,10 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.12.2 \
               golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
               github.com/golang/mock/mockgen@v1.4.3 \
-              github.com/vektra/mockery/.../@v1.1.2
+              github.com/vektra/mockery/.../@v1.1.2 \
+              gotest.tools/gotestsum@v0.5.3 \
+              github.com/axw/gocov/gocov \
+              github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 RUN pip3 install boto3==1.13.14 waiting==1.4.1 requests==2.22.0
 RUN curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.10.1/minikube-linux-amd64 \
   && chmod +x minikube && mkdir -p /usr/local/bin/ && install minikube /usr/local/bin/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,15 @@ pipeline {
 
         stage('Build') {
             steps {
-                sh "make build-image build-minimal-assisted-iso-generator-image"
+                sh "skipper make build-image build-minimal-assisted-iso-generator-image"
                 sh "make jenkins-deploy-for-subsystem"
                 sh "kubectl get pods -A"
+            }
+            post {
+                always {
+                    junit '**/reports/*test.xml'
+                    cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
+                }
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ endif
 ifdef FOCUS
         GINKGO_FOCUS_FLAG = -ginkgo.focus=${FOCUS}
 endif
+REPORTS = $(ROOT_DIR)/reports
+TEST_PUBLISH_FLAGS = --junitfile-testsuite-name=relative --junitfile-testcase-classname=relative --junitfile $(REPORTS)/unittest.xml
 
 
 all: build
@@ -257,15 +259,18 @@ deploy-grafana: $(BUILD_FOLDER)
 
 deploy-monitoring: deploy-olm deploy-prometheus deploy-grafana
 
-unit-test:
-	docker kill postgres || true
-	sleep 3
+unit-test: $(REPORTS)
+	docker ps -q --filter "name=postgres" | xargs -r docker kill && sleep 3
 	docker run -d --rm --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 \
 		-p 127.0.0.1:5432:5432 quay.io/ocpmetal/postgresql-12-centos7
-	until PGPASSWORD=admin pg_isready -U postgres --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done
-	SKIP_UT_DB=1 go test -v $(or ${TEST}, ${TEST}, $(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) \
-		-cover -timeout 20m -count=1 || (docker kill postgres && /bin/false)
+	timeout 1m bash -c "until PGPASSWORD=admin pg_isready -U postgres --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done"
+	SKIP_UT_DB=1 gotestsum --format=pkgname $(TEST_PUBLISH_FLAGS) -- -cover -coverprofile=$(REPORTS)/coverage.out $(or ${TEST},${TEST},$(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) \
+		-ginkgo.v -timeout 20m -count=1 || (docker kill postgres && /bin/false)
+	gocov convert $(REPORTS)/coverage.out | gocov-xml > $(REPORTS)/coverage.xml
 	docker kill postgres
+
+$(REPORTS):
+	-mkdir -p $(REPORTS)
 
 test-onprem:
 	INVENTORY=127.0.0.1:8090 \
@@ -281,7 +286,7 @@ test-onprem:
 clear-all: clean subsystem-clean clear-deployment
 
 clean:
-	-rm -rf $(BUILD_FOLDER)
+	-rm -rf $(BUILD_FOLDER) $(REPORTS)
 
 subsystem-clean:
 	-$(KUBECTL) get pod -o name | grep createimage | xargs -r $(KUBECTL) delete 1> /dev/null || true

--- a/pkg/log/logcontext_test.go
+++ b/pkg/log/logcontext_test.go
@@ -98,7 +98,7 @@ func waitForServer(bmclient *client.AssistedInstall, mockInstallApi *mocks.MockI
 	}
 }
 
-func TestTestLogContext(t *testing.T) {
+func TestLogContext(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Log Context Suite")
 }

--- a/pkg/requestid/requestid_test.go
+++ b/pkg/requestid/requestid_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -20,6 +22,14 @@ type mockTransport struct {
 func (m *mockTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	m.Called(r)
 	return nil, nil
+}
+
+// This is an old package test. While all of our testing infrastructure was switched to use ginkgo -
+// this test remains until it would get converted.
+// This ginkgo wrapper was added to allow running this packge with ginkgo flags.
+func TestRequestID(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Request id tests")
 }
 
 func TestTransport(t *testing.T) {

--- a/pkg/thread/example_test.go
+++ b/pkg/thread/example_test.go
@@ -3,10 +3,14 @@ package thread_test
 import (
 	"fmt"
 	"io/ioutil"
+	"testing"
 	"time"
 
 	"github.com/openshift/assisted-service/pkg/thread"
 	"github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var counter uint64
@@ -27,12 +31,18 @@ func useThread() {
 }
 
 // ExampleThread is a testable example for the thread package.
-// when executed with 'go test', the test will fail, if the 'output' remark, at the end of the function is not
-// correct.
+// The test will fail if the 'output' remark, at the end of the function, is not printed.
 func ExampleThread() {
 	useThread()
 	passed := counter <= 9 || counter <= 11
 	fmt.Println(passed)
 	// Output: true
+}
 
+// This is an old package test. While all of our testing infrastructure was switched to use ginkgo
+// This test remains until it would get converted.
+// This ginkgo wrapper was added to allow running this packge with ginkgo flags.
+func TestThread(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Request id tests")
 }


### PR DESCRIPTION
- Using [gotestsum](https://github.com/gotestyourself/gotestsum) tool for cleaner results
- Exporting results to `JUnit` format for Jenkins to be published
- Results are in a dedicated `$(REPORTS)` folder (ignored on `.gitignore`)
- Adding a timeout of 1m for postgres initialization (was endless in case of an error)