### PR TITLE
MGMT-2318 pass verify CIDR flag to APIVIPConnectivityCheckCmd

### DIFF
--- a/internal/host/apivipconnectivitycheckcmd.go
+++ b/internal/host/apivipconnectivitycheckcmd.go
@@ -17,13 +17,15 @@ type apivipConnectivityCheckCmd struct {
 	baseCmd
 	db                     *gorm.DB
 	connectivityCheckImage string
+	verifyAPIVipCidr       bool
 }
 
-func NewAPIVIPConnectivityCheckCmd(log logrus.FieldLogger, db *gorm.DB, connectivityCheckImage string) *apivipConnectivityCheckCmd {
+func NewAPIVIPConnectivityCheckCmd(log logrus.FieldLogger, db *gorm.DB, connectivityCheckImage string, verifyAPIVipCidr bool) *apivipConnectivityCheckCmd {
 	return &apivipConnectivityCheckCmd{
 		baseCmd:                baseCmd{log: log},
 		db:                     db,
 		connectivityCheckImage: connectivityCheckImage,
+		verifyAPIVipCidr:       verifyAPIVipCidr,
 	}
 }
 
@@ -36,7 +38,8 @@ func (c *apivipConnectivityCheckCmd) GetStep(ctx context.Context, host *models.H
 
 	apiURL := fmt.Sprintf("http://%s:22624/config/worker", *cluster.APIVipDNSName)
 	request := models.APIVipConnectivityRequest{
-		URL: &apiURL,
+		URL:        &apiURL,
+		VerifyCidr: c.verifyAPIVipCidr,
 	}
 	requestBytes, err := json.Marshal(request)
 	if err != nil {

--- a/internal/host/apivipconnectivitycheckcmd_test.go
+++ b/internal/host/apivipconnectivitycheckcmd_test.go
@@ -26,7 +26,7 @@ var _ = Describe("apivipconnectivitycheckcmd", func() {
 
 	BeforeEach(func() {
 		db = common.PrepareTestDB(dbName)
-		apivipConnectivityCheckCmd = NewAPIVIPConnectivityCheckCmd(getTestLog(), db, "quay.io/ocpmetal/assisted-installer-agent:latest")
+		apivipConnectivityCheckCmd = NewAPIVIPConnectivityCheckCmd(getTestLog(), db, "quay.io/ocpmetal/assisted-installer-agent:latest", true)
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
@@ -40,7 +40,7 @@ var _ = Describe("apivipconnectivitycheckcmd", func() {
 	It("get_step", func() {
 		stepReply, stepErr = apivipConnectivityCheckCmd.GetStep(ctx, &host)
 		Expect(stepReply).ShouldNot(BeNil())
-		Expect(stepReply.Args[len(stepReply.Args)-1]).Should(Equal("{\"url\":\"http://test.com:22624/config/worker\"}"))
+		Expect(stepReply.Args[len(stepReply.Args)-1]).Should(Equal("{\"url\":\"http://test.com:22624/config/worker\",\"verify_cidr\":true}"))
 		Expect(stepErr).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -52,6 +52,7 @@ type InstructionConfig struct {
 	DhcpLeaseAllocatorImage      string `envconfig:"DHCP_LEASE_ALLOCATOR_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
 	APIVIPConnectivityCheckImage string `envconfig:"API_VIP_CONNECTIVITY_CHECK_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
 	SkipCertVerification         bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	VerifyAPIVipCidr             bool   `envconfig:"VERIFY_API_VIP_CIDR" default:"true"`
 	InstallationTimeout          uint   `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
 }
 
@@ -63,7 +64,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	resetCmd := NewResetInstallationCmd(log)
 	stopCmd := NewStopInstallationCmd(log)
 	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.DhcpLeaseAllocatorImage, db)
-	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.APIVIPConnectivityCheckImage)
+	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.APIVIPConnectivityCheckImage, instructionConfig.VerifyAPIVipCidr)
 
 	return &InstructionManager{
 		log: log,

--- a/models/api_vip_connectivity_request.go
+++ b/models/api_vip_connectivity_request.go
@@ -20,6 +20,9 @@ type APIVipConnectivityRequest struct {
 	// URL address of the API.
 	// Required: true
 	URL *string `json:"url"`
+
+	// Whether to verify if the API VIP belongs to one of the interfaces.
+	VerifyCidr bool `json:"verify_cidr,omitempty"`
 }
 
 // Validate validates this api vip connectivity request

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2667,6 +2667,10 @@ func init() {
         "url": {
           "description": "URL address of the API.",
           "type": "string"
+        },
+        "verify_cidr": {
+          "description": "Whether to verify if the API VIP belongs to one of the interfaces.",
+          "type": "boolean"
         }
       }
     },
@@ -6793,6 +6797,10 @@ func init() {
         "url": {
           "description": "URL address of the API.",
           "type": "string"
+        },
+        "verify_cidr": {
+          "description": "Whether to verify if the API VIP belongs to one of the interfaces.",
+          "type": "boolean"
         }
       }
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2790,6 +2790,9 @@ definitions:
       url:
         type: string
         description: URL address of the API.
+      verify_cidr:
+        type: boolean
+        description: Whether to verify if the API VIP belongs to one of the interfaces.
   
   api_vip_connectivity_response:
     type: object


### PR DESCRIPTION
Added verify CIDR flag to:
- swagger: api_vip_connectivity_request -> verify_cidr
- InstructionConfig: VERIFY_API_VIP_CIDR env var

Passed to apivipConnectivityCheckCmd for invoking apivip_check accordingly.