### PR TITLE
MGMT-2313: Send an event when a host is chosen for bootstrap

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -312,6 +312,8 @@ func (m *Manager) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap 
 		if err != nil {
 			return errors.Wrapf(err, "failed to set bootstrap to host %s", h.ID.String())
 		}
+		m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo,
+			fmt.Sprintf("Host %s: set as bootstrap", hostutil.GetHostnameForMsg(h)), time.Now())
 	}
 	return nil
 }

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1028,6 +1028,12 @@ var _ = Describe("SetBootstrap", func() {
 	for i := range tests {
 		t := tests[i]
 		It(fmt.Sprintf("Boostrap %s", strconv.FormatBool(t.IsBootstrap)), func() {
+			if t.IsBootstrap {
+				mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo,
+					fmt.Sprintf("Host %s: set as bootstrap", host.ID.String()),
+					gomock.Any())
+
+			}
 			Expect(hapi.SetBootstrap(ctx, &host, t.IsBootstrap, db)).ShouldNot(HaveOccurred())
 
 			h := getHost(*host.ID, host.ClusterID, db)


### PR DESCRIPTION
Send an event once when a host transitions to bootstrap.

The text of the event will be
```
Host <hostid>: set as bootstrap
```