### PR TITLE
MGMT-2480: Wait until server is ready

### DIFF
--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -202,6 +202,22 @@ func TestAuthz(t *testing.T) {
 		assert.Contains(t, err.Error(), expectedCode)
 	}
 
+	waitForServerToBecomeReady := func(timeout time.Duration) {
+		start := time.Now()
+		for {
+			passAccessReview(1)
+			passCapabilityReview(1)
+			if err := listClusters(ctx, userClient); err == nil {
+				break
+			} else if time.Since(start) >= timeout {
+				panic(err)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		authzCache.Flush()
+	}
+	waitForServerToBecomeReady(5 * time.Second)
+
 	t.Run("should store payload in cache", func(t *testing.T) {
 		assert.Equal(t, shouldStorePayloadInCache(nil), true)
 		err := common.NewApiError(http.StatusUnauthorized, errors.New(""))


### PR DESCRIPTION
On some cases authz tests starts before the mock server get to start.
In this commit added function to verify server is ready before starting
the tests (or throw timeout after a minute)