### PR TITLE
MGMT-2416 None bootstrap nodes failing on waiting for control plane

### DIFF
--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -43,13 +43,13 @@ func (m *Manager) HostMonitoring() {
 		if len(hosts) == 0 {
 			break
 		}
-		for _, host := range hosts {
+		for i := range hosts {
 			if !m.leaderElector.IsLeader() {
 				m.log.Debugf("Not a leader, exiting HostMonitoring")
 				return
 			}
-			if err := m.RefreshStatus(ctx, host, m.db); err != nil {
-				log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
+			if err := m.RefreshStatus(ctx, hosts[i], m.db); err != nil {
+				log.WithError(err).Errorf("failed to refresh host %s state", *hosts[i].ID)
 			}
 		}
 		offset += limit


### PR DESCRIPTION
Caused by iteration of the host pointer in the for statement
Seems that each RefreshStatus created in the for loop will reference the same host