### PR TITLE
MGMT-3872 Fix s3 url for boot files

### DIFF
--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -559,7 +559,7 @@ func (c *S3Client) DownloadBootFile(ctx context.Context, isoObjectName, fileType
 
 func (c *S3Client) GetS3BootFileURL(isoObjectName, fileType string) string {
 	objectName := BootFileTypeToObjectName(isoObjectName, fileType)
-	if c.cfg.S3EndpointURL == "" {
+	if c.IsAwsS3() {
 		return fmt.Sprintf("https://%s.s3.%s.amazonaws.com/%s", c.cfg.PublicS3Bucket, c.cfg.Region, objectName)
 	} else {
 		return fmt.Sprintf("%s/%s", c.cfg.S3EndpointURL, objectName)

--- a/pkg/s3wrapper/client_test.go
+++ b/pkg/s3wrapper/client_test.go
@@ -150,6 +150,10 @@ var _ = Describe("s3client", func() {
 		client2 := &S3Client{cfg: &Config{PublicS3Bucket: "public", S3EndpointURL: "http://foo.com:1234"}}
 		url = client2.GetS3BootFileURL(defaultTestRhcosObject, "initrd.img")
 		Expect(url).To(Equal(fmt.Sprintf("http://foo.com:1234/%s", BootFileTypeToObjectName(defaultTestRhcosObject, "initrd.img"))))
+
+		client3 := &S3Client{cfg: &Config{PublicS3Bucket: "public", Region: "us-east-1", S3EndpointURL: "s3.us-east-1.amazonaws.com"}}
+		url = client3.GetS3BootFileURL(defaultTestRhcosObject, "rootfs.img")
+		Expect(url).To(Equal(fmt.Sprintf("https://public.s3.us-east-1.amazonaws.com/%s", BootFileTypeToObjectName(defaultTestRhcosObject, "rootfs.img"))))
 	})
 	Context("upload iso", func() {
 		success := func(hexBytes []byte, baseISOSize, areaOffset, areaLength int64, cached bool) {


### PR DESCRIPTION
Previously this would return the local url if S3EndpointURL was set
to the real aws endpoint leading to a failure

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1923245

cc @danielerez @lalon4 