### PR TITLE
fix podman pod create format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,8 @@ podman-pull-service-from-docker-daemon:
 	podman pull "docker-daemon:${SERVICE}"
 
 deploy-onprem:
-	podman pod create --name assisted-installer -p 5432,8000,8090,8080
+	# Format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
+	podman pod create --name assisted-installer -p 5432:5432,8000:8000,8090:8090,8080:8080
 	# These are required because when running on RHCOS livecd, the coreos-installer binary and
 	# livecd are bind-mounted from the host into the assisted-service container at runtime.
 	[ -f livecd.iso ] || curl $(BASE_OS_IMAGE) --retry 5 -o livecd.iso


### PR DESCRIPTION
The older format created containerPorts
We need the ports exposed on the host

see
https://github.com/containers/podman/blob/master/docs/source/markdown/podman-pod-create.1.md#--publishport--p

for clarity also added relevant line from podman doc into Makefile.

this is needed at lest in order to make it work with podman 2.2.1 ...