### PR TITLE
MGMT-2678: Adding list of IPs to logs cmd.

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -193,7 +193,7 @@ func updateRole(h *models.Host, role models.HostRole, db *gorm.DB, srcRole *stri
 	return nil
 }
 
-func CreateUploadLogsCmd(host *models.Host, baseURL, agentImage string, skipCertVerification, preservePreviousCommandReturnCode,
+func CreateUploadLogsCmd(host *models.Host, baseURL, agentImage, mastersIPs string, skipCertVerification, preservePreviousCommandReturnCode,
 	withInstallerGatherLogging bool) (string, error) {
 
 	cmdArgsTmpl := ""
@@ -209,12 +209,14 @@ func CreateUploadLogsCmd(host *models.Host, baseURL, agentImage string, skipCert
 		"SKIP_CERT_VERIFICATION": strconv.FormatBool(skipCertVerification),
 		"BOOTSTRAP":              strconv.FormatBool(host.Bootstrap),
 		"INSTALLER_GATHER":       strconv.FormatBool(withInstallerGatherLogging),
+		"MASTERS_IPS":            mastersIPs,
 	}
 	cmdArgsTmpl += "podman run --rm --privileged " +
 		"-v /run/systemd/journal/socket:/run/systemd/journal/socket -v /var/log:/var/log " +
 		"--env PULL_SECRET_TOKEN --name logs-sender --pid=host {{.AGENT_IMAGE}} logs_sender " +
 		"-url {{.BASE_URL}} -cluster-id {{.CLUSTER_ID}} -host-id {{.HOST_ID}} " +
-		"--insecure={{.SKIP_CERT_VERIFICATION}} -bootstrap={{.BOOTSTRAP}} -with-installer-gather-logging={{.INSTALLER_GATHER}}"
+		"--insecure={{.SKIP_CERT_VERIFICATION}} -bootstrap={{.BOOTSTRAP}} -with-installer-gather-logging={{.INSTALLER_GATHER}}" +
+		"{{if .MASTERS_IPS}} -masters-ips={{.MASTERS_IPS}} {{end}}"
 
 	if preservePreviousCommandReturnCode {
 		cmdArgsTmpl = cmdArgsTmpl + "; exit $returnCode; )"

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -64,7 +64,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	freeAddressesCmd := NewFreeAddressesCmd(log, instructionConfig.FreeAddressesImage)
 	resetCmd := NewResetInstallationCmd(log)
 	stopCmd := NewStopInstallationCmd(log)
-	logsCmd := NewLogsCmd(log, instructionConfig)
+	logsCmd := NewLogsCmd(log, db, instructionConfig)
 	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.DhcpLeaseAllocatorImage, db)
 	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.APIVIPConnectivityCheckImage, instructionConfig.SupportL2)
 	downloadInstallerCmd := NewDownloadInstallerCmd(log, instructionConfig)

--- a/internal/host/logscmd.go
+++ b/internal/host/logscmd.go
@@ -6,21 +6,26 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/jinzhu/gorm"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
 )
 
 type logsCmd struct {
 	baseCmd
 	instructionConfig InstructionConfig
+	db                *gorm.DB
 }
 
-func NewLogsCmd(log logrus.FieldLogger, instructionConfig InstructionConfig) *logsCmd {
+func NewLogsCmd(log logrus.FieldLogger, db *gorm.DB, instructionConfig InstructionConfig) *logsCmd {
 	return &logsCmd{
 		baseCmd:           baseCmd{log: log},
 		instructionConfig: instructionConfig,
+		db:                db,
 	}
 }
 
@@ -29,9 +34,20 @@ func (i *logsCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.St
 	if host.LogsCollectedAt != strfmt.DateTime(time.Time{}) {
 		return nil, nil
 	}
+
+	var mastersIPs []string
+	var err error
+	if host.Bootstrap {
+		mastersIPs, err = i.getNonBootstrapMastersIPsInHostCluster(ctx, host)
+		if err != nil {
+			i.log.WithError(err).Errorf("Failed to get non-bootstrap masters IPs from cluster %s", host.ClusterID)
+			return nil, err
+		}
+	}
+
 	logsCommand, err := CreateUploadLogsCmd(host, i.instructionConfig.ServiceBaseURL,
-		i.instructionConfig.InventoryImage, i.instructionConfig.SkipCertVerification,
-		false, true)
+		i.instructionConfig.InventoryImage, strings.Join(mastersIPs, ","),
+		i.instructionConfig.SkipCertVerification, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -43,4 +59,27 @@ func (i *logsCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.St
 	}
 
 	return []*models.Step{step}, nil
+}
+
+func (i *logsCmd) getNonBootstrapMastersIPsInHostCluster(ctx context.Context, host *models.Host) ([]string, error) {
+
+	var cluster common.Cluster
+	if err := i.db.Preload("Hosts", "cluster_id = ?", host.ClusterID).First(&cluster, "id = ?", host.ClusterID).Error; err != nil {
+		i.log.WithError(err).Errorf("failed to get cluster for host %s", host.ID)
+		return nil, err
+	}
+
+	var ips []string
+	for _, h := range cluster.Hosts {
+		if h.Bootstrap {
+			continue
+		}
+		ip, err := network.GetMachineCIDRIP(h, &cluster)
+		if err != nil {
+			i.log.WithError(err).Errorf("failed to get machine cidr IP for host %s", host.ID)
+			return nil, err
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
 }

--- a/internal/host/logscmd_test.go
+++ b/internal/host/logscmd_test.go
@@ -26,7 +26,7 @@ var _ = Describe("upload_logs", func() {
 
 	BeforeEach(func() {
 		db = common.PrepareTestDB(dbName)
-		logsCmd = NewLogsCmd(getTestLog(), DefaultInstructionConfig)
+		logsCmd = NewLogsCmd(getTestLog(), db, DefaultInstructionConfig)
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
In order to gather logs on the agent side before the cluster creating is
completed we will need to use SSH in order to let bootstrap gather logs
from other masters, in order to do so we will need there IPs.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>