### PR TITLE
MGMT-2211 Move next step runner command to host package

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -502,6 +502,11 @@ var _ = Describe("RegisterHost", func() {
 			AddEvent(gomock.Any(), clusterID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
 			Times(1)
 
+		bm.ServiceBaseURL = uuid.New().String()
+		bm.ServiceCACertPath = uuid.New().String()
+		bm.AgentDockerImg = uuid.New().String()
+		bm.SkipCertVerification = true
+
 		reply := bm.RegisterHost(ctx, installer.RegisterHostParams{
 			ClusterID: clusterID,
 			NewHostParams: &models.HostCreateParams{
@@ -511,6 +516,14 @@ var _ = Describe("RegisterHost", func() {
 		})
 		_, ok := reply.(*installer.RegisterHostCreated)
 		Expect(ok).Should(BeTrue())
+
+		By("register_returns_next_step_runner_command")
+		payload := reply.(*installer.RegisterHostCreated).Payload
+		Expect(payload).ShouldNot(BeNil())
+		command := payload.NextStepRunnerCommand
+		Expect(command).ShouldNot(BeNil())
+		Expect(command.Command).ShouldNot(BeEmpty())
+		Expect(command.Args).ShouldNot(BeEmpty())
 	})
 
 	It("host_api_failure", func() {
@@ -3480,5 +3493,27 @@ var _ = Describe("TestRegisterCluster", func() {
 			},
 		})
 		Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterBadRequest())))
+	})
+})
+
+var _ = Describe("extract image version", func() {
+
+	tag := uuid.New().String()
+	image := "quay.io/ocpmetal/image"
+
+	It("image contains name and tag", func() {
+		Expect(extractImageTag(fmt.Sprintf("%s:%s", image, tag))).Should(Equal(tag))
+	})
+
+	It("image does not contain tag", func() {
+		Expect(extractImageTag(image)).Should(Equal(image))
+	})
+
+	It("image contains multiple colons", func() {
+		Expect(extractImageTag(fmt.Sprintf("%s:%s:last_element", image, tag))).Should(Equal("last_element"))
+	})
+
+	It("image is an empty string", func() {
+		Expect(extractImageTag("")).Should(Equal(""))
 	})
 })

--- a/internal/host/nextsteprunnercmd.go
+++ b/internal/host/nextsteprunnercmd.go
@@ -1,0 +1,44 @@
+package host
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/assisted-service/internal/common"
+)
+
+type NextStepRunnerConfig struct {
+	ServiceBaseURL       string
+	ClusterID            string
+	HostID               string
+	UseCustomCACert      bool
+	NextStepRunnerImage  string
+	SkipCertVerification bool
+}
+
+func GetNextStepRunnerCommand(config *NextStepRunnerConfig) (string, *[]string) {
+
+	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--net=host",
+		"-v", "/dev:/dev:rw", "-v", "/opt:/opt:rw",
+		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+		"-v", "/var/log:/var/log:rw"}
+
+	if config.UseCustomCACert {
+		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", common.HostCACertPath, common.HostCACertPath))
+	}
+
+	arguments = append(arguments,
+		"--env", "PULL_SECRET_TOKEN",
+		"--env", "HTTP_PROXY", "--env", "HTTPS_PROXY", "--env", "NO_PROXY",
+		"--env", "http_proxy", "--env", "https_proxy", "--env", "no_proxy",
+		"--name", "next-step-runner", config.NextStepRunnerImage, "next_step_runner",
+		"--url", strings.TrimSpace(config.ServiceBaseURL), "--cluster-id", config.ClusterID, "--host-id", config.HostID,
+		"--agent-version", config.NextStepRunnerImage, fmt.Sprintf("--insecure=%s", strconv.FormatBool(config.SkipCertVerification)))
+
+	if config.UseCustomCACert {
+		arguments = append(arguments, "--cacert", common.HostCACertPath)
+	}
+
+	return "podman", &arguments
+}

--- a/internal/host/nextsteprunnercmd_test.go
+++ b/internal/host/nextsteprunnercmd_test.go
@@ -1,0 +1,97 @@
+package host
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/openshift/assisted-service/internal/common"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Format command for starting next step agent", func() {
+
+	var config NextStepRunnerConfig
+
+	clusterID := uuid.New().String()
+	hostID := uuid.New().String()
+	serviceURL := uuid.New().String()
+	image := uuid.New().String()
+	certVolume := fmt.Sprintf("%s:%s", common.HostCACertPath, common.HostCACertPath)
+
+	BeforeEach(func() {
+		config = NextStepRunnerConfig{
+			ClusterID:           clusterID,
+			HostID:              hostID,
+			NextStepRunnerImage: image,
+		}
+	})
+
+	It("standard formatting", func() {
+		config.ServiceBaseURL = serviceURL
+		command, args := GetNextStepRunnerCommand(&config)
+		Expect(command).Should(Equal("podman"))
+		assertValue("--cluster-id", clusterID, *args)
+		assertValue("--host-id", hostID, *args)
+		assertValue("--url", serviceURL, *args)
+		assertValue("--agent-version", image, *args)
+		Expect(*args).ShouldNot(ContainElement("--cacert"))
+		Expect(*args).ShouldNot(ContainElement(certVolume))
+		Expect(*args).Should(ContainElement("--insecure=false"))
+		Expect(*args).ShouldNot(ContainElement("--insecure=true"))
+	})
+
+	It("trim service URL", func() {
+		config.ServiceBaseURL = fmt.Sprintf(" %s ", serviceURL)
+		Expect(config.ServiceBaseURL).ShouldNot(Equal(serviceURL))
+		_, args := GetNextStepRunnerCommand(&config)
+		assertValue("--url", serviceURL, *args)
+	})
+
+	It("without custom CA certificate", func() {
+		config.UseCustomCACert = false
+		_, args := GetNextStepRunnerCommand(&config)
+		Expect(*args).ShouldNot(ContainElement("--cacert"))
+		Expect(*args).ShouldNot(ContainElement(certVolume))
+	})
+
+	It("with custom CA certificate", func() {
+		config.UseCustomCACert = true
+		_, args := GetNextStepRunnerCommand(&config)
+		assertValue("--cacert", common.HostCACertPath, *args)
+		Expect(*args).Should(ContainElement(certVolume))
+	})
+
+	It("certificate verification on", func() {
+		config.SkipCertVerification = false
+		_, args := GetNextStepRunnerCommand(&config)
+		Expect(*args).Should(ContainElement("--insecure=false"))
+		Expect(*args).ShouldNot(ContainElement("--insecure=true"))
+	})
+
+	It("certificate verification off", func() {
+		config.SkipCertVerification = true
+		_, args := GetNextStepRunnerCommand(&config)
+		Expect(*args).Should(ContainElement("--insecure=true"))
+		Expect(*args).ShouldNot(ContainElement("--insecure=false"))
+	})
+})
+
+func assertValue(key string, value string, args []string) {
+	i := search(key, args)
+	Expect(i).Should(BeNumerically(">", -1))
+	Expect(i).Should(BeNumerically("<", len(args)-1))
+	Expect(args[i+1]).Should(Equal(value))
+}
+
+func search(term string, s []string) int {
+
+	for i, v := range s {
+		if v == term {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -555,12 +555,12 @@ var _ = Describe("cluster install", func() {
 	}
 
 	register3nodes := func(clusterID strfmt.UUID) []*models.Host {
-		h1 := registerHost(clusterID)
+		h1 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h1, validHwInfo, "h1")
 		generateFAPostStepReply(h1, validFreeAddresses)
-		h2 := registerHost(clusterID)
+		h2 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h2, validHwInfo, "h2")
-		h3 := registerHost(clusterID)
+		h3 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h3, validHwInfo, "h3")
 
 		apiVip := "1.2.3.5"
@@ -580,12 +580,12 @@ var _ = Describe("cluster install", func() {
 	It("auto-assign", func() {
 		By("register 3 hosts all with master hw information cluster expected to be ready")
 		clusterID := *cluster.ID
-		h1 := registerHost(clusterID)
+		h1 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h1, validMasterHwInfo, "h1")
 		generateFAPostStepReply(h1, validFreeAddresses)
-		h2 := registerHost(clusterID)
+		h2 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h2, validMasterHwInfo, "h2")
-		h3 := registerHost(clusterID)
+		h3 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h3, validMasterHwInfo, "h3")
 		apiVip := "1.2.3.5"
 		ingressVip := "1.2.3.6"
@@ -607,9 +607,9 @@ var _ = Describe("cluster install", func() {
 			IgnoreStateInfo)
 
 		By("add two more hosts with master inventory expect the cluster to be ready")
-		h4 := registerHost(clusterID)
+		h4 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h4, validMasterHwInfo, "h4")
-		h5 := registerHost(clusterID)
+		h5 := &registerHost(clusterID).Host
 
 		waitForClusterState(ctx, clusterID, models.ClusterStatusInsufficient, defaultWaitForClusterStateTimeout,
 			IgnoreStateInfo)
@@ -621,7 +621,7 @@ var _ = Describe("cluster install", func() {
 			IgnoreStateInfo)
 
 		By("add hosts with worker inventory expect the cluster to be ready")
-		h6 := registerHost(clusterID)
+		h6 := &registerHost(clusterID).Host
 		waitForClusterState(ctx, clusterID, models.ClusterStatusInsufficient, defaultWaitForClusterStateTimeout,
 			IgnoreStateInfo)
 
@@ -894,7 +894,7 @@ var _ = Describe("cluster install", func() {
 		// will not be ready of all the hosts are not ready.
 		//It("installation_conflicts", func() {
 		//	By("try to install host with host without a role")
-		//	host := registerHost(clusterID)
+		//	host := &registerHost(clusterID).Host
 		//	generateHWPostStepReply(host, validHwInfo, "host")
 		//	_, err := userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
 		//	Expect(reflect.TypeOf(err)).To(Equal(reflect.TypeOf(installer.NewInstallClusterConflict())))
@@ -1365,7 +1365,7 @@ var _ = Describe("cluster install", func() {
 			})
 			It("[only_k8s]cancel installation with a disabled host", func() {
 				By("register a new worker")
-				disabledHost := registerHost(clusterID)
+				disabledHost := &registerHost(clusterID).Host
 				generateHWPostStepReply(ctx, disabledHost, validHwInfo, "hostname")
 				generateFAPostStepReply(disabledHost, validFreeAddresses)
 				_, err := userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
@@ -1540,7 +1540,7 @@ var _ = Describe("cluster install", func() {
 							Expect(err).NotTo(HaveOccurred())
 						}
 					}
-					h := registerHost(clusterID)
+					h := &registerHost(clusterID).Host
 					generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 					generateFAPostStepReply(h, validFreeAddresses)
 					_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
@@ -1632,7 +1632,7 @@ var _ = Describe("cluster install", func() {
 			})
 			It("[only_k8s]reset cluster with a disabled host", func() {
 				By("register a new worker")
-				disabledHost := registerHost(clusterID)
+				disabledHost := &registerHost(clusterID).Host
 				generateHWPostStepReply(ctx, disabledHost, validHwInfo, "hostname")
 				generateFAPostStepReply(disabledHost, validFreeAddresses)
 				_, err := userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
@@ -1693,7 +1693,7 @@ var _ = Describe("cluster install", func() {
 
 			It("[only_k8s]reset cluster with hosts after reboot and one disabled host", func() {
 				By("register a new worker")
-				disabledHost := registerHost(clusterID)
+				disabledHost := &registerHost(clusterID).Host
 				generateHWPostStepReply(ctx, disabledHost, validHwInfo, "hostname")
 				generateFAPostStepReply(disabledHost, validFreeAddresses)
 				_, err := userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
@@ -1758,7 +1758,7 @@ var _ = Describe("cluster install", func() {
 
 		hosts := register3nodes(clusterID)
 
-		h4 := registerHost(clusterID)
+		h4 := &registerHost(clusterID).Host
 
 		apiVip := "1.2.3.5"
 		ingressVip := "1.2.3.6"
@@ -1802,11 +1802,11 @@ var _ = Describe("cluster install", func() {
 		clusterID := *cluster.ID
 		waitForClusterState(ctx, clusterID, models.ClusterStatusPendingForInput, 60*time.Second, clusterPendingForInputStateInfo)
 
-		wh1 := registerHost(clusterID)
+		wh1 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, wh1, validHwInfo, "wh1")
-		wh2 := registerHost(clusterID)
+		wh2 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, wh2, validHwInfo, "wh2")
-		wh3 := registerHost(clusterID)
+		wh3 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, wh3, validHwInfo, "wh3")
 
 		apiVip := "1.2.3.5"
@@ -1836,12 +1836,12 @@ var _ = Describe("cluster install", func() {
 		Expect(len(clusterReply.Payload.HostNetworks)).To(Equal(1))
 		Expect(clusterReply.Payload.HostNetworks[0].Cidr).To(Equal("1.2.3.0/24"))
 
-		mh1 := registerHost(clusterID)
+		mh1 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, mh1, validHwInfo, "mh1")
 		generateFAPostStepReply(mh1, validFreeAddresses)
-		mh2 := registerHost(clusterID)
+		mh2 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, mh2, validHwInfo, "mh2")
-		mh3 := registerHost(clusterID)
+		mh3 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, mh3, validHwInfo, "mh3")
 		clusterReply, _ = userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{
 			ClusterID: clusterID,
@@ -1943,7 +1943,7 @@ var _ = Describe("cluster install", func() {
 			},
 			Timestamp: 1601853088,
 		}
-		h1 := registerHost(clusterID)
+		h1 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h1, hwInfo, "h1")
 		generateFAPostStepReply(h1, validFreeAddresses)
 		apiVip := "1.2.3.8"
@@ -1960,11 +1960,11 @@ var _ = Describe("cluster install", func() {
 		waitForHostState(ctx, clusterID, *h1.ID, models.HostStatusKnown, defaultWaitForClusterStateTimeout)
 
 		By("Register 3 more hosts with valid hw info")
-		h2 := registerHost(clusterID)
+		h2 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h2, validHwInfo, "h2")
-		h3 := registerHost(clusterID)
+		h3 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h3, validHwInfo, "h3")
-		h4 := registerHost(clusterID)
+		h4 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h4, validHwInfo, "h4")
 
 		_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
@@ -1997,7 +1997,7 @@ var _ = Describe("cluster install", func() {
 		Expect(h1.RequestedHostname).Should(Equal("h1"))
 
 		By("Registering host with same hostname")
-		h4 := registerHost(clusterID)
+		h4 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h4, validHwInfo, "h1")
 		h4 = getHost(clusterID, *h4.ID)
 		waitForHostState(ctx, clusterID, *h1.ID, "insufficient", 60*time.Second)
@@ -2020,7 +2020,7 @@ var _ = Describe("cluster install", func() {
 		Expect(err).Should(HaveOccurred())
 
 		By("Registering one more host with same hostname")
-		disabledHost := registerHost(clusterID)
+		disabledHost := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, disabledHost, validHwInfo, "h1")
 		disabledHost = getHost(clusterID, *disabledHost.ID)
 		waitForHostState(ctx, clusterID, *disabledHost.ID, models.HostStatusInsufficient,
@@ -2167,7 +2167,7 @@ var _ = Describe("cluster install", func() {
 
 		// register new host with the same name in inventory
 		By("Registering new host with same hostname as in node's inventory")
-		h4 := registerHost(clusterID)
+		h4 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h4, validHwInfo, "h3")
 		h4 = getHost(clusterID, *h4.ID)
 		waitForHostState(ctx, clusterID, *h4.ID, models.HostStatusInsufficient, time.Minute)
@@ -2178,7 +2178,7 @@ var _ = Describe("cluster install", func() {
 		Expect(err).Should(HaveOccurred())
 
 		By("Registering new host with same hostname as in node's requested_hostname")
-		h5 := registerHost(clusterID)
+		h5 := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, h5, validHwInfo, "reqh0")
 		h5 = getHost(clusterID, *h5.ID)
 		waitForHostState(ctx, clusterID, *h5.ID, models.HostStatusInsufficient, time.Minute)
@@ -2318,7 +2318,7 @@ func registerHostsAndSetRoles(clusterID strfmt.UUID, numHosts int) []*models.Hos
 	}
 	for i := 0; i < numHosts; i++ {
 		hostname := fmt.Sprintf("h%d", i)
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, host, validHwInfo, hostname)
 		generateFAPostStepReply(host, validFreeAddresses)
 		var role models.HostRoleUpdateParams
@@ -2391,7 +2391,7 @@ func registerHostsAndSetRolesDHCP(clusterID strfmt.UUID, numHosts int) []*models
 	}
 	for i := 0; i < numHosts; i++ {
 		hostname := fmt.Sprintf("h%d", i)
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		generateHWPostStepReply(ctx, host, validHwInfo, hostname)
 		var role models.HostRoleUpdateParams
 		if i < 3 {

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Day2 cluster tests", func() {
 	}
 
 	It("cluster CRUD", func() {
-		_ = registerHost(clusterID)
+		_ = &registerHost(clusterID).Host
 		Expect(err).NotTo(HaveOccurred())
 		getReply, err1 := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 		Expect(err1).NotTo(HaveOccurred())
@@ -96,8 +96,8 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("cluster update hostname", func() {
-		host1 := registerHost(clusterID)
-		host2 := registerHost(clusterID)
+		host1 := &registerHost(clusterID).Host
+		host2 := &registerHost(clusterID).Host
 
 		_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
 			ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -116,7 +116,7 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check host states - one node", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 
 		By("checking discovery state")
@@ -138,9 +138,9 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check host states - two nodes", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h1 := getHost(clusterID, *host.ID)
-		host = registerHost(clusterID)
+		host = &registerHost(clusterID).Host
 		h2 := getHost(clusterID, *host.ID)
 
 		By("checking discovery state")
@@ -173,7 +173,7 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check installation - one node", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
@@ -193,7 +193,7 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check installation - one node", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
@@ -215,9 +215,9 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check installation - 2 nodes", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h1 := getHost(clusterID, *host.ID)
-		host = registerHost(clusterID)
+		host = &registerHost(clusterID).Host
 		h2 := getHost(clusterID, *host.ID)
 
 		generateHWPostStepReply(ctx, h1, validHwInfo, "hostname1")
@@ -259,9 +259,9 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check installation - 0 nodes", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h1 := getHost(clusterID, *host.ID)
-		host = registerHost(clusterID)
+		host = &registerHost(clusterID).Host
 		h2 := getHost(clusterID, *host.ID)
 
 		generateHWPostStepReply(ctx, h1, validHwInfo, "hostname1")
@@ -285,7 +285,7 @@ var _ = Describe("Day2 cluster tests", func() {
 	})
 
 	It("check installation - node registers after reboot", func() {
-		host := registerHost(clusterID)
+		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -27,12 +27,12 @@ func strToUUID(s string) *strfmt.UUID {
 	return &u
 }
 
-func registerHost(clusterID strfmt.UUID) *models.Host {
+func registerHost(clusterID strfmt.UUID) *models.HostRegistrationResponse {
 	uuid := strToUUID(uuid.New().String())
 	return registerHostByUUID(clusterID, *uuid)
 }
 
-func registerHostByUUID(clusterID, hostID strfmt.UUID) *models.Host {
+func registerHostByUUID(clusterID, hostID strfmt.UUID) *models.HostRegistrationResponse {
 	host, err := agentBMClient.Installer.RegisterHost(context.Background(), &installer.RegisterHostParams{
 		ClusterID: clusterID,
 		NewHostParams: &models.HostCreateParams{
@@ -40,7 +40,7 @@ func registerHostByUUID(clusterID, hostID strfmt.UUID) *models.Host {
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
-	return &host.GetPayload().Host
+	return host.GetPayload()
 }
 
 func getHost(clusterID, hostID strfmt.UUID) *models.Host {


### PR DESCRIPTION
Following review comments, moving the command for running the next-step agent to the `host` package