### PR TITLE
MGMT-2652 Inform there was a disconnectio when stage is timed out + test

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -39,6 +39,7 @@ const (
 	statusInfoAbortingDueClusterErrors       = "Host is part of a cluster that failed to install"
 	statusInfoInstallationTimedOut           = "Host failed to install due to timeout while starting installation"
 	statusInfoInstallationInProgressTimedOut = "Host failed to install because its installation stage $STAGE took longer than expected $MAX_TIME"
+	hostNotRespondingNotification            = ", Host is not responding, last respond was at "
 )
 
 type UpdateReply struct {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -62,6 +62,11 @@ var InstallationProgressTimeout = map[models.HostStage]time.Duration{
 	"DEFAULT":                                   60 * time.Minute,
 }
 
+var disconnectionValidationStages = []models.HostStage{
+	models.HostStageWritingImageToDisk,
+	models.HostStageInstalling,
+}
+
 var WrongBootOrderIgnoreTimeoutStages = []models.HostStage{
 	models.HostStageStartWaitingForControlPlane,
 	models.HostStageWaitingForControlPlane,
@@ -69,6 +74,8 @@ var WrongBootOrderIgnoreTimeoutStages = []models.HostStage{
 }
 
 var InstallationTimeout = 20 * time.Minute
+
+var MaxHostDisconnectionTime = 3 * time.Minute
 
 type Config struct {
 	EnableAutoReset  bool          `envconfig:"ENABLE_AUTO_RESET" default:"false"`

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -515,6 +515,10 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 			template = strings.Replace(template, "$FAILING_VALIDATIONS", strings.Join(failedValidations, " ; "), 1)
 		}
 
+		if funk.Contains(disconnectionValidationStages, sHost.host.Progress.CurrentStage) && !hostIsResponsive(sHost.host) {
+			template += hostNotRespondingNotification + sHost.host.CheckedInAt.String()
+		}
+
 		_, err = updateHostStatus(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, th.eventsHandler, sHost.host.ClusterID, *sHost.host.ID,
 			sHost.srcState, swag.StringValue(sHost.host.Status), template, "validations_info", string(b))
 		return err
@@ -541,6 +545,10 @@ func getFailedValidations(params *TransitionArgsRefreshHost) []string {
 		}
 	}
 	return failedValidations
+}
+
+func hostIsResponsive(host *models.Host) bool {
+	return host.CheckedInAt.String() == "" || time.Since(time.Time(host.CheckedInAt)) <= MaxHostDisconnectionTime
 }
 
 func (th *transitionHandler) PostRefreshHostRefreshStageUpdateTime(

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -147,7 +147,7 @@ type validator struct {
 }
 
 func (v *validator) isConnected(c *validationContext) validationStatus {
-	return boolValue(c.host.CheckedInAt.String() == "" || time.Since(time.Time(c.host.CheckedInAt)) <= 3*time.Minute)
+	return boolValue(c.host.CheckedInAt.String() == "" || time.Since(time.Time(c.host.CheckedInAt)) <= MaxHostDisconnectionTime)
 }
 
 func (v *validator) printConnected(context *validationContext, status validationStatus) string {


### PR DESCRIPTION
when the installation stages writing the image to disk and installing are timed out 
in case there was no check-in by the host for more then 3m the state info will contain information about the last checked in time
for example:
```
 Host failed to install because its installation stage Writing the image to disk took longer than expected 10m0s, Host is not responding, last respond was at 2020-11-16T10:29:18.696Z
```
and 
```
Host failed to install because its installation stage Installing took longer than expected 1h0m0s, Host is not responding, last respond was at 2020-11-16T10:29:18.556
```