### PR TITLE
MGMT-2976 create and upload minimal iso template

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -362,7 +362,7 @@ func main() {
 				currVresion := version
 				errs.Go(func() error {
 					return errors.Wrapf(baseISOUploadLeader.RunWithLeader(context.Background(), func() error {
-						return objectHandler.UploadBootFiles(context.Background(), currVresion)
+						return objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL)
 					}), "Failed uploading boot files for OCP version %s", currVresion)
 				})
 			}
@@ -370,7 +370,7 @@ func main() {
 			for version := range openshiftVersionsMap {
 				currVresion := version
 				errs.Go(func() error {
-					return errors.Wrapf(objectHandler.UploadBootFiles(context.Background(), currVresion),
+					return errors.Wrapf(objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL),
 						"Failed uploading boot files for OCP version %s", currVresion)
 				})
 			}

--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -1,0 +1,145 @@
+package isoeditor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+
+	"github.com/openshift/assisted-service/internal/isoutil"
+	"github.com/openshift/assisted-service/restapi/operations/bootfiles"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// BaseIsoTempDir is a temporary directory pattern for the extracted base ISO
+	BaseIsoTempDir string = "baseiso"
+)
+
+type Editor interface {
+	CreateMinimalISOTemplate(serviceBaseURL string) (string, error)
+}
+
+type rhcosEditor struct {
+	isoHandler       isoutil.Handler
+	openshiftVersion string
+	log              logrus.FieldLogger
+}
+
+func NewEditor(isoHandler isoutil.Handler, openshiftVersion string, log logrus.FieldLogger) Editor {
+	return &rhcosEditor{
+		isoHandler:       isoHandler,
+		openshiftVersion: openshiftVersion,
+		log:              log,
+	}
+}
+
+func CreateEditor(isoPath string, openshiftVersion string, log logrus.FieldLogger) Editor {
+	isoTmpWorkDir, err := ioutil.TempDir("", BaseIsoTempDir)
+	if err != nil {
+		return nil
+	}
+	isoHandler := isoutil.NewHandler(isoPath, isoTmpWorkDir)
+	return NewEditor(isoHandler, openshiftVersion, log)
+}
+
+func (e *rhcosEditor) getRootFSURL(serviceBaseURL string) string {
+	var downloadBootFilesURL = &bootfiles.DownloadBootFilesURL{
+		FileType:         "rootfs.img",
+		OpenshiftVersion: e.openshiftVersion,
+	}
+	url, err := downloadBootFilesURL.Build()
+	if err != nil {
+		return ""
+	}
+
+	return fmt.Sprintf("%s%s", serviceBaseURL, url.RequestURI())
+}
+
+// Creates the template minimal iso by removing the rootfs and adding the url
+// Returns the path to the created iso file
+func (e *rhcosEditor) CreateMinimalISOTemplate(serviceBaseURL string) (string, error) {
+	if err := e.isoHandler.Extract(); err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := e.isoHandler.CleanWorkDir(); err != nil {
+			e.log.WithError(err).Warnf("Failed to clean isoHandler work dir")
+		}
+	}()
+
+	if err := os.Remove(e.isoHandler.ExtractedPath("images/pxeboot/rootfs.img")); err != nil {
+		return "", err
+	}
+
+	if err := e.addRootFSURL(serviceBaseURL); err != nil {
+		e.log.WithError(err).Warnf("Can't add rootfs_url (missing cfg files)")
+		return "", err
+	}
+
+	isoPath, err := tempFileName()
+	if err != nil {
+		return "", err
+	}
+
+	e.log.Infof("Creating minimal ISO template: %s", isoPath)
+	if err := e.create(isoPath); err != nil {
+		return "", err
+	}
+
+	return isoPath, nil
+}
+
+func (e *rhcosEditor) create(outPath string) error {
+	volumeID, err := e.isoHandler.VolumeIdentifier()
+	if err != nil {
+		return err
+	}
+	if err = e.isoHandler.Create(outPath, volumeID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *rhcosEditor) addRootFSURL(serviceBaseURL string) error {
+	replacement := fmt.Sprintf("$1 $2 coreos.live.rootfs_url=%s", e.getRootFSURL(serviceBaseURL))
+	if err := editFile(e.isoHandler.ExtractedPath("EFI/redhat/grub.cfg"), `(?m)^(\s+linux) (.+| )+$`, replacement); err != nil {
+		return err
+	}
+	if err := editFile(e.isoHandler.ExtractedPath("isolinux/isolinux.cfg"), `(?m)^(\s+append) (.+| )+$`, replacement); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func editFile(fileName string, reString string, replacement string) error {
+	content, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	re := regexp.MustCompile(reString)
+	newContent := re.ReplaceAllString(string(content), replacement)
+
+	if err := ioutil.WriteFile(fileName, []byte(newContent), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func tempFileName() (string, error) {
+	f, err := ioutil.TempFile("", "isoeditor")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+
+	if err := os.Remove(path); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/internal/isoeditor/rhcos_test.go
+++ b/internal/isoeditor/rhcos_test.go
@@ -1,0 +1,118 @@
+package isoeditor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	defaultTestOpenShiftVersion = "4.6"
+	defaultTestServiceBaseURL   = "http://198.51.100.0:6000"
+)
+
+func TestIsoEditor(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IsoEditor")
+}
+
+var _ = Context("with test files", func() {
+	var (
+		isoDir   string
+		isoFile  string
+		filesDir string
+		volumeID = "Assisted123"
+		log      logrus.FieldLogger
+	)
+	BeforeSuite(func() {
+		filesDir, isoDir, isoFile = createIsoViaGenisoimage(volumeID)
+		log = getTestLog()
+	})
+
+	AfterSuite(func() {
+		os.RemoveAll(filesDir)
+		os.RemoveAll(isoDir)
+	})
+
+	Describe("CreateMinimalISOTemplate", func() {
+		It("iso created successfully", func() {
+			editor := CreateEditor(isoFile, defaultTestOpenShiftVersion, log)
+			_, err := editor.CreateMinimalISOTemplate(defaultTestServiceBaseURL)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("missing iso file", func() {
+			editor := CreateEditor("invalid", defaultTestOpenShiftVersion, log)
+			_, err := editor.CreateMinimalISOTemplate(defaultTestServiceBaseURL)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("addRootFSURL", func() {
+		It("rootfs_url added successfully", func() {
+			editor := CreateEditor(isoFile, defaultTestOpenShiftVersion, log)
+			rootfsURL := fmt.Sprintf("%s/api/assisted-install/v1/boot-files?file_type=rootfs.img&openshift_version=%s",
+				defaultTestServiceBaseURL, defaultTestOpenShiftVersion)
+			isoHandler := editor.(*rhcosEditor).isoHandler
+			err := isoHandler.Extract()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = editor.(*rhcosEditor).addRootFSURL(defaultTestServiceBaseURL)
+			Expect(err).ToNot(HaveOccurred())
+
+			grubCfg := fmt.Sprintf(" linux /images/pxeboot/vmlinuz coreos.live.rootfs_url=%s", rootfsURL)
+			validateFileContent(isoHandler.ExtractedPath("EFI/redhat/grub.cfg"), grubCfg)
+
+			isolinuxCfg := fmt.Sprintf(" append initrd=/images/pxeboot/initrd.img coreos.live.rootfs_url=%s", rootfsURL)
+			validateFileContent(isoHandler.ExtractedPath("isolinux/isolinux.cfg"), isolinuxCfg)
+		})
+	})
+})
+
+func createIsoViaGenisoimage(volumeID string) (string, string, string) {
+	filesDir, err := ioutil.TempDir("", "isotest")
+	Expect(err).ToNot(HaveOccurred())
+
+	isoDir, err := ioutil.TempDir("", "isotest")
+	Expect(err).ToNot(HaveOccurred())
+	isoFile := filepath.Join(isoDir, "test.iso")
+
+	err = os.Mkdir(filepath.Join(filesDir, "files"), 0755)
+	Expect(err).ToNot(HaveOccurred())
+	err = os.MkdirAll(filepath.Join(filesDir, "files/images/pxeboot"), 0755)
+	Expect(err).ToNot(HaveOccurred())
+	err = ioutil.WriteFile(filepath.Join(filesDir, "files/images/pxeboot/rootfs.img"), []byte("this is rootfs"), 0664)
+	Expect(err).ToNot(HaveOccurred())
+	err = os.MkdirAll(filepath.Join(filesDir, "files/EFI/redhat"), 0755)
+	Expect(err).ToNot(HaveOccurred())
+	err = ioutil.WriteFile(filepath.Join(filesDir, "files/EFI/redhat/grub.cfg"), []byte(" linux /images/pxeboot/vmlinuz"), 0664)
+	Expect(err).ToNot(HaveOccurred())
+	err = os.MkdirAll(filepath.Join(filesDir, "files/isolinux"), 0755)
+	Expect(err).ToNot(HaveOccurred())
+	err = ioutil.WriteFile(filepath.Join(filesDir, "files/isolinux/isolinux.cfg"), []byte(" append initrd=/images/pxeboot/initrd.img"), 0664)
+	Expect(err).ToNot(HaveOccurred())
+	cmd := exec.Command("genisoimage", "-rational-rock", "-J", "-joliet-long", "-V", volumeID, "-o", isoFile, filepath.Join(filesDir, "files"))
+	err = cmd.Run()
+	Expect(err).ToNot(HaveOccurred())
+
+	return filesDir, isoDir, isoFile
+}
+
+func getTestLog() logrus.FieldLogger {
+	l := logrus.New()
+	l.SetOutput(ioutil.Discard)
+	return l
+}
+
+func validateFileContent(filename string, content string) {
+	fileContent, err := ioutil.ReadFile(filename)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(string(fileContent)).To(Equal(content))
+}

--- a/internal/isoutil/isoutil.go
+++ b/internal/isoutil/isoutil.go
@@ -21,6 +21,7 @@ type Handler interface {
 	Create(outPath string, volumeLabel string) error
 	ReadFile(filePath string) (io.ReadWriteSeeker, error)
 	VolumeIdentifier() (string, error)
+	CleanWorkDir() error
 }
 
 type installerHandler struct {
@@ -254,4 +255,8 @@ func (h *installerHandler) VolumeIdentifier() (string, error) {
 	}
 
 	return strings.TrimSpace(string(volumeId)), nil
+}
+
+func (h *installerHandler) CleanWorkDir() error {
+	return os.RemoveAll(h.workDir)
 }

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -33,6 +33,20 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
+// CleanWorkDir mocks base method
+func (m *MockHandler) CleanWorkDir() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanWorkDir")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanWorkDir indicates an expected call of CleanWorkDir
+func (mr *MockHandlerMockRecorder) CleanWorkDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanWorkDir", reflect.TypeOf((*MockHandler)(nil).CleanWorkDir))
+}
+
 // Create mocks base method
 func (m *MockHandler) Create(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -286,17 +286,17 @@ func (mr *MockAPIMockRecorder) Upload(arg0, arg1, arg2 interface{}) *gomock.Call
 }
 
 // UploadBootFiles mocks base method
-func (m *MockAPI) UploadBootFiles(arg0 context.Context, arg1 string) error {
+func (m *MockAPI) UploadBootFiles(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadBootFiles", arg0, arg1)
+	ret := m.ctrl.Call(m, "UploadBootFiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadBootFiles indicates an expected call of UploadBootFiles
-func (mr *MockAPIMockRecorder) UploadBootFiles(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) UploadBootFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBootFiles", reflect.TypeOf((*MockAPI)(nil).UploadBootFiles), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBootFiles", reflect.TypeOf((*MockAPI)(nil).UploadBootFiles), arg0, arg1, arg2)
 }
 
 // UploadFile mocks base method


### PR DESCRIPTION
- Added an iso editor that uses the isoutil package to modify the rhcos iso..
   It currently implements creating the minimal iso template which
   removes the rootfs and adds a reference to the url where the rootfs
   should be downloaded ([MGMT-3535](https://issues.redhat.com/browse/MGMT-3535)).
- Boot files upload logic resides on S3Client (UploadBootFiles func).
  Hence, in order to avoid re-downloading RHCOS image, integrated
  minimal iso creation and upload in uploadBootFiles.
- Extracted upload logic from rhcosEditor into S3Client in order
  to avoid cyclic dependency (i.e. so the editor won't import the client).
- Within boot files upload flow, use downloaded RHCOS image to create
  the minimal ISO template.
- Uploaded the template to the public S3 bucket if doesn't exist.