### PR TITLE
NO-ISSUE Handle ISO generation cancellation

### DIFF
--- a/pkg/s3wrapper/upload_iso.go
+++ b/pkg/s3wrapper/upload_iso.go
@@ -353,7 +353,8 @@ func (m *multiUpload) complete() {
 }
 
 func (m *multiUpload) fail() {
-	_, err := m.uploader.s3client.AbortMultipartUploadWithContext(m.ctx, &s3.AbortMultipartUploadInput{
+	// using new context because m.ctx may be canceled and it will fail the operation
+	_, err := m.uploader.s3client.AbortMultipartUploadWithContext(context.Background(), &s3.AbortMultipartUploadInput{
 		Bucket:   aws.String(m.uploader.bucket),
 		Key:      aws.String(m.destObjectKey),
 		UploadId: aws.String(m.uploadID),


### PR DESCRIPTION
AbortMultipartUploadWithContext use a new context because the opraiton will fail if the cancled context is used

Error before the fix:
```
time="2020-11-16T13:13:09Z" level=error msg="Failed to copy part 13 for file discovery-image-a36b49ad-2200-4fc0-914b-788f6d9e7246.iso: RequestCanceled: request context canceled\ncaused by: context canceled" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*multiUpload).uploadPartCopy" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/upload_iso.go:377" cluster_id=a36b49ad-2200-4fc0-914b-788f6d9e7246 go-id=3714 request_id=b8e1cf9a-5657-4576-b886-7b36f18a9221
time="2020-11-16T13:13:09Z" level=error msg="Failed to copy part 14 for file discovery-image-a36b49ad-2200-4fc0-914b-788f6d9e7246.iso: RequestCanceled: request context canceled\ncaused by: context canceled" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*multiUpload).uploadPartCopy" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/upload_iso.go:377" cluster_id=a36b49ad-2200-4fc0-914b-788f6d9e7246 go-id=3714 request_id=b8e1cf9a-5657-4576-b886-7b36f18a9221
time="2020-11-16T13:13:09Z" level=error msg="Failed to copy part 15 for file discovery-image-a36b49ad-2200-4fc0-914b-788f6d9e7246.iso: RequestCanceled: request context canceled\ncaused by: context canceled" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*multiUpload).uploadPartCopy" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/upload_iso.go:377" cluster_id=a36b49ad-2200-4fc0-914b-788f6d9e7246 go-id=3714 request_id=b8e1cf9a-5657-4576-b886-7b36f18a9221
...
...
time="2020-11-16T13:13:17Z" level=warning msg="Failed to abort failed multipart upload with ID 78f7ea02f48b49da8c530774812839bc" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*multiUpload).fail" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/upload_iso.go:362" cluster_id=a36b49ad-2200-4fc0-914b-788f6d9e7246 error="RequestCanceled: request context canceled\ncaused by: context canceled" go-id=3714 request_id=b8e1cf9a-5657-4576-b886-7b36f18a9221
time="2020-11-16T13:13:17Z" level=error msg="Failed to create ISO discovery-image-a36b49ad-2200-4fc0-914b-788f6d9e7246.iso: Failed to copy part 15 for file discovery-image-a36b49ad-2200-4fc0-914b-788f6d9e7246.iso: RequestCanceled: request context canceled\ncaused by: context canceled" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*ISOUploader).UploadISO" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/upload_iso.go:75" cluster_id=a36b49ad-2200-4fc0-914b-788f6d9e7246 go-id=3714 request_id=b8e1cf9a-5657-4576-b886-7b36f18a9221

```