### PR TITLE
NO-ISSUE: Fixed typo in spec.channel in lsoSubscription manifest

### DIFF
--- a/internal/operators/lso/utils.go
+++ b/internal/operators/lso/utils.go
@@ -16,7 +16,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-  channel: {{.OPENSHIFT_VERSION}}
+  channel: "{{.OPENSHIFT_VERSION}}"
   installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators


### PR DESCRIPTION
This PR is for the fix in the `lsoSubscription` manifest. The data type of the `spec.channel` is "string" (string with the quotes). 
cc: @rollandf 
Signed off by: Priyanka Jiandani <pjiandan@redhat.com>
