### PR TITLE
MGMT-2466 Make the override columns text and add migrations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	golang.org/x/sys v0.0.0-20200909081042-eff7692f9009 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200914190812-8f9ed77dd8e5 // indirect
+	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.3.0
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.33.1/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -233,6 +234,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
+github.com/denisenkom/go-mssqldb v0.0.0-20181014144952-4e0d7dc8888f/go.mod h1:xN/JuLBIz4bjkxNmByTiV1IbhfnYb6oo99phBn4Eqhc=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
@@ -453,6 +455,7 @@ github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhD
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -626,10 +629,13 @@ github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80s
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jessevdk/go-flags v0.0.0-20180331124232-1c38ed7ad0cc/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/gorm v1.9.2/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
 github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
+github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3/go.mod h1:oHTiXerJ20+SfYcrdlBO7rzZRJWGwSTQ0iUY2jI6Gfc=
 github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
 github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -640,6 +646,7 @@ github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeY
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -1105,6 +1112,7 @@ goji.io v2.0.2+incompatible/go.mod h1:sbqFwrtqZACxLBTQcdgVjFh54yGVCvwq8+w49MVMMI
 golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -1500,6 +1508,8 @@ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
+gopkg.in/gormigrate.v1 v1.6.0 h1:XpYM6RHQPmzwY7Uyu+t+xxMXc86JYFJn4nEc9HzQjsI=
+gopkg.in/gormigrate.v1 v1.6.0/go.mod h1:Lf00lQrHqfSYWiTtPcyQabsDdM6ejZaMgV0OU6JMSlw=
 gopkg.in/gorp.v1 v1.7.2/go.mod h1:Wo3h+DBQZIxATwftsglhdD/62zRFPhGhTiu5jUJmCaw=
 gopkg.in/imdario/mergo.v0 v0.3.7/go.mod h1:9qPP6AGrlC1G2PTNXko614FwGZvorN7MiBU0Eppok+U=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/migrations"
 	"github.com/openshift/assisted-service/models"
 	"github.com/ory/dockertest/v3"
 )
@@ -91,6 +92,9 @@ func PrepareTestDB(dbName string, extrasSchemas ...interface{}) *gorm.DB {
 	Expect(err).ShouldNot(HaveOccurred())
 	// db = db.Debug()
 	db.AutoMigrate(&models.Host{}, &Cluster{})
+	err = migrations.Migrate(db)
+	Expect(err).ShouldNot(HaveOccurred())
+
 	if len(extrasSchemas) > 0 {
 		for _, schema := range extrasSchemas {
 			db = db.AutoMigrate(schema)

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/assisted-service/internal/migrations"
 	"github.com/openshift/assisted-service/models"
 	"github.com/ory/dockertest/v3"
 )
@@ -92,8 +91,6 @@ func PrepareTestDB(dbName string, extrasSchemas ...interface{}) *gorm.DB {
 	Expect(err).ShouldNot(HaveOccurred())
 	// db = db.Debug()
 	db.AutoMigrate(&models.Host{}, &Cluster{})
-	err = migrations.Migrate(db)
-	Expect(err).ShouldNot(HaveOccurred())
 
 	if len(extrasSchemas) > 0 {
 		for _, schema := range extrasSchemas {

--- a/internal/migrations/20201019194303_change_overrides_to_text.go
+++ b/internal/migrations/20201019194303_change_overrides_to_text.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/models"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func changeOverridesToText() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		return tx.Model(&models.Cluster{}).ModifyColumn("install_config_overrides", "text").Error
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		return tx.Model(&models.Cluster{}).ModifyColumn("install_config_overrides", "varchar(2048)").Error
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20201019194303",
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/20201019194303_change_overrides_to_text.go
+++ b/internal/migrations/20201019194303_change_overrides_to_text.go
@@ -17,7 +17,7 @@ func changeOverridesToText() *gormigrate.Migration {
 
 	return &gormigrate.Migration{
 		ID:       "20201019194303",
-		Migrate:  migrate,
-		Rollback: rollback,
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
 	}
 }

--- a/internal/migrations/20201019194303_change_overrides_to_text_test.go
+++ b/internal/migrations/20201019194303_change_overrides_to_text_test.go
@@ -1,0 +1,88 @@
+package migrations
+
+import (
+	"errors"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/events"
+	"github.com/openshift/assisted-service/models"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	gormigrate "gopkg.in/gormigrate.v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("changeOverridesToText", func() {
+	var (
+		db        *gorm.DB
+		gm        *gormigrate.Gormigrate
+		clusterID strfmt.UUID
+		overrides string
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB("change_overrides_to_text", &events.Event{})
+
+		overrides = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster := common.Cluster{Cluster: models.Cluster{
+			ID:                      &clusterID,
+			IgnitionConfigOverrides: overrides,
+		}}
+		err := db.Create(&cluster).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, all())
+		err = gm.MigrateTo("20201019194303")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Migrates down and up", func() {
+		t, err := columnType(db)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectOverride(db, clusterID.String(), overrides)
+
+		err = gm.RollbackMigration(changeOverridesToText())
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = columnType(db)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("VARCHAR"))
+		expectOverride(db, clusterID.String(), overrides)
+
+		err = gm.MigrateTo("20201019194303")
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = columnType(db)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectOverride(db, clusterID.String(), overrides)
+	})
+})
+
+func columnType(db *gorm.DB) (string, error) {
+	rows, err := db.Model(&common.Cluster{}).Rows()
+	Expect(err).NotTo(HaveOccurred())
+
+	colTypes, err := rows.ColumnTypes()
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, colType := range colTypes {
+		if colType.Name() == "install_config_overrides" {
+			return colType.DatabaseTypeName(), nil
+		}
+	}
+	return "", errors.New("Failed to find install_config_overrides column in clusters")
+}
+
+func expectOverride(db *gorm.DB, clusterID string, override string) {
+	var c common.Cluster
+	err := db.First(&c, "id = ?", clusterID).Error
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(c.IgnitionConfigOverrides).To(Equal(override))
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"sort"
+
+	"github.com/jinzhu/gorm"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func Migrate(db *gorm.DB) error {
+	return gormigrate.New(db, gormigrate.DefaultOptions, all()).Migrate()
+}
+
+func all() []*gormigrate.Migration {
+	allMigrations := []*gormigrate.Migration{
+		changeOverridesToText(),
+	}
+
+	sort.SliceStable(allMigrations, func(i, j int) bool { return allMigrations[i].ID < allMigrations[j].ID })
+
+	return allMigrations
+}

--- a/internal/migrations/migrations_suite_test.go
+++ b/internal/migrations/migrations_suite_test.go
@@ -1,0 +1,13 @@
+package migrations_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrations(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Migrations Suite")
+}

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/events"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Migrate", func() {
+	It("Succeeds", func() {
+		db := common.PrepareTestDB("migration_test", &events.Event{})
+		err := Migrate(db)
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -76,7 +76,7 @@ type Cluster struct {
 	ID *strfmt.UUID `json:"id" gorm:"primary_key"`
 
 	// Json formatted string containing the user overrides for the initial ignition config
-	IgnitionConfigOverrides string `json:"ignition_config_overrides,omitempty"`
+	IgnitionConfigOverrides string `json:"ignition_config_overrides,omitempty" gorm:"type:text"`
 
 	// ignition generator version
 	IgnitionGeneratorVersion string `json:"ignition_generator_version,omitempty"`
@@ -94,7 +94,7 @@ type Cluster struct {
 	InstallCompletedAt strfmt.DateTime `json:"install_completed_at,omitempty" gorm:"type:timestamp with time zone;default:'2000-01-01 00:00:00z'"`
 
 	// JSON-formatted string containing the user overrides for the install-config.yaml file.
-	InstallConfigOverrides string `json:"install_config_overrides,omitempty" gorm:"type:varchar(2048)"`
+	InstallConfigOverrides string `json:"install_config_overrides,omitempty" gorm:"type:text"`
 
 	// The time that this cluster started installation.
 	// Format: date-time

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3371,6 +3371,7 @@ func init() {
         "ignition_config_overrides": {
           "description": "Json formatted string containing the user overrides for the initial ignition config",
           "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}"
         },
         "ignition_generator_version": {
@@ -3394,7 +3395,7 @@ func init() {
         "install_config_overrides": {
           "description": "JSON-formatted string containing the user overrides for the install-config.yaml file.",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\"",
+          "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
         },
         "install_started_at": {
@@ -8227,6 +8228,7 @@ func init() {
         "ignition_config_overrides": {
           "description": "Json formatted string containing the user overrides for the initial ignition config",
           "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}"
         },
         "ignition_generator_version": {
@@ -8250,7 +8252,7 @@ func init() {
         "install_config_overrides": {
           "description": "JSON-formatted string containing the user overrides for the install-config.yaml file.",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\"",
+          "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
         },
         "install_started_at": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2781,11 +2781,12 @@ definitions:
         description: JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
         x-go-custom-tag: gorm:"type:varchar(2048)"
       install_config_overrides:
+        x-go-custom-tag: gorm:"type:text"
         type: string
         description: JSON-formatted string containing the user overrides for the install-config.yaml file.
         example: '{"networking":{"networkType": "OVN-Kubernetes"},"fips":true}'
-        x-go-custom-tag: gorm:"type:varchar(2048)"
       ignition_config_overrides:
+        x-go-custom-tag: gorm:"type:text"
         type: string
         description: Json formatted string containing the user overrides for the initial ignition config
         example: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'


### PR DESCRIPTION
The default for the swagger string type is 2048 characters and
these could be quite large if someone wants to specify an entire
config

Curious if column type changes like this can be cleanly handled by the automigration.
@filanov do you know? Do we have tests for this kind of thing (ensuring that schema changes don't break stuff)?

Fixes [MGMT-2466](https://issues.redhat.com/browse/MGMT-2466)