### PR TITLE
MGMT-2431: Copy 'logs_sender' binary file to host.

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -166,7 +166,9 @@ func updateRole(h *models.Host, role models.HostRole, db *gorm.DB, srcRole *stri
 	return nil
 }
 
-func CreateUploadLogsCmd(host *models.Host, baseURL string, agentImage string, skipCertVerification bool, preservePreviousCommandReturnCode bool) (string, error) {
+func CreateUploadLogsCmd(host *models.Host, baseURL, agentImage string, skipCertVerification, preservePreviousCommandReturnCode,
+	withInstallerGaterLogging bool) (string, error) {
+
 	cmdArgsTmpl := ""
 	if preservePreviousCommandReturnCode {
 		cmdArgsTmpl = "( returnCode=$?; "
@@ -179,11 +181,13 @@ func CreateUploadLogsCmd(host *models.Host, baseURL string, agentImage string, s
 		"AGENT_IMAGE":            strings.TrimSpace(agentImage),
 		"SKIP_CERT_VERIFICATION": strconv.FormatBool(skipCertVerification),
 		"BOOTSTRAP":              strconv.FormatBool(host.Bootstrap),
+		"INSTALLER_GATHER":       strconv.FormatBool(withInstallerGaterLogging),
 	}
 	cmdArgsTmpl += "podman run --rm --privileged " +
 		"-v /run/systemd/journal/socket:/run/systemd/journal/socket -v /var/log:/var/log " +
-		"--env PULL_SECRET_TOKEN --name logs-sender {{.AGENT_IMAGE}} logs_sender " +
-		"-url {{.BASE_URL}} -cluster-id {{.CLUSTER_ID}} -host-id {{.HOST_ID}} --insecure={{.SKIP_CERT_VERIFICATION}} -bootstrap={{.BOOTSTRAP}}"
+		"--env PULL_SECRET_TOKEN --name logs-sender --pid=host {{.AGENT_IMAGE}} logs_sender " +
+		"-url {{.BASE_URL}} -cluster-id {{.CLUSTER_ID}} -host-id {{.HOST_ID}} " +
+		"--insecure={{.SKIP_CERT_VERIFICATION}} -bootstrap={{.BOOTSTRAP}} -with-installer-gather-logging={{.INSTALLER_GATHER}}"
 
 	if preservePreviousCommandReturnCode {
 		cmdArgsTmpl = cmdArgsTmpl + "; exit $returnCode; )"

--- a/internal/host/stopinstallation.go
+++ b/internal/host/stopinstallation.go
@@ -34,7 +34,7 @@ func (h *stopInstallationCmd) GetSteps(ctx context.Context, host *models.Host) (
 	// will return same exit code as stop command command
 	if host.LogsCollectedAt == strfmt.DateTime(time.Time{}) {
 		logsCommand, err := CreateUploadLogsCmd(host, h.instructionConfig.ServiceBaseURL,
-			h.instructionConfig.InventoryImage, h.instructionConfig.SkipCertVerification, false)
+			h.instructionConfig.InventoryImage, h.instructionConfig.SkipCertVerification, false, true)
 		if err != nil {
 			h.log.WithError(err).Error("Failed to create logs upload command")
 		}


### PR DESCRIPTION
[MGMT-2431](https://issues.redhat.com/browse/MGMT-2431): Added parameters to get logs command on installation failure.
--pid=host:

    installer-gather.sh needs to run on the host filesystem rather than on
    the container filesystem.

    for installer-gather.sh command, in `assisted-installer-agent` we use
    `nsenter` and we also need to add this flag in `assisted-service`.

-with-installer-gather-logging:

    this is set to true because on cluster installation failure we need
    those logs.

    logs_sender (assisted-installer-agent) is also used from
    `assisted-installer` in order to get logs on a cluster installation
    success, in this case we won't need those logs.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>