### PR TITLE
MGMT-2955 POST /assisted-service-iso should return presigned url

### DIFF
--- a/client/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
+++ b/client/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
@@ -69,13 +69,25 @@ func NewCreateISOAndUploadToS3Created() *CreateISOAndUploadToS3Created {
 Success.
 */
 type CreateISOAndUploadToS3Created struct {
+	Payload *models.Presigned
 }
 
 func (o *CreateISOAndUploadToS3Created) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3Created ", 201)
+	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3Created  %+v", 201, o.Payload)
+}
+
+func (o *CreateISOAndUploadToS3Created) GetPayload() *models.Presigned {
+	return o.Payload
 }
 
 func (o *CreateISOAndUploadToS3Created) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Presigned)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/internal/assistedserviceiso/assistedserviceiso_api.go
+++ b/internal/assistedserviceiso/assistedserviceiso_api.go
@@ -104,6 +104,11 @@ func (a *assistedServiceISOApi) CreateISOAndUploadToS3(ctx context.Context, para
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 
+	// If service is running on AWS S3, generate the presigned URL and return it
+	if a.objectHandler.IsAwsS3() {
+		return a.GetPresignedForAssistedServiceISO(ctx, assisted_service_iso.NewGetPresignedForAssistedServiceISOParams())
+	}
+
 	return assisted_service_iso.NewCreateISOAndUploadToS3Created()
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -113,7 +113,10 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "Success."
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/presigned"
+            }
           },
           "400": {
             "description": "Error.",
@@ -7686,7 +7689,10 @@ func init() {
         ],
         "responses": {
           "201": {
-            "description": "Success."
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/presigned"
+            }
           },
           "400": {
             "description": "Error.",

--- a/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
+++ b/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
@@ -21,6 +21,11 @@ const CreateISOAndUploadToS3CreatedCode int = 201
 swagger:response createISOAndUploadToS3Created
 */
 type CreateISOAndUploadToS3Created struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Presigned `json:"body,omitempty"`
 }
 
 // NewCreateISOAndUploadToS3Created creates CreateISOAndUploadToS3Created with default headers values
@@ -29,12 +34,27 @@ func NewCreateISOAndUploadToS3Created() *CreateISOAndUploadToS3Created {
 	return &CreateISOAndUploadToS3Created{}
 }
 
+// WithPayload adds the payload to the create i s o and upload to s3 created response
+func (o *CreateISOAndUploadToS3Created) WithPayload(payload *models.Presigned) *CreateISOAndUploadToS3Created {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the create i s o and upload to s3 created response
+func (o *CreateISOAndUploadToS3Created) SetPayload(payload *models.Presigned) {
+	o.Payload = payload
+}
+
 // WriteResponse to the client
 func (o *CreateISOAndUploadToS3Created) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
-
 	rw.WriteHeader(201)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
 }
 
 // CreateISOAndUploadToS3BadRequestCode is the HTTP code returned for type CreateISOAndUploadToS3BadRequest

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3071,6 +3071,8 @@ paths:
       responses:
         "201":
           description: Success.
+          schema:
+            $ref: '#/definitions/presigned'
         "400":
           description: Error.
           schema:


### PR DESCRIPTION
As an optimization and when the object storage back end is AWS
S3, POST /assisted-service-iso should also generate the presigned
URL and return it in the response. This will save the UI an extra
call.