### PR TITLE
MGMT-3371 Introducing generic OLM operator API and migrating OLM+LSO.

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -207,7 +207,7 @@ func (m *Manager) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm
 	if err != nil {
 		return c, err
 	}
-	conditions, validationsResults, err := m.rp.preprocess(vc)
+	conditions, validationsResults, err := m.rp.preprocess(ctx, vc)
 	if err != nil {
 		return c, err
 	}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
-	"github.com/openshift/assisted-service/internal/operators/ocs"
+	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/leader"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
@@ -38,12 +38,6 @@ func getDefaultConfig() Config {
 	var cfg Config
 	Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
 	return cfg
-}
-
-func getOcsConfig() *ocs.Config {
-	var cfg ocs.Config
-	Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
-	return &cfg
 }
 
 var _ = Describe("stateMachine", func() {
@@ -70,7 +64,10 @@ var _ = Describe("stateMachine", func() {
 		}}
 
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
-		mockOperators.EXPECT().GetOperatorStatus(cluster, models.OperatorTypeOcs).AnyTimes().Return("Mock status")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 
 	Context("unknown_cluster_state", func() {
@@ -131,8 +128,10 @@ var _ = Describe("TestClusterMonitoring", func() {
 		expectedState = ""
 		shouldHaveUpdated = false
 
-		mockOperators.EXPECT().GetOperatorStatus(gomock.Any(), models.OperatorTypeOcs).AnyTimes().Return("Mock status")
-		mockOperators.EXPECT().ValidateOCSRequirements(gomock.Any()).AnyTimes().Return("success")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 	Context("single cluster monitoring", func() {
 		Context("from installing state", func() {
@@ -555,8 +554,10 @@ var _ = Describe("lease timeout event", func() {
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators)
 
-		mockOperators.EXPECT().GetOperatorStatus(gomock.Any(), models.OperatorTypeOcs).AnyTimes().Return("Mock status")
-		mockOperators.EXPECT().ValidateOCSRequirements(gomock.Any()).AnyTimes().Return("success")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 	tests := []struct {
 		name                string
@@ -661,8 +662,10 @@ var _ = Describe("Auto assign machine CIDR", func() {
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators)
 
-		mockOperators.EXPECT().GetOperatorStatus(gomock.Any(), models.OperatorTypeOcs).AnyTimes().Return("Mock status")
-		mockOperators.EXPECT().ValidateOCSRequirements(gomock.Any()).AnyTimes().Return("success")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 	tests := []struct {
 		name                    string
@@ -1782,8 +1785,10 @@ var _ = Describe("Majority groups", func() {
 		}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 
-		mockOperators.EXPECT().GetOperatorStatus(gomock.Any(), models.OperatorTypeOcs).AnyTimes().Return("Mock status")
-		mockOperators.EXPECT().ValidateOCSRequirements(gomock.Any()).AnyTimes().Return("success")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 
 	setup := func(ips []string) {
@@ -1886,8 +1891,10 @@ var _ = Describe("ready_state", func() {
 		Expect(len(cluster.Hosts)).Should(Equal(3))
 		mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-		mockOperators.EXPECT().GetOperatorStatus(&cluster, models.OperatorTypeOcs).AnyTimes().Return("Mock status")
-		mockOperators.EXPECT().ValidateOCSRequirements(&cluster).AnyTimes().Return("success")
+		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).AnyTimes().Return([]api.ValidationResult{
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOcsRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
+		}, nil)
 	})
 
 	Context("refresh_state", func() {

--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -92,7 +92,7 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var pendingConditions = stateswitch.And(If(IsMachineCidrDefined), If(isClusterCidrDefined), If(isServiceCidrDefined), If(IsDNSDomainDefined), If(IsPullSecretSet))
 	var vipsDefinedConditions = stateswitch.And(If(isApiVipDefined), If(isIngressVipDefined))
 	var requiredForInstall = stateswitch.And(If(isMachineCidrEqualsToCalculatedCidr), If(isApiVipValid), If(isIngressVipValid), If(AllHostsAreReadyToInstall),
-		If(SufficientMastersCount), If(networkPrefixValid), If(noCidrOverlapping), If(IsNtpServerConfigured), If(IsOcsRequirementsSatisfied))
+		If(SufficientMastersCount), If(networkPrefixValid), If(noCidrOverlapping), If(IsNtpServerConfigured), If(IsOcsRequirementsSatisfied), If(IsLsoRequirementsSatisfied))
 
 	// Refresh cluster status conditions - Non DHCP
 	var requiredInputFieldsExistNonDhcp = stateswitch.And(vipsDefinedConditions, pendingConditions)

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/operators"
-	"github.com/openshift/assisted-service/internal/operators/ocs"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
@@ -42,7 +41,7 @@ var _ = Describe("Transition tests", func() {
 		eventsHandler = events.New(db, logrus.New())
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, nil, &operatorsManager)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
@@ -166,7 +165,7 @@ var _ = Describe("Cancel cluster installation", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, mockMetric, nil, nil, &operatorsManager)
 	})
 
@@ -236,7 +235,7 @@ var _ = Describe("Reset cluster", func() {
 		db = common.PrepareTestDB(dbName, &events.Event{})
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, nil, nil, nil, &operatorsManager)
 	})
 
@@ -371,7 +370,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 
@@ -1008,7 +1007,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 
@@ -1844,7 +1843,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 
@@ -2361,7 +2360,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 
@@ -2631,7 +2630,7 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 		hid1 = strfmt.UUID(uuid.New().String())
@@ -3343,7 +3342,7 @@ var _ = Describe("Single node", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), getOcsConfig())
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 		hid1 = strfmt.UUID(uuid.New().String())
@@ -3636,7 +3635,6 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockEvents                                    *events.MockHandler
 		mockHostAPI                                   *host.MockAPI
 		mockMetric                                    *metrics.MockAPI
-		cfg                                           *ocs.Config
 		ctrl                                          *gomock.Controller
 		dbName                                        string = "cluster_transition_test_with_ocs_validations"
 	)
@@ -3653,8 +3651,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		cfg = getOcsConfig()
-		operatorsManager := operators.NewManagerWithConfig(common.GetTestLog(), cfg)
+		operatorsManager := operators.NewManager(common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, &operatorsManager)
 		hid1 = strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d")
@@ -4325,9 +4322,6 @@ var _ = Describe("Ocs Operator use-cases", func() {
 				Expect(err).To(HaveOccurred())
 			} else {
 				Expect(err).ToNot(HaveOccurred())
-			}
-			if t.name == "ocs enabled, 6 sufficient nodes" {
-				Expect(cfg.OCSMinimalDeployment).Should(Equal(true))
 			}
 			Expect(clusterAfterRefresh.Status).To(Equal(&t.dstState))
 			t.statusInfoChecker.check(clusterAfterRefresh.StatusInfo)

--- a/internal/cluster/validation_id.go
+++ b/internal/cluster/validation_id.go
@@ -27,6 +27,7 @@ const (
 	IsPullSecretSet                     = validationID(models.ClusterValidationIDPullSecretSet)
 	IsNtpServerConfigured               = validationID(models.ClusterValidationIDNtpServerConfigured)
 	IsOcsRequirementsSatisfied          = validationID(models.ClusterValidationIDOcsRequirementsSatisfied)
+	IsLsoRequirementsSatisfied          = validationID(models.ClusterValidationIDLsoRequirementsSatisfied)
 )
 
 func (v validationID) category() (string, error) {
@@ -38,7 +39,7 @@ func (v validationID) category() (string, error) {
 		return "hosts-data", nil
 	case IsPullSecretSet:
 		return "configuration", nil
-	case IsOcsRequirementsSatisfied:
+	case IsOcsRequirementsSatisfied, IsLsoRequirementsSatisfied:
 		return "operators", nil
 	}
 	return "", common.NewApiError(http.StatusInternalServerError, errors.Errorf("Unexpected cluster validation id %s", string(v)))

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/network"
-	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 )
@@ -83,9 +82,8 @@ func boolValue(b bool) validationStatus {
 }
 
 type clusterValidator struct {
-	log              logrus.FieldLogger
-	hostAPI          host.API
-	operatorsManager operators.API
+	log     logrus.FieldLogger
+	hostAPI host.API
 }
 
 func (v *clusterValidator) isMachineCidrDefined(c *clusterPreprocessContext) validationStatus {
@@ -524,27 +522,5 @@ func (v *clusterValidator) printNtpServerConfigured(c *clusterPreprocessContext,
 		return "Host clocks are not synchronized, please configure an NTP server via DHCP."
 	default:
 		return fmt.Sprintf("Unexpected status %s", status)
-	}
-}
-
-func (v *clusterValidator) isOcsRequirementsSatisfied(c *clusterPreprocessContext) validationStatus {
-	validationStatus := (v.operatorsManager.ValidateOCSRequirements(c.cluster))
-	if validationStatus == "pending" {
-		return ValidationPending
-	} else if validationStatus == "success" {
-		return ValidationSuccess
-	}
-	return ValidationFailure
-}
-
-func (v *clusterValidator) printOcsRequirementsSatisfied(c *clusterPreprocessContext, status validationStatus) string {
-
-	switch status {
-	case ValidationSuccess, ValidationFailure:
-		return v.operatorsManager.GetOperatorStatus(c.cluster, models.OperatorTypeOcs)
-	case ValidationPending:
-		return "Missing Inventory in some of the hosts"
-	default:
-		return fmt.Sprintf("Unexpected status %s.", status)
 	}
 }

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host/hostcommands"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/metrics"
+	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/leader"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -144,7 +145,7 @@ type Manager struct {
 }
 
 func NewManager(log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, hwValidator hardware.Validator, instructionApi hostcommands.InstructionApi,
-	hwValidatorCfg *hardware.ValidatorCfg, metricApi metrics.API, config *Config, leaderElector leader.ElectorInterface) *Manager {
+	hwValidatorCfg *hardware.ValidatorCfg, metricApi metrics.API, config *Config, leaderElector leader.ElectorInterface, operatorsApi operators.API) *Manager {
 	th := &transitionHandler{
 		db:            db,
 		log:           log,
@@ -157,7 +158,7 @@ func NewManager(log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handle
 		hwValidator:    hwValidator,
 		eventsHandler:  eventsHandler,
 		sm:             NewHostStateMachine(th),
-		rp:             newRefreshPreprocessor(log, hwValidatorCfg, hwValidator),
+		rp:             newRefreshPreprocessor(log, hwValidatorCfg, hwValidator, operatorsApi),
 		metricApi:      metricApi,
 		Config:         *config,
 		leaderElector:  leaderElector,

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -383,7 +383,8 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr),
-		If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup))
+		If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup),
+		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/metrics"
+	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
 	"github.com/thoas/go-funk"
 )
@@ -54,7 +55,8 @@ var _ = Describe("RegisterHost", func() {
 		db = common.PrepareTestDB(dbName, &events.Event{})
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
@@ -436,7 +438,8 @@ var _ = Describe("HostInstallationFailed", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 		host = hostutil.GenerateTestHost(hostId, clusterId, "")
@@ -479,7 +482,8 @@ var _ = Describe("RegisterInstalledOCPHost", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 		host = hostutil.GenerateTestHost(hostId, clusterId, "")
@@ -513,7 +517,8 @@ var _ = Describe("Cancel host installation", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEventsHandler, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEventsHandler, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 	})
 
 	tests := []struct {
@@ -599,7 +604,8 @@ var _ = Describe("Reset host", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEventsHandler, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEventsHandler, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 	})
 
 	tests := []struct {
@@ -686,7 +692,8 @@ var _ = Describe("Install", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
@@ -840,7 +847,8 @@ var _ = Describe("Disable", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
@@ -972,7 +980,8 @@ var _ = Describe("Enable", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
@@ -1179,7 +1188,8 @@ var _ = Describe("Refresh Host", func() {
 				return disk.SizeBytes >= hardware.GibToBytes(validatorCfg.MinDiskSizeGb)
 			}).([]*models.Disk)
 		}).AnyTimes()
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, nil, defaultConfig, nil)
+		operatorsManager := operators.NewManager(common.GetTestLog())
+		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, nil, defaultConfig, nil, &operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -27,6 +27,8 @@ const (
 	IsPlatformValid             = validationID(models.HostValidationIDValidPlatform)
 	IsNTPSynced                 = validationID(models.HostValidationIDNtpSynced)
 	AreContainerImagesAvailable = validationID(models.HostValidationIDContainerImagesAvailable)
+	AreLsoRequirementsSatisfied = validationID(models.HostValidationIDLsoRequirementsSatisfied)
+	AreOcsRequirementsSatisfied = validationID(models.HostValidationIDOcsRequirementsSatisfied)
 )
 
 func (v validationID) category() (string, error) {
@@ -37,6 +39,8 @@ func (v validationID) category() (string, error) {
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid:
 		return "hardware", nil
+	case AreLsoRequirementsSatisfied, AreOcsRequirementsSatisfied:
+		return "operators", nil
 	}
 	return "", common.NewApiError(http.StatusInternalServerError, errors.Errorf("Unexpected validation id %s", string(v)))
 }

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -117,13 +117,12 @@ type installerGenerator struct {
 	encodedDhcpFileContents  string
 	s3Client                 s3wrapper.API
 	enableMetal3Provisioning bool
-	operatorsManager         *operators.Manager
+	operatorsApi             operators.API
 }
 
 // NewGenerator returns a generator that can generate ignition files
 func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, releaseImage string, releaseImageMirror string,
-	serviceCACert string, s3Client s3wrapper.API, log logrus.FieldLogger,
-	operatorsManager *operators.Manager) Generator {
+	serviceCACert string, s3Client s3wrapper.API, log logrus.FieldLogger, operatorsApi operators.API) Generator {
 	return &installerGenerator{
 		cluster:                  cluster,
 		log:                      log,
@@ -134,7 +133,7 @@ func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, 
 		serviceCACert:            serviceCACert,
 		s3Client:                 s3Client,
 		enableMetal3Provisioning: true,
-		operatorsManager:         operatorsManager,
+		operatorsApi:             operatorsApi,
 	}
 }
 
@@ -168,7 +167,7 @@ func (g *installerGenerator) writeManifests(manifests map[string]string) error {
 }
 
 func (g *installerGenerator) writeOperatorManifests(installerPath string, envVars []string) error {
-	if !g.operatorsManager.AnyOperatorEnabled(g.cluster) {
+	if !g.operatorsApi.AnyOperatorEnabled(g.cluster) {
 		return nil
 	}
 	err := g.createManifestDirectory(installerPath, envVars)
@@ -176,7 +175,7 @@ func (g *installerGenerator) writeOperatorManifests(installerPath string, envVar
 		g.log.Error("Failed to create Manifest directory ", err)
 		return err
 	}
-	operatorManifests, err := g.operatorsManager.GenerateManifests(g.cluster)
+	operatorManifests, err := g.operatorsApi.GenerateManifests(g.cluster)
 	if err != nil {
 		return err
 	}

--- a/internal/migrations/20210218160100_validations_info_to_text.go
+++ b/internal/migrations/20210218160100_validations_info_to_text.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/internal/common"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func changeClusterValidationsInfoToText() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		return tx.Model(&common.Cluster{}).ModifyColumn("validations_info", "text").Error
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		return tx.Model(&common.Cluster{}).ModifyColumn("validations_info", "varchar(2048)").Error
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20210218160100",
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/20210218160100_validations_info_to_text_test.go
+++ b/internal/migrations/20210218160100_validations_info_to_text_test.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gopkg.in/gormigrate.v1"
+)
+
+const clusterValidationsInfo = `{"configuration":[{"id":"pull-secret-set","status":"success","message":"The pull secret is set."}]}`
+
+var _ = Describe("ChangeValidationsInfoToText", func() {
+	var (
+		db        *gorm.DB
+		gm        *gormigrate.Gormigrate
+		clusterID strfmt.UUID
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB("change_validations_info_to_text")
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster := common.Cluster{Cluster: models.Cluster{
+			ID:              &clusterID,
+			ValidationsInfo: clusterValidationsInfo,
+		}}
+		err := db.Create(&cluster).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, all())
+		err = gm.MigrateTo("20210218160100")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Migrates down and up", func() {
+		t, err := getColumnType(db, &common.Cluster{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectValidationsInfo(db, clusterID.String(), clusterValidationsInfo)
+
+		err = gm.RollbackMigration(changeClusterValidationsInfoToText())
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &common.Cluster{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("VARCHAR"))
+		expectValidationsInfo(db, clusterID.String(), clusterValidationsInfo)
+
+		err = gm.MigrateTo("20210218160100")
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &common.Cluster{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectValidationsInfo(db, clusterID.String(), clusterValidationsInfo)
+	})
+})
+
+func expectValidationsInfo(db *gorm.DB, clusterID string, validationsInfo string) {
+	var c common.Cluster
+	err := db.First(&c, "id = ?", clusterID).Error
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(c.ValidationsInfo).To(Equal(validationsInfo))
+}

--- a/internal/migrations/20210223090000_host_validations_info_to_text.go
+++ b/internal/migrations/20210223090000_host_validations_info_to_text.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/models"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func changeHostValidationsInfoToText() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		return tx.Model(&models.Host{}).ModifyColumn("validations_info", "text").Error
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		return tx.Model(&models.Host{}).ModifyColumn("validations_info", "varchar(2048)").Error
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20210223090000",
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/20210223090000_host_validations_info_to_text_test.go
+++ b/internal/migrations/20210223090000_host_validations_info_to_text_test.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gopkg.in/gormigrate.v1"
+)
+
+const hostValidationsInfo = `{"operators":[{"id":"ocs-requirements-satisfied","status":"success","message":"ocs is disabled"}]}`
+
+var _ = Describe("ChangeHostValidationsInfoToText", func() {
+	var (
+		db     *gorm.DB
+		gm     *gormigrate.Gormigrate
+		hostID strfmt.UUID
+	)
+
+	BeforeEach(func() {
+		db = common.PrepareTestDB("change_host_validations_info_to_text")
+		hostID = strfmt.UUID(uuid.New().String())
+		clusterID := strfmt.UUID(uuid.New().String())
+		host := models.Host{
+			ID:              &hostID,
+			ValidationsInfo: hostValidationsInfo,
+			ClusterID:       clusterID,
+		}
+		err := db.Create(&host).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, all())
+		err = gm.MigrateTo("20210223090000")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Migrates down and up", func() {
+		t, err := getColumnType(db, &models.Host{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectHostValidationsInfo(db, hostID.String(), hostValidationsInfo)
+
+		err = gm.RollbackMigration(changeHostValidationsInfoToText())
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &models.Host{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("VARCHAR"))
+		expectHostValidationsInfo(db, hostID.String(), hostValidationsInfo)
+
+		err = gm.MigrateTo("20210223090000")
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &models.Host{}, "validations_info")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(t).To(Equal("TEXT"))
+		expectHostValidationsInfo(db, hostID.String(), hostValidationsInfo)
+	})
+})
+
+func expectHostValidationsInfo(db *gorm.DB, hostID string, validationsInfo string) {
+	var c models.Host
+	err := db.First(&c, "id = ?", hostID).Error
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(c.ValidationsInfo).To(Equal(validationsInfo))
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -15,6 +15,8 @@ func all() []*gormigrate.Migration {
 	allMigrations := []*gormigrate.Migration{
 		changeOverridesToText(),
 		changeImageSSHKeyToText(),
+		changeClusterValidationsInfoToText(),
+		changeHostValidationsInfoToText(),
 	}
 
 	sort.SliceStable(allMigrations, func(i, j int) bool { return allMigrations[i].ID < allMigrations[j].ID })

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+)
+
+// ValidationResult hold result of operator validation
+type ValidationResult struct {
+	// ValidationId is an id of the validation
+	ValidationId models.ClusterValidationID
+	// Valid specifies whether validation was successful
+	Valid bool
+	// Reasons hold list of reasons of a validation failure
+	Reasons []string
+}
+
+// Manifests hold generated manifests
+type Manifests struct {
+	// Files maps file name to file's content
+	Files map[string]string
+}
+
+// Operator provides generic API of an OLM operator installation plugin
+type Operator interface {
+	// GetType reports type of an operator this Operator manages
+	GetType() models.OperatorType
+	// GetDependencies provides a list of dependencies of the Operator
+	GetDependencies() []models.OperatorType
+	// ValidateCluster verifies whether this operator is valid for given cluster
+	ValidateCluster(ctx context.Context, cluster *common.Cluster) (ValidationResult, error)
+	// ValidateHost verifies whether this operator is valid for given host
+	ValidateHost(context.Context, *common.Cluster, *models.Host) (ValidationResult, error)
+	// GenerateManifests generates manifests for the operator
+	GenerateManifests(*common.Cluster) (*Manifests, error)
+	// GetCPURequirementForWorker provides worker CPU requirements for the operator
+	GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error)
+	// GetCPURequirementForMaster provides master CPU requirements for the operator
+	GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error)
+	// GetMemoryRequirementForWorker provides worker memory requirements for the operator
+	GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
+	// GetMemoryRequirementForMaster provides master memory requirements for the operator
+	GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
+	// GetValidationID returns validation ID for the Operator
+	GetValidationID() models.ClusterValidationID
+}

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -7,12 +7,20 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
+type ValidationStatus string
+
+const (
+	Success ValidationStatus = "success"
+	Failure ValidationStatus = "failure"
+	Pending ValidationStatus = "pending"
+)
+
 // ValidationResult hold result of operator validation
 type ValidationResult struct {
 	// ValidationId is an id of the validation
-	ValidationId models.ClusterValidationID
-	// Valid specifies whether validation was successful
-	Valid bool
+	ValidationId string
+	// Status specifies the status of the validation: success, failure or pending
+	Status ValidationStatus
 	// Reasons hold list of reasons of a validation failure
 	Reasons []string
 }
@@ -39,10 +47,16 @@ type Operator interface {
 	GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error)
 	// GetCPURequirementForMaster provides master CPU requirements for the operator
 	GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error)
-	// GetMemoryRequirementForWorker provides worker memory requirements for the operator
+	// GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
 	GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetMemoryRequirementForMaster provides master memory requirements for the operator
+	// GetMemoryRequirementForMaster provides master memory requirements for the operator in MB
 	GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetValidationID returns validation ID for the Operator
-	GetValidationID() models.ClusterValidationID
+	// GetDisksRequirementForMaster provides a number of disks required in a master
+	GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error)
+	// GetDisksRequirementForWorker provides a number of disks required in a worker
+	GetDisksRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
+	// GetClusterValidationID returns cluster validation ID for the Operator
+	GetClusterValidationID() string
+	// GetHostValidationID returns host validation ID for the Operator
+	GetHostValidationID() string
 }

--- a/internal/operators/builder.go
+++ b/internal/operators/builder.go
@@ -1,0 +1,37 @@
+package operators
+
+import (
+	"github.com/kelseyhightower/envconfig"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/internal/operators/lso"
+	"github.com/openshift/assisted-service/internal/operators/ocs"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+// NewManager creates new instance of an Operator Manager
+func NewManager(log logrus.FieldLogger) Manager {
+	cfg := ocs.Config{}
+	err := envconfig.Process("myapp", &cfg)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return NewManagerWithConfig(log, &cfg)
+}
+
+// NewManagerWithConfig creates new instance of an Operator Manager
+func NewManagerWithConfig(log logrus.FieldLogger, cfg *ocs.Config) Manager {
+	ocsValidator := ocs.NewOCSValidator(log.WithField("pkg", "ocs-operator-state"), cfg)
+
+	//TODO: for better testability refactor into a proper builder pattern when hardcoded OCS dependency is gone
+	typeToOperator := map[models.OperatorType]api.Operator{
+		models.OperatorTypeLso: lso.NewLSOperator(),
+	}
+
+	return Manager{
+		log:                log,
+		ocsValidatorConfig: cfg,
+		ocsValidator:       ocsValidator,
+		operators:          typeToOperator,
+	}
+}

--- a/internal/operators/builder.go
+++ b/internal/operators/builder.go
@@ -1,7 +1,6 @@
 package operators
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/internal/operators/ocs"
@@ -11,27 +10,16 @@ import (
 
 // NewManager creates new instance of an Operator Manager
 func NewManager(log logrus.FieldLogger) Manager {
-	cfg := ocs.Config{}
-	err := envconfig.Process("myapp", &cfg)
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	return NewManagerWithConfig(log, &cfg)
+	return NewManagerWithOperators(log, lso.NewLSOperator(), ocs.NewOcsOperator(log))
 }
 
-// NewManagerWithConfig creates new instance of an Operator Manager
-func NewManagerWithConfig(log logrus.FieldLogger, cfg *ocs.Config) Manager {
-	ocsValidator := ocs.NewOCSValidator(log.WithField("pkg", "ocs-operator-state"), cfg)
-
-	//TODO: for better testability refactor into a proper builder pattern when hardcoded OCS dependency is gone
-	typeToOperator := map[models.OperatorType]api.Operator{
-		models.OperatorTypeLso: lso.NewLSOperator(),
+func NewManagerWithOperators(log logrus.FieldLogger, operators ...api.Operator) Manager {
+	typeToOperator := make(map[models.OperatorType]api.Operator)
+	for _, operator := range operators {
+		typeToOperator[operator.GetType()] = operator
 	}
-
 	return Manager{
-		log:                log,
-		ocsValidatorConfig: cfg,
-		ocsValidator:       ocsValidator,
-		operators:          typeToOperator,
+		log:       log,
+		operators: typeToOperator,
 	}
 }

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -1,0 +1,68 @@
+package lso
+
+import (
+	"context"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/models"
+)
+
+type lsOperator struct {
+}
+
+// New LsOperator creates new instance of a Local Storage Operator installation plugin
+func NewLSOperator() *lsOperator {
+	return &lsOperator{}
+}
+
+// GetType reports type of an operator this Operator manages
+func (l *lsOperator) GetType() models.OperatorType {
+	return models.OperatorTypeLso
+}
+
+// GetDependencies provides a list of dependencies of the Operator
+func (l *lsOperator) GetDependencies() []models.OperatorType {
+	return make([]models.OperatorType, 0)
+}
+
+func (l *lsOperator) GetValidationID() models.ClusterValidationID {
+	return models.ClusterValidationIDLsoRequirementsSatisfied
+}
+
+// ValidateCluster always return "valid" result
+func (l *lsOperator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+	return api.ValidationResult{Valid: true, ValidationId: l.GetValidationID()}, nil
+}
+
+// ValidateHost always return "valid" result
+func (l *lsOperator) ValidateHost(context.Context, *common.Cluster, *models.Host) (api.ValidationResult, error) {
+	return api.ValidationResult{Valid: true}, nil
+}
+
+// GetCPURequirementForWorker provides worker CPU requirements for the operator
+func (l *lsOperator) GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetCPURequirementForMaster provides master CPU requirements for the operator
+func (l *lsOperator) GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetMemoryRequirementForWorker provides worker memory requirements for the operator
+func (l *lsOperator) GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetMemoryRequirementForMaster provides master memory requirements for the operator
+func (l *lsOperator) GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GenerateManifests generates manifests for the operator
+func (l *lsOperator) GenerateManifests(c *common.Cluster) (*api.Manifests, error) {
+	manifestFiles, err := Manifests(c.Cluster.OpenshiftVersion)
+	return &api.Manifests{Files: manifestFiles}, err
+
+}

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -11,7 +11,7 @@ import (
 type lsOperator struct {
 }
 
-// New LsOperator creates new instance of a Local Storage Operator installation plugin
+// New LSOperator creates new instance of a Local Storage Operator installation plugin
 func NewLSOperator() *lsOperator {
 	return &lsOperator{}
 }
@@ -26,18 +26,24 @@ func (l *lsOperator) GetDependencies() []models.OperatorType {
 	return make([]models.OperatorType, 0)
 }
 
-func (l *lsOperator) GetValidationID() models.ClusterValidationID {
-	return models.ClusterValidationIDLsoRequirementsSatisfied
+// GetClusterValidationID returns cluster validation ID for the Operator
+func (l *lsOperator) GetClusterValidationID() string {
+	return string(models.ClusterValidationIDLsoRequirementsSatisfied)
+}
+
+// GetHostValidationID returns host validation ID for the Operator
+func (l *lsOperator) GetHostValidationID() string {
+	return string(models.HostValidationIDLsoRequirementsSatisfied)
 }
 
 // ValidateCluster always return "valid" result
 func (l *lsOperator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	return api.ValidationResult{Valid: true, ValidationId: l.GetValidationID()}, nil
+	return api.ValidationResult{Status: api.Success, ValidationId: l.GetClusterValidationID(), Reasons: []string{}}, nil
 }
 
 // ValidateHost always return "valid" result
 func (l *lsOperator) ValidateHost(context.Context, *common.Cluster, *models.Host) (api.ValidationResult, error) {
-	return api.ValidationResult{Valid: true}, nil
+	return api.ValidationResult{Status: api.Success, ValidationId: l.GetHostValidationID(), Reasons: []string{}}, nil
 }
 
 // GetCPURequirementForWorker provides worker CPU requirements for the operator
@@ -51,12 +57,12 @@ func (l *lsOperator) GetCPURequirementForMaster(context.Context, *common.Cluster
 }
 
 // GetMemoryRequirementForWorker provides worker memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error) {
+func (l *lsOperator) GetMemoryRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error) {
+func (l *lsOperator) GetMemoryRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
@@ -65,4 +71,14 @@ func (l *lsOperator) GenerateManifests(c *common.Cluster) (*api.Manifests, error
 	manifestFiles, err := Manifests(c.Cluster.OpenshiftVersion)
 	return &api.Manifests{Files: manifestFiles}, err
 
+}
+
+// GetDisksRequirementForMaster provides a number of disks required in a master
+func (l *lsOperator) GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetDisksRequirementForWorker provides a number of disks required in a worker
+func (l *lsOperator) GetDisksRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+	return 1, nil
 }

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -77,6 +77,20 @@ func (mr *MockAPIMockRecorder) GetOperatorStatus(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorStatus", reflect.TypeOf((*MockAPI)(nil).GetOperatorStatus), arg0, arg1)
 }
 
+// UpdateDependencies mocks base method
+func (m *MockAPI) UpdateDependencies(arg0 *common.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDependencies", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDependencies indicates an expected call of UpdateDependencies
+func (mr *MockAPIMockRecorder) UpdateDependencies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDependencies", reflect.TypeOf((*MockAPI)(nil).UpdateDependencies), arg0)
+}
+
 // ValidateOCSRequirements mocks base method
 func (m *MockAPI) ValidateOCSRequirements(arg0 *common.Cluster) string {
 	m.ctrl.T.Helper()

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -5,8 +5,10 @@
 package operators
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	common "github.com/openshift/assisted-service/internal/common"
+	api "github.com/openshift/assisted-service/internal/operators/api"
 	models "github.com/openshift/assisted-service/models"
 	reflect "reflect"
 )
@@ -63,20 +65,6 @@ func (mr *MockAPIMockRecorder) GenerateManifests(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifests", reflect.TypeOf((*MockAPI)(nil).GenerateManifests), arg0)
 }
 
-// GetOperatorStatus mocks base method
-func (m *MockAPI) GetOperatorStatus(arg0 *common.Cluster, arg1 models.OperatorType) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOperatorStatus", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetOperatorStatus indicates an expected call of GetOperatorStatus
-func (mr *MockAPIMockRecorder) GetOperatorStatus(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorStatus", reflect.TypeOf((*MockAPI)(nil).GetOperatorStatus), arg0, arg1)
-}
-
 // UpdateDependencies mocks base method
 func (m *MockAPI) UpdateDependencies(arg0 *common.Cluster) error {
 	m.ctrl.T.Helper()
@@ -91,16 +79,32 @@ func (mr *MockAPIMockRecorder) UpdateDependencies(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDependencies", reflect.TypeOf((*MockAPI)(nil).UpdateDependencies), arg0)
 }
 
-// ValidateOCSRequirements mocks base method
-func (m *MockAPI) ValidateOCSRequirements(arg0 *common.Cluster) string {
+// ValidateCluster mocks base method
+func (m *MockAPI) ValidateCluster(arg0 context.Context, arg1 *common.Cluster) ([]api.ValidationResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateOCSRequirements", arg0)
-	ret0, _ := ret[0].(string)
-	return ret0
+	ret := m.ctrl.Call(m, "ValidateCluster", arg0, arg1)
+	ret0, _ := ret[0].([]api.ValidationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ValidateOCSRequirements indicates an expected call of ValidateOCSRequirements
-func (mr *MockAPIMockRecorder) ValidateOCSRequirements(arg0 interface{}) *gomock.Call {
+// ValidateCluster indicates an expected call of ValidateCluster
+func (mr *MockAPIMockRecorder) ValidateCluster(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateOCSRequirements", reflect.TypeOf((*MockAPI)(nil).ValidateOCSRequirements), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCluster", reflect.TypeOf((*MockAPI)(nil).ValidateCluster), arg0, arg1)
+}
+
+// ValidateHost mocks base method
+func (m *MockAPI) ValidateHost(arg0 context.Context, arg1 *common.Cluster, arg2 *models.Host) ([]api.ValidationResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateHost", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]api.ValidationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateHost indicates an expected call of ValidateHost
+func (mr *MockAPIMockRecorder) ValidateHost(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateHost", reflect.TypeOf((*MockAPI)(nil).ValidateHost), arg0, arg1, arg2)
 }

--- a/internal/operators/ocs/consts.go
+++ b/internal/operators/ocs/consts.go
@@ -1,9 +1,6 @@
 package ocs
 
 const (
-	validationSuccess string = "success"
-	validationFailure string = "failure"
-	validationPending string = "pending"
-	ssdDrive          string = "SSD"
-	hddDrive          string = "HDD"
+	ssdDrive string = "SSD"
+	hddDrive string = "HDD"
 )

--- a/internal/operators/ocs/mock_validations.go
+++ b/internal/operators/ocs/mock_validations.go
@@ -5,12 +5,13 @@
 package ocs
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	reflect "reflect"
 )
 
-// MockOcsValidator is a mock of OcsValidator interface
+// MockOcsValidator is a mock of OCSValidator interface
 type MockOcsValidator struct {
 	ctrl     *gomock.Controller
 	recorder *MockOcsValidatorMockRecorder

--- a/internal/operators/ocs/mock_validations.go
+++ b/internal/operators/ocs/mock_validations.go
@@ -5,45 +5,46 @@
 package ocs
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
+	api "github.com/openshift/assisted-service/internal/operators/api"
 	models "github.com/openshift/assisted-service/models"
+	reflect "reflect"
 )
 
-// MockOcsValidator is a mock of OCSValidator interface
-type MockOcsValidator struct {
+// MockOCSValidator is a mock of OCSValidator interface
+type MockOCSValidator struct {
 	ctrl     *gomock.Controller
-	recorder *MockOcsValidatorMockRecorder
+	recorder *MockOCSValidatorMockRecorder
 }
 
-// MockOcsValidatorMockRecorder is the mock recorder for MockOcsValidator
-type MockOcsValidatorMockRecorder struct {
-	mock *MockOcsValidator
+// MockOCSValidatorMockRecorder is the mock recorder for MockOCSValidator
+type MockOCSValidatorMockRecorder struct {
+	mock *MockOCSValidator
 }
 
-// NewMockOcsValidator creates a new mock instance
-func NewMockOcsValidator(ctrl *gomock.Controller) *MockOcsValidator {
-	mock := &MockOcsValidator{ctrl: ctrl}
-	mock.recorder = &MockOcsValidatorMockRecorder{mock}
+// NewMockOCSValidator creates a new mock instance
+func NewMockOCSValidator(ctrl *gomock.Controller) *MockOCSValidator {
+	mock := &MockOCSValidator{ctrl: ctrl}
+	mock.recorder = &MockOCSValidatorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockOcsValidator) EXPECT() *MockOcsValidatorMockRecorder {
+func (m *MockOCSValidator) EXPECT() *MockOCSValidatorMockRecorder {
 	return m.recorder
 }
 
-// ValidateOCSRequirements mocks base method
-func (m *MockOcsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
+// ValidateRequirements mocks base method
+func (m *MockOCSValidator) ValidateRequirements(cluster *models.Cluster) (api.ValidationStatus, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateOCSRequirements", cluster)
-	ret0, _ := ret[0].(string)
-	return ret0
+	ret := m.ctrl.Call(m, "ValidateRequirements", cluster)
+	ret0, _ := ret[0].(api.ValidationStatus)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
 }
 
-// ValidateOCSRequirements indicates an expected call of ValidateOCSRequirements
-func (mr *MockOcsValidatorMockRecorder) ValidateOCSRequirements(cluster interface{}) *gomock.Call {
+// ValidateRequirements indicates an expected call of ValidateRequirements
+func (mr *MockOCSValidatorMockRecorder) ValidateRequirements(cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateOCSRequirements", reflect.TypeOf((*MockOcsValidator)(nil).ValidateOCSRequirements), cluster)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateRequirements", reflect.TypeOf((*MockOCSValidator)(nil).ValidateRequirements), cluster)
 }

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -1,0 +1,105 @@
+package ocs
+
+import (
+	"context"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+type ocsOperator struct {
+	log                logrus.FieldLogger
+	ocsValidatorConfig Config
+	ocsValidator       OCSValidator
+}
+
+// NewOcsOperator creates new OCSOperator
+func NewOcsOperator(log logrus.FieldLogger) *ocsOperator {
+	cfg := Config{}
+	err := envconfig.Process("myapp", &cfg)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	validator := NewOCSValidator(log.WithField("pkg", "ocs-operator-state"), &cfg)
+	return NewOcsOperatorWithConfig(log, cfg, validator)
+}
+
+// NewOcsOperatorWithConfig creates new OCSOperator with given configuration and validator
+func NewOcsOperatorWithConfig(log logrus.FieldLogger, config Config, validator OCSValidator) *ocsOperator {
+	return &ocsOperator{
+		log:                log,
+		ocsValidatorConfig: config,
+		ocsValidator:       validator,
+	}
+}
+
+// GetType reports type of an operator this Operator manages
+func (o *ocsOperator) GetType() models.OperatorType {
+	return models.OperatorTypeOcs
+}
+
+// GetDependencies provides a list of dependencies of the Operator
+func (o *ocsOperator) GetDependencies() []models.OperatorType {
+	return []models.OperatorType{models.OperatorTypeLso}
+}
+
+// GetClusterValidationID returns cluster validation ID for the Operator
+func (o *ocsOperator) GetClusterValidationID() string {
+	return string(models.ClusterValidationIDOcsRequirementsSatisfied)
+}
+
+// GetHostValidationID returns host validation ID for the Operator
+func (o *ocsOperator) GetHostValidationID() string {
+	return string(models.HostValidationIDOcsRequirementsSatisfied)
+}
+
+// ValidateCluster verifies whether this operator is valid for given cluster
+func (o *ocsOperator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+	status, message := o.ocsValidator.ValidateRequirements(&cluster.Cluster)
+
+	return api.ValidationResult{Status: status, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+}
+
+// ValidateHost verifies whether this operator is valid for given host
+func (o *ocsOperator) ValidateHost(context.Context, *common.Cluster, *models.Host) (api.ValidationResult, error) {
+	return api.ValidationResult{Status: api.Success, ValidationId: o.GetHostValidationID(), Reasons: []string{}}, nil
+}
+
+// GenerateManifests generates manifests for the operator
+func (o *ocsOperator) GenerateManifests(cluster *common.Cluster) (*api.Manifests, error) {
+	manifests, err := Manifests(o.ocsValidatorConfig.OCSMinimalDeployment, o.ocsValidatorConfig.OCSDisksAvailable, len(cluster.Cluster.Hosts))
+	return &api.Manifests{Files: manifests}, err
+}
+
+// GetCPURequirementForWorker provides worker CPU requirements for the operator
+func (o *ocsOperator) GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetCPURequirementForMaster provides master CPU requirements for the operator
+func (o *ocsOperator) GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
+func (o *ocsOperator) GetMemoryRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetMemoryRequirementForMaster provides master memory requirements for the operator
+func (o *ocsOperator) GetMemoryRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetDisksRequirementForMaster provides a number of disks required in a master
+func (o *ocsOperator) GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}
+
+// GetDisksRequirementForWorker provides a number of disks required in a worker
+func (o *ocsOperator) GetDisksRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+	return 0, nil
+}

--- a/internal/operators/ocs/validations.go
+++ b/internal/operators/ocs/validations.go
@@ -10,7 +10,7 @@ import (
 )
 
 //go:generate mockgen -source=validations.go -package=ocs -destination=mock_validations.go
-type OcsValidator interface {
+type OCSValidator interface {
 	ValidateOCSRequirements(cluster *models.Cluster) string
 }
 
@@ -19,7 +19,7 @@ type ocsValidator struct {
 	log logrus.FieldLogger
 }
 
-func NewOCSValidator(log logrus.FieldLogger, cfg *Config) OcsValidator {
+func NewOCSValidator(log logrus.FieldLogger, cfg *Config) OCSValidator {
 	return &ocsValidator{
 		log:    log,
 		Config: cfg,

--- a/internal/operators/ocs/validations.go
+++ b/internal/operators/ocs/validations.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 
 	"github.com/docker/go-units"
+	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 )
 
 //go:generate mockgen -source=validations.go -package=ocs -destination=mock_validations.go
 type OCSValidator interface {
-	ValidateOCSRequirements(cluster *models.Cluster) string
+	ValidateRequirements(cluster *models.Cluster) (api.ValidationStatus, string)
 }
 
 type ocsValidator struct {
@@ -65,7 +66,7 @@ func setOperatorStatus(cluster *models.Cluster, status string) error {
 }
 
 // ValidateOCSRequirements is used to validate min requirements of OCS
-func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
+func (o *ocsValidator) ValidateRequirements(cluster *models.Cluster) (api.ValidationStatus, string) {
 	var status string
 	var err error
 	var inventoryMissing bool
@@ -76,10 +77,10 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 		err = setOperatorStatus(cluster, status)
 		if err != nil {
 			o.log.Error("Failed to set Operator status ", err)
-			return validationFailure
+			return api.Failure, "Failed to set Operator status "
 		}
 		o.log.Info("Setting Operator Status ", status)
-		return validationFailure
+		return api.Failure, status
 	}
 	var cpuCount int64 = 0       //count the total CPUs on the cluster
 	var totalRAM int64 = 0       // count the total available RAM on the cluster
@@ -91,9 +92,9 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 			inventoryMissing, err = o.nodeResources(host, &cpuCount, &totalRAM, &diskCount, &hostsWithDisks, &insufficientHosts)
 			if err != nil {
 				o.log.Fatal("Error occured while calculating Node requirements ", err)
-				return validationFailure
+				return api.Failure, "Error occured while calculating Node requirements "
 			} else if inventoryMissing {
-				return validationPending
+				return api.Pending, "Missing Inventory in some of the hosts"
 			}
 		}
 
@@ -103,8 +104,9 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 		err = setOperatorStatus(cluster, status)
 		if err != nil {
 			o.log.Error("Failed to set Operator status ", err)
+			return api.Failure, "Failed to set Operator status "
 		}
-		return validationFailure
+		return api.Failure, status
 	} else {
 		for _, host := range hosts { // if the worker nodes >=3 , install OCS on all the worker nodes if they satisfy OCS requirements
 			/* If the Role is set to Auto-assign for a host, it is not possible to determine whether the node will end up as a master or worker node.
@@ -118,15 +120,15 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 				if err != nil {
 					o.log.Error("Failed to set Operator status", err)
 				}
-				return validationFailure
+				return api.Failure, status
 			}
 			if host.Role == models.HostRoleWorker {
 				inventoryMissing, err = o.nodeResources(host, &cpuCount, &totalRAM, &diskCount, &hostsWithDisks, &insufficientHosts)
 				if err != nil {
 					o.log.Error("Error occured while calculating Node requirements ", err)
-					return validationFailure
+					return api.Failure, "Error occured while calculating Node requirements "
 				} else if inventoryMissing {
-					return validationPending
+					return api.Pending, "Missing Inventory in some of the hosts"
 				}
 
 			}
@@ -140,10 +142,10 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 		err = setOperatorStatus(cluster, status)
 		if err != nil {
 			o.log.Error("Failed to set Operator status ", err)
-			return validationFailure
+			return api.Failure, status
 		}
 		o.log.Info("Setting Operator Status ", status)
-		return validationFailure
+		return api.Failure, status
 	}
 
 	// total disks excluding boot disk must be a multiple of 3
@@ -154,24 +156,24 @@ func (o *ocsValidator) ValidateOCSRequirements(cluster *models.Cluster) string {
 		if err != nil {
 			o.log.Error("Failed to set Operator status ", err)
 		}
-		return validationFailure
+		return api.Failure, "Failed to set Operator status "
 	}
 
 	// this will be used to set count of StorageDevices in StorageCluster manifest
 	o.OCSDisksAvailable = diskCount
-	canDeployOCS, status := o.validateOCS(o.log, hosts, cpuCount, totalRAM, diskCount, hostsWithDisks)
+	canDeployOCS, status := o.validate(hosts, cpuCount, totalRAM, diskCount, hostsWithDisks)
 
 	o.log.Info(status)
 	err = setOperatorStatus(cluster, status)
 	if err != nil {
 		o.log.Error("Failed to set Operator status ", err)
-		return validationFailure
+		return api.Failure, "Failed to set Operator status "
 	}
 
 	if canDeployOCS {
-		return validationSuccess
+		return api.Success, status
 	}
-	return validationFailure
+	return api.Failure, status
 }
 
 func (o *ocsValidator) nodeResources(host *models.Host, cpuCount *int64, totalRAM *int64, diskCount *int64, hostsWithDisks *int64, insufficientHosts *[]string) (bool, error) {
@@ -185,7 +187,7 @@ func (o *ocsValidator) nodeResources(host *models.Host, cpuCount *int64, totalRA
 		return false, err
 	}
 
-	disks := getValidOCSDiskCount(inventory.Disks)
+	disks := getValidDiskCount(inventory.Disks)
 
 	if disks > 1 { // OCS must use the non-boot disks
 		requiredDiskCPU := int64(disks-1) * o.OCSRequiredDiskCPUCount
@@ -213,7 +215,7 @@ func gbToBytes(gb int64) int64 {
 }
 
 // count all disks of drive type ssd or hdd
-func getValidOCSDiskCount(disks []*models.Disk) int {
+func getValidDiskCount(disks []*models.Disk) int {
 
 	var countDisks int
 
@@ -228,7 +230,7 @@ func getValidOCSDiskCount(disks []*models.Disk) int {
 }
 
 // used to validate resource requirements for OCS excluding disk requirements and set a status message
-func (o *ocsValidator) validateOCS(log logrus.FieldLogger, hosts []*models.Host, cpu int64, ram int64, disk int64, hostsWithDisks int64) (bool, string) {
+func (o *ocsValidator) validate(hosts []*models.Host, cpu int64, ram int64, disk int64, hostsWithDisks int64) (bool, string) {
 	var TotalCPUs int64
 	var TotalRAM int64
 	var status string

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -181,7 +181,7 @@ type Cluster struct {
 	UserName string `json:"user_name,omitempty"`
 
 	// JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
-	ValidationsInfo string `json:"validations_info,omitempty" gorm:"type:varchar(2048)"`
+	ValidationsInfo string `json:"validations_info,omitempty" gorm:"type:text"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.
 	VipDhcpAllocation *bool `json:"vip_dhcp_allocation,omitempty"`

--- a/models/host.go
+++ b/models/host.go
@@ -137,7 +137,7 @@ type Host struct {
 	UserName string `json:"user_name,omitempty"`
 
 	// JSON-formatted string containing the validation results for each validation id grouped by category (network, hardware, etc.)
-	ValidationsInfo string `json:"validations_info,omitempty" gorm:"type:varchar(2048)"`
+	ValidationsInfo string `json:"validations_info,omitempty" gorm:"type:text"`
 }
 
 // Validate validates this host

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -67,6 +67,12 @@ const (
 
 	// HostValidationIDContainerImagesAvailable captures enum value "container-images-available"
 	HostValidationIDContainerImagesAvailable HostValidationID = "container-images-available"
+
+	// HostValidationIDLsoRequirementsSatisfied captures enum value "lso-requirements-satisfied"
+	HostValidationIDLsoRequirementsSatisfied HostValidationID = "lso-requirements-satisfied"
+
+	// HostValidationIDOcsRequirementsSatisfied captures enum value "ocs-requirements-satisfied"
+	HostValidationIDOcsRequirementsSatisfied HostValidationID = "ocs-requirements-satisfied"
 )
 
 // for schema
@@ -74,7 +80,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -50,22 +50,22 @@ type Config struct {
 	DummyIgnition        bool   `envconfig:"DUMMY_IGNITION"`
 }
 
-func New(log logrus.FieldLogger, kube client.Client, s3Client s3wrapper.API, cfg Config, operatorsManager *operators.Manager) *kubeJob {
+func New(log logrus.FieldLogger, kube client.Client, s3Client s3wrapper.API, cfg Config, operatorsApi operators.API) *kubeJob {
 	return &kubeJob{
-		Config:           cfg,
-		log:              log,
-		kube:             kube,
-		s3Client:         s3Client,
-		operatorsManager: operatorsManager,
+		Config:       cfg,
+		log:          log,
+		kube:         kube,
+		s3Client:     s3Client,
+		operatorsApi: operatorsApi,
 	}
 }
 
 type kubeJob struct {
 	Config
-	log              logrus.FieldLogger
-	kube             client.Client
-	s3Client         s3wrapper.API
-	operatorsManager *operators.Manager
+	log          logrus.FieldLogger
+	kube         client.Client
+	s3Client     s3wrapper.API
+	operatorsApi operators.API
 }
 
 func (k *kubeJob) getJob(ctx context.Context, job *batch.Job, name, namespace string) error {
@@ -200,7 +200,7 @@ func (k *kubeJob) GenerateInstallConfig(ctx context.Context, cluster common.Clus
 	if k.Config.DummyIgnition {
 		generator = ignition.NewDummyGenerator(workDir, &cluster, k.s3Client, log)
 	} else {
-		generator = ignition.NewGenerator(workDir, installerCacheDir, &cluster, releaseImage, "", k.Config.ServiceCACertPath, k.s3Client, log, k.operatorsManager)
+		generator = ignition.NewGenerator(workDir, installerCacheDir, &cluster, releaseImage, "", k.Config.ServiceCACertPath, k.s3Client, log, k.operatorsApi)
 	}
 	err = generator.Generate(ctx, cfg)
 	if err != nil {

--- a/pkg/job/local_job.go
+++ b/pkg/job/local_job.go
@@ -15,17 +15,17 @@ import (
 
 type localJob struct {
 	Config
-	log              logrus.FieldLogger
-	s3Client         s3wrapper.API
-	operatorsManager *operators.Manager
+	log          logrus.FieldLogger
+	s3Client     s3wrapper.API
+	operatorsApi operators.API
 }
 
-func NewLocalJob(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config, operatorsManager *operators.Manager) *localJob {
+func NewLocalJob(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config, operatorsApi operators.API) *localJob {
 	return &localJob{
-		Config:           cfg,
-		log:              log,
-		s3Client:         s3Client,
-		operatorsManager: operatorsManager,
+		Config:       cfg,
+		log:          log,
+		s3Client:     s3Client,
+		operatorsApi: operatorsApi,
 	}
 }
 
@@ -44,7 +44,7 @@ func (j *localJob) GenerateInstallConfig(ctx context.Context, cluster common.Clu
 	if j.Config.DummyIgnition {
 		generator = ignition.NewDummyGenerator(workDir, &cluster, j.s3Client, log)
 	} else {
-		generator = ignition.NewGenerator(workDir, installerCacheDir, &cluster, releaseImage, j.Config.ReleaseImageMirror, j.Config.ServiceCACertPath, j.s3Client, log, j.operatorsManager)
+		generator = ignition.NewGenerator(workDir, installerCacheDir, &cluster, releaseImage, j.Config.ReleaseImageMirror, j.Config.ServiceCACertPath, j.s3Client, log, j.operatorsApi)
 	}
 	err = generator.Generate(ctx, cfg)
 	if err != nil {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4575,7 +4575,7 @@ func init() {
         "validations_info": {
           "description": "JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\""
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "vip_dhcp_allocation": {
           "description": "Indicate if virtual IP DHCP allocation mode is enabled.",
@@ -5715,7 +5715,7 @@ func init() {
         "validations_info": {
           "description": "JSON-formatted string containing the validation results for each validation id grouped by category (network, hardware, etc.)",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\""
+          "x-go-custom-tag": "gorm:\"type:text\""
         }
       }
     },
@@ -5867,7 +5867,9 @@ func init() {
         "belongs-to-majority-group",
         "valid-platform",
         "ntp-synced",
-        "container-images-available"
+        "container-images-available",
+        "lso-requirements-satisfied",
+        "ocs-requirements-satisfied"
       ]
     },
     "host_network": {
@@ -11232,7 +11234,7 @@ func init() {
         "validations_info": {
           "description": "JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\""
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "vip_dhcp_allocation": {
           "description": "Indicate if virtual IP DHCP allocation mode is enabled.",
@@ -12296,7 +12298,7 @@ func init() {
         "validations_info": {
           "description": "JSON-formatted string containing the validation results for each validation id grouped by category (network, hardware, etc.)",
           "type": "string",
-          "x-go-custom-tag": "gorm:\"type:varchar(2048)\""
+          "x-go-custom-tag": "gorm:\"type:text\""
         }
       }
     },
@@ -12448,7 +12450,9 @@ func init() {
         "belongs-to-majority-group",
         "valid-platform",
         "ntp-synced",
-        "container-images-available"
+        "container-images-available",
+        "lso-requirements-satisfied",
+        "ocs-requirements-satisfied"
       ]
     },
     "host_network": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3051,7 +3051,7 @@ definitions:
       validations_info:
         type: string
         description: JSON-formatted string containing the validation results for each validation id grouped by category (network, hardware, etc.)
-        x-go-custom-tag: gorm:"type:varchar(2048)"
+        x-go-custom-tag: gorm:"type:text"
       status_updated_at:
         type: string
         format: date-time
@@ -3665,7 +3665,7 @@ definitions:
       validations_info:
         type: string
         description: JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
-        x-go-custom-tag: gorm:"type:varchar(2048)"
+        x-go-custom-tag: gorm:"type:text"
       install_config_overrides:
         x-go-custom-tag: gorm:"type:text"
         type: string
@@ -4284,6 +4284,8 @@ definitions:
       - 'valid-platform'
       - 'ntp-synced'
       - 'container-images-available'
+      - 'lso-requirements-satisfied'
+      - 'ocs-requirements-satisfied'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
This PR builds on top of #1074 and introduces generic API for building OLM operator plugins.
Also, LSO and OCS plugins have been migrated to use that API.