### PR TITLE
MGMT-3721 ClusterDeployments support creation

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -18,16 +18,24 @@ package controllers
 
 import (
 	"context"
+	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/jinzhu/gorm"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/cluster"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host"
+	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/apis/hive/v1/agent"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -35,7 +43,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
-// ClusterReconciler reconciles a Cluster object
+const (
+	AgentPlatformError     = "AgentPlatformError"
+	AgentPlatformCondition = "AgentPlatformCondition"
+	AgentPlatformState     = "AgentPlatformState"
+	AgentPlatformStateInfo = "AgnetPlatformStateInfo"
+)
+
+// ClusterDeploymentsReconciler reconciles a Cluster object
 type ClusterDeploymentsReconciler struct {
 	client.Client
 	Log                      logrus.FieldLogger
@@ -62,7 +77,211 @@ func (r *ClusterDeploymentsReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		return ctrl.Result{Requeue: true}, nil
 	}
 
-	return ctrl.Result{}, nil
+	// ignore unsupported platforms
+	if !isSupportedPlatform(cluster) {
+		return ctrl.Result{}, nil
+	}
+
+	c, err := r.Installer.GetClusterByKubeKey(req.NamespacedName)
+	if gorm.IsRecordNotFoundError(err) {
+		return r.createNewCluster(ctx, req.NamespacedName, cluster)
+	}
+	if err != nil {
+		return r.updateState(ctx, cluster, nil, err)
+	}
+
+	return r.updateState(ctx, cluster, c, nil)
+}
+
+func isSupportedPlatform(cluster *hivev1.ClusterDeployment) bool {
+	if cluster.Spec.Platform.AgentBareMetal == nil ||
+		cluster.Spec.InstallStrategy == nil ||
+		cluster.Spec.InstallStrategy.Agent == nil {
+		return false
+	}
+	return true
+}
+
+func (r *ClusterDeploymentsReconciler) createNewCluster(
+	ctx context.Context,
+	key types.NamespacedName,
+	cluster *hivev1.ClusterDeployment) (ctrl.Result, error) {
+
+	r.Log.Infof("Creating a new cluster %s %s", cluster.Name, cluster.Namespace)
+	spec := cluster.Spec
+
+	pullSecret, err := getPullSecret(ctx, r.Client, spec.PullSecretRef.Name, key.Namespace)
+	if err != nil {
+		r.Log.WithError(err).Error("failed to get pull secret")
+		return ctrl.Result{}, nil
+	}
+
+	clusterParams := &models.ClusterCreateParams{
+		//AdditionalNtpSource:      swag.String(spec.AdditionalNtpSource), // TODO: get from AgentEnvSpec
+		//HTTPProxy:                swag.String(spec.HTTPProxy), // TODO: get from AgentEnvSpec
+		//HTTPSProxy:               swag.String(spec.HTTPSProxy), // TODO: get from AgentEnvSpec
+		//NoProxy:                  swag.String(spec.NoProxy), // TODO: get from AgentEnvSpec
+		//SSHPublicKey:          spec.SSHPublicKey, // TODO: get from AgentEnvSpec
+		BaseDNSDomain:     spec.BaseDomain,
+		Name:              swag.String(spec.ClusterName),
+		OpenshiftVersion:  swag.String("4.7"), // TODO: check how to set openshift version
+		Operators:         nil,                // TODO: handle operators
+		PullSecret:        swag.String(pullSecret),
+		VipDhcpAllocation: swag.Bool(spec.Platform.AgentBareMetal.VIPDHCPAllocation),
+		IngressVip:        spec.Platform.AgentBareMetal.IngressVIP,
+		SSHPublicKey:      spec.InstallStrategy.Agent.SSHPublicKey,
+	}
+
+	if len(spec.InstallStrategy.Agent.Networking.ClusterNetwork) > 0 {
+		clusterParams.ClusterNetworkCidr = swag.String(spec.InstallStrategy.Agent.Networking.ClusterNetwork[0].CIDR)
+		clusterParams.ClusterNetworkHostPrefix = int64(spec.InstallStrategy.Agent.Networking.ClusterNetwork[0].HostPrefix)
+	}
+
+	if len(spec.InstallStrategy.Agent.Networking.ServiceNetwork) > 0 {
+		clusterParams.ServiceNetworkCidr = swag.String(spec.InstallStrategy.Agent.Networking.ServiceNetwork[0])
+	}
+
+	if cluster.Spec.InstallStrategy.Agent.ProvisionRequirements.ControlPlaneAgents == 1 &&
+		cluster.Spec.InstallStrategy.Agent.ProvisionRequirements.WorkerAgents == 0 {
+		clusterParams.UserManagedNetworking = swag.Bool(true)
+	}
+
+	c, err := r.Installer.RegisterClusterInternal(ctx, &key, installer.RegisterClusterParams{
+		NewClusterParams: clusterParams,
+	})
+
+	// TODO: handle specific errors, 5XX retry, 4XX update status with the error
+	return r.updateState(ctx, cluster, c, err)
+}
+
+func (r *ClusterDeploymentsReconciler) updateState(ctx context.Context, cluster *hivev1.ClusterDeployment, c *common.Cluster,
+	err error) (ctrl.Result, error) {
+
+	reply := ctrl.Result{}
+	if c != nil {
+		r.syncClusterState(cluster, c)
+	}
+
+	if err != nil {
+		setClusterApiError(err, cluster)
+		reply.RequeueAfter = defaultRequeueAfterOnError
+	}
+
+	if err := r.Status().Update(ctx, cluster); err != nil {
+		r.Log.WithError(err).Errorf("failed set state for %s %s", cluster.Name, cluster.Namespace)
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return reply, nil
+}
+
+func setClusterApiError(err error, cluster *hivev1.ClusterDeployment) {
+	if err != nil {
+		errorCondition := hivev1.ClusterDeploymentCondition{
+			Type:               hivev1.UnreachableCondition,
+			Status:             corev1.ConditionFalse,
+			LastProbeTime:      metav1.Time{Time: time.Now()},
+			LastTransitionTime: metav1.Time{Time: time.Now()},
+			Reason:             AgentPlatformError,
+			Message:            err.Error(),
+		}
+		setCondition(errorCondition, &cluster.Status.Conditions)
+	} else {
+		if index := findConditionIndexByReason(AgentPlatformError, &cluster.Status.Conditions); index >= 0 {
+			cluster.Status.Conditions = append(cluster.Status.Conditions[:index],
+				cluster.Status.Conditions[index+1:]...)
+		}
+	}
+}
+
+func getAgentRefsFromIDs(uuidArr []strfmt.UUID) []agent.AgentRef {
+	agentsRef := make([]agent.AgentRef, len(uuidArr))
+	for i := range uuidArr {
+		agentsRef[i] = agent.AgentRef{
+			Namespace: "",                  // TODO: get namespace once agent CRD is implemented
+			Name:      uuidArr[i].String(), // TODO: get name once agent CRD is implemented
+		}
+	}
+	return agentsRef
+}
+
+func (r *ClusterDeploymentsReconciler) syncClusterState(cluster *hivev1.ClusterDeployment, c *common.Cluster) {
+	if cluster.Status.Conditions == nil {
+		cluster.Status.Conditions = []hivev1.ClusterDeploymentCondition{}
+	}
+
+	setStateAndStateInfo(cluster, c)
+
+	cluster.Status.InstallStrategy = &hivev1.InstallStrategyStatus{Agent: &agent.InstallStrategyStatus{}}
+	if len(c.HostNetworks) > 0 {
+		cluster.Status.InstallStrategy.Agent.AgentNetworks = make([]agent.AgentNetwork, len(c.HostNetworks))
+		for i, hn := range c.HostNetworks {
+			cluster.Status.InstallStrategy.Agent.AgentNetworks[i] = agent.AgentNetwork{
+				CIDR:      hn.Cidr,
+				AgentRefs: getAgentRefsFromIDs(c.HostNetworks[i].HostIds),
+			}
+		}
+	}
+	cluster.Status.InstallStrategy.Agent.ConnectivityMajorityGroups = c.ConnectivityMajorityGroups
+
+	// TODO: count hosts in specific states
+	//cluster.Status.InstallStrategy.Agent...
+
+	setValidations(cluster, c)
+}
+
+func setStateAndStateInfo(cluster *hivev1.ClusterDeployment, c *common.Cluster) {
+	// TODO: find proper way to set state and state info
+	setCondition(hivev1.ClusterDeploymentCondition{
+		Type:               hivev1.UnreachableCondition,
+		Status:             corev1.ConditionUnknown,
+		LastProbeTime:      metav1.Time{Time: time.Now()},
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+		Reason:             AgentPlatformState,
+		Message:            swag.StringValue(c.Status),
+	}, &cluster.Status.Conditions)
+	setCondition(hivev1.ClusterDeploymentCondition{
+		Type:               hivev1.UnreachableCondition,
+		Status:             corev1.ConditionUnknown,
+		LastProbeTime:      metav1.Time{Time: time.Now()},
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+		Reason:             AgentPlatformStateInfo,
+		Message:            swag.StringValue(c.StatusInfo),
+	}, &cluster.Status.Conditions)
+}
+
+func findConditionIndexByReason(reason string, conditions *[]hivev1.ClusterDeploymentCondition) int {
+	if conditions == nil {
+		return -1
+	}
+	for cIndex, c := range *conditions {
+		if c.Reason == reason {
+			return cIndex
+		}
+	}
+	return -1
+}
+
+// Set existing or append condition by reason
+func setCondition(condition hivev1.ClusterDeploymentCondition, conditions *[]hivev1.ClusterDeploymentCondition) {
+	if index := findConditionIndexByReason(condition.Reason, conditions); index >= 0 {
+		(*conditions)[index] = condition
+	} else {
+		*conditions = append(*conditions, condition)
+	}
+}
+
+func setValidations(cluster *hivev1.ClusterDeployment, c *common.Cluster) {
+	// TODO: translate validations into conditions, currently put all the validations as string to unknown condition.
+	validations := hivev1.ClusterDeploymentCondition{
+		Type:               hivev1.UnreachableCondition,
+		Status:             corev1.ConditionUnknown,
+		LastProbeTime:      metav1.Time{Time: time.Now()},
+		LastTransitionTime: metav1.Time{Time: time.Now()},
+		Reason:             AgentPlatformCondition,
+		Message:            c.ValidationsInfo,
+	}
+	setCondition(validations, &cluster.Status.Conditions)
 }
 
 func (r *ClusterDeploymentsReconciler) deregisterClusterIfNeeded(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/bminventory"
@@ -15,6 +17,8 @@ import (
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/apis/hive/v1/agent"
+	"github.com/openshift/hive/pkg/apis/hive/v1/aws"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,16 +59,47 @@ func getDefaultClusterDeploymentSpec(clusterName, pullSecretName string) hivev1.
 			ImageSetRef:            &hivev1.ClusterImageSetReference{Name: "openshift-v4.7.0"},
 			InstallConfigSecretRef: v1.LocalObjectReference{Name: "cluster-install-config"},
 		},
+		InstallStrategy: &hivev1.InstallStrategy{
+			Agent: &agent.InstallStrategy{
+				Networking: agent.Networking{
+					MachineNetwork: nil,
+					ClusterNetwork: []agent.ClusterNetworkEntry{{
+						CIDR:       "10.128.0.0/14",
+						HostPrefix: 23,
+					}},
+					ServiceNetwork: []string{"172.30.0.0/16"},
+				},
+				SSHPublicKey: "some-key",
+				ProvisionRequirements: agent.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       2,
+				},
+			},
+		},
+		Platform: hivev1.Platform{
+			AgentBareMetal: &agent.Platform{
+				APIVIP:            "1.2.3.8",
+				APIVIPDNSName:     "example.com",
+				IngressVIP:        "1.2.3.9",
+				VIPDHCPAllocation: false,
+			},
+		},
 		PullSecretRef: &v1.LocalObjectReference{
 			Name: pullSecretName,
 		},
 	}
 }
 
+func getConditionByReason(reason string, cluster *hivev1.ClusterDeployment) hivev1.ClusterDeploymentCondition {
+	index := findConditionIndexByReason(reason, &cluster.Status.Conditions)
+	Expect(index >= 0).Should(BeTrue(), fmt.Sprintf("condition %s was not found in cluster deployment", reason))
+	return cluster.Status.Conditions[index]
+}
+
 var _ = Describe("cluster reconcile", func() {
 	var (
 		c                     client.Client
-		cr                    *ClusterReconciler
+		cr                    *ClusterDeploymentsReconciler
 		ctx                   = context.Background()
 		mockCtrl              *gomock.Controller
 		mockInstallerInternal *bminventory.MockInstallerInternals
@@ -76,13 +111,23 @@ var _ = Describe("cluster reconcile", func() {
 
 	defaultClusterSpec := getDefaultClusterDeploymentSpec(clusterName, pullSecretName)
 
+	getTestCluster := func() *hivev1.ClusterDeployment {
+		var cluster hivev1.ClusterDeployment
+		key := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      clusterName,
+		}
+		Expect(c.Get(ctx, key, &cluster)).To(BeNil())
+		return &cluster
+	}
+
 	BeforeEach(func() {
 		c = fakeclient.NewFakeClientWithScheme(scheme.Scheme)
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockClusterApi = cluster.NewMockAPI(mockCtrl)
 		mockHostApi = host.NewMockAPI(mockCtrl)
-		cr = &ClusterReconciler{
+		cr = &ClusterDeploymentsReconciler{
 			Client:     c,
 			Scheme:     scheme.Scheme,
 			Log:        common.GetTestLog(),
@@ -94,6 +139,96 @@ var _ = Describe("cluster reconcile", func() {
 
 	AfterEach(func() {
 		mockCtrl.Finish()
+	})
+
+	Context("create cluster", func() {
+		BeforeEach(func() {
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
+			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
+			Expect(c.Create(ctx, pullSecret)).To(BeNil())
+		})
+
+		It("create new cluster", func() {
+			id := strfmt.UUID(uuid.New().String())
+			clusterReply := &common.Cluster{
+				Cluster: models.Cluster{
+					Status:     swag.String(models.ClusterStatusPendingForInput),
+					StatusInfo: swag.String("User input required"),
+					ID:         &id,
+				},
+			}
+			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(clusterReply, nil)
+
+			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			cluster = getTestCluster()
+			Expect(getConditionByReason(AgentPlatformState, cluster).Message).To(Equal(models.ClusterStatusPendingForInput))
+			Expect(getConditionByReason(AgentPlatformStateInfo, cluster).Message).To(Equal("User input required"))
+		})
+
+		It("create new cluster backend failure", func() {
+			expectedError := errors.Errorf("internal error")
+			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, expectedError)
+
+			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}))
+
+			cluster = getTestCluster()
+			Expect(getConditionByReason(AgentPlatformError, cluster).Message).To(Equal(expectedError.Error()))
+		})
+	})
+
+	It("not supported platform", func() {
+		spec := hivev1.ClusterDeploymentSpec{
+			ClusterName: clusterName,
+			Provisioning: &hivev1.Provisioning{
+				ImageSetRef:            &hivev1.ClusterImageSetReference{Name: "openshift-v4.7.0"},
+				InstallConfigSecretRef: v1.LocalObjectReference{Name: "cluster-install-config"},
+			},
+			Platform: hivev1.Platform{
+				AWS: &aws.Platform{},
+			},
+			PullSecretRef: &v1.LocalObjectReference{
+				Name: pullSecretName,
+			},
+		}
+		cluster := newClusterDeployment(clusterName, testNamespace, spec)
+		cluster.Status = hivev1.ClusterDeploymentStatus{}
+		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+		request := newClusterDeploymentRequest(cluster)
+		result, err := cr.Reconcile(request)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result).Should(Equal(ctrl.Result{}))
+	})
+
+	It("failed to get cluster from backend", func() {
+		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+		cluster.Status = hivev1.ClusterDeploymentStatus{}
+		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+		expectedErr := "expected-error"
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, errors.Errorf(expectedErr))
+
+		request := newClusterDeploymentRequest(cluster)
+		result, err := cr.Reconcile(request)
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}))
+		cluster = getTestCluster()
+		Expect(getConditionByReason(AgentPlatformError, cluster).Message).To(Equal(expectedErr))
 	})
 
 	Context("cluster deletion", func() {
@@ -108,6 +243,8 @@ var _ = Describe("cluster reconcile", func() {
 			sId = strfmt.UUID(id.String())
 			cluster.Status = hivev1.ClusterDeploymentStatus{}
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
+			Expect(c.Create(ctx, pullSecret)).To(BeNil())
 		})
 
 		It("cluster resource deleted - verify call to deregister cluster", func() {
@@ -145,32 +282,31 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(result).Should(Equal(ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}))
 		})
 
-		// TODO: add it after create is handled
-		//It("cluster resource deleted and created again", func() {
-		//	backEndCluster := &common.Cluster{
-		//		Cluster: models.Cluster{
-		//			ID: &sId,
-		//		},
-		//	}
-		//	mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		//	mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
-		//
-		//	Expect(c.Delete(ctx, cluster)).ShouldNot(HaveOccurred())
-		//	request := newClusterDeploymentRequest(cluster)
-		//	result, err := cr.Reconcile(request)
-		//	Expect(err).ShouldNot(HaveOccurred())
-		//	Expect(result).Should(Equal(ctrl.Result{}))
-		//
-		//	mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
-		//	mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(backEndCluster, nil)
-		//
-		//	cluster = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
-		//	Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
-		//
-		//	request = newClusterDeploymentRequest(cluster)
-		//	result, err = cr.Reconcile(request)
-		//	Expect(err).To(BeNil())
-		//	Expect(result).To(Equal(ctrl.Result{}))
-		//})
+		It("cluster resource deleted and created again", func() {
+			backEndCluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID: &sId,
+				},
+			}
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
+
+			Expect(c.Delete(ctx, cluster)).ShouldNot(HaveOccurred())
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(request)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).Should(Equal(ctrl.Result{}))
+
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
+			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(backEndCluster, nil)
+
+			cluster = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+			request = newClusterDeploymentRequest(cluster)
+			result, err = cr.Reconcile(request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
 	})
 })

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getPullSecret(ctx context.Context, c client.Client, name, namespace string) (string, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	if err := c.Get(ctx, key, secret); err != nil {
+		return "", errors.Wrapf(err, "failed to get pull secret %s", key)
+	}
+
+	data, ok := secret.Data["pullSecret"]
+	if !ok {
+		return "", errors.Errorf("pullSecret is not configured")
+	}
+
+	return string(data), nil
+}


### PR DESCRIPTION
Support cluster creation with ClusterDeploymnet definition
Missing variables from AgentEnvSpec
Currently putting all validtions, status and status info under conditions UnreachableCondition later need to move it to proper conditions or other variables that will store this data