### PR TITLE
MGMT-2295 Give the test cluster a unique name

### DIFF
--- a/openshift/template-post-deploy-job.yaml
+++ b/openshift/template-post-deploy-job.yaml
@@ -28,7 +28,7 @@ objects:
               - POST
               - --user
               - $(USER):$(TOKEN)
-              - $(URL)?OFFLINE_TOKEN_CRED=$(OFFLINE_TOKEN_CRED)&PULL_SECRET_CRED=$(PULL_SECRET_CRED)&ASSISTED_SERVICE_URL=$(ASSISTED_SERVICE_URL)
+              - $(URL)?OFFLINE_TOKEN_CRED=$(OFFLINE_TOKEN_CRED)&PULL_SECRET_CRED=$(PULL_SECRET_CRED)&ASSISTED_SERVICE_URL=$(ASSISTED_SERVICE_URL)&CLUSTER_NAME=assisted-test-cluster-${JOBID}
             env:
               - name: URL
                 valueFrom:


### PR DESCRIPTION
Previously all these clusters deployed to the various cloud
environments were a very generic "test-cluster" because we were
not providing anything different.

After this change the cluster will have a slightly more unique base
name but will also share a name with the openshift job that kicked
off the install which might be helpful in the future.

Fixes [MGMT-2295](https://issues.redhat.com/browse/MGMT-2295)

cc @gamli75 