### PR TITLE
NO-ISSUE Extend on-prem installer startup timeout from 1m to 3m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ deploy-onprem:
 		-v ./livecd.iso:/data/livecd.iso:z \
 		-v ./coreos-installer:/data/coreos-installer:z \
 		--restart always --name installer $(SERVICE)
-	./hack/retry.sh 30 2 "curl http://127.0.0.1:8090/ready"
+	./hack/retry.sh 90 2 "curl http://127.0.0.1:8090/ready"
 
 deploy-onprem-for-subsystem:
 	export DUMMY_IGNITION="true" && $(MAKE) deploy-onprem


### PR DESCRIPTION
deploy-onprem is timing out waiting for installer to pass health
check. The installer container at times is waiting to establish
a db connection. CI logs show the installer does eventually
establish a connection to db and starts up:

http://assisted-jenkins.usersys.redhat.com/job/assisted-service/job/master/4699/