### PR TITLE
MGMT-2662 re-enable the baremetalProvisioningConfig

### DIFF
--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -1,0 +1,15 @@
+package common
+
+import "github.com/hashicorp/go-version"
+
+func VersionGreaterOrEqual(version1, version2 string) (bool, error) {
+	v1, err := version.NewVersion(version1)
+	if err != nil {
+		return false, err
+	}
+	v2, err := version.NewVersion(version2)
+	if err != nil {
+		return false, err
+	}
+	return !v1.LessThan(v2), nil
+}

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vincent-petithory/dataurl"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -37,7 +38,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -87,29 +87,31 @@ type Generator interface {
 }
 
 type installerGenerator struct {
-	log                     logrus.FieldLogger
-	workDir                 string
-	cluster                 *common.Cluster
-	releaseImage            string
-	releaseImageMirror      string
-	installerDir            string
-	serviceCACert           string
-	encodedDhcpFileContents string
-	s3Client                s3wrapper.API
+	log                      logrus.FieldLogger
+	workDir                  string
+	cluster                  *common.Cluster
+	releaseImage             string
+	releaseImageMirror       string
+	installerDir             string
+	serviceCACert            string
+	encodedDhcpFileContents  string
+	s3Client                 s3wrapper.API
+	enableMetal3Provisioning bool
 }
 
 // NewGenerator returns a generator that can generate ignition files
 func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, releaseImage string, releaseImageMirror string,
 	serviceCACert string, s3Client s3wrapper.API, log logrus.FieldLogger) Generator {
 	return &installerGenerator{
-		cluster:            cluster,
-		log:                log,
-		releaseImage:       releaseImage,
-		releaseImageMirror: releaseImageMirror,
-		workDir:            workDir,
-		installerDir:       installerDir,
-		serviceCACert:      serviceCACert,
-		s3Client:           s3Client,
+		cluster:                  cluster,
+		log:                      log,
+		releaseImage:             releaseImage,
+		releaseImageMirror:       releaseImageMirror,
+		workDir:                  workDir,
+		installerDir:             installerDir,
+		serviceCACert:            serviceCACert,
+		s3Client:                 s3Client,
+		enableMetal3Provisioning: true,
 	}
 }
 
@@ -185,6 +187,11 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte)
 		return err
 	}
 	installConfigPath := filepath.Join(g.workDir, "install-config.yaml")
+
+	g.enableMetal3Provisioning, err = common.VersionGreaterOrEqual(g.cluster.Cluster.OpenshiftVersion, "4.7")
+	if err != nil {
+		return err
+	}
 
 	g.encodedDhcpFileContents, err = network.GetEncodedDhcpParamFileContents(g.cluster)
 	if err != nil {
@@ -384,8 +391,10 @@ func (g *installerGenerator) updateBootstrap(bootstrapPath string) error {
 	for i, file := range config.Storage.Files {
 		switch {
 		case isBaremetalProvisioningConfig(&config.Storage.Files[i]):
-			// drop this from the list of Files because we don't want to run BMO
-			continue
+			if !g.enableMetal3Provisioning {
+				// drop this from the list of Files because we don't want to run BMO
+				continue
+			}
 		case isMOTD(&config.Storage.Files[i]):
 			// workaround for https://github.com/openshift/machine-config-operator/issues/2086
 			g.fixMOTDFile(&config.Storage.Files[i])
@@ -552,6 +561,9 @@ func (g *installerGenerator) modifyBMHFile(file *config_31_types.File, bmh *bmh_
 		return err
 	}
 	metav1.SetMetaDataAnnotation(&bmh.ObjectMeta, bmh_v1alpha1.StatusAnnotation, string(statusJSON))
+	if g.enableMetal3Provisioning {
+		bmh.Spec.ExternallyProvisioned = true
+	}
 
 	serializer := k8sjson.NewSerializerWithOptions(
 		k8sjson.DefaultMetaFactory, nil, nil,

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -11,14 +11,15 @@ import (
 	"strings"
 
 	"github.com/go-openapi/swag"
-	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/host/hostutil"
-	"github.com/openshift/assisted-service/internal/network"
-	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"gopkg.in/yaml.v2"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/network"
+	"github.com/openshift/assisted-service/models"
 )
 
 type host struct {
@@ -261,9 +262,20 @@ func setBMPlatformInstallconfig(log logrus.FieldLogger, cluster *common.Cluster,
 		}
 		yamlHostIdx += 1
 	}
+
+	enableMetal3Provisioning, err := common.VersionGreaterOrEqual(cluster.Cluster.OpenshiftVersion, "4.7")
+	if err != nil {
+		return err
+	}
+	provNetwork := "Unmanaged"
+	if enableMetal3Provisioning {
+		provNetwork = "Disabled"
+	}
+	log.Infof("setting Baremetal.ProvisioningNetwork to %s", provNetwork)
+
 	cfg.Platform = platform{
 		Baremetal: &baremetal{
-			ProvisioningNetwork: "Unmanaged",
+			ProvisioningNetwork: provNetwork,
 			APIVIP:              cluster.APIVip,
 			IngressVIP:          cluster.IngressVip,
 			Hosts:               hosts,


### PR DESCRIPTION
The last PR got reverted. The main difference between this and the last PR is highlighted below as a comment.
I have tested 4.6 with
```
export OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.13-x86_64
export SERVICE=quay.io/asalkeld/assisted-service:latest
```
with the above the cluster comes up correctly.
/cc @tsorya 