### PR TITLE
MGMT-3630 - Fix missing validation for minimum host valid disks

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/alecthomas/units"
 	"github.com/openshift/assisted-service/models"
-	"github.com/pkg/errors"
 )
 
 //go:generate mockgen -source=validator.go -package=hardware -destination=mock_validator.go
@@ -58,11 +57,7 @@ func (v *validator) GetHostValidDisks(host *models.Host) ([]*models.Disk, error)
 	if err := json.Unmarshal([]byte(host.Inventory), &inventory); err != nil {
 		return nil, err
 	}
-	disks := v.ListEligibleDisks(&inventory)
-	if len(disks) == 0 {
-		return disks, errors.Errorf("host %s doesn't have valid disks", host.ID)
-	}
-	return disks, nil
+	return v.ListEligibleDisks(&inventory), nil
 }
 
 func gbToBytes(gb int64) int64 {

--- a/internal/host/installcmd.go
+++ b/internal/host/installcmd.go
@@ -226,9 +226,16 @@ func getBootDevice(log logrus.FieldLogger, hwValidator hardware.Validator, host 
 	//  path is empty, it means there are no valid disks to install on.
 	disks, err := hwValidator.GetHostValidDisks(&host)
 	if err != nil || len(disks) == 0 {
-		err := errors.Errorf("Failed to get valid disks on host with id %s", host.ID)
 		log.Errorf("Failed to get valid disks on host with id %s", host.ID)
-		return "", err
+
+		var newErr error
+		if err != nil {
+			newErr = errors.Wrapf(err, "failed to get valid disks on host with id %s", host.ID)
+		} else {
+			newErr = errors.Errorf("host has no valid disks id %s", host.ID)
+		}
+
+		return "", newErr
 	}
 	return GetDeviceFullName(disks[0].Name), nil
 }


### PR DESCRIPTION
`GetHostValidDisks` had a surprising behavior of returning an error when there are no disks, instead of just returning an empty list and leaving it to the caller to decide whether that's an error or not.

Changed it so it only returns an error if the host inventory JSON is invalid, and changed all callers to behave properly when it returns an actual error.

This behavior caused a bug in these lines as part of the `UpdateInventory` function:
https://github.com/openshift/assisted-service/blob/b18e08ae96844c5c2743c1a27fc0af7362ed7834/internal/host/host.go#L297-L300

Those lines assumed that an error means an error and not just no-eligible disks - so the entire `UpdateInventory` call failed. Instead it should not fail and that scenario should be reflected to the user via the "minimum disks for installation" validation.

The reason this was not caught by CI is that the unit tests for the validations created their own inventory - this is an integration bug.

The e2e tests for validation only checked CPU and RAM validations, there were no e2e tests for the minimum valid disks validation ([MGMT-3631](https://issues.redhat.com/browse/MGMT-3631))