### PR TITLE
OCPBUGSM-24603 Remove the cluster-id from http request/response metrics

### DIFF
--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -88,7 +88,7 @@ func NewRecorder(cfg Config) metrics.Recorder {
 			Name:      "request_duration_seconds",
 			Help:      "The latency of the HTTP requests.",
 			Buckets:   cfg.DurationBuckets,
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel, cfg.IDLabel}),
+		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel}),
 
 		httpResponseSizeHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: cfg.Prefix,
@@ -96,14 +96,14 @@ func NewRecorder(cfg Config) metrics.Recorder {
 			Name:      "response_size_bytes",
 			Help:      "The size of the HTTP responses.",
 			Buckets:   cfg.SizeBuckets,
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel, cfg.IDLabel}),
+		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel}),
 
 		httpRequestsInflight: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: cfg.Prefix,
 			Subsystem: "http",
 			Name:      "requests_inflight",
 			Help:      "The number of inflight requests being handled at the same time.",
-		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel, cfg.IDLabel}),
+		}, []string{cfg.ServiceLabel, cfg.HandlerIDLabel, cfg.MethodLabel}),
 	}
 
 	cfg.Registry.MustRegister(
@@ -143,15 +143,15 @@ func extractRequestLabels(ctx context.Context) metricLabels {
 
 func (r recorder) ObserveHTTPRequestDuration(ctx context.Context, p metrics.HTTPReqProperties, duration time.Duration) {
 	labels := extractRequestLabels(ctx)
-	r.httpRequestDurHistogram.WithLabelValues(p.Service, labels.path, labels.method, p.Code, labels.clusterID).Observe(duration.Seconds())
+	r.httpRequestDurHistogram.WithLabelValues(p.Service, labels.path, labels.method, p.Code).Observe(duration.Seconds())
 }
 
 func (r recorder) ObserveHTTPResponseSize(ctx context.Context, p metrics.HTTPReqProperties, sizeBytes int64) {
 	labels := extractRequestLabels(ctx)
-	r.httpResponseSizeHistogram.WithLabelValues(p.Service, labels.path, labels.method, p.Code, labels.clusterID).Observe(float64(sizeBytes))
+	r.httpResponseSizeHistogram.WithLabelValues(p.Service, labels.path, labels.method, p.Code).Observe(float64(sizeBytes))
 }
 
 func (r recorder) AddInflightRequests(ctx context.Context, p metrics.HTTPProperties, quantity int) {
 	labels := extractRequestLabels(ctx)
-	r.httpRequestsInflight.WithLabelValues(p.Service, labels.path, labels.method, labels.clusterID).Add(float64(quantity))
+	r.httpRequestsInflight.WithLabelValues(p.Service, labels.path, labels.method).Add(float64(quantity))
 }


### PR DESCRIPTION
impacts on the metrics dashboards: https://coreos.slack.com/archives/C01FJCM6MBQ/p1612876189066400