### PR TITLE
MGMT-2943 Expose discovery ignition separately from iso

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -46,6 +46,7 @@ var S3FileNames = []string{
 	"kubeadmin-password",
 	"kubeconfig-noingress",
 	"install-config.yaml",
+	"discovery.ign",
 }
 
 //go:generate mockgen -source=cluster.go -package=cluster -destination=mock_cluster_api.go

--- a/internal/common/error_utils.go
+++ b/internal/common/error_utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/s3wrapper"
 )
 
 func GenerateError(id int32, err error) *models.Error {
@@ -101,6 +102,8 @@ func GenerateErrorResponder(err error) middleware.Responder {
 		return errValue
 	case *InfraErrorResponse:
 		return errValue
+	case s3wrapper.NotFound:
+		return NewApiError(http.StatusNotFound, err)
 	default:
 		return NewApiError(http.StatusInternalServerError, err)
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1167,7 +1167,8 @@ func init() {
               "kubeadmin-password",
               "kubeconfig",
               "kubeconfig-noingress",
-              "install-config.yaml"
+              "install-config.yaml",
+              "discovery.ign"
             ],
             "type": "string",
             "name": "file_name",
@@ -6685,7 +6686,8 @@ func init() {
               "kubeadmin-password",
               "kubeconfig",
               "kubeconfig-noingress",
-              "install-config.yaml"
+              "install-config.yaml",
+              "discovery.ign"
             ],
             "type": "string",
             "name": "file_name",

--- a/restapi/operations/installer/download_cluster_files_parameters.go
+++ b/restapi/operations/installer/download_cluster_files_parameters.go
@@ -157,7 +157,7 @@ func (o *DownloadClusterFilesParams) bindFileName(rawData []string, hasKey bool,
 // validateFileName carries on validations for parameter FileName
 func (o *DownloadClusterFilesParams) validateFileName(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"bootstrap.ign", "master.ign", "metadata.json", "worker.ign", "kubeadmin-password", "kubeconfig", "kubeconfig-noingress", "install-config.yaml"}, true); err != nil {
+	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"bootstrap.ign", "master.ign", "metadata.json", "worker.ign", "kubeadmin-password", "kubeconfig", "kubeconfig-noingress", "install-config.yaml", "discovery.ign"}, true); err != nil {
 		return err
 	}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -376,7 +376,7 @@ paths:
         - in: query
           name: file_name
           type: string
-          enum: [bootstrap.ign, master.ign, metadata.json, worker.ign, kubeadmin-password, kubeconfig, kubeconfig-noingress, install-config.yaml]
+          enum: [bootstrap.ign, master.ign, metadata.json, worker.ign, kubeadmin-password, kubeconfig, kubeconfig-noingress, install-config.yaml, discovery.ign]
           required: true
         - in: header
           name: discovery_agent_version


### PR DESCRIPTION
This commit uploads the discovery ignition to S3 in addition to
the iso with the ignition embedded. It also allows for the ignition
to be downloaded through the same file download endpoint we use for
other cluster files.

This will be used for cases where the rest of the iso will be
made available in some other manner.

Fixes [MGMT-2943](https://issues.redhat.com/browse/MGMT-2943)

cc @avishayt @yrobla 