### PR TITLE
MGMT-3568 - fix formatting of boolean input arguments in Install command

### DIFF
--- a/internal/host/fioperfcheckcmd.go
+++ b/internal/host/fioperfcheckcmd.go
@@ -84,7 +84,10 @@ func (c *fioPerfCheckCmd) GetArgs() ([]string, error) {
 		"--env", "http_proxy", "--env", "https_proxy", "--env", "no_proxy",
 		c.config.FioPerfCheckImage, "fio_perf_check",
 		"--url", strings.TrimSpace(c.config.ServiceBaseURL), "--cluster-id", c.config.ClusterID, "--host-id", c.config.HostID,
-		"--agent-version", c.config.FioPerfCheckImage, fmt.Sprintf("--insecure %s", strconv.FormatBool(c.config.SkipCertVerification)))
+		"--agent-version", c.config.FioPerfCheckImage)
+	if c.config.SkipCertVerification {
+		arguments = append(arguments, "--insecure")
+	}
 
 	if c.config.UseCustomCACert {
 		arguments = append(arguments, "--cacert", common.HostCACertPath)

--- a/internal/host/installcmd_test.go
+++ b/internal/host/installcmd_test.go
@@ -278,7 +278,7 @@ var _ = Describe("installcmd arguments", func() {
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
-			verifyArgInCommand(stepReply[0].Args[1], "--insecure", strconv.FormatBool(false), 2)
+			Expect(strings.Contains(stepReply[0].Args[1], "--insecure")).Should(BeFalse())
 		})
 
 		It("insecure_cert_is_set_to_false", func() {
@@ -289,7 +289,7 @@ var _ = Describe("installcmd arguments", func() {
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
-			verifyArgInCommand(stepReply[0].Args[1], "--insecure", strconv.FormatBool(false), 2)
+			Expect(strings.Contains(stepReply[0].Args[1], "--insecure")).Should(BeFalse())
 		})
 
 		It("insecure_cert_is_set_to_true", func() {
@@ -300,7 +300,7 @@ var _ = Describe("installcmd arguments", func() {
 			stepReply, err := installCmd.GetSteps(ctx, &host)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stepReply).NotTo(BeNil())
-			verifyArgInCommand(stepReply[0].Args[1], "--insecure", strconv.FormatBool(true), 2)
+			Expect(strings.Contains(stepReply[0].Args[1], "--insecure")).Should(BeTrue())
 		})
 
 		It("target_url_is_passed", func() {
@@ -472,7 +472,7 @@ func validateInstallCommand(installCmd *installCmd, reply *models.Step, role mod
 		"-v /run/systemd/journal/socket:/run/systemd/journal/socket " +
 		"--env PULL_SECRET_TOKEN --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY --env http_proxy --env https_proxy --env no_proxy " +
 		"quay.io/ocpmetal/assisted-installer-agent:latest fio_perf_check " +
-		fmt.Sprintf("--url %s --cluster-id %s --host-id %s --agent-version quay.io/ocpmetal/assisted-installer-agent:latest --insecure false ", installCmd.instructionConfig.ServiceBaseURL, string(clusterId), string(hostId)) +
+		fmt.Sprintf("--url %s --cluster-id %s --host-id %s --agent-version quay.io/ocpmetal/assisted-installer-agent:latest ", installCmd.instructionConfig.ServiceBaseURL, string(clusterId), string(hostId)) +
 		fmt.Sprintf("\"{\\\"duration_threshold_ms\\\":10,\\\"exit_code\\\":222,\\\"path\\\":\\\"%s\\\"}\" ; ", bootDevice)
 
 	installCommandPrefix := fioPerfCheckCmd


### PR DESCRIPTION
"flag" package in golang can accept a boolean input arguement in 2 format:
1) just an arguement without any value, the flag will be set to True (preferred)
2) <arguement>=<value> - flag will be set to value

if the argument is used in the following way:
   <arguement> <value>

then the flag will be set to true, but all the rest of the input arguements will not be processed at all