### PR TITLE
MGMT-2629 Added secretdump package

### DIFF
--- a/pkg/secretdump/secretdump_test.go
+++ b/pkg/secretdump/secretdump_test.go
@@ -24,14 +24,15 @@ var _ = Describe("Secretdump", func() {
 		}
 
 		type Example struct {
-			A   string
-			B   int
-			C   string `secret:"true"` // Tests that fields marked secret get redacted. Top level.
-			N   Nested
-			Ppn *int
-			Ppv *int
-			Psn *Nested
-			Psv *Nested
+			A       string
+			B       int
+			C       string `secret:"true"` // Tests that fields marked secret get redacted. Top level.
+			N       Nested
+			Ppn     *int
+			Ppv     *int
+			Psn     *Nested
+			Psv     *Nested
+			private int
 		}
 
 		test1Nested1 := Nested{
@@ -49,14 +50,15 @@ var _ = Describe("Secretdump", func() {
 		test1IntValue := 10
 
 		test1 := Example{
-			A:   "Hello",
-			B:   5,
-			C:   "ThisIsASecret",
-			N:   test1Nested1,   // Tests nested structs
-			Ppn: nil,            // Tests nil pointers to primitives
-			Ppv: &test1IntValue, // Tests real pointers to primitives
-			Psn: nil,            // Tests nil pointers to structs
-			Psv: &test1Nested2,  // Tests real pointers to structs
+			A:       "Hello",
+			B:       5,
+			C:       "ThisIsASecret",
+			N:       test1Nested1,   // Tests nested structs
+			Ppn:     nil,            // Tests nil pointers to primitives
+			Ppv:     &test1IntValue, // Tests real pointers to primitives
+			Psn:     nil,            // Tests nil pointers to structs
+			Psv:     &test1Nested2,  // Tests real pointers to structs
+			private: 2,              // Tests not crashing on unexported fields
 		}
 
 		test1Expected := strings.TrimSpace(`
@@ -73,6 +75,7 @@ struct Example {
 	Ppv: <*int>,
 	Psn: <*secretdump_test.Nested>,
 	Psv: <*secretdump_test.Nested>,
+	private: <PRIVATE>,
 }
 `)
 		test1Actual := DumpSecretStruct(test1)

--- a/pkg/secretdump/secretdump_test.go
+++ b/pkg/secretdump/secretdump_test.go
@@ -64,11 +64,11 @@ var _ = Describe("Secretdump", func() {
 struct Example {
 	A: "Hello",
 	B: 5,
-	C: <REDACTED>,
+	C: <SECRET>,
 	N: struct Nested {
 		D: "World",
 		E: 6,
-		F: <REDACTED>,
+		F: <SECRET>,
 	},
 	Ppn: <*int>,
 	Ppv: <*int>,

--- a/pkg/secretdump/secretdump_test.go
+++ b/pkg/secretdump/secretdump_test.go
@@ -33,33 +33,34 @@ var _ = Describe("Secretdump", func() {
 			private int
 		}
 
-		test1Nested1 := Nested{
-			D: "World",
-			E: 6,
-			F: "ThisIsAnotherSecret",
-		}
+		It("should be as expected", func() {
+			nested1 := Nested{
+				D: "World",
+				E: 6,
+				F: "ThisIsAnotherSecret",
+			}
 
-		test1Nested2 := Nested{
-			D: "!",
-			E: 7,
-			F: "ThisIsAnotherAnotherSecret",
-		}
+			nested2 := Nested{
+				D: "!",
+				E: 7,
+				F: "ThisIsAnotherAnotherSecret",
+			}
 
-		test1IntValue := 10
+			testIntValue := 10
 
-		test1 := Example{
-			A:       "Hello",
-			B:       5,
-			C:       "ThisIsASecret",
-			N:       test1Nested1,   // Tests nested structs
-			Ppn:     nil,            // Tests nil pointers to primitives
-			Ppv:     &test1IntValue, // Tests real pointers to primitives
-			Psn:     nil,            // Tests nil pointers to structs
-			Psv:     &test1Nested2,  // Tests real pointers to structs
-			private: 2,              // Tests not crashing on unexported fields
-		}
+			testExample := Example{
+				A:       "Hello",
+				B:       5,
+				C:       "ThisIsASecret",
+				N:       nested1,       // Tests nested structs
+				Ppn:     nil,           // Tests nil pointers to primitives
+				Ppv:     &testIntValue, // Tests real pointers to primitives
+				Psn:     nil,           // Tests nil pointers to structs
+				Psv:     &nested2,      // Tests real pointers to structs
+				private: 2,             // Tests not crashing on unexported fields
+			}
 
-		test1Expected := strings.TrimSpace(`
+			expected := strings.TrimSpace(`
 struct Example {
 	A: "Hello",
 	B: 5,
@@ -76,10 +77,9 @@ struct Example {
 	private: <PRIVATE>,
 }
 `)
-		test1Actual := DumpSecretStruct(test1)
+			actual := DumpSecretStruct(testExample)
 
-		It("should be as expected", func() {
-			Expect(test1Actual).To(Equal(test1Expected))
+			Expect(actual).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/secretdump/secretdump_test.go
+++ b/pkg/secretdump/secretdump_test.go
@@ -1,0 +1,84 @@
+package secretdump_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openshift/assisted-service/pkg/secretdump"
+
+	"strings"
+	"testing"
+)
+
+func TestSecretdump(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secretdump Suite")
+}
+
+var _ = Describe("Secretdump", func() {
+	Context("Dump secret structs", func() {
+		type Nested struct {
+			D string `secret:"false"`   // Tests that only "true" secrets get redacted
+			E int    `otherTag:"value"` // Tests that not all tags get redacted
+			F string `secret:"true"`    // Tests that even nested struct secrets get redacted
+		}
+
+		type Example struct {
+			A   string
+			B   int
+			C   string `secret:"true"` // Tests that fields marked secret get redacted. Top level.
+			N   Nested
+			Ppn *int
+			Ppv *int
+			Psn *Nested
+			Psv *Nested
+		}
+
+		test1Nested1 := Nested{
+			D: "World",
+			E: 6,
+			F: "ThisIsAnotherSecret",
+		}
+
+		test1Nested2 := Nested{
+			D: "!",
+			E: 7,
+			F: "ThisIsAnotherAnotherSecret",
+		}
+
+		test1IntValue := 10
+
+		test1 := Example{
+			A:   "Hello",
+			B:   5,
+			C:   "ThisIsASecret",
+			N:   test1Nested1,   // Tests nested structs
+			Ppn: nil,            // Tests nil pointers to primitives
+			Ppv: &test1IntValue, // Tests real pointers to primitives
+			Psn: nil,            // Tests nil pointers to structs
+			Psv: &test1Nested2,  // Tests real pointers to structs
+		}
+
+		test1Expected := strings.TrimSpace(`
+struct Example {
+	A: "Hello",
+	B: 5,
+	C: <REDACTED>,
+	N: struct Nested {
+		D: "World",
+		E: 6,
+		F: <REDACTED>,
+	},
+	Ppn: <*int>,
+	Ppv: <*int>,
+	Psn: <*secretdump_test.Nested>,
+	Psv: <*secretdump_test.Nested>,
+}
+`)
+		test1Actual := DumpSecretStruct(test1)
+
+		It("should be as expected", func() {
+			Expect(test1Actual).To(Equal(test1Expected))
+		})
+	})
+})

--- a/pkg/secretdump/secretdump_test.go
+++ b/pkg/secretdump/secretdump_test.go
@@ -1,10 +1,8 @@
-package secretdump_test
+package secretdump
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/openshift/assisted-service/pkg/secretdump"
 
 	"strings"
 	"testing"
@@ -73,8 +71,8 @@ struct Example {
 	},
 	Ppn: <*int>,
 	Ppv: <*int>,
-	Psn: <*secretdump_test.Nested>,
-	Psv: <*secretdump_test.Nested>,
+	Psn: <*secretdump.Nested>,
+	Psv: <*secretdump.Nested>,
 	private: <PRIVATE>,
 }
 `)

--- a/pkg/secretdump/struct.go
+++ b/pkg/secretdump/struct.go
@@ -58,5 +58,5 @@ func dumpSecretStructInternal(obj interface{}, sb *strings.Builder, depth int) {
 		sb.WriteString("\t")
 	}
 
-	sb.WriteString(fmt.Sprintf("}"))
+	sb.WriteString("}")
 }

--- a/pkg/secretdump/struct.go
+++ b/pkg/secretdump/struct.go
@@ -35,7 +35,7 @@ func dumpSecretStructInternal(obj interface{}, sb *strings.Builder, depth int) {
 		sb.WriteString(fmt.Sprintf("%s: ", name))
 
 		if tag.Get("secret") == "true" {
-			sb.WriteString("<REDACTED>")
+			sb.WriteString("<SECRET>")
 		} else {
 			if field.CanInterface() {
 				value := field.Interface()

--- a/pkg/secretdump/struct.go
+++ b/pkg/secretdump/struct.go
@@ -1,0 +1,58 @@
+package secretdump
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// DumpSecretStruct generates a string representation of a struct with
+// `secret:"true"` tagged fields removed.
+// Does not recurse into pointers to structs (or show pointer values in general),
+// only regular nested structs.
+// Pointer addresses are also redacted in order to not leak addresses
+func DumpSecretStruct(obj interface{}) string {
+	var sb strings.Builder
+	dumpSecretStructInternal(obj, &sb, 1)
+	return sb.String()
+}
+
+func dumpSecretStructInternal(obj interface{}, sb *strings.Builder, depth int) {
+	v := reflect.ValueOf(obj)
+
+	sb.WriteString(fmt.Sprintf("struct %s {\n", v.Type().Name()))
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+
+		name, value, tag := v.Type().Field(i).Name,
+			field.Interface(),
+			reflect.TypeOf(obj).Field(i).Tag
+
+		for j := 0; j < depth; j++ {
+			sb.WriteString("\t")
+		}
+
+		sb.WriteString(fmt.Sprintf("%s: ", name))
+
+		if tag.Get("secret") == "true" {
+			sb.WriteString("<REDACTED>")
+		} else {
+			if field.Kind() == reflect.Struct {
+				dumpSecretStructInternal(value, sb, depth+1)
+			} else if field.Kind() == reflect.Ptr {
+				sb.WriteString(fmt.Sprintf("<%T>", value))
+			} else {
+				sb.WriteString(fmt.Sprintf("%#v", value))
+			}
+		}
+
+		sb.WriteString(",\n")
+	}
+
+	for j := 0; j < depth-1; j++ {
+		sb.WriteString("\t")
+	}
+
+	sb.WriteString(fmt.Sprintf("}"))
+}


### PR DESCRIPTION
Contains functionality to dump structs in a manner that censors struct fields marked as secret

DumpSecretStruct generates a string representation of a struct with `secret:"true"` tagged fields removed.

Currently does not recurse into pointers to structs (or show pointer values in general), only regular nested structs.
This limitation can be improved in the future if needed.

Pointer addresses are redacted in order to not leak addresses.