### PR TITLE
MGMT-2256: openshift ci test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ endif
 # That line is checking if we run on minikube
 # check if SERVICE_REPLICAS_COUNT was set and if yes change default value to required one
 # Default for 1 replica
-REPLICAS_COUNT = $(shell if ! [ "${TARGET}" = "minikube" ];then echo 3; else echo $(or ${SERVICE_REPLICAS_COUNT},1);fi)
+REPLICAS_COUNT = $(shell if ! [ "${TARGET}" = "minikube" ] && ! [ "${TARGET}" = "oc" ];then echo 3; else echo $(or ${SERVICE_REPLICAS_COUNT},1);fi)
 
 ifdef INSTALLATION_TIMEOUT
         INSTALLATION_TIMEOUT_FLAG = --installation-timeout $(INSTALLATION_TIMEOUT)
@@ -345,7 +345,8 @@ test-onprem:
 	go test -v ./subsystem/... -count=1 $(GINKGO_FOCUS_FLAG) -ginkgo.v -timeout 30m
 
 test-on-openshift-ci:
-	echo "placeholder for testing on openshift ci"
+	export TARGET='oc' && export PROFILE='openshift-ci' && unset GOFLAGS && \
+	$(MAKE) test FOCUS="[minimal-set]"
 
 #########
 # Clean #

--- a/subsystem/leader_test.go
+++ b/subsystem/leader_test.go
@@ -2,6 +2,7 @@ package subsystem
 
 import (
 	"context"
+	"os"
 	"os/user"
 	"path"
 	"time"
@@ -102,6 +103,14 @@ func verifySingleLeader(tests []*Test) {
 	Expect(count == 1).Should(Equal(true))
 }
 
+func getKubeconfig() string {
+	kcEnv := os.Getenv("KUBECONFIG")
+	if kcEnv != "" {
+		return kcEnv
+	}
+	return path.Join(getHomeDir(), ".kube/config")
+}
+
 func getHomeDir() string {
 	usr, err := user.Current()
 	if err != nil {
@@ -117,7 +126,8 @@ var _ = Describe("Leader tests", func() {
 	}
 
 	configMapName := "leader-test"
-	kubeconfig := path.Join(getHomeDir(), ".kube/config")
+
+	kubeconfig := getKubeconfig()
 	if kubeconfig == "" {
 		panic("--kubeconfig must be provided")
 	}

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -16,6 +16,7 @@ KEY_FILE = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'auth-te
 TEST_CLUSTER_MONITOR_INTERVAL = "1s"
 TEST_HOST_MONITOR_INTERVAL = "1s"
 
+WIREMOCK_SERVICE = "http://wiremock:8080"
 
 def load_key():
     try:
@@ -46,8 +47,8 @@ def main():
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name': 'JWKS_CERT', 'value': load_key()})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'SUBSYSTEM_RUN', 'value': 'True'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DUMMY_IGNITION', 'value': 'True'})
-            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_BASE_URL', 'value': 'http://wiremock.assisted-installer.svc.cluster.local:8080'})
-            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_TOKEN_URL', 'value': 'http://wiremock.assisted-installer.svc.cluster.local:8080/token'})
+            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_BASE_URL', 'value': WIREMOCK_SERVICE})
+            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_TOKEN_URL', 'value': WIREMOCK_SERVICE + '/token'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_ID', 'value': 'mock-ocm-client-id'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_SECRET', 'value': 'mock-ocm-client-secret'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'ENABLE_KUBE_API', 'value': str(deploy_options.enable_kube_api).lower()})


### PR DESCRIPTION
Populated Makefile target for openshift ci tests.
Modified procedure for establishing kubeconfig location in leader_test.go to support kubeconfig location in openshift ci