### PR TITLE
MGMT-2982 Fix image build race condition

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -8,9 +8,10 @@ DOCKER_CONF="${PWD}/.docker"
 mkdir -p "${DOCKER_CONF}"
 docker --config="${DOCKER_CONF}" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
-docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"
+docker tag "${ASSISTED_SERVICE_IMAGE}:${TAG}" "${ASSISTED_SERVICE_IMAGE}:latest"
 docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:${TAG}"
+docker --config="${DOCKER_CONF}" push "${ASSISTED_SERVICE_IMAGE}:latest"
 
-docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:latest"
+docker tag "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}" "${ASSISTED_ISO_CREATE_IMAGE}:latest"
 docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"
-
+docker --config="${DOCKER_CONF}" push "${ASSISTED_ISO_CREATE_IMAGE}:latest"

--- a/build_images.sh
+++ b/build_images.sh
@@ -11,8 +11,5 @@ TAG=$(git rev-parse --short=7 HEAD)
 ASSISTED_SERVICE_IMAGE=quay.io/app-sre/assisted-service
 ASSISTED_ISO_CREATE_IMAGE=quay.io/app-sre/assisted-iso-create
 
-SERVICE="${ASSISTED_SERVICE_IMAGE}:latest" skipper make update-minimal
-docker tag "${ASSISTED_SERVICE_IMAGE}:latest" "${ASSISTED_SERVICE_IMAGE}:${TAG}"
-
-ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:latest" skipper make build-minimal-assisted-iso-generator-image
-docker tag "${ASSISTED_ISO_CREATE_IMAGE}:latest" "${ASSISTED_ISO_CREATE_IMAGE}:${TAG}"
+SERVICE="${ASSISTED_SERVICE_IMAGE}:${TAG}" skipper make update-minimal
+ISO_CREATION="${ASSISTED_ISO_CREATE_IMAGE}:${TAG}" skipper make build-minimal-assisted-iso-generator-image


### PR DESCRIPTION
Before this change it was possible for an image built for a PR
to end up deployed to the integration environment.

To fix, we should have built the initial image as the git sha
then only if we needed to push, tag latest.

The race happened like this:
1. build for master starts
2. build for pr starts
3. build for master finishes and tags latest
4. build for pr finishes and tags latest
5. push latest

Fixes [MGMT-2982](https://issues.redhat.com/browse/MGMT-2982)