### PR TITLE
MGMT-2465: assisted-controller as a deployment for day2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ OCM_CLIENT_SECRET := ${OCM_CLIENT_SECRET}
 ENABLE_AUTH := $(or ${ENABLE_AUTH},False)
 DELETE_PVC := $(or ${DELETE_PVC},False)
 PUBLIC_CONTAINER_REGISTRIES := $(or ${PUBLIC_CONTAINER_REGISTRIES},quay.io)
+CONTROLLER_OCP_IMAGE := $(or ${CONTROLLER_OCP_IMAGE},quay.io/ocpmetal/assisted-installer-controller-ocp:latest)
 
 # We decided to have an option to change replicas count only while running in minikube
 # That line is checking if we run on minikube
@@ -220,10 +221,14 @@ deploy-postgres: deploy-namespace
 	python3 ./tools/deploy_postgres.py --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)"
 
 deploy-service-on-ocp-cluster:
-	export TARGET=ocp && $(MAKE) deploy-postgres deploy-ocm-secret deploy-s3-secret deploy-service
+	export TARGET=ocp && $(MAKE) deploy-postgres deploy-ocm-secret deploy-s3-secret deploy-service deploy-controller-on-ocp-cluster
 
 deploy-ui-on-ocp-cluster:
 	export TARGET=ocp && $(MAKE) deploy-ui
+
+deploy-controller-on-ocp-cluster:
+	python3 ./tools/deploy_assisted_controller.py --target "ocp" --namespace $(NAMESPACE) \
+		--inventory-url ${SERVICE_BASE_URL} --controller-image ${CONTROLLER_OCP_IMAGE}
 
 jenkins-deploy-for-subsystem: _verify_minikube generate-keys
 	export TEST_FLAGS=--subsystem-test && export ENABLE_AUTH="True" && export DUMMY_IGNITION=${DUMMY_IGNITION} && \

--- a/deploy/assisted-controller/assisted-controller-configmap-patch.yaml
+++ b/deploy/assisted-controller/assisted-controller-configmap-patch.yaml
@@ -1,0 +1,2 @@
+data:
+  inventory-url: INVENTORY_URL

--- a/deploy/assisted-controller/assisted-controller-deployment.yaml
+++ b/deploy/assisted-controller/assisted-controller-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assisted-installer-controller
+  namespace: REPLACE_NAMESPACE
+spec:
+  selector:
+    matchLabels:
+      app: assisted-installer-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: assisted-installer-controller
+    spec:
+      containers:
+        - name: assisted-installer-controller
+          image: REPLACE_CONTROLLER_OCP_IMAGE
+          imagePullPolicy: Always
+          command:
+            - /assisted-installer-controller-ocp
+          env:
+            # Define the environment variable
+            - name: CLUSTER_ID
+              valueFrom:
+                configMapKeyRef:
+                  # The ConfigMap containing the value you want to assign to SPECIAL_LEVEL_KEY
+                  name: assisted-installer-controller-config
+                  key: cluster-id
+            - name: INVENTORY_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: assisted-installer-controller-config
+                  key: inventory-url
+            - name: PULL_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: assisted-installer-controller-secret
+                  key: pull-secret-token
+            - name: SKIP_CERT_VERIFICATION
+              valueFrom:
+                configMapKeyRef:
+                  name: assisted-installer-controller-config
+                  key: skip-cert-verification
+                  optional: true
+            - name: DEPLOY_TARGET
+              valueFrom:
+                configMapKeyRef:
+                  name: assisted-installer-controller-config
+                  key: deploy-target
+                  optional: true
+          envFrom:
+            - configMapRef:
+                name: assisted-installer-controller-config
+      restartPolicy: Always
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      serviceAccountName: assisted-installer-controller
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+        operator: Exists

--- a/tools/deploy_assisted_controller.py
+++ b/tools/deploy_assisted_controller.py
@@ -1,0 +1,62 @@
+import os
+import utils
+import deployment_options
+import pvc_size_utils
+import argparse
+import deployment_options
+
+log = utils.get_logger('deploy_assisted_controller')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--inventory-url")
+    parser.add_argument("--controller-image")
+    deploy_options = deployment_options.load_deployment_options(parser)
+
+    log.info('Starting assisted-installer-controller deployment')
+    utils.verify_build_directory(deploy_options.namespace)
+    deploy_configmap(deploy_options)
+    deploy_controller(deploy_options)
+    log.info('Completed assisted-installer-controller deployment')
+
+def deploy_controller(deploy_options):
+    src_file = os.path.join(os.getcwd(), 'deploy/assisted-controller/assisted-controller-deployment.yaml')
+    dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'assisted-controller-deployment.yaml')
+    with open(src_file, "r") as src:
+        with open(dst_file, "w+") as dst:
+            data = src.read()
+            data = data.replace('REPLACE_CONTROLLER_OCP_IMAGE', f'"{deploy_options.controller_image}"')
+            data = data.replace('REPLACE_NAMESPACE', f'"{deploy_options.namespace}"')
+            print("Deploying {}".format(dst_file))
+            dst.write(data)
+
+    log.info('Deploying %s', dst_file)
+    utils.apply(
+        target=deploy_options.target,
+        namespace=deploy_options.namespace,
+        profile=deploy_options.profile,
+        file=dst_file
+    )
+
+def deploy_configmap(deploy_options):
+    src_file = os.path.join(os.getcwd(), 'deploy/assisted-controller/assisted-controller-configmap-patch.yaml')
+    dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'assisted-controller-configmap-patch.yaml')
+    with open(src_file, "r") as src:
+        with open(dst_file, "w+") as dst:
+            data = src.read()
+            data = data.replace('INVENTORY_URL', f'"{deploy_options.inventory_url}"')
+            print("Deploying {}".format(dst_file))
+            dst.write(data)
+
+    log.info('Deploying %s', dst_file)
+    utils.patch(
+        target=deploy_options.target,
+        namespace=deploy_options.namespace,
+        profile=deploy_options.profile,
+        file=dst_file,
+        resource_type="configmap",
+        resource_name="assisted-installer-controller-config",
+    )
+
+if __name__ == "__main__":
+    main()

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -54,6 +54,7 @@ def main():
         else:
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
         if deploy_options.target == utils.OCP_TARGET:
+            data["spec"]["replicas"] = 1 # force single replica
             spec = data["spec"]["template"]["spec"]
             service_container = spec["containers"][0]
             service_container["env"].append({'name': 'DEPLOY_TARGET', 'value': "ocp"})

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -157,6 +157,11 @@ def apply(target, namespace, profile, file):
     print(check_output(f'{kubectl_cmd} apply -f {file}'))
 
 
+def patch(target, namespace, profile, file, resource_type, resource_name):
+    kubectl_cmd = get_kubectl_command(target, namespace, profile)
+    print(check_output(f'{kubectl_cmd} patch {resource_type} {resource_name} -p "$(cat {file})"'))
+
+
 def get_domain(domain="", target='minikube', namespace='assisted-installer', profile='minikube'):
     if domain:
         return domain


### PR DESCRIPTION
For 'ocp' target, the assisted-installer-controller should be
installed as a deployment. That way, the controller could monitor
new nodes progress, approve CSRs, etc.