### PR TITLE
MGMT-2381 Missed image expiration events upon leader change

### DIFF
--- a/internal/imgexpirer/imgexpirer.go
+++ b/internal/imgexpirer/imgexpirer.go
@@ -48,9 +48,6 @@ func (m *Manager) ExpirationTask() {
 }
 
 func (m *Manager) DeletedImageCallback(ctx context.Context, log logrus.FieldLogger, objectName string) {
-	if !m.leaderElector.IsLeader() {
-		return
-	}
 	matches := uuidRegex.FindStringSubmatch(objectName)
 	if len(matches) != 2 {
 		log.Errorf("Cannot find cluster ID in object name: %s", objectName)

--- a/internal/imgexpirer/imgexpirer_test.go
+++ b/internal/imgexpirer/imgexpirer_test.go
@@ -34,10 +34,6 @@ var _ = Describe("imgexpirer", func() {
 		log        = logrus.New()
 	)
 
-	leaderSuccess := func() {
-		leaderMock.EXPECT().IsLeader().Return(true).Times(1)
-	}
-
 	BeforeEach(func() {
 		log.SetOutput(ioutil.Discard)
 		ctrl = gomock.NewController(GinkgoT())
@@ -48,19 +44,12 @@ var _ = Describe("imgexpirer", func() {
 	})
 	It("callback_valid_objname", func() {
 		clusterId := "53116787-3eb0-4211-93ac-611d5cedaa30"
-		leaderSuccess()
 		mockEvents.EXPECT().AddEvent(gomock.Any(), strfmt.UUID(clusterId), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any())
 		imgExp.DeletedImageCallback(ctx, log, fmt.Sprintf("discovery-image-%s.iso", clusterId))
 	})
 	It("callback_invalid_objname", func() {
 		clusterId := "53116787-3eb0-4211-93ac-611d5cedaa30"
-		leaderSuccess()
 		imgExp.DeletedImageCallback(ctx, log, fmt.Sprintf("discovery-image-%s", clusterId))
-	})
-	It("callback_not_leader", func() {
-		clusterId := "53116787-3eb0-4211-93ac-611d5cedaa30"
-		leaderMock.EXPECT().IsLeader().Return(false).Times(1)
-		imgExp.DeletedImageCallback(ctx, log, fmt.Sprintf("discovery-image-%s.iso", clusterId))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Leader is already checked before starting the task, so the running task should be able to call its callbacks