### PR TITLE
MGMT-2758 Remove image from s3 when editing the discovery ignition

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -446,14 +446,11 @@ func (b *bareMetalInventory) UpdateDiscoveryIgnition(ctx context.Context, params
 		return installer.NewUpdateDiscoveryIgnitionInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
-	exists, err := b.objectHandler.DoesObjectExist(ctx, getImageName(*c.ID))
+	existed, err := b.objectHandler.DeleteObject(ctx, getImageName(*c.ID))
 	if err != nil {
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
-	if exists {
-		if err := b.objectHandler.DeleteObject(ctx, getImageName(*c.ID)); err != nil {
-			return common.NewApiError(http.StatusInternalServerError, err)
-		}
+	if existed {
 		b.eventsHandler.AddEvent(ctx, *c.ID, nil, models.EventSeverityInfo, "Deleted image from backend because its ignition was updated. The image may be regenerated at any time.", time.Now())
 	}
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -425,7 +425,7 @@ func (b *bareMetalInventory) GetDiscoveryIgnition(ctx context.Context, params in
 func (b *bareMetalInventory) UpdateDiscoveryIgnition(ctx context.Context, params installer.UpdateDiscoveryIgnitionParams) middleware.Responder {
 	log := logutil.FromContext(ctx, b.log)
 
-	_, err := b.getCluster(ctx, params.ClusterID.String())
+	c, err := b.getCluster(ctx, params.ClusterID.String())
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}
@@ -444,6 +444,17 @@ func (b *bareMetalInventory) UpdateDiscoveryIgnition(ctx context.Context, params
 	err = b.db.Model(&common.Cluster{}).Where(identity.AddUserFilter(ctx, "id = ?"), params.ClusterID).Update("ignition_config_overrides", params.DiscoveryIgnitionParams.Config).Error
 	if err != nil {
 		return installer.NewUpdateDiscoveryIgnitionInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+	}
+
+	exists, err := b.objectHandler.DoesObjectExist(ctx, getImageName(*c.ID))
+	if err != nil {
+		return common.NewApiError(http.StatusInternalServerError, err)
+	}
+	if exists {
+		if err := b.objectHandler.DeleteObject(ctx, getImageName(*c.ID)); err != nil {
+			return common.NewApiError(http.StatusInternalServerError, err)
+		}
+		b.eventsHandler.AddEvent(ctx, *c.ID, nil, models.EventSeverityInfo, "Deleted image from backend because its ignition was updated. The image may be regenerated at any time.", time.Now())
 	}
 
 	return installer.NewUpdateDiscoveryIgnitionCreated()

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -684,7 +684,8 @@ func (m *Manager) DeleteClusterLogs(ctx context.Context, c *common.Cluster, obje
 	var failedToDelete []string
 	for _, file := range files {
 		log.Debugf("Deleting cluster %s S3 log file: %s", c.ID.String(), file)
-		if err := objectHandler.DeleteObject(ctx, file); err != nil {
+		_, err = objectHandler.DeleteObject(ctx, file)
+		if err != nil {
 			m.log.WithError(err).Errorf("failed deleting s3 log %s", file)
 			failedToDelete = append(failedToDelete, file)
 		}
@@ -714,7 +715,8 @@ func (m *Manager) DeleteClusterFiles(ctx context.Context, c *common.Cluster, obj
 		if strings.Contains(fileName, "logs") {
 			continue
 		}
-		if err := objectHandler.DeleteObject(ctx, fileName); err != nil {
+		_, err := objectHandler.DeleteObject(ctx, fileName)
+		if err != nil {
 			m.log.WithError(err).Errorf("failed deleting s3 file %s", fileName)
 			failedToDelete = append(failedToDelete, fileName)
 		}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2026,7 +2026,7 @@ var _ = Describe("Permanently delete clusters", func() {
 		Expect(db.First(&common.Cluster{}, "id = ?", c2.ID).RowsAffected).Should(Equal(int64(0)))
 		Expect(db.Unscoped().First(&common.Cluster{}, "id = ?", c2.ID).RowsAffected).Should(Equal(int64(1)))
 
-		mockS3Api.EXPECT().DeleteObject(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockS3Api.EXPECT().DeleteObject(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		mockS3Api.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
 
 		Expect(state.PermanentClustersDeletion(ctx, strfmt.DateTime(time.Now()), mockS3Api)).ShouldNot(HaveOccurred())

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -130,7 +130,8 @@ func (m *Manifests) DeleteClusterManifest(ctx context.Context, params operations
 		return operations.NewDeleteClusterManifestOK()
 	}
 
-	if err := m.objectHandler.DeleteObject(ctx, objectName); err != nil {
+	_, err = m.objectHandler.DeleteObject(ctx, objectName)
+	if err != nil {
 		return common.GenerateErrorResponder(errors.Errorf("failed to delete %s from s3", objectName))
 	}
 

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -274,7 +274,7 @@ var _ = Describe("ClusterManifestTests", func() {
 			clusterID := registerCluster().ID
 			mockUpload(1)
 			mockObjectExists(true)
-			mockS3Client.EXPECT().DeleteObject(ctx, getObjectName(clusterID, defaultFolder, "file-1.yaml")).Return(nil)
+			mockS3Client.EXPECT().DeleteObject(ctx, getObjectName(clusterID, defaultFolder, "file-1.yaml")).Return(true, nil)
 			addManifestToCluster(clusterID, content, "file-1.yaml", defaultFolder)
 
 			response := manifestsAPI.DeleteClusterManifest(ctx, operations.DeleteClusterManifestParams{
@@ -288,7 +288,7 @@ var _ = Describe("ClusterManifestTests", func() {
 			clusterID := registerCluster().ID
 			mockUpload(1)
 			mockObjectExists(true)
-			mockS3Client.EXPECT().DeleteObject(ctx, getObjectName(clusterID, validFolder, "file-1.yaml")).Return(nil)
+			mockS3Client.EXPECT().DeleteObject(ctx, getObjectName(clusterID, validFolder, "file-1.yaml")).Return(true, nil)
 			addManifestToCluster(clusterID, content, "file-1.yaml", validFolder)
 
 			response := manifestsAPI.DeleteClusterManifest(ctx, operations.DeleteClusterManifestParams{

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -171,19 +171,19 @@ func (f *FSClient) DoesObjectExist(ctx context.Context, objectName string) (bool
 	return true, nil
 }
 
-func (f *FSClient) DeleteObject(ctx context.Context, objectName string) error {
+func (f *FSClient) DeleteObject(ctx context.Context, objectName string) (bool, error) {
 	log := logutil.FromContext(ctx, f.log)
 	filePath := filepath.Join(f.basedir, objectName)
 	err := os.Remove(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return errors.Wrapf(err, "Failed to delete file %s", filePath)
+		return false, errors.Wrapf(err, "Failed to delete file %s", filePath)
 	}
 
 	log.Infof("Deleted file %s", filePath)
-	return nil
+	return true, nil
 }
 
 func (f *FSClient) GetObjectSizeBytes(ctx context.Context, objectName string) (int64, error) {

--- a/pkg/s3wrapper/filesystem_test.go
+++ b/pkg/s3wrapper/filesystem_test.go
@@ -97,7 +97,8 @@ var _ = Describe("s3filesystem", func() {
 		Expect(err).Should(BeNil())
 		Expect(exists).To(Equal(true))
 
-		err = client.DeleteObject(ctx, objKey)
+		existed, err := client.DeleteObject(ctx, objKey)
+		Expect(existed).To(Equal(true))
 		Expect(err).Should(BeNil())
 
 		exists, err = client.DoesObjectExist(ctx, objKey)

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -153,11 +153,12 @@ func (mr *MockAPIMockRecorder) DoesObjectExist(ctx, objectName interface{}) *gom
 }
 
 // DeleteObject mocks base method
-func (m *MockAPI) DeleteObject(ctx context.Context, objectName string) error {
+func (m *MockAPI) DeleteObject(ctx context.Context, objectName string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteObject", ctx, objectName)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteObject indicates an expected call of DeleteObject


### PR DESCRIPTION
This will force the user to re-generate the image after making changes

Fixes [MGMT-2758](https://issues.redhat.com/browse/MGMT-2758)

cc @eranco74 