### PR TITLE
MGMT-2857: Fix image expiration

### DIFF
--- a/pkg/s3wrapper/client_test.go
+++ b/pkg/s3wrapper/client_test.go
@@ -54,12 +54,9 @@ var _ = Describe("s3client", func() {
 	})
 	It("expired_image_not_reused", func() {
 		imgCreatedAt, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00+00:00") // Two hours ago
-		unixTime := imgCreatedAt.Unix()                                          // Tag is also two hours ago
 		obj := s3.Object{Key: &objKey, LastModified: &imgCreatedAt}
 		taggingInput := s3.GetObjectTaggingInput{Bucket: &bucket, Key: &objKey}
-		tagValue := strconv.Itoa(int(unixTime))
-		tag := s3.Tag{Key: &tagKey, Value: &tagValue}
-		tagSet := []*s3.Tag{&tag}
+		tagSet := []*s3.Tag{}
 		taggingOutput := s3.GetObjectTaggingOutput{TagSet: tagSet}
 		mockAPI.EXPECT().GetObjectTagging(&taggingInput).Return(&taggingOutput, nil)
 		deleteInput := s3.DeleteObjectInput{Bucket: &bucket, Key: &objKey}


### PR DESCRIPTION
Before the ISO generation optimization, we added a tag with the current
timestamp to the generated ISO and overwrote it if we wanted to reuse
the ISO.  The image expiration looked only at the tag to determine if it
should delete the image.
However, placing the tag on the initial image was accidentally left out
when the optimization code went in.  Thus, images that were never reused
do not have the timestamp tag, and are therefore never deleted.
This could be fixed by adding the tag back to the image generation flow.
However this would mean that we would need to manually clean old images
from deployments that do not have a tag.  Therefore the approach of this
commit is to check if the tag exists, and if not, fall back to the
object's creation time.