### PR TITLE
Revert "MGMT-2283 change unit-tests db into quay.io/ocpmetal/postgres…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,9 @@ deploy-monitoring: deploy-olm deploy-prometheus deploy-grafana
 
 unit-test: $(REPORTS)
 	docker ps -q --filter "name=postgres" | xargs -r docker kill && sleep 3
-	docker run -d --rm --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 \
-		-p 127.0.0.1:5432:5432 quay.io/ocpmetal/postgresql-12-centos7
-	timeout 1m bash -c "until PGPASSWORD=admin pg_isready -U postgres --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done"
+	docker run -d  --rm --name postgres -e POSTGRES_PASSWORD=admin -e POSTGRES_USER=admin -p 127.0.0.1:5432:5432 \
+		postgres:12.3-alpine -c 'max_connections=10000'
+	timeout 1m bash -c "until PGPASSWORD=admin pg_isready -U admin --dbname postgres --host 127.0.0.1 --port 5432; do sleep 1; done"
 	SKIP_UT_DB=1 gotestsum --format=pkgname $(TEST_PUBLISH_FLAGS) -- -cover -coverprofile=$(REPORTS)/coverage.out $(or ${TEST},${TEST},$(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) \
 		-ginkgo.v -timeout 30m -count=1 || (docker kill postgres && /bin/false)
 	gocov convert $(REPORTS)/coverage.out | gocov-xml > $(REPORTS)/coverage.xml


### PR DESCRIPTION
…ql-12-centos7 (#444)"

This reverts commit d0132974c15c8970d7335f0959d0c75f3df753b4.


Looks like  with the version that we have our unit tests run for half an hour so until we finish the investigation lets revert this commit
