### PR TITLE
NO-ISSUE Wrap deploy namespace with double quotes

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -55,7 +55,7 @@ def set_namespace_in_yaml_docs(docs, ns):
     for doc in docs:
         try:
             if 'namespace' in doc['metadata']:
-                doc['metadata']['namespace'] = ns
+                doc['metadata']['namespace'] = f'"{ns}"'
         except KeyError:
             continue
 


### PR DESCRIPTION
CI is failing from time to time on generated namespace without quotes

```bash
05:01:59  python3 ./tools/deploy_postgres.py --namespace "06175907" --profile "9e76a55c" --target "minikube"
05:01:59  /usr/local/lib/python3.6/site-packages/requests/__init__.py:91: RequestsDependencyWarning: urllib3 (1.26.2) or chardet (3.0.4) doesn't match a supported version!
05:01:59    RequestsDependencyWarning)
05:01:59  [INFO] 2020-11-26 02:59:07,338 - deploy_postgres - Starting postgres deployment
05:01:59  [INFO] 2020-11-26 02:59:07,340 - deploy_postgres - Deploying /home/workspace/assisted-test-infra_master/assisted-service/build/06175907/postgres-secret.yaml
05:02:00  error: unable to decode "/home/workspace/assisted-test-infra_master/assisted-service/build/06175907/postgres-secret.yaml": resource.metadataOnlyObject.ObjectMeta: v1.ObjectMeta.Namespace: ReadString: expects " or n, but found 6, error found in #10 byte of ...|mespace":6175907},"s|..., bigger context ...|es"},"name":"assisted-installer-rds","namespace":6175907},"stringData":{"db.host":"postgres","db.nam|...
05:02:00  Traceback (most recent call last):
05:02:00    File "./tools/deploy_postgres.py", line 94, in <module>
05:02:00      main()
05:02:00    File "./tools/deploy_postgres.py", line 16, in main
05:02:00      deploy_postgres_secret(deploy_options)
05:02:00    File "./tools/deploy_postgres.py", line 39, in deploy_postgres_secret
05:02:00      file=dst_file
05:02:00    File "/home/workspace/assisted-test-infra_master/assisted-service/tools/utils.py", line 157, in apply
05:02:00      print(check_output(f'{kubectl_cmd} apply -f {file}'))
05:02:00    File "/home/workspace/assisted-test-infra_master/assisted-service/tools/utils.py", line 64, in check_output
05:02:00      return subprocess.check_output(cmd, shell=True).decode("utf-8")
05:02:00    File "/usr/lib64/python3.6/subprocess.py", line 356, in check_output
05:02:00      **kwargs).stdout
05:02:00    File "/usr/lib64/python3.6/subprocess.py", line 438, in run
05:02:00      output=stdout, stderr=stderr)
05:02:00  subprocess.CalledProcessError: Command 'kubectl --namespace 06175907 --server https://192.168.39.54:8443 apply -f /home/workspace/assisted-test-infra_master/assisted-service/build/06175907/postgres-secret.yaml' returned non-zero exit status 1.
05:02:00  make: *** [Makefile:222: deploy-postgres] Error 1
05:02:00  make: Leaving directory '/home/workspace/assisted-test-infra_master/assisted-service'
05:02:00  make: *** [Makefile:297: deploy_assisted_service] Error 2
```