### PR TITLE
NO-ISSUE: Generate and verify onprem configs in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ Default tag is latest
 
 ### Deploy without a Kubernetes cluster
 
-The assisted service can also be deployed without using a Kubernetes cluster. In this scenario the service and associated components are deployed onto your local host as a pod using Podman.
+There are two ways the assisted service can be deployed without using a Kubernetes cluster:
 
-This type of deployment requires a different container image that combines components that are used to generate the installer ISO and configuration files. First build the image:
+#### Using a pod on your local host
+In this scenario the service and associated components are deployed onto your local host as a pod using Podman.
 
 ```shell
 export SERVICE=quay.io/<your-org>/assisted-service:latest
-make build-onprem
 ```
 
 To deploy, update SERVICE_BASE_URL in the onprem-environment file to match the hostname or IP address of your host. For example if your IP address is 192.168.122.2, then the SERVICE_BASE_URL would be set to <http://192.168.122.2:8090>. Port 8090 is the assisted-service API.
@@ -246,7 +246,7 @@ Check all containers are up and running:
 podman ps -a
 ```
 
-The UI will available at: `https://<host-ip-address>:8443`
+The UI will available at: `http://<host-ip-address>:8080`
 
 To remove the containers:
 
@@ -259,6 +259,12 @@ To run the subsystem tests:
 ```shell
 make test-onprem
 ```
+
+#### Using assisted-service Live-ISO
+The assisted-service live ISO is a RHCOS live ISO that is customized with an ignition config file.
+The live ISO boots up and deploys the assisted-service using containers on host.
+
+[Using assisted-service Live-ISO](docs/installer-live-iso.md)
 
 ### Storage
 

--- a/config/onprem-iso-config.ign
+++ b/config/onprem-iso-config.ign
@@ -29,7 +29,7 @@
         "path": "/etc/assisted-service/environment",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/1TOUWvzIBQG4Pv8l5qm7ce3FbywzVkTSKOo3diVSGJbwWgW3dj+/QiMdrs778PhPYdRIQ8chCp32PqYtHNmym7KiBAvlJdY94P1dz8J4D9W7lRFhcTF6j9aoiUqZmGUS/xvs17N4e/yXHlPLTnCr8MC+HO9B7UjAtSJN/ia0hi3ea5jtDGZfqFHi1zotENhND5e7TkhG7YPm806K4E19FVJwg8gcfDjZIZb5Z6oPXCpGJEVznuddO4v1n8uonHnaC/e9KibUkYZtKKqn6SqWyFJ0ygODcz/1EdyAPz2rr+QDXnoxsEk7eZhMRlndDTbjwIt0SMqsu8AAAD//xTKvnhYAQAA"
+          "source": "data:;base64,H4sIAAAAAAAC/1SOzW7iMBSF93mXOPxkGITkhUnuBEsh9thmRl1ZFjFgKThp7Fb07atIhdLld8/Vdw5nUlUC5N9al0SRLZGAnQ/RdJ0dk6eUEyn/M1Fi016df04OEsTXtdzqHZMKzxe/0QzN0Hy6cCYU/pUvFxP8fJ6k39SQ/XO5BPGPFqCnTfoganyJcQibLDMhuBBtm5rBoa4/mg71g/Xh4k4RuX6zzvNlUgKv2YtWRFSgcO+H0V4fyoLoAoTSnKgdzloTTebPzt/SYLtTcGdvW3QcY8I4NHJH/yhNG6lIXWsBNUx76J5UgF/fzAdyffaoT0fbWRNs2tr3rD8Od97kaIXm6W290qs84YdtTQtdsEYR2oDQAioqlaAg78rkMwAA//83qwcMmQEAAA=="
         },
         "mode": 420
       },

--- a/config/onprem-iso-fcc.yaml
+++ b/config/onprem-iso-fcc.yaml
@@ -127,7 +127,8 @@ storage:
                 SERVICE_BASE_URL=https://assisted-api.local.openshift.io:8443
                 DEPLOY_TARGET=onprem
                 SERVICE_CA_CERT_PATH=/data/nginx-selfsigned.crt
-                OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/ocpmetal/ocp-release:v1.0.9.1
+                OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.1-x86_64
+                PUBLIC_CONTAINER_REGISTRIES=quay.io
         - path: /etc/assisted-service/nginx.conf
           mode: 0644
           contents:

--- a/docs/installer-live-iso.md
+++ b/docs/installer-live-iso.md
@@ -104,4 +104,9 @@ The FCC file transpiles to an ignition config using:
 podman run --rm -v ./config/onprem-iso-fcc.yaml:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict /config.fcc > onprem-iso-config.ign
 ````
 
+There is also a make target that you can use, which wraps the above command to generate the ignition file:
+
+````
+make generate-onprem-iso-ignition
+````
 

--- a/hack/verify-latest-onprem-config.sh
+++ b/hack/verify-latest-onprem-config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -n "$(git status --porcelain onprem-environment)" ]] || [[ -n "$(git status --porcelain config)" ]]; then
+	git diff -u onprem-environment
+	git diff -u config
+	echo "uncommitted onprem config changes. run 'make verify-latest-onprem-config' and commit any changes."
+	exit 1
+fi
+
+echo "Success: no out of source tree changes found for onprem configs"

--- a/onprem-environment
+++ b/onprem-environment
@@ -9,6 +9,5 @@ DB_NAME=installer
 SERVICE_BASE_URL=http://127.0.0.1:8090
 DEPLOY_TARGET=onprem
 DUMMY_IGNITION=false
-OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/ocpmetal/ocp-release:v1.0.9.1
-SERVICE_IPS=<Comma separated list of IPs>
+OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.1-x86_64
 PUBLIC_CONTAINER_REGISTRIES=quay.io


### PR DESCRIPTION
* Use OPENSHIFT_INSTALL_RELEASE_IMAGE to use the same openshift version
* Add target to generate onprem ignition file
* Remove SERVICE_IPS from onprem-environment, as it's optional and
SERVICE_BASE_URL with ip:port serves the purpose. See
config/onprem-iso-fcc.yaml for how SERVICE_IPS is used.