### PR TITLE
OCPBUGSM-21552 Add workers chrony manifest

### DIFF
--- a/internal/network/ntp_utils_test.go
+++ b/internal/network/ntp_utils_test.go
@@ -39,7 +39,7 @@ var _ = Describe("chrony manifest", func() {
 
 			response, err := createChronyManifestContent(&common.Cluster{Cluster: models.Cluster{
 				Hosts: hosts,
-			}})
+			}}, models.HostRoleMaster)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			expectedContent := defaultChronyConf
@@ -58,7 +58,7 @@ var _ = Describe("chrony manifest", func() {
 
 			response, err := createChronyManifestContent(&common.Cluster{Cluster: models.Cluster{
 				Hosts: hosts,
-			}})
+			}}, models.HostRoleMaster)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			expectedContent := defaultChronyConf
@@ -77,7 +77,7 @@ var _ = Describe("chrony manifest", func() {
 
 			response, err := createChronyManifestContent(&common.Cluster{Cluster: models.Cluster{
 				Hosts: hosts,
-			}})
+			}}, models.HostRoleMaster)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			expectedContent := defaultChronyConf
@@ -96,7 +96,7 @@ var _ = Describe("chrony manifest", func() {
 
 			response, err := createChronyManifestContent(&common.Cluster{Cluster: models.Cluster{
 				Hosts: hosts,
-			}})
+			}}, models.HostRoleMaster)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			expectedContent := defaultChronyConf
@@ -149,7 +149,7 @@ var _ = Describe("chrony manifest", func() {
 		})
 
 		It("CreateClusterManifest success", func() {
-			manifestsApi.EXPECT().CreateClusterManifest(gomock.Any(), gomock.Any()).Return(operations.NewCreateClusterManifestCreated()).Times(1)
+			manifestsApi.EXPECT().CreateClusterManifest(gomock.Any(), gomock.Any()).Return(operations.NewCreateClusterManifestCreated()).Times(2)
 			Expect(ntpUtils.AddChronyManifest(ctx, log, &cluster)).ShouldNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
Two manifests should be created and uploaded - one per role.

- masters-chrony-configuration.yaml
- workers-chrony-configuration.yaml