### PR TITLE
MGMT-3980 Update go-diskfs to expose file offset in iso

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/ignition/v2 v2.6.0
 	github.com/danielerez/go-dns-client v0.0.0-20200630114514-0b60d1703f0b
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/diskfs/go-diskfs v1.1.2-0.20210126085940-5b529d606a0a
+	github.com/diskfs/go-diskfs v1.1.2-0.20210208175329-a9a84ddce08a
 	github.com/docker/go-units v0.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filanov/stateswitch v0.0.0-20200714113403-51a42a34c604

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dhui/dktest v0.3.0/go.mod h1:cyzIUfGsBEbZ6BT7tnXqAShHSXCZhSNmFl70sZ7c1yc=
-github.com/diskfs/go-diskfs v1.1.2-0.20210126085940-5b529d606a0a h1:FU8WeudjCzCNJjznbR3tyy+r9uwcAIt4iVL6AqTVuw8=
-github.com/diskfs/go-diskfs v1.1.2-0.20210126085940-5b529d606a0a/go.mod h1:ZTeTbzixuyfnZW5y5qKMtjV2o+GLLHo1KfMhotJI4Rk=
+github.com/diskfs/go-diskfs v1.1.2-0.20210208175329-a9a84ddce08a h1:2wrzCVdLPQzzcOsRYD2RTX/nKpJgJX93LX2OzjdaJXg=
+github.com/diskfs/go-diskfs v1.1.2-0.20210208175329-a9a84ddce08a/go.mod h1:ZTeTbzixuyfnZW5y5qKMtjV2o+GLLHo1KfMhotJI4Rk=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=


### PR DESCRIPTION
This will be used in [MGMT-3979](https://issues.redhat.com/browse/MGMT-3979) to find where we need to write
the ignition and ramdisk files without unpacking the iso locally

Fixes [MGMT-3980](https://issues.redhat.com/browse/MGMT-3980)

cc @danielerez 