### PR TITLE
MGMT-3658: Generate event/metric in case an host validation is changing.

### DIFF
--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -33,6 +33,7 @@ const (
 	counterClusterHostNTPFailuresCount            = "assisted_installer_cluster_host_ntp_failures"
 	counterClusterHostDiskSyncDurationMiliSeconds = "assisted_installer_cluster_host_disk_sync_duration_ms"
 	counterHostValidationFailed                   = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	counterHostValidationChanged                  = "assisted_installer_host_validation_failed_after_success_before_installation"
 )
 
 const (
@@ -50,6 +51,7 @@ const (
 	counterDescriptionClusterHostNicGb                       = "Histogram/sum/count of management network NIC speed in hosts of completed clusters, by role, result, and OCP version"
 	counterDescriptionClusterHostDiskSyncDurationMiliSeconds = "Histogram/sum/count of the disk's fdatasync duration (fetched from fio)"
 	counterDescriptionHostValidationFailed                   = "Number of host validation errors"
+	counterDescriptionHostValidationChanged                  = "Number of host validations that already succeed but start to fail again"
 )
 
 const (
@@ -76,6 +78,7 @@ const (
 type API interface {
 	ClusterRegistered(clusterVersion string, clusterID strfmt.UUID, emailDomain string)
 	HostValidationFailed(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID)
+	HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID)
 	InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string)
 	ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string)
 	ClusterHostsNTPFailures(clusterID strfmt.UUID, emailDomain string, hostNTPFailureCount int)
@@ -102,6 +105,7 @@ type MetricsManager struct {
 	serviceLogicClusterHostNicGb                       *prometheus.HistogramVec
 	serviceLogicClusterHostDiskSyncDurationMiliSeconds *prometheus.HistogramVec
 	serviceLogicHostValidationFailed                   *prometheus.CounterVec
+	serviceLogicHostValidationChanged                  *prometheus.CounterVec
 }
 
 func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
@@ -219,6 +223,14 @@ func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
 				Name:      counterHostValidationFailed,
 				Help:      counterDescriptionHostValidationFailed,
 			}, []string{openshiftVersionLabel, clusterIdLabel, emailDomainLabel, hostValidationTypeLabel}),
+
+		serviceLogicHostValidationChanged: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      counterHostValidationChanged,
+				Help:      counterDescriptionHostValidationChanged,
+			}, []string{openshiftVersionLabel, clusterIdLabel, emailDomainLabel, hostValidationTypeLabel}),
 	}
 
 	registry.MustRegister(
@@ -234,6 +246,7 @@ func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
 		m.serviceLogicClusterHostNicGb,
 		m.serviceLogicClusterHostDiskSyncDurationMiliSeconds,
 		m.serviceLogicHostValidationFailed,
+		m.serviceLogicHostValidationChanged,
 	)
 	return m
 }
@@ -244,6 +257,10 @@ func (m *MetricsManager) ClusterRegistered(clusterVersion string, clusterID strf
 
 func (m *MetricsManager) HostValidationFailed(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
 	m.serviceLogicHostValidationFailed.WithLabelValues(clusterVersion, clusterID.String(), emailDomain, string(hostValidationType)).Inc()
+}
+
+func (m *MetricsManager) HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
+	m.serviceLogicHostValidationChanged.WithLabelValues(clusterVersion, clusterID.String(), emailDomain, string(hostValidationType)).Inc()
 }
 
 func (m *MetricsManager) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string) {

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -60,6 +60,18 @@ func (mr *MockAPIMockRecorder) HostValidationFailed(clusterVersion, clusterID, e
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationFailed", reflect.TypeOf((*MockAPI)(nil).HostValidationFailed), clusterVersion, clusterID, emailDomain, hostValidationType)
 }
 
+// HostValidationChanged mocks base method
+func (m *MockAPI) HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HostValidationChanged", clusterVersion, clusterID, emailDomain, hostValidationType)
+}
+
+// HostValidationChanged indicates an expected call of HostValidationChanged
+func (mr *MockAPIMockRecorder) HostValidationChanged(clusterVersion, clusterID, emailDomain, hostValidationType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationChanged", reflect.TypeOf((*MockAPI)(nil).HostValidationChanged), clusterVersion, clusterID, emailDomain, hostValidationType)
+}
+
 // InstallationStarted mocks base method
 func (m *MockAPI) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain, userManagedNetworking string) {
 	m.ctrl.T.Helper()

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/jinzhu/copier"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/client/events"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	hostValidationMetric = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	hostValidationFailedMetric  = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	hostValidationChangedMetric = "assisted_installer_host_validation_failed_after_success_before_installation"
 )
 
 type hostValidationResult struct {
@@ -31,7 +32,7 @@ type hostValidationResult struct {
 	Message string                  `json:"message"`
 }
 
-func isHostValidationInFailedStatus(clusterID, hostID strfmt.UUID, validationID models.HostValidationID) (bool, error) {
+func isHostValidationInStatus(clusterID, hostID strfmt.UUID, validationID models.HostValidationID, expectedStatus string) (bool, error) {
 	var validationRes map[string][]hostValidationResult
 	h := getHost(clusterID, hostID)
 	if h.ValidationsInfo == "" {
@@ -44,10 +45,25 @@ func isHostValidationInFailedStatus(clusterID, hostID strfmt.UUID, validationID 
 			if v.ID != validationID {
 				continue
 			}
-			return v.Status == "failure", nil
+			return v.Status == expectedStatus, nil
 		}
 	}
 	return false, nil
+}
+
+func waitForHostValidationStatus(clusterID, hostID strfmt.UUID, expectedStatus string, hostValidationIDs ...models.HostValidationID) {
+
+	waitFunc := func() (bool, error) {
+		for _, vID := range hostValidationIDs {
+			cond, _ := isHostValidationInStatus(clusterID, hostID, vID, expectedStatus)
+			if !cond {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func filterMetrics(metrics []string, substrings ...string) []string {
@@ -67,7 +83,7 @@ func filterMetrics(metrics []string, substrings ...string) []string {
 	return res
 }
 
-func assertValidationCounter(clusterID strfmt.UUID, validationID models.HostValidationID, expectedCounter int) {
+func assertValidationMetricCounter(clusterID strfmt.UUID, validationID models.HostValidationID, expectedMetric string, expectedCounter int) {
 
 	url := fmt.Sprintf("http://%s/metrics", Options.InventoryHost)
 
@@ -76,12 +92,34 @@ func assertValidationCounter(clusterID strfmt.UUID, validationID models.HostVali
 	Expect(err).NotTo(HaveOccurred())
 
 	metrics := strings.Split(string(output), "\n")
-	filteredMetrics := filterMetrics(metrics, string(clusterID), hostValidationMetric, string(validationID))
+	filteredMetrics := filterMetrics(metrics, string(clusterID), expectedMetric, string(validationID))
 	Expect(len(filteredMetrics)).To(Equal(1))
 
 	counter, err := strconv.Atoi(strings.ReplaceAll((strings.Split(filteredMetrics[0], "}")[1]), " ", ""))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(counter).To(Equal(expectedCounter))
+}
+
+func assertValidationEvent(ctx context.Context, clusterID strfmt.UUID, hostName string, validationID models.HostValidationID, isFailure bool) {
+
+	eventsReply, err := userBMClient.Events.ListEvents(ctx, &events.ListEventsParams{
+		ClusterID: clusterID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	var eventExist bool
+	var eventMsg string
+	if isFailure {
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' that used to succeed is now failing", hostName, validationID)
+	} else {
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' is now fixed", hostName, validationID)
+	}
+	for _, ev := range eventsReply.Payload {
+		if eventMsg == *ev.Message {
+			eventExist = true
+		}
+	}
+	Expect(eventExist).To(BeTrue())
 }
 
 func metricsDeregisterCluster(ctx context.Context, clusterID strfmt.UUID) {
@@ -92,11 +130,26 @@ func metricsDeregisterCluster(ctx context.Context, clusterID strfmt.UUID) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func generateValidInventory() string {
+
+	inventory := models.Inventory{
+		CPU:          &models.CPU{Count: 4},
+		Memory:       &models.Memory{PhysicalBytes: int64(16 * units.GiB)},
+		Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
+		Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
+	}
+	b, err := json.Marshal(&inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 var _ = Describe("Metrics tests", func() {
 
 	var (
-		ctx       context.Context = context.Background()
-		clusterID strfmt.UUID
+		ctx                    context.Context = context.Background()
+		clusterID              strfmt.UUID
+		hostStatusInsufficient string = models.HostStatusInsufficient
 	)
 
 	BeforeEach(func() {
@@ -117,128 +170,209 @@ var _ = Describe("Metrics tests", func() {
 
 	Context("Host validation metrics", func() {
 
-		It("has-min-hw-capacity", func() {
+		It("'has-min-hw-capacity' failed", func() {
 
+			// create a validation success
 			host := &registerHost(clusterID).Host
-
-			var lowHwInfo models.Inventory
-			err := copier.CopyWithOption(&lowHwInfo, validHwInfo, copier.Option{DeepCopy: true})
+			err := db.Model(host).UpdateColumns(&models.Host{Inventory: generateValidInventory(), Status: &hostStatusInsufficient}).Error
 			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *host.ID, "success",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
 
-			lowHwInfo.CPU.Count = 1
-			lowHwInfo.Memory.PhysicalBytes = int64(4 * units.GiB)
-
-			generateHWPostStepReply(ctx, host, &lowHwInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				cpuCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMinCPUCores)
-				memoryCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMinMemory)
-				return cpuCond && memoryCond, nil
+			// create a validation failure
+			nonValidInventory := &models.Inventory{
+				CPU:          &models.CPU{Count: 1},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
+				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
 			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			generateHWPostStepReply(ctx, host, nonValidInventory, "master-0")
+			waitForHostValidationStatus(clusterID, *host.ID, "failure",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
 
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinCPUCores, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinMemory, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDValidPlatform, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasCPUCoresForRole, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMemoryForRole, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinCPUCores, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinMemory, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDValidPlatform, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMemoryForRole, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMinCPUCores, 1)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMinMemory, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinCPUCores, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinMemory, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDValidPlatform, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMemoryForRole, hostValidationFailedMetric, 1)
+
 		})
 
-		It("has-min-hw-capacity-for-role", func() {
+		It("'has-min-hw-capacity' got fixed", func() {
 
+			// create a validation failure
 			host := &registerHost(clusterID).Host
-
-			var lowHwInfo models.Inventory
-			err := copier.CopyWithOption(&lowHwInfo, validHwInfo, copier.Option{DeepCopy: true})
-			Expect(err).NotTo(HaveOccurred())
-
-			lowHwInfo.CPU.Count = 1
-			lowHwInfo.Memory.PhysicalBytes = int64(4 * units.GiB)
-
-			generateHWPostStepReply(ctx, host, &lowHwInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				cpuCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasCPUCoresForRole)
-				memoryCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMemoryForRole)
-				return cpuCond && memoryCond, nil
+			nonValidInventory := &models.Inventory{
+				CPU:          &models.CPU{Count: 1},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
+				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
 			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			generateHWPostStepReply(ctx, host, nonValidInventory, "master-0")
+			waitForHostValidationStatus(clusterID, *host.ID, "failure",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
 
-			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, 1)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMemoryForRole, 1)
+			// create a validation success
+			generateHWPostStepReply(ctx, host, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *host.ID, "success",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinCPUCores, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinMemory, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDValidPlatform, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasCPUCoresForRole, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMemoryForRole, false)
 		})
 
-		It("hostname-unique", func() {
+		It("'hostname-unique' failed", func() {
 
+			// create a validation success
 			host1 := &registerHost(clusterID).Host
-			generateHWPostStepReply(ctx, host1, validHwInfo, "nonUniqName")
-
 			host2 := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, host1, validHwInfo, "master-0")
+			generateHWPostStepReply(ctx, host2, validHwInfo, "master-1")
+			waitForHostValidationStatus(clusterID, *host1.ID, "success", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *host2.ID, "success", models.HostValidationIDHostnameUnique)
+
+			// create a validation failure
+			generateHWPostStepReply(ctx, host1, validHwInfo, "nonUniqName")
 			generateHWPostStepReply(ctx, host2, validHwInfo, "nonUniqName")
+			waitForHostValidationStatus(clusterID, *host1.ID, "failure", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *host2.ID, "failure", models.HostValidationIDHostnameUnique)
 
-			waitFunc := func() (bool, error) {
-				host1Cond, _ := isHostValidationInFailedStatus(clusterID, *host1.ID, models.HostValidationIDHostnameUnique)
-				host2Cond, _ := isHostValidationInFailedStatus(clusterID, *host2.ID, models.HostValidationIDHostnameUnique)
-				return host1Cond && host2Cond, nil
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "nonUniqName", models.HostValidationIDHostnameUnique, true)
+			assertValidationEvent(ctx, clusterID, "nonUniqName", models.HostValidationIDHostnameUnique, true)
 
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameUnique, hostValidationChangedMetric, 2)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHostnameUnique, 2)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameUnique, hostValidationFailedMetric, 2)
 		})
 
-		It("hostname-valid", func() {
+		It("'hostname-unique' got fixed", func() {
 
+			// create a validation failure
+			host1 := &registerHost(clusterID).Host
+			host2 := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, host1, validHwInfo, "master-0")
+			generateHWPostStepReply(ctx, host2, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *host1.ID, "failure", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *host2.ID, "failure", models.HostValidationIDHostnameUnique)
+
+			// create a validation success
+			generateHWPostStepReply(ctx, host2, validHwInfo, "master-1")
+			waitForHostValidationStatus(clusterID, *host1.ID, "success", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *host2.ID, "success", models.HostValidationIDHostnameUnique)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHostnameUnique, false)
+			assertValidationEvent(ctx, clusterID, "master-1", models.HostValidationIDHostnameUnique, false)
+		})
+
+		It("'hostname-valid' failed", func() {
+
+			// create a validation success
+			host := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, host, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *host.ID, "success", models.HostValidationIDHostnameValid)
+
+			// create a validation failure
 			// 'localhost' is a forbidden host name
-			host := &registerHost(clusterID).Host
 			generateHWPostStepReply(ctx, host, validHwInfo, "localhost")
+			waitForHostValidationStatus(clusterID, *host.ID, "failure", models.HostValidationIDHostnameValid)
 
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHostnameValid)
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "localhost", models.HostValidationIDHostnameValid, true)
 
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameValid, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHostnameValid, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameValid, hostValidationFailedMetric, 1)
 		})
 
-		It("valid-platform", func() {
+		It("'hostname-valid' got fixed", func() {
 
+			// create a validation failure
 			host := &registerHost(clusterID).Host
+			// 'localhost' is a forbidden host name
+			generateHWPostStepReply(ctx, host, validHwInfo, "localhost")
+			waitForHostValidationStatus(clusterID, *host.ID, "failure", models.HostValidationIDHostnameValid)
 
-			var nonValidPlatformVendorInfo models.Inventory
-			err := copier.CopyWithOption(&nonValidPlatformVendorInfo, validHwInfo, copier.Option{DeepCopy: true})
-			Expect(err).NotTo(HaveOccurred())
+			// create a validation success
+			generateHWPostStepReply(ctx, host, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *host.ID, "success", models.HostValidationIDHostnameValid)
 
-			nonValidPlatformVendorInfo.SystemVendor.ProductName = "OpenStack Compute"
-
-			generateHWPostStepReply(ctx, host, &nonValidPlatformVendorInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDValidPlatform)
-			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
-
-			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDValidPlatform, 1)
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHostnameValid, false)
 		})
 
-		It("ntp-synced", func() {
+		It("'ntp-synced' failed", func() {
 
+			// create a validation success
 			host := &registerHost(clusterID).Host
+			generateNTPPostStepReply(ctx, host, validNtpSources)
+			waitForHostValidationStatus(clusterID, *host.ID, "success", models.HostValidationIDNtpSynced)
 
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDNtpSynced)
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			// create a validation failure
+			generateNTPPostStepReply(ctx, host, nil)
+			waitForHostValidationStatus(clusterID, *host.ID, "failure", models.HostValidationIDNtpSynced)
 
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*host.ID), models.HostValidationIDNtpSynced, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDNtpSynced, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDNtpSynced, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDNtpSynced, hostValidationFailedMetric, 1)
+		})
+
+		It("'ntp-synced' got fixed", func() {
+
+			// create a validation failure
+			host := &registerHost(clusterID).Host
+			generateNTPPostStepReply(ctx, host, nil)
+			waitForHostValidationStatus(clusterID, *host.ID, "failure", models.HostValidationIDNtpSynced)
+
+			// create a validation success
+			generateNTPPostStepReply(ctx, host, validNtpSources)
+			waitForHostValidationStatus(clusterID, *host.ID, "success", models.HostValidationIDNtpSynced)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*host.ID), models.HostValidationIDNtpSynced, false)
 		})
 	})
 })


### PR DESCRIPTION
The case we are trying to catch is if a host validation was went to
`failed` state after being in `succeed` state.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>
