### PR TITLE
MGMT-3456 - Will not attempt to format bootable disks that look like installation media

### DIFF
--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -6,10 +6,11 @@ package bminventory
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	installer "github.com/openshift/assisted-service/restapi/operations/installer"
-	reflect "reflect"
 )
 
 // MockInstallerInternals is a mock of InstallerInternals interface

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,12 +6,13 @@ package cluster
 
 import (
 	context "context"
+	reflect "reflect"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
-	reflect "reflect"
 )
 
 // MockRegistrationAPI is a mock of RegistrationAPI interface

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,9 +5,10 @@
 package connectivity
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,10 +6,11 @@ package events
 
 import (
 	context "context"
-	strfmt "github.com/go-openapi/strfmt"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	strfmt "github.com/go-openapi/strfmt"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,9 +5,10 @@
 package hardware
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -213,7 +213,7 @@ func (i *installCmd) getDiskUnbootableCmd(ctx context.Context, host models.Host)
 	formatCmds := ""
 	for _, disk := range inventory.Disks {
 		isFcIscsi := strings.Contains(disk.ByPath, "-fc-") || strings.Contains(disk.ByPath, "-iscsi-")
-		if disk.Bootable && !isFcIscsi {
+		if disk.Bootable && !isFcIscsi && !disk.IsInstallationMedia {
 			dev := GetDeviceFullName(disk.Name)
 			formatCmds += fmt.Sprintf("dd if=/dev/zero of=%s bs=512 count=1 ; ", dev)
 			i.eventsHandler.AddEvent(

--- a/internal/host/installcmd_test.go
+++ b/internal/host/installcmd_test.go
@@ -169,7 +169,7 @@ var _ = Describe("installcmd", func() {
 		Expect(hostFromDb.InstallationDiskPath).Should(Equal(GetDeviceFullName(disks[0].Name)))
 	})
 
-	It("format_multiple_bootable_skip_fc_iscsi", func() {
+	It("format_multiple_bootable_skip", func() {
 		disks = []*models.Disk{
 			{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize},
 			{DriveType: "HDD", Name: "sda", SizeBytes: validDiskSize, Bootable: true},
@@ -178,6 +178,7 @@ var _ = Describe("installcmd", func() {
 			{DriveType: "HDD", Name: "sdi", SizeBytes: validDiskSize, Bootable: true, ByPath: "pci-0000:04:00.0-fc-0x5006016b08603d0d-lun-0"},
 			{DriveType: "HDD", Name: "sdf", SizeBytes: validDiskSize},
 			{DriveType: "HDD", Name: "sdg", SizeBytes: validDiskSize, Bootable: true, ByPath: "ip-10.188.2.249:3260-iscsi-iqn.2001-05.com.equallogic:0-fe83b6-aaea957cc-b6e9d343a9758fdc-volume-50a72e0c-0a4a-4b2d-92ab-b0500dfe5c64-lun-0"},
+			{DriveType: "HDD", Name: "sdg", SizeBytes: validDiskSize, Bootable: true, IsInstallationMedia: true},
 		}
 		inventory := models.Inventory{
 			Disks: disks,

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,13 +6,14 @@ package host
 
 import (
 	context "context"
+	reflect "reflect"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,9 +6,10 @@ package host
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -5,9 +5,10 @@
 package isoutil
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,12 +5,13 @@
 package metrics
 
 import (
+	reflect "reflect"
+	time "time"
+
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
-	time "time"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/network/mock_ntp_utils.go
+++ b/internal/network/mock_ntp_utils.go
@@ -6,10 +6,11 @@ package network
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockNtpUtilsAPI is a mock of NtpUtilsAPI interface

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -5,9 +5,10 @@
 package oc
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
-	reflect "reflect"
 )
 
 // MockRelease is a mock of Release interface

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -6,10 +6,11 @@ package versions
 
 import (
 	context "context"
+	reflect "reflect"
+
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	versions "github.com/openshift/assisted-service/restapi/operations/versions"
-	reflect "reflect"
 )
 
 // MockHandler is a mock of Handler interface

--- a/models/disk.go
+++ b/models/disk.go
@@ -34,6 +34,9 @@ type Disk struct {
 	// io perf
 	IoPerf *IoPerf `json:"io_perf,omitempty"`
 
+	// Whether the disk appears to be an installation media or not
+	IsInstallationMedia bool `json:"is_installation_media,omitempty"`
+
 	// model
 	Model string `json:"model,omitempty"`
 

--- a/pkg/executer/mock_executer.go
+++ b/pkg/executer/mock_executer.go
@@ -5,9 +5,10 @@
 package executer
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockExecuter is a mock of Executer interface

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,9 +6,10 @@ package generator
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
-	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface

--- a/pkg/k8sclient/mock_k8sclient.go
+++ b/pkg/k8sclient/mock_k8sclient.go
@@ -5,10 +5,11 @@
 package k8sclient
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/config/v1"
 	v10 "k8s.io/api/core/v1"
-	reflect "reflect"
 )
 
 // MockK8SClient is a mock of K8SClient interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,8 +6,9 @@ package leader
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -6,8 +6,9 @@ package ocm
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockOCMAuthorization is a mock of OCMAuthorization interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,8 +6,9 @@ package ocm
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,10 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	reflect "reflect"
+
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3manageriface.go
+++ b/pkg/s3wrapper/mock_s3manageriface.go
@@ -6,9 +6,10 @@ package s3wrapper
 
 import (
 	context "context"
+	reflect "reflect"
+
 	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockUploaderAPI is a mock of UploaderAPI interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,11 +6,12 @@ package s3wrapper
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4885,6 +4885,10 @@ func init() {
         "io_perf": {
           "$ref": "#/definitions/io_perf"
         },
+        "is_installation_media": {
+          "description": "Whether the disk appears to be an installation media or not",
+          "type": "boolean"
+        },
         "model": {
           "type": "string"
         },
@@ -10927,6 +10931,10 @@ func init() {
         },
         "io_perf": {
           "$ref": "#/definitions/io_perf"
+        },
+        "is_installation_media": {
+          "description": "Whether the disk appears to be an installation media or not",
+          "type": "boolean"
         },
         "model": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3745,6 +3745,9 @@ definitions:
         type: integer
       bootable:
         type: boolean
+      is_installation_media:
+        type: boolean
+        description: Whether the disk appears to be an installation media or not
       installation_eligibility:
         x-nullable: false
         type: object


### PR DESCRIPTION
It's harder for the service to tell apart which disks are installation media and which are not (as opposed to the agent which does it by looking at disk partition information, which is not passed on to the service).

Added a new column to inventory disks that says whether they're installation media or not (ISO) so the agent can tell the service. (Will open a PR for the agent)

Service will no longer attempt to format bootable disks marked as installation media, as they're usually read-only and that results in confusing errors / events.