### PR TITLE
KNIECO-2810: Add a new Dockerfile to enable ocp-ci

### DIFF
--- a/Dockerfile.assisted-iso-create-ocp-ci
+++ b/Dockerfile.assisted-iso-create-ocp-ci
@@ -1,0 +1,28 @@
+FROM quay.io/coreos/coreos-installer:v0.7.0 AS installer-image
+
+# Build binaries
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 as builder
+COPY . .
+RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-iso-create assisted-iso-create/main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG WORK_DIR=/data
+ENV OS_IMAGE
+ENV COREOS_IMAGE=$WORK_DIR/livecd.iso
+
+ENV WORK_DIR=$WORK_DIR
+ENV BASE_OS_IMAGE=$OS_IMAGE
+
+RUN mkdir $WORK_DIR
+RUN chmod 775 $WORK_DIR
+
+RUN curl -L -k  --fail ${BASE_OS_IMAGE} -o $WORK_DIR/livecd.iso && \
+    chmod 644 $WORK_DIR/livecd.iso
+
+COPY --from=installer-image /usr/sbin/coreos-installer $WORK_DIR
+
+COPY --from=builder /build/assisted-iso-create $WORK_DIR
+
+ENV COMMMAND_LINE=$WORK_DIR/assisted-iso-create
+ENTRYPOINT exec $COMMMAND_LINE


### PR DESCRIPTION
The existing Dockerfile for assisted-iso-create is expecting
a Docker build-arg, yet ci-operator does not support passing a
build argument.

A workaround is switching from using an ARG to an ENV, as ENVs
are supported in ocp-ci.

Since the work on this is still WIP, a new Dockerfile was created
in order to avoid any issues with the current functional Jenkins
pipeline.