### PR TITLE
MGMT-3459 added metrics for disk sync duration

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2518,6 +2518,9 @@ func (b *bareMetalInventory) processFioPerfCheckResponse(ctx context.Context, h 
 		log.Warnf(msg)
 		b.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityWarning, msg, time.Now())
 	}
+
+	b.metricApi.DiskSyncDuration(h.ClusterID, *h.ID, fioPerfCheckResponse.Path, fioPerfCheckResponse.IoSyncDuration)
+
 	return nil
 }
 

--- a/internal/metrics/mock_netricsManager_api.go
+++ b/internal/metrics/mock_netricsManager_api.go
@@ -107,3 +107,15 @@ func (mr *MockAPIMockRecorder) ReportHostInstallationMetrics(log, clusterVersion
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportHostInstallationMetrics", reflect.TypeOf((*MockAPI)(nil).ReportHostInstallationMetrics), log, clusterVersion, clusterID, emailDomain, boot, h, previousProgress, currentStage)
 }
+
+// DiskSyncDuration mocks base method
+func (m *MockAPI) DiskSyncDuration(clusterID, hostID strfmt.UUID, diskPath string, syncDuration int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DiskSyncDuration", clusterID, hostID, diskPath, syncDuration)
+}
+
+// DiskSyncDuration indicates an expected call of DiskSyncDuration
+func (mr *MockAPIMockRecorder) DiskSyncDuration(clusterID, hostID, diskPath, syncDuration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), clusterID, hostID, diskPath, syncDuration)
+}


### PR DESCRIPTION
Added "assisted_installer_cluster_host_disk_sync_duration_ms" metric for fdatasync duration fetched from fio.