### PR TITLE
NO-ISSUE - Fix kubectl symlink already exists error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ deploy-onprem-for-subsystem:
 	export DUMMY_IGNITION="true" && $(MAKE) deploy-onprem
 
 deploy-on-openshift-ci:
-	ln -s $(shell which oc) $(shell dirname $(shell which oc))/kubectl
+	ln -s -f $(shell which oc) $(shell dirname $(shell which oc))/kubectl
 	export TARGET='oc' && export PROFILE='openshift-ci' && unset GOFLAGS && \
 	$(MAKE) ci-deploy-for-subsystem
 	oc get pods


### PR DESCRIPTION
You can see the error in this [prow run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/1002/pull-ci-openshift-assisted-service-master-assisted-service-aws/1356598393991860224):

```
ln -s /usr/local/bin/oc /usr/local/bin/kubectl
ln: failed to create symbolic link '/usr/local/bin/kubectl': File exists
make: *** [deploy-on-openshift-ci] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2021-02-02T14:31:25Z"}
error: failed to execute wrapped command: exit status 2
```