### PR TITLE
NO-ISSUE Publish susbsystem reports

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -3,29 +3,10 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.15
 ENV GO111MODULE=on
 ENV GOFLAGS=""
 
-RUN yum install -y docker libvirt-clients awscli python3-pip postgresql genisoimage && \
-    yum clean all
-RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
-    bash -s -- 3.8.8 && mv kustomize /usr/bin/
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
-RUN curl -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
-RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.14.2 \
-              golang.org/x/tools/cmd/goimports@v0.0.0-20200616195046-dc31b401abb5 \
-              github.com/golang/mock/mockgen@v1.4.3 \
-              github.com/vektra/mockery/.../@v1.1.2 \
-              gotest.tools/gotestsum@v0.5.3 \
-              github.com/axw/gocov/gocov \
-              sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 \
-              github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
-RUN pip3 install --upgrade pip
-RUN pip3 install boto3==1.13.14 waiting==1.4.1 requests==2.22.0 mkdocs==1.1.2 \
-    vcversioner==2.16.0.0 twine==3.3.0 wheel==0.36.2 setuptools==53.0.0
+COPY ./hack/setup_env.sh ./dev-requirements.txt ./
+RUN ./setup_env.sh
+
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
-RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
-  && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2 \
-  && curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} \
-  && chmod +x operator-sdk_${OS}_${ARCH} \
-  && install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,12 +46,6 @@ pipeline {
             steps {
                 sh "make build-all"
             }
-            post {
-                always {
-                    junit '**/reports/*test.xml'
-                    cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
-                }
-            }
         }
 
         stage('Publish') {
@@ -91,9 +85,11 @@ pipeline {
                     sh '''curl -X POST -H 'Content-type: application/json' --data-binary "@data.txt" https://hooks.slack.com/services/${SLACK_TOKEN}'''
                 }
 
-                sh "make clear-all"
-
                 archiveArtifacts artifacts: '*.log', fingerprint: true, allowEmptyArchive: true
+                junit '**/reports/junit*.xml'
+                cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
+
+                sh "make clear-all"
             }
         }
     }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,8 @@
+boto3==1.13.14
+mkdocs==1.1.2
+requests==2.22.0
+setuptools==53.0.0
+twine==3.3.0
+vcversioner==2.16.0.0
+waiting==1.4.1
+wheel==0.36.2

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
+
+yum install -y docker libvirt-clients awscli python3-pip postgresql genisoimage && \
+    yum clean all
+curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
+    bash -s -- 3.8.8 && mv kustomize /usr/bin/
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
+curl -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
+
+ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
+OS=$(uname | awk '{print tolower($0)}')
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2
+curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+chmod +x operator-sdk_${OS}_${ARCH}
+install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+
+go get -u github.com/onsi/ginkgo/ginkgo@v1.16.1 \
+    golang.org/x/tools/cmd/goimports@v0.1.0 \
+    github.com/golang/mock/mockgen@v1.4.3 \
+    github.com/vektra/mockery/.../@v1.1.2 \
+    gotest.tools/gotestsum@v1.6.3 \
+    github.com/axw/gocov/gocov \
+    sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 \
+    github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
+
+python3 -m pip install --upgrade pip
+python3 -m pip install -r ./dev-requirements.txt


### PR DESCRIPTION
Adding a setup_env.sh script for users that don't use Dockerfile to run
the Makefile targets, for example our Prow CI.
    
Make a common _test Makefile target that all tests targets would call -
subsystem, onprem, unit-test
    
The _test target will have the same flags except for TIMEOUT and TEST
    
Coverage will be generated only in case the BUILD_TYPE is not standalone