### PR TITLE
MGMT-2411: Added error_utils.go

### DIFF
--- a/pkg/error/error_utils.go
+++ b/pkg/error/error_utils.go
@@ -1,0 +1,48 @@
+package error
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+)
+
+type AssistedServiceErrorAPI interface {
+	Error() string
+	GetPayload() *models.Error
+}
+
+type AssistedServiceInfraErrorAPI interface {
+	Error() string
+	GetPayload() *models.InfraError
+}
+
+func assistedErrorToError(err AssistedServiceErrorAPI) error {
+	payload := err.GetPayload()
+	return errors.Errorf(
+		"AssistedServiceError Code: %s Href: %s ID: %d Kind: %s Reason: %s",
+		swag.StringValue(payload.Code),
+		swag.StringValue(payload.Href),
+		swag.Int32Value(payload.ID),
+		swag.StringValue(payload.Kind),
+		swag.StringValue(payload.Reason))
+}
+
+func infraErrorToError(err AssistedServiceInfraErrorAPI) error {
+	payload := err.GetPayload()
+	return errors.Errorf(
+		"AssistedServiceInfraError Code: %d Message: %s",
+		swag.Int32Value(payload.Code),
+		swag.StringValue(payload.Message))
+}
+
+func GetAssistedError(err error) error {
+	switch err := err.(type) {
+	case AssistedServiceErrorAPI:
+		return assistedErrorToError(err)
+	case AssistedServiceInfraErrorAPI:
+		return infraErrorToError(err)
+	default:
+		return err
+	}
+}

--- a/pkg/error/error_utils_test.go
+++ b/pkg/error/error_utils_test.go
@@ -1,0 +1,74 @@
+package error
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/swag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/models"
+)
+
+func TestErrorUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Error Utils")
+}
+
+var _ = Describe("Error Utils", func() {
+
+	It("AssistedServiceErrorAPI tests", func() {
+
+		err := installer.DownloadHostIgnitionConflict{
+			Payload: &models.Error{
+				Href:   swag.String("href"),
+				ID:     swag.Int32(555),
+				Kind:   swag.String("kind"),
+				Reason: swag.String("reason"),
+			},
+		}
+
+		expectedFmt := "AssistedServiceError Code:  Href: href ID: 555 Kind: kind Reason: reason"
+
+		By("test AssistedServiceError original error - expect bad error formatting", func() {
+			Expect(err.Error()).ShouldNot(Equal(expectedFmt))
+		})
+
+		By("test AssistedServiceError error - expect good formatting", func() {
+			ase := GetAssistedError(&err)
+			Expect(ase).Should(HaveOccurred())
+			Expect(ase.Error()).Should(Equal(expectedFmt))
+		})
+	})
+
+	It("AssistedServiceInfraError tests", func() {
+
+		err := installer.DownloadHostIgnitionForbidden{
+			Payload: &models.InfraError{
+				Code:    swag.Int32(403),
+				Message: swag.String("forbidden"),
+			},
+		}
+
+		expectedFmt := "AssistedServiceInfraError Code: 403 Message: forbidden"
+
+		By("test AssistedServiceInfraError original error - expect bad error formatting", func() {
+			Expect(err.Error()).ShouldNot(Equal(expectedFmt))
+		})
+
+		By("test AssistedServiceInfraError error - expect good formatting", func() {
+			ase := GetAssistedError(&err)
+			Expect(ase).Should(HaveOccurred())
+			Expect(ase.Error()).Should(Equal(expectedFmt))
+		})
+	})
+
+	It("test regular error", func() {
+		err := errors.New("test error")
+		Expect(err.Error()).Should(Equal("test error"))
+		ase := GetAssistedError(err)
+		Expect(ase).Should(HaveOccurred())
+		Expect(ase.Error()).Should(Equal("test error"))
+	})
+})


### PR DESCRIPTION
Provides a work around for the error format bug returned
from the assisted service.
GetAssistedError function receives error and manually build
the message from Payload by the error type which is a struct
of pointers.
Will be used by assisted installer client when logging the
error messages.