### PR TITLE
MGMT-3446 Update Waiting for ignition timeout to 24 hours

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -59,7 +59,7 @@ var InstallationProgressTimeout = map[models.HostStage]time.Duration{
 	models.HostStageWritingImageToDisk:          30 * time.Minute,
 	models.HostStageRebooting:                   70 * time.Minute,
 	models.HostStageConfiguring:                 60 * time.Minute,
-	models.HostStageWaitingForIgnition:          60 * time.Minute,
+	models.HostStageWaitingForIgnition:          24 * time.Hour,
 	"DEFAULT":                                   60 * time.Minute,
 }
 

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1178,7 +1178,7 @@ var _ = Describe("Refresh Host", func() {
 			{models.HostStageConfiguring, true},
 			{models.HostStageDone, true},
 			{models.HostStageJoined, true},
-			{models.HostStageWaitingForIgnition, true},
+			{models.HostStageWaitingForIgnition, false},
 			{models.HostStageFailed, true},
 		}
 
@@ -1327,7 +1327,6 @@ var _ = Describe("Refresh Host", func() {
 			models.HostStageWritingImageToDisk,
 			models.HostStageRebooting,
 			models.HostStageConfiguring,
-			models.HostStageWaitingForIgnition,
 			models.HostStageInstalling,
 			invalidStage,
 		}
@@ -1406,7 +1405,7 @@ var _ = Describe("Refresh Host", func() {
 			host.Role = models.HostRoleWorker
 			host.CheckedInAt = strfmt.DateTime(time.Now())
 			progress := models.HostProgressInfo{
-				CurrentStage:   models.HostStageWaitingForIgnition,
+				CurrentStage:   models.HostStageConfiguring,
 				StageStartedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
 				StageUpdatedAt: strfmt.DateTime(time.Now().Add(-90 * time.Minute)),
 			}
@@ -1432,7 +1431,7 @@ var _ = Describe("Refresh Host", func() {
 			info := formatProgressTimedOutInfo(models.HostStageWaitingForControlPlane)
 			Expect(swag.StringValue(resultMaster.StatusInfo)).To(Equal(info))
 
-			info = formatProgressTimedOutInfo(models.HostStageWaitingForIgnition)
+			info = formatProgressTimedOutInfo(models.HostStageConfiguring)
 			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(info))
 		})
 


### PR DESCRIPTION
Worker nodes might need to wait longer than master nodes for the ignition since they get only after the master nodes formed a cluster.
24 hours should be more than enough for the worker to get the ignition from the MCS