### PR TITLE
MGMT-3078 - Add disk filtering reasons to the API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/coreos/ignition/v2 v2.6.0
 	github.com/danielerez/go-dns-client v0.0.0-20200630114514-0b60d1703f0b
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustin/go-humanize v1.0.0
 	github.com/filanov/stateswitch v0.0.0-20200714113403-51a42a34c604
 	github.com/fsouza/go-dockerclient v1.6.6 // indirect
 	github.com/go-openapi/errors v0.19.6

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,7 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QL
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface
@@ -61,4 +60,19 @@ func (m *MockValidator) GetHostRequirements(role models.HostRole) models.HostReq
 func (mr *MockValidatorMockRecorder) GetHostRequirements(role interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements), role)
+}
+
+// DiskIsEligible mocks base method
+func (m *MockValidator) DiskIsEligible(disk *models.Disk) (bool, []string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiskIsEligible", disk)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].([]string)
+	return ret0, ret1
+}
+
+// DiskIsEligible indicates an expected call of DiskIsEligible
+func (mr *MockValidatorMockRecorder) DiskIsEligible(disk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), disk)
 }

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -221,7 +221,7 @@ func (v *validator) hasMinValidDisks(c *validationContext) validationStatus {
 	if c.inventory == nil {
 		return ValidationPending
 	}
-	disks := hardware.ListValidDisks(c.inventory, gibToBytes(v.hwValidatorCfg.MinDiskSizeGb))
+	disks := hardware.ListValidDisks(c.inventory)
 	return boolValue(len(disks) > 0)
 }
 

--- a/models/cluster_update_params.go
+++ b/models/cluster_update_params.go
@@ -69,6 +69,8 @@ type ClusterUpdateParams struct {
 	MachineNetworkCidr *string `json:"machine_network_cidr,omitempty"`
 
 	// OpenShift cluster name.
+	// Max Length: 54
+	// Min Length: 1
 	Name *string `json:"name,omitempty"`
 
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
@@ -124,6 +126,10 @@ func (m *ClusterUpdateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMachineNetworkCidr(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateName(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -275,6 +281,23 @@ func (m *ClusterUpdateParams) validateMachineNetworkCidr(formats strfmt.Registry
 	}
 
 	if err := validate.Pattern("machine_network_cidr", "body", string(*m.MachineNetworkCidr), `^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ClusterUpdateParams) validateName(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Name) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("name", "body", string(*m.Name), 1); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("name", "body", string(*m.Name), 54); err != nil {
 		return err
 	}
 

--- a/models/disk.go
+++ b/models/disk.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -26,6 +27,9 @@ type Disk struct {
 
 	// hctl
 	Hctl string `json:"hctl,omitempty"`
+
+	// installation eligibility
+	InstallationEligibility *DiskInstallationEligibility `json:"installation_eligibility,omitempty"`
 
 	// model
 	Model string `json:"model,omitempty"`
@@ -54,6 +58,33 @@ type Disk struct {
 
 // Validate validates this disk
 func (m *Disk) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateInstallationEligibility(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Disk) validateInstallationEligibility(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.InstallationEligibility) { // not required
+		return nil
+	}
+
+	if m.InstallationEligibility != nil {
+		if err := m.InstallationEligibility.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("installation_eligibility")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -68,6 +99,41 @@ func (m *Disk) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *Disk) UnmarshalBinary(b []byte) error {
 	var res Disk
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// DiskInstallationEligibility disk installation eligibility
+//
+// swagger:model DiskInstallationEligibility
+type DiskInstallationEligibility struct {
+
+	// Whether the disk is eligible for installation or not.
+	Eligible bool `json:"eligible,omitempty"`
+
+	// Reasons for why this disk is not elligible for installation.
+	NotEligibleReasons []string `json:"not_eligible_reasons"`
+}
+
+// Validate validates this disk installation eligibility
+func (m *DiskInstallationEligibility) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *DiskInstallationEligibility) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *DiskInstallationEligibility) UnmarshalBinary(b []byte) error {
+	var res DiskInstallationEligibility
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -514,8 +514,6 @@ func init() {
         "operationId": "UpdateCluster",
         "parameters": [
           {
-            "maxLength": 54,
-            "minLength": 1,
             "type": "string",
             "format": "uuid",
             "name": "cluster_id",
@@ -4449,6 +4447,8 @@ func init() {
         "name": {
           "description": "OpenShift cluster name.",
           "type": "string",
+          "maxLength": 54,
+          "minLength": 1,
           "x-nullable": true
         },
         "no_proxy": {
@@ -4732,6 +4732,22 @@ func init() {
         },
         "hctl": {
           "type": "string"
+        },
+        "installation_eligibility": {
+          "type": "object",
+          "properties": {
+            "eligible": {
+              "description": "Whether the disk is eligible for installation or not.",
+              "type": "boolean"
+            },
+            "not_eligible_reasons": {
+              "description": "Reasons for why this disk is not elligible for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         },
         "model": {
           "type": "string"
@@ -6228,8 +6244,6 @@ func init() {
         "operationId": "UpdateCluster",
         "parameters": [
           {
-            "maxLength": 54,
-            "minLength": 1,
             "type": "string",
             "format": "uuid",
             "name": "cluster_id",
@@ -9645,6 +9659,22 @@ func init() {
         }
       }
     },
+    "DiskInstallationEligibility": {
+      "type": "object",
+      "properties": {
+        "eligible": {
+          "description": "Whether the disk is eligible for installation or not.",
+          "type": "boolean"
+        },
+        "not_eligible_reasons": {
+          "description": "Reasons for why this disk is not elligible for installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "HostRegistrationResponseAO1NextStepRunnerCommand": {
       "description": "Command for starting the next step runner",
       "type": "object",
@@ -10191,6 +10221,8 @@ func init() {
         "name": {
           "description": "OpenShift cluster name.",
           "type": "string",
+          "maxLength": 54,
+          "minLength": 1,
           "x-nullable": true
         },
         "no_proxy": {
@@ -10474,6 +10506,22 @@ func init() {
         },
         "hctl": {
           "type": "string"
+        },
+        "installation_eligibility": {
+          "type": "object",
+          "properties": {
+            "eligible": {
+              "description": "Whether the disk is eligible for installation or not.",
+              "type": "boolean"
+            },
+            "not_eligible_reasons": {
+              "description": "Reasons for why this disk is not elligible for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         },
         "model": {
           "type": "string"

--- a/restapi/operations/installer/update_cluster_parameters.go
+++ b/restapi/operations/installer/update_cluster_parameters.go
@@ -41,8 +41,6 @@ type UpdateClusterParams struct {
 	ClusterUpdateParams *models.ClusterUpdateParams
 	/*
 	  Required: true
-	  Max Length: 54
-	  Min Length: 1
 	  In: path
 	*/
 	ClusterID strfmt.UUID
@@ -116,14 +114,6 @@ func (o *UpdateClusterParams) bindClusterID(rawData []string, hasKey bool, forma
 
 // validateClusterID carries on validations for parameter ClusterID
 func (o *UpdateClusterParams) validateClusterID(formats strfmt.Registry) error {
-
-	if err := validate.MinLength("cluster_id", "path", o.ClusterID.String(), 1); err != nil {
-		return err
-	}
-
-	if err := validate.MaxLength("cluster_id", "path", o.ClusterID.String(), 54); err != nil {
-		return err
-	}
 
 	if err := validate.FormatOf("cluster_id", "path", "uuid", o.ClusterID.String(), formats); err != nil {
 		return err

--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Host tests", func() {
 					Name:      "sda1",
 					DriveType: "HDD",
 					SizeBytes: int64(120) * (int64(1) << 30),
+					InstallationEligibility: &models.DiskInstallationEligibility{
+						Eligible:           true,
+						NotEligibleReasons: []string{},
+					},
 				},
 			},
 			Memory: &models.Memory{

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3625,6 +3625,17 @@ definitions:
         type: integer
       bootable:
         type: boolean
+      installation_eligibility:
+        type: object
+        properties:
+          eligible:
+            type: boolean
+            description: Whether the disk is eligible for installation or not.
+          not_eligible_reasons:
+            type: array
+            description: Reasons for why this disk is not elligible for installation.
+            items:
+              type: string
       smart:
         type: string
 


### PR DESCRIPTION
Each disk in the API now has an "eligibility" field composed of a boolean saying whether it's eligible and an array of reasons of why it's not eligible.

It is expected that the agent fill in that struct with why **it** thinks the disk is not eligible. The service will then unmarshal the inventory blob, and add its own reasons on top of the agent's reasons of why it thinks the disk is ineligible, then combine (`&&`) the final decision and write it all in the eligibility struct.

Older agents will not report that struct - so we'll see a nil struct from older agents, so the service uses that to detect that the agent is old and behaves as if the agent marked the disk as eligible. 

The reason for not doing the entire decision-making in the service is because the agent (unlike the service) has access to the `ghw.Disk` object for each disk, which contains crucial information information that would be very awkward to include in the API. So either we include that info in the API or do this "combined" decision making in both the agent and the service like we do in this PR.