### PR TITLE
MGMT-2326: Added controller_logs_collected_at to 'cluster' relation in DB.

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -74,6 +74,7 @@ type API interface {
 	SetVips(ctx context.Context, c *common.Cluster, apiVip, ingressVip string, db *gorm.DB) error
 	IsReadyForInstallation(c *common.Cluster) (bool, string)
 	CreateTarredClusterLogs(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) (string, error)
+	SetUploadControllerLogsAt(ctx context.Context, c *common.Cluster, db *gorm.DB) error
 }
 
 type PrepareConfig struct {
@@ -191,6 +192,14 @@ func (m *Manager) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm
 	}
 	return &clusterAfterRefresh, nil
 
+}
+
+func (m *Manager) SetUploadControllerLogsAt(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
+	err := db.Model(c).Update("controller_logs_collected_at", strfmt.DateTime(time.Now())).Error
+	if err != nil {
+		return errors.Wrapf(err, "failed to set controller_logs_collected_at to cluster %s", c.ID.String())
+	}
+	return nil
 }
 
 func (m *Manager) Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,13 +6,12 @@ package cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
+	reflect "reflect"
 )
 
 // MockRegistrationAPI is a mock of RegistrationAPI interface
@@ -337,20 +336,6 @@ func (mr *MockAPIMockRecorder) AcceptRegistration(c interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptRegistration", reflect.TypeOf((*MockAPI)(nil).AcceptRegistration), c)
 }
 
-// SetGeneratorVersion mocks base method
-func (m *MockAPI) SetGeneratorVersion(c *common.Cluster, version string, db *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetGeneratorVersion", c, version, db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetGeneratorVersion indicates an expected call of SetGeneratorVersion
-func (mr *MockAPIMockRecorder) SetGeneratorVersion(c, version, db interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGeneratorVersion", reflect.TypeOf((*MockAPI)(nil).SetGeneratorVersion), c, version, db)
-}
-
 // CancelInstallation mocks base method
 func (m *MockAPI) CancelInstallation(ctx context.Context, c *common.Cluster, reason string, db *gorm.DB) *common.ApiErrorResponse {
 	m.ctrl.T.Helper()
@@ -461,4 +446,18 @@ func (m *MockAPI) CreateTarredClusterLogs(ctx context.Context, c *common.Cluster
 func (mr *MockAPIMockRecorder) CreateTarredClusterLogs(ctx, c, objectHandler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTarredClusterLogs", reflect.TypeOf((*MockAPI)(nil).CreateTarredClusterLogs), ctx, c, objectHandler)
+}
+
+// SetUploadControllerLogsAt mocks base method
+func (m *MockAPI) SetUploadControllerLogsAt(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetUploadControllerLogsAt", ctx, c, db)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetUploadControllerLogsAt indicates an expected call of SetUploadControllerLogsAt
+func (mr *MockAPIMockRecorder) SetUploadControllerLogsAt(ctx, c, db interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUploadControllerLogsAt", reflect.TypeOf((*MockAPI)(nil).SetUploadControllerLogsAt), ctx, c, db)
 }

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -72,7 +72,7 @@ func (th *transitionHandler) PostResetCluster(sw stateswitch.StateSwitch, args s
 	}
 
 	return th.updateTransitionCluster(logutil.FromContext(params.ctx, th.log), params.db, sCluster,
-		params.reason)
+		params.reason, "ControllerLogsCollectedAt", strfmt.DateTime(time.Time{}))
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,10 +5,9 @@
 package connectivity
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,11 +6,10 @@ package events
 
 import (
 	context "context"
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
+	time "time"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,13 +6,12 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,13 +5,12 @@
 package metrics
 
 import (
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
+	time "time"
 )
 
 // MockAPI is a mock of API interface

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -39,6 +39,10 @@ type Cluster struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// controller logs collected at
+	// Format: date-time
+	ControllerLogsCollectedAt strfmt.DateTime `json:"controller_logs_collected_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// The time that this cluster was created.
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" gorm:"type:timestamp with time zone"`
@@ -168,6 +172,10 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateControllerLogsCollectedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCreatedAt(formats); err != nil {
 		res = append(res, err)
 	}
@@ -279,6 +287,19 @@ func (m *Cluster) validateClusterNetworkHostPrefix(formats strfmt.Registry) erro
 	}
 
 	if err := validate.MaximumInt("cluster_network_host_prefix", "body", int64(m.ClusterNetworkHostPrefix), 32, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Cluster) validateControllerLogsCollectedAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ControllerLogsCollectedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("controller_logs_collected_at", "body", "date-time", m.ControllerLogsCollectedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,10 +6,9 @@ package generator
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,9 +6,8 @@ package leader
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,11 +6,10 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,12 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2851,6 +2851,11 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "controller_logs_collected_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
         "created_at": {
           "description": "The time that this cluster was created.",
           "type": "string",
@@ -7167,6 +7172,11 @@ func init() {
           "type": "integer",
           "maximum": 32,
           "minimum": 1
+        },
+        "controller_logs_collected_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
         "created_at": {
           "description": "The time that this cluster was created.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2535,7 +2535,10 @@ definitions:
         type: string
         description: Json formatted string containing the user overrides for the initial ignition config
         example: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
-
+      controller_logs_collected_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone"
   image_info:
     type: object
     properties:


### PR DESCRIPTION
When we upload controller logs we are setting this flag, when we reset
the cluster we are resetting it and when we are downloading logs we are
making sure is set with a valid timestamp otherwise we don't download.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>