### PR TITLE
MGMT-2480: change authz test server port

### DIFF
--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -163,7 +163,10 @@ func TestAuthz(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	srvAddr := "localhost:8082"
+	// port must be differentiate from other suite tests ports in the project
+	// to avoid collision with other tests (logcontext_test uses port 8082) when
+	// running all tests in parallel.
+	srvAddr := "localhost:8083"
 	server := &http.Server{
 		Addr:    srvAddr,
 		Handler: h,

--- a/pkg/log/logcontext_test.go
+++ b/pkg/log/logcontext_test.go
@@ -72,8 +72,11 @@ func createClient() *client.AssistedInstall {
 	cfg := client.Config{
 		URL: &url.URL{
 			Scheme: client.DefaultSchemes[0],
-			Host:   "localhost:8082",
-			Path:   client.DefaultBasePath,
+			// port must be differentiate from other suite tests ports in the project
+			// to avoid collision with other tests (authz_handler_test uses port 8083) when
+			// running all tests in parallel.
+			Host: "localhost:8082",
+			Path: client.DefaultBasePath,
 		},
 	}
 


### PR DESCRIPTION
Since it collides with the logs test service port (8082).