### PR TITLE
MGMT-2448 Add installer image caching to host discovery

### DIFF
--- a/internal/host/downloadinstallercmd.go
+++ b/internal/host/downloadinstallercmd.go
@@ -1,0 +1,47 @@
+package host
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+type downloadInstallerCmd struct {
+	baseCmd
+	instructionConfig InstructionConfig
+}
+
+func NewDownloadInstallerCmd(log logrus.FieldLogger, cfg InstructionConfig) *downloadInstallerCmd {
+	return &downloadInstallerCmd{
+		baseCmd:           baseCmd{log: log},
+		instructionConfig: cfg,
+	}
+}
+
+func (d *downloadInstallerCmd) GetStep(ctx context.Context, host *models.Host) (*models.Step, error) {
+	step := &models.Step{}
+	step.StepType = models.StepTypeExecute
+	step.Command = "timeout"
+
+	cmdArgsTmpl := "until podman pull {{.INSTALLER}}; do sleep 1; done"
+
+	data := map[string]string{
+		"INSTALLER": d.instructionConfig.InstallerImage,
+	}
+
+	t, err := template.New("cmd").Parse(cmdArgsTmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := &bytes.Buffer{}
+	if err := t.Execute(buf, data); err != nil {
+		return nil, err
+	}
+	step.Args = []string{"15m", "bash", "-c", buf.String()}
+
+	return step, nil
+}

--- a/internal/host/downloadinstallercmd_test.go
+++ b/internal/host/downloadinstallercmd_test.go
@@ -1,0 +1,37 @@
+package host
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kelseyhightower/envconfig"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("downloadInstallerCmd", func() {
+	var (
+		ctx       = context.Background()
+		host      models.Host
+		invCmd    *downloadInstallerCmd
+		stepReply *models.Step
+		stepErr   error
+		cfg       InstructionConfig
+	)
+
+	BeforeEach(func() {
+		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
+		invCmd = NewDownloadInstallerCmd(getTestLog(), cfg)
+	})
+
+	It("get_step", func() {
+		stepReply, stepErr = invCmd.GetStep(ctx, &host)
+		Expect(stepReply.StepType).To(Equal(models.StepTypeExecute))
+		Expect(stepErr).ShouldNot(HaveOccurred())
+		Expect(stepReply.Command).Should(Equal("timeout"))
+		expectedArgs := []string{"15m", "bash", "-c",
+			fmt.Sprintf("until podman pull %s; do sleep 1; done", cfg.InstallerImage)}
+		Expect(stepReply.Args).Should(Equal(expectedArgs))
+	})
+})

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -65,6 +65,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	stopCmd := NewStopInstallationCmd(log, instructionConfig)
 	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.DhcpLeaseAllocatorImage, db)
 	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.APIVIPConnectivityCheckImage, instructionConfig.SupportL2)
+	downloadInstallerCmd := NewDownloadInstallerCmd(log, instructionConfig)
 
 	return &InstructionManager{
 		log: log,
@@ -73,7 +74,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusKnown:                    {[]CommandGetter{connectivityCmd, freeAddressesCmd, dhcpAllocateCmd, inventoryCmd}, defaultNextInstructionInSec},
 			models.HostStatusInsufficient:             {[]CommandGetter{inventoryCmd, connectivityCmd, freeAddressesCmd, dhcpAllocateCmd}, defaultNextInstructionInSec},
 			models.HostStatusDisconnected:             {[]CommandGetter{inventoryCmd}, defaultBackedOffInstructionInSec},
-			models.HostStatusDiscovering:              {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec},
+			models.HostStatusDiscovering:              {[]CommandGetter{inventoryCmd, downloadInstallerCmd}, defaultNextInstructionInSec},
 			models.HostStatusPendingForInput:          {[]CommandGetter{inventoryCmd, connectivityCmd, freeAddressesCmd, dhcpAllocateCmd}, defaultNextInstructionInSec},
 			models.HostStatusInstalling:               {[]CommandGetter{installCmd, dhcpAllocateCmd}, defaultBackedOffInstructionInSec},
 			models.HostStatusInstallingInProgress:     {[]CommandGetter{dhcpAllocateCmd}, defaultNextInstructionInSec},
@@ -87,7 +88,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusKnown:                {[]CommandGetter{connectivityCmd, apivipConnectivityCmd}, defaultNextInstructionInSec},
 			models.HostStatusInsufficient:         {[]CommandGetter{inventoryCmd, connectivityCmd, apivipConnectivityCmd}, defaultNextInstructionInSec},
 			models.HostStatusDisconnected:         {[]CommandGetter{inventoryCmd}, defaultBackedOffInstructionInSec},
-			models.HostStatusDiscovering:          {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec},
+			models.HostStatusDiscovering:          {[]CommandGetter{inventoryCmd, downloadInstallerCmd}, defaultNextInstructionInSec},
 			models.HostStatusPendingForInput:      {[]CommandGetter{inventoryCmd, connectivityCmd, apivipConnectivityCmd}, defaultNextInstructionInSec},
 			models.HostStatusInstalling:           {[]CommandGetter{installCmd}, defaultBackedOffInstructionInSec},
 			models.HostStatusInstallingInProgress: {[]CommandGetter{}, defaultNextInstructionInSec},

--- a/internal/host/instructionmanager_test.go
+++ b/internal/host/instructionmanager_test.go
@@ -67,7 +67,7 @@ var _ = Describe("instructionmanager", func() {
 			})
 			It("discovering", func() {
 				checkStepsByState(models.HostStatusDiscovering, &host, db, mockEvents, instMng, hwValidator, cnValidator, ctx,
-					[]models.StepType{models.StepTypeInventory})
+					[]models.StepType{models.StepTypeInventory, models.StepTypeExecute})
 			})
 			It("known", func() {
 				checkStepsByState(models.HostStatusKnown, &host, db, mockEvents, instMng, hwValidator, cnValidator, ctx,
@@ -117,7 +117,7 @@ var _ = Describe("instructionmanager", func() {
 			})
 			It("discovering", func() {
 				checkStepsByState(models.HostStatusDiscovering, &host, db, mockEvents, instMng, hwValidator, cnValidator, ctx,
-					[]models.StepType{models.StepTypeInventory})
+					[]models.StepType{models.StepTypeInventory, models.StepTypeExecute})
 			})
 			It("known", func() {
 				checkStepsByState(models.HostStatusKnown, &host, db, mockEvents, instMng, hwValidator, cnValidator, ctx,
@@ -168,8 +168,10 @@ var _ = Describe("instructionmanager", func() {
 
 })
 
-func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents *events.MockHandler, instMng *InstructionManager, mockValidator *hardware.MockValidator, mockConnecitvity *connectivity.MockValidator, ctx context.Context,
-	expectedStepTypes []models.StepType) {
+func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents *events.MockHandler,
+	instMng *InstructionManager, mockValidator *hardware.MockValidator, mockConnectivity *connectivity.MockValidator,
+	ctx context.Context, expectedStepTypes []models.StepType) {
+
 	mockEvents.EXPECT().AddEvent(gomock.Any(), host.ClusterID, host.ID, hostutil.GetEventSeverityFromHostStatus(state), gomock.Any(), gomock.Any())
 	updateReply, updateErr := updateHostStatus(ctx, getTestLog(), db, mockEvents, host.ClusterID, *host.ID, *host.Status, state, "")
 	ExpectWithOffset(1, updateErr).ShouldNot(HaveOccurred())
@@ -184,7 +186,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 	mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(disks, nil).AnyTimes()
 	if funk.Contains(expectedStepTypes, models.StepTypeConnectivityCheck) {
-		mockConnecitvity.EXPECT().GetHostValidInterfaces(gomock.Any()).Return([]*models.Interface{
+		mockConnectivity.EXPECT().GetHostValidInterfaces(gomock.Any()).Return([]*models.Interface{
 			{
 				Name: "eth0",
 				IPV4Addresses: []string{


### PR DESCRIPTION
Added download of the installer image in order to cache it for the installtion.
The command have a timeout of 15 minuts and will try to download the image during this period.

Images list from one of the hosts before installation:
```
sudo podman images
REPOSITORY                                  TAG      IMAGE ID       CREATED        SIZE
quay.io/ocpmetal/assisted-installer-agent   latest   10b6aace1fab   9 hours ago    473 MB
quay.io/ocpmetal/assisted-installer         latest   4cc8e21c65d5   12 hours ago   69.9 MB
```
Passed test-infra