### PR TITLE
MGMT-2888 Add marker file to bootstrap ignition

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -243,6 +243,8 @@ func (g *installerGenerator) updateBootstrap(bootstrapPath string) error {
 
 	config.Storage.Files = newFiles
 
+	setFileInIgnition(config, "/opt/openshift/assisted-install-bootstrap", "data:,", false, 420)
+
 	err = writeIgnitionFile(bootstrapPath, config)
 	if err != nil {
 		g.log.Error(err)

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 	var (
 		err         error
 		examplePath string
-		file        *config_31_types.File
 		bmh         *bmh_v1alpha1.BareMetalHost
+		config      config_31_types.Config
 	)
 
 	BeforeEach(func() {
@@ -103,10 +103,15 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		err = g.updateBootstrap(examplePath)
 
 		bootstrapBytes, _ := ioutil.ReadFile(examplePath)
-		config, _, err1 := config_31.Parse(bootstrapBytes)
+		config, _, err1 = config_31.Parse(bootstrapBytes)
 		Expect(err1).NotTo(HaveOccurred())
-		Expect(config.Storage.Files).To(HaveLen(1))
-		file = &config.Storage.Files[0]
+
+		var file *config_31_types.File
+		for i := range config.Storage.Files {
+			if isBMHFile(&config.Storage.Files[i]) {
+				file = &config.Storage.Files[i]
+			}
+		}
 		bmh, _ = fileToBMH(file)
 	})
 
@@ -118,6 +123,15 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 			It("adds annotation", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(bmh.Annotations).To(HaveKey(bmh_v1alpha1.StatusAnnotation))
+			})
+			It("adds the marker file", func() {
+				var found bool
+				for _, f := range config.Storage.Files {
+					if f.Path == "/opt/openshift/assisted-install-bootstrap" {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
This adds a marker file to the bootstrap ignition so that the rest of the openshift installation knows that this cluster is using the assisted-installer and will need, for some time, to have a healthy 2-member etcd cluster.

This is intended to replace the [unsupported flag we currently use](https://github.com/openshift/assisted-installer/blob/08a0ca837247d867a3fbb1953415e8f417754ed2/src/k8s_client/k8s_client.go#L134-L154) to allow a 2-member etcd cluster.

I thought the `.done` naming was a bit misleading as we're not done with bootstrap when we write this file.
If anyone has a better name I'm open to suggestions.

cc @ironcladlou @hexfusion 