### PR TITLE
MGMT-4219: update cluster: skip cidr validations 

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1897,14 +1897,13 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 	}
 
 	var err error
-	*machineCidr, err = network.CalculateMachineNetworkCIDR(apiVip, ingressVip, cluster.Hosts)
+	err = verifyParsableVIPs(apiVip, ingressVip)
 	if err != nil {
-		log.WithError(err).Errorf("failed to calculate machine network cidr for cluster: %s", params.ClusterID)
-		return common.NewApiError(http.StatusBadRequest, err)
+		log.WithError(err).Errorf("Failed validating VIPs of cluster id=%s", params.ClusterID)
+		return err
 	}
-	setMachineNetworkCIDRForUpdate(updates, *machineCidr)
 
-	err = network.VerifyVips(cluster.Hosts, *machineCidr, apiVip, ingressVip, false, log)
+	err = network.VerifyDifferentVipAddresses(apiVip, ingressVip)
 	if err != nil {
 		log.WithError(err).Errorf("VIP verification failed for cluster: %s", params.ClusterID)
 		return common.NewApiError(http.StatusBadRequest, err)
@@ -1912,7 +1911,17 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 	return nil
 }
 
-func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interface{}, cluster *common.Cluster, params installer.UpdateClusterParams, log logrus.FieldLogger, machineCidr *string) error {
+func verifyParsableVIPs(apiVip string, ingressVip string) error {
+	if apiVip != "" && net.ParseIP(apiVip) == nil {
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("Could not parse VIP ip %s", apiVip))
+	}
+	if ingressVip != "" && net.ParseIP(ingressVip) == nil {
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("Could not parse VIP ip %s", ingressVip))
+	}
+	return nil
+}
+
+func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interface{}, params installer.UpdateClusterParams, log logrus.FieldLogger, machineCidr *string) error {
 	if params.ClusterUpdateParams.APIVip != nil {
 		err := errors.New("Setting API VIP is forbidden when cluster is in vip-dhcp-allocation mode")
 		log.WithError(err).Warnf("Set API VIP")
@@ -1929,7 +1938,7 @@ func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interfac
 		setMachineNetworkCIDRForUpdate(updates, *machineCidr)
 		updates["api_vip"] = ""
 		updates["ingress_vip"] = ""
-		return network.VerifyMachineCIDR(swag.StringValue(params.ClusterUpdateParams.MachineNetworkCidr), cluster.Hosts, log)
+		return network.VerifyMachineCIDR(swag.StringValue(params.ClusterUpdateParams.MachineNetworkCidr))
 	}
 	return nil
 }
@@ -2034,7 +2043,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 	}
 	if !userManagedNetworking {
 		if vipDhcpAllocation {
-			err = b.updateDhcpNetworkParams(updates, cluster, params, log, &machineCidr)
+			err = b.updateDhcpNetworkParams(updates, params, log, &machineCidr)
 		} else {
 			err = b.updateNonDhcpNetworkParams(updates, cluster, params, log, &machineCidr)
 		}

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -148,7 +148,7 @@ func (v *clusterValidator) isMachineCidrEqualsToCalculatedCidr(c *clusterPreproc
 	if c.cluster.APIVip == "" && c.cluster.IngressVip == "" {
 		return ValidationPending
 	}
-	cidr, err := network.CalculateMachineNetworkCIDR(c.cluster.APIVip, c.cluster.IngressVip, c.cluster.Hosts)
+	cidr, err := network.CalculateMachineNetworkCIDR(c.cluster.APIVip, c.cluster.IngressVip, c.cluster.Hosts, true)
 	c.calculateCidr = cidr
 	return boolValue(err == nil && cidr == c.cluster.MachineNetworkCidr)
 }

--- a/internal/network/machine_network_cidr_test.go
+++ b/internal/network/machine_network_cidr_test.go
@@ -68,7 +68,7 @@ var _ = Describe("inventory", func() {
 			cluster := createCluster("1.2.5.6", "",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(cidr).To(Equal("1.2.4.0/23"))
 		})
@@ -78,7 +78,7 @@ var _ = Describe("inventory", func() {
 				createInventory(addIPv6Addresses(createInterface(), "1001:db8::1/120")),
 				createInventory(addIPv6Addresses(createInterface(), "1001:db8::2/120")),
 				createInventory(addIPv6Addresses(createInterface(), "1001:db8::3/120")))
-			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(cidr).To(Equal("1001:db8::/120"))
 		})
@@ -87,7 +87,7 @@ var _ = Describe("inventory", func() {
 			cluster := createDisabledCluster("1.2.5.6", "",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			_, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			_, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -95,7 +95,7 @@ var _ = Describe("inventory", func() {
 			cluster := createCluster("1.2.5.257", "",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(HaveOccurred())
 			Expect(cidr).To(Equal(""))
 		})
@@ -104,7 +104,7 @@ var _ = Describe("inventory", func() {
 			cluster := createCluster("1.2.5.200", "",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.6.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(HaveOccurred())
 			Expect(cidr).To(Equal(""))
 		})
@@ -113,9 +113,17 @@ var _ = Describe("inventory", func() {
 				"Bad inventory",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts)
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, true)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(cidr).To(Equal("1.2.4.0/23"))
+		})
+		It("No Match - no match required", func() {
+			cluster := createCluster("1.2.5.200", "",
+				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.6.7/23")),
+				createInventory(createInterface("127.0.0.1/17")))
+			cidr, err := CalculateMachineNetworkCIDR(cluster.APIVip, cluster.IngressVip, cluster.Hosts, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cidr).To(Equal(""))
 		})
 	})
 	Context("GetMachineCIDRHosts", func() {

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -527,7 +527,7 @@ var _ = Describe("Metrics tests", func() {
 			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDBelongsToMachineCidr)
 
 			// create a validation failure
-			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.2.2/24")}).Error
+			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("")}).Error
 			Expect(err).NotTo(HaveOccurred())
 			// machine-cidr doesn't change after it is set
 			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDBelongsToMachineCidr)
@@ -549,9 +549,9 @@ var _ = Describe("Metrics tests", func() {
 			err := db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.3.4/24")}).Error
 			Expect(err).NotTo(HaveOccurred())
 			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDBelongsToMachineCidr)
-			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("1.2.2.2/24")}).Error
+			err = db.Model(h).UpdateColumns(&models.Host{Inventory: generateValidInventoryWithInterface("")}).Error
 			Expect(err).NotTo(HaveOccurred())
-			// machine-cidr doesn't change after it is set
+			// machine-cidr removed after the network interface was deleted
 			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDBelongsToMachineCidr)
 
 			// create a validation success

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	defaultWaitForHostStateTimeout    = 20 * time.Second
-	defaultWaitForClusterStateTimeout = 40 * time.Second
+	defaultWaitForHostStateTimeout          = 20 * time.Second
+	defaultWaitForClusterStateTimeout       = 40 * time.Second
+	defaultWaitForMachineNetworkCIDRTimeout = 40 * time.Second
 )
 
 func clearDB() {


### PR DESCRIPTION
Cluster update should not validate that machine network cidr belong to once of the host.
Those network validations are done as part of the async validations anyway