### PR TITLE
MGMT-3078 - Add disk filtering reasons to the API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/coreos/ignition/v2 v2.6.0
 	github.com/danielerez/go-dns-client v0.0.0-20200630114514-0b60d1703f0b
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustin/go-humanize v1.0.0
 	github.com/filanov/stateswitch v0.0.0-20200714113403-51a42a34c604
 	github.com/fsouza/go-dockerclient v1.6.6 // indirect
 	github.com/go-openapi/errors v0.19.6

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,7 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QL
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,12 +6,13 @@ package cluster
 
 import (
 	context "context"
+	reflect "reflect"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
-	reflect "reflect"
 )
 
 // MockRegistrationAPI is a mock of RegistrationAPI interface

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,9 +5,10 @@
 package connectivity
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,10 +6,11 @@ package events
 
 import (
 	context "context"
-	strfmt "github.com/go-openapi/strfmt"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	strfmt "github.com/go-openapi/strfmt"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,9 +5,10 @@
 package hardware
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface
@@ -60,4 +61,32 @@ func (m *MockValidator) GetHostRequirements(role models.HostRole) models.HostReq
 func (mr *MockValidatorMockRecorder) GetHostRequirements(role interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements), role)
+}
+
+// DiskIsEligible mocks base method
+func (m *MockValidator) DiskIsEligible(disk *models.Disk) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiskIsEligible", disk)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// DiskIsEligible indicates an expected call of DiskIsEligible
+func (mr *MockValidatorMockRecorder) DiskIsEligible(disk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), disk)
+}
+
+// ListEligibleDisks mocks base method
+func (m *MockValidator) ListEligibleDisks(inventory *models.Inventory) []*models.Disk {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEligibleDisks", inventory)
+	ret0, _ := ret[0].([]*models.Disk)
+	return ret0
+}
+
+// ListEligibleDisks indicates an expected call of ListEligibleDisks
+func (mr *MockValidatorMockRecorder) ListEligibleDisks(inventory interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEligibleDisks", reflect.TypeOf((*MockValidator)(nil).ListEligibleDisks), inventory)
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,13 +6,14 @@ package host
 
 import (
 	context "context"
+	reflect "reflect"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,9 +6,10 @@ package host
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/hardware"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
@@ -36,7 +38,9 @@ var _ = Describe("monitor_disconnection", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
-		state = NewManager(getTestLog(), db, mockEvents, nil, nil, createValidatorCfg(),
+		mockHwValidator := hardware.NewMockValidator(ctrl)
+		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
+		state = NewManager(getTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, defaultConfig, dummy)
 		clusterID := strfmt.UUID(uuid.New().String())
 		host = getTestHost(strfmt.UUID(uuid.New().String()), clusterID, models.HostStatusDiscovering)
@@ -127,7 +131,9 @@ var _ = Describe("TestHostMonitoring", func() {
 			AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			AnyTimes()
 		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
-		state = NewManager(getTestLog(), db, mockEvents, nil, nil, createValidatorCfg(),
+		mockHwValidator := hardware.NewMockValidator(ctrl)
+		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
+		state = NewManager(getTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, &cfg, &leader.DummyElector{})
 	})
 

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -16,10 +16,10 @@ type refreshPreprocessor struct {
 	validations []validation
 }
 
-func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg) *refreshPreprocessor {
+func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator) *refreshPreprocessor {
 	return &refreshPreprocessor{
 		log:         log,
-		validations: newValidations(log, hwValidatorCfg),
+		validations: newValidations(log, hwValidatorCfg, hwValidator),
 	}
 }
 
@@ -44,10 +44,11 @@ func (r *refreshPreprocessor) preprocess(c *validationContext) (map[validationID
 	return stateMachineInput, validationsOutput, nil
 }
 
-func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg) []validation {
+func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator) []validation {
 	v := validator{
 		log:            log,
 		hwValidatorCfg: hwValidatorCfg,
+		hwValidator:    hwValidator,
 	}
 	ret := []validation{
 		{

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -144,6 +144,7 @@ func boolValue(b bool) validationStatus {
 type validator struct {
 	log            logrus.FieldLogger
 	hwValidatorCfg *hardware.ValidatorCfg
+	hwValidator    hardware.Validator
 }
 
 func (v *validator) isConnected(c *validationContext) validationStatus {
@@ -221,7 +222,8 @@ func (v *validator) hasMinValidDisks(c *validationContext) validationStatus {
 	if c.inventory == nil {
 		return ValidationPending
 	}
-	disks := hardware.ListValidDisks(c.inventory, gibToBytes(v.hwValidatorCfg.MinDiskSizeGb))
+
+	disks := v.hwValidator.ListEligibleDisks(c.inventory)
 	return boolValue(len(disks) > 0)
 }
 

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,104 +5,105 @@
 package metrics
 
 import (
+	reflect "reflect"
+	time "time"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
-	time "time"
 )
 
-// MockAPI is a mock of API interface.
+// MockAPI is a mock of API interface
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI.
+// MockAPIMockRecorder is the mock recorder for MockAPI
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance.
+// NewMockAPI creates a new mock instance
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// ClusterRegistered mocks base method.
+// ClusterRegistered mocks base method
 func (m *MockAPI) ClusterRegistered(clusterVersion string, clusterID strfmt.UUID, emailDomain string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterRegistered", clusterVersion, clusterID, emailDomain)
 }
 
-// ClusterRegistered indicates an expected call of ClusterRegistered.
+// ClusterRegistered indicates an expected call of ClusterRegistered
 func (mr *MockAPIMockRecorder) ClusterRegistered(clusterVersion, clusterID, emailDomain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterRegistered", reflect.TypeOf((*MockAPI)(nil).ClusterRegistered), clusterVersion, clusterID, emailDomain)
 }
 
-// InstallationStarted mocks base method.
+// InstallationStarted mocks base method
 func (m *MockAPI) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain, userManagedNetworking string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "InstallationStarted", clusterVersion, clusterID, emailDomain, userManagedNetworking)
 }
 
-// InstallationStarted indicates an expected call of InstallationStarted.
+// InstallationStarted indicates an expected call of InstallationStarted
 func (mr *MockAPIMockRecorder) InstallationStarted(clusterVersion, clusterID, emailDomain, userManagedNetworking interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallationStarted", reflect.TypeOf((*MockAPI)(nil).InstallationStarted), clusterVersion, clusterID, emailDomain, userManagedNetworking)
 }
 
-// ClusterHostInstallationCount mocks base method.
+// ClusterHostInstallationCount mocks base method
 func (m *MockAPI) ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterHostInstallationCount", clusterID, emailDomain, hostCount)
 }
 
-// ClusterHostInstallationCount indicates an expected call of ClusterHostInstallationCount.
+// ClusterHostInstallationCount indicates an expected call of ClusterHostInstallationCount
 func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(clusterID, emailDomain, hostCount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), clusterID, emailDomain, hostCount)
 }
 
-// Duration mocks base method.
+// Duration mocks base method
 func (m *MockAPI) Duration(operation string, duration time.Duration) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Duration", operation, duration)
 }
 
-// Duration indicates an expected call of Duration.
+// Duration indicates an expected call of Duration
 func (mr *MockAPIMockRecorder) Duration(operation, duration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Duration", reflect.TypeOf((*MockAPI)(nil).Duration), operation, duration)
 }
 
-// ClusterInstallationFinished mocks base method.
+// ClusterInstallationFinished mocks base method
 func (m *MockAPI) ClusterInstallationFinished(log logrus.FieldLogger, result, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ClusterInstallationFinished", log, result, clusterVersion, clusterID, emailDomain, installationStartedTime)
 }
 
-// ClusterInstallationFinished indicates an expected call of ClusterInstallationFinished.
+// ClusterInstallationFinished indicates an expected call of ClusterInstallationFinished
 func (mr *MockAPIMockRecorder) ClusterInstallationFinished(log, result, clusterVersion, clusterID, emailDomain, installationStartedTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterInstallationFinished", reflect.TypeOf((*MockAPI)(nil).ClusterInstallationFinished), log, result, clusterVersion, clusterID, emailDomain, installationStartedTime)
 }
 
-// ReportHostInstallationMetrics mocks base method.
+// ReportHostInstallationMetrics mocks base method
 func (m *MockAPI) ReportHostInstallationMetrics(log logrus.FieldLogger, clusterVersion string, clusterID strfmt.UUID, emailDomain string, boot *models.Disk, h *models.Host, previousProgress *models.HostProgressInfo, currentStage models.HostStage) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ReportHostInstallationMetrics", log, clusterVersion, clusterID, emailDomain, boot, h, previousProgress, currentStage)
 }
 
-// ReportHostInstallationMetrics indicates an expected call of ReportHostInstallationMetrics.
+// ReportHostInstallationMetrics indicates an expected call of ReportHostInstallationMetrics
 func (mr *MockAPIMockRecorder) ReportHostInstallationMetrics(log, clusterVersion, clusterID, emailDomain, boot, h, previousProgress, currentStage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportHostInstallationMetrics", reflect.TypeOf((*MockAPI)(nil).ReportHostInstallationMetrics), log, clusterVersion, clusterID, emailDomain, boot, h, previousProgress, currentStage)

--- a/internal/network/mock_ntp_utils.go
+++ b/internal/network/mock_ntp_utils.go
@@ -6,10 +6,11 @@ package network
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockNtpUtilsAPI is a mock of NtpUtilsAPI interface

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -5,9 +5,10 @@
 package oc
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockRelease is a mock of Release interface

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -6,10 +6,11 @@ package versions
 
 import (
 	context "context"
+	reflect "reflect"
+
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	versions "github.com/openshift/assisted-service/restapi/operations/versions"
-	reflect "reflect"
 )
 
 // MockHandler is a mock of Handler interface

--- a/models/disk.go
+++ b/models/disk.go
@@ -6,6 +6,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -26,6 +27,9 @@ type Disk struct {
 
 	// hctl
 	Hctl string `json:"hctl,omitempty"`
+
+	// installation eligibility
+	InstallationEligibility DiskInstallationEligibility `json:"installation_eligibility,omitempty"`
 
 	// model
 	Model string `json:"model,omitempty"`
@@ -54,6 +58,31 @@ type Disk struct {
 
 // Validate validates this disk
 func (m *Disk) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateInstallationEligibility(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *Disk) validateInstallationEligibility(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.InstallationEligibility) { // not required
+		return nil
+	}
+
+	if err := m.InstallationEligibility.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("installation_eligibility")
+		}
+		return err
+	}
+
 	return nil
 }
 
@@ -68,6 +97,41 @@ func (m *Disk) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *Disk) UnmarshalBinary(b []byte) error {
 	var res Disk
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// DiskInstallationEligibility disk installation eligibility
+//
+// swagger:model DiskInstallationEligibility
+type DiskInstallationEligibility struct {
+
+	// Whether the disk is eligible for installation or not.
+	Eligible bool `json:"eligible,omitempty"`
+
+	// Reasons for why this disk is not elligible for installation.
+	NotEligibleReasons []string `json:"not_eligible_reasons"`
+}
+
+// Validate validates this disk installation eligibility
+func (m *DiskInstallationEligibility) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *DiskInstallationEligibility) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *DiskInstallationEligibility) UnmarshalBinary(b []byte) error {
+	var res DiskInstallationEligibility
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/models/image_info.go
+++ b/models/image_info.go
@@ -28,6 +28,9 @@ type ImageInfo struct {
 	// Format: date-time
 	ExpiresAt strfmt.DateTime `json:"expires_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// Image generator version.
+	GeneratorVersion string `json:"generator_version,omitempty"`
+
 	// size bytes
 	// Minimum: 0
 	SizeBytes *int64 `json:"size_bytes,omitempty"`

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,9 +6,10 @@ package generator
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
-	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface
@@ -60,18 +61,4 @@ func (m *MockISOInstallConfigGenerator) GenerateInstallConfig(arg0 context.Conte
 func (mr *MockISOInstallConfigGeneratorMockRecorder) GenerateInstallConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateInstallConfig", reflect.TypeOf((*MockISOInstallConfigGenerator)(nil).GenerateInstallConfig), arg0, arg1, arg2, arg3)
-}
-
-// UploadBaseISO mocks base method
-func (m *MockISOInstallConfigGenerator) UploadBaseISO() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadBaseISO")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UploadBaseISO indicates an expected call of UploadBaseISO
-func (mr *MockISOInstallConfigGeneratorMockRecorder) UploadBaseISO() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBaseISO", reflect.TypeOf((*MockISOInstallConfigGenerator)(nil).UploadBaseISO))
 }

--- a/pkg/k8sclient/mock_k8sclient.go
+++ b/pkg/k8sclient/mock_k8sclient.go
@@ -5,10 +5,11 @@
 package k8sclient
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/config/v1"
 	v10 "k8s.io/api/core/v1"
-	reflect "reflect"
 )
 
 // MockK8SClient is a mock of K8SClient interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,8 +6,9 @@ package leader
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -6,8 +6,9 @@ package ocm
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockOCMAuthorization is a mock of OCMAuthorization interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,8 +6,9 @@ package ocm
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,10 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	reflect "reflect"
+
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,11 +6,12 @@ package s3wrapper
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4780,6 +4780,23 @@ func init() {
         "hctl": {
           "type": "string"
         },
+        "installation_eligibility": {
+          "type": "object",
+          "properties": {
+            "eligible": {
+              "description": "Whether the disk is eligible for installation or not.",
+              "type": "boolean"
+            },
+            "not_eligible_reasons": {
+              "description": "Reasons for why this disk is not elligible for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "x-nullable": false
+        },
         "model": {
           "type": "string"
         },
@@ -9823,6 +9840,23 @@ func init() {
         }
       }
     },
+    "DiskInstallationEligibility": {
+      "type": "object",
+      "properties": {
+        "eligible": {
+          "description": "Whether the disk is eligible for installation or not.",
+          "type": "boolean"
+        },
+        "not_eligible_reasons": {
+          "description": "Reasons for why this disk is not elligible for installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-nullable": false
+    },
     "HostRegistrationResponseAO1NextStepRunnerCommand": {
       "description": "Command for starting the next step runner",
       "type": "object",
@@ -10659,6 +10693,23 @@ func init() {
         },
         "hctl": {
           "type": "string"
+        },
+        "installation_eligibility": {
+          "type": "object",
+          "properties": {
+            "eligible": {
+              "description": "Whether the disk is eligible for installation or not.",
+              "type": "boolean"
+            },
+            "not_eligible_reasons": {
+              "description": "Reasons for why this disk is not elligible for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "x-nullable": false
         },
         "model": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3691,6 +3691,18 @@ definitions:
         type: integer
       bootable:
         type: boolean
+      installation_eligibility:
+        x-nullable: false
+        type: object
+        properties:
+          eligible:
+            type: boolean
+            description: Whether the disk is eligible for installation or not.
+          not_eligible_reasons:
+            type: array
+            description: Reasons for why this disk is not elligible for installation.
+            items:
+              type: string
       smart:
         type: string
 


### PR DESCRIPTION
Similar to #772, this time with ~correct database migrations~ `x-nullable: true` struct and better backwards compatibility.