### PR TITLE
NO-ISSUE Remove docker objects cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
-                sh 'docker system prune -a'
                 sh 'make ci-lint'
 
                 // Login to quay.io


### PR DESCRIPTION
Sinch the VM cleanup job is added, no need to run this
http://assisted-jenkins.lab.eng.tlv2.redhat.com/job/vm-cleanup/
(never really worked anyway)