### PR TITLE
Ori/mgmt 2401 Support connectivity majority groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.5
 	github.com/go-openapi/swag v0.19.9
 	github.com/go-openapi/validate v0.19.10
+	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259 h1:ZHJ7+IGpuOXtVf6Zk/a3WuHQgkC+vXwaqfUBDFwahtI=
+github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259/go.mod h1:9Qcha0gTWLw//0VNka1Cbnjvg3pNKGFdAm7E9sBabxE=
 github.com/golang-migrate/migrate/v4 v4.6.2/go.mod h1:JYi6reN3+Z734VZ0akNuyOJNcrg45ZL7LDBMW3WGJL0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -864,6 +864,10 @@ func (c *clusterInstaller) installHosts(cluster *common.Cluster, tx *gorm.DB) er
 }
 
 func (b *bareMetalInventory) refreshAllHosts(ctx context.Context, cluster *common.Cluster) error {
+	err := b.setMajorityGroupForCluster(cluster.ID, b.db)
+	if err != nil {
+		return err
+	}
 	for _, chost := range cluster.Hosts {
 		if swag.StringValue(chost.Status) != models.HostStatusKnown && swag.StringValue(chost.Kind) != models.HostKindAddToExistingClusterHost {
 			return common.NewApiError(http.StatusBadRequest, errors.Errorf("Host %s is in status %s and not ready for install",
@@ -1171,6 +1175,11 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 }
 
 func (b *bareMetalInventory) refreshClusterHosts(ctx context.Context, cluster *common.Cluster, tx *gorm.DB, log logrus.FieldLogger) error {
+	err := b.setMajorityGroupForCluster(cluster.ID, tx)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to set cluster %s majority groups", cluster.ID.String())
+		return common.NewApiError(http.StatusInternalServerError, err)
+	}
 	for _, h := range cluster.Hosts {
 		var host models.Host
 		var err error
@@ -2169,7 +2178,10 @@ func (b *bareMetalInventory) refreshHostAndClusterStatuses(
 		}
 		err = common.NewApiError(http.StatusInternalServerError, err)
 	}()
-
+	err = b.setMajorityGroupForCluster(clusterID, db)
+	if err != nil {
+		return nil, err
+	}
 	err = b.refreshHostStatus(ctx, hostID, clusterID, db)
 	if err != nil {
 		return nil, err
@@ -2197,6 +2209,10 @@ func (b *bareMetalInventory) refreshHostStatus(
 	}
 
 	return nil
+}
+
+func (b *bareMetalInventory) setMajorityGroupForCluster(clusterID *strfmt.UUID, db *gorm.DB) error {
+	return b.clusterApi.SetConnectivityMajorityGroupsForCluster(*clusterID, db)
 }
 
 func (b *bareMetalInventory) refreshClusterStatus(

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1067,6 +1067,14 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 	})
 })
 
+func mockSetConnectivityMajorityGroupsForCluster(mockClusterApi *cluster.MockAPI) {
+	mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+}
+
+func mockSetConnectivityMajorityGroupsForClusterTimes(mockClusterApi *cluster.MockAPI, times int) {
+	mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(times)
+}
+
 var _ = Describe("cluster", func() {
 	masterHostId1 := strfmt.UUID(uuid.New().String())
 	masterHostId2 := strfmt.UUID(uuid.New().String())
@@ -1339,6 +1347,7 @@ var _ = Describe("cluster", func() {
 			})
 
 			It("pull-secret with newline", func() {
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				pullSecret := "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}" // #nosec
 				pullSecretWithNewline := pullSecret + " \n"
 				clusterID = strfmt.UUID(uuid.New().String())
@@ -1373,6 +1382,7 @@ var _ = Describe("cluster", func() {
 
 				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
 					ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1412,6 +1422,7 @@ var _ = Describe("cluster", func() {
 				})
 
 				updateCluster := func(httpProxy, httpsProxy, noProxy string) *common.Cluster {
+					mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1459,6 +1470,7 @@ var _ = Describe("cluster", func() {
 					mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+					mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1476,6 +1488,7 @@ var _ = Describe("cluster", func() {
 					mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+					mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1543,6 +1556,7 @@ var _ = Describe("cluster", func() {
 					fileName := fmt.Sprintf("%s/worker.ign", clusterID)
 					mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), fileName).Return(nil).Times(1)
 					mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+					mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1611,6 +1625,7 @@ var _ = Describe("cluster", func() {
 						mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
 						mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+						mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 						reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 							ClusterID: clusterID,
 							ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1676,6 +1691,7 @@ var _ = Describe("cluster", func() {
 						mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
 						mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+						mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 						reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 							ClusterID: clusterID,
 							ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1777,6 +1793,7 @@ var _ = Describe("cluster", func() {
 						mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
 						mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+						mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 						reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 							ClusterID: clusterID,
 							ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1847,6 +1864,7 @@ var _ = Describe("cluster", func() {
 						mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(9)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
 						mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(2)
+						mockSetConnectivityMajorityGroupsForClusterTimes(mockClusterApi, 3)
 						reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 							ClusterID: clusterID,
 							ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -1979,6 +1997,7 @@ var _ = Describe("cluster", func() {
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2014,6 +2033,7 @@ var _ = Describe("cluster", func() {
 				mockClusterPrepareForInstallationFailure(mockClusterApi)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2034,6 +2054,7 @@ var _ = Describe("cluster", func() {
 				mockHostPrepareForInstallationFailure(mockHostApi, 1)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2047,6 +2068,7 @@ var _ = Describe("cluster", func() {
 				mockHostPrepareForRefresh(mockHostApi)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationFalse(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				Expect(db.Model(&common.Cluster{Cluster: models.Cluster{ID: &clusterID}}).UpdateColumn("status", "insufficient").Error).To(Not(HaveOccurred()))
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
@@ -2069,6 +2091,7 @@ var _ = Describe("cluster", func() {
 				mockClusterApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("cluster has a error"))
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
 				})
@@ -2094,6 +2117,7 @@ var _ = Describe("cluster", func() {
 				mockHandlePreInstallationError(mockClusterApi, DoneChannel)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2116,6 +2140,7 @@ var _ = Describe("cluster", func() {
 				mockHandlePreInstallationError(mockClusterApi, DoneChannel)
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2139,6 +2164,7 @@ var _ = Describe("cluster", func() {
 				mockHostPrepareForInstallationSuccess(mockHostApi, 3)
 				setIsReadyForInstallationTrue(mockClusterApi)
 
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
 				})
@@ -2161,6 +2187,7 @@ var _ = Describe("cluster", func() {
 					Return([]*strfmt.UUID{&masterHostId1, &masterHostId2, &masterHostId3}, errors.Errorf("nop"))
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
+				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -3372,7 +3399,7 @@ var _ = Describe("Install Hosts test", func() {
 		bm = NewBareMetalInventory(db, getTestLog(), mockHostApi, mockClusterApi, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler())
 		body := &bytes.Buffer{}
 		request, _ = http.NewRequest("POST", "test", body)
-
+		mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 	})
 
 	AfterEach(func() {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1117,6 +1117,58 @@ func addInstallationRequirements(clusterId strfmt.UUID, db *gorm.DB) {
 	Expect(db.Model(&common.Cluster{Cluster: models.Cluster{ID: &clusterId}}).Updates(map[string]interface{}{"api_vip": "1.2.3.5", "ingress_vip": "1.2.3.6"}).Error).To(Not(HaveOccurred()))
 }
 
+func addInstallationRequirementsWithConnectivity(clusterId strfmt.UUID, db *gorm.DB, outgoingIpAddresses ...string) {
+	var hostId strfmt.UUID
+	var host models.Host
+	hostIds := []strfmt.UUID{
+		strfmt.UUID(uuid.New().String()),
+		strfmt.UUID(uuid.New().String()),
+		strfmt.UUID(uuid.New().String()),
+	}
+	for i := 0; i < 3; i++ {
+		hostId = hostIds[i]
+		otherIds := []strfmt.UUID{
+			hostIds[(i+1)%3],
+			hostIds[(i+2)%3],
+		}
+		makeL2Connectivity := func() []*models.L2Connectivity {
+			ret := make([]*models.L2Connectivity, 0)
+			for _, o := range outgoingIpAddresses {
+				ret = append(ret, &models.L2Connectivity{
+					Successful:        true,
+					OutgoingIPAddress: o,
+				})
+			}
+			return ret
+		}
+		connectivityReport := models.ConnectivityReport{
+			RemoteHosts: []*models.ConnectivityRemoteHost{
+				{
+					HostID:         otherIds[0],
+					L2Connectivity: makeL2Connectivity(),
+				},
+				{
+					HostID:         otherIds[1],
+					L2Connectivity: makeL2Connectivity(),
+				},
+			},
+		}
+		b, err := json.Marshal(&connectivityReport)
+		Expect(err).ToNot(HaveOccurred())
+		host = models.Host{
+			ID:           &hostId,
+			ClusterID:    clusterId,
+			Role:         models.HostRoleMaster,
+			Status:       swag.String("known"),
+			Inventory:    twoNetworksInventory(),
+			Connectivity: string(b),
+		}
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+	}
+	Expect(db.Model(&common.Cluster{Cluster: models.Cluster{ID: &clusterId}}).Updates(map[string]interface{}{"api_vip": "1.2.3.5", "ingress_vip": "1.2.3.6"}).Error).To(Not(HaveOccurred()))
+}
+
 func defaultInventory() string {
 	inventory := models.Inventory{
 		Interfaces: []*models.Interface{
@@ -1488,6 +1540,106 @@ var _ = Describe("SetVips", func() {
 	}
 	AfterEach(func() {
 		common.DeleteTestDB(db, dbName)
+	})
+})
+
+var _ = Describe("Majority groups", func() {
+	var (
+		dbIndex    int
+		clusterApi *Manager
+		db         *gorm.DB
+		id         strfmt.UUID
+		cluster    common.Cluster
+		ctrl       *gomock.Controller
+		mockEvents *events.MockHandler
+		dbName     = "cluster_majority_groups"
+	)
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB(dbName, &events.Event{})
+		dbIndex++
+		ctrl = gomock.NewController(GinkgoT())
+		mockEvents = events.NewMockHandler(ctrl)
+		dummy := &leader.DummyElector{}
+		clusterApi = NewManager(getDefaultConfig(), getTestLog().WithField("pkg", "cluster-monitor"), db,
+			mockEvents, nil, nil, dummy)
+
+		id = strfmt.UUID(uuid.New().String())
+		cluster = common.Cluster{Cluster: models.Cluster{
+			ID:                       &id,
+			Status:                   swag.String(models.ClusterStatusReady),
+			MachineNetworkCidr:       "1.2.3.0/24",
+			BaseDNSDomain:            "test.com",
+			PullSecretSet:            true,
+			ServiceNetworkCidr:       "1.2.4.0/24",
+			ClusterNetworkCidr:       "1.3.0.0/16",
+			ClusterNetworkHostPrefix: 24,
+		}}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+	})
+
+	setup := func(ips []string) {
+		addInstallationRequirementsWithConnectivity(id, db, ips...)
+
+		cluster = geCluster(*cluster.ID, db)
+		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusReady))
+		Expect(len(cluster.Hosts)).Should(Equal(3))
+	}
+	expect := func(networks ...string) {
+		c := getCluster(*cluster.ID, db)
+		majorityGroups := make(map[string][]strfmt.UUID)
+		Expect(json.Unmarshal([]byte(c.ConnectivityMajorityGroups), &majorityGroups)).ToNot(HaveOccurred())
+		Expect(majorityGroups).ToNot(BeEmpty())
+		for _, n := range []string{"1.2.3.0/24", "10.0.0.0/24"} {
+			group := majorityGroups[n]
+			if funk.ContainsString(networks, n) {
+				for _, h := range cluster.Hosts {
+					Expect(group).To(ContainElement(*h.ID))
+				}
+			} else {
+				Expect(group).To(BeEmpty())
+			}
+		}
+	}
+	Context("Set Majority groups", func() {
+		run := func(ips ...string) {
+			setup(ips)
+			Expect(clusterApi.SetConnectivityMajorityGroupsForCluster(id, db)).ToNot(HaveOccurred())
+		}
+		It("Empty", func() {
+			run()
+			expect()
+		})
+		It("Success", func() {
+			run("1.2.3.10")
+			expect("1.2.3.0/24")
+		})
+		It("Two networks", func() {
+			run("1.2.3.10", "10.0.0.15")
+			expect("1.2.3.0/24", "10.0.0.0/24")
+		})
+	})
+	Context("monitoring", func() {
+		run := func(ips ...string) {
+			setup(ips)
+			clusterApi.ClusterMonitoring()
+		}
+		It("Empty", func() {
+			run()
+			expect()
+		})
+		It("Success", func() {
+			run("1.2.3.10")
+			expect("1.2.3.0/24")
+		})
+		It("Two networks", func() {
+			run("1.2.3.10", "10.0.0.15")
+			expect("1.2.3.0/24", "10.0.0.0/24")
+		})
 	})
 })
 

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -461,3 +461,17 @@ func (mr *MockAPIMockRecorder) SetUploadControllerLogsAt(ctx, c, db interface{})
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUploadControllerLogsAt", reflect.TypeOf((*MockAPI)(nil).SetUploadControllerLogsAt), ctx, c, db)
 }
+
+// SetConnectivityMajorityGroupsForCluster mocks base method
+func (m *MockAPI) SetConnectivityMajorityGroupsForCluster(clusterID strfmt.UUID, db *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetConnectivityMajorityGroupsForCluster", clusterID, db)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetConnectivityMajorityGroupsForCluster indicates an expected call of SetConnectivityMajorityGroupsForCluster
+func (mr *MockAPIMockRecorder) SetConnectivityMajorityGroupsForCluster(clusterID, db interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectivityMajorityGroupsForCluster", reflect.TypeOf((*MockAPI)(nil).SetConnectivityMajorityGroupsForCluster), clusterID, db)
+}

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -110,6 +110,11 @@ func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCf
 			condition: v.isAPIVipConnected,
 			formatter: v.printAPIVipConnected,
 		},
+		{
+			id:        BelongsToMajorityGroup,
+			condition: v.belongsToMajorityGroup,
+			formatter: v.printBelongsToMajorityGroup,
+		},
 	}
 	return ret
 }

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -313,7 +313,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr),
-		If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected))
+		If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -12,23 +12,24 @@ import (
 type validationID models.HostValidationID
 
 const (
-	IsConnected          = validationID(models.HostValidationIDConnected)
-	HasInventory         = validationID(models.HostValidationIDHasInventory)
-	IsMachineCidrDefined = validationID(models.HostValidationIDMachineCidrDefined)
-	BelongsToMachineCidr = validationID(models.HostValidationIDBelongsToMachineCidr)
-	HasMinCPUCores       = validationID(models.HostValidationIDHasMinCPUCores)
-	HasMinValidDisks     = validationID(models.HostValidationIDHasMinValidDisks)
-	HasMinMemory         = validationID(models.HostValidationIDHasMinMemory)
-	HasCPUCoresForRole   = validationID(models.HostValidationIDHasCPUCoresForRole)
-	HasMemoryForRole     = validationID(models.HostValidationIDHasMemoryForRole)
-	IsHostnameUnique     = validationID(models.HostValidationIDHostnameUnique)
-	IsHostnameValid      = validationID(models.HostValidationIDHostnameValid)
-	IsAPIVipConnected    = validationID(models.HostValidationIDAPIVipConnected)
+	IsConnected            = validationID(models.HostValidationIDConnected)
+	HasInventory           = validationID(models.HostValidationIDHasInventory)
+	IsMachineCidrDefined   = validationID(models.HostValidationIDMachineCidrDefined)
+	BelongsToMachineCidr   = validationID(models.HostValidationIDBelongsToMachineCidr)
+	HasMinCPUCores         = validationID(models.HostValidationIDHasMinCPUCores)
+	HasMinValidDisks       = validationID(models.HostValidationIDHasMinValidDisks)
+	HasMinMemory           = validationID(models.HostValidationIDHasMinMemory)
+	HasCPUCoresForRole     = validationID(models.HostValidationIDHasCPUCoresForRole)
+	HasMemoryForRole       = validationID(models.HostValidationIDHasMemoryForRole)
+	IsHostnameUnique       = validationID(models.HostValidationIDHostnameUnique)
+	IsHostnameValid        = validationID(models.HostValidationIDHostnameValid)
+	IsAPIVipConnected      = validationID(models.HostValidationIDAPIVipConnected)
+	BelongsToMajorityGroup = validationID(models.HostValidationIDBelongsToMajorityGroup)
 )
 
 func (v validationID) category() (string, error) {
 	switch v {
-	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr, IsAPIVipConnected:
+	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr, IsAPIVipConnected, BelongsToMajorityGroup:
 		return "network", nil
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid:

--- a/internal/network/connectivity_groups.go
+++ b/internal/network/connectivity_groups.go
@@ -1,0 +1,300 @@
+package network
+
+import (
+	"encoding/json"
+	"net"
+	"sort"
+
+	"github.com/golang-collections/go-datastructures/bitarray"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/openshift/assisted-service/models"
+)
+
+type connectivityKey struct {
+	first, second int
+}
+
+type connectivityValue struct {
+	first2second, second2first bool
+}
+
+// Map for indicating if there is mutual connectivity between 2 hosts
+type connectivityMap map[connectivityKey]*connectivityValue
+
+func makeKey(from, to int) connectivityKey {
+	if from < to {
+		return connectivityKey{first: from, second: to}
+	} else {
+		return connectivityKey{first: to, second: from}
+	}
+}
+
+func (c connectivityMap) add(from, to int, connected bool) {
+	key := makeKey(from, to)
+	value, ok := c[key]
+	if !ok {
+		value = &connectivityValue{}
+		c[key] = value
+	}
+	if from == key.first {
+		value.first2second = connected
+	} else {
+		value.second2first = connected
+	}
+}
+
+func (c connectivityMap) isConnected(from, to int) bool {
+	value, ok := c[makeKey(from, to)]
+	return ok && value.first2second && value.second2first
+}
+
+/*
+ * connectivitySet is used to indicate that there is connectivity between at least one of the set members to the other members.
+ * The actual meaning of the specific instance depends on the context.
+ */
+type connectivitySet struct {
+	array   bitarray.BitArray
+	groupId groupId
+}
+
+func NewConnectivitySet(size int) *connectivitySet {
+	return &connectivitySet{array: bitarray.NewBitArray(uint64(size))}
+}
+
+func (c *connectivitySet) add(item int) error {
+	return c.array.SetBit(uint64(item))
+}
+
+func (c *connectivitySet) intersect(other *connectivitySet) *connectivitySet {
+	return &connectivitySet{
+		array: c.array.And(other.array),
+	}
+}
+
+func (c *connectivitySet) containsElement(id int) bool {
+	b, err := c.array.GetBit(uint64(id))
+	return err == nil && b
+}
+
+func (c *connectivitySet) equals(other *connectivitySet) bool {
+	return c.array.Equals(other.array)
+}
+
+func (c *connectivitySet) isSupersetOf(other *connectivitySet) bool {
+	intersection := c.intersect(other)
+	return intersection.equals(other)
+}
+
+func (c *connectivitySet) id() groupId {
+	if c.groupId == nil {
+		c.groupId = c.array.ToNums()
+	}
+	return c.groupId
+}
+
+func (c *connectivitySet) toList(hosts []*models.Host) []strfmt.UUID {
+	ret := make([]strfmt.UUID, 0)
+	for _, k := range c.id() {
+		ret = append(ret, *hosts[k].ID)
+	}
+	return ret
+}
+
+func (c *connectivitySet) len() int {
+	return len(c.id())
+}
+
+// groupId is used for unique sorting of a list containing connectivitySet elements
+type groupId []uint64
+
+func (g groupId) isLess(other groupId) bool {
+	if len(g) != len(other) {
+		return len(g) > len(other)
+	}
+	index := 0
+	for ; index != len(g) && g[index] == other[index]; index++ {
+	}
+	return index < len(g) && g[index] < other[index]
+}
+
+// Auxiliary type to find out if the contained set has a full mesh connectivity
+type connectivityGroup struct {
+	set   *connectivitySet
+	count int
+}
+
+// Unique list of connectivity group elements.  The uniqueness is by the set elements
+type connectivityGroupList struct {
+	groups []*connectivityGroup
+}
+
+func (c *connectivityGroupList) containsSet(cs *connectivitySet) bool {
+	for _, group := range c.groups {
+		if group.set.equals(cs) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *connectivityGroupList) addSet(cs *connectivitySet) {
+	if !c.containsSet(cs) {
+		c.groups = append(c.groups, &connectivityGroup{
+			set:   cs,
+			count: 0,
+		})
+	}
+}
+
+// Group candidate is the connectivity view of a single host (me)
+type groupCandidate struct {
+	set *connectivitySet
+	me  int
+}
+
+func createGroupList(groupCandidates []groupCandidate) connectivityGroupList {
+	var groupList connectivityGroupList
+
+	// First iteration - gather the sets
+	for _, candidate := range groupCandidates {
+
+		// All sets pending for insertion
+		pendingSets := make([]*connectivitySet, 0)
+
+		// Add the set of the current candidate to the pending list
+		pendingSets = append(pendingSets, candidate.set)
+		for _, group := range groupList.groups {
+
+			// Intersect the set of the current candidate with each member of the groupList.  The result is added to the
+			// Pending sets
+			set := candidate.set.intersect(group.set)
+			if set.len() >= 3 {
+				pendingSets = append(pendingSets, set)
+			}
+		}
+
+		// Add the sets in the pending list to the groupList
+		for _, set := range pendingSets {
+			groupList.addSet(set)
+		}
+	}
+
+	// Second iteration - Per groupList element. count the number of candidates that are part of that element.
+	// Since every candidate represents a host, if the number of participants == the set size, then there is a full
+	// mesh connectivity between the members
+	for _, candidate := range groupCandidates {
+		for _, cs := range groupList.groups {
+			if candidate.set.isSupersetOf(cs.set) && cs.set.containsElement(candidate.me) {
+				cs.count++
+			}
+		}
+	}
+	return groupList
+}
+
+func filterFullMeshGroups(groupList connectivityGroupList) []*connectivitySet {
+	ret := make([]*connectivitySet, 0)
+	for _, r := range groupList.groups {
+		// Add only sets with full mesh connectivity
+		if r.set.len() == r.count {
+			ret = append(ret, r.set)
+		}
+	}
+	return ret
+}
+
+// Create sorted list of connectivity sets.  The sort is by set size (descending)
+func createConnectivityGroups(groupCandidates []groupCandidate) []*connectivitySet {
+	groupList := createGroupList(groupCandidates)
+	ret := filterFullMeshGroups(groupList)
+
+	// Sort by set size descending, which means the largest group first.
+	sort.Slice(ret, func(i, j int) bool {
+		// If the sizes are equal then compare the contained elements of each set
+		return ret[i].id().isLess(ret[j].id())
+	})
+	return ret
+}
+
+/*
+ * Create group candidate for a specific host.  The group candidate contains a set with all the hosts it has
+ * connectivity to.
+ */
+func createHostGroupCandidate(hostIndex, numHosts int, cMap connectivityMap) groupCandidate {
+	set := NewConnectivitySet(numHosts)
+	_ = set.add(hostIndex)
+	for index := 0; index != numHosts; index++ {
+		if cMap.isConnected(hostIndex, index) {
+			_ = set.add(index)
+		}
+	}
+	return groupCandidate{
+		set: set,
+		me:  hostIndex,
+	}
+}
+
+/*
+ * Create connectivity map from host list.  It is the information if a host has connectivity to other host on specific
+ * CIDR (network)
+ */
+func createMachineCidrConnectivityMap(cidr string, hosts []*models.Host, idToIndex map[strfmt.UUID]int) (connectivityMap, error) {
+	ret := make(connectivityMap)
+	_, parsedCidr, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	for fromIndex, h := range hosts {
+		if h.Connectivity == "" {
+			continue
+		}
+		var connectivityReport models.ConnectivityReport
+		err = json.Unmarshal([]byte(h.Connectivity), &connectivityReport)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range connectivityReport.RemoteHosts {
+			for _, l2 := range r.L2Connectivity {
+				ip := net.ParseIP(l2.OutgoingIPAddress)
+				if ip != nil && parsedCidr.Contains(ip) && l2.Successful {
+					toIndex, ok := idToIndex[r.HostID]
+					if ok {
+						ret.add(fromIndex, toIndex, true)
+					}
+					break
+				}
+			}
+		}
+	}
+	return ret, nil
+}
+
+/*
+ * Crate majority for a cidr.  A majority group is a the largest group of hosts in a cluster that all of them have full mesh
+ * to the other group members.
+ * It is done by taking a sorted connectivity group list according to the group size, and from this group take the
+ * largest one
+ */
+func CreateMajorityGroup(cidr string, hosts []*models.Host) ([]strfmt.UUID, error) {
+	idToIndex := make(map[strfmt.UUID]int)
+	for i, h := range hosts {
+		idToIndex[*h.ID] = i
+	}
+	cMap, err := createMachineCidrConnectivityMap(cidr, hosts, idToIndex)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]groupCandidate, 0)
+	for hostIndex := range hosts {
+		candidate := createHostGroupCandidate(hostIndex, len(hosts), cMap)
+		if candidate.set.len() >= 3 {
+			candidates = append(candidates, candidate)
+		}
+	}
+	groups := createConnectivityGroups(candidates)
+	if len(groups) > 0 {
+		return groups[0].toList(hosts), nil
+	}
+	return make([]strfmt.UUID, 0), nil
+}

--- a/internal/network/connectivity_groups_test.go
+++ b/internal/network/connectivity_groups_test.go
@@ -1,0 +1,343 @@
+package network
+
+import (
+	"encoding/json"
+
+	"github.com/go-openapi/strfmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("connectivity groups", func() {
+
+	var (
+		hid1 strfmt.UUID = "11111111-1111-1111-1111-111111111111"
+		hid2 strfmt.UUID = "22222222-2222-2222-2222-222222222222"
+		hid3 strfmt.UUID = "33333333-3333-3333-3333-333333333333"
+		hid4 strfmt.UUID = "44444444-4444-4444-4444-444444444444"
+		hid5 strfmt.UUID = "55555555-5555-5555-5555-555555555555"
+		hid6 strfmt.UUID = "66666666-6666-6666-6666-666666666666"
+		hid7 strfmt.UUID = "77777777-7777-7777-7777-777777777777"
+	)
+
+	createL2 := func(outgoingIpAddress string, successful bool) *models.L2Connectivity {
+		return &models.L2Connectivity{
+			OutgoingIPAddress: outgoingIpAddress,
+			Successful:        successful,
+		}
+	}
+
+	createRemoteHost := func(id strfmt.UUID, l2s ...*models.L2Connectivity) *models.ConnectivityRemoteHost {
+		return &models.ConnectivityRemoteHost{
+			HostID:         id,
+			L2Connectivity: l2s,
+		}
+	}
+
+	createConnectiityReport := func(remoteHosts ...*models.ConnectivityRemoteHost) string {
+		report := models.ConnectivityReport{
+			RemoteHosts: remoteHosts,
+		}
+		b, err := json.Marshal(&report)
+		Expect(err).ToNot(HaveOccurred())
+		return string(b)
+	}
+
+	Context("connectivity groups", func() {
+		It("Empty", func() {
+			hosts := []*models.Host{
+				{
+					ID:           &hid1,
+					Connectivity: createConnectiityReport(),
+				},
+				{
+					ID:           &hid2,
+					Connectivity: createConnectiityReport(),
+				},
+				{
+					ID:           &hid3,
+					Connectivity: createConnectiityReport(),
+				},
+			}
+			ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal([]strfmt.UUID{}))
+		})
+		It("Empty 2", func() {
+			hosts := []*models.Host{
+				{
+					ID: &hid1,
+				},
+				{
+					ID: &hid2,
+				},
+				{
+					ID: &hid3,
+				},
+			}
+			ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal([]strfmt.UUID{}))
+		})
+	})
+	It("One with data", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID:           &hid2,
+				Connectivity: createConnectiityReport(),
+			},
+			{
+				ID:           &hid3,
+				Connectivity: createConnectiityReport(),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(Equal([]strfmt.UUID{}))
+	})
+	It("3 with data", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true))),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
+					createRemoteHost(hid2, createL2("1.2.3.6", true))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(3))
+		Expect(ret).To(ContainElement(hid1))
+		Expect(ret).To(ContainElement(hid2))
+		Expect(ret).To(ContainElement(hid3))
+	})
+	It("Different network", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true))),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("2.2.3.6", true)),
+					createRemoteHost(hid2, createL2("2.2.3.6", true))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(Equal([]strfmt.UUID{}))
+	})
+	It("3 with data, additional network", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true), createL2("2.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true)),
+					createRemoteHost(hid4, createL2("2.2.3.4", true)),
+				),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true), createL2("2.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true)),
+					createRemoteHost(hid4, createL2("2.2.3.4", true)),
+				),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true), createL2("2.2.3.6", true)),
+					createRemoteHost(hid2, createL2("1.2.3.6", true), createL2("2.2.3.5", true))),
+			},
+			{
+				ID: &hid4,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("2.2.3.6", true)),
+					createRemoteHost(hid2, createL2("2.2.3.6", true))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(3))
+		Expect(ret).To(ContainElement(hid1))
+		Expect(ret).To(ContainElement(hid2))
+		Expect(ret).To(ContainElement(hid3))
+		ret, err = CreateMajorityGroup("2.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(3))
+		Expect(ret).To(ContainElement(hid1))
+		Expect(ret).To(ContainElement(hid2))
+		Expect(ret).To(ContainElement(hid4))
+	})
+	It("7 - 2 groups", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true))),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
+					createRemoteHost(hid2, createL2("1.2.3.6", true))),
+			},
+			{
+				ID: &hid4,
+				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true)),
+				),
+			},
+			{
+				ID: &hid5,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid6,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid7,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(4))
+		Expect(ret).To(ContainElement(hid4))
+		Expect(ret).To(ContainElement(hid5))
+		Expect(ret).To(ContainElement(hid6))
+		Expect(ret).To(ContainElement(hid7))
+	})
+	It("7 - 1 direction missing", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true))),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
+					createRemoteHost(hid2, createL2("1.2.3.6", true))),
+			},
+			{
+				ID: &hid4,
+				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true)),
+				),
+			},
+			{
+				ID: &hid5,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid6,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid7,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", false))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(3))
+		Expect(ret).To(ContainElement(hid1))
+		Expect(ret).To(ContainElement(hid2))
+		Expect(ret).To(ContainElement(hid3))
+	})
+	It("7 - 2 directions missing", func() {
+		hosts := []*models.Host{
+			{
+				ID: &hid1,
+				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
+					createRemoteHost(hid3, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid2,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
+					createRemoteHost(hid3, createL2("1.2.3.5", true))),
+			},
+			{
+				ID: &hid3,
+				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
+					createRemoteHost(hid2, createL2("1.2.3.6", false))),
+			},
+			{
+				ID: &hid4,
+				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true)),
+				),
+			},
+			{
+				ID: &hid5,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid6,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid7, createL2("1.2.3.4", true))),
+			},
+			{
+				ID: &hid7,
+				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
+					createRemoteHost(hid5, createL2("1.2.3.4", true)),
+					createRemoteHost(hid6, createL2("1.2.3.4", false))),
+			},
+		}
+		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ret).To(HaveLen(3))
+		Expect(ret).To(ContainElement(hid4))
+		Expect(ret).To(ContainElement(hid5))
+		Expect(ret).To(ContainElement(hid6))
+	})
+})

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -194,10 +194,10 @@ func GetMachineCIDRHosts(log logrus.FieldLogger, cluster *common.Cluster) ([]*mo
 	return ret, nil
 }
 
-func GetClusterNetworks(cluster *common.Cluster, log logrus.FieldLogger) []string {
+func GetClusterNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
 	var err error
 	cidrs := make(map[string]bool)
-	for _, h := range cluster.Hosts {
+	for _, h := range hosts {
 		if h.Inventory != "" {
 			var inventory models.Inventory
 			err = json.Unmarshal([]byte(h.Inventory), &inventory)

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -39,6 +39,9 @@ type Cluster struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// Json formatted string containing the majority groups for conectivity checks.
+	ConnectivityMajorityGroups string `json:"connectivity_majority_groups,omitempty" gorm:"type:text"`
+
 	// controller logs collected at
 	// Format: date-time
 	ControllerLogsCollectedAt strfmt.DateTime `json:"controller_logs_collected_at,omitempty" gorm:"type:timestamp with time zone"`

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -58,6 +58,9 @@ const (
 
 	// HostValidationIDAPIVipConnected captures enum value "api-vip-connected"
 	HostValidationIDAPIVipConnected HostValidationID = "api-vip-connected"
+
+	// HostValidationIDBelongsToMajorityGroup captures enum value "belongs-to-majority-group"
+	HostValidationIDBelongsToMajorityGroup HostValidationID = "belongs-to-majority-group"
 )
 
 // for schema
@@ -65,7 +68,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","role-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","role-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3310,6 +3310,11 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "connectivity_majority_groups": {
+          "description": "Json formatted string containing the majority groups for conectivity checks.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "controller_logs_collected_at": {
           "type": "string",
           "format": "date-time",
@@ -4366,7 +4371,8 @@ func init() {
         "hostname-unique",
         "hostname-valid",
         "belongs-to-machine-cidr",
-        "api-vip-connected"
+        "api-vip-connected",
+        "belongs-to-majority-group"
       ]
     },
     "host_network": {
@@ -8146,6 +8152,11 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "connectivity_majority_groups": {
+          "description": "Json formatted string containing the majority groups for conectivity checks.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "controller_logs_collected_at": {
           "type": "string",
           "format": "date-time",
@@ -9184,7 +9195,8 @@ func init() {
         "hostname-unique",
         "hostname-valid",
         "belongs-to-machine-cidr",
-        "api-vip-connected"
+        "api-vip-connected",
+        "belongs-to-majority-group"
       ]
     },
     "host_network": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2780,6 +2780,11 @@ definitions:
         type: string
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"
+      connectivity_majority_groups:
+        type: string
+        description: Json formatted string containing the majority groups for conectivity checks.
+        x-go-custom-tag: gorm:"type:text"
+
   image_info:
     type: object
     properties:
@@ -3200,6 +3205,7 @@ definitions:
       - 'hostname-valid'
       - 'belongs-to-machine-cidr'
       - 'api-vip-connected'
+      - 'belongs-to-majority-group'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
- Add logic to calculate connectivity majority groups
- Add validation to check that host belongs to majority groups
/cc @ronniel1 
/cc @filanov 
/cc @avishayt 