### PR TITLE
MGMT-3033 - Add S.M.A.R.T. field to inventory host disks

### DIFF
--- a/models/disk.go
+++ b/models/disk.go
@@ -42,6 +42,9 @@ type Disk struct {
 	// size bytes
 	SizeBytes int64 `json:"size_bytes,omitempty"`
 
+	// smart
+	Smart string `json:"smart,omitempty"`
+
 	// vendor
 	Vendor string `json:"vendor,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4560,6 +4560,9 @@ func init() {
         "size_bytes": {
           "type": "integer"
         },
+        "smart": {
+          "type": "string"
+        },
         "vendor": {
           "type": "string"
         },
@@ -10099,6 +10102,9 @@ func init() {
         },
         "size_bytes": {
           "type": "integer"
+        },
+        "smart": {
+          "type": "string"
         },
         "vendor": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3490,6 +3490,8 @@ definitions:
         type: integer
       bootable:
         type: boolean
+      smart:
+        type: string
 
   boot:
     type: object


### PR DESCRIPTION
This field will be populated by the agent in a later pull request with the output of `smartctl -x --json=c <device>`