### PR TITLE
MGMT-2462: deploy on ocp - copy livecd

### DIFF
--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -54,7 +54,21 @@ def main():
         else:
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
         if deploy_options.target == utils.OCP_TARGET:
-            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DEPLOY_TARGET', 'value': "ocp"})
+            spec = data["spec"]["template"]["spec"]
+            service_container = spec["containers"][0]
+            service_container["env"].append({'name': 'DEPLOY_TARGET', 'value': "ocp"})
+
+            # Copy livecd from 'assisted-iso-create' image
+            service_container["volumeMounts"].append({'name': 'iso', 'mountPath': "/data"})
+            spec["volumes"].append({'name': 'iso', 'emptyDir': {}})
+            spec["initContainers"] = [{
+                "name": "assisted-iso-create",
+                "image": "quay.io/ocpmetal/assisted-iso-create:latest",
+                "command": ["bash", "-c"],
+                "args": ["cp -r /data/* /iso-data"],
+                "volumeMounts": [{"mountPath": "/iso-data", "name": "iso"}]
+            }]
+
 
     with open(DST_FILE, "w+") as dst:
         yaml.dump(data, dst, default_flow_style=False)


### PR DESCRIPTION
'onprem' image has been recently removed: https://github.com/openshift/assisted-service/pull/592
Thus, the livecd should be manually copied on service deployment:
- Create an emptyDir volume.
- Mount assisted-iso-create image on initContainers.
- Copy iso to data folder in service container.