### PR TITLE
NO-ISSUE Organize DB preloads with common functions

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6027,9 +6027,9 @@ var _ = Describe("Calculate host networks", func() {
 		common.DeleteTestDB(db, dbName)
 	})
 	It("Duplicates and IPv6", func() {
-		var cluster common.Cluster
-		Expect(db.Preload("Hosts").Take(&cluster, "id = ?", clusterID.String()).Error).ToNot(HaveOccurred())
-		networks := calculateHostNetworks(logrus.New(), &cluster)
+		cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+		Expect(err).ToNot(HaveOccurred())
+		networks := calculateHostNetworks(logrus.New(), cluster)
 		Expect(len(networks)).To(Equal(1))
 		Expect(networks[0].Cidr).To(Equal("1.1.1.0/24"))
 		Expect(len(networks[0].HostIds)).To(Equal(1))

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -113,20 +113,14 @@ func UpdateCluster(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID, s
 		return nil, errors.Errorf("failed to update cluster %s. nothing has changed", clusterId)
 	}
 
-	var cluster common.Cluster
-
-	if err := db.Preload("Hosts").Take(&cluster, "id = ?", clusterId.String()).Error; err != nil {
-		return nil, errors.Wrapf(err, "failed to get cluster %s", clusterId.String())
-	}
-
-	return &cluster, nil
+	return common.GetClusterFromDB(db, clusterId, common.UseEagerLoading)
 }
 
 func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {
-
-	var cluster common.Cluster
+	var cluster *common.Cluster
+	var err error
 	var masterNodesIds []*strfmt.UUID
-	if err := db.Preload("Hosts").First(&cluster, "id = ?", c.ID).Error; err != nil {
+	if cluster, err = common.GetClusterFromDB(db, *c.ID, common.UseEagerLoading); err != nil {
 		return nil, errors.Errorf("cluster %s not found", c.ID)
 	}
 

--- a/internal/cluster/installer_test.go
+++ b/internal/cluster/installer_test.go
@@ -78,8 +78,7 @@ var _ = Describe("installer", func() {
 			err := installerManager.Install(ctx, &cluster, db)
 			Expect(err).Should(BeNil())
 
-			Expect(db.Preload("Hosts").First(&cluster, "id = ?", cluster.ID).Error).ShouldNot(HaveOccurred())
-
+			cluster = getClusterFromDB(*cluster.ID, db)
 			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInstalling))
 		})
 	})

--- a/internal/cluster/registrar.go
+++ b/internal/cluster/registrar.go
@@ -65,7 +65,7 @@ func (r *registrar) registerCluster(ctx context.Context, cluster *common.Cluster
 		}
 	}
 
-	if err := tx.Preload("Hosts").Create(cluster).Error; err != nil {
+	if err := common.LoadHostsFromDB(tx).Create(cluster).Error; err != nil {
 		r.log.Errorf("Error registering cluster %s", cluster.Name)
 		return err
 	}

--- a/internal/cluster/registrar_test.go
+++ b/internal/cluster/registrar_test.go
@@ -39,7 +39,7 @@ var _ = Describe("registrar", func() {
 		updateErr = registerManager.RegisterCluster(ctx, &cluster)
 		Expect(updateErr).Should(BeNil())
 		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
-		cluster = geCluster(*cluster.ID, db)
+		cluster = getClusterFromDB(*cluster.ID, db)
 		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("registrar", func() {
 			updateErr = registerManager.RegisterCluster(ctx, &cluster)
 			Expect(updateErr).Should(HaveOccurred())
 
-			cluster = geCluster(*cluster.ID, db)
+			cluster = getClusterFromDB(*cluster.ID, db)
 			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
 		})
 
@@ -58,7 +58,7 @@ var _ = Describe("registrar", func() {
 			updateErr = registerManager.RegisterCluster(ctx, &cluster)
 			Expect(updateErr).ShouldNot(HaveOccurred())
 
-			cluster = geCluster(*cluster.ID, db)
+			cluster = getClusterFromDB(*cluster.ID, db)
 			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
 
 			updateErr = registerManager.DeregisterCluster(ctx, &cluster)
@@ -69,7 +69,7 @@ var _ = Describe("registrar", func() {
 			updateErr = registerManager.RegisterCluster(ctx, &cluster)
 			Expect(updateErr).ShouldNot(HaveOccurred())
 
-			cluster = geCluster(*cluster.ID, db)
+			cluster = getClusterFromDB(*cluster.ID, db)
 			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
 		})
 	})
@@ -79,9 +79,10 @@ var _ = Describe("registrar", func() {
 			updateErr = registerManager.DeregisterCluster(ctx, &cluster)
 			Expect(updateErr).Should(BeNil())
 
-			Expect(db.Preload("Hosts").First(&cluster, "id = ?", cluster.ID).Error).Should(HaveOccurred())
+			_, err := common.GetClusterFromDB(db, *cluster.ID, common.UseEagerLoading)
+			Expect(err).Should(HaveOccurred())
 
-			Expect(db.First(&cluster, "id = ?", cluster.ID).Error).Should(HaveOccurred())
+			Expect(db.First(&common.Cluster{}, "id = ?", cluster.ID).Error).Should(HaveOccurred())
 			Expect(db.First(&host, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
 
 		})

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -946,7 +946,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -1395,7 +1395,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -1793,7 +1793,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -2297,7 +2297,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -2584,7 +2584,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -2933,7 +2933,7 @@ var _ = Describe("NTP refresh cluster", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -3288,7 +3288,7 @@ var _ = Describe("NTP refresh cluster", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -3595,7 +3595,7 @@ var _ = Describe("Single node", func() {
 					t.hosts[i].ClusterID = clusterId
 					Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 				}
-				cluster = getCluster(clusterId, db)
+				cluster = getClusterFromDB(clusterId, db)
 				if srcState != t.dstState {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -4246,7 +4246,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 				t.hosts[i].ClusterID = clusterId
 				Expect(db.Create(&t.hosts[i]).Error).ShouldNot(HaveOccurred())
 			}
-			cluster = getCluster(clusterId, db)
+			cluster = getClusterFromDB(clusterId, db)
 			if t.dstState == models.ClusterStatusInsufficient {
 				mockHostAPIIsRequireUserActionResetFalse()
 			}
@@ -4278,8 +4278,8 @@ var _ = Describe("Ocs Operator use-cases", func() {
 
 })
 
-func getCluster(clusterId strfmt.UUID, db *gorm.DB) common.Cluster {
-	var cluster common.Cluster
-	Expect(db.Preload("Hosts").First(&cluster, "id = ?", clusterId).Error).ShouldNot(HaveOccurred())
-	return cluster
+func getClusterFromDB(clusterId strfmt.UUID, db *gorm.DB) common.Cluster {
+	c, err := common.GetClusterFromDB(db, clusterId, common.UseEagerLoading)
+	Expect(err).ShouldNot(HaveOccurred())
+	return *c
 }

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -51,10 +51,9 @@ type validation struct {
 }
 
 func (c *clusterPreprocessContext) loadCluster() error {
-	var cluster common.Cluster
-	err := c.db.Preload("Hosts", "status <> ?", models.HostStatusDisabled).Take(&cluster, "id = ?", c.clusterId.String()).Error
+	cluster, err := common.GetClusterFromDBWithoutDisabledHosts(c.db, c.clusterId)
 	if err == nil {
-		c.cluster = &cluster
+		c.cluster = cluster
 	}
 	return err
 }

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -4,7 +4,9 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/jinzhu/gorm"
 	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
 )
 
 type Cluster struct {
@@ -33,4 +35,56 @@ type Cluster struct {
 
 	// The ID of the subscription created in AMS
 	AmsSubscriptionID strfmt.UUID `json:"ams_subscription_id"`
+}
+
+type EagerLoadingState bool
+
+const (
+	UseEagerLoading  EagerLoadingState = true
+	SkipEagerLoading EagerLoadingState = false
+)
+
+type DeleteRecordsState bool
+
+const (
+	IncludeDeletedRecords DeleteRecordsState = true
+	SkipDeletedRecords    DeleteRecordsState = false
+)
+
+func LoadHostsFromDB(db *gorm.DB, conditions ...interface{}) *gorm.DB {
+	return db.Preload("Hosts", conditions...)
+}
+
+func GetClusterFromDB(db *gorm.DB, clusterId strfmt.UUID, eagerLoading EagerLoadingState) (*Cluster, error) {
+	c, err := GetClusterFromDBWhere(db, eagerLoading, SkipDeletedRecords, "id = ?", clusterId.String())
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to get cluster %s", clusterId.String())
+	}
+
+	return c, nil
+}
+
+func GetClusterFromDBWithoutDisabledHosts(db *gorm.DB, clusterId strfmt.UUID) (*Cluster, error) {
+	db = LoadHostsFromDB(db, "status <> ?", models.HostStatusDisabled)
+	return GetClusterFromDB(db, clusterId, SkipEagerLoading)
+}
+
+func GetClusterFromDBWhere(db *gorm.DB, eagerLoading EagerLoadingState, includeDeleted DeleteRecordsState, where ...interface{}) (*Cluster, error) {
+	var cluster Cluster
+
+	if includeDeleted {
+		db = db.Unscoped()
+	}
+
+	if eagerLoading {
+		db = LoadHostsFromDB(db, func(db *gorm.DB) *gorm.DB {
+			if includeDeleted {
+				return db.Unscoped()
+			}
+			return db
+		})
+	}
+
+	err := db.Take(&cluster, where...).Error
+	return &cluster, err
 }

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -62,10 +62,9 @@ type validation struct {
 }
 
 func (c *validationContext) loadCluster() error {
-	var cluster common.Cluster
-	err := c.db.Preload("Hosts", "status <> ?", models.HostStatusDisabled).Take(&cluster, "id = ?", c.host.ClusterID.String()).Error
+	clusterFromDB, err := common.GetClusterFromDBWithoutDisabledHosts(c.db, c.host.ClusterID)
 	if err == nil {
-		c.cluster = &cluster
+		c.cluster = clusterFromDB
 	}
 	return err
 }

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -81,7 +81,7 @@ func getClusterFromDB(
 	cluster := &common.Cluster{}
 	start := time.Now()
 	for time.Duration(timeout)*time.Second > time.Since(start) {
-		err = db.Preload("Hosts").Take(&cluster, "kube_key_name = ? and kube_key_namespace = ?", key.Name, key.Namespace).Error
+		cluster, err = common.GetClusterFromDBWhere(db, common.UseEagerLoading, common.SkipDeletedRecords, "kube_key_name = ? and kube_key_namespace = ?", key.Name, key.Namespace)
 		if err == nil {
 			return cluster
 		}


### PR DESCRIPTION
Add functions
- `GetClusterFromDB`
- `GetClusterFromDBWithoutDisabledHosts`
- `GetClusterFromDBWhere`
- `LoadHostsFromDB`

Introducing two new boolean types to be used for queries:
- `EagerLoadingState` including `UseEagerLoading`, `SkipEagerLoading`
- `DeleteRecordsState` including `IncludeDeletedRecords`, `SkipDeletedRecords`