### PR TITLE
OCPBUGSM-21583 Remove RHEL default NTP source

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -92,7 +92,7 @@ type Config struct {
 	AgentTimeoutStart        time.Duration     `envconfig:"AGENT_TIMEOUT_START" default:"3m"`
 	ServiceIPs               string            `envconfig:"SERVICE_IPS" default:""`
 	DeletedUnregisteredAfter time.Duration     `envconfig:"DELETED_UNREGISTERED_AFTER" default:"168h"`
-	DefaultNTPSource         string            `envconfig:"NTP_DEFAULT_SERVER" default:"0.rhel.pool.ntp.org"`
+	DefaultNTPSource         string            `envconfig:"NTP_DEFAULT_SERVER"`
 }
 
 const agentMessageOfTheDay = `

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4550,6 +4550,7 @@ var _ = Describe("TestRegisterCluster", func() {
 	)
 
 	BeforeEach(func() {
+		cfg.DefaultNTPSource = ""
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db = common.PrepareTestDB(dbName)
 		ctrl = gomock.NewController(GinkgoT())
@@ -4653,24 +4654,52 @@ var _ = Describe("TestRegisterCluster", func() {
 		verifyApiError(reply, http.StatusBadRequest)
 	})
 
-	It("NTPSource default value", func() {
-		mockClusterApi.EXPECT().RegisterCluster(ctx, gomock.Any()).Return(nil).Times(1)
-		mockEvents.EXPECT().
-			AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-			Times(1)
-		mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	Context("NTPSource", func() {
+		It("NTPSource default value", func() {
+			defaultNtpSource := "clock.redhat.com"
+			bm.Config.DefaultNTPSource = defaultNtpSource
 
-		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
-			NewClusterParams: &models.ClusterCreateParams{
-				Name:             swag.String("some-cluster-name"),
-				OpenshiftVersion: swag.String("4.6"),
-				PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
-			},
+			mockClusterApi.EXPECT().RegisterCluster(ctx, gomock.Any()).Return(nil).Times(1)
+			mockEvents.EXPECT().
+				AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
+				Times(1)
+			mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String("some-cluster-name"),
+					OpenshiftVersion: swag.String("4.6"),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+				},
+			})
+			Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterCreated())))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.AdditionalNtpSource).To(Equal(defaultNtpSource))
 		})
-		Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterCreated())))
-		actual := reply.(*installer.RegisterClusterCreated)
-		Expect(actual.Payload.AdditionalNtpSource).To(Equal(bm.Config.DefaultNTPSource))
+
+		It("NTPSource non default value", func() {
+			newNtpSource := "new.ntp.source"
+
+			mockClusterApi.EXPECT().RegisterCluster(ctx, gomock.Any()).Return(nil).Times(1)
+			mockEvents.EXPECT().
+				AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
+				Times(1)
+			mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:                swag.String("some-cluster-name"),
+					OpenshiftVersion:    swag.String("4.6"),
+					PullSecret:          swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+					AdditionalNtpSource: &newNtpSource,
+				},
+			})
+			Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterCreated())))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.AdditionalNtpSource).To(Equal(newNtpSource))
+		})
 	})
 
 	It("cluster api failed to register", func() {


### PR DESCRIPTION
RHCOS already have RHEL default pool 2.rhel.pool.ntp.org defined on
/etc/chrony.conf.
Removing default RHEL value but keeping NTP_DEFAULT_SERVER configuration
option.

Adding some more tests to AdditionalNtpSource assignment.