### PR TITLE
MGMT-3295: On installation delete old cluster logs

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1255,6 +1255,11 @@ func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installe
 		return common.GenerateErrorResponder(err)
 	}
 
+	// Delete previews installation log files from object storage (if exist).
+	if err := b.clusterApi.DeleteClusterLogs(ctx, &cluster, b.objectHandler); err != nil {
+		log.WithError(err).Warnf("Failed deleting s3 logs of cluster %s", cluster.ID.String())
+	}
+
 	go func() {
 		var err error
 		asyncCtx := requestid.ToContext(context.Background(), requestid.FromContext(ctx))

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -103,7 +103,8 @@ func (th *transitionHandler) PostPrepareForInstallation(sw stateswitch.StateSwit
 	}
 
 	return th.updateTransitionCluster(logutil.FromContext(params.ctx, th.log), th.db, sCluster,
-		statusInfoPreparingForInstallation, "install_started_at", strfmt.DateTime(time.Now()))
+		statusInfoPreparingForInstallation, "install_started_at", strfmt.DateTime(time.Now()),
+		"controller_logs_collected_at", strfmt.DateTime(time.Time{}))
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1510,6 +1510,7 @@ var _ = Describe("PrepareForInstallation", func() {
 
 	It("success", func() {
 		host = getTestHost(hostId, clusterId, models.HostStatusKnown)
+		host.LogsCollectedAt = strfmt.DateTime(time.Now())
 		mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo,
 			fmt.Sprintf("Host %s: updated status from \"known\" to \"preparing-for-installation\" (Host is preparing for installation)", host.ID.String()),
 			gomock.Any())
@@ -1518,6 +1519,7 @@ var _ = Describe("PrepareForInstallation", func() {
 		h := getHost(hostId, clusterId, db)
 		Expect(swag.StringValue(h.Status)).To(Equal(models.HostStatusPreparingForInstallation))
 		Expect(swag.StringValue(h.StatusInfo)).To(Equal(statusInfoPreparingForInstallation))
+		Expect(h.LogsCollectedAt).To(Equal(strfmt.DateTime(time.Time{})))
 	})
 
 	It("failure - no role set", func() {

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -364,7 +364,7 @@ func (th *transitionHandler) PostPrepareForInstallation(sw stateswitch.StateSwit
 	sHost, _ := sw.(*stateHost)
 	params, _ := args.(*TransitionArgsPrepareForInstallation)
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost,
-		statusInfoPreparingForInstallation)
+		statusInfoPreparingForInstallation, "logs_collected_at", strfmt.DateTime(time.Time{}))
 }
 
 func (th *transitionHandler) updateTransitionHost(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, state *stateHost,


### PR DESCRIPTION
We saw in some triaging tickets that when we retrieve failed cluster
logs we can get hosts that were part of the previous installation.
In addition, if a host was re-registered with the same dns, we will
get duplicated log files after the second installation.
To avoid this we can simply delete previous installation log files
just before starting the new installation.