### PR TITLE
wip: MGMT-3608: Add support for cluster deletion in cluster controller

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -285,6 +285,7 @@ type InstallerInternals interface {
 	GenerateClusterISOInternal(ctx context.Context, params installer.GenerateClusterISOParams) (*common.Cluster, error)
 	GetClusterByKubeKey(key types.NamespacedName) (*common.Cluster, error)
 	InstallClusterInternal(ctx context.Context, params installer.InstallClusterParams) (*common.Cluster, error)
+	DeregisterClusterInternal(ctx context.Context, params installer.DeregisterClusterParams) error
 }
 
 type bareMetalInventory struct {
@@ -786,13 +787,19 @@ func (b *bareMetalInventory) createAndUploadNodeIgnition(ctx context.Context, cl
 }
 
 func (b *bareMetalInventory) DeregisterCluster(ctx context.Context, params installer.DeregisterClusterParams) middleware.Responder {
+	if err := b.DeregisterClusterInternal(ctx, params); err != nil {
+		return common.GenerateErrorResponder(err)
+	}
+	return installer.NewDeregisterClusterNoContent()
+}
+
+func (b *bareMetalInventory) DeregisterClusterInternal(ctx context.Context, params installer.DeregisterClusterParams) error {
 	log := logutil.FromContext(ctx, b.log)
 	var cluster common.Cluster
 	log.Infof("Deregister cluster id %s", params.ClusterID)
 
 	if err := b.db.Preload("Hosts").First(&cluster, "id = ?", params.ClusterID).Error; err != nil {
-		return installer.NewDeregisterClusterNotFound().
-			WithPayload(common.GenerateError(http.StatusNotFound, err))
+		return common.NewApiError(http.StatusNotFound, err)
 	}
 
 	if err := b.deleteDNSRecordSets(ctx, cluster); err != nil {
@@ -802,11 +809,9 @@ func (b *bareMetalInventory) DeregisterCluster(ctx context.Context, params insta
 	err := b.clusterApi.DeregisterCluster(ctx, &cluster)
 	if err != nil {
 		log.WithError(err).Errorf("failed to deregister cluster cluster %s", params.ClusterID)
-		return installer.NewDeregisterClusterNotFound().
-			WithPayload(common.GenerateError(http.StatusNotFound, err))
+		return common.NewApiError(http.StatusNotFound, err)
 	}
-
-	return installer.NewDeregisterClusterNoContent()
+	return nil
 }
 
 func (b *bareMetalInventory) DownloadClusterISO(ctx context.Context, params installer.DownloadClusterISOParams) middleware.Responder {

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -36,6 +36,20 @@ func (m *MockInstallerInternals) EXPECT() *MockInstallerInternalsMockRecorder {
 	return m.recorder
 }
 
+// DeregisterClusterInternal mocks base method
+func (m *MockInstallerInternals) DeregisterClusterInternal(arg0 context.Context, arg1 installer.DeregisterClusterParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterClusterInternal", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterClusterInternal indicates an expected call of DeregisterClusterInternal
+func (mr *MockInstallerInternalsMockRecorder) DeregisterClusterInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).DeregisterClusterInternal), arg0, arg1)
+}
+
 // GenerateClusterISOInternal mocks base method
 func (m *MockInstallerInternals) GenerateClusterISOInternal(arg0 context.Context, arg1 installer.GenerateClusterISOParams) (*common.Cluster, error) {
 	m.ctrl.T.Helper()

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -784,7 +784,8 @@ func (m Manager) PermanentClustersDeletion(ctx context.Context, olderThen strfmt
 
 func (m *Manager) GetClusterByKubeKey(key types.NamespacedName) (*common.Cluster, error) {
 	c := &common.Cluster{}
-	if err := m.db.Preload("Hosts").Take(c, "kube_key_name = ? and kube_key_namespace = ?", key.Name, key.Namespace).Error; err != nil {
+	if err := m.db.Preload("Hosts").Unscoped().Take(
+		c, "kube_key_name = ? and kube_key_namespace = ?", key.Name, key.Namespace).Error; err != nil {
 		return nil, err
 	}
 	return c, nil


### PR DESCRIPTION
Two possible situations, cluster CRD is deleted and therefore needs to be deleted
from database, or cluster deleted in database (from any reason), then CRD needs to be
deleted so the kube api will be synced with the service actual state.