### PR TITLE
OCPBUGSM-20532: Allow register deleted hosts

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1712,14 +1712,28 @@ func (b *bareMetalInventory) RegisterHost(ctx context.Context, params installer.
 	var cluster common.Cluster
 	log.Infof("Register host: %+v", params)
 
-	if err := b.db.First(&cluster, "id = ?", params.ClusterID.String()).Error; err != nil {
+	txSuccess := false
+	tx := b.db.Begin()
+	tx = transaction.AddForUpdateQueryOption(tx)
+	defer func() {
+		if !txSuccess {
+			log.Error("RegisterHost failed")
+			tx.Rollback()
+		}
+		if r := recover(); r != nil {
+			log.Error("RegisterHost failed")
+			tx.Rollback()
+		}
+	}()
+
+	if err := tx.First(&cluster, "id = ?", params.ClusterID.String()).Error; err != nil {
 		log.WithError(err).Errorf("failed to get cluster: %s", params.ClusterID.String())
 		if gorm.IsRecordNotFoundError(err) {
 			return common.NewApiError(http.StatusNotFound, err)
 		}
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
-	err := b.db.First(&host, "id = ? and cluster_id = ?", *params.NewHostParams.HostID, params.ClusterID).Error
+	err := tx.First(&host, "id = ? and cluster_id = ?", *params.NewHostParams.HostID, params.ClusterID).Error
 	if err != nil && !gorm.IsRecordNotFoundError(err) {
 		log.WithError(err).Errorf("failed to get host %s in cluster: %s",
 			*params.NewHostParams.HostID, params.ClusterID.String())
@@ -1757,7 +1771,7 @@ func (b *bareMetalInventory) RegisterHost(ctx context.Context, params installer.
 		Role:                  models.HostRoleAutoAssign,
 	}
 
-	if err = b.hostApi.RegisterHost(ctx, &host); err != nil {
+	if err = b.hostApi.RegisterHost(ctx, &host, tx); err != nil {
 		log.WithError(err).Errorf("failed to register host <%s> cluster <%s>",
 			params.NewHostParams.HostID.String(), params.ClusterID.String())
 		uerr := errors.Wrap(err, "Failed to register host: error creating host metadata")
@@ -1779,6 +1793,13 @@ func (b *bareMetalInventory) RegisterHost(ctx context.Context, params installer.
 		Host:                  host,
 		NextStepRunnerCommand: b.generateNextStepRunnerCommand(ctx, &params),
 	}
+
+	if err := tx.Commit().Error; err != nil {
+		log.Error(err)
+		return installer.NewRegisterHostInternalServerError().
+			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+	}
+	txSuccess = true
 
 	return installer.NewRegisterHostCreated().WithPayload(&hostRegistration)
 }

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -558,8 +558,8 @@ var _ = Describe("RegisterHost", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
 
 		mockClusterAPI.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockHostAPI.EXPECT().RegisterHost(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, h *models.Host) error {
+		mockHostAPI.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
 				// validate that host is registered with auto-assign role
 				Expect(h.Role).Should(Equal(models.HostRoleAutoAssign))
 				return nil
@@ -598,7 +598,7 @@ var _ = Describe("RegisterHost", func() {
 		expectedErrMsg := "some-internal-error"
 
 		mockClusterAPI.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockHostAPI.EXPECT().RegisterHost(gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
+		mockHostAPI.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEventsHandler.EXPECT().
 			AddEvent(gomock.Any(), *cluster.ID, &hostID, models.EventSeverityError, gomock.Any(), gomock.Any()).
 			Times(1)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -532,7 +532,7 @@ var _ = Describe("reset host", func() {
 			clusterId := strfmt.UUID(uuid.New().String())
 			h = getTestHost(id, clusterId, models.HostStatusResetting)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
-			Expect(state.RegisterHost(ctx, &h)).ShouldNot(HaveOccurred())
+			Expect(state.RegisterHost(ctx, &h, db)).ShouldNot(HaveOccurred())
 			db.First(&h, "id = ? and cluster_id = ?", h.ID, h.ClusterID)
 			Expect(*h.Status).Should(Equal(models.HostStatusDiscovering))
 		})
@@ -627,8 +627,6 @@ var _ = Describe("register host", func() {
 		dummy := &leader.DummyElector{}
 		state = NewManager(getTestLog(), db, eventsHandler, nil, nil, nil, nil, &config, dummy)
 	})
-	AfterEach(func() {
-	})
 
 	BeforeEach(func() {
 		id := strfmt.UUID(uuid.New().String())
@@ -637,20 +635,21 @@ var _ = Describe("register host", func() {
 	})
 
 	It("register host success", func() {
-		Expect(state.RegisterHost(ctx, &h)).ShouldNot(HaveOccurred())
+		Expect(state.RegisterHost(ctx, &h, db)).ShouldNot(HaveOccurred())
 		db.First(&h, "id = ? and cluster_id = ?", h.ID, h.ClusterID)
 		Expect(*h.Status).Should(Equal(models.HostStatusDiscovering))
 	})
 
 	It("register (soft) deleted host success", func() {
-		Expect(state.RegisterHost(ctx, &h)).ShouldNot(HaveOccurred())
+		Expect(state.RegisterHost(ctx, &h, db)).ShouldNot(HaveOccurred())
 		db.First(&h, "id = ? and cluster_id = ?", h.ID, h.ClusterID)
 		Expect(*h.Status).Should(Equal(models.HostStatusDiscovering))
 		Expect(db.Delete(&h).RowsAffected).Should(Equal(int64(1)))
 		Expect(db.Unscoped().Find(&h).RowsAffected).Should(Equal(int64(1)))
-		Expect(state.RegisterHost(ctx, &h)).ShouldNot(HaveOccurred())
+		Expect(state.RegisterHost(ctx, &h, db)).ShouldNot(HaveOccurred())
 		db.First(&h, "id = ? and cluster_id = ?", h.ID, h.ClusterID)
 		Expect(*h.Status).Should(Equal(models.HostStatusDiscovering))
+
 	})
 
 	AfterEach(func() {

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -39,17 +39,17 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 }
 
 // RegisterHost mocks base method
-func (m *MockAPI) RegisterHost(ctx context.Context, h *models.Host) error {
+func (m *MockAPI) RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterHost", ctx, h)
+	ret := m.ctrl.Call(m, "RegisterHost", ctx, h, db)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RegisterHost indicates an expected call of RegisterHost
-func (mr *MockAPIMockRecorder) RegisterHost(ctx, h interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) RegisterHost(ctx, h, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHost", reflect.TypeOf((*MockAPI)(nil).RegisterHost), ctx, h)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHost", reflect.TypeOf((*MockAPI)(nil).RegisterHost), ctx, h, db)
 }
 
 // RegisterInstalledOCPHost mocks base method

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -43,7 +43,7 @@ var _ = Describe("monitor_disconnection", func() {
 		cluster := getTestCluster(clusterID, "1.1.0.0/16")
 		Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
 		host.Inventory = workerInventory()
-		err := state.RegisterHost(ctx, &host)
+		err := state.RegisterHost(ctx, &host, db)
 		Expect(err).ShouldNot(HaveOccurred())
 		db.First(&host, "id = ? and cluster_id = ?", host.ID, host.ClusterID)
 	})
@@ -146,7 +146,7 @@ var _ = Describe("TestHostMonitoring", func() {
 				}
 				host = getTestHost(strfmt.UUID(uuid.New().String()), clusterID, models.HostStatusDiscovering)
 				host.Inventory = workerInventory()
-				Expect(state.RegisterHost(ctx, &host)).ShouldNot(HaveOccurred())
+				Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
 				host.CheckedInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 				db.Save(&host)
 			}

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -59,7 +59,7 @@ var _ = Describe("RegisterHost", func() {
 	})
 
 	It("register_new", func() {
-		Expect(hapi.RegisterHost(ctx, &models.Host{ID: &hostId, ClusterID: clusterId, DiscoveryAgentVersion: "v1.0.1"})).ShouldNot(HaveOccurred())
+		Expect(hapi.RegisterHost(ctx, &models.Host{ID: &hostId, ClusterID: clusterId, DiscoveryAgentVersion: "v1.0.1"}, db)).ShouldNot(HaveOccurred())
 		h := getHost(hostId, clusterId, db)
 		Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusDiscovering))
 		Expect(h.DiscoveryAgentVersion).To(Equal("v1.0.1"))
@@ -123,7 +123,8 @@ var _ = Describe("RegisterHost", func() {
 					ID:        &hostId,
 					ClusterID: clusterId,
 					Status:    swag.String(t.srcState),
-				})
+				},
+					db)
 
 				if t.errorCode == 0 {
 					Expect(err).ShouldNot(HaveOccurred())
@@ -160,7 +161,8 @@ var _ = Describe("RegisterHost", func() {
 			ClusterID:             clusterId,
 			Status:                swag.String(models.HostStatusDisabled),
 			DiscoveryAgentVersion: "v2.0.5",
-		})).ShouldNot(HaveOccurred())
+		},
+			db)).ShouldNot(HaveOccurred())
 	})
 
 	It("register host in error state", func() {
@@ -177,7 +179,8 @@ var _ = Describe("RegisterHost", func() {
 			ClusterID:             clusterId,
 			Status:                swag.String(models.HostStatusError),
 			DiscoveryAgentVersion: "v2.0.5",
-		})).ShouldNot(HaveOccurred())
+		},
+			db)).ShouldNot(HaveOccurred())
 	})
 
 	Context("host already exists register success", func() {
@@ -235,7 +238,8 @@ var _ = Describe("RegisterHost", func() {
 					ClusterID:             clusterId,
 					Status:                swag.String(t.srcState),
 					DiscoveryAgentVersion: discoveryAgentVersion,
-				})).ShouldNot(HaveOccurred())
+				},
+					db)).ShouldNot(HaveOccurred())
 			})
 		}
 	})
@@ -268,7 +272,8 @@ var _ = Describe("RegisterHost", func() {
 					ID:        &hostId,
 					ClusterID: clusterId,
 					Status:    swag.String(t.srcState),
-				})).Should(HaveOccurred())
+				},
+					db)).Should(HaveOccurred())
 
 				h := getHost(hostId, clusterId, db)
 				Expect(swag.StringValue(h.Status)).Should(Equal(t.srcState))
@@ -381,7 +386,8 @@ var _ = Describe("RegisterHost", func() {
 					ID:        &hostId,
 					ClusterID: clusterId,
 					Status:    swag.String(t.srcState),
-				})).ShouldNot(HaveOccurred())
+				},
+					db)).ShouldNot(HaveOccurred())
 
 				h := getHost(hostId, clusterId, db)
 				Expect(swag.StringValue(h.Status)).Should(Equal(t.dstState))

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -129,6 +129,25 @@ var _ = Describe("Cluster tests", func() {
 		clusterID = *cluster.GetPayload().ID
 	})
 
+	It("register an unregistered host success", func() {
+		h := registerHost(clusterID)
+		_, err1 := userBMClient.Installer.DeregisterHost(ctx, &installer.DeregisterHostParams{
+			ClusterID: clusterID,
+			HostID:    *h.ID,
+		})
+		Expect(err1).ShouldNot(HaveOccurred())
+		_, err2 := agentBMClient.Installer.RegisterHost(ctx, &installer.RegisterHostParams{
+			ClusterID: clusterID,
+			NewHostParams: &models.HostCreateParams{
+				HostID: h.ID,
+			},
+		})
+		Expect(err2).ShouldNot(HaveOccurred())
+		c := getCluster(clusterID)
+		Expect(len(c.Hosts)).Should(Equal(1))
+		Expect(c.Hosts[0].ID.String()).Should(Equal(h.ID.String()))
+	})
+
 	It("list clusters - get unregistered cluster", func() {
 		_ = registerHost(clusterID)
 		_, err1 := userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})


### PR DESCRIPTION
If a host is soft deleted by the user, there is a chance that
it will try to be registered to the cluster again. In
such cases, we should just remove the previews record of
the deleted host while registering it.