### PR TITLE
MGMT-4090 Use nmconnection settings relevant to current host

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -133,3 +133,58 @@ function correlate_int_mac() {
 
 correlate_int_mac
 `
+
+// PreNetworkConfigScript script runs on hosts before network manager service starts in order to copy
+// the host specifics *.nmconnection files to /NetworkManager/system-connections/ based on host MAC-address matching
+const PreNetworkConfigScript = `
+#!/bin/bash
+
+# directory containing nmconnection files of all nodes
+NMCONNECTIONS_DIR=/etc/assisted/network
+if [ ! -d "$NMCONNECTIONS_DIR" ]
+then
+  exit 0
+fi
+
+if [[ $(find ${NMCONNECTIONS_DIR} -type f -name "*.nmconnection" | wc -l) -eq 0 ]]
+then
+  exit 0
+fi
+
+# array storing all host mac addresses
+host_macs=()
+
+# find destination directory based on ISO mode
+if [[ -f /etc/initrd-release ]]; then
+  ETC_NETWORK_MANAGER="/run/NetworkManager/system-connections"
+else
+  ETC_NETWORK_MANAGER="/etc/NetworkManager/system-connections"
+fi
+
+# list host mac addresses for active network interfaces
+function list_macs() {
+  SYS_CLASS_NET_DIR='/sys/class/net'
+  for nic in $( ls $SYS_CLASS_NET_DIR )
+  do
+    mac=$(cat $SYS_CLASS_NET_DIR/$nic/address | tr '[:lower:]' '[:upper:]')
+    host_macs+=($mac)
+  done
+}
+
+function copy_connection_files_by_mac_address() {
+  # iterate over nmconnection files to find associated file with current host
+  for nmconn_file in $(ls -1 ${NMCONNECTIONS_DIR}/*.nmconnection)
+  do
+    # get mac-address from connection files to search by
+    mac_address=$(grep -A1 '\[802-3-ethernet\].*' $nmconn_file | grep -v "802-3-ethernet" | cut -d= -f2 | tr '[:lower:]' '[:upper:]')
+
+    # compare mac-address from nmconnection with host's mac addresses
+    if [[ " ${host_macs[@]} " =~ " ${mac_address} " ]]; then
+      cp $nmconn_file ${ETC_NETWORK_MANAGER}/
+    fi
+  done
+}
+
+list_macs
+copy_connection_files_by_mac_address
+`

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -264,8 +264,8 @@ func (i *installCmd) getDiskUnbootableCmd(ctx context.Context, host models.Host)
 
 /*
 	This function combines existing InstallerArgs ( set by user for his own reasons ) with the
-	--copy-nework argument needed by the static ips configuration. In case user has also
-	set --copy-nework, function will set only one such argument
+	--copy-network argument needed by the static ips configuration. In case user has also
+	set --copy-network, function will set only one such argument
 */
 func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host) (string, error) {
 	if cluster.ImageInfo.StaticNetworkConfig == "" {


### PR DESCRIPTION
The discovery ignition file will contain nmconnection files for all of the nodes.
This patch is responsible to copy only the relevant files for to the current host to the network-manager config directory.
Therefore the service to perform that action will run only once and before network manager service.
The destination folder on the host will be `./NetworkManager/system-connections/static_connection.nmconnection`

Depends on Depends on https://github.com/openshift/assisted-service/pull/1143

Signed-off-by: Moti Asayag <masayag@redhat.com>