### PR TITLE
OCPBUGSM-25004 Avoid printing empty image status measurements

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -539,9 +539,15 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 		m.log.Infof("Adding new image status for %s with status %s to host %s", newImageStatus.Name, newImageStatus.Result, h.ID.String())
 		hostImageStatuses[newImageStatus.Name] = newImageStatus
 		m.metricApi.ImagePullStatus(h.ClusterID, *h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
-		eventInfo := fmt.Sprintf("Host %s: New image status %s. result: %s; time: %f seconds; size: %f bytes; download rate: %f MBps",
-			hostutil.GetHostnameForMsg(h), newImageStatus.Name, newImageStatus.Result,
-			newImageStatus.Time, newImageStatus.SizeBytes, newImageStatus.DownloadRate)
+
+		eventInfo := fmt.Sprintf("Host %s: New image status %s. result: %s.",
+			hostutil.GetHostnameForMsg(h), newImageStatus.Name, newImageStatus.Result)
+
+		if newImageStatus.SizeBytes > 0 {
+			eventInfo += fmt.Sprintf(" time: %f seconds; size: %f bytes; download rate: %f MBps",
+				newImageStatus.Time, newImageStatus.SizeBytes, newImageStatus.DownloadRate)
+		}
+
 		m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo, eventInfo, time.Now())
 	}
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1698,9 +1698,14 @@ var _ = Describe("UpdateImageStatus", func() {
 			}
 
 			if len(t.originalImageStatuses) == 0 {
-				eventMsg := fmt.Sprintf("Host %s: New image status %s. result: %s; time: %f seconds; size: %f bytes; download rate: %f MBps",
-					hostutil.GetHostnameForMsg(&host), expectedImage.Name, expectedImage.Result,
-					expectedImage.Time, expectedImage.SizeBytes, expectedImage.DownloadRate)
+				eventMsg := fmt.Sprintf("Host %s: New image status %s. result: %s.",
+					hostutil.GetHostnameForMsg(&host), expectedImage.Name, expectedImage.Result)
+
+				if expectedImage.SizeBytes > 0 {
+					eventMsg += fmt.Sprintf(" time: %f seconds; size: %f bytes; download rate: %f MBps",
+						expectedImage.Time, expectedImage.SizeBytes, expectedImage.DownloadRate)
+				}
+
 				mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo, eventMsg, gomock.Any()).Times(1)
 				mockMetric.EXPECT().ImagePullStatus(clusterId, hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
 			} else {


### PR DESCRIPTION
Having empty measurements is normal. But in that case, we would want to avoid printing just zeroes.

/cc @gamli75 @lalon4 