### PR TITLE
OCPBUGSM-23207 - Fix GenerateClusterISO sometimes return null 

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1046,7 +1046,7 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 
 		log.Infof("Re-used existing cluster <%s> image", params.ClusterID)
 		b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityInfo, "Re-used existing image rather than generating a new one", time.Now())
-		return &cluster, nil
+		return b.GetClusterInternal(ctx, installer.GetClusterParams{ClusterID: *cluster.ID})
 	}
 	ignitionConfig, formatErr := b.formatIgnitionFile(&cluster, params, log, false)
 	if formatErr != nil {
@@ -1110,7 +1110,7 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	msg = fmt.Sprintf("%s (%s)", msg, strings.Join(msgExtras, ", "))
 
 	b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityInfo, msg, time.Now())
-	return &cluster, nil
+	return b.GetClusterInternal(ctx, installer.GetClusterParams{ClusterID: *cluster.ID})
 }
 
 func (b *bareMetalInventory) generateClusterMinimalISO(ctx context.Context, log logrus.FieldLogger,

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -182,6 +182,7 @@ var _ = Describe("GenerateClusterISO", func() {
 		Expect(generateReply).Should(BeAssignableToTypeOf(installer.NewGenerateClusterISOCreated()))
 		getReply := bm.GetCluster(ctx, installer.GetClusterParams{ClusterID: *clusterId}).(*installer.GetClusterOK)
 		Expect(getReply.Payload.ID).To(Equal(clusterId))
+		Expect(generateReply.(*installer.GenerateClusterISOCreated).Payload.HostNetworks).ToNot(BeNil())
 	})
 
 	It("success with proxy", func() {
@@ -223,6 +224,7 @@ var _ = Describe("GenerateClusterISO", func() {
 		Expect(generateReply).Should(BeAssignableToTypeOf(installer.NewGenerateClusterISOCreated()))
 		getReply := bm.GetCluster(ctx, installer.GetClusterParams{ClusterID: clusterId}).(*installer.GetClusterOK)
 		Expect(*getReply.Payload.ID).To(Equal(clusterId))
+		Expect(generateReply.(*installer.GenerateClusterISOCreated).Payload.HostNetworks).ToNot(BeNil())
 	})
 
 	It("image expired", func() {


### PR DESCRIPTION
[OCPBUGSM-23207](https://issues.redhat.com/browse/OCPBUGSM-23207) - Fix GenerateClusterISO sometimes return null in certain fields
https://bugzilla.redhat.com/show_bug.cgi?id=1916661