### PR TITLE
MGMT-2480: Fixed flaky authz test

### DIFF
--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func TestAuthz(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.TODO()
 	log := logrus.New()
 


### PR DESCRIPTION
There are tests that uses a shared cache, but each tests should start with an empty one.
Although we flush it at the begging of each test, if it runs in parallel one test might get an error because of other test cached a different value for the requester authz.
This test takes no time to run, so it safer not to run in parallel anyway.


Error:
03:33:16  === Failed
03:33:16  === FAIL: pkg/auth TestAuthz/pass_access_review_from_cache (0.00s)
03:33:16  STEP: get cluster first attempt, store user in cache
03:33:16      TestAuthz/pass_access_review_from_cache: authz_handler_test.go:222:
03:33:16          	Error Trace:	authz_handler_test.go:222
03:33:16          	            				ginkgo_dsl.go:435
03:33:16          	            				authz_handler_test.go:218
03:33:16          	Error:      	Not equal:
03:33:16          	            	expected: *url.Error(&url.Error{Op:"Get", URL:"http://localhost:8082/api/assisted-install/v1/clusters/96b6e3b9-db98-41ae-b56f-0851431bd030", Err:(*net.OpError)(0xc000180190)})
03:33:16          	            	actual  : <nil>(<nil>)
03:33:16          	Test:       	TestAuthz/pass_access_review_from_cache
03:33:16  STEP: get cluster second attempt, get user from cache
03:33:16      --- FAIL: TestAuthz/pass_access_review_from_cache (0.00s)
03:33:16
03:33:16  === FAIL: pkg/auth TestAuthz/test_register_cluster (0.00s)
03:33:16  STEP: register cluster: with user scope
03:33:16  time="2020-10-17T00:29:47Z" level=warning msg="Unauthorized user test@user: insufficient role: read-only-admin allowed roles: map[\"userAuth\":[\"admin\" \"user\"]]" pkg=auth
03:33:16      TestAuthz/test_register_cluster: authz_handler_test.go:460:
03:33:16          	Error Trace:	authz_handler_test.go:460
03:33:16          	            				ginkgo_dsl.go:435
03:33:16          	            				authz_handler_test.go:449
03:33:16          	Error:      	Not equal:
03:33:16          	            	expected: *installer.RegisterClusterForbidden(&installer.RegisterClusterForbidden{Payload:(*models.InfraError)(0xc000b98840)})