### PR TITLE
MGMT-3999 http proxy support for minimal-iso

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1111,7 +1111,12 @@ func (b *bareMetalInventory) generateClusterMinimalISO(ctx context.Context, log 
 	err = b.isoEditorFactory.WithEditor(ctx, isoPath, cluster.OpenshiftVersion, log, func(editor isoeditor.Editor) error {
 		log.Infof("Creating minimal ISO for cluster %s", cluster.ID)
 		var createError error
-		clusterISOPath, createError = editor.CreateClusterMinimalISO(ignitionConfig, cluster.ImageInfo.StaticIpsConfig)
+		clusterProxyInfo := isoeditor.ClusterProxyInfo{
+			HTTPProxy:  cluster.HTTPProxy,
+			HTTPSProxy: cluster.HTTPSProxy,
+			NoProxy:    cluster.NoProxy,
+		}
+		clusterISOPath, createError = editor.CreateClusterMinimalISO(ignitionConfig, cluster.ImageInfo.StaticIpsConfig, &clusterProxyInfo)
 		return createError
 	})
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -554,7 +554,7 @@ var _ = Describe("GenerateClusterISO", func() {
 			mockS3Client.EXPECT().GetMinimalIsoObjectName(cluster.OpenshiftVersion).Return("rhcos-minimal.iso", nil)
 			mockS3Client.EXPECT().DownloadPublic(gomock.Any(), "rhcos-minimal.iso").Return(ioutil.NopCloser(strings.NewReader("totallyaniso")), int64(12), nil)
 			editor := isoeditor.NewMockEditor(ctrl)
-			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "").Return(isoFilePath, nil)
+			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "", gomock.Any()).Return(isoFilePath, nil)
 
 			stubWithEditor(mockIsoEditorFactory, editor, cluster.OpenshiftVersion)
 
@@ -588,7 +588,7 @@ var _ = Describe("GenerateClusterISO", func() {
 			// Generate minimal-iso
 			editor := isoeditor.NewMockEditor(ctrl)
 			stubWithEditor(mockIsoEditorFactory, editor, cluster.OpenshiftVersion)
-			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "").Return(isoFilePath, nil)
+			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "", gomock.Any()).Return(isoFilePath, nil)
 			mockS3Client.EXPECT().UploadFile(gomock.Any(), isoFilePath, fmt.Sprintf("discovery-image-%s.iso", cluster.ID))
 			mockS3Client.EXPECT().GetMinimalIsoObjectName(cluster.OpenshiftVersion).Return("rhcos-minimal.iso", nil)
 			mockS3Client.EXPECT().DownloadPublic(gomock.Any(), "rhcos-minimal.iso").Return(ioutil.NopCloser(strings.NewReader("totallyaniso")), int64(12), nil)
@@ -644,7 +644,7 @@ var _ = Describe("GenerateClusterISO", func() {
 			mockS3Client.EXPECT().DownloadPublic(gomock.Any(), "rhcos-minimal.iso").Return(ioutil.NopCloser(strings.NewReader("totallyaniso")), int64(12), nil)
 			editor := isoeditor.NewMockEditor(ctrl)
 			stubWithEditor(mockIsoEditorFactory, editor, cluster.OpenshiftVersion)
-			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "").Return("", errors.New(expectedErrMsg))
+			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "", gomock.Any()).Return("", errors.New(expectedErrMsg))
 
 			generateReply := generateClusterISO(models.ImageTypeMinimalIso)
 			Expect(generateReply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
@@ -659,7 +659,7 @@ var _ = Describe("GenerateClusterISO", func() {
 			mockS3Client.EXPECT().DownloadPublic(gomock.Any(), "rhcos-minimal.iso").Return(ioutil.NopCloser(strings.NewReader("totallyaniso")), int64(12), nil)
 			editor := isoeditor.NewMockEditor(ctrl)
 			stubWithEditor(mockIsoEditorFactory, editor, cluster.OpenshiftVersion)
-			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "").Return(isoFilePath, nil)
+			editor.EXPECT().CreateClusterMinimalISO(gomock.Any(), "", gomock.Any()).Return(isoFilePath, nil)
 			mockS3Client.EXPECT().UploadFile(gomock.Any(), isoFilePath, fmt.Sprintf("discovery-image-%s.iso", cluster.ID)).Return(errors.New(expectedErrMsg))
 
 			generateReply := generateClusterISO(models.ImageTypeMinimalIso)

--- a/internal/isoeditor/mock_editor.go
+++ b/internal/isoeditor/mock_editor.go
@@ -33,18 +33,18 @@ func (m *MockEditor) EXPECT() *MockEditorMockRecorder {
 }
 
 // CreateClusterMinimalISO mocks base method
-func (m *MockEditor) CreateClusterMinimalISO(arg0, arg1 string) (string, error) {
+func (m *MockEditor) CreateClusterMinimalISO(arg0, arg1 string, arg2 *ClusterProxyInfo) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateClusterMinimalISO", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateClusterMinimalISO", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateClusterMinimalISO indicates an expected call of CreateClusterMinimalISO
-func (mr *MockEditorMockRecorder) CreateClusterMinimalISO(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockEditorMockRecorder) CreateClusterMinimalISO(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterMinimalISO", reflect.TypeOf((*MockEditor)(nil).CreateClusterMinimalISO), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterMinimalISO", reflect.TypeOf((*MockEditor)(nil).CreateClusterMinimalISO), arg0, arg1, arg2)
 }
 
 // CreateMinimalISOTemplate mocks base method

--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"text/template"
 
 	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/isoutil"
@@ -18,10 +19,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-//go:generate mockgen -package=isoeditor -destination=mock_editor.go . Editor
+const rootfsServiceConfigFormat = `[Service]
+Environment=http_proxy={{.HTTP_PROXY}}
+Environment=https_proxy={{.HTTPS_PROXY}}
+Environment=no_proxy={{.NO_PROXY}}`
+
+type ClusterProxyInfo struct {
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
+}
+
+//go:generate mockgen -package=isoeditor -destination=mock_editor.go -self_package=github.com/openshift/assisted-service/internal/isoeditor . Editor
 type Editor interface {
 	CreateMinimalISOTemplate(serviceBaseURL string) (string, error)
-	CreateClusterMinimalISO(ignition string, staticIPConfig string) (string, error)
+	CreateClusterMinimalISO(ignition string, staticIPConfig string, clusterProxyInfo *ClusterProxyInfo) (string, error)
 }
 
 type rhcosEditor struct {
@@ -68,7 +80,7 @@ func (e *rhcosEditor) CreateMinimalISOTemplate(serviceBaseURL string) (string, e
 	return e.create()
 }
 
-func (e *rhcosEditor) CreateClusterMinimalISO(ignition string, staticIPConfig string) (string, error) {
+func (e *rhcosEditor) CreateClusterMinimalISO(ignition string, staticIPConfig string, clusterProxyInfo *ClusterProxyInfo) (string, error) {
 	if err := e.isoHandler.Extract(); err != nil {
 		return "", errors.Wrap(err, "failed to extract iso")
 	}
@@ -82,8 +94,8 @@ func (e *rhcosEditor) CreateClusterMinimalISO(ignition string, staticIPConfig st
 		return "", errors.Wrap(err, "failed to add ignition archive")
 	}
 
-	if staticIPConfig != "" {
-		if err := e.addCustomRAMDisk(staticIPConfig); err != nil {
+	if staticIPConfig != "" || clusterProxyInfo.HTTPProxy != "" || clusterProxyInfo.HTTPSProxy != "" {
+		if err := e.addCustomRAMDisk(staticIPConfig, clusterProxyInfo); err != nil {
 			return "", errors.Wrap(err, "failed to add additional ramdisk")
 		}
 	}
@@ -100,23 +112,35 @@ func (e *rhcosEditor) addIgnitionArchive(ignition string) error {
 	return ioutil.WriteFile(e.isoHandler.ExtractedPath("images/ignition.img"), archiveBytes, 0644)
 }
 
-func (e *rhcosEditor) addCustomRAMDisk(staticIPConfig string) error {
-	configPath := "/etc/static_ips_config.csv"
-	scriptPath := "/usr/lib/dracut/hooks/initqueue/settled/90-assisted-static-ip-config.sh"
-	scriptContent := constants.ConfigStaticIpsScript
+func (e *rhcosEditor) addCustomRAMDisk(staticIPConfig string, clusterProxyInfo *ClusterProxyInfo) error {
 	imagePath := "/images/assisted_installer_custom.img"
-
 	f, err := os.Create(e.isoHandler.ExtractedPath(imagePath))
 	if err != nil {
 		return err
 	}
 
 	w := cpio.NewWriter(f)
-	if err = addFileToArchive(w, configPath, staticIPConfig, 0o664); err != nil {
-		return err
+	if staticIPConfig != "" {
+		configPath := "/etc/static_ips_config.csv"
+		scriptPath := "/usr/lib/dracut/hooks/initqueue/settled/90-assisted-static-ip-config.sh"
+		scriptContent := constants.ConfigStaticIpsScript
+
+		if err = addFileToArchive(w, configPath, staticIPConfig, 0o664); err != nil {
+			return err
+		}
+		if err = addFileToArchive(w, scriptPath, scriptContent, 0o755); err != nil {
+			return err
+		}
 	}
-	if err = addFileToArchive(w, scriptPath, scriptContent, 0o755); err != nil {
-		return err
+	if clusterProxyInfo.HTTPProxy != "" || clusterProxyInfo.HTTPSProxy != "" {
+		rootfsServiceConfigPath := "/etc/systemd/system/coreos-livepxe-rootfs.service.d/10-proxy.conf"
+		rootfsServiceConfig, err1 := e.formatRootfsServiceConfigFile(clusterProxyInfo)
+		if err1 != nil {
+			return err1
+		}
+		if err = addFileToArchive(w, rootfsServiceConfigPath, rootfsServiceConfig, 0o664); err != nil {
+			return err
+		}
 	}
 	if err = w.Close(); err != nil {
 		return err
@@ -128,6 +152,23 @@ func (e *rhcosEditor) addCustomRAMDisk(staticIPConfig string) error {
 		return err
 	}
 	return editFile(e.isoHandler.ExtractedPath("isolinux/isolinux.cfg"), `(?m)^(\s+append.*initrd=\S+) (.*)$`, fmt.Sprintf("${1},%s ${2}", imagePath))
+}
+
+func (e *rhcosEditor) formatRootfsServiceConfigFile(clusterProxyInfo *ClusterProxyInfo) (string, error) {
+	var rootfsServicConfigParams = map[string]string{
+		"HTTP_PROXY":  clusterProxyInfo.HTTPProxy,
+		"HTTPS_PROXY": clusterProxyInfo.HTTPSProxy,
+		"NO_PROXY":    clusterProxyInfo.NoProxy,
+	}
+	tmpl, err := template.New("rootfsServiceConfig").Parse(rootfsServiceConfigFormat)
+	if err != nil {
+		return "", err
+	}
+	buf := &bytes.Buffer{}
+	if err = tmpl.Execute(buf, rootfsServicConfigParams); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }
 
 func addFileToArchive(w *cpio.Writer, path string, content string, mode cpio.FileMode) error {

--- a/internal/isoeditor/rhcos_test.go
+++ b/internal/isoeditor/rhcos_test.go
@@ -111,14 +111,20 @@ var _ = Context("with test files", func() {
 			err := isoHandler.Extract()
 			Expect(err).ToNot(HaveOccurred())
 
-			err = editor.(*rhcosEditor).addCustomRAMDisk("staticipconfig")
+			clusterProxyInfo := ClusterProxyInfo{
+				HTTPProxy:  "http://10.10.1.1:3128",
+				HTTPSProxy: "https://10.10.1.1:3128",
+				NoProxy:    "quay.io",
+			}
+
+			err = editor.(*rhcosEditor).addCustomRAMDisk("staticipconfig", &clusterProxyInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking that the files are present in the archive")
 			f, err := os.Open(isoHandler.ExtractedPath("images/assisted_installer_custom.img"))
 			Expect(err).ToNot(HaveOccurred())
 
-			var configContent, scriptContent string
+			var configContent, scriptContent, rootfsServiceConfigContent string
 			r := cpio.NewReader(f)
 			for {
 				hdr, err := r.Next()
@@ -135,11 +141,20 @@ var _ = Context("with test files", func() {
 					scriptBytes, err := ioutil.ReadAll(r)
 					Expect(err).ToNot(HaveOccurred())
 					scriptContent = string(scriptBytes)
+				case "/etc/systemd/system/coreos-livepxe-rootfs.service.d/10-proxy.conf":
+					rootfsServiceConfigBytes, err := ioutil.ReadAll(r)
+					Expect(err).ToNot(HaveOccurred())
+					rootfsServiceConfigContent = string(rootfsServiceConfigBytes)
 				}
 			}
 
 			Expect(configContent).To(Equal("staticipconfig"))
 			Expect(scriptContent).To(Equal(constants.ConfigStaticIpsScript))
+
+			rootfsServiceConfig := fmt.Sprintf(
+				"[Service]\nEnvironment=http_proxy=%s\nEnvironment=https_proxy=%s\nEnvironment=no_proxy=%s",
+				clusterProxyInfo.HTTPProxy, clusterProxyInfo.HTTPSProxy, clusterProxyInfo.NoProxy)
+			Expect(rootfsServiceConfigContent).To(Equal(rootfsServiceConfig))
 
 			By("checking that the config files were edited correctly")
 			grubLine := "	initrd /images/pxeboot/initrd.img /images/ignition.img /images/assisted_installer_custom.img"


### PR DESCRIPTION
In order to support the http proxy functionality, added the proxy
config to the custom RAM disk created as part of the minimal ISO.

rootfs image is fetched using curl in the dracut script[2],
so we can add the proxy config to the global curl config file (/root/.curlrc).

Another solution mentioned in [2] is to add the proxy env vars to
/etc/systemd/system/coreos-livepxe-rootfs.service.d/10-proxy.conf

[1] https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core[…]usr/lib/dracut/modules.d/35coreos-live/coreos-livepxe-rootfs.sh
[2] https://github.com/coreos/fedora-coreos-tracker/issues/744#issuecomment-778231239