### PR TITLE
MGMT-792 - Swagger - added virtual field to system_vendor

### DIFF
--- a/models/system_vendor.go
+++ b/models/system_vendor.go
@@ -23,6 +23,9 @@ type SystemVendor struct {
 
 	// serial number
 	SerialNumber string `json:"serial_number,omitempty"`
+
+	// Whether the machine appears to be a virtual machine or not
+	Virtual bool `json:"virtual,omitempty"`
 }
 
 // Validate validates this system vendor

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5403,6 +5403,10 @@ func init() {
         },
         "serial_number": {
           "type": "string"
+        },
+        "virtual": {
+          "description": "Whether the machine appears to be a virtual machine or not",
+          "type": "boolean"
         }
       }
     },
@@ -10852,6 +10856,10 @@ func init() {
         },
         "serial_number": {
           "type": "string"
+        },
+        "virtual": {
+          "description": "Whether the machine appears to be a virtual machine or not",
+          "type": "boolean"
         }
       }
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3445,6 +3445,9 @@ definitions:
         type: string
       manufacturer:
         type: string
+      virtual:
+        type: boolean
+        description: Whether the machine appears to be a virtual machine or not
 
   memory:
     type: object


### PR DESCRIPTION
(First PR to solve https://issues.redhat.com/browse/MGMT-792)

This adds a virtual field to the system_vendor struct in the API so it can be populated by the agent. "false" if it doesn't think it's a virtual machine, "true" otherwise.

Will open a corresponding PR in the agent repo that actually populates this field once this one is merged.