### PR TITLE
MGMT-3153 - Disable password login for discovery ISO core user

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -388,7 +388,7 @@ func (b *bareMetalInventory) getUserSshKey(params installer.GenerateClusterISOPa
 	}
 	return fmt.Sprintf(`{
 		"name": "core",
-		"passwordHash": "$6$MWO4bibU8TIWG0XV$Hiuj40lWW7pHiwJmXA8MehuBhdxSswLgvGxEh8ByEzeX2D1dk87JILVUYS4JQOP45bxHRegAB9Fs/SWfszXa5.",
+		"passwordHash": "!",
 		"sshAuthorizedKeys": [
 		"%s"],
 		"groups": [ "sudo" ]}`, sshKey)


### PR DESCRIPTION
Disabled password-based login for the `core` user in the discovery ISO. SSH login with public key based authentication is still supported.

In the future a mechanism for a randomized, per-cluster password will be added.
Until it's implemented, we remove the ability to login with the hard-coded password with this PR.