### PR TITLE
MGMT-2659 DHCP server changes the VIPs addresses after installation has started - code changes

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2004,7 +2004,18 @@ func (b *bareMetalInventory) processDhcpAllocationResponse(ctx context.Context, 
 		log.WithError(err).Warn("IP in CIDR")
 		return err
 	}
-	return b.clusterApi.SetVips(ctx, &cluster, apiVip, ingressVip, b.db)
+
+	err = network.VerifyLease(dhcpAllocationReponse.APIVipLease)
+	if err != nil {
+		log.WithError(err).Warnf("API Vip not validated")
+		return err
+	}
+	err = network.VerifyLease(dhcpAllocationReponse.IngressVipLease)
+	if err != nil {
+		log.WithError(err).Warnf("Ingress Vip not validated")
+		return err
+	}
+	return b.clusterApi.SetVipsData(ctx, &cluster, apiVip, ingressVip, dhcpAllocationReponse.APIVipLease, dhcpAllocationReponse.IngressVipLease, b.db)
 }
 
 func handleReplyByType(params installer.PostStepReplyParams, b *bareMetalInventory, ctx context.Context, host models.Host, stepReply string) error {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -404,18 +404,18 @@ func (mr *MockAPIMockRecorder) CompleteInstallation(ctx, c, successfullyFinished
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockAPI)(nil).CompleteInstallation), ctx, c, successfullyFinished, reason)
 }
 
-// SetVips mocks base method
-func (m *MockAPI) SetVips(ctx context.Context, c *common.Cluster, apiVip, ingressVip string, db *gorm.DB) error {
+// SetVipsData mocks base method
+func (m *MockAPI) SetVipsData(ctx context.Context, c *common.Cluster, apiVip, ingressVip, apiVipLease, ingressVipLease string, db *gorm.DB) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetVips", ctx, c, apiVip, ingressVip, db)
+	ret := m.ctrl.Call(m, "SetVipsData", ctx, c, apiVip, ingressVip, apiVipLease, ingressVipLease, db)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetVips indicates an expected call of SetVips
-func (mr *MockAPIMockRecorder) SetVips(ctx, c, apiVip, ingressVip, db interface{}) *gomock.Call {
+// SetVipsData indicates an expected call of SetVipsData
+func (mr *MockAPIMockRecorder) SetVipsData(ctx, c, apiVip, ingressVip, apiVipLease, ingressVipLease, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVips", reflect.TypeOf((*MockAPI)(nil).SetVips), ctx, c, apiVip, ingressVip, db)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVipsData", reflect.TypeOf((*MockAPI)(nil).SetVipsData), ctx, c, apiVip, ingressVip, apiVipLease, ingressVipLease, db)
 }
 
 // IsReadyForInstallation mocks base method

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -17,4 +17,10 @@ type Cluster struct {
 
 	// Used to detect if DHCP allocation task is timed out
 	MachineNetworkCidrUpdatedAt time.Time
+
+	// The lease acquired for API vip
+	ApiVipLease string `gorm:"type:text"`
+
+	// The lease acquired for API vip
+	IngressVipLease string `gorm:"type:text"`
 }

--- a/internal/host/dhcpallocatecmd.go
+++ b/internal/host/dhcpallocatecmd.go
@@ -41,9 +41,11 @@ func (f *dhcpAllocateCmd) prepareParam(host *models.Host, cluster *common.Cluste
 	clusterID := host.ClusterID.String()
 
 	request := models.DhcpAllocationRequest{
-		APIVipMac:     asMAC(network.GenerateAPIVipMAC(clusterID)),
-		IngressVipMac: asMAC(network.GenerateIngressVipMAC(clusterID)),
-		Interface:     swag.String(nic),
+		APIVipMac:       asMAC(network.GenerateAPIVipMAC(clusterID)),
+		IngressVipMac:   asMAC(network.GenerateIngressVipMAC(clusterID)),
+		APIVipLease:     cluster.ApiVipLease,
+		IngressVipLease: cluster.IngressVipLease,
+		Interface:       swag.String(nic),
 	}
 	b, err := json.Marshal(&request)
 	if err != nil {

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,13 +6,12 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -263,9 +263,29 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			content = GetServiceIPHostnames("10.10.10.1,10.10.10.2")
 			Expect(content).To(Equal("10.10.10.1 assisted-api.local.openshift.io\n10.10.10.2 assisted-api.local.openshift.io\n"))
 		})
-		It("DHCP generation", func() {
+		Context("DHCP generation", func() {
+			It("Definitions only", func() {
+				g := NewGenerator(workDir, installerCacheDir, cluster, "", "", nil, log).(*installerGenerator)
+				g.encodedDhcpFileContents = "data:,abc"
+				err := g.updateIgnitions()
+				Expect(err).NotTo(HaveOccurred())
+
+				masterBytes, err := ioutil.ReadFile(masterPath)
+				Expect(err).ToNot(HaveOccurred())
+				masterConfig, _, err := config_31.Parse(masterBytes)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(masterConfig.Storage.Files).To(HaveLen(1))
+				f := masterConfig.Storage.Files[0]
+				Expect(f.Mode).To(Equal(swag.Int(0o644)))
+				Expect(f.Contents.Source).To(Equal(swag.String("data:,abc")))
+				Expect(f.Path).To(Equal("/etc/keepalived/unsupported-monitor.conf"))
+			})
+		})
+		It("Definitions+leases", func() {
 			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", nil, log).(*installerGenerator)
 			g.encodedDhcpFileContents = "data:,abc"
+			cluster.ApiVipLease = "api"
+			cluster.IngressVipLease = "ingress"
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -273,11 +293,19 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			Expect(err).ToNot(HaveOccurred())
 			masterConfig, _, err := config_31.Parse(masterBytes)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(masterConfig.Storage.Files).To(HaveLen(1))
+			Expect(masterConfig.Storage.Files).To(HaveLen(3))
 			f := masterConfig.Storage.Files[0]
 			Expect(f.Mode).To(Equal(swag.Int(0o644)))
 			Expect(f.Contents.Source).To(Equal(swag.String("data:,abc")))
 			Expect(f.Path).To(Equal("/etc/keepalived/unsupported-monitor.conf"))
+			f = masterConfig.Storage.Files[1]
+			Expect(f.Mode).To(Equal(swag.Int(0o644)))
+			Expect(f.Contents.Source).To(Equal(swag.String("data:,api")))
+			Expect(f.Path).To(Equal("/etc/keepalived/lease-api"))
+			f = masterConfig.Storage.Files[2]
+			Expect(f.Mode).To(Equal(swag.Int(0o644)))
+			Expect(f.Contents.Source).To(Equal(swag.String("data:,ingress")))
+			Expect(f.Path).To(Equal("/etc/keepalived/lease-ingress"))
 		})
 	})
 })

--- a/internal/network/lease_utils.go
+++ b/internal/network/lease_utils.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/pkg/errors"
+)
+
+func VerifyLease(lease string) error {
+	matched, err := regexp.MatchString(`^(?:|\s*lease\s*[{](?:\s+[a-z-]+ [^;}]*;)*\s+[}]\s*)$`, lease)
+	if err != nil {
+		return common.NewApiError(http.StatusInternalServerError, errors.Wrap(err, "Lease verification"))
+	}
+	if !matched {
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("Lease %s was not matched", lease))
+	}
+	return nil
+}
+
+func FormatLease(lease string) string {
+	c := regexp.MustCompile(`(\s)(renew|rebind|expire) [^;]*;`)
+	return c.ReplaceAllString(lease, "${1}${2} never;")
+}
+
+func getEncoded(input string) string {
+	if input == "" {
+		return ""
+	}
+	return fmt.Sprintf("data:,%s", url.PathEscape(input))
+
+}
+
+func GetEncodedApiVipLease(c *common.Cluster) string {
+	return getEncoded(c.ApiVipLease)
+}
+
+func GetEncodedIngressVipLease(c *common.Cluster) string {
+	return getEncoded(c.IngressVipLease)
+}

--- a/internal/network/lease_utils_test.go
+++ b/internal/network/lease_utils_test.go
@@ -1,0 +1,95 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+)
+
+const apiLease = `lease {
+  interface "api";
+  fixed-address 10.0.0.16;
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 3600;
+  option routers 10.0.0.138;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 10.0.0.138;
+  option domain-name-servers 10.0.0.138;
+  option domain-name "Home";
+  renew 0 2020/10/25 14:48:38;
+  rebind 0 2020/10/25 15:11:32;
+  expire 0 2020/10/25 15:19:02;
+}`
+
+const ingressLease = `lease {
+  interface "ingress";
+  fixed-address 10.0.0.17;
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 3600;
+  option routers 10.0.0.138;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 10.0.0.138;
+  option domain-name-servers 10.0.0.138;
+  option domain-name "Home";
+  renew 0 2020/10/25 14:48:38;
+  rebind 0 2020/10/25 15:11:32;
+  expire 0 2020/10/25 15:19:02;
+}`
+
+const twoLeases = `lease {
+  interface "macvlan";
+  fixed-address 10.0.0.17;
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 3600;
+  option routers 10.0.0.138;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 10.0.0.138;
+  option domain-name-servers 10.0.0.138;
+  option domain-name "Home";
+  renew 0 2020/10/25 14:48:38;
+  rebind 0 2020/10/25 15:11:32;
+  expire 0 2020/10/25 15:19:02;
+}
+lease {
+  interface "macvlan";
+  fixed-address 10.0.0.16;
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 3600;
+  option routers 10.0.0.138;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 10.0.0.138;
+  option domain-name-servers 10.0.0.138;
+  option domain-name "Home";
+  renew 0 2020/10/25 14:48:38;
+  rebind 0 2020/10/25 15:11:32;
+  expire 0 2020/10/25 15:19:02;
+}`
+
+var _ = Describe("dhcp param file", func() {
+	It("Format_lease", func() {
+		r := FormatLease(apiLease)
+		Expect(r).To(ContainSubstring("renew never;"))
+		Expect(r).To(ContainSubstring("rebind never;"))
+		Expect(r).To(ContainSubstring("expire never;"))
+	})
+	Context("VerifyLease", func() {
+		It("valid lease", func() {
+			Expect(VerifyLease(apiLease)).ToNot(HaveOccurred())
+		})
+		It("2 leases", func() {
+			Expect(VerifyLease(twoLeases)).To(HaveOccurred())
+		})
+		It("Invalid lease", func() {
+			Expect(VerifyLease(apiLease[1:])).To(HaveOccurred())
+			Expect(VerifyLease("l" + apiLease)).To(HaveOccurred())
+		})
+	})
+	It("Encoded", func() {
+		cluster := &common.Cluster{
+			ApiVipLease:     apiLease,
+			IngressVipLease: ingressLease,
+		}
+		Expect(GetEncodedApiVipLease(cluster)).To(Equal("data:,lease%20%7B%0A%20%20interface%20%22api%22%3B%0A%20%20fixed-address%2010.0.0.16%3B%0A%20%20option%20subnet-mask%20255.255.255.0%3B%0A%20%20option%20dhcp-lease-time%203600%3B%0A%20%20option%20routers%2010.0.0.138%3B%0A%20%20option%20dhcp-message-type%205%3B%0A%20%20option%20dhcp-server-identifier%2010.0.0.138%3B%0A%20%20option%20domain-name-servers%2010.0.0.138%3B%0A%20%20option%20domain-name%20%22Home%22%3B%0A%20%20renew%200%202020%2F10%2F25%2014:48:38%3B%0A%20%20rebind%200%202020%2F10%2F25%2015:11:32%3B%0A%20%20expire%200%202020%2F10%2F25%2015:19:02%3B%0A%7D"))
+		Expect(GetEncodedIngressVipLease(cluster)).To(Equal("data:,lease%20%7B%0A%20%20interface%20%22ingress%22%3B%0A%20%20fixed-address%2010.0.0.17%3B%0A%20%20option%20subnet-mask%20255.255.255.0%3B%0A%20%20option%20dhcp-lease-time%203600%3B%0A%20%20option%20routers%2010.0.0.138%3B%0A%20%20option%20dhcp-message-type%205%3B%0A%20%20option%20dhcp-server-identifier%2010.0.0.138%3B%0A%20%20option%20domain-name-servers%2010.0.0.138%3B%0A%20%20option%20domain-name%20%22Home%22%3B%0A%20%20renew%200%202020%2F10%2F25%2014:48:38%3B%0A%20%20rebind%200%202020%2F10%2F25%2015:11:32%3B%0A%20%20expire%200%202020%2F10%2F25%2015:19:02%3B%0A%7D"))
+	})
+})


### PR DESCRIPTION


- Add lease information for DHCP leases in cluster DB
- Save leases when VIPs are saved in DB in DHCP mode
- Send leases to agent when renewing leases - so agent will renew and not ask for a new lease
- Create lease files in OCP using ignition so OCP will renew and not ask for a new lease

/cc @YuviGold 
/cc @ronniel1 