### PR TITLE
MGMT-3844 Limit concurrent minimal iso generations

### DIFF
--- a/internal/isoeditor/factory.go
+++ b/internal/isoeditor/factory.go
@@ -1,6 +1,7 @@
 package isoeditor
 
 import (
+	"context"
 	"io/ioutil"
 
 	"github.com/openshift/assisted-service/internal/isoutil"
@@ -8,14 +9,50 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//go:generate mockgen -package=isoeditor -destination=mock_factory.go -self_package=github.com/openshift/assisted-service/internal/isoeditor . Factory
-type Factory interface {
-	NewEditor(isoPath string, openshiftVersion string, log logrus.FieldLogger) (Editor, error)
+type Config struct {
+	ConcurrentEdits int `envconfig:"CONCURRENT_EDITS" default:"10"`
 }
 
-type RhcosFactory struct{}
+type EditFunc func(myEditor Editor) error
 
-func (f *RhcosFactory) NewEditor(isoPath string, openshiftVersion string, log logrus.FieldLogger) (Editor, error) {
+//go:generate mockgen -package=isoeditor -destination=mock_factory.go -self_package=github.com/openshift/assisted-service/internal/isoeditor . Factory
+type Factory interface {
+	WithEditor(ctx context.Context, isoPath string, openshiftVersion string, log logrus.FieldLogger, proc EditFunc) error
+}
+
+type token struct{}
+type RhcosFactory struct {
+	// "semaphore" for tracking editors in use, send to checkout, receive to checkin
+	sem chan token
+}
+
+func NewFactory(config Config) Factory {
+	f := &RhcosFactory{
+		sem: make(chan token, config.ConcurrentEdits),
+	}
+	return f
+}
+
+func (f *RhcosFactory) WithEditor(ctx context.Context, isoPath string, openshiftVersion string, log logrus.FieldLogger, proc EditFunc) error {
+	select {
+	case f.sem <- token{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	defer func() {
+		<-f.sem
+	}()
+
+	ed, err := f.newEditor(isoPath, openshiftVersion, log)
+	if err != nil {
+		return err
+	}
+
+	return proc(ed)
+}
+
+func (f *RhcosFactory) newEditor(isoPath string, openshiftVersion string, log logrus.FieldLogger) (Editor, error) {
 	isoTmpWorkDir, err := ioutil.TempDir("", "isoeditor")
 	if err != nil {
 		return nil, err

--- a/internal/isoeditor/mock_factory.go
+++ b/internal/isoeditor/mock_factory.go
@@ -5,6 +5,7 @@
 package isoeditor
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
 	reflect "reflect"
@@ -33,17 +34,16 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewEditor mocks base method
-func (m *MockFactory) NewEditor(arg0, arg1 string, arg2 logrus.FieldLogger) (Editor, error) {
+// WithEditor mocks base method
+func (m *MockFactory) WithEditor(arg0 context.Context, arg1, arg2 string, arg3 logrus.FieldLogger, arg4 EditFunc) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewEditor", arg0, arg1, arg2)
-	ret0, _ := ret[0].(Editor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "WithEditor", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// NewEditor indicates an expected call of NewEditor
-func (mr *MockFactoryMockRecorder) NewEditor(arg0, arg1, arg2 interface{}) *gomock.Call {
+// WithEditor indicates an expected call of WithEditor
+func (mr *MockFactoryMockRecorder) WithEditor(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEditor", reflect.TypeOf((*MockFactory)(nil).NewEditor), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithEditor", reflect.TypeOf((*MockFactory)(nil).WithEditor), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/s3wrapper/client_test.go
+++ b/pkg/s3wrapper/client_test.go
@@ -15,16 +15,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/versions"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/sirupsen/logrus"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("s3client", func() {
@@ -54,13 +55,15 @@ var _ = Describe("s3client", func() {
 		uploader = NewMockUploaderAPI(ctrl)
 		publicUploader = NewMockUploaderAPI(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
+		editorFactory := isoeditor.NewFactory(isoeditor.Config{ConcurrentEdits: 10})
 		log.SetOutput(ioutil.Discard)
 		bucket = "test"
 		publicBucket = "pub-test"
 		cfg := Config{S3Bucket: bucket, PublicS3Bucket: publicBucket}
 		isoUploader = &ISOUploader{log: log, bucket: bucket, publicBucket: publicBucket, s3client: mockAPI}
-		client = &S3Client{log: log, session: nil, client: mockAPI, publicClient: publicMockAPI,
-			uploader: uploader, publicUploader: publicUploader, cfg: &cfg, isoUploader: isoUploader, versionsHandler: mockVersions}
+		client = &S3Client{log: log, session: nil, client: mockAPI, publicClient: publicMockAPI, uploader: uploader,
+			publicUploader: publicUploader, cfg: &cfg, isoUploader: isoUploader, versionsHandler: mockVersions,
+			isoEditorFactory: editorFactory}
 		deleteTime, _ = time.ParseDuration("60m")
 		now, _ = time.Parse(time.RFC3339, "2020-01-01T10:00:00+00:00")
 	})

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/versions"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 
@@ -29,13 +30,14 @@ const (
 )
 
 type FSClient struct {
-	log             logrus.FieldLogger
-	basedir         string
-	versionsHandler versions.Handler
+	log              logrus.FieldLogger
+	basedir          string
+	versionsHandler  versions.Handler
+	isoEditorFactory isoeditor.Factory
 }
 
-func NewFSClient(basedir string, logger logrus.FieldLogger, versionsHandler versions.Handler) *FSClient {
-	return &FSClient{log: logger, basedir: basedir, versionsHandler: versionsHandler}
+func NewFSClient(basedir string, logger logrus.FieldLogger, versionsHandler versions.Handler, isoEditorFactory isoeditor.Factory) *FSClient {
+	return &FSClient{log: logger, basedir: basedir, versionsHandler: versionsHandler, isoEditorFactory: isoEditorFactory}
 }
 
 func (f *FSClient) IsAwsS3() bool {
@@ -356,7 +358,7 @@ func (f *FSClient) UploadBootFiles(ctx context.Context, openshiftVersion, servic
 	}
 
 	if !minimalExists {
-		if err = CreateAndUploadMinimalIso(ctx, log, isoFilePath, minimalIsoObject, openshiftVersion, serviceBaseURL, f); err != nil {
+		if err = CreateAndUploadMinimalIso(ctx, log, isoFilePath, minimalIsoObject, openshiftVersion, serviceBaseURL, f, f.isoEditorFactory); err != nil {
 			return err
 		}
 	}

--- a/pkg/s3wrapper/filesystem_test.go
+++ b/pkg/s3wrapper/filesystem_test.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/openshift/assisted-service/internal/isoeditor"
+	"github.com/openshift/assisted-service/internal/versions"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -38,7 +40,8 @@ var _ = Describe("s3filesystem", func() {
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockVersions = versions.NewMockHandler(ctrl)
-		client = &FSClient{basedir: baseDir, log: log, versionsHandler: mockVersions}
+		editorFactory := isoeditor.NewFactory(isoeditor.Config{ConcurrentEdits: 10})
+		client = &FSClient{basedir: baseDir, log: log, versionsHandler: mockVersions, isoEditorFactory: editorFactory}
 		deleteTime, _ = time.ParseDuration("60m")
 		now, _ = time.Parse(time.RFC3339, "2020-01-01T10:00:00+00:00")
 	})

--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -128,17 +128,16 @@ func DoAllBootFilesExist(ctx context.Context, isoObjectName string, api API) (bo
 }
 
 func CreateAndUploadMinimalIso(ctx context.Context, log logrus.FieldLogger,
-	isoPath, minimalIsoObject, openshiftVersion, serviceBaseURL string, api API) error {
-
-	editorFactory := isoeditor.RhcosFactory{}
-	editor, err := editorFactory.NewEditor(isoPath, openshiftVersion, log)
-	if err != nil {
-		log.Errorf("Error creating ISO editor (%v)", err)
-		return err
-	}
+	isoPath, minimalIsoObject, openshiftVersion, serviceBaseURL string,
+	api API, editorFactory isoeditor.Factory) error {
 
 	log.Infof("Extracting rhcos ISO (%s)", isoPath)
-	minimalIsoPath, err := editor.CreateMinimalISOTemplate(serviceBaseURL)
+	var minimalIsoPath string
+	err := editorFactory.WithEditor(ctx, isoPath, openshiftVersion, log, func(editor isoeditor.Editor) error {
+		var createError error
+		minimalIsoPath, createError = editor.CreateMinimalISOTemplate(serviceBaseURL)
+		return createError
+	})
 	if err != nil {
 		log.Errorf("Error extracting rhcos ISO (%v)", err)
 		return err


### PR DESCRIPTION
This commit uses a buffered channel as a semephore to ensure
we're only running 10 minimal iso generation processes concurrently
by default.

To do this the isoeditor factory API changes implement a WithEditor
function that is provided a callback function to run when an editor
is available to use.

WithEditor will block the calling thread until an editor is available
or the provided context times out.