### PR TITLE
MGMT-2889 Allow registration of host in error state

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -91,6 +91,17 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostRegisterDuringInstallation,
 	})
 
+	// Host in error should be able to register without changes.
+	// if the registration return conflict or error then we have infinite number of events.
+	// if the registration is blocked (403) it will break auto-reset feature.
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRegisterHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusError),
+		},
+		DestinationState: stateswitch.State(models.HostStatusError),
+	})
+
 	// Register host
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeRegisterInstalledHost,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -163,6 +163,23 @@ var _ = Describe("RegisterHost", func() {
 		})).ShouldNot(HaveOccurred())
 	})
 
+	It("register host in error state", func() {
+		Expect(db.Create(&models.Host{
+			ID:        &hostId,
+			ClusterID: clusterId,
+			Role:      models.HostRoleMaster,
+			Inventory: defaultHwInfo,
+			Status:    swag.String(models.HostStatusError),
+		}).Error).ShouldNot(HaveOccurred())
+
+		Expect(hapi.RegisterHost(ctx, &models.Host{
+			ID:                    &hostId,
+			ClusterID:             clusterId,
+			Status:                swag.String(models.HostStatusError),
+			DiscoveryAgentVersion: "v2.0.5",
+		})).ShouldNot(HaveOccurred())
+	})
+
 	Context("host already exists register success", func() {
 		discoveryAgentVersion := "v2.0.5"
 		tests := []struct {
@@ -229,10 +246,6 @@ var _ = Describe("RegisterHost", func() {
 			srcState    string
 			targetState string
 		}{
-			{
-				name:     "error",
-				srcState: models.HostStatusError,
-			},
 			{
 				name:     "installed",
 				srcState: models.HostStatusInstalled,


### PR DESCRIPTION
It can happen that user rebooted the host manually after installation failure without changes in the cluster
if the registration return conflict or error then we have infinite number of events.
if the registration is blocked (403) it will break auto-reset feature.
So the best option is just accept the registration without changes in the DB