### PR TITLE
MGMT-3979: Embed ignition and ramdisk into cluster iso

### DIFF
--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -31,10 +31,12 @@ Environment=NO_PROXY={{.NO_PROXY}}`
 
 const RamDiskPaddingLength = uint64(1024 * 1024) // 1MB
 const IgnitionPaddingLength = uint64(256 * 1024) // 256KB
+
 const ignitionImagePath = "/images/ignition.img"
 const ramDiskImagePath = "/images/assisted_installer_custom.img"
 const ignitionHeaderKey = "coreiso+"
 const ramdiskHeaderKey = "ramdisk+"
+const headerLength = int64(32768) // first 32KB in ISO
 
 type ClusterProxyInfo struct {
 	HTTPProxy  string
@@ -112,21 +114,35 @@ func (e *rhcosEditor) CreateMinimalISOTemplate(serviceBaseURL string) (string, e
 }
 
 func (e *rhcosEditor) CreateClusterMinimalISO(ignition string, staticNetworkConfig string, clusterProxyInfo *ClusterProxyInfo) (string, error) {
-	if err := e.isoHandler.Extract(); err != nil {
-		return "", errors.Wrap(err, "failed to extract iso")
+	clusterISOPath, err := tempFileName(e.workDir)
+	if err != nil {
+		return "", err
 	}
 
-	if err := e.addIgnitionArchive(ignition); err != nil {
+	if err = e.isoHandler.Copy(clusterISOPath); err != nil {
+		return "", errors.Wrap(err, "failed to copy iso")
+	}
+
+	ignitionOffsetInfo, ramDiskOffsetInfo, err := readHeader(clusterISOPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := e.addIgnitionArchive(clusterISOPath, ignition, ignitionOffsetInfo.Offset); err != nil {
 		return "", errors.Wrap(err, "failed to add ignition archive")
 	}
 
 	if staticNetworkConfig != "" || clusterProxyInfo.HTTPProxy != "" || clusterProxyInfo.HTTPSProxy != "" {
-		if err := e.addCustomRAMDisk(staticNetworkConfig, clusterProxyInfo); err != nil {
+		if err := e.addCustomRAMDisk(clusterISOPath, staticNetworkConfig, clusterProxyInfo, ramDiskOffsetInfo.Offset); err != nil {
 			return "", errors.Wrap(err, "failed to add additional ramdisk")
 		}
 	}
 
-	return e.create()
+	if err := e.isoHandler.CleanWorkDir(); err != nil {
+		e.log.WithError(err).Warnf("Failed to clean isoHandler work dir")
+	}
+
+	return clusterISOPath, nil
 }
 
 func (e *rhcosEditor) embedInitrdPlaceholders() error {
@@ -187,29 +203,25 @@ func (e *rhcosEditor) createImagePlaceholder(imagePath string, paddingLength uin
 	return nil
 }
 
-func (e *rhcosEditor) addIgnitionArchive(ignition string) error {
+func (e *rhcosEditor) addIgnitionArchive(clusterISOPath, ignition string, ignitionOffset uint64) error {
 	archiveBytes, err := IgnitionImageArchive(ignition)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(e.isoHandler.ExtractedPath("images/ignition.img"), archiveBytes, 0644) //nolint:gosec
+	return writeAt(archiveBytes, int64(ignitionOffset), clusterISOPath)
 }
 
-func (e *rhcosEditor) addCustomRAMDisk(staticNetworkConfig string, clusterProxyInfo *ClusterProxyInfo) error {
-	f, err := os.Create(e.isoHandler.ExtractedPath(ramDiskImagePath))
-	if err != nil {
-		return err
-	}
-
-	w := cpio.NewWriter(f)
+func (e *rhcosEditor) addCustomRAMDisk(clusterISOPath, staticNetworkConfig string, clusterProxyInfo *ClusterProxyInfo, ramdiskOffset uint64) error {
+	buffer := new(bytes.Buffer)
+	w := cpio.NewWriter(buffer)
 	if staticNetworkConfig != "" {
 		filesList, newErr := e.staticNetworkConfig.GenerateStaticNetworkConfigData(staticNetworkConfig)
 		if newErr != nil {
 			return newErr
 		}
 		for _, file := range filesList {
-			err = addFileToArchive(w, filepath.Join("/etc/assisted/network", file.FilePath), file.FileContents, 0o600)
+			err := addFileToArchive(w, filepath.Join("/etc/assisted/network", file.FilePath), file.FileContents, 0o600)
 			if err != nil {
 				return err
 			}
@@ -217,25 +229,25 @@ func (e *rhcosEditor) addCustomRAMDisk(staticNetworkConfig string, clusterProxyI
 		scriptPath := "/usr/lib/dracut/hooks/initqueue/settled/90-assisted-pre-static-network-config.sh"
 		scriptContent := constants.PreNetworkConfigScript
 
-		if err = addFileToArchive(w, scriptPath, scriptContent, 0o755); err != nil {
+		if err := addFileToArchive(w, scriptPath, scriptContent, 0o755); err != nil {
 			return err
 		}
 	}
 	if clusterProxyInfo.HTTPProxy != "" || clusterProxyInfo.HTTPSProxy != "" {
 		rootfsServiceConfigPath := "/etc/systemd/system/coreos-livepxe-rootfs.service.d/10-proxy.conf"
-		rootfsServiceConfig, err1 := e.formatRootfsServiceConfigFile(clusterProxyInfo)
-		if err1 != nil {
-			return err1
+		rootfsServiceConfig, err := e.formatRootfsServiceConfigFile(clusterProxyInfo)
+		if err != nil {
+			return err
 		}
-		if err = addFileToArchive(w, rootfsServiceConfigPath, rootfsServiceConfig, 0o664); err != nil {
+		if err := addFileToArchive(w, rootfsServiceConfigPath, rootfsServiceConfig, 0o664); err != nil {
 			return err
 		}
 	}
-	if err = w.Close(); err != nil {
+	if err := w.Close(); err != nil {
 		return err
 	}
 
-	return nil
+	return writeAt(buffer.Bytes(), int64(ramdiskOffset), clusterISOPath)
 }
 
 func (e *rhcosEditor) formatRootfsServiceConfigFile(clusterProxyInfo *ClusterProxyInfo) (string, error) {
@@ -364,6 +376,21 @@ func tempFileName(baseDir string) (string, error) {
 	return path, nil
 }
 
+func writeAt(b []byte, offset int64, clusterISOPath string) error {
+	iso, err := os.OpenFile(clusterISOPath, os.O_WRONLY, 0o664)
+	if err != nil {
+		return err
+	}
+	defer iso.Close()
+
+	_, err = iso.WriteAt(b, offset)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func IgnitionImageArchive(ignitionConfig string) ([]byte, error) {
 	ignitionBytes := []byte(ignitionConfig)
 
@@ -392,6 +419,37 @@ func IgnitionImageArchive(ignitionConfig string) ([]byte, error) {
 	}
 
 	return compressedBuffer.Bytes(), nil
+}
+
+func readHeader(isoPath string) (*OffsetInfo, *OffsetInfo, error) {
+	iso, err := os.OpenFile(isoPath, os.O_RDONLY, 0o664)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer iso.Close()
+
+	// Read 48 bytes with offsets metadata from the end of system area
+	ignitionMetadata := make([]byte, 24)
+	_, err = iso.ReadAt(ignitionMetadata, headerLength-24)
+	if err != nil {
+		return nil, nil, err
+	}
+	ramdiskMetadata := make([]byte, 24)
+	_, err = iso.ReadAt(ramdiskMetadata, headerLength-48)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ignitionOffsetInfo, err := GetIgnitionArea(ignitionMetadata)
+	if err != nil {
+		return nil, nil, err
+	}
+	ramdiskOffsetInfo, err := GetRamDiskArea(ramdiskMetadata)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ignitionOffsetInfo, ramdiskOffsetInfo, nil
 }
 
 // Writing the offsets of initrd images in the end of system area (first 32KB).
@@ -441,4 +499,45 @@ func writeOffsetInfo(headerOffset int64, offsetInfo *OffsetInfo, iso *os.File) (
 	}
 
 	return bytesLength, nil
+}
+
+func validateOffsetInfoKey(offsetInfo *OffsetInfo, key string) error {
+	if string(offsetInfo.Key[:]) != key {
+		return errors.Errorf("Invalid key in offset metadata: %s", key)
+	}
+	return nil
+}
+
+func GetIgnitionArea(offsetMetadata []byte) (*OffsetInfo, error) {
+	offsetInfo, err := ParseOffsetInfo(offsetMetadata)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateOffsetInfoKey(offsetInfo, ignitionHeaderKey); err != nil {
+		return nil, err
+	}
+	return offsetInfo, nil
+}
+
+func GetRamDiskArea(offsetMetadata []byte) (*OffsetInfo, error) {
+	offsetInfo, err := ParseOffsetInfo(offsetMetadata)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateOffsetInfoKey(offsetInfo, ramdiskHeaderKey); err != nil {
+		return nil, err
+	}
+	return offsetInfo, nil
+}
+
+// ParseOffsetInfo gets a 24 bytes array with offset metadata and
+// returns an OffsetInfo struct with the parsed data.
+func ParseOffsetInfo(headerBytes []byte) (*OffsetInfo, error) {
+	buf := bytes.NewReader(headerBytes)
+	offsetInfo := new(OffsetInfo)
+	err := binary.Read(buf, binary.LittleEndian, offsetInfo)
+	if err != nil {
+		return nil, err
+	}
+	return offsetInfo, nil
 }

--- a/internal/isoutil/mock_isoutil.go
+++ b/internal/isoutil/mock_isoutil.go
@@ -33,6 +33,34 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
+// CleanWorkDir mocks base method
+func (m *MockHandler) CleanWorkDir() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanWorkDir")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanWorkDir indicates an expected call of CleanWorkDir
+func (mr *MockHandlerMockRecorder) CleanWorkDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanWorkDir", reflect.TypeOf((*MockHandler)(nil).CleanWorkDir))
+}
+
+// Copy mocks base method
+func (m *MockHandler) Copy(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Copy", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Copy indicates an expected call of Copy
+func (mr *MockHandlerMockRecorder) Copy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Copy", reflect.TypeOf((*MockHandler)(nil).Copy), arg0)
+}
+
 // Create mocks base method
 func (m *MockHandler) Create(arg0, arg1 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When customizing an iso for a specific cluster:
    * Discover the offsets of the ramdisk and ignition placeholders (using initrd metadata in header's system area).
    * Overwrite with the custom data for the cluster.