### PR TITLE
NO-ISSUE Merge all agent sub-images into one

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -198,11 +198,7 @@ func main() {
 		Options.BMConfig.AgentDockerImg,
 		Options.InstructionConfig.InstallerImage,
 		Options.InstructionConfig.ControllerImage,
-		Options.InstructionConfig.ConnectivityCheckImage,
-		Options.InstructionConfig.InventoryImage,
-		Options.InstructionConfig.FreeAddressesImage,
-		Options.InstructionConfig.DhcpLeaseAllocatorImage,
-		Options.InstructionConfig.APIVIPConnectivityCheckImage,
+		Options.InstructionConfig.AgentImage,
 	}
 
 	for _, ocpVersion := range openshiftVersionsMap {

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -89,7 +89,7 @@ func (i *installCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models
 		ClusterID:            string(host.ClusterID),
 		HostID:               string(*host.ID),
 		UseCustomCACert:      i.hasCACert(),
-		FioPerfCheckImage:    i.instructionConfig.FioPerfCheckImage,
+		FioPerfCheckImage:    i.instructionConfig.AgentImage,
 		SkipCertVerification: i.instructionConfig.SkipCertVerification,
 		Path:                 bootdevice,
 		DurationThresholdMs:  FioDurationThresholdMs,
@@ -140,7 +140,7 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		"--high-availability-mode", haMode,
 		"--mco-image", mcoImage,
 		"--controller-image", i.instructionConfig.ControllerImage,
-		"--agent-image", i.instructionConfig.InventoryImage,
+		"--agent-image", i.instructionConfig.AgentImage,
 	}
 
 	/*

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -32,8 +32,7 @@ var DefaultInstructionConfig = InstructionConfig{
 	ServiceBaseURL:      "http://10.35.59.36:30485",
 	InstallerImage:      "quay.io/ocpmetal/assisted-installer:latest",
 	ControllerImage:     "quay.io/ocpmetal/assisted-installer-controller:latest",
-	InventoryImage:      "quay.io/ocpmetal/assisted-installer-agent:latest",
-	FioPerfCheckImage:   "quay.io/ocpmetal/assisted-installer-agent:latest",
+	AgentImage:          "quay.io/ocpmetal/assisted-installer-agent:latest",
 	InstallationTimeout: 120,
 	ReleaseImageMirror:  "local.registry:5000/ocp@sha256:eab93b4591699a5a4ff50ad3517892653f04fb840127895bb3609b3cc68f98f3",
 }
@@ -497,7 +496,7 @@ func validateInstallCommand(installCmd *installCmd, reply *models.Step, role mod
 	verifyArgInCommand(reply.Args[1], "--url", installCmd.instructionConfig.ServiceBaseURL, 2)
 	verifyArgInCommand(reply.Args[1], "--mco-image", defaultMCOImage, 1)
 	verifyArgInCommand(reply.Args[1], "--controller-image", installCmd.instructionConfig.ControllerImage, 1)
-	verifyArgInCommand(reply.Args[1], "--agent-image", installCmd.instructionConfig.InventoryImage, 1)
+	verifyArgInCommand(reply.Args[1], "--agent-image", installCmd.instructionConfig.AgentImage, 1)
 	verifyArgInCommand(reply.Args[1], "--installation-timeout", strconv.Itoa(int(installCmd.instructionConfig.InstallationTimeout)), 1)
 
 	fioPerfCheckCmd := "podman run --privileged --net=host --rm --quiet --name=assisted-installer -v /dev:/dev:rw -v /var/log:/var/log " +

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -46,38 +46,32 @@ type InstructionManager struct {
 }
 
 type InstructionConfig struct {
-	ServiceBaseURL               string `envconfig:"SERVICE_BASE_URL"`
-	ServiceCACertPath            string `envconfig:"SERVICE_CA_CERT_PATH" default:""`
-	ServiceIPs                   string `envconfig:"SERVICE_IPS" default:""`
-	InstallerImage               string `envconfig:"INSTALLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer:latest"`
-	ControllerImage              string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-controller:latest"`
-	ConnectivityCheckImage       string `envconfig:"CONNECTIVITY_CHECK_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	InventoryImage               string `envconfig:"INVENTORY_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	FreeAddressesImage           string `envconfig:"FREE_ADDRESSES_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	DhcpLeaseAllocatorImage      string `envconfig:"DHCP_LEASE_ALLOCATOR_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	APIVIPConnectivityCheckImage string `envconfig:"API_VIP_CONNECTIVITY_CHECK_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	NtpSynchronizerImage         string `envconfig:"NTP_SYNCHRONIZER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	FioPerfCheckImage            string `envconfig:"FIO_PERF_CHECK_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	SkipCertVerification         bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
-	CheckClusterVersion          bool   `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
-	SupportL2                    bool   `envconfig:"SUPPORT_L2" default:"true"`
-	InstallationTimeout          uint   `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
-	ReleaseImageMirror           string
+	ServiceBaseURL       string `envconfig:"SERVICE_BASE_URL"`
+	ServiceCACertPath    string `envconfig:"SERVICE_CA_CERT_PATH" default:""`
+	ServiceIPs           string `envconfig:"SERVICE_IPS" default:""`
+	InstallerImage       string `envconfig:"INSTALLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer:latest"`
+	ControllerImage      string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-controller:latest"`
+	AgentImage           string `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
+	SkipCertVerification bool   `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	CheckClusterVersion  bool   `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
+	SupportL2            bool   `envconfig:"SUPPORT_L2" default:"true"`
+	InstallationTimeout  uint   `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
+	ReleaseImageMirror   string
 }
 
 func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, ocRelease oc.Release,
 	instructionConfig InstructionConfig, connectivityValidator connectivity.Validator, eventsHandler events.Handler, versionHandler versions.Handler) *InstructionManager {
-	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.ConnectivityCheckImage)
+	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.AgentImage)
 	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler)
-	inventoryCmd := NewInventoryCmd(log, instructionConfig.InventoryImage)
-	freeAddressesCmd := NewFreeAddressesCmd(log, instructionConfig.FreeAddressesImage)
+	inventoryCmd := NewInventoryCmd(log, instructionConfig.AgentImage)
+	freeAddressesCmd := NewFreeAddressesCmd(log, instructionConfig.AgentImage)
 	resetCmd := NewResetInstallationCmd(log)
 	stopCmd := NewStopInstallationCmd(log)
 	logsCmd := NewLogsCmd(log, db, instructionConfig)
-	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.DhcpLeaseAllocatorImage, db)
-	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.APIVIPConnectivityCheckImage, instructionConfig.SupportL2)
+	dhcpAllocateCmd := NewDhcpAllocateCmd(log, instructionConfig.AgentImage, db)
+	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.AgentImage, instructionConfig.SupportL2)
 	downloadInstallerCmd := NewDownloadInstallerCmd(log, instructionConfig)
-	ntpSynchronizerCmd := NewNtpSyncCmd(log, instructionConfig.NtpSynchronizerImage, db)
+	ntpSynchronizerCmd := NewNtpSyncCmd(log, instructionConfig.AgentImage, db)
 
 	return &InstructionManager{
 		log: log,

--- a/internal/host/hostcommands/logs_cmd.go
+++ b/internal/host/hostcommands/logs_cmd.go
@@ -52,7 +52,7 @@ func (i *logsCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.St
 	}
 
 	logsCommand, err := createUploadLogsCmd(host, i.instructionConfig.ServiceBaseURL,
-		i.instructionConfig.InventoryImage, strings.Join(mastersIPs, ","),
+		i.instructionConfig.AgentImage, strings.Join(mastersIPs, ","),
 		i.instructionConfig.SkipCertVerification, false, true)
 	if err != nil {
 		return nil, err

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -66,27 +66,6 @@ parameters:
 - name: AGENT_DOCKER_IMAGE
   value: ''
   required: true
-- name: CONNECTIVITY_CHECK_IMAGE
-  value: ''
-  required: true
-- name: INVENTORY_IMAGE
-  value: ''
-  required: true
-- name: FREE_ADDRESSES_IMAGE
-  value: ''
-  required: true
-- name: DHCP_LEASE_ALLOCATOR_IMAGE
-  value: ''
-  required: true
-- name: API_VIP_CONNECTIVITY_CHECK_IMAGE
-  value: ''
-  required: true
-- name: NTP_SYNCHRONIZER_IMAGE
-  value: ''
-  required: true
-- name: FIO_PERF_CHECK_IMAGE
-  value: ''
-  required: true
 - name: INSTALL_RH_CA
   value: "false"
   required: true
@@ -287,20 +266,6 @@ objects:
                 value: ${CONTROLLER_IMAGE}
               - name: AGENT_DOCKER_IMAGE
                 value: ${AGENT_DOCKER_IMAGE}
-              - name: CONNECTIVITY_CHECK_IMAGE
-                value: ${CONNECTIVITY_CHECK_IMAGE}
-              - name: INVENTORY_IMAGE
-                value: ${INVENTORY_IMAGE}
-              - name: FREE_ADDRESSES_IMAGE
-                value: ${FREE_ADDRESSES_IMAGE}
-              - name: DHCP_LEASE_ALLOCATOR_IMAGE
-                value: ${DHCP_LEASE_ALLOCATOR_IMAGE}
-              - name: API_VIP_CONNECTIVITY_CHECK_IMAGE
-                value: ${API_VIP_CONNECTIVITY_CHECK_IMAGE}
-              - name: NTP_SYNCHRONIZER_IMAGE
-                value: ${NTP_SYNCHRONIZER_IMAGE}
-              - name: FIO_PERF_CHECK_IMAGE
-                value: ${FIO_PERF_CHECK_IMAGE}
               - name: SUPPORT_L2
                 value: ${SUPPORT_L2}
               - name: LOG_LEVEL

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -68,14 +68,7 @@ def main():
 
             versions = {"INSTALLER_IMAGE": "assisted-installer",
                         "CONTROLLER_IMAGE": "assisted-installer-controller",
-                        "AGENT_DOCKER_IMAGE": "assisted-installer-agent",
-                        "CONNECTIVITY_CHECK_IMAGE": "assisted-installer-agent",
-                        "INVENTORY_IMAGE": "assisted-installer-agent",
-                        "FREE_ADDRESSES_IMAGE": "assisted-installer-agent",
-                        "DHCP_LEASE_ALLOCATOR_IMAGE": "assisted-installer-agent",
-                        "API_VIP_CONNECTIVITY_CHECK_IMAGE": "assisted-installer-agent",
-                        "FIO_PERF_CHECK_IMAGE": "assisted-installer-agent",
-                        "NTP_SYNCHRONIZER_IMAGE": "assisted-installer-agent"}
+                        "AGENT_DOCKER_IMAGE": "assisted-installer-agent"}
             for env_var_name, image_short_name in versions.items():
                 versions[env_var_name] = deployment_options.get_image_override(deploy_options, image_short_name, env_var_name)
 


### PR DESCRIPTION
Use a singular agent image from configmap AGENT_DOCKER_IMAGE instead of

- CONNECTIVITY_CHECK_IMAGE
- INVENTORY_IMAGE
- FREE_ADDRESSES_IMAGE
- DHCP_LEASE_ALLOCATOR_IMAGE
- API_VIP_CONNECTIVITY_CHECK_IMAGE
- NTP_SYNCHRONIZER_IMAGE
- FIO_PERF_CHECK_IMAGE