### PR TITLE
MGMT-3078 - Add an unfiltered_disks list entry to the inventory API

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5232,6 +5232,7 @@ func init() {
           "$ref": "#/definitions/cpu"
         },
         "disks": {
+          "description": "Disks that are candidates for installation, filtered",
           "type": "array",
           "items": {
             "$ref": "#/definitions/disk"
@@ -5254,6 +5255,13 @@ func init() {
         },
         "timestamp": {
           "type": "integer"
+        },
+        "unfiltered_disks": {
+          "description": "All disks found on the system, unfiltered",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/disk"
+          }
         }
       }
     },
@@ -10798,6 +10806,7 @@ func init() {
           "$ref": "#/definitions/cpu"
         },
         "disks": {
+          "description": "Disks that are candidates for installation, filtered",
           "type": "array",
           "items": {
             "$ref": "#/definitions/disk"
@@ -10820,6 +10829,13 @@ func init() {
         },
         "timestamp": {
           "type": "integer"
+        },
+        "unfiltered_disks": {
+          "description": "All disks found on the system, unfiltered",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/disk"
+          }
         }
       }
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3567,6 +3567,12 @@ definitions:
           $ref: '#/definitions/interface'
       disks:
         type: array
+        description: "Disks that are candidates for installation, filtered"
+        items:
+          $ref: '#/definitions/disk'
+      unfiltered_disks:
+        type: array
+        description: "All disks found on the system, unfiltered"
         items:
           $ref: '#/definitions/disk'
       boot:


### PR DESCRIPTION
This list entry will contain all disks, even the ones that were filtered out. This is in contrast to the existing `disks` entry, which contains just the disks that are relevant for installation.