### PR TITLE
MGMT-2765 Run a subet of subsystem tests for onprem in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
-                sh 'make clean-onprem || true'
                 sh 'docker system prune -a'
                 sh 'make ci-lint'
 
@@ -56,8 +55,7 @@ pipeline {
             steps {
                 sh "make podman-pull-service-from-docker-daemon"
                 sh "export PODMAN_PULL_FLAG='--pull never'; make deploy-onprem-for-subsystem"
-                sh "export GINKGO_FOCUS_FLAG=-ginkgo.focus=minimal-set; make test-onprem"
-                sh "make clean-onprem || true"
+                sh "make test-onprem FOCUS=minimal-set"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
+                sh 'make clean-onprem || true'
                 sh 'docker system prune -a'
                 sh 'make ci-lint'
 
@@ -48,6 +49,15 @@ pipeline {
         stage('Subsystem Test') {
             steps {
                 sh "make subsystem-run"
+            }
+        }
+
+        stage('Subsystem Test onprem') {
+            steps {
+                sh "make podman-pull-service-from-docker-daemon"
+                sh "export PODMAN_PULL_FLAG='--pull never'; make deploy-onprem-for-subsystem"
+                sh "export GINKGO_FOCUS_FLAG=-ginkgo.focus=minimal-set; make test-onprem"
+                sh "make clean-onprem || true"
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ test-onprem:
 # Clean #
 #########
 
-clear-all: clean subsystem-clean clear-deployment clear-images
+clear-all: clean subsystem-clean clear-deployment clear-images clean-onprem
 
 clean:
 	-rm -rf $(BUILD_FOLDER) $(REPORTS)

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ OCM_CLIENT_SECRET := ${OCM_CLIENT_SECRET}
 ENABLE_AUTH := $(or ${ENABLE_AUTH},False)
 DELETE_PVC := $(or ${DELETE_PVC},False)
 PUBLIC_CONTAINER_REGISTRIES := $(or ${PUBLIC_CONTAINER_REGISTRIES},quay.io)
+PODMAN_PULL_FLAG := $(or ${PODMAN_PULL_FLAG},--pull always)
 
 # We decided to have an option to change replicas count only while running in minikube
 # That line is checking if we run on minikube
@@ -248,6 +249,11 @@ verify-latest-onprem-config: generate-onprem-environment generate-onprem-iso-ign
 	@echo "Verifying onprem config changes"
 	hack/verify-latest-onprem-config.sh
 
+# $SERVICE is built with docker. If we want the latest version of $SERVICE
+# we need to pull it from the docker daemon before deploy-onprem.
+podman-pull-service-from-docker-daemon:
+	podman pull "docker-daemon:${SERVICE}"
+
 deploy-onprem:
 	podman pod create --name assisted-installer -p 5432,8000,8090,8080
 	# These are required because when running on RHCOS livecd, the coreos-installer binary and
@@ -258,7 +264,7 @@ deploy-onprem:
 		quay.io/coreos/coreos-installer:v0.7.0 -c 'cp /usr/sbin/coreos-installer /data/coreos-installer'
 	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always --name db quay.io/ocpmetal/postgresql-12-centos7
 	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always -v $(PWD)/deploy/ui/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest
-	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always --env DUMMY_IGNITION=$(DUMMY_IGNITION) \
+	podman run -dt --pod assisted-installer --env-file onprem-environment ${PODMAN_PULL_FLAG} --env DUMMY_IGNITION=$(DUMMY_IGNITION) \
 		-v ./livecd.iso:/data/livecd.iso:z \
 		-v ./coreos-installer:/data/coreos-installer:z \
 		--restart always --name installer $(SERVICE)

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -844,7 +844,7 @@ var _ = Describe("cluster install", func() {
 			})
 		})
 
-		It("[only_k8s]install_cluster", func() {
+		It("[only_k8s][minimal-set]install_cluster", func() {
 			By("Installing cluster till finalize")
 			c := installCluster(clusterID)
 			Expect(swag.StringValue(c.Status)).Should(Equal("installing"))
@@ -1098,7 +1098,7 @@ var _ = Describe("cluster install", func() {
 			})
 		})
 
-		It("[only_k8s]install download_config_files", func() {
+		It("[only_k8s][minimal-set]install download_config_files", func() {
 			//Test downloading kubeconfig files in worng state
 			//This test uses Agent Auth for DownloadClusterFiles (as opposed to the other tests), to cover both supported authentication types for this API endpoint.
 			file, err := ioutil.TempFile("", "tmp")

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -43,7 +43,7 @@ var _ = Describe("system-test image tests", func() {
 		clusterID = *cluster.GetPayload().ID
 	})
 
-	It("[only_k8s]create_and_get_image", func() {
+	It("[only_k8s][minimal-set]create_and_get_image", func() {
 		file, err := ioutil.TempFile("", "tmp")
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
We have a shortage of resources in Jenkins and this prevents
us from running all subsystem tests for onprem in parallel.
To ensure we have some test coverage, we decided to run a small
subset of the subsystem tests that can exercise the onprem code
paths.

The tests that constitute the small subset have been tagged with
[minimal-set] in the test definitions.