### PR TITLE
MGMT-3120 IPv6 connectivity check

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1085,7 +1085,7 @@ func addInstallationRequirements(clusterId strfmt.UUID, db *gorm.DB) {
 	Expect(db.Model(&common.Cluster{Cluster: models.Cluster{ID: &clusterId}}).Updates(map[string]interface{}{"api_vip": "1.2.3.5", "ingress_vip": "1.2.3.6"}).Error).To(Not(HaveOccurred()))
 }
 
-func addInstallationRequirementsWithConnectivity(clusterId strfmt.UUID, db *gorm.DB, outgoingIpAddresses ...string) {
+func addInstallationRequirementsWithConnectivity(clusterId strfmt.UUID, db *gorm.DB, remoteIpAddresses ...string) {
 	var hostId strfmt.UUID
 	var host models.Host
 	hostIds := []strfmt.UUID{
@@ -1101,10 +1101,10 @@ func addInstallationRequirementsWithConnectivity(clusterId strfmt.UUID, db *gorm
 		}
 		makeL2Connectivity := func() []*models.L2Connectivity {
 			ret := make([]*models.L2Connectivity, 0)
-			for _, o := range outgoingIpAddresses {
+			for _, r := range remoteIpAddresses {
 				ret = append(ret, &models.L2Connectivity{
-					Successful:        true,
-					OutgoingIPAddress: o,
+					Successful:      true,
+					RemoteIPAddress: r,
 				})
 			}
 			return ret

--- a/internal/host/connectivitycheckconvertor.go
+++ b/internal/host/connectivitycheckconvertor.go
@@ -46,9 +46,15 @@ func convertInterfacesToConnectivityCheckHost(hostId *strfmt.UUID, interfaces []
 		var ipAddresses []string
 		connectivityNic.Mac = hostInterface.MacAddress
 		connectivityNic.Name = hostInterface.Name
+
 		for _, ip := range hostInterface.IPV4Addresses {
 			ipAddresses = append(ipAddresses, strings.Split(ip, "/")[0])
 		}
+
+		for _, ip := range hostInterface.IPV6Addresses {
+			ipAddresses = append(ipAddresses, strings.Split(ip, "/")[0])
+		}
+
 		connectivityNic.IPAddresses = ipAddresses
 		connectivityHost.Nics = append(connectivityHost.Nics, &connectivityNic)
 	}

--- a/internal/host/connectivitycheckconvertor_test.go
+++ b/internal/host/connectivitycheckconvertor_test.go
@@ -39,8 +39,16 @@ var _ = Describe("connectivitycheckconvertor", func() {
 		}
 
 		interfaces = []*models.Interface{
-			{Name: "eth0", MacAddress: "44:85:00:80:12:a4", IPV4Addresses: []string{"10.0.0.1/24", "10.0.0.2", "10.0.0.3/24"}},
-			{Name: "eth1", MacAddress: "45:85:00:80:12:a4", IPV4Addresses: []string{"10.0.0.4", "10.0.0.5/24", "10.0.0.6", "10.0.0.7/24"}},
+			{
+				Name: "eth0", MacAddress: "44:85:00:80:12:a4",
+				IPV4Addresses: []string{"10.0.0.1/24", "10.0.0.2", "10.0.0.3/24"},
+				IPV6Addresses: []string{"2001:db8::4/120", "2001:db8::a"},
+			},
+			{
+				Name: "eth1", MacAddress: "45:85:00:80:12:a4",
+				IPV4Addresses: []string{"10.0.0.4", "10.0.0.5/24", "10.0.0.6", "10.0.0.7/24"},
+				IPV6Addresses: []string{"fe80:5054::1f", "fe80:5054::5/120", "fe80:5054::ff"},
+			},
 		}
 	})
 
@@ -48,8 +56,8 @@ var _ = Describe("connectivitycheckconvertor", func() {
 		connectivityParamsHost := convertInterfacesToConnectivityCheckHost(&currentHostId, interfaces)
 		Expect(connectivityParamsHost.HostID.String()).To(Equal(currentHostId.String()))
 		Expect(connectivityParamsHost.Nics).To(HaveLen(2))
-		Expect(connectivityParamsHost.Nics[0].IPAddresses).To(HaveLen(3))
-		Expect(connectivityParamsHost.Nics[1].IPAddresses).To(HaveLen(4))
+		Expect(connectivityParamsHost.Nics[0].IPAddresses).To(HaveLen(5))
+		Expect(connectivityParamsHost.Nics[1].IPAddresses).To(HaveLen(7))
 	})
 
 	It("convertHostsToConnectivityParamsHosts_success", func() {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -481,8 +481,7 @@ func (v *validator) printAPIVipConnected(c *validationContext, status validation
 }
 
 func (v *validator) belongsToMajorityGroup(c *validationContext) validationStatus {
-	// TODO Remove condition for IPv6 when connectivity check is implemented (Phase 3)
-	if IsDay2Host(c.host) || swag.BoolValue(c.cluster.UserManagedNetworking) || network.IsIPv6CIDR(c.cluster.MachineNetworkCidr) {
+	if IsDay2Host(c.host) || swag.BoolValue(c.cluster.UserManagedNetworking) {
 		return ValidationSuccess
 	}
 	if c.cluster.MachineNetworkCidr == "" || c.cluster.ConnectivityMajorityGroups == "" {

--- a/internal/network/connectivity_groups.go
+++ b/internal/network/connectivity_groups.go
@@ -256,7 +256,7 @@ func createMachineCidrConnectivityMap(cidr string, hosts []*models.Host, idToInd
 		}
 		for _, r := range connectivityReport.RemoteHosts {
 			for _, l2 := range r.L2Connectivity {
-				ip := net.ParseIP(l2.OutgoingIPAddress)
+				ip := net.ParseIP(l2.RemoteIPAddress)
 				if ip != nil && parsedCidr.Contains(ip) && l2.Successful {
 					toIndex, ok := idToIndex[r.HostID]
 					if ok {

--- a/internal/network/connectivity_groups_test.go
+++ b/internal/network/connectivity_groups_test.go
@@ -2,342 +2,459 @@ package network
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/models"
 )
 
-var _ = Describe("connectivity groups", func() {
+type node struct {
+	id          *strfmt.UUID
+	addressNet1 string
+	addressNet2 string
+}
 
-	var (
-		hid1 strfmt.UUID = "11111111-1111-1111-1111-111111111111"
-		hid2 strfmt.UUID = "22222222-2222-2222-2222-222222222222"
-		hid3 strfmt.UUID = "33333333-3333-3333-3333-333333333333"
-		hid4 strfmt.UUID = "44444444-4444-4444-4444-444444444444"
-		hid5 strfmt.UUID = "55555555-5555-5555-5555-555555555555"
-		hid6 strfmt.UUID = "66666666-6666-6666-6666-666666666666"
-		hid7 strfmt.UUID = "77777777-7777-7777-7777-777777777777"
-	)
+func linkNet1(n *node) *models.L2Connectivity {
+	return &models.L2Connectivity{
+		RemoteIPAddress: n.addressNet1,
+		Successful:      true,
+	}
+}
 
-	createL2 := func(outgoingIpAddress string, successful bool) *models.L2Connectivity {
-		return &models.L2Connectivity{
-			OutgoingIPAddress: outgoingIpAddress,
-			Successful:        successful,
+func linkNet2(n *node) *models.L2Connectivity {
+	return &models.L2Connectivity{
+		RemoteIPAddress: n.addressNet2,
+		Successful:      true,
+	}
+}
+
+func unLinkNet1(n *node) *models.L2Connectivity {
+	return &models.L2Connectivity{
+		RemoteIPAddress: n.addressNet1,
+		Successful:      false,
+	}
+}
+
+func generateIPv4Nodes(count int, net1CIDR, net2CIDR string) []*node {
+
+	net1, _, _ := net.ParseCIDR(net1CIDR)
+	net1Address := net1.To4()
+	net1Address[3] += 4
+
+	net2, _, _ := net.ParseCIDR(net2CIDR)
+	net2Address := net2.To4()
+	net2Address[3] += 4
+
+	ret := make([]*node, count)
+	for i := 0; i < count; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		ret[i] = &node{
+			id:          &id,
+			addressNet1: net1Address.String(),
+			addressNet2: net2Address.String(),
 		}
+
+		net1Address[3]++
+		net2Address[3]++
 	}
 
-	createRemoteHost := func(id strfmt.UUID, l2s ...*models.L2Connectivity) *models.ConnectivityRemoteHost {
-		return &models.ConnectivityRemoteHost{
-			HostID:         id,
-			L2Connectivity: l2s,
+	return ret
+}
+
+func generateIPv6Nodes(count int, net1CIDR, net2CIDR string) []*node {
+
+	net1, _, _ := net.ParseCIDR(net1CIDR)
+	net1Address := net1.To16()
+	net1Address[15] += 4
+
+	net2, _, _ := net.ParseCIDR(net2CIDR)
+	net2Address := net2.To16()
+	net2Address[15] += 4
+
+	ret := make([]*node, count)
+	for i := 0; i < count; i++ {
+		id := strfmt.UUID(uuid.New().String())
+		ret[i] = &node{
+			id:          &id,
+			addressNet1: net1Address.String(),
+			addressNet2: net2Address.String(),
 		}
+		net1Address[15]++
+		net2Address[15]++
 	}
 
-	createConnectiityReport := func(remoteHosts ...*models.ConnectivityRemoteHost) string {
-		report := models.ConnectivityReport{
-			RemoteHosts: remoteHosts,
-		}
-		b, err := json.Marshal(&report)
-		Expect(err).ToNot(HaveOccurred())
-		return string(b)
+	return ret
+}
+
+func createRemote(remote *node, connFuncs ...func(h *node) *models.L2Connectivity) *models.ConnectivityRemoteHost {
+
+	l2s := make([]*models.L2Connectivity, 0)
+	for _, f := range connFuncs {
+		l2s = append(l2s, f(remote))
 	}
 
-	Context("connectivity groups", func() {
-		It("Empty", func() {
-			hosts := []*models.Host{
-				{
-					ID:           &hid1,
-					Connectivity: createConnectiityReport(),
-				},
-				{
-					ID:           &hid2,
-					Connectivity: createConnectiityReport(),
-				},
-				{
-					ID:           &hid3,
-					Connectivity: createConnectiityReport(),
-				},
-			}
-			ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ret).To(Equal([]strfmt.UUID{}))
-		})
-		It("Empty 2", func() {
-			hosts := []*models.Host{
-				{
-					ID: &hid1,
-				},
-				{
-					ID: &hid2,
-				},
-				{
-					ID: &hid3,
-				},
-			}
-			ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ret).To(Equal([]strfmt.UUID{}))
-		})
-	})
-	It("One with data", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID:           &hid2,
-				Connectivity: createConnectiityReport(),
-			},
-			{
-				ID:           &hid3,
-				Connectivity: createConnectiityReport(),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(Equal([]strfmt.UUID{}))
-	})
-	It("3 with data", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true))),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
-					createRemoteHost(hid2, createL2("1.2.3.6", true))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(3))
-		Expect(ret).To(ContainElement(hid1))
-		Expect(ret).To(ContainElement(hid2))
-		Expect(ret).To(ContainElement(hid3))
-	})
-	It("Different network", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true))),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("2.2.3.6", true)),
-					createRemoteHost(hid2, createL2("2.2.3.6", true))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(Equal([]strfmt.UUID{}))
-	})
-	It("3 with data, additional network", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true), createL2("2.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true)),
-					createRemoteHost(hid4, createL2("2.2.3.4", true)),
-				),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true), createL2("2.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true)),
-					createRemoteHost(hid4, createL2("2.2.3.4", true)),
-				),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true), createL2("2.2.3.6", true)),
-					createRemoteHost(hid2, createL2("1.2.3.6", true), createL2("2.2.3.5", true))),
-			},
-			{
-				ID: &hid4,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("2.2.3.6", true)),
-					createRemoteHost(hid2, createL2("2.2.3.6", true))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(3))
-		Expect(ret).To(ContainElement(hid1))
-		Expect(ret).To(ContainElement(hid2))
-		Expect(ret).To(ContainElement(hid3))
-		ret, err = CreateMajorityGroup("2.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(3))
-		Expect(ret).To(ContainElement(hid1))
-		Expect(ret).To(ContainElement(hid2))
-		Expect(ret).To(ContainElement(hid4))
-	})
-	It("7 - 2 groups", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true))),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
-					createRemoteHost(hid2, createL2("1.2.3.6", true))),
-			},
-			{
-				ID: &hid4,
-				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true)),
-				),
-			},
-			{
-				ID: &hid5,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid6,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid7,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(4))
-		Expect(ret).To(ContainElement(hid4))
-		Expect(ret).To(ContainElement(hid5))
-		Expect(ret).To(ContainElement(hid6))
-		Expect(ret).To(ContainElement(hid7))
-	})
-	It("7 - 1 direction missing", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true))),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
-					createRemoteHost(hid2, createL2("1.2.3.6", true))),
-			},
-			{
-				ID: &hid4,
-				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true)),
-				),
-			},
-			{
-				ID: &hid5,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid6,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid7,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", false))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(3))
-		Expect(ret).To(ContainElement(hid1))
-		Expect(ret).To(ContainElement(hid2))
-		Expect(ret).To(ContainElement(hid3))
-	})
-	It("7 - 2 directions missing", func() {
-		hosts := []*models.Host{
-			{
-				ID: &hid1,
-				Connectivity: createConnectiityReport(createRemoteHost(hid2, createL2("1.2.3.4", true)),
-					createRemoteHost(hid3, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid2,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.5", true)),
-					createRemoteHost(hid3, createL2("1.2.3.5", true))),
-			},
-			{
-				ID: &hid3,
-				Connectivity: createConnectiityReport(createRemoteHost(hid1, createL2("1.2.3.6", true)),
-					createRemoteHost(hid2, createL2("1.2.3.6", false))),
-			},
-			{
-				ID: &hid4,
-				Connectivity: createConnectiityReport(createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true)),
-				),
-			},
-			{
-				ID: &hid5,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.5", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid6,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid7, createL2("1.2.3.4", true))),
-			},
-			{
-				ID: &hid7,
-				Connectivity: createConnectiityReport(createRemoteHost(hid4, createL2("1.2.3.6", true)),
-					createRemoteHost(hid5, createL2("1.2.3.4", true)),
-					createRemoteHost(hid6, createL2("1.2.3.4", false))),
-			},
-		}
-		ret, err := CreateMajorityGroup("1.2.3.0/24", hosts)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(ret).To(HaveLen(3))
-		Expect(ret).To(ContainElement(hid4))
-		Expect(ret).To(ContainElement(hid5))
-		Expect(ret).To(ContainElement(hid6))
-	})
+	return &models.ConnectivityRemoteHost{
+		HostID:         *remote.id,
+		L2Connectivity: l2s,
+	}
+}
+
+var _ = Describe("connectivity groups all", func() {
+	GenerateConnectivityGroupTests(true, "1.2.3.0/24", "2.2.3.0/24")
+	GenerateConnectivityGroupTests(false, "2001:db8::/120", "fe80:5054::/120")
 })
+
+func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
+
+	var ipVersion string
+	var nodes []*node
+	if ipV4 {
+		ipVersion = "IPv4"
+		nodes = generateIPv4Nodes(7, net1CIDR, net2CIDR)
+	} else {
+		ipVersion = "IPv6"
+		nodes = generateIPv6Nodes(7, net1CIDR, net2CIDR)
+	}
+
+	Describe(fmt.Sprintf("connectivity groups %s", ipVersion), func() {
+
+		createConnectivityReport := func(remoteHosts ...*models.ConnectivityRemoteHost) string {
+			report := models.ConnectivityReport{
+				RemoteHosts: remoteHosts,
+			}
+			b, err := json.Marshal(&report)
+			Expect(err).ToNot(HaveOccurred())
+			return string(b)
+		}
+
+		Context("connectivity groups", func() {
+			It("Empty", func() {
+				hosts := []*models.Host{
+					{
+						ID:           nodes[0].id,
+						Connectivity: createConnectivityReport(),
+					},
+					{
+						ID:           nodes[1].id,
+						Connectivity: createConnectivityReport(),
+					},
+					{
+						ID:           nodes[2].id,
+						Connectivity: createConnectivityReport(),
+					},
+				}
+				ret, err := CreateMajorityGroup(net1CIDR, hosts)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ret).To(Equal([]strfmt.UUID{}))
+			})
+			It("Empty 2", func() {
+				hosts := []*models.Host{
+					{
+						ID: nodes[0].id,
+					},
+					{
+						ID: nodes[1].id,
+					},
+					{
+						ID: nodes[2].id,
+					},
+				}
+				ret, err := CreateMajorityGroup(net1CIDR, hosts)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ret).To(Equal([]strfmt.UUID{}))
+			})
+		})
+		It("One with data", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID:           nodes[1].id,
+					Connectivity: createConnectivityReport(),
+				},
+				{
+					ID:           nodes[2].id,
+					Connectivity: createConnectivityReport(),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal([]strfmt.UUID{}))
+		})
+		It("3 with data", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[1], linkNet1)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+		})
+		It("Different network", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet2),
+						createRemote(nodes[1], linkNet2)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal([]strfmt.UUID{}))
+		})
+		It("3 with data, additional network", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1, linkNet2),
+						createRemote(nodes[2], linkNet1),
+						createRemote(nodes[3], linkNet2),
+					),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1, linkNet2),
+						createRemote(nodes[2], linkNet1),
+						createRemote(nodes[3], linkNet2),
+					),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1, linkNet2),
+						createRemote(nodes[1], linkNet1, linkNet2)),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet2),
+						createRemote(nodes[1], linkNet2)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+			ret, err = CreateMajorityGroup(net2CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[3].id))
+		})
+		It("7 - 2 groups", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[1], linkNet1)),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1),
+					),
+				},
+				{
+					ID: nodes[4].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[5].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[6].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], linkNet1)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(4))
+			Expect(ret).To(ContainElement(*nodes[3].id))
+			Expect(ret).To(ContainElement(*nodes[4].id))
+			Expect(ret).To(ContainElement(*nodes[5].id))
+			Expect(ret).To(ContainElement(*nodes[6].id))
+		})
+		It("7 - 1 direction missing", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[1], linkNet1)),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1),
+					),
+				},
+				{
+					ID: nodes[4].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[5].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[6].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], unLinkNet1)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+		})
+		It("7 - 2 directions missing", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[1], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[0], linkNet1),
+						createRemote(nodes[2], linkNet1)),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(createRemote(nodes[0], linkNet1),
+						createRemote(nodes[1], unLinkNet1)),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1),
+					),
+				},
+				{
+					ID: nodes[4].id,
+					Connectivity: createConnectivityReport(createRemote(nodes[3], linkNet1),
+						createRemote(nodes[5], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[5].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[6], linkNet1)),
+				},
+				{
+					ID: nodes[6].id,
+					Connectivity: createConnectivityReport(
+						createRemote(nodes[3], linkNet1),
+						createRemote(nodes[4], linkNet1),
+						createRemote(nodes[5], unLinkNet1)),
+				},
+			}
+			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[3].id))
+			Expect(ret).To(ContainElement(*nodes[4].id))
+			Expect(ret).To(ContainElement(*nodes[5].id))
+		})
+	})
+}

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -246,10 +246,20 @@ func GetClusterNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
 				continue
 			}
 			for _, inf := range inventory.Interfaces {
+
 				for _, ipv4 := range inf.IPV4Addresses {
 					_, cidr, err := net.ParseCIDR(ipv4)
 					if err != nil {
 						log.WithError(err).Warnf("Parse CIDR %s", ipv4)
+						continue
+					}
+					cidrs[cidr.String()] = true
+				}
+
+				for _, ipv6 := range inf.IPV6Addresses {
+					_, cidr, err := net.ParseCIDR(ipv6)
+					if err != nil {
+						log.WithError(err).Warnf("Parse CIDR %s", ipv6)
 						continue
 					}
 					cidrs[cidr.String()] = true


### PR DESCRIPTION
Enable L2 connectivity check in IPv6 environments.
This change depends on the agent reporting L2 connectivity when the addresses are IPv6.