### PR TITLE
MGMT-2245 Extract OCP version from OCP images

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -43,6 +42,7 @@ import (
 	"github.com/openshift/assisted-service/pkg/auth"
 	paramctx "github.com/openshift/assisted-service/pkg/context"
 	"github.com/openshift/assisted-service/pkg/db"
+	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/openshift/assisted-service/pkg/generator"
 	"github.com/openshift/assisted-service/pkg/job"
 	"github.com/openshift/assisted-service/pkg/k8sclient"
@@ -86,6 +86,8 @@ var Options struct {
 	HostStateMonitorInterval    time.Duration `envconfig:"HOST_MONITOR_INTERVAL" default:"8s"`
 	Versions                    versions.Versions
 	OpenshiftVersions           string        `envconfig:"OPENSHIFT_VERSIONS"`
+	ReleaseImageOverride        string        `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE"`
+	ReleaseImageMirror          string        `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
 	CreateS3Bucket              bool          `envconfig:"CREATE_S3_BUCKET" default:"false"`
 	ImageExpirationInterval     time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
 	ClusterConfig               cluster.Config
@@ -162,21 +164,26 @@ func main() {
 
 	ocmClient := getOCMClient(log, metricsManager)
 
+	Options.InstructionConfig.ReleaseImageMirror = Options.ReleaseImageMirror
+	Options.JobConfig.ReleaseImageMirror = Options.ReleaseImageMirror
+
 	var lead leader.ElectorInterface
 	var k8sClient *kubernetes.Clientset
 	var autoMigrationLeader leader.ElectorInterface
 	authHandler := auth.NewAuthHandler(Options.Auth, ocmClient, log.WithField("pkg", "auth"), db)
 	authzHandler := auth.NewAuthzHandler(Options.Auth, ocmClient, log.WithField("pkg", "authz"))
-	versionHandler := versions.NewHandler(Options.Versions, openshiftVersionsMap, os.Getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE"))
+	releaseHandler := oc.NewRelease(&executer.CommonExecuter{})
+	versionHandler := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler,
+		Options.Versions, openshiftVersionsMap, Options.ReleaseImageOverride, Options.ReleaseImageMirror)
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	eventsHandler := events.New(db, log.WithField("pkg", "events"))
 	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
 	instructionApi := host.NewInstructionManager(log.WithField("pkg", "instructions"), db, hwValidator,
-		oc.NewRelease(), Options.InstructionConfig, connectivityValidator, eventsHandler, versionHandler)
+		releaseHandler, Options.InstructionConfig, connectivityValidator, eventsHandler, versionHandler)
 
 	images := []string{
-		Options.JobConfig.ReleaseImageMirror,
+		Options.ReleaseImageMirror,
 		Options.BMConfig.AgentDockerImg,
 		Options.InstructionConfig.InstallerImage,
 		Options.InstructionConfig.ControllerImage,
@@ -185,7 +192,6 @@ func main() {
 		Options.InstructionConfig.FreeAddressesImage,
 		Options.InstructionConfig.DhcpLeaseAllocatorImage,
 		Options.InstructionConfig.APIVIPConnectivityCheckImage,
-		Options.InstructionConfig.ReleaseImageMirror,
 	}
 
 	for _, ocpVersion := range openshiftVersionsMap {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/openshift/assisted-service
 go 1.13
 
 require (
-	github.com/Microsoft/go-winio v0.4.15-0.20200113171025-3fe6c5262873 // indirect
 	github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/alessio/shellescape v1.4.1
@@ -17,9 +16,9 @@ require (
 	github.com/danielerez/go-dns-client v0.0.0-20200630114514-0b60d1703f0b
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/diskfs/go-diskfs v1.1.2-0.20201217091417-af766c9708d3
-	github.com/docker/docker v17.12.0-ce-rc1.0.20200505174321-1655290016ac+incompatible // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filanov/stateswitch v0.0.0-20200714113403-51a42a34c604
+	github.com/fsouza/go-dockerclient v1.6.6 // indirect
 	github.com/go-openapi/errors v0.19.6
 	github.com/go-openapi/loads v0.19.5
 	github.com/go-openapi/runtime v0.19.20
@@ -29,8 +28,8 @@ require (
 	github.com/go-openapi/validate v0.19.10
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
 	github.com/golang/mock v1.4.4
-	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/google/uuid v1.1.1
+	github.com/hashicorp/go-version v1.2.1
 	github.com/iancoleman/strcase v0.1.2
 	github.com/jinzhu/gorm v1.9.12
 	github.com/json-iterator/go v1.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -192,9 +192,11 @@ github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMX
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F0UxetA=
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20200107194136-26c1120b8d41/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=
+github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb/go.mod h1:Dq467ZllaHgAtVp4p1xUQWBrFXR9s/wyoTpG8zOJGkY=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe h1:PEmIrUvwG9Yyv+0WKZqjXfSFDeZjs/q15g0m08BYS9k=
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
@@ -344,6 +346,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
+github.com/fsouza/go-dockerclient v1.6.6/go.mod h1:3/oRIWoe7uT6bwtAayj/EmJmepBjeL4pYvt7ZxC7Rnk=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -603,6 +606,7 @@ github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
@@ -645,7 +649,10 @@ github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjG
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -828,9 +835,12 @@ github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQ
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/moby v1.13.1 h1:mC5WwQwCXt/dYxZ1cIrRsnJAWw7VdtcTZUIGr4tXzOM=
 github.com/moby/moby v1.13.1/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+github.com/moby/sys/mount v0.1.0/go.mod h1:FVQFLDRWwyBjDTBNQXDlWnSFREqOo3OKX9aqhmeoo74=
+github.com/moby/sys/mountinfo v0.1.0/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
 github.com/moby/sys/mountinfo v0.3.1 h1:R+C9GycEzoR3GdwQ7mANRhJORnVDJiRkf0JMY82MeI0=
 github.com/moby/sys/mountinfo v0.3.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
+github.com/moby/term v0.0.0-20200429084858-129dac9f73f6/go.mod h1:or9wGItza1sRcM4Wd3dIv8DsFHYQuFsMHEdxUIlUxms=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1238,6 +1248,7 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200429183012-4b2356b1ed79/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,13 +6,12 @@ package cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
+	reflect "reflect"
 )
 
 // MockRegistrationAPI is a mock of RegistrationAPI interface

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,10 +5,9 @@
 package connectivity
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,11 +6,10 @@ package events
 
 import (
 	context "context"
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
+	time "time"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/instructionmanager.go
+++ b/internal/host/instructionmanager.go
@@ -61,7 +61,7 @@ type InstructionConfig struct {
 	SkipCertVerification         bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
 	SupportL2                    bool   `envconfig:"SUPPORT_L2" default:"true"`
 	InstallationTimeout          uint   `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
-	ReleaseImageMirror           string `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
+	ReleaseImageMirror           string
 }
 
 func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, ocRelease oc.Release,

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,14 +6,13 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,7 +47,7 @@ func Get(releaseID, releaseIDMirror, cacheDir, pullSecret string, log logrus.Fie
 	var err error
 	//cache miss
 	if r.path == "" {
-		path, err = oc.NewRelease().Extract(log, releaseID, releaseIDMirror, cacheDir, pullSecret)
+		path, err = oc.NewRelease(&executer.CommonExecuter{}).Extract(log, releaseID, releaseIDMirror, cacheDir, pullSecret)
 		if err != nil {
 			return "", err
 		}

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -5,10 +5,9 @@
 package isoutil
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,13 +5,12 @@
 package metrics
 
 import (
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
+	time "time"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/network/mock_ntp_utils.go
+++ b/internal/network/mock_ntp_utils.go
@@ -6,11 +6,10 @@ package network
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockNtpUtilsAPI is a mock of NtpUtilsAPI interface

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -5,10 +5,9 @@
 package oc
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockRelease is a mock of Release interface
@@ -47,6 +46,36 @@ func (m *MockRelease) GetMCOImage(log logrus.FieldLogger, releaseImage, releaseI
 func (mr *MockReleaseMockRecorder) GetMCOImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMCOImage", reflect.TypeOf((*MockRelease)(nil).GetMCOImage), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
+// GetOpenshiftVersion mocks base method
+func (m *MockRelease) GetOpenshiftVersion(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOpenshiftVersion", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOpenshiftVersion indicates an expected call of GetOpenshiftVersion
+func (mr *MockReleaseMockRecorder) GetOpenshiftVersion(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftVersion", reflect.TypeOf((*MockRelease)(nil).GetOpenshiftVersion), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
+// GetMajorMinorVersion mocks base method
+func (m *MockRelease) GetMajorMinorVersion(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMajorMinorVersion", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMajorMinorVersion indicates an expected call of GetMajorMinorVersion
+func (mr *MockReleaseMockRecorder) GetMajorMinorVersion(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMajorMinorVersion", reflect.TypeOf((*MockRelease)(nil).GetMajorMinorVersion), log, releaseImage, releaseImageMirror, pullSecret)
 }
 
 // Extract mocks base method

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -1,36 +1,176 @@
 package oc
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-version"
+	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/sirupsen/logrus"
 )
 
 //go:generate mockgen -source=release.go -package=oc -destination=mock_release.go
 type Release interface {
 	GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
+	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
+	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error)
 }
 
 type release struct {
+	executer executer.Executer
 }
 
-func NewRelease() Release {
-	return &release{}
+func NewRelease(executer executer.Executer) Release {
+	return &release{executer}
 }
 
-var execCommand = exec.Command
+const (
+	templateGetMCOImage = "oc adm release info --image-for=machine-config-operator --insecure=%t %s"
+	templateGetVersion  = "oc adm release info -o template --template '{{.metadata.version}}' --insecure=%t %s"
+	templateExtract     = "oc adm release extract --command=openshift-baremetal-install --to=%s --insecure=%t %s"
+)
 
-func execute(log logrus.FieldLogger, pullSecret string, command string, args ...string) (string, error) {
+// GetMCOImage gets mcoImage url from the releaseImageMirror if provided.
+// Else gets it from the source releaseImage
+func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	var mcoImage string
+	var err error
+	if releaseImage == "" && releaseImageMirror == "" {
+		return "", errors.New("no releaseImage nor releaseImageMirror provided")
+	}
+	if releaseImageMirror != "" {
+		//TODO: Get mirror registry certificate from install-config
+		mcoImage, err = r.getMCOImageFromRelease(log, releaseImageMirror, pullSecret, true)
+		if err != nil {
+			log.WithError(err).Errorf("failed to get mco image from mirror release image %s", releaseImageMirror)
+			return "", err
+		}
+	} else {
+		mcoImage, err = r.getMCOImageFromRelease(log, releaseImage, pullSecret, false)
+		if err != nil {
+			log.WithError(err).Errorf("failed to get mco image from release image %s", releaseImage)
+			return "", err
+		}
+	}
+	return mcoImage, err
+}
+
+func (r *release) GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	var openshiftVersion string
+	var err error
+	if releaseImage == "" && releaseImageMirror == "" {
+		return "", errors.New("no releaseImage nor releaseImageMirror provided")
+	}
+	if releaseImageMirror != "" {
+		//TODO: Get mirror registry certificate from install-config
+		openshiftVersion, err = r.getOpenshiftVersionFromRelease(log, releaseImageMirror, pullSecret, true)
+		if err != nil {
+			log.WithError(err).Errorf("failed to get image openshift version from mirror release image %s", releaseImageMirror)
+			return "", err
+		}
+	} else {
+		openshiftVersion, err = r.getOpenshiftVersionFromRelease(log, releaseImage, pullSecret, false)
+		if err != nil {
+			log.WithError(err).Errorf("failed to get image openshift version from release image %s", releaseImage)
+			return "", err
+		}
+	}
+
+	return openshiftVersion, err
+}
+
+func (r *release) GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	openshiftVersion, err := r.GetOpenshiftVersion(log, releaseImage, releaseImageMirror, pullSecret)
+	if err != nil {
+		return "", err
+	}
+
+	v, err := version.NewVersion(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1]), nil
+}
+
+func (r *release) getMCOImageFromRelease(log logrus.FieldLogger, releaseImage string, pullSecret string, insecure bool) (string, error) {
+	cmd := fmt.Sprintf(templateGetMCOImage, insecure, releaseImage)
+	args := strings.Split(cmd, " ")
+	mcoImage, err := r.execute(log, pullSecret, args[0], args[1:]...)
+	if err != nil {
+		log.WithError(err).Errorf("error running \"oc adm release info\" for release %s", releaseImage)
+		return "", err
+	}
+	return mcoImage, nil
+}
+
+func (r *release) getOpenshiftVersionFromRelease(log logrus.FieldLogger, releaseImage string, pullSecret string, insecure bool) (string, error) {
+	cmd := fmt.Sprintf(templateGetVersion, insecure, releaseImage)
+	args := strings.Split(cmd, " ")
+	version, err := r.execute(log, pullSecret, args[0], args[1:]...)
+	if err != nil {
+		log.WithError(err).Errorf("error running \"oc adm release info\" for release %s", releaseImage)
+		return "", err
+	}
+	return version, nil
+}
+
+// Extract openshift-baremetal-install binary from releaseImageMirror if provided.
+// Else extract from the source releaseImage
+func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
+	var path string
+	var err error
+	if releaseImage == "" && releaseImageMirror == "" {
+		return "", errors.New("no releaseImage or releaseImageMirror provided")
+	}
+	if releaseImageMirror != "" {
+		//TODO: Get mirror registry certificate from install-config
+		path, err = r.extractFromRelease(log, releaseImageMirror, cacheDir, pullSecret, true)
+		if err != nil {
+			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from mirror release image %s", releaseImageMirror)
+			return "", err
+		}
+	} else {
+		path, err = r.extractFromRelease(log, releaseImage, cacheDir, pullSecret, false)
+		if err != nil {
+			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from release image %s", releaseImageMirror)
+			return "", err
+		}
+	}
+	return path, err
+}
+
+// extractFromRelease returns the path to an openshift-baremetal-install binary extracted from
+// the referenced release image.
+func (r *release) extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool) (string, error) {
+	workdir := filepath.Join(cacheDir, releaseImage)
+	log.Infof("extracting openshift-baremetal-install binary to %s", workdir)
+	err := os.MkdirAll(workdir, 0755)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := fmt.Sprintf(templateExtract, workdir, insecure, releaseImage)
+	args := strings.Split(cmd, " ")
+	_, err = r.execute(log, pullSecret, args[0], args[1:]...)
+	if err != nil {
+		log.WithError(err).Errorf("error running \"oc adm release extract\" for release %s", releaseImage)
+		return "", err
+	}
+
+	// set path
+	path := filepath.Join(workdir, "openshift-baremetal-install")
+
+	return path, nil
+}
+
+func (r *release) execute(log logrus.FieldLogger, pullSecret string, command string, args ...string) (string, error) {
 	// write pull secret to a temp file
-	ps, err := ioutil.TempFile("", "registry-config")
+	ps, err := r.executer.TempFile("", "registry-config")
 	if err != nil {
 		return "", err
 	}
@@ -47,99 +187,11 @@ func execute(log logrus.FieldLogger, pullSecret string, command string, args ...
 
 	args = append(args, "--registry-config="+ps.Name())
 
-	cmd := execCommand(command, args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err = cmd.Run()
-	if err != nil {
-		log.Error(out.String())
-		return "", err
-	}
-	return strings.TrimSpace(out.String()), nil
-}
+	stdout, stderr, exitCode := r.executer.Execute(command, args...)
 
-// GetMCOImage gets mcoImage url from the releaseImageMirror if provided.
-// Else gets it from the source releaseImage
-func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
-	var mcoImage string
-	var err error
-	if releaseImage == "" && releaseImageMirror == "" {
-		return "", errors.New("no releaseImage nor releaseImageMirror provided")
-	}
-	if releaseImageMirror != "" {
-		//TODO: Get mirror registry certificate from install-config
-		mcoImage, err = getMCOImageFromRelease(log, releaseImageMirror, pullSecret, true)
-		if err != nil {
-			log.WithError(err).Errorf("failed to get mco image from mirror release image %s", releaseImageMirror)
-			return "", err
-		}
+	if exitCode == 0 {
+		return strings.TrimSpace(stdout), nil
 	} else {
-		mcoImage, err = getMCOImageFromRelease(log, releaseImage, pullSecret, false)
-		if err != nil {
-			log.WithError(err).Errorf("failed to get mco image from release image %s", releaseImage)
-			return "", err
-		}
+		return "", fmt.Errorf("command %s exited with non-zero exit code %d: %s\n%s", command, exitCode, stdout, stderr)
 	}
-	return mcoImage, err
-}
-
-func getMCOImageFromRelease(log logrus.FieldLogger, releaseImage string, pullSecret string, insecure bool) (string, error) {
-	cmd := fmt.Sprintf("oc adm release info --image-for=machine-config-operator --insecure=%t %s", insecure, releaseImage)
-	args := strings.Split(cmd, " ")
-	mcoImage, err := execute(log, pullSecret, args[0], args[1:]...)
-	if err != nil {
-		log.WithError(err).Errorf("error running \"oc adm release info\" for release %s", releaseImage)
-		return "", err
-	}
-	return mcoImage, nil
-}
-
-// Extract openshift-baremetal-install binary from releaseImageMirror if provided.
-// Else extract from the source releaseImage
-func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
-	var path string
-	var err error
-	if releaseImage == "" && releaseImageMirror == "" {
-		return "", errors.New("no releaseImage or releaseImageMirror provided")
-	}
-	if releaseImageMirror != "" {
-		//TODO: Get mirror registry certificate from install-config
-		path, err = extractFromRelease(log, releaseImageMirror, cacheDir, pullSecret, true)
-		if err != nil {
-			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from mirror release image %s", releaseImageMirror)
-			return "", err
-		}
-	} else {
-		path, err = extractFromRelease(log, releaseImage, cacheDir, pullSecret, false)
-		if err != nil {
-			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from release image %s", releaseImageMirror)
-			return "", err
-		}
-	}
-	return path, err
-}
-
-// extractFromRelease returns the path to an openshift-baremetal-install binary extracted from
-// the referenced release image.
-func extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool) (string, error) {
-	workdir := filepath.Join(cacheDir, releaseImage)
-	log.Infof("extracting openshift-baremetal-install binary to %s", workdir)
-	err := os.MkdirAll(workdir, 0755)
-	if err != nil {
-		return "", err
-	}
-
-	cmd := fmt.Sprintf("oc adm release extract --command=openshift-baremetal-install --to=%s --insecure=%t %s", workdir, insecure, releaseImage)
-	args := strings.Split(cmd, " ")
-	_, err = execute(log, pullSecret, args[0], args[1:]...)
-	if err != nil {
-		log.WithError(err).Errorf("error running \"oc adm release extract\" for release %s", releaseImage)
-		return "", err
-	}
-
-	// set path
-	path := filepath.Join(workdir, "openshift-baremetal-install")
-
-	return path, nil
 }

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -1,13 +1,17 @@
 package oc
 
 import (
-	"os"
-	"os/exec"
+	"fmt"
+	"io/ioutil"
+	os "os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	gomock "github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/pkg/executer"
 	logrus "github.com/sirupsen/logrus"
 )
 
@@ -17,71 +21,203 @@ var (
 	releaseImageMirror = "release_image_mirror"
 	cacheDir           = "/tmp"
 	pullSecret         = "pull secret"
+	fullVersion        = "4.6.0-0.nightly-2020-08-31-220837"
+	mcoImage           = "mco_image"
 )
 
 var _ = Describe("oc", func() {
 	var (
-		oc Release
+		oc                 Release
+		tempPullSecretFile *os.File
+		ctrl               *gomock.Controller
+		mockExecuter       *executer.MockExecuter
 	)
 
 	BeforeEach(func() {
-		oc = NewRelease()
-		execCommand = fakeExecCommand
+		ctrl = gomock.NewController(GinkgoT())
+		mockExecuter = executer.NewMockExecuter(ctrl)
+		oc = NewRelease(mockExecuter)
+
+		var err error
+		tempPullSecretFile, err = ioutil.TempFile("", "")
+		Expect(err).ShouldNot(HaveOccurred())
+		mockExecuter.EXPECT().TempFile(gomock.Any(), gomock.Any()).Return(tempPullSecretFile, nil).AnyTimes()
 	})
 
 	AfterEach(func() {
-		execCommand = exec.Command
+		os.Remove(tempPullSecretFile.Name())
 	})
 
-	It("mco image from release image", func() {
-		mco, err := oc.GetMCOImage(log, releaseImage, "", pullSecret)
-		Expect(mco).ShouldNot(BeEmpty())
-		Expect(err).ShouldNot(HaveOccurred())
+	Context("GetMCOImage", func() {
+		It("mco image from release image", func() {
+			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
+				false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mcoImage, "", 0).Times(1)
+
+			mco, err := oc.GetMCOImage(log, releaseImage, "", pullSecret)
+			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("mco image from release image mirror", func() {
+			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
+				true, releaseImageMirror, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mcoImage, "", 0).Times(1)
+
+			mco, err := oc.GetMCOImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("mco image with no release image or mirror", func() {
+			mco, err := oc.GetMCOImage(log, "", "", pullSecret)
+			Expect(mco).Should(BeEmpty())
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("stdout with new lines", func() {
+			stdout := fmt.Sprintf("\n%s\n", mcoImage)
+
+			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
+				false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(stdout, "", 0).Times(1)
+
+			mco, err := oc.GetMCOImage(log, releaseImage, "", pullSecret)
+			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 
-	It("mco image from release image mirror", func() {
-		mco, err := oc.GetMCOImage(log, releaseImage, releaseImageMirror, pullSecret)
-		Expect(mco).ShouldNot(BeEmpty())
-		Expect(err).ShouldNot(HaveOccurred())
+	Context("GetOpenshiftVersion", func() {
+		It("image version from release image", func() {
+			command := fmt.Sprintf(templateGetVersion+" --registry-config=%s",
+				false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(fullVersion, "", 0).Times(1)
+
+			version, err := oc.GetOpenshiftVersion(log, releaseImage, "", pullSecret)
+			Expect(version).Should(Equal(fullVersion))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("image version from release image mirror", func() {
+			command := fmt.Sprintf(templateGetVersion+" --registry-config=%s",
+				true, releaseImageMirror, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(fullVersion, "", 0).Times(1)
+
+			version, err := oc.GetOpenshiftVersion(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(version).Should(Equal(fullVersion))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("image version with no release image or mirror", func() {
+			version, err := oc.GetOpenshiftVersion(log, "", "", pullSecret)
+			Expect(version).Should(BeEmpty())
+			Expect(err).Should(HaveOccurred())
+		})
 	})
 
-	It("mco image with no release image or mirror", func() {
-		mco, err := oc.GetMCOImage(log, "", "", pullSecret)
-		Expect(mco).Should(BeEmpty())
-		Expect(err).Should(HaveOccurred())
+	Context("GetMajorMinorVersion", func() {
+		tests := []struct {
+			fullVersion  string
+			shortVersion string
+			isValid      bool
+		}{
+			{
+				fullVersion:  "4.6.0",
+				shortVersion: "4.6",
+				isValid:      true,
+			},
+			{
+				fullVersion:  "4.6.4",
+				shortVersion: "4.6",
+				isValid:      true,
+			},
+			{
+				fullVersion:  "4.6",
+				shortVersion: "4.6",
+				isValid:      true,
+			},
+			{
+				fullVersion:  "4.6.0-0.nightly-2020-08-31-220837",
+				shortVersion: "4.6",
+				isValid:      true,
+			},
+			{
+				fullVersion: "-44",
+				isValid:     false,
+			},
+		}
+
+		for i := range tests {
+			t := tests[i]
+			It(t.fullVersion, func() {
+				command := fmt.Sprintf(templateGetVersion+" --registry-config=%s",
+					false, releaseImage, tempPullSecretFile.Name())
+				args := splitStringToInterfacesArray(command)
+				mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(t.fullVersion, "", 0).Times(1)
+
+				version, err := oc.GetMajorMinorVersion(log, releaseImage, "", pullSecret)
+
+				if t.isValid {
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(version).Should(Equal(t.shortVersion))
+				} else {
+					Expect(err).Should(HaveOccurred())
+					Expect(version).Should(BeEmpty())
+				}
+			})
+		}
 	})
 
-	It("extract baremetal-install from release image", func() {
-		path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
-		filePath := filepath.Join(cacheDir+"/"+releaseImage, "openshift-baremetal-install")
-		Expect(path).To(Equal(filePath))
-		Expect(err).ShouldNot(HaveOccurred())
-	})
+	Context("Extract", func() {
+		It("extract baremetal-install from release image", func() {
+			command := fmt.Sprintf(templateExtract+" --registry-config=%s",
+				filepath.Join(cacheDir, releaseImage), false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-	It("extract baremetal-install from release image mirror", func() {
-		path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
-		filePath := filepath.Join(cacheDir+"/"+releaseImageMirror, "openshift-baremetal-install")
-		Expect(path).To(Equal(filePath))
-		Expect(err).ShouldNot(HaveOccurred())
-	})
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
+			filePath := filepath.Join(cacheDir+"/"+releaseImage, "openshift-baremetal-install")
+			Expect(path).To(Equal(filePath))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 
-	It("extract baremetal-install with no release image or mirror", func() {
-		path, err := oc.Extract(log, "", "", cacheDir, pullSecret)
-		Expect(path).Should(BeEmpty())
-		Expect(err).Should(HaveOccurred())
-	})
+		It("extract baremetal-install from release image mirror", func() {
+			command := fmt.Sprintf(templateExtract+" --registry-config=%s",
+				filepath.Join(cacheDir, releaseImageMirror), true, releaseImageMirror, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
+			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
+			filePath := filepath.Join(cacheDir+"/"+releaseImageMirror, "openshift-baremetal-install")
+			Expect(path).To(Equal(filePath))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("extract baremetal-install with no release image or mirror", func() {
+			path, err := oc.Extract(log, "", "", cacheDir, pullSecret)
+			Expect(path).Should(BeEmpty())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
 })
 
-func fakeExecCommand(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestHelperProcess", "--", command}
-	cs = append(cs, args...)
-	cmd := exec.Command(os.Args[0], cs...) //nolint:gosec
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
-	return cmd
+func splitStringToInterfacesArray(str string) []interface{} {
+	argsAsString := strings.Split(str, " ")
+	argsAsInterface := make([]interface{}, len(argsAsString))
+	for i, v := range argsAsString {
+		argsAsInterface[i] = v
+	}
+
+	return argsAsInterface
 }
 
-func TestSubsystem(t *testing.T) {
+func TestOC(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "oc tests")
 }

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -6,11 +6,10 @@ package versions
 
 import (
 	context "context"
-	reflect "reflect"
-
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	versions "github.com/openshift/assisted-service/restapi/operations/versions"
+	reflect "reflect"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi"
 	operations "github.com/openshift/assisted-service/restapi/operations/versions"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type Versions struct {
@@ -25,7 +27,9 @@ type Handler interface {
 	IsOpenshiftVersionSupported(openshiftVersion string) bool
 }
 
-func NewHandler(versions Versions, openshiftVersions models.OpenshiftVersions, releaseImageOverride string) *handler {
+func NewHandler(log logrus.FieldLogger, releaseHandler oc.Release,
+	versions Versions, openshiftVersions models.OpenshiftVersions,
+	releaseImageOverride string, releaseImageMirror string) *handler {
 	return &handler{
 		versions:             versions,
 		openshiftVersions:    openshiftVersions,

--- a/pkg/executer/executer.go
+++ b/pkg/executer/executer.go
@@ -1,0 +1,51 @@
+package executer
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+//go:generate mockgen -package executer -destination mock_executer.go . Executer
+type Executer interface {
+	Execute(command string, args ...string) (stdout string, stderr string, exitCode int)
+	TempFile(dir, pattern string) (f *os.File, err error)
+}
+
+type CommonExecuter struct{}
+
+func (e *CommonExecuter) TempFile(dir, pattern string) (f *os.File, err error) {
+	return ioutil.TempFile(dir, pattern)
+}
+
+func (e *CommonExecuter) Execute(command string, args ...string) (stdout string, stderr string, exitCode int) {
+	cmd := exec.Command(command, args...)
+	var stdoutBytes, stderrBytes bytes.Buffer
+	cmd.Stdout = &stdoutBytes
+	cmd.Stderr = &stderrBytes
+	err := cmd.Run()
+	return stdoutBytes.String(), getErrorStr(err, &stderrBytes), getExitCode(err)
+}
+
+func getExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	switch value := err.(type) {
+	case *exec.ExitError:
+		return value.ExitCode()
+	default:
+		return -1
+	}
+}
+
+func getErrorStr(err error, stderr *bytes.Buffer) string {
+	b := stderr.Bytes()
+	if len(b) > 0 {
+		return string(b)
+	} else if err != nil {
+		return err.Error()
+	}
+	return ""
+}

--- a/pkg/executer/mock_executer.go
+++ b/pkg/executer/mock_executer.go
@@ -5,10 +5,9 @@
 package executer
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockExecuter is a mock of Executer interface

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,10 +6,9 @@ package generator
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -42,8 +42,8 @@ type Config struct {
 	ServiceCACertPath   string        `envconfig:"SERVICE_CA_CERT_PATH" default:""`
 	ServiceIPs          string        `envconfig:"SERVICE_IPS" default:""`
 	//[TODO] -  change the default of Releae image to "", once everyine wll update their environment
-	SubsystemRun         bool   `envconfig:"SUBSYSTEM_RUN"`
-	ReleaseImageMirror   string `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
+	SubsystemRun         bool `envconfig:"SUBSYSTEM_RUN"`
+	ReleaseImageMirror   string
 	SkipCertVerification bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
 	WorkDir              string `envconfig:"WORK_DIR" default:"/data/"`
 	DummyIgnition        bool   `envconfig:"DUMMY_IGNITION"`

--- a/pkg/k8sclient/mock_k8sclient.go
+++ b/pkg/k8sclient/mock_k8sclient.go
@@ -5,11 +5,10 @@
 package k8sclient
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/config/v1"
 	v10 "k8s.io/api/core/v1"
+	reflect "reflect"
 )
 
 // MockK8SClient is a mock of K8SClient interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,9 +6,8 @@ package leader
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthorization is a mock of OCMAuthorization interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,11 +6,10 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3manageriface.go
+++ b/pkg/s3wrapper/mock_s3manageriface.go
@@ -6,10 +6,9 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockUploaderAPI is a mock of UploaderAPI interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,12 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface


### PR DESCRIPTION
Original https://github.com/openshift/assisted-service/pull/820, after revert PR https://github.com/openshift/assisted-service/pull/840 and addition of shell escaping on https://github.com/openshift/assisted-service/pull/855.

Wrapping `execute` returned `stdout` with `strings.TrimSpace`.
Verified on test-infra :+1: 