### PR TITLE
Revert "NO-ISSUE: checking hosts' status before checking status of the cluster"

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -2803,11 +2803,6 @@ func registerHostsAndSetRoles(clusterID strfmt.UUID, numHosts int) []*models.Hos
 	})
 
 	Expect(err).NotTo(HaveOccurred())
-
-	for _, host := range hosts {
-		waitForHostState(ctx, clusterID, *host.ID, models.HostStatusKnown, defaultWaitForHostStateTimeout)
-	}
-
 	waitForClusterState(ctx, clusterID, models.ClusterStatusReady, 60*time.Second, clusterReadyStateInfo)
 
 	return hosts


### PR DESCRIPTION
Reverts openshift/assisted-service#1092
/cc @oshercc