### PR TITLE
MGMT-2367 Fix multiple events unit test

### DIFF
--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Events library", func() {
 			Expect(evs[0]).Should(WithTime(t1))
 			Expect(evs[0]).Should(WithSeverity(swag.String(models.EventSeverityInfo)))
 
+			time.Sleep(1 * time.Second)
 			t2 := time.Now()
 			theEvents.AddEvent(context.TODO(), cluster1, nil, models.EventSeverityInfo, "event1", t2)
 			Expect(numOfEvents(cluster1, nil)).Should(Equal(2))
@@ -102,7 +103,7 @@ var _ = Describe("Events library", func() {
 			evs, err = theEvents.GetEvents(cluster1, nil)
 			Expect(err).Should(BeNil())
 			Expect(evs[0]).Should(WithMessage(swag.String("event1")))
-			Expect(evs[0]).Should(WithTime(t2))
+			Expect(evs[0]).Should(WithTime(t1))
 			Expect(evs[0]).Should(WithSeverity(swag.String(models.EventSeverityInfo)))
 
 			Expect(numOfEvents(cluster2, nil)).Should(Equal(0))


### PR DESCRIPTION
Events are listed with the oldest first, but the unit test checked that
the newest was returned first. This mostly passed because on faster
machines the two timestamps were very similar and so the check passed.