### PR TITLE
MGMT-3489 Support None HighAvailabilityMode 

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -453,9 +453,9 @@ func (g *installerGenerator) updateBootstrap(bootstrapPath string) error {
 	}
 
 	config.Storage.Files = newFiles
-
-	setFileInIgnition(config, "/opt/openshift/assisted-install-bootstrap", "data:,", false, 420)
-
+	if swag.StringValue(g.cluster.HighAvailabilityMode) != models.ClusterHighAvailabilityModeNone {
+		setFileInIgnition(config, "/opt/openshift/assisted-install-bootstrap", "data:,", false, 420)
+	}
 	err = writeIgnitionFile(bootstrapPath, config)
 	if err != nil {
 		g.log.Error(err)


### PR DESCRIPTION
- Monitor should allow single master node
- No need to add the assisted-marker since it conflicts with the current SNO patch allowing etcd to start with a single node