### PR TITLE
MGMT-3763 - Fix misleading host progress error when cluster enters error state

### DIFF
--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -512,7 +512,8 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 		if err != nil {
 			return err
 		}
-		if sHost.host.Progress.CurrentStage == models.HostStageWritingImageToDisk {
+		if sHost.host.Progress.CurrentStage == models.HostStageWritingImageToDisk &&
+			reason == statusInfoInstallationInProgressTimedOut {
 			template = statusInfoInstallationInProgressWritingImageToDiskTimedOut
 		}
 		template = strings.Replace(template, "$STAGE", string(sHost.host.Progress.CurrentStage), 1)


### PR DESCRIPTION
The statusInfoInstallationInProgressWritingImageToDiskTimedOut message should only be set if the transition that caused it is the "timeout" transition.

Hosts that were in the middle of writing to disk while the cluster entered an error state looked like they were timing out - even though what actually happened is they simply entered the error state like the rest of the hosts in the cluster. A wrong `if` statement in the post-refresh function wrongly assumed it was called from a timeout transition, although it was actually called from the "move all hosts to error because cluster is in error" transition.