### PR TITLE
NO-ISSUE - Remove romfreiman from OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,6 +4,7 @@ filters:
   .*:
     approvers:
       - code-reviewers
+      - romfreiman
     reviewers:
       - code-reviewers
   Jenkinsfile:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,7 +6,6 @@ aliases:
     - erezalster
     - filanov
     - gamli75
-    - romfreiman
     - ronniel1
   code-reviewers:
     - avishayt
@@ -17,7 +16,6 @@ aliases:
     - ori-amizur
     - oshercc
     - razregev
-    - romfreiman
     - ronniel1
     - tsorya
     - yevgeny-shnaidman


### PR DESCRIPTION
Removed @romfreiman from all alias groups, made it so @romfreiman is only an approver (in `OWNERS` directly, without a group), so he won't be randomly assigned to review PRs