### PR TITLE
OCPBUGSM-18132: Added AddForUpdateQueryOption to cancel/reset

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2711,6 +2711,7 @@ func (b *bareMetalInventory) CancelInstallation(ctx context.Context, params inst
 
 	txSuccess := false
 	tx := b.db.Begin()
+	tx = transaction.AddForUpdateQueryOption(tx)
 	defer func() {
 		if !txSuccess {
 			log.Error("cancel installation failed")
@@ -2771,6 +2772,7 @@ func (b *bareMetalInventory) ResetCluster(ctx context.Context, params installer.
 
 	txSuccess := false
 	tx := b.db.Begin()
+	tx = transaction.AddForUpdateQueryOption(tx)
 	defer func() {
 		if !txSuccess {
 			log.Error("reset cluster failed")


### PR DESCRIPTION
In cancel and reset routs we read and write from the db multiple times
from a single transaction, therefore we need to add the for-update query
option, in order to avoid possible conflicts.