### PR TITLE
MGMT-2415 change id label name for HTTP metrics to clusterId

### DIFF
--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -64,7 +64,7 @@ func (c *Config) defaults() {
 		c.ServiceLabel = "service"
 	}
 	if c.IDLabel == "" {
-		c.IDLabel = "id"
+		c.IDLabel = "clusterId"
 	}
 }
 


### PR DESCRIPTION
This change is for matching cluster Id label name for HTTP
metrics (currently named `id`) to application metrics (`clusterId`)