### PR TITLE
NO-ISSUE Use golang images from quay to avoid docker rate limiting

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,4 +1,4 @@
-FROM golang:1.14.3
+FROM quay.io/app-sre/golang:1.14.3
 
 ENV GO111MODULE=on
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM        golang:1.14.3
+FROM        quay.io/app-sre/golang:1.14.3
 
 ENV         GO111MODULE=on
 


### PR DESCRIPTION
This was causing failures like this in the app-sre test suite:
```
 + ./pr_check.sh
 Sending build context to Docker daemon  49.66MB

 Step 1/8 : FROM        golang:1.14.3
 Get https://registry-1.docker.io/v2/: dial tcp 127.0.0.0:443: connect: network is unreachable
```

Here's one example https://ci.ext.devshift.net/job/openshift-assisted-service-gh-pr-check/1455/console