### PR TITLE
MGMT-2635 Bugfix: GenerateClusterISO failing in subsystem tests

### DIFF
--- a/Dockerfile.assisted-iso-create
+++ b/Dockerfile.assisted-iso-create
@@ -1,4 +1,4 @@
-FROM quay.io/coreos/coreos-installer:release AS installer-image
+FROM quay.io/coreos/coreos-installer:v0.7.0 AS installer-image
 
 # Build binaries
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 as builder


### PR DESCRIPTION
The latest coreos-installer:release version was compiled with a newer
glibc version (2.32). Switching to an older tag.

https://issues.redhat.com/browse/MGMT-2635