### PR TITLE
OCPBUGSM-20820: Removing workers IPs from logs cmd.

### DIFF
--- a/internal/host/logscmd.go
+++ b/internal/host/logscmd.go
@@ -71,7 +71,7 @@ func (i *logsCmd) getNonBootstrapMastersIPsInHostCluster(ctx context.Context, ho
 
 	var ips []string
 	for _, h := range cluster.Hosts {
-		if h.Bootstrap {
+		if h.Bootstrap || h.Role == models.HostRoleWorker {
 			continue
 		}
 		ip, err := network.GetMachineCIDRIP(h, &cluster)


### PR DESCRIPTION
Workers don't have the public SSH key of bootstrap anyway so SSH to them
will fail, this is just adding noise to the real logs collection.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>