### PR TITLE
MGMT-2977 Enhancements to isoutil

### DIFF
--- a/internal/isoutil/isoutil.go
+++ b/internal/isoutil/isoutil.go
@@ -18,6 +18,7 @@ import (
 type Handler interface {
 	Extract() error
 	Create(outPath string, size int64, volumeLabel string) error
+	ExtractedPath(rel string) string
 	ReadFile(filePath string) (io.ReadWriteSeeker, error)
 	VolumeIdentifier() (string, error)
 }
@@ -58,6 +59,10 @@ func (h *installerHandler) ReadFile(filePath string) (io.ReadWriteSeeker, error)
 	}
 
 	return fsFile, nil
+}
+
+func (h *installerHandler) ExtractedPath(rel string) string {
+	return filepath.Join(h.workDir, rel)
 }
 
 // Extract unpacks the iso contents into the working directory

--- a/internal/isoutil/isoutil_test.go
+++ b/internal/isoutil/isoutil_test.go
@@ -73,11 +73,8 @@ var _ = Context("with test files", func() {
 			defer os.RemoveAll(dir)
 			isoPath := filepath.Join(dir, "test.iso")
 
-			isoInfo, err := os.Stat(isoFile)
-			Expect(err).NotTo(HaveOccurred())
-
 			h := NewHandler("", filepath.Join(filesDir, "files"))
-			Expect(h.Create(isoPath, isoInfo.Size(), "my-vol")).To(Succeed())
+			Expect(h.Create(isoPath, "my-vol")).To(Succeed())
 
 			d, err := diskfs.OpenWithMode(isoPath, diskfs.ReadOnly)
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/isoutil/isoutil_test.go
+++ b/internal/isoutil/isoutil_test.go
@@ -146,6 +146,15 @@ var _ = Context("with test files", func() {
 			Expect(haveBootFiles).To(BeFalse())
 		})
 	})
+
+	Describe("VolumeIdentifier", func() {
+		It("returns the correct value", func() {
+			h := NewHandler(isoFile, "")
+			id, err := h.VolumeIdentifier()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id).To(Equal(volumeID))
+		})
+	})
 })
 
 func createIsoViaGenisoimage(volumeID string) (string, string, string) {

--- a/internal/isoutil/isoutil_test.go
+++ b/internal/isoutil/isoutil_test.go
@@ -61,8 +61,8 @@ var _ = Context("with test files", func() {
 			h := NewHandler(isoFile, dir)
 			Expect(h.Extract()).To(Succeed())
 
-			validateFileContent(filepath.Join(dir, "test"), "testcontent\n")
-			validateFileContent(filepath.Join(dir, "testdir/stuff"), "morecontent\n")
+			validateFileContent(h.ExtractedPath("test"), "testcontent\n")
+			validateFileContent(h.ExtractedPath("testdir/stuff"), "morecontent\n")
 		})
 	})
 

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -34,17 +34,17 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // Create mocks base method
-func (m *MockHandler) Create(arg0 string, arg1 int64, arg2 string) error {
+func (m *MockHandler) Create(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Create indicates an expected call of Create
-func (mr *MockHandlerMockRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockHandler)(nil).Create), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockHandler)(nil).Create), arg0, arg1)
 }
 
 // Extract mocks base method
@@ -61,6 +61,20 @@ func (mr *MockHandlerMockRecorder) Extract() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockHandler)(nil).Extract))
 }
 
+// ExtractedPath mocks base method
+func (m *MockHandler) ExtractedPath(arg0 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractedPath", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ExtractedPath indicates an expected call of ExtractedPath
+func (mr *MockHandlerMockRecorder) ExtractedPath(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractedPath", reflect.TypeOf((*MockHandler)(nil).ExtractedPath), arg0)
+}
+
 // ReadFile mocks base method
 func (m *MockHandler) ReadFile(arg0 string) (io.ReadWriteSeeker, error) {
 	m.ctrl.T.Helper()
@@ -74,4 +88,19 @@ func (m *MockHandler) ReadFile(arg0 string) (io.ReadWriteSeeker, error) {
 func (mr *MockHandlerMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockHandler)(nil).ReadFile), arg0)
+}
+
+// VolumeIdentifier mocks base method
+func (m *MockHandler) VolumeIdentifier() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VolumeIdentifier")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VolumeIdentifier indicates an expected call of VolumeIdentifier
+func (mr *MockHandlerMockRecorder) VolumeIdentifier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeIdentifier", reflect.TypeOf((*MockHandler)(nil).VolumeIdentifier))
 }


### PR DESCRIPTION
This PR makes a few additions and enhancements to the isoutil handler that will be useful when creating and customizing the minimal iso.

Specifically:
- Re-adds some code to get an iso's volume identifier which was originally added in #645 and removed in #755
  - We will use it to preserve the original volume identifier when repackaging the minimal iso template and the customized minimal iso.
- Adds an `ExtractedPath` method which allows us to get a reference to a file in the extracted iso without knowing about the working directory
- Enhances the `Create` method so that we don't have to provide a size
  - This size value doesn't determine the final image size, but is used to truncate the initial file. This value would be relevant if we were writing to a particular partition on a device, but we are not so the minimum iso size will work for us here.

cc @danielerez 