### PR TITLE
OCPBUGSM-20497 limit cluster name to 54 characters

### DIFF
--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -47,6 +47,8 @@ type ClusterCreateParams struct {
 
 	// Name of the OpenShift cluster.
 	// Required: true
+	// Max Length: 54
+	// Min Length: 1
 	Name *string `json:"name"`
 
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
@@ -159,6 +161,14 @@ func (m *ClusterCreateParams) validateIngressVip(formats strfmt.Registry) error 
 func (m *ClusterCreateParams) validateName(formats strfmt.Registry) error {
 
 	if err := validate.Required("name", "body", m.Name); err != nil {
+		return err
+	}
+
+	if err := validate.MinLength("name", "body", string(*m.Name), 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", string(*m.Name), 54); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4054,7 +4054,9 @@ func init() {
         },
         "name": {
           "description": "Name of the OpenShift cluster.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 54,
+          "minLength": 1
         },
         "no_proxy": {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
@@ -9547,7 +9549,9 @@ func init() {
         },
         "name": {
           "description": "Name of the OpenShift cluster.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 54,
+          "minLength": 1
         },
         "no_proxy": {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -146,6 +146,21 @@ var _ = Describe("Cluster", func() {
 		Expect(c.Hosts[0].ID.String()).Should(Equal(h.ID.String()))
 	})
 
+	It("cluster name exceed max length (54 characters)", func() {
+		_, err1 := userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{
+			ClusterID: clusterID,
+		})
+		Expect(err1).ShouldNot(HaveOccurred())
+		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
+			NewClusterParams: &models.ClusterCreateParams{
+				Name:             swag.String("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"),
+				OpenshiftVersion: swag.String("4.5"),
+				PullSecret:       swag.String(pullSecret),
+			},
+		})
+		Expect(err).Should(HaveOccurred())
+	})
+
 	It("register an unregistered cluster success", func() {
 		_, err1 := userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{
 			ClusterID: clusterID,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2797,6 +2797,8 @@ definitions:
     properties:
       name:
         type: string
+        minLength: 1
+        maxLength: 54
         description: Name of the OpenShift cluster.
       openshift_version:
         type: string


### PR DESCRIPTION
[OCPBUGSM-20497](https://issues.redhat.com/browse/OCPBUGSM-20497) limit cluster name to 54 characters