### PR TITLE
OCPBUGSM-18587: updated stop installation cmd

### DIFF
--- a/internal/host/stopinstallation.go
+++ b/internal/host/stopinstallation.go
@@ -23,7 +23,7 @@ func (h *stopInstallationCmd) GetStep(ctx context.Context, host *models.Host) (*
 		StepType: models.StepTypeExecute,
 		Command:  "/usr/bin/podman",
 		Args: []string{
-			"kill", "--all",
+			"stop", "--all",
 		},
 	}
 	return step, nil


### PR DESCRIPTION
On installation cancelling, use podman stop instead of kill,
so containers that exited won't throw error. It will exit with
status code 0.