### PR TITLE
MGMT-3821 Fix kubectl binary fetching for assisted-service OpenShift CI build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,9 @@ deploy-onprem-for-subsystem:
 	export DUMMY_IGNITION="true" && $(MAKE) deploy-onprem
 
 deploy-on-openshift-ci:
+ifeq ("$(wildcard $(shell which kubectl))","")
 	ln -s $(shell which oc) $(shell dirname $(shell which oc))/kubectl
+endif
 	export TARGET='oc' && export PROFILE='openshift-ci' && unset GOFLAGS && \
 	$(MAKE) ci-deploy-for-subsystem
 	oc get pods


### PR DESCRIPTION
Added a conditional statement in the `deploy-on-openshift-ci` task, NOT to create the link if `kubectl` is already present (avoid `File exists` error).