### PR TITLE
MGMT-3999 minimal-iso proxy - capital env vars

### DIFF
--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -21,7 +21,10 @@ import (
 const rootfsServiceConfigFormat = `[Service]
 Environment=http_proxy={{.HTTP_PROXY}}
 Environment=https_proxy={{.HTTPS_PROXY}}
-Environment=no_proxy={{.NO_PROXY}}`
+Environment=no_proxy={{.NO_PROXY}}
+Environment=HTTP_PROXY={{.HTTP_PROXY}}
+Environment=HTTPS_PROXY={{.HTTPS_PROXY}}
+Environment=NO_PROXY={{.NO_PROXY}}`
 
 type ClusterProxyInfo struct {
 	HTTPProxy  string

--- a/internal/isoeditor/rhcos_test.go
+++ b/internal/isoeditor/rhcos_test.go
@@ -149,8 +149,10 @@ var _ = Context("with test files", func() {
 			Expect(configContent).To(Equal("staticipconfig"))
 			Expect(scriptContent).To(Equal(constants.ConfigStaticIpsScript))
 
-			rootfsServiceConfig := fmt.Sprintf(
-				"[Service]\nEnvironment=http_proxy=%s\nEnvironment=https_proxy=%s\nEnvironment=no_proxy=%s",
+			rootfsServiceConfig := fmt.Sprintf("[Service]\n"+
+				"Environment=http_proxy=%s\nEnvironment=https_proxy=%s\nEnvironment=no_proxy=%s\n"+
+				"Environment=HTTP_PROXY=%s\nEnvironment=HTTPS_PROXY=%s\nEnvironment=NO_PROXY=%s",
+				clusterProxyInfo.HTTPProxy, clusterProxyInfo.HTTPSProxy, clusterProxyInfo.NoProxy,
 				clusterProxyInfo.HTTPProxy, clusterProxyInfo.HTTPSProxy, clusterProxyInfo.NoProxy)
 			Expect(rootfsServiceConfigContent).To(Equal(rootfsServiceConfig))
 


### PR DESCRIPTION
Added proxy env vars in capital letters as well, per suggested improvement:
https://github.com/openshift/assisted-service/pull/1075#discussion_r576656603