### PR TITLE
NO-ISSUE adding gitattributes declaring generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Mocks generated
+*mock_*.go -diff -merge
+*mock_*.go linguist-generated=true
+
+# Swagger generated
+restapi/** -diff -merge
+restapi/** linguist-generated=true
+models/** -diff -merge
+models/** linguist-generated=true
+client/** -diff -merge
+client/** linguist-generated=true
+
+# Docs generated
+site/** -diff -merge
+site/** linguist-generated=true


### PR DESCRIPTION
`git diff` output would be nicer.

Instead of generated files diff looking like that:
```bash
 // MockS3API is a mock of S3API interface
diff --git a/pkg/s3wrapper/mock_s3wrapper.go b/pkg/s3wrapper/mock_s3wrapper.go
index 2a42b8b..b0a6ec4 100644
--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,12 +6,11 @@ package s3wrapper
 
 import (
        context "context"
+       gomock "github.com/golang/mock/gomock"
+       logrus "github.com/sirupsen/logrus"
        io "io"
        reflect "reflect"
        time "time"
-
-       gomock "github.com/golang/mock/gomock"
-       logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface
diff --git a/site/ClusterStatus.dot b/site/ClusterStatus.dot
index 6c552d4..35bd3bb 100644
--- a/site/ClusterStatus.dot
+++ b/site/ClusterStatus.dot
@@ -14,19 +14,29 @@ digraph ClusterStateMachine {
     }
     installed [shape = doublecircle, color = chartreuse];
     error [shape = doublecircle, color = crimson];
+    cancelled [shape = doublecircle, color = slategray];
 
     start -> insufficient [label = "cluster\ncreated", color=lightpink3, fontcolor=lightpink3];
+
     insufficient -> ready [label = "min reqs met", color=cadetblue4, fontcolor=cadetblue4];
+
     ready -> insufficient [label = "min reqs\nnot met", color=lightpink3, fontcolor=lightpink3];
-    error -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
     ready -> "preparing-for-installation" [label = "installation started", color=darkolivegreen3, fontcolor=darkolivegreen4];
+
+    cancelled -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
```

It will look like that

```bash
diff --git a/pkg/leader/mock_leader_elector.go b/pkg/leader/mock_leader_elector.go
index 1b6f159..d2cbcba 100644
Binary files a/pkg/leader/mock_leader_elector.go and b/pkg/leader/mock_leader_elector.go differ
diff --git a/pkg/ocm/mock_pullsecret_auth.go b/pkg/ocm/mock_pullsecret_auth.go
index 03a381a..4c94e6b 100644
Binary files a/pkg/ocm/mock_pullsecret_auth.go and b/pkg/ocm/mock_pullsecret_auth.go differ
diff --git a/pkg/s3wrapper/mock_s3iface.go b/pkg/s3wrapper/mock_s3iface.go
index 6506a60..3c374b2 100644
Binary files a/pkg/s3wrapper/mock_s3iface.go and b/pkg/s3wrapper/mock_s3iface.go differ
diff --git a/pkg/s3wrapper/mock_s3wrapper.go b/pkg/s3wrapper/mock_s3wrapper.go
index 2a42b8b..b0a6ec4 100644
Binary files a/pkg/s3wrapper/mock_s3wrapper.go and b/pkg/s3wrapper/mock_s3wrapper.go differ
diff --git a/site/ClusterStatus.dot b/site/ClusterStatus.dot
index 6c552d4..35bd3bb 100644
Binary files a/site/ClusterStatus.dot and b/site/ClusterStatus.dot differ
diff --git a/site/ClusterStatus.png b/site/ClusterStatus.png
index 3dd9d67..3eab8fd 100644
Binary files a/site/ClusterStatus.png and b/site/ClusterStatus.png differ
diff --git a/site/HostStatus.dot b/site/HostStatus.dot
```