### PR TITLE
MGMT-2622 - Add disk and user to event when booted into the ISO instead of into the installed OCP on disk

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2263,7 +2263,7 @@ func (b *bareMetalInventory) RegisterHost(ctx context.Context, params installer.
 	if err = b.hostApi.RegisterHost(ctx, &host, tx); err != nil {
 		log.WithError(err).Errorf("failed to register host <%s> cluster <%s>",
 			params.NewHostParams.HostID.String(), params.ClusterID.String())
-		uerr := errors.Wrap(err, "Failed to register host: error creating host metadata")
+		uerr := errors.Wrap(err, fmt.Sprintf("Failed to register host %s", hostutil.GetHostnameForMsg(&host)))
 		b.eventsHandler.AddEvent(ctx, params.ClusterID, params.NewHostParams.HostID, models.EventSeverityError,
 			uerr.Error(), time.Now())
 		return returnRegisterHostTransitionError(http.StatusBadRequest, err)

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -108,7 +108,7 @@ func (th *transitionHandler) PostRegisterDuringReboot(sw stateswitch.StateSwitch
 		return errors.New("PostRegisterDuringReboot incompatible type of StateSwitch")
 	}
 	if swag.StringValue(&sHost.srcState) == models.HostStatusInstallingPendingUserAction {
-		return common.NewApiError(http.StatusForbidden, errors.New("Host is required to be booted from disk"))
+		return common.NewApiError(http.StatusForbidden, errors.Errorf("Host is required to be booted from disk %s", sHost.host.InstallationDiskPath))
 	}
 	params, ok := args.(*TransitionArgsRegisterHost)
 	if !ok {


### PR DESCRIPTION
Reformat event message and add disk and user details 
`Host name missing in event :"error Failed to register host: error creating host metadata: Host is required to be booted from disk"`