### PR TITLE
NO-ISSUE - make format target shouldn't format anything the linter doesn't check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,7 @@ $(BUILD_FOLDER):
 	mkdir -p $(BUILD_FOLDER)
 
 format:
-	goimports -w -l cmd/ internal/ subsystem/ pkg/
-	gofmt -w -l cmd/ internal/ subsystem/ pkg/
+	golangci-lint run --fix -v
 
 ############
 # Generate #

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -6,11 +6,10 @@ package bminventory
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	installer "github.com/openshift/assisted-service/restapi/operations/installer"
+	reflect "reflect"
 )
 
 // MockInstallerInternals is a mock of InstallerInternals interface

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -6,13 +6,12 @@ package cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	s3wrapper "github.com/openshift/assisted-service/pkg/s3wrapper"
+	reflect "reflect"
 )
 
 // MockRegistrationAPI is a mock of RegistrationAPI interface

--- a/internal/connectivity/mock_connectivity_validator.go
+++ b/internal/connectivity/mock_connectivity_validator.go
@@ -5,10 +5,9 @@
 package connectivity
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -6,11 +6,10 @@ package events
 
 import (
 	context "context"
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
+	time "time"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,10 +5,9 @@
 package hardware
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockValidator is a mock of Validator interface

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -6,14 +6,13 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	gorm "github.com/jinzhu/gorm"
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/host/mock_instruction_api.go
+++ b/internal/host/mock_instruction_api.go
@@ -6,10 +6,9 @@ package host
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
 // MockInstructionApi is a mock of InstructionApi interface

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -5,10 +5,9 @@
 package isoutil
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockHandler is a mock of Handler interface

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -5,13 +5,12 @@
 package metrics
 
 import (
-	reflect "reflect"
-	time "time"
-
 	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
+	time "time"
 )
 
 // MockAPI is a mock of API interface

--- a/internal/network/mock_ntp_utils.go
+++ b/internal/network/mock_ntp_utils.go
@@ -6,11 +6,10 @@ package network
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockNtpUtilsAPI is a mock of NtpUtilsAPI interface

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -5,10 +5,9 @@
 package oc
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
+	reflect "reflect"
 )
 
 // MockRelease is a mock of Release interface

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -6,11 +6,10 @@ package versions
 
 import (
 	context "context"
-	reflect "reflect"
-
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	versions "github.com/openshift/assisted-service/restapi/operations/versions"
+	reflect "reflect"
 )
 
 // MockHandler is a mock of Handler interface

--- a/pkg/executer/mock_executer.go
+++ b/pkg/executer/mock_executer.go
@@ -5,10 +5,9 @@
 package executer
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	os "os"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockExecuter is a mock of Executer interface

--- a/pkg/generator/mock_install_config.go
+++ b/pkg/generator/mock_install_config.go
@@ -6,10 +6,9 @@ package generator
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	reflect "reflect"
 )
 
 // MockISOInstallConfigGenerator is a mock of ISOInstallConfigGenerator interface

--- a/pkg/k8sclient/mock_k8sclient.go
+++ b/pkg/k8sclient/mock_k8sclient.go
@@ -5,11 +5,10 @@
 package k8sclient
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/config/v1"
 	v10 "k8s.io/api/core/v1"
+	reflect "reflect"
 )
 
 // MockK8SClient is a mock of K8SClient interface

--- a/pkg/leader/mock_leader_elector.go
+++ b/pkg/leader/mock_leader_elector.go
@@ -6,9 +6,8 @@ package leader
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockLeader is a mock of Leader interface

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthorization is a mock of OCMAuthorization interface

--- a/pkg/ocm/mock_pullsecret_auth.go
+++ b/pkg/ocm/mock_pullsecret_auth.go
@@ -6,9 +6,8 @@ package ocm
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockOCMAuthentication is a mock of OCMAuthentication interface

--- a/pkg/s3wrapper/mock_s3iface.go
+++ b/pkg/s3wrapper/mock_s3iface.go
@@ -6,11 +6,10 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	request "github.com/aws/aws-sdk-go/aws/request"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockS3API is a mock of S3API interface

--- a/pkg/s3wrapper/mock_s3manageriface.go
+++ b/pkg/s3wrapper/mock_s3manageriface.go
@@ -6,10 +6,9 @@ package s3wrapper
 
 import (
 	context "context"
-	reflect "reflect"
-
 	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockUploaderAPI is a mock of UploaderAPI interface

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -6,12 +6,11 @@ package s3wrapper
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 	io "io"
 	reflect "reflect"
 	time "time"
-
-	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 )
 
 // MockAPI is a mock of API interface


### PR DESCRIPTION
`make lint` uses [golangci-lint](https://github.com/golangci/golangci-lint
) for linting purposes.

This utility auto detects (and silently skips) generated files. It detects them by looking at comments at the top of the file and looking for phrases that might indicate that those files are generated.

On the other hand, as of now, `make format` blindly runs `goimports` and `gofmt` on a bunch of folders, some of them containing, among other things, some generated files.

**There are two problems with the way things are right now:**

1) `goimports` automatically runs `gofmt` too so it's redundant to run both of them

2) If someone generates files and doesn't run `make format`, the resulting files will pass the CI (because they're ignored by `make lint` since they're generated). The next person that tries to run `make format` will all of a sudden encounter a bunch of diffs on generated files that have nothing to do with their own changes. This is because `make format` doesn't ignore generated files, as mentioned above. This causes confusion (why are files I didn't touch suddenly changing?) and clutters up PR diffs and thus requires manual interaction to avoid committing all those irrelevant changes.

**Solution:**
Make `make format` run `golangci-lint` with the `--fix` flag instead of running `gofmt` and `goimports`. This runs `golangci-lint` as usual, but attempts to automatically fix any errors that come up during that lint.

This way we make sure `format` only touches files that `golangci-lint` would otherwise complain about - Generated files are now skipped by both `format` and `golangci-lint`, rather than only `golangci-lint`.

Another thing to note is that `golangci-lint` aggregates the results of a bunch of "linters". These include `gofmt` and `goimports`. What that actually means is that `golangci-lint` runs `goimports` on each file, checks if it caused and diffs, and if it did, that's a "lint error". `--fix` would then apply that diff, resulting in a file identical to what we would've otherwise received by simply running `gofmt`