### PR TITLE
NO-ISSUE Add 4.7 support on swagger

### DIFF
--- a/models/cluster.go
+++ b/models/cluster.go
@@ -130,7 +130,7 @@ type Cluster struct {
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`
 
 	// Version of the OpenShift cluster.
-	// Enum: [4.5 4.6]
+	// Enum: [4.5 4.6 4.7]
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 
 	// org id
@@ -572,7 +572,7 @@ var clusterTypeOpenshiftVersionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["4.5","4.6"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["4.5","4.6","4.7"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -587,6 +587,9 @@ const (
 
 	// ClusterOpenshiftVersionNr46 captures enum value "4.6"
 	ClusterOpenshiftVersionNr46 string = "4.6"
+
+	// ClusterOpenshiftVersionNr47 captures enum value "4.7"
+	ClusterOpenshiftVersionNr47 string = "4.7"
 )
 
 // prop value enum

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -59,7 +59,7 @@ type ClusterCreateParams struct {
 
 	// Version of the OpenShift cluster.
 	// Required: true
-	// Enum: [4.5 4.6]
+	// Enum: [4.5 4.6 4.7]
 	OpenshiftVersion *string `json:"openshift_version"`
 
 	// The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.
@@ -182,7 +182,7 @@ var clusterCreateParamsTypeOpenshiftVersionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["4.5","4.6"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["4.5","4.6","4.7"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -197,6 +197,9 @@ const (
 
 	// ClusterCreateParamsOpenshiftVersionNr46 captures enum value "4.6"
 	ClusterCreateParamsOpenshiftVersionNr46 string = "4.6"
+
+	// ClusterCreateParamsOpenshiftVersionNr47 captures enum value "4.7"
+	ClusterCreateParamsOpenshiftVersionNr47 string = "4.7"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4140,7 +4140,8 @@ func init() {
           "type": "string",
           "enum": [
             "4.5",
-            "4.6"
+            "4.6",
+            "4.7"
           ]
         },
         "org_id": {
@@ -4278,7 +4279,8 @@ func init() {
           "type": "string",
           "enum": [
             "4.5",
-            "4.6"
+            "4.6",
+            "4.7"
           ]
         },
         "pull_secret": {
@@ -9905,7 +9907,8 @@ func init() {
           "type": "string",
           "enum": [
             "4.5",
-            "4.6"
+            "4.6",
+            "4.7"
           ]
         },
         "org_id": {
@@ -10043,7 +10046,8 @@ func init() {
           "type": "string",
           "enum": [
             "4.5",
-            "4.6"
+            "4.6",
+            "4.7"
           ]
         },
         "pull_secret": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2943,7 +2943,7 @@ definitions:
         description: Name of the OpenShift cluster.
       openshift_version:
         type: string
-        enum: ['4.5', '4.6']
+        enum: ['4.5', '4.6', '4.7']
         description: Version of the OpenShift cluster.
       base_dns_domain:
         type: string
@@ -3186,7 +3186,7 @@ definitions:
         type: string
       openshift_version:
         type: string
-        enum: ['4.5', '4.6']
+        enum: ['4.5', '4.6', '4.7']
         description: Version of the OpenShift cluster.
       openshift_cluster_id:
         type: string


### PR DESCRIPTION
Must be added in order to make https://github.com/openshift/assisted-test-infra/pull/328 work
Prow already runs with OCP version 4.7