### PR TITLE
MGMT-2692: Fixed waiting for server in authz test

### DIFF
--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -204,9 +204,9 @@ func TestAuthz(t *testing.T) {
 
 	waitForServerToBecomeReady := func(timeout time.Duration) {
 		start := time.Now()
+		passAccessReview(1)
+		passCapabilityReview(1)
 		for {
-			passAccessReview(1)
-			passCapabilityReview(1)
 			if err := listClusters(ctx, userClient); err == nil {
 				break
 			} else if time.Since(start) >= timeout {


### PR DESCRIPTION
In a fix made to authz unit test where we wait for the server to be up, I created unexpected calls to access review and capability review. This causes the ci to fail sometimes:

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
15:32:14  	panic: runtime error: invalid memory address or nil pointer dereference
15:32:14  [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xea429f]
15:32:14
15:32:14  goroutine 88 [running]:
15:32:14  testing.tRunner.func1.1(0xfd68a0, 0x1ccc380)
15:32:14  	/usr/local/go/src/testing/testing.go:940 +0x2f5
15:32:14  testing.tRunner.func1(0xc0008a27e0)
15:32:14  	/usr/local/go/src/testing/testing.go:943 +0x3f9
15:32:14  panic(0xfd68a0, 0x1ccc380)
15:32:14  	/usr/local/go/src/runtime/panic.go:969 +0x166
15:32:14  github.com/openshift/assisted-service/pkg/auth.TestAuthz.func9(0x0, 0x0, 0xc000bdff00)
15:32:14  	/home/workspace/assisted-service_master/pkg/auth/authz_handler_test.go:202 +0x2f
15:32:14  github.com/openshift/assisted-service/pkg/auth.TestAuthz.func14(0xc0008a27e0)
15:32:14  	/home/workspace/assisted-service_master/pkg/auth/authz_handler_test.go:254 +0xed
15:32:14  testing.tRunner(0xc0008a27e0, 0xc000186180)
15:32:14  	/usr/local/go/src/testing/testing.go:991 +0xdc
15:32:14  created by testing.(*T).Run
15:32:14  	/usr/local/go/src/testing/testing.go:1042 +0x357
15:32:14

We need to call the mock instances once, since we expect to success only one time in order to know the server is up.

Related to:
06ee8d4c1453d9b2e7a88274fe9003f7a5a3778c