### PR TITLE
MGMT-2977 Add a cache for downloading files from S3

### DIFF
--- a/pkg/s3wrapper/file_cache.go
+++ b/pkg/s3wrapper/file_cache.go
@@ -1,0 +1,76 @@
+package s3wrapper
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// list of files keyed by the s3 object id
+type fileList struct {
+	sync.Mutex
+	files map[string]*file
+}
+
+type file struct {
+	sync.Mutex
+	path string
+}
+
+var cache fileList = fileList{
+	files: make(map[string]*file),
+}
+
+func (l *fileList) get(objectName string) *file {
+	l.Lock()
+	defer l.Unlock()
+
+	f, present := l.files[objectName]
+	if !present {
+		f = &file{}
+		l.files[objectName] = f
+	}
+	return f
+}
+
+func downloadFile(ctx context.Context, objectHandler API, objectName string, cacheDir string) (string, error) {
+	reader, size, err := objectHandler.Download(ctx, objectName)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Create(filepath.Join(cacheDir, objectName))
+	if err != nil {
+		return "", err
+	}
+
+	written, err := io.Copy(f, reader)
+	if err != nil {
+		return "", err
+	}
+	if written != size {
+		return "", fmt.Errorf("failed to write file, expected %d bytes, wrote %d", size, written)
+	}
+
+	return f.Name(), nil
+}
+
+func GetFile(ctx context.Context, objectHandler API, objectName string, cacheDir string) (string, error) {
+	f := cache.get(objectName)
+	f.Lock()
+	defer f.Unlock()
+
+	//cache miss
+	if f.path == "" {
+		path, err := downloadFile(ctx, objectHandler, objectName, cacheDir)
+		if err != nil {
+			return "", err
+		}
+		f.path = path
+	}
+
+	return f.path, nil
+}

--- a/pkg/s3wrapper/file_cache_test.go
+++ b/pkg/s3wrapper/file_cache_test.go
@@ -1,0 +1,71 @@
+package s3wrapper
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/golang/mock/gomock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetFile", func() {
+	var (
+		ctrl     *gomock.Controller
+		mockAPI  *MockAPI
+		cacheDir string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockAPI = NewMockAPI(ctrl)
+		var err error
+		cacheDir, err = ioutil.TempDir("", "file_cache_test")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		os.RemoveAll(cacheDir)
+	})
+
+	It("Downloads files only when not present in the cache", func() {
+		ctx := context.Background()
+
+		objName1 := "my-test-object"
+		content1 := "hello world"
+		r1 := ioutil.NopCloser(strings.NewReader(content1))
+		mockAPI.EXPECT().Download(ctx, objName1).Times(1).Return(r1, int64(len(content1)), nil)
+
+		objName2 := "my-other-object"
+		content2 := "HELLO WORLD"
+		r2 := ioutil.NopCloser(strings.NewReader(content2))
+		mockAPI.EXPECT().Download(ctx, objName2).Times(1).Return(r2, int64(len(content2)), nil)
+
+		path1, err := GetFile(ctx, mockAPI, objName1, cacheDir)
+		Expect(err).ToNot(HaveOccurred())
+		validateFileContent(path1, content1)
+
+		path2, err := GetFile(ctx, mockAPI, objName2, cacheDir)
+		Expect(err).ToNot(HaveOccurred())
+		validateFileContent(path2, content2)
+
+		// get both files again to ensure download isn't called more than once
+		path1, err = GetFile(ctx, mockAPI, objName1, cacheDir)
+		Expect(err).ToNot(HaveOccurred())
+		validateFileContent(path1, content1)
+
+		path2, err = GetFile(ctx, mockAPI, objName2, cacheDir)
+		Expect(err).ToNot(HaveOccurred())
+		validateFileContent(path2, content2)
+	})
+})
+
+func validateFileContent(path string, content string) {
+	fileContent, err := ioutil.ReadFile(path)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(string(fileContent)).To(Equal(content))
+}


### PR DESCRIPTION
This will be needed when we start editing the minimal iso template
per cluster. The cache will ensure that we don't download the iso
template unless we need to.

Based heavily on the [installercache package](https://github.com/openshift/assisted-service/blob/4ec616b70864668d8b497e266de46dc0ba61acd8/internal/installercache/installercache.go).
I can make this generic using some kind of callback function for how to fetch a file on a cache miss, but wasn't sure if it was worth the effort given the actual caching mechanism is pretty slim.

cc @danielerez 