### PR TITLE
OCPBUGSM-25012 Fixing bad bandwidth subsystem test

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -582,8 +582,7 @@ func (v *validator) areImagesAvailable(c *validationContext) ValidationStatus {
 	}
 
 	for _, imageStatus := range imageStatuses {
-		if imageStatus.Result == models.ContainerImageAvailabilityResultFailure ||
-			(imageStatus.SizeBytes > 0 && imageStatus.DownloadRate < ImageStatusDownloadRateThreshold) {
+		if isInvalidImageStatus(imageStatus) {
 			return ValidationFailure
 		}
 	}
@@ -628,11 +627,15 @@ func (v *validator) getFailedImagesNames(host *models.Host) ([]string, error) {
 	imageNames := make([]string, 0)
 
 	for _, imageStatus := range imageStatuses {
-		if imageStatus.Result == models.ContainerImageAvailabilityResultFailure ||
-			imageStatus.DownloadRate < ImageStatusDownloadRateThreshold {
+		if isInvalidImageStatus(imageStatus) {
 			imageNames = append(imageNames, imageStatus.Name)
 		}
 	}
 
 	return imageNames, nil
+}
+
+func isInvalidImageStatus(imageStatus *models.ContainerImageAvailability) bool {
+	return imageStatus.Result == models.ContainerImageAvailabilityResultFailure ||
+		(imageStatus.SizeBytes > 0 && imageStatus.DownloadRate < ImageStatusDownloadRateThreshold)
 }

--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -460,8 +460,13 @@ var _ = Describe("Host tests", func() {
 
 		It("First success bad bandwidth", func() {
 			By("pull success", func() {
-				imageStatus = common.TestImageStatusesSuccess
-				imageStatus.DownloadRate = 0.000001
+				imageStatus = &models.ContainerImageAvailability{
+					Name:         common.TestDefaultConfig.ImageName,
+					Result:       models.ContainerImageAvailabilityResultSuccess,
+					DownloadRate: 0.000333,
+					SizeBytes:    333000000.0,
+					Time:         1000000.0,
+				}
 
 				generateContainerImageAvailabilityPostStepReply(ctx, h, []*models.ContainerImageAvailability{imageStatus})
 				Expect(getHostImageStatus(*h.ID, imageStatus.Name)).Should(Equal(imageStatus))


### PR DESCRIPTION
The 'First success bad bandwidth' host subsystem test used `common.TestImageStatusesSuccess` and changed its download rate for that test.
Afterward, other tests using the same global variable had a malformed download rate.
The flakiness was caused because the tests are running in random order.

In order to fix that bug, a new `ContainerImageAvailability` object was created with a bad download rate.

Fixes https://github.com/openshift/assisted-service/pull/1086.

Thanks, @rollandf for finding the bug.