### PR TITLE
MGMT-2678: Adding /root/.ssh to mounted volumes in installcmd.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -192,7 +192,14 @@ const ignitionConfigFormat = `{
 	    "name": "root"
 	  },
 	  "append": [{ "source": "{{.ServiceIPs}}" }]
-  	}{{end}}]
+	}{{end}}],
+    "directories": [{
+      "overwrite": false,
+      "path": "/root/.ssh",
+      "user": {
+          "name": "root"
+      }
+	}]
   }
 }`
 

--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -51,7 +51,7 @@ func (i *installCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models
 		role = models.HostRoleBootstrap
 	}
 
-	cmdArgsTmpl := "podman run -v /dev:/dev:rw -v /opt:/opt:rw {{if .HOST_CA_CERT_PATH}}-v {{.HOST_CA_CERT_PATH}}:{{.HOST_CA_CERT_PATH}}:rw {{end}}-v /run/systemd/journal/socket:/run/systemd/journal/socket --privileged --pid=host --net=host " +
+	cmdArgsTmpl := "podman run -v /dev:/dev:rw -v /opt:/opt:rw -v /root/.ssh:/root/.ssh {{if .HOST_CA_CERT_PATH}}-v {{.HOST_CA_CERT_PATH}}:{{.HOST_CA_CERT_PATH}}:rw {{end}}-v /run/systemd/journal/socket:/run/systemd/journal/socket --privileged --pid=host --net=host " +
 		"-v /var/log:/var/log:rw --env PULL_SECRET_TOKEN --name assisted-installer {{.INSTALLER}} --role {{.ROLE}} --cluster-id {{.CLUSTER_ID}} " +
 		"--boot-device {{.BOOT_DEVICE}} --host-id {{.HOST_ID}} --openshift-version {{.OPENSHIFT_VERSION}} " +
 		"--controller-image {{.CONTROLLER_IMAGE}} --url {{.BASE_URL}} --insecure={{.SKIP_CERT_VERIFICATION}} --agent-image {{.AGENT_IMAGE}}"

--- a/internal/host/installcmd_test.go
+++ b/internal/host/installcmd_test.go
@@ -232,7 +232,7 @@ func postvalidation(isstepreplynil bool, issteperrnil bool, expectedstepreply *m
 }
 
 func validateInstallCommand(reply *models.Step, role models.HostRole, clusterId string, hostId string, proxy string) {
-	template := "podman run -v /dev:/dev:rw -v /opt:/opt:rw -v /run/systemd/journal/socket:/run/systemd/journal/socket " +
+	template := "podman run -v /dev:/dev:rw -v /opt:/opt:rw -v /root/.ssh:/root/.ssh -v /run/systemd/journal/socket:/run/systemd/journal/socket " +
 		"--privileged --pid=host " +
 		"--net=host -v /var/log:/var/log:rw --env PULL_SECRET_TOKEN " +
 		"--name assisted-installer quay.io/ocpmetal/assisted-installer:latest --role %s " +


### PR DESCRIPTION
assisted-installer's container needs to access this directory in order
to insert bootstrap public SSH key to master's ignition.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>