### PR TITLE
NO-ISSUE Regenerate files after swagger changes

### DIFF
--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -51,7 +51,7 @@ type ClusterCreateParams struct {
 	// Min Length: 1
 	Name *string `json:"name"`
 
-	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
+	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
 	// Version of the OpenShift cluster.

--- a/models/cluster_update_params.go
+++ b/models/cluster_update_params.go
@@ -65,7 +65,7 @@ type ClusterUpdateParams struct {
 	// OpenShift cluster name.
 	Name *string `json:"name,omitempty"`
 
-	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
+	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
 	// The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3129,7 +3129,7 @@ func init() {
             "required": true
           },
           {
-            "maxLength": 20971520,
+            "maxLength": 104857600,
             "type": "file",
             "x-mimetype": "application/zip",
             "description": "The file to upload.",
@@ -4059,7 +4059,7 @@ func init() {
           "minLength": 1
         },
         "no_proxy": {
-          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
         },
@@ -4201,7 +4201,7 @@ func init() {
           "x-nullable": true
         },
         "no_proxy": {
-          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
         },
@@ -8581,7 +8581,7 @@ func init() {
             "required": true
           },
           {
-            "maxLength": 20971520,
+            "maxLength": 104857600,
             "type": "file",
             "x-mimetype": "application/zip",
             "description": "The file to upload.",
@@ -9554,7 +9554,7 @@ func init() {
           "minLength": 1
         },
         "no_proxy": {
-          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
         },
@@ -9678,7 +9678,7 @@ func init() {
           "x-nullable": true
         },
         "no_proxy": {
-          "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
+          "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
         },

--- a/restapi/operations/installer/upload_logs_parameters.go
+++ b/restapi/operations/installer/upload_logs_parameters.go
@@ -48,7 +48,7 @@ type UploadLogsParams struct {
 	*/
 	LogsType string
 	/*The file to upload.
-	  Max Length: 20971520
+	  Max Length: 104857600
 	  In: formData
 	*/
 	Upfile io.ReadCloser
@@ -215,8 +215,8 @@ func (o *UploadLogsParams) validateLogsType(formats strfmt.Registry) error {
 func (o *UploadLogsParams) bindUpfile(file multipart.File, header *multipart.FileHeader) error {
 	size, _ := file.Seek(0, io.SeekEnd)
 	file.Seek(0, io.SeekStart)
-	if size > 20971520 {
-		return errors.ExceedsMaximum("upfile", "formData", 20971520, false, size)
+	if size > 104857600 {
+		return errors.ExceedsMaximum("upfile", "formData", 104857600, false, size)
 	}
 	return nil
 }


### PR DESCRIPTION
This was the result of running `make generate-from-swagger` on the latest master

It looks like commits 89c1250f6d6901775c6d92d078f8f25cfbd33e07 and 0d610b28d817b91b55cf67d3d6ab6e463e03d567 should have included these changes.

cc @slaviered @asalkeld 

@filanov @YuviGold is this something we can add to a test suite? If files should be regenerated it would be great for the PR to fail tests. Otherwise I feel like these kinds of things will get missed constantly.