### PR TITLE
MGMT-2256: placeholder makefile targets for openshift ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,9 @@ endef # publish_image
 publish:
 	$(call publish_image,docker,${SERVICE},quay.io/ocpmetal/assisted-service:${PUBLISH_TAG})
 
+build-openshift-ci-test-bin:
+	echo "placeholder for openshift ci image build steps"
+
 ##########
 # Deploy #
 ##########
@@ -266,6 +269,9 @@ deploy-onprem:
 deploy-onprem-for-subsystem:
 	export DUMMY_IGNITION="true" && $(MAKE) deploy-onprem
 
+deploy-on-openshift-ci:
+	echo "placeholder for deployment on openshift ci"
+
 docs:
 	mkdocs build
 
@@ -322,6 +328,9 @@ test-onprem:
 	DB_PORT=5432 \
 	DEPLOY_TARGET=onprem \
 	go test -v ./subsystem/... -count=1 $(GINKGO_FOCUS_FLAG) -ginkgo.v -timeout 30m
+
+test-on-openshift-ci:
+	echo "placeholder for testing on openshift ci"
 
 #########
 # Clean #


### PR DESCRIPTION
Added makefile targets for managing build, deploy and test.

Those targets should allow us to finalize the Prow job definition for assisted-service on openshift/release repo.
Once we have that in place, we could apply further changes to the Prow CI process for assisted-service via PRs to the assisted-service repo alone.