### PR TITLE
OCPBUGSM-17327: If noProxy has "*", it must have nothing else

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4848,6 +4848,10 @@ var _ = Describe("proxySettingsForIgnition", func() {
 				`"proxy": { "httpProxy": "http://proxy.proxy", "noProxy": [".domain"] }`,
 			},
 			{
+				"http://proxy.proxy", "", "*",
+				`"proxy": { "httpProxy": "http://proxy.proxy", "noProxy": ["*"] }`,
+			},
+			{
 				"http://proxy.proxy", "https://proxy.proxy", ".domain",
 				`"proxy": { "httpProxy": "http://proxy.proxy", "httpsProxy": "https://proxy.proxy", "noProxy": [".domain"] }`,
 			},

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -419,6 +419,10 @@ var _ = Describe("Proxy validations", func() {
 			err := ValidateNoProxyFormat("domain.com,...")
 			Expect(err).ShouldNot(BeNil())
 		})
+		It("invalid format '*' and others", func() {
+			err := ValidateNoProxyFormat("*,domain.com")
+			Expect(err).ShouldNot(BeNil())
+		})
 	})
 })
 

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -346,7 +346,8 @@ func ValidateNoProxyFormat(noProxy string) error {
 		}
 		return errors.Errorf("NO Proxy format is not valid: '%s'. "+
 			"NO Proxy is a comma-separated list of destination domain names, domains, IP addresses or other network CIDRs. "+
-			"A domain can be prefaced with '.' to include all subdomains of that domain.", noProxy)
+			"A domain can be prefaced with '.' to include all subdomains of that domain.  "+
+			"Use '*' to bypass the proxy for all destinations.", noProxy)
 	}
 	return nil
 }

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -147,6 +147,9 @@ func getNetworkType(cluster *common.Cluster) string {
 
 func generateNoProxy(cluster *common.Cluster) string {
 	noProxy := strings.TrimSpace(cluster.NoProxy)
+	if noProxy == "*" {
+		return noProxy
+	}
 	splitNoProxy := funk.FilterString(strings.Split(noProxy, ","), func(s string) bool { return s != "" })
 	if cluster.MachineNetworkCidr != "" {
 		splitNoProxy = append(splitNoProxy, cluster.MachineNetworkCidr)


### PR DESCRIPTION
This commit ensures that nothing else will get appended to the noProxy
list if there is the wildcard "*"

Note: this improve the current situation but there is still a problem when the bootstrap gets rebooted and workers are also
not getting up correctly.