### PR TITLE
MGMT-2592: enable HW detection of host via new root path

### DIFF
--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,10 +5,9 @@
 package connectivity
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,11 +6,10 @@ package events
 
 import (
 	context "context"
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
+	time "time"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/inventorycmd.go
+++ b/internal/host/inventorycmd.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -21,18 +23,41 @@ func NewInventoryCmd(log logrus.FieldLogger, inventoryImage string) *inventoryCm
 }
 
 func (h *inventoryCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
-	step := &models.Step{
+	podmanRunCmd := strings.Join([]string{
+		"podman", "run", "--privileged", "--net=host", "--rm", "--quiet",
+		"-v", "/var/log:/var/log",
+		"-v", "/run/udev:/run/udev",
+		"-v", "/dev/disk:/dev/disk",
+		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+
+		// Enable capturing host's HW using a different root path for GHW library
+		"-v", "/var/log:/host/var/log:ro",
+		"-v", "/proc/meminfo:/host/proc/meminfo:ro",
+		"-v", "/sys/kernel/mm/hugepages:/host/sys/kernel/mm/hugepages:ro",
+		"-v", "/proc/cpuinfo:/host/proc/cpuinfo:ro",
+		"-v", "/root/mtab:/host/etc/mtab:ro",
+		"-v", "/sys/block:/host/sys/block:ro",
+		"-v", "/sys/devices:/host/sys/devices:ro",
+		"-v", "/sys/bus:/host/sys/bus:ro",
+		"-v", "/sys/class:/host/sys/class:ro",
+		"-v", "/run/udev:/host/run/udev:ro",
+		"-v", "/dev/disk:/host/dev/disk:ro",
+
+		h.inventoryImage,
+		"inventory",
+	}, " ")
+
+	// Copying mounts file, which is not available by podman's PID
+	copyMountsFileCmd := "cp /etc/mtab /root/mtab"
+
+	inventoryCmd := &models.Step{
 		StepType: models.StepTypeInventory,
-		Command:  "podman",
+		Command:  "sh",
 		Args: []string{
-			"run", "--privileged", "--net=host", "--rm", "--quiet",
-			"-v", "/var/log:/var/log",
-			"-v", "/run/udev:/run/udev",
-			"-v", "/dev/disk:/dev/disk",
-			"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-			h.inventoryImage,
-			"inventory",
+			"-c",
+			fmt.Sprintf("%v && %v", copyMountsFileCmd, podmanRunCmd),
 		},
 	}
-	return []*models.Step{step}, nil
+
+	return []*models.Step{inventoryCmd}, nil
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,14 +6,13 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,13 +5,12 @@
 package metrics
 
 import (
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
+	time "time"
 )
 
 // MockAPI is a mock of API interface

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,10 +6,9 @@ package generator
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface

--- a/pkg/k8sclient/mock_k8sclient.go
+++ b/pkg/k8sclient/mock_k8sclient.go
@@ -5,11 +5,10 @@
 package k8sclient
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/config/v1"
 	v10 "k8s.io/api/core/v1"
+	reflect "reflect"
 )
 
 // MockK8SClient is a mock of K8SClient interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,9 +6,8 @@ package leader
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthorization is a mock of OCMAuthorization interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,11 +6,10 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,12 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface


### PR DESCRIPTION
* It should enable getting disks and partitions additional info, such as: MOUNTPOINTs, FSTYPEs, storage controllers, etc.
* It should be backward-compatible with old AI agents as well