### PR TITLE
APPSRE-2377 Use a random ID instead of the commit hash

### DIFF
--- a/openshift/template-post-deploy-job.yaml
+++ b/openshift/template-post-deploy-job.yaml
@@ -1,7 +1,8 @@
 ---
 parameters:
-- name: IMAGE_TAG
-  required: true
+- name: JOBID
+  generate: expression
+  from: "[0-9a-f]{7}"
 apiVersion: v1
 kind: Template
 metadata:
@@ -10,7 +11,7 @@ objects:
 - apiVersion: batch/v1
   kind: Job
   metadata:
-    name: assisted-service-post-deploy-${IMAGE_TAG}
+    name: assisted-service-post-deploy-${JOBID}
   spec:
     backoffLimit: 5
     template:


### PR DESCRIPTION
When a Job is created again out of the same git commit, K8S won't re-run the Job.

This patch assures that each time we create a Job it actually runs since the name will be unique.