### PR TITLE
MGMT-2470 silently fail if free addresses container already running

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
+	github.com/alessio/shellescape v1.4.1
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/aws/aws-sdk-go v1.32.6
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcy
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873 h1:93nQ7k53GjoMQ07HVP8g6Zj1fQZDDj7Xy2VkNNtvX8o=
 github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
@@ -110,6 +111,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/aliyun/aliyun-oss-go-sdk v2.0.4+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=

--- a/internal/host/freeaddressescmd.go
+++ b/internal/host/freeaddressescmd.go
@@ -3,12 +3,13 @@ package host
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/alessio/shellescape"
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type freeAddressesCmd struct {
@@ -64,18 +65,33 @@ func (f *freeAddressesCmd) GetSteps(ctx context.Context, host *models.Host) ([]*
 	if err != nil {
 		return nil, err
 	}
+
+	const containerName = "free_addresses_scanner"
+
+	podmanRunCmd := shellescape.QuoteCommand([]string{
+		"podman", "run", "--privileged", "--net=host", "--rm", "--quiet",
+		"--name", containerName,
+		"-v", "/var/log:/var/log",
+		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+		f.freeAddressesImage,
+		"free_addresses",
+		param,
+	})
+
+	// Sometimes the address scanning takes longer than the interval we wait between invocations.
+	// To avoid flooding the log with "container already exists" errors, we silently fail by manually
+	// checking if it exists and only running if it doesn't
+	checkAlreadyRunningCmd := fmt.Sprintf("podman ps --format '{{.Names}}' | grep -q '^%s$'", containerName)
+
 	step := &models.Step{
 		StepType: models.StepTypeFreeNetworkAddresses,
-		Command:  "podman",
+		Command:  "sh",
 		Args: []string{
-			"run", "--privileged", "--net=host", "--rm", "--quiet",
-			"--name", "free_addresses_scanner",
-			"-v", "/var/log:/var/log",
-			"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-			f.freeAddressesImage,
-			"free_addresses",
-			param,
+			"-c",
+			fmt.Sprintf("%s || %s", checkAlreadyRunningCmd, podmanRunCmd),
 		},
 	}
+
 	return []*models.Step{step}, nil
+
 }


### PR DESCRIPTION
Sometimes the address scanning takes longer than the interval we wait between invocations. To avoid flooding the log with "container already exists" errors, we silently fail by manually checking if it exists and only running if it doesn't