### PR TITLE
MGMT-2662 re-enable the baremetalProvisioningConfig

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -16,11 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/openshift/assisted-service/pkg/ocm"
-	"github.com/openshift/assisted-service/restapi"
-
 	ign_3_1 "github.com/coreos/ignition/v2/config/v3_1"
 	ign_3_1_types "github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/go-openapi/runtime/middleware"
@@ -33,6 +28,12 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
@@ -48,12 +49,10 @@ import (
 	"github.com/openshift/assisted-service/pkg/filemiddleware"
 	"github.com/openshift/assisted-service/pkg/generator"
 	"github.com/openshift/assisted-service/pkg/k8sclient"
+	"github.com/openshift/assisted-service/pkg/ocm"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
+	"github.com/openshift/assisted-service/restapi"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-	v1 "k8s.io/api/core/v1"
 )
 
 const ClusterStatusInstalled = "installed"
@@ -1761,6 +1760,7 @@ var _ = Describe("cluster", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
 			err := db.Create(&common.Cluster{Cluster: models.Cluster{
 				ID:                 &clusterID,
+				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
 				APIVip:             "10.11.12.13",
 				IngressVip:         "10.11.12.14",
 				MachineNetworkCidr: "10.11.0.0/16",
@@ -2941,6 +2941,7 @@ var _ = Describe("cluster", func() {
 				APIVip:             "10.11.12.13",
 				IngressVip:         "10.11.20.50",
 				MachineNetworkCidr: "10.11.0.0/16",
+				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
 				Status:             swag.String(models.ClusterStatusReady),
 			}}).Error
 			Expect(err).ShouldNot(HaveOccurred())
@@ -3376,8 +3377,9 @@ var _ = Describe("KubeConfig download", func() {
 
 		bm = NewBareMetalInventory(db, common.GetTestLog(), nil, clusterApi, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
-			ID:     &clusterID,
-			APIVip: "10.11.12.13",
+			ID:               &clusterID,
+			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			APIVip:           "10.11.12.13",
 		}}
 		err := db.Create(&c).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -3503,8 +3505,9 @@ var _ = Describe("UploadClusterIngressCert test", func() {
 			db, nil, nil, nil, nil, nil)
 		bm = NewBareMetalInventory(db, common.GetTestLog(), nil, clusterApi, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
-			ID:     &clusterID,
-			APIVip: "10.11.12.13",
+			ID:               &clusterID,
+			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			APIVip:           "10.11.12.13",
 		}}
 		kubeconfigNoingress = fmt.Sprintf("%s/%s", clusterID, "kubeconfig-noingress")
 		kubeconfigObject = fmt.Sprintf("%s/%s", clusterID, kubeconfig)
@@ -3677,9 +3680,10 @@ var _ = Describe("List unregistered clusters", func() {
 		mockSecretValidator = validations.NewMockPullSecretValidator(ctrl)
 		bm = NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterAPI, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
-			ID:     &clusterID,
-			Name:   "mycluster",
-			APIVip: "10.11.12.13",
+			ID:               &clusterID,
+			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			Name:             "mycluster",
+			APIVip:           "10.11.12.13",
 		}}
 		err := db.Create(&c).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -3754,9 +3758,10 @@ var _ = Describe("Get unregistered clusters", func() {
 		mockSecretValidator = validations.NewMockPullSecretValidator(ctrl)
 		bm = NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterAPI, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
-			ID:     &clusterID,
-			Name:   "mycluster",
-			APIVip: "10.11.12.13",
+			ID:               &clusterID,
+			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			Name:             "mycluster",
+			APIVip:           "10.11.12.13",
 		}}
 		err := db.Create(&c).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -3833,9 +3838,10 @@ var _ = Describe("Upload and Download logs test", func() {
 
 		bm = NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterAPI, cfg, nil, nil, mockS3Client, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
-			ID:     &clusterID,
-			Name:   "mycluster",
-			APIVip: "10.11.12.13",
+			ID:               &clusterID,
+			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			Name:             "mycluster",
+			APIVip:           "10.11.12.13",
 		}}
 		err := db.Create(&c).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -4191,6 +4197,7 @@ var _ = Describe("GetClusterInstallConfig", func() {
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:                     &clusterID,
 			BaseDNSDomain:          "example.com",
+			OpenshiftVersion:       common.TestDefaultConfig.OpenShiftVersion,
 			InstallConfigOverrides: `{"controlPlane": {"hyperthreading": "Disabled"}}`,
 		}}
 		err := db.Create(&c).Error
@@ -4243,7 +4250,13 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 		clusterID = strfmt.UUID(uuid.New().String())
 		mockSecretValidator = validations.NewMockPullSecretValidator(ctrl)
 		bm = NewBareMetalInventory(db, common.GetTestLog(), nil, nil, cfg, nil, nil, nil, nil, getTestAuthHandler(), nil, nil, mockSecretValidator, nil, nil)
-		c = common.Cluster{Cluster: models.Cluster{ID: &clusterID}}
+		c = common.Cluster{
+			Cluster: models.Cluster{
+				ID:               &clusterID,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			},
+		}
+
 		err := db.Create(&c).Error
 		Expect(err).ShouldNot(HaveOccurred())
 	})

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -1,0 +1,15 @@
+package common
+
+import "github.com/hashicorp/go-version"
+
+func VersionGreaterOrEqual(version1, version2 string) (bool, error) {
+	v1, err := version.NewVersion(version1)
+	if err != nil {
+		return false, err
+	}
+	v2, err := version.NewVersion(version2)
+	if err != nil {
+		return false, err
+	}
+	return !v1.LessThan(v2), nil
+}

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 
 	"github.com/go-openapi/swag"
-	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/host/hostutil"
-	"github.com/openshift/assisted-service/internal/network"
-	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"gopkg.in/yaml.v2"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/network"
+	"github.com/openshift/assisted-service/models"
 )
 
 type host struct {
@@ -260,9 +261,10 @@ func setBMPlatformInstallconfig(log logrus.FieldLogger, cluster *common.Cluster,
 		}
 		yamlHostIdx += 1
 	}
+
 	cfg.Platform = platform{
 		Baremetal: &baremetal{
-			ProvisioningNetwork: "Unmanaged",
+			ProvisioningNetwork: "Disabled",
 			APIVIP:              cluster.APIVip,
 			IngressVIP:          cluster.IngressVip,
 			Hosts:               hosts,


### PR DESCRIPTION
This will cause 4.7 clusters to have a Provisioning CR and for the baremetal-operator to be more enabled.