### PR TITLE
MGMT-2462 AI on OCP cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,12 @@ deploy-role: deploy-namespace
 deploy-postgres: deploy-namespace
 	python3 ./tools/deploy_postgres.py --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)"
 
+deploy-service-on-ocp-cluster:
+	export TARGET=ocp && $(MAKE) deploy-postgres deploy-ocm-secret deploy-s3-secret deploy-service
+
+deploy-ui-on-ocp-cluster:
+	export TARGET=ocp && $(MAKE) deploy-ui
+
 jenkins-deploy-for-subsystem: _verify_minikube generate-keys
 	export TEST_FLAGS=--subsystem-test && export ENABLE_AUTH="True" && export DUMMY_IGNITION=${DUMMY_IGNITION} && \
 	$(MAKE) deploy-wiremock deploy-all

--- a/deploy/postgres/postgres-deployment-ephemeral.yaml
+++ b/deploy/postgres/postgres-deployment-ephemeral.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: REPLACE_NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: quay.io/ocpmetal/postgresql-12-centos7
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: assisted-installer-rds
+                  key: db.name
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: assisted-installer-rds
+                  key: db.user
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: assisted-installer-rds
+                  key: db.password
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 400Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: REPLACE_NAMESPACE
+  labels:
+    app: postgres
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5432
+  selector:
+    app: postgres
+status:
+  loadBalancer: {}

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -53,6 +53,8 @@ def main():
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Never"
         else:
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
+        if deploy_options.target == utils.OCP_TARGET:
+            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DEPLOY_TARGET', 'value': "ocp"})
 
     with open(DST_FILE, "w+") as dst:
         yaml.dump(data, dst, default_flow_style=False)

--- a/tools/deploy_postgres.py
+++ b/tools/deploy_postgres.py
@@ -15,7 +15,8 @@ def main():
 
     deploy_postgres_secret(deploy_options)
     deploy_postgres(deploy_options)
-    deploy_postgres_storage(deploy_options)
+    if deploy_options.target != utils.OCP_TARGET:
+        deploy_postgres_storage(deploy_options)
 
     log.info('Completed postgres deployment')
 
@@ -40,7 +41,10 @@ def deploy_postgres_secret(deploy_options):
 
 
 def deploy_postgres(deploy_options):
-    docs = utils.load_yaml_file_docs('deploy/postgres/postgres-deployment.yaml')
+    postgres_dep_file = 'deploy/postgres/postgres-deployment.yaml'
+    if deploy_options.target == utils.OCP_TARGET:
+        postgres_dep_file = 'deploy/postgres/postgres-deployment-ephemeral.yaml'
+    docs = utils.load_yaml_file_docs(postgres_dep_file)
 
     utils.set_namespace_in_yaml_docs(docs, deploy_options.namespace)
 

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -27,7 +27,7 @@ def load_deployment_options(parser=None):
     parser.add_argument(
         '--target',
         help='Target kubernetes distribution',
-        choices=['minikube', 'oc', 'oc-ingress'],
+        choices=['minikube', 'oc', 'oc-ingress', 'ocp'],
         default='minikube'
     )
     parser.add_argument(


### PR DESCRIPTION
- Added 'deploy-service-on-ocp-cluster' target - deploys the service on an OCP cluster
   - kubeconfig is retrieved from OCP_KUBECONFIG env var (default: build/kubeconfig).
- Added 'deploy-ui-on-ocp-cluster' target - same as above for the UI.
- Updated utils->get_kubectl_command: support 'ocp' target.
- DEPLOY_TARGET is set to 'ocp' (as it should use local FS for S3).
- Deploys ephemeral postgres (i.e. without a persistent storage volume).