### PR TITLE
NO-ISSUE Don't recreate the s3 client for local ignition generator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -265,7 +265,7 @@ func main() {
 		lead = &leader.DummyElector{}
 		autoMigrationLeader = lead
 		// in on-prem mode, setup file system s3 driver and use localjob implementation
-		objectHandler = s3wrapper.NewFSClient("/data", log, versionHandler)
+		objectHandler = s3wrapper.NewFSClient(Options.JobConfig.WorkDir, log, versionHandler)
 		createS3Bucket(objectHandler)
 		generator = job.NewLocalJob(log.WithField("pkg", "local-job-wrapper"), objectHandler, Options.JobConfig, &Options.OCSValidatorConfig)
 		if Options.DeployTarget == deployment_type_ocp {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,7 +267,7 @@ func main() {
 		// in on-prem mode, setup file system s3 driver and use localjob implementation
 		objectHandler = s3wrapper.NewFSClient("/data", log, versionHandler)
 		createS3Bucket(objectHandler)
-		generator = job.NewLocalJob(log.WithField("pkg", "local-job-wrapper"), Options.JobConfig, versionHandler, &Options.OCSValidatorConfig)
+		generator = job.NewLocalJob(log.WithField("pkg", "local-job-wrapper"), objectHandler, Options.JobConfig, &Options.OCSValidatorConfig)
 		if Options.DeployTarget == deployment_type_ocp {
 			ocpClient, err = k8sclient.NewK8SClient("", log)
 			failOnError(err, "Failed to create client for OCP")

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -295,7 +295,7 @@ func (f *FSClient) ListObjectsByPrefix(ctx context.Context, prefix string) ([]st
 				return err
 			}
 
-			matches = append(matches, filepath.Join("/", relative))
+			matches = append(matches, relative)
 		}
 		return nil
 	})


### PR DESCRIPTION
I'm also not sure how this worked previously. It looks like the s3 client used when uploading the generated files would have had a separate data directory form the one we then would have used to download the files.

It feels like it's either broken now, or this will break something, but I'm also not sure how to test this.
@djzager @mhrivnak can you help out here (or suggest someone who might be able to)?