### PR TITLE
MGMT-3295: On installation delete previews cluster logs

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1160,6 +1160,11 @@ func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installe
 			fmt.Sprintf("Updated status of cluster %s to installing", cluster.Name), time.Now())
 	}()
 
+	// Delete previews installation log files from object storage (if exist) and reset logs flags.
+	if err := b.clusterApi.ClearClusterLogs(ctx, &cluster, b.objectHandler, b.db); err != nil {
+		log.WithError(err).Warnf("Failed deleting s3 logs of cluster %s", cluster.ID.String())
+	}
+
 	log.Infof("Successfully prepared cluster <%s> for installation", params.ClusterID.String())
 	return installer.NewInstallClusterAccepted().WithPayload(&cluster.Cluster)
 }

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1160,7 +1160,7 @@ func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installe
 			fmt.Sprintf("Updated status of cluster %s to installing", cluster.Name), time.Now())
 	}()
 
-	// Delete previews installation log files from object storage (if exist) and reset logs flags.
+	// Delete previous installation log files from object storage (if exist) and reset logs flags.
 	if err := b.clusterApi.ClearClusterLogs(ctx, &cluster, b.objectHandler, b.db); err != nil {
 		log.WithError(err).Warnf("Failed deleting s3 logs of cluster %s", cluster.ID.String())
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1411,7 +1411,9 @@ var _ = Describe("cluster", func() {
 	mockClusterIsReadyForInstallationSuccess := func() {
 		mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 	}
-
+	mockClusterClearLogsSuccess := func() {
+		mockClusterApi.EXPECT().ClearClusterLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	}
 	getInventoryStr := func(hostname, bootMode string, ipv4Addresses ...string) string {
 		inventory := models.Inventory{
 			Interfaces: []*models.Interface{
@@ -2553,6 +2555,7 @@ var _ = Describe("cluster", func() {
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
 				mockEvents.EXPECT().
 					AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					MinTimes(0)
@@ -2653,6 +2656,7 @@ var _ = Describe("cluster", func() {
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
 				})
@@ -2679,6 +2683,7 @@ var _ = Describe("cluster", func() {
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2702,6 +2707,7 @@ var _ = Describe("cluster", func() {
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2724,8 +2730,9 @@ var _ = Describe("cluster", func() {
 				mockClusterPrepareForInstallationSuccess(mockClusterApi)
 				mockHostPrepareForInstallationSuccess(mockHostApi, 3)
 				setIsReadyForInstallationTrue(mockClusterApi)
-
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
+
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
 				})
@@ -2749,6 +2756,7 @@ var _ = Describe("cluster", func() {
 				mockClusterRefreshStatus(mockClusterApi)
 				setIsReadyForInstallationTrue(mockClusterApi)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+				mockClusterClearLogsSuccess()
 
 				reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
 					ClusterID: clusterID,
@@ -2757,7 +2765,6 @@ var _ = Describe("cluster", func() {
 				Expect(reply).Should(BeAssignableToTypeOf(installer.NewInstallClusterAccepted()))
 				waitForDoneChannel()
 			})
-
 			It("get DNS domain success", func() {
 				bm.Config.BaseDNSDomains = map[string]string{
 					"dns.example.com": "abc/route53",

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -476,20 +476,6 @@ func (mr *MockAPIMockRecorder) SetConnectivityMajorityGroupsForCluster(clusterID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConnectivityMajorityGroupsForCluster", reflect.TypeOf((*MockAPI)(nil).SetConnectivityMajorityGroupsForCluster), clusterID, db)
 }
 
-// DeleteClusterLogs mocks base method
-func (m *MockAPI) DeleteClusterLogs(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteClusterLogs", ctx, c, objectHandler)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteClusterLogs indicates an expected call of DeleteClusterLogs
-func (mr *MockAPIMockRecorder) DeleteClusterLogs(ctx, c, objectHandler interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterLogs", reflect.TypeOf((*MockAPI)(nil).DeleteClusterLogs), ctx, c, objectHandler)
-}
-
 // DeleteClusterFiles mocks base method
 func (m *MockAPI) DeleteClusterFiles(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
 	m.ctrl.T.Helper()
@@ -530,4 +516,32 @@ func (m *MockAPI) UpdateInstallProgress(ctx context.Context, c *common.Cluster, 
 func (mr *MockAPIMockRecorder) UpdateInstallProgress(ctx, c, progress interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInstallProgress", reflect.TypeOf((*MockAPI)(nil).UpdateInstallProgress), ctx, c, progress)
+}
+
+// ClearClusterLogs mocks base method
+func (m *MockAPI) ClearClusterLogs(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API, db *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearClusterLogs", ctx, c, objectHandler, db)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearClusterLogs indicates an expected call of ClearClusterLogs
+func (mr *MockAPIMockRecorder) ClearClusterLogs(ctx, c, objectHandler, db interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearClusterLogs", reflect.TypeOf((*MockAPI)(nil).ClearClusterLogs), ctx, c, objectHandler, db)
+}
+
+// DeleteClusterLogsFromS3 mocks base method
+func (m *MockAPI) DeleteClusterLogsFromS3(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteClusterLogsFromS3", ctx, c, objectHandler)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteClusterLogsFromS3 indicates an expected call of DeleteClusterLogsFromS3
+func (mr *MockAPIMockRecorder) DeleteClusterLogsFromS3(ctx, c, objectHandler interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterLogsFromS3", reflect.TypeOf((*MockAPI)(nil).DeleteClusterLogsFromS3), ctx, c, objectHandler)
 }

--- a/internal/cluster/registrar.go
+++ b/internal/cluster/registrar.go
@@ -56,13 +56,13 @@ func (r *registrar) registerCluster(ctx context.Context, cluster *common.Cluster
 		r.log.WithError(err).Errorf("Error registering cluster %s", cluster.Name)
 		return err
 	} else if gorm.IsRecordNotFoundError(err) {
-		// Delete any previews record of the cluster if it was soft deleted in the past,
+		// Delete any previous record of the cluster if it was soft deleted in the past,
 		// no error will be returned it wasn't existed.
 		if err := tx.Unscoped().Delete(&cluster, queryParams).Error; err != nil {
 			r.log.WithError(err).Errorf("Error registering cluster %s", cluster.Name)
 			return errors.Wrapf(
 				err,
-				"error while trying to delete previews record from db (if exists) of cluster %s",
+				"error while trying to delete previous record from db (if exists) of cluster %s",
 				cluster.ID.String())
 		}
 	}

--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -55,15 +55,6 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	})
 
 	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType: TransitionTypeUpdateInstallationProgress,
-		SourceStates: []stateswitch.State{
-			stateswitch.State(models.ClusterStatusInstalling),
-		},
-		DestinationState: stateswitch.State(models.ClusterStatusInstalling),
-		PostTransition:   th.PostUpdateInstallationProgress,
-	})
-
-	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeCompleteInstallation,
 		Condition:      th.isSuccess,
 		Transition: func(stateSwitch stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
@@ -279,6 +270,17 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		DestinationState: stateswitch.State(models.ClusterStatusError),
 		PostTransition:   th.PostRefreshCluster(statusInfoError),
 	})
+
+	for _, state := range []stateswitch.State{
+		stateswitch.State(models.ClusterStatusInstalling),
+		stateswitch.State(models.ClusterStatusFinalizing)} {
+		sm.AddTransition(stateswitch.TransitionRule{
+			TransitionType:   TransitionTypeUpdateInstallationProgress,
+			SourceStates:     []stateswitch.State{state},
+			DestinationState: state,
+			PostTransition:   th.PostUpdateInstallationProgress,
+		})
+	}
 
 	// Noop transitions
 	for _, state := range []stateswitch.State{

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -167,12 +167,12 @@ func (m *Manager) RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB)
 
 	pHost := &host
 	if err != nil && gorm.IsRecordNotFoundError(err) {
-		// Delete any previews record of the host if it was soft deleted from the cluster,
+		// Delete any previous record of the host if it was soft deleted from the cluster,
 		// no error will be returned if the host was not existed.
 		if err := db.Unscoped().Delete(&host, "id = ? and cluster_id = ?", *h.ID, h.ClusterID).Error; err != nil {
 			return errors.Wrapf(
 				err,
-				"error while trying to delete previews record from db (if exists) of host %s in cluster %s",
+				"error while trying to delete previous record from db (if exists) of host %s in cluster %s",
 				host.ID.String(), host.ClusterID.String())
 		}
 		pHost = h


### PR DESCRIPTION
We saw in some triaging tickets that when we retrieve failed cluster
logs we can get hosts that were part of the previews installation.
In addition, if a host was re-registered with the same dns, we will
get duplicated log files after the second installation.
To avoid this we can simply delete previews installation log files
just before starting the new installation.