### PR TITLE
MGMT-2792 Update host Known state to cover new "Ready to install" UI

### DIFF
--- a/internal/cluster/installer.go
+++ b/internal/cluster/installer.go
@@ -42,7 +42,7 @@ func (i *installer) Install(ctx context.Context, c *common.Cluster, db *gorm.DB)
 		if err != nil {
 			return err
 		}
-		return errors.Errorf("cluster %s is expected to have exactly %d known master to be installed, got %d",
+		return errors.Errorf("cluster %s is expected to have exactly %d known (Ready to install) master to be installed, got %d",
 			c.ID, common.MinMasterHostsNeededForInstallation, len(masterKnownHosts))
 	case models.ClusterStatusReady:
 		return errors.Errorf("cluster %s is ready expected %s", c.ID, models.ClusterStatusPreparingForInstallation)

--- a/internal/cluster/installer_test.go
+++ b/internal/cluster/installer_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -42,7 +43,7 @@ var _ = Describe("installer", func() {
 		It("cluster is insufficient", func() {
 			cluster = updateClusterState(cluster, models.ClusterStatusInsufficient, db)
 			err := installerManager.Install(ctx, &cluster, db)
-			Expect(err.Error()).Should(MatchRegexp(errors.Errorf("cluster %s is expected to have exactly 3 known master to be installed, got 0", cluster.ID).Error()))
+			Expect(err.Error()).Should(MatchRegexp(regexp.QuoteMeta(errors.Errorf("cluster %s is expected to have exactly 3 known (Ready to install) master to be installed, got 0", cluster.ID).Error())))
 		})
 		It("cluster is installing", func() {
 			cluster = updateClusterState(cluster, models.ClusterStatusInstalling, db)


### PR DESCRIPTION
The UI is changing host's `Known` state to `Ready to install`, this PR provides necessary changes on the backend unless we want dynamically parse&change texts on the UI.

It would be nice to even call the `Known` state as `Ready-to-install` internally, but it is not a must for now, imo.
Text-changes are a good-enough solution when accepting the fact that naming in the UI and rest API calls differs.