### PR TITLE
NO-ISSUE Organize makefile

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -7,14 +7,14 @@ WORKDIR     /assisted-service
 COPY        . ./
 
 RUN         curl -sSfL \
-https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-sh -s -- -b $(go env GOPATH)/bin v1.24.0
+    https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+    sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
 RUN         go get -u \
-github.com/onsi/ginkgo/ginkgo@v1.12.2 \
-golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
-github.com/golang/mock/mockgen@v1.4.3 \
-github.com/vektra/mockery/.../@v1.1.2
+    github.com/onsi/ginkgo/ginkgo@v1.12.2 \
+    golang.org/x/tools/cmd/goimports@v0.0.0-20200520220537-cf2d1e09c845 \
+    github.com/golang/mock/mockgen@v1.4.3 \
+    github.com/vektra/mockery/.../@v1.1.2
 
 ENTRYPOINT  ["make"]
-CMD         ["build-minimal"]
+CMD         ["compile-service"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
-                sh 'docker system prune -a'
                 sh 'make ci-lint'
 
                 // Login to quay.io
@@ -33,15 +32,20 @@ pipeline {
 
         stage('Build') {
             steps {
-                sh "make build-all"
-                sh "make jenkins-deploy-for-subsystem"
-                sh "kubectl get pods -A"
+                sh "make build"
             }
             post {
                 always {
                     junit '**/reports/*test.xml'
                     cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
                 }
+            }
+        }
+
+        stage('Deploy') {
+            steps {
+                sh "make jenkins-deploy-for-subsystem"
+                sh "kubectl get pods -A"
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you want to update the underlying operating system image used by the discover
 
    ```sh
    # Example with RHCOS
-   BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-4.6.0-0.nightly-2020-08-26-093617-x86_64-live.x86_64.iso make build-assisted-iso-generator-image
+   BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/rhcos-4.6.0-0.nightly-2020-08-26-093617-x86_64-live.x86_64.iso make image-iso-generator
    ```
 
 ## Deployment
@@ -224,7 +224,7 @@ This type of deployment requires a different container image that combines compo
 
 ```
 export SERVICE=quay.io/<your-org>/assisted-service:latest
-make build-onprem
+make image-onprem
 ```
 
 To deploy, update SERVICE_BASE_URL in the onprem-environment file to match the hostname or IP address of your host. For example if your IP address is 192.168.122.2, then the SERVICE_BASE_URL would be set to http://192.168.122.2:8090. Port 8090 is the assisted-service API.

--- a/build_images.sh
+++ b/build_images.sh
@@ -11,8 +11,8 @@ TAG=$(git rev-parse --short=7 HEAD)
 ASSISTED_SERVICE_IMAGE=quay.io/app-sre/assisted-service
 ASSISTED_ISO_CREATE_IMAGE=quay.io/app-sre/assisted-iso-create
 
-SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make update-minimal
+SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make image-service
 docker tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
 
-ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:latest" skipper make build-minimal-assisted-iso-generator-image
+ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:latest" skipper make image-iso-generator
 docker tag "${ASSISTED_ISO_CREATE_IMAGE}:latest" "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"

--- a/docs/installer-live-iso.md
+++ b/docs/installer-live-iso.md
@@ -27,7 +27,7 @@ need to build a custom container image and push it to quay.io.
 
 ````
 export SERVICE=quay.io/<your-org>/assisted-service:latest
-make build-onprem
+make image-onprem
 podman push ${SERVICE}
 ````
 

--- a/docs/user-guide/assisted-service-on-local.md
+++ b/docs/user-guide/assisted-service-on-local.md
@@ -22,7 +22,7 @@ This type of deployment requires a different container image that combines compo
 
 ```
 export SERVICE_ONPREM=quay.io/<your-org>/assisted-service:latest
-make build-onprem
+make image-onprem
 ```
 
 To deploy, update SERVICE_BASE_URL in the onprem-environment file to match the hostname or IP address of your host. For example if your IP address is 192.168.122.2, then the SERVICE_BASE_URL would be set to http://192.168.122.2:8090. Port 8090 is the assisted-service API.


### PR DESCRIPTION
Multiple problems with the current organization:
* Clear naming - "build" stands for both "docker build" and "go build"
* Multiple dependencies calling each other

Only `build` calls everything
```make
all: build
build: lint unit-test images

images: image-service image-iso-generation image-onprem

image-service: compile-service
image-iso-generation: compile-iso-generation
```

Continuing #519 

What do you think? /cc @ronniel1  @eranco74  @filanov 
/hold