### PR TITLE
MGMT-3658: Generate event/metric in case an host validation is changing. (#952)

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -321,6 +321,9 @@ func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB
 	if err != nil {
 		return err
 	}
+	if err = m.reportValidationStatusChanged(ctx, vc, h, validationsResults); err != nil {
+		return err
+	}
 	err = m.sm.Run(TransitionTypeRefresh, newStateHost(h), &TransitionArgsRefreshHost{
 		ctx:               ctx,
 		db:                db,
@@ -723,6 +726,34 @@ func (m *Manager) ReportValidationFailedMetrics(ctx context.Context, h *models.H
 		for _, v := range vRes {
 			if v.Status == ValidationFailure {
 				m.metricApi.HostValidationFailed(ocpVersion, h.ClusterID, emailDomain, models.HostValidationID(v.ID))
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validationContext, h *models.Host, newValidationRes map[string][]validationResult) error {
+	var currentValidationRes map[string][]validationResult
+	if h.ValidationsInfo != "" {
+		if err := json.Unmarshal([]byte(h.ValidationsInfo), &currentValidationRes); err != nil {
+			return errors.Wrapf(err, "Failed to unmarshal validations info from host %s in cluster %s", h.ID, h.ClusterID)
+		}
+		for vCategory, vRes := range currentValidationRes {
+			for i, v := range vRes {
+				// after reboot there is no agent, therefore, the host validation for 'connected' will constantly fail.
+				// this is the expected behaviour and we don't need to generate event/metric for it.
+				if v.ID == IsConnected && funk.Contains(manualRebootStages, h.Progress.CurrentStage) {
+					continue
+				}
+				if newValidationRes[vCategory][i].Status == ValidationFailure && v.Status == ValidationSuccess {
+					m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, h.ClusterID, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
+					eventMsg := fmt.Sprintf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)
+					m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityWarning, eventMsg, time.Now())
+				}
+				if newValidationRes[vCategory][i].Status == ValidationSuccess && v.Status == ValidationFailure {
+					eventMsg := fmt.Sprintf("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
+					m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo, eventMsg, time.Now())
+				}
 			}
 		}
 	}

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -33,6 +33,7 @@ const (
 	counterClusterHostNTPFailuresCount            = "assisted_installer_cluster_host_ntp_failures"
 	counterClusterHostDiskSyncDurationMiliSeconds = "assisted_installer_cluster_host_disk_sync_duration_ms"
 	counterHostValidationFailed                   = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	counterHostValidationChanged                  = "assisted_installer_host_validation_failed_after_success_before_installation"
 )
 
 const (
@@ -50,6 +51,7 @@ const (
 	counterDescriptionClusterHostNicGb                       = "Histogram/sum/count of management network NIC speed in hosts of completed clusters, by role, result, and OCP version"
 	counterDescriptionClusterHostDiskSyncDurationMiliSeconds = "Histogram/sum/count of the disk's fdatasync duration (fetched from fio)"
 	counterDescriptionHostValidationFailed                   = "Number of host validation errors"
+	counterDescriptionHostValidationChanged                  = "Number of host validations that already succeed but start to fail again"
 )
 
 const (
@@ -76,6 +78,7 @@ const (
 type API interface {
 	ClusterRegistered(clusterVersion string, clusterID strfmt.UUID, emailDomain string)
 	HostValidationFailed(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID)
+	HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID)
 	InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string)
 	ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string)
 	ClusterHostsNTPFailures(clusterID strfmt.UUID, emailDomain string, hostNTPFailureCount int)
@@ -102,6 +105,7 @@ type MetricsManager struct {
 	serviceLogicClusterHostNicGb                       *prometheus.HistogramVec
 	serviceLogicClusterHostDiskSyncDurationMiliSeconds *prometheus.HistogramVec
 	serviceLogicHostValidationFailed                   *prometheus.CounterVec
+	serviceLogicHostValidationChanged                  *prometheus.CounterVec
 }
 
 func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
@@ -219,6 +223,14 @@ func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
 				Name:      counterHostValidationFailed,
 				Help:      counterDescriptionHostValidationFailed,
 			}, []string{openshiftVersionLabel, clusterIdLabel, emailDomainLabel, hostValidationTypeLabel}),
+
+		serviceLogicHostValidationChanged: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      counterHostValidationChanged,
+				Help:      counterDescriptionHostValidationChanged,
+			}, []string{openshiftVersionLabel, clusterIdLabel, emailDomainLabel, hostValidationTypeLabel}),
 	}
 
 	registry.MustRegister(
@@ -234,6 +246,7 @@ func NewMetricsManager(registry prometheus.Registerer) *MetricsManager {
 		m.serviceLogicClusterHostNicGb,
 		m.serviceLogicClusterHostDiskSyncDurationMiliSeconds,
 		m.serviceLogicHostValidationFailed,
+		m.serviceLogicHostValidationChanged,
 	)
 	return m
 }
@@ -244,6 +257,10 @@ func (m *MetricsManager) ClusterRegistered(clusterVersion string, clusterID strf
 
 func (m *MetricsManager) HostValidationFailed(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
 	m.serviceLogicHostValidationFailed.WithLabelValues(clusterVersion, clusterID.String(), emailDomain, string(hostValidationType)).Inc()
+}
+
+func (m *MetricsManager) HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
+	m.serviceLogicHostValidationChanged.WithLabelValues(clusterVersion, clusterID.String(), emailDomain, string(hostValidationType)).Inc()
 }
 
 func (m *MetricsManager) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string) {

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -60,6 +60,18 @@ func (mr *MockAPIMockRecorder) HostValidationFailed(clusterVersion, clusterID, e
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationFailed", reflect.TypeOf((*MockAPI)(nil).HostValidationFailed), clusterVersion, clusterID, emailDomain, hostValidationType)
 }
 
+// HostValidationChanged mocks base method
+func (m *MockAPI) HostValidationChanged(clusterVersion string, clusterID strfmt.UUID, emailDomain string, hostValidationType models.HostValidationID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "HostValidationChanged", clusterVersion, clusterID, emailDomain, hostValidationType)
+}
+
+// HostValidationChanged indicates an expected call of HostValidationChanged
+func (mr *MockAPIMockRecorder) HostValidationChanged(clusterVersion, clusterID, emailDomain, hostValidationType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationChanged", reflect.TypeOf((*MockAPI)(nil).HostValidationChanged), clusterVersion, clusterID, emailDomain, hostValidationType)
+}
+
 // InstallationStarted mocks base method
 func (m *MockAPI) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain, userManagedNetworking string) {
 	m.ctrl.T.Helper()

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -2,7 +2,6 @@ package subsystem
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -60,25 +59,6 @@ var _ = Describe("Day2 cluster tests", func() {
 	AfterEach(func() {
 		clearDB()
 	})
-
-	generateApiVipPostStepReply := func(h *models.Host, success bool) {
-		checkVipApiResponse := models.APIVipConnectivityResponse{
-			IsSuccess: success,
-		}
-		bytes, jsonErr := json.Marshal(checkVipApiResponse)
-		Expect(jsonErr).NotTo(HaveOccurred())
-		_, err = agentBMClient.Installer.PostStepReply(ctx, &installer.PostStepReplyParams{
-			ClusterID: h.ClusterID,
-			HostID:    *h.ID,
-			Reply: &models.StepReply{
-				ExitCode: 0,
-				StepType: models.StepTypeAPIVipConnectivityCheck,
-				Output:   string(bytes),
-				StepID:   "apivip-connectivity-check-step",
-			},
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-	}
 
 	It("cluster CRUD", func() {
 		_ = &registerHost(clusterID).Host
@@ -163,7 +143,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		checkStepsInList(steps, []models.StepType{models.StepTypeInventory, models.StepTypeAPIVipConnectivityCheck}, 2)
 
 		By("checking known state state - one host, no connectivity check")
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		steps = getNextSteps(clusterID, *host.ID)
 		checkStepsInList(steps, []models.StepType{models.StepTypeAPIVipConnectivityCheck}, 1)
@@ -200,7 +180,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		checkStepsInList(steps, []models.StepType{models.StepTypeInventory, models.StepTypeAPIVipConnectivityCheck, models.StepTypeConnectivityCheck}, 3)
 
 		By("checking known state state")
-		generateApiVipPostStepReply(h1, true)
+		generateApiVipPostStepReply(ctx, h1, true)
 		waitForHostState(ctx, clusterID, *h1.ID, "known", 60*time.Second)
 		steps = getNextSteps(clusterID, *h1.ID)
 		checkStepsInList(steps, []models.StepType{models.StepTypeAPIVipConnectivityCheck, models.StepTypeConnectivityCheck}, 2)
@@ -212,7 +192,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
@@ -233,7 +213,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
@@ -259,13 +239,13 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h1, validHwInfo, "hostname1")
 		generateNTPPostStepReply(ctx, h1, validNtpSources)
 		waitForHostState(ctx, clusterID, *h1.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h1, true)
+		generateApiVipPostStepReply(ctx, h1, true)
 		waitForHostState(ctx, clusterID, *h1.ID, "known", 60*time.Second)
 
 		generateHWPostStepReply(ctx, h2, validHwInfo, "hostname2")
 		generateNTPPostStepReply(ctx, h2, validNtpSources)
 		waitForHostState(ctx, clusterID, *h2.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h2, true)
+		generateApiVipPostStepReply(ctx, h2, true)
 		waitForHostState(ctx, clusterID, *h2.ID, "known", 60*time.Second)
 
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
@@ -330,7 +310,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHost(ctx, &installer.InstallHostParams{ClusterID: clusterID, HostID: *host.ID})
 		Expect(err).NotTo(HaveOccurred())
@@ -351,7 +331,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
@@ -379,7 +359,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
@@ -409,7 +389,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
@@ -434,7 +414,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		generateHWPostStepReply(ctx, h, validHwInfo, "hostname")
 		generateNTPPostStepReply(ctx, h, validNtpSources)
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
-		generateApiVipPostStepReply(h, true)
+		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, *h.ID, "known", 60*time.Second)
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -12,17 +12,20 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/jinzhu/copier"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/client/events"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/models"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
-	hostValidationMetric = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	hostValidationFailedMetric  = "assisted_installer_host_validation_is_in_failed_status_on_cluster_deletion"
+	hostValidationChangedMetric = "assisted_installer_host_validation_failed_after_success_before_installation"
 )
 
 type hostValidationResult struct {
@@ -31,7 +34,7 @@ type hostValidationResult struct {
 	Message string                  `json:"message"`
 }
 
-func isHostValidationInFailedStatus(clusterID, hostID strfmt.UUID, validationID models.HostValidationID) (bool, error) {
+func isHostValidationInStatus(clusterID, hostID strfmt.UUID, validationID models.HostValidationID, expectedStatus string) (bool, error) {
 	var validationRes map[string][]hostValidationResult
 	h := getHost(clusterID, hostID)
 	if h.ValidationsInfo == "" {
@@ -44,10 +47,25 @@ func isHostValidationInFailedStatus(clusterID, hostID strfmt.UUID, validationID 
 			if v.ID != validationID {
 				continue
 			}
-			return v.Status == "failure", nil
+			return v.Status == expectedStatus, nil
 		}
 	}
 	return false, nil
+}
+
+func waitForHostValidationStatus(clusterID, hostID strfmt.UUID, expectedStatus string, hostValidationIDs ...models.HostValidationID) {
+
+	waitFunc := func() (bool, error) {
+		for _, vID := range hostValidationIDs {
+			cond, _ := isHostValidationInStatus(clusterID, hostID, vID, expectedStatus)
+			if !cond {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+	err := wait.Poll(time.Millisecond, 30*time.Second, waitFunc)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func filterMetrics(metrics []string, substrings ...string) []string {
@@ -67,7 +85,7 @@ func filterMetrics(metrics []string, substrings ...string) []string {
 	return res
 }
 
-func assertValidationCounter(clusterID strfmt.UUID, validationID models.HostValidationID, expectedCounter int) {
+func assertValidationMetricCounter(clusterID strfmt.UUID, validationID models.HostValidationID, expectedMetric string, expectedCounter int) {
 
 	url := fmt.Sprintf("http://%s/metrics", Options.InventoryHost)
 
@@ -76,12 +94,75 @@ func assertValidationCounter(clusterID strfmt.UUID, validationID models.HostVali
 	Expect(err).NotTo(HaveOccurred())
 
 	metrics := strings.Split(string(output), "\n")
-	filteredMetrics := filterMetrics(metrics, string(clusterID), hostValidationMetric, string(validationID))
+	filteredMetrics := filterMetrics(metrics, string(clusterID), expectedMetric, string(validationID))
 	Expect(len(filteredMetrics)).To(Equal(1))
 
 	counter, err := strconv.Atoi(strings.ReplaceAll((strings.Split(filteredMetrics[0], "}")[1]), " ", ""))
 	Expect(err).NotTo(HaveOccurred())
 	Expect(counter).To(Equal(expectedCounter))
+}
+
+func assertValidationEvent(ctx context.Context, clusterID strfmt.UUID, hostName string, validationID models.HostValidationID, isFailure bool) {
+
+	eventsReply, err := userBMClient.Events.ListEvents(ctx, &events.ListEventsParams{
+		ClusterID: clusterID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	var eventExist bool
+	var eventMsg string
+	if isFailure {
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' that used to succeed is now failing", hostName, validationID)
+	} else {
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' is now fixed", hostName, validationID)
+	}
+	for _, ev := range eventsReply.Payload {
+		if eventMsg == *ev.Message {
+			eventExist = true
+		}
+	}
+	Expect(eventExist).To(BeTrue())
+}
+
+func assertNoValidationEvent(ctx context.Context, clusterID strfmt.UUID, hostName string, validationID models.HostValidationID) {
+
+	eventsReply, err := userBMClient.Events.ListEvents(ctx, &events.ListEventsParams{
+		ClusterID: clusterID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	var eventExist bool
+	eventMsg := fmt.Sprintf("Host %v: validation '%v' that used to succeed is now failing", hostName, validationID)
+	for _, ev := range eventsReply.Payload {
+		if eventMsg == *ev.Message {
+			eventExist = true
+		}
+	}
+	Expect(eventExist).To(BeFalse())
+}
+
+func registerDay2Cluster(ctx context.Context) strfmt.UUID {
+
+	c, err := userBMClient.Installer.RegisterAddHostsCluster(ctx, &installer.RegisterAddHostsClusterParams{
+		NewAddHostsClusterParams: &models.AddHostsClusterCreateParams{
+			Name:             swag.String("test-metrics-day2-cluster"),
+			OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+			APIVipDnsname:    swag.String("api_vip_dnsname"),
+			ID:               strToUUID(uuid.New().String()),
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	clusterID := *c.GetPayload().ID
+
+	_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
+		ClusterUpdateParams: &models.ClusterUpdateParams{
+			PullSecret: swag.String(pullSecret),
+		},
+		ClusterID: clusterID,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return clusterID
 }
 
 func metricsDeregisterCluster(ctx context.Context, clusterID strfmt.UUID) {
@@ -92,11 +173,30 @@ func metricsDeregisterCluster(ctx context.Context, clusterID strfmt.UUID) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func generateValidInventory() string {
+	return generateValidInventoryWithInterface("1.2.3.4/24")
+}
+
+func generateValidInventoryWithInterface(networkInterface string) string {
+
+	inventory := models.Inventory{
+		CPU:          &models.CPU{Count: 4},
+		Memory:       &models.Memory{PhysicalBytes: int64(16 * units.GiB)},
+		Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
+		Interfaces:   []*models.Interface{{IPV4Addresses: []string{networkInterface}}},
+	}
+	b, err := json.Marshal(&inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 var _ = Describe("Metrics tests", func() {
 
 	var (
-		ctx       context.Context = context.Background()
-		clusterID strfmt.UUID
+		ctx                    context.Context = context.Background()
+		clusterID              strfmt.UUID
+		hostStatusInsufficient string = models.HostStatusInsufficient
 	)
 
 	BeforeEach(func() {
@@ -117,128 +217,451 @@ var _ = Describe("Metrics tests", func() {
 
 	Context("Host validation metrics", func() {
 
-		It("has-min-hw-capacity", func() {
+		It("'connected' failed before reboot", func() {
 
-			host := &registerHost(clusterID).Host
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDConnected)
 
-			var lowHwInfo models.Inventory
-			err := copier.CopyWithOption(&lowHwInfo, validHwInfo, copier.Option{DeepCopy: true})
+			// create a validation failure
+			checkedInAt := time.Now().Add(-host.MaxHostDisconnectionTime)
+			err := db.Model(h).UpdateColumns(&models.Host{CheckedInAt: strfmt.DateTime(checkedInAt)}).Error
 			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDConnected)
 
-			lowHwInfo.CPU.Count = 1
-			lowHwInfo.Memory.PhysicalBytes = int64(4 * units.GiB)
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDConnected, true)
 
-			generateHWPostStepReply(ctx, host, &lowHwInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				cpuCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMinCPUCores)
-				memoryCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMinMemory)
-				return cpuCond && memoryCond, nil
-			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
-
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDConnected, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMinCPUCores, 1)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMinMemory, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDConnected, hostValidationFailedMetric, 1)
 		})
 
-		It("has-min-hw-capacity-for-role", func() {
+		It("'connected' failed after reboot", func() {
 
-			host := &registerHost(clusterID).Host
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDConnected)
 
-			var lowHwInfo models.Inventory
-			err := copier.CopyWithOption(&lowHwInfo, validHwInfo, copier.Option{DeepCopy: true})
+			// create a validation failure
+			checkedInAt := time.Now().Add(-host.MaxHostDisconnectionTime)
+			err := db.Model(h).UpdateColumns(&models.Host{
+				CheckedInAt: strfmt.DateTime(checkedInAt),
+				Progress: &models.HostProgressInfo{
+					CurrentStage: models.HostStageRebooting,
+				},
+			}).Error
 			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDConnected)
 
-			lowHwInfo.CPU.Count = 1
-			lowHwInfo.Memory.PhysicalBytes = int64(4 * units.GiB)
-
-			generateHWPostStepReply(ctx, host, &lowHwInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				cpuCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasCPUCoresForRole)
-				memoryCond, _ := isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHasMemoryForRole)
-				return cpuCond && memoryCond, nil
-			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
-
-			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, 1)
-			assertValidationCounter(clusterID, models.HostValidationIDHasMemoryForRole, 1)
+			// check no generated events
+			assertNoValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDConnected)
 		})
 
-		It("hostname-unique", func() {
+		It("'connected' got fixed", func() {
 
-			host1 := &registerHost(clusterID).Host
-			generateHWPostStepReply(ctx, host1, validHwInfo, "nonUniqName")
-
-			host2 := &registerHost(clusterID).Host
-			generateHWPostStepReply(ctx, host2, validHwInfo, "nonUniqName")
-
-			waitFunc := func() (bool, error) {
-				host1Cond, _ := isHostValidationInFailedStatus(clusterID, *host1.ID, models.HostValidationIDHostnameUnique)
-				host2Cond, _ := isHostValidationInFailedStatus(clusterID, *host2.ID, models.HostValidationIDHostnameUnique)
-				return host1Cond && host2Cond, nil
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			checkedInAt := time.Now().Add(-host.MaxHostDisconnectionTime)
+			err := db.Model(h).UpdateColumns(&models.Host{CheckedInAt: strfmt.DateTime(checkedInAt)}).Error
 			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDConnected)
 
-			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHostnameUnique, 2)
+			// create a validation success
+			err = db.Model(h).UpdateColumns(&models.Host{CheckedInAt: strfmt.DateTime(time.Now())}).Error
+			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDConnected)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDConnected, false)
 		})
 
-		It("hostname-valid", func() {
+		It("'has-inventory' failed", func() {
 
+			// Inventory is sent to service or not, there is no usecase in which the service hold an inventroy
+			// for the host and at a later time loose it, therefore this case isn't tested and we directly
+			// test the validation failure
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDHasInventory)
+
+			// check generated metrics
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasInventory, hostValidationFailedMetric, 1)
+		})
+
+		It("'has-inventory' got fixed", func() {
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDHasInventory)
+
+			// create a validation success
+			generateHWPostStepReply(ctx, h, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDHasInventory)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasInventory, false)
+		})
+
+		It("'has-min-hw-capacity' failed", func() {
+
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			err := db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventory(), Status: &hostStatusInsufficient}).Error
+			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "success",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
+
+			// create a validation failure
+			nonValidInventory := &models.Inventory{
+				CPU:          &models.CPU{Count: 1},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
+				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
+			}
+			generateHWPostStepReply(ctx, h, nonValidInventory, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "failure",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinCPUCores, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinMemory, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDValidPlatform, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasCPUCoresForRole, true)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMemoryForRole, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinCPUCores, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinMemory, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDValidPlatform, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, hostValidationChangedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMemoryForRole, hostValidationChangedMetric, 1)
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinCPUCores, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMinMemory, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDValidPlatform, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasCPUCoresForRole, hostValidationFailedMetric, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHasMemoryForRole, hostValidationFailedMetric, 1)
+
+		})
+
+		It("'has-min-hw-capacity' got fixed", func() {
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			nonValidInventory := &models.Inventory{
+				CPU:          &models.CPU{Count: 1},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
+				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
+				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
+			}
+			generateHWPostStepReply(ctx, h, nonValidInventory, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "failure",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
+
+			// create a validation success
+			generateHWPostStepReply(ctx, h, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "success",
+				models.HostValidationIDHasMinCPUCores,
+				models.HostValidationIDHasMinMemory,
+				models.HostValidationIDValidPlatform,
+				models.HostValidationIDHasCPUCoresForRole,
+				models.HostValidationIDHasMemoryForRole)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinCPUCores, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMinMemory, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDValidPlatform, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasCPUCoresForRole, false)
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHasMemoryForRole, false)
+		})
+
+		It("'machine-cidr-defined' failed", func() {
+
+			// MachineCidr is sent to service or not, there is no usecase in which the service hold a MachineCidr
+			// for the host and at a later time loose it, therefore this case isn't tested and we directly
+			// test the validation failure
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDMachineCidrDefined)
+
+			// check generated metrics
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDMachineCidrDefined, hostValidationFailedMetric, 1)
+		})
+
+		It("'machine-cidr-defined' got fixed", func() {
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDMachineCidrDefined)
+
+			// create a validation success
+			generateHWPostStepReply(ctx, h, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDMachineCidrDefined)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDMachineCidrDefined, false)
+		})
+
+		It("'hostname-unique' failed", func() {
+
+			// create a validation success
+			h1 := &registerHost(clusterID).Host
+			h2 := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, h1, validHwInfo, "master-0")
+			generateHWPostStepReply(ctx, h2, validHwInfo, "master-1")
+			waitForHostValidationStatus(clusterID, *h1.ID, "success", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *h2.ID, "success", models.HostValidationIDHostnameUnique)
+
+			// create a validation failure
+			generateHWPostStepReply(ctx, h1, validHwInfo, "nonUniqName")
+			generateHWPostStepReply(ctx, h2, validHwInfo, "nonUniqName")
+			waitForHostValidationStatus(clusterID, *h1.ID, "failure", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *h2.ID, "failure", models.HostValidationIDHostnameUnique)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "nonUniqName", models.HostValidationIDHostnameUnique, true)
+			assertValidationEvent(ctx, clusterID, "nonUniqName", models.HostValidationIDHostnameUnique, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameUnique, hostValidationChangedMetric, 2)
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameUnique, hostValidationFailedMetric, 2)
+		})
+
+		It("'hostname-unique' got fixed", func() {
+
+			// create a validation failure
+			h1 := &registerHost(clusterID).Host
+			h2 := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, h1, validHwInfo, "master-0")
+			generateHWPostStepReply(ctx, h2, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h1.ID, "failure", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *h2.ID, "failure", models.HostValidationIDHostnameUnique)
+
+			// create a validation success
+			generateHWPostStepReply(ctx, h2, validHwInfo, "master-1")
+			waitForHostValidationStatus(clusterID, *h1.ID, "success", models.HostValidationIDHostnameUnique)
+			waitForHostValidationStatus(clusterID, *h2.ID, "success", models.HostValidationIDHostnameUnique)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHostnameUnique, false)
+			assertValidationEvent(ctx, clusterID, "master-1", models.HostValidationIDHostnameUnique, false)
+		})
+
+		It("'hostname-valid' failed", func() {
+
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			generateHWPostStepReply(ctx, h, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDHostnameValid)
+
+			// create a validation failure
 			// 'localhost' is a forbidden host name
-			host := &registerHost(clusterID).Host
-			generateHWPostStepReply(ctx, host, validHwInfo, "localhost")
+			generateHWPostStepReply(ctx, h, validHwInfo, "localhost")
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDHostnameValid)
 
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDHostnameValid)
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "localhost", models.HostValidationIDHostnameValid, true)
 
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameValid, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDHostnameValid, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDHostnameValid, hostValidationFailedMetric, 1)
 		})
 
-		It("valid-platform", func() {
+		It("'hostname-valid' got fixed", func() {
 
-			host := &registerHost(clusterID).Host
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			// 'localhost' is a forbidden host name
+			generateHWPostStepReply(ctx, h, validHwInfo, "localhost")
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDHostnameValid)
 
-			var nonValidPlatformVendorInfo models.Inventory
-			err := copier.CopyWithOption(&nonValidPlatformVendorInfo, validHwInfo, copier.Option{DeepCopy: true})
-			Expect(err).NotTo(HaveOccurred())
+			// create a validation success
+			generateHWPostStepReply(ctx, h, validHwInfo, "master-0")
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDHostnameValid)
 
-			nonValidPlatformVendorInfo.SystemVendor.ProductName = "OpenStack Compute"
-
-			generateHWPostStepReply(ctx, host, &nonValidPlatformVendorInfo, "master-0")
-
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDValidPlatform)
-			}
-			err = wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
-			Expect(err).NotTo(HaveOccurred())
-
-			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDValidPlatform, 1)
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "master-0", models.HostValidationIDHostnameValid, false)
 		})
 
-		It("ntp-synced", func() {
+		It("'belongs-to-machine-cidr' failed", func() {
 
-			host := &registerHost(clusterID).Host
-
-			waitFunc := func() (bool, error) {
-				return isHostValidationInFailedStatus(clusterID, *host.ID, models.HostValidationIDNtpSynced)
-			}
-			err := wait.Poll(time.Millisecond, 10*time.Second, waitFunc)
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			err := db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.3.4/24")}).Error
 			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDBelongsToMachineCidr)
 
+			// create a validation failure
+			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.2.2/24")}).Error
+			Expect(err).NotTo(HaveOccurred())
+			// machine-cidr doesn't change after it is set
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDBelongsToMachineCidr)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDBelongsToMachineCidr, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDBelongsToMachineCidr, hostValidationChangedMetric, 1)
 			metricsDeregisterCluster(ctx, clusterID)
-			assertValidationCounter(clusterID, models.HostValidationIDNtpSynced, 1)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDBelongsToMachineCidr, hostValidationFailedMetric, 1)
+		})
+
+		It("'belongs-to-machine-cidr' got fixed", func() {
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			err := db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.3.4/24")}).Error
+			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDBelongsToMachineCidr)
+			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.2.2/24")}).Error
+			Expect(err).NotTo(HaveOccurred())
+			// machine-cidr doesn't change after it is set
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDBelongsToMachineCidr)
+
+			// create a validation success
+			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.3.4/24")}).Error
+			Expect(err).NotTo(HaveOccurred())
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDBelongsToMachineCidr)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDBelongsToMachineCidr, false)
+		})
+
+		It("'api-vip-connected' failed", func() {
+
+			day2ClusterID := registerDay2Cluster(ctx)
+
+			// create a validation success
+			h := registerNode(ctx, day2ClusterID, "master-0")
+			generateApiVipPostStepReply(ctx, h, true)
+			waitForHostValidationStatus(day2ClusterID, *h.ID, "success", models.HostValidationIDAPIVipConnected)
+
+			// create a validation failure
+			generateApiVipPostStepReply(ctx, h, false)
+			waitForHostValidationStatus(day2ClusterID, *h.ID, "failure", models.HostValidationIDAPIVipConnected)
+
+			// check generated events
+			assertValidationEvent(ctx, day2ClusterID, "master-0", models.HostValidationIDAPIVipConnected, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(day2ClusterID, models.HostValidationIDAPIVipConnected, hostValidationChangedMetric, 1)
+			metricsDeregisterCluster(ctx, day2ClusterID)
+			assertValidationMetricCounter(day2ClusterID, models.HostValidationIDAPIVipConnected, hostValidationFailedMetric, 1)
+		})
+
+		It("'api-vip-connected' got fixed", func() {
+
+			day2ClusterID := registerDay2Cluster(ctx)
+
+			// create a validation failure
+			h := registerNode(ctx, day2ClusterID, "master-0")
+			generateApiVipPostStepReply(ctx, h, false)
+			waitForHostValidationStatus(day2ClusterID, *h.ID, "failure", models.HostValidationIDAPIVipConnected)
+
+			// create a validation success
+			generateApiVipPostStepReply(ctx, h, true)
+			waitForHostValidationStatus(day2ClusterID, *h.ID, "success", models.HostValidationIDAPIVipConnected)
+
+			// check generated events
+			assertValidationEvent(ctx, day2ClusterID, "master-0", models.HostValidationIDAPIVipConnected, false)
+		})
+
+		It("'belongs-to-majority-group' failed", func() {
+
+			// create a validation success
+			h1 := registerNode(ctx, clusterID, "h1")
+			h2 := registerNode(ctx, clusterID, "h2")
+			h3 := registerNode(ctx, clusterID, "h3")
+			h4 := registerNode(ctx, clusterID, "h4")
+			generateFullMeshConnectivity(ctx, "1.2.3.10", h1, h2, h3, h4)
+			waitForHostValidationStatus(clusterID, *h1.ID, "success", models.HostValidationIDBelongsToMajorityGroup)
+
+			// create a validation failure
+			generateFullMeshConnectivity(ctx, "1.2.3.10", h2, h3, h4)
+			waitForHostValidationStatus(clusterID, *h1.ID, "failure", models.HostValidationIDBelongsToMajorityGroup)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "h1", models.HostValidationIDBelongsToMajorityGroup, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDBelongsToMajorityGroup, hostValidationChangedMetric, 1)
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDBelongsToMajorityGroup, hostValidationFailedMetric, 1)
+		})
+
+		It("'belongs-to-majority-group' got fixed", func() {
+
+			// create a validation failure
+			h1 := registerNode(ctx, clusterID, "h1")
+			h2 := registerNode(ctx, clusterID, "h2")
+			h3 := registerNode(ctx, clusterID, "h3")
+			h4 := registerNode(ctx, clusterID, "h4")
+			generateFullMeshConnectivity(ctx, "1.2.3.10", h2, h3, h4)
+			waitForHostValidationStatus(clusterID, *h1.ID, "failure", models.HostValidationIDBelongsToMajorityGroup)
+
+			// create a validation success
+			generateFullMeshConnectivity(ctx, "1.2.3.10", h1, h2, h3, h4)
+			waitForHostValidationStatus(clusterID, *h1.ID, "success", models.HostValidationIDBelongsToMajorityGroup)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, "h1", models.HostValidationIDBelongsToMajorityGroup, false)
+		})
+
+		It("'ntp-synced' failed", func() {
+
+			// create a validation success
+			h := &registerHost(clusterID).Host
+			generateNTPPostStepReply(ctx, h, validNtpSources)
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDNtpSynced)
+
+			// create a validation failure
+			generateNTPPostStepReply(ctx, h, nil)
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDNtpSynced)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDNtpSynced, true)
+
+			// check generated metrics
+			assertValidationMetricCounter(clusterID, models.HostValidationIDNtpSynced, hostValidationChangedMetric, 1)
+			metricsDeregisterCluster(ctx, clusterID)
+			assertValidationMetricCounter(clusterID, models.HostValidationIDNtpSynced, hostValidationFailedMetric, 1)
+		})
+
+		It("'ntp-synced' got fixed", func() {
+
+			// create a validation failure
+			h := &registerHost(clusterID).Host
+			generateNTPPostStepReply(ctx, h, nil)
+			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDNtpSynced)
+
+			// create a validation success
+			generateNTPPostStepReply(ctx, h, validNtpSources)
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDNtpSynced)
+
+			// check generated events
+			assertValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDNtpSynced, false)
 		})
 	})
 })


### PR DESCRIPTION
The case we are trying to catch is if a host validation was went to
`failed` state after being in `succeed` state. Another event will be
sent once the validation is fixed.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>