### PR TITLE
MGMT-3137 Fix bminventory unit test with AMS mock

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5307,13 +5307,21 @@ var _ = Describe("TestRegisterCluster", func() {
 		ctrl.Finish()
 	})
 
-	It("success", func() {
+	mockClusterRegisterSuccess := func() {
 		mockEvents.EXPECT().
 			AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
 			Times(2)
 		mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+
+		if bm.Config.WithAMSSubscriptions {
+			mockAccountsMgmt.EXPECT().CreateSubscription(ctx, gomock.Any()).Return(&amgmtv1.Subscription{}, nil)
+		}
+	}
+
+	It("success", func() {
+		mockClusterRegisterSuccess()
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
@@ -5326,12 +5334,7 @@ var _ = Describe("TestRegisterCluster", func() {
 	})
 
 	It("UserManagedNetworking default value", func() {
-		mockEvents.EXPECT().
-			AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-			Times(2)
-		mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+		mockClusterRegisterSuccess()
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
@@ -5346,12 +5349,7 @@ var _ = Describe("TestRegisterCluster", func() {
 	})
 
 	It("UserManagedNetworking non default value", func() {
-		mockEvents.EXPECT().
-			AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-			Times(2)
-		mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+		mockClusterRegisterSuccess()
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
@@ -5398,12 +5396,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			defaultNtpSource := "clock.redhat.com"
 			bm.Config.DefaultNTPSource = defaultNtpSource
 
-			mockEvents.EXPECT().
-				AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-				Times(2)
-			mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+			mockClusterRegisterSuccess()
 
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
@@ -5420,12 +5413,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		It("NTPSource non default value", func() {
 			newNtpSource := "new.ntp.source"
 
-			mockEvents.EXPECT().
-				AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-				Times(2)
-			mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+			mockClusterRegisterSuccess()
 
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
@@ -5459,12 +5447,7 @@ var _ = Describe("TestRegisterCluster", func() {
 
 	It("Host Networks default value", func() {
 		defaultHostNetworks := make([]*models.HostNetwork, 0)
-		mockEvents.EXPECT().
-			AddEvent(gomock.Any(), gomock.Any(), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
-			Times(2)
-		mockMetric.EXPECT().ClusterRegistered(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().IsOpenshiftVersionSupported(gomock.Any()).Return(true).Times(1)
+		mockClusterRegisterSuccess()
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{


### PR DESCRIPTION
When unit tests where running with `WITH_AMS_SUBSCRIPTIONS="True"` the following tests failed:

```
Summarizing 6 Failures:
[Fail] TestRegisterCluster [It] success 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
[Fail] TestRegisterCluster [It] UserManagedNetworking default value 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
[Fail] TestRegisterCluster [It] UserManagedNetworking non default value 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
[Fail] TestRegisterCluster NTPSource [It] NTPSource default value 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
[Fail] TestRegisterCluster NTPSource [It] NTPSource non default value 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
[Fail] TestRegisterCluster [It] Host Networks default value 
/home/jdzon/projects/assisted-service/pkg/ocm/mock_accounts_mgmt.go:41
Ran 267 of 267 Specs in 53.569 seconds
FAIL! -- 261 Passed | 6 Failed | 0 Pending | 0 Skipped
```

Resolves an issue introduced only when calling `make deploy-test` since https://github.com/openshift/assisted-service/pull/771

/cc @jakub-dzon @ybettan 