### PR TITLE
MGMT-2977 Allow downloading and caching from the public S3 bucket

### DIFF
--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -66,6 +66,7 @@ type API interface {
 	UploadStreamToPublicBucket(ctx context.Context, reader io.Reader, objectName string) error
 	UploadFileToPublicBucket(ctx context.Context, filePath, objectName string) error
 	DoesPublicObjectExist(ctx context.Context, objectName string) (bool, error)
+	DownloadPublic(ctx context.Context, objectName string) (io.ReadCloser, int64, error)
 }
 
 var _ API = &S3Client{}
@@ -280,6 +281,10 @@ func (c *S3Client) download(ctx context.Context, objectName, bucket string, clie
 
 func (c *S3Client) Download(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
 	return c.download(ctx, objectName, c.cfg.S3Bucket, c.client)
+}
+
+func (c *S3Client) DownloadPublic(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
+	return c.download(ctx, objectName, c.cfg.PublicS3Bucket, c.client)
 }
 
 func (c *S3Client) doesObjectExist(ctx context.Context, objectName, bucket string, client s3iface.S3API) (bool, error) {

--- a/pkg/s3wrapper/file_cache.go
+++ b/pkg/s3wrapper/file_cache.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 )
 
-// list of files keyed by the s3 object id
 type fileList struct {
 	sync.Mutex
 	files map[string]*file
@@ -24,25 +23,42 @@ var cache fileList = fileList{
 	files: make(map[string]*file),
 }
 
-func (l *fileList) get(objectName string) *file {
+func (l *fileList) get(key string) *file {
 	l.Lock()
 	defer l.Unlock()
 
-	f, present := l.files[objectName]
+	f, present := l.files[key]
 	if !present {
 		f = &file{}
-		l.files[objectName] = f
+		l.files[key] = f
 	}
 	return f
 }
 
-func downloadFile(ctx context.Context, objectHandler API, objectName string, cacheDir string) (string, error) {
-	reader, size, err := objectHandler.Download(ctx, objectName)
+func (l *fileList) clear() {
+	l.Lock()
+	defer l.Unlock()
+
+	l.files = make(map[string]*file)
+}
+
+func downloadFile(ctx context.Context, objectHandler API, objectName string, cacheDir string, public bool) (string, error) {
+	var (
+		reader io.ReadCloser
+		err    error
+		size   int64
+	)
+
+	if public {
+		reader, size, err = objectHandler.DownloadPublic(ctx, objectName)
+	} else {
+		reader, size, err = objectHandler.Download(ctx, objectName)
+	}
 	if err != nil {
 		return "", err
 	}
 
-	f, err := os.Create(filepath.Join(cacheDir, objectName))
+	f, err := os.Create(filepath.Join(cacheDir, cacheKey(objectName, public)))
 	if err != nil {
 		return "", err
 	}
@@ -58,14 +74,23 @@ func downloadFile(ctx context.Context, objectHandler API, objectName string, cac
 	return f.Name(), nil
 }
 
-func GetFile(ctx context.Context, objectHandler API, objectName string, cacheDir string) (string, error) {
-	f := cache.get(objectName)
+func cacheKey(objectName string, public bool) string {
+	prefix := "private"
+	if public {
+		prefix = "public"
+	}
+
+	return fmt.Sprintf("%s-%s", prefix, objectName)
+}
+
+func GetFile(ctx context.Context, objectHandler API, objectName string, cacheDir string, public bool) (string, error) {
+	f := cache.get(cacheKey(objectName, public))
 	f.Lock()
 	defer f.Unlock()
 
 	//cache miss
 	if f.path == "" {
-		path, err := downloadFile(ctx, objectHandler, objectName, cacheDir)
+		path, err := downloadFile(ctx, objectHandler, objectName, cacheDir, public)
 		if err != nil {
 			return "", err
 		}
@@ -73,4 +98,8 @@ func GetFile(ctx context.Context, objectHandler API, objectName string, cacheDir
 	}
 
 	return f.path, nil
+}
+
+func ClearFileCache() {
+	cache.clear()
 }

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -177,6 +177,10 @@ func (f *FSClient) Download(ctx context.Context, objectName string) (io.ReadClos
 	return ioutils.NewReadCloserWrapper(fp, fp.Close), info.Size(), nil
 }
 
+func (f *FSClient) DownloadPublic(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
+	return f.Download(ctx, objectName)
+}
+
 func (f *FSClient) DoesObjectExist(ctx context.Context, objectName string) (bool, error) {
 	filePath := filepath.Join(f.basedir, objectName)
 	info, err := os.Stat(filePath)

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -157,6 +157,22 @@ func (mr *MockAPIMockRecorder) DownloadBootFile(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadBootFile", reflect.TypeOf((*MockAPI)(nil).DownloadBootFile), arg0, arg1, arg2)
 }
 
+// DownloadPublic mocks base method
+func (m *MockAPI) DownloadPublic(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DownloadPublic", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DownloadPublic indicates an expected call of DownloadPublic
+func (mr *MockAPIMockRecorder) DownloadPublic(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadPublic", reflect.TypeOf((*MockAPI)(nil).DownloadPublic), arg0, arg1)
+}
+
 // ExpireObjects mocks base method
 func (m *MockAPI) ExpireObjects(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 func(context.Context, logrus.FieldLogger, string)) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The minimal iso template is stored in the public S3 bucket so we need to be able to download it.
Currently the s3 client `Download` function only downloads from the non-public bucket and the boot files (the only objects we store in the public bucket) have a specific download function which is not a good match for a general-purpose s3 object cache.