### PR TITLE
MGMT-4066 Add enabled operator CPU and memory requirements to host validation

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -838,7 +838,7 @@ func (m *Manager) GenerateAdditionalManifests(ctx context.Context, cluster *comm
 		}
 	}
 
-	if err := m.rp.operatorsApi.GenerateManifests(ctx, cluster); err != nil {
+	if err := m.rp.operatorsAPI.GenerateManifests(ctx, cluster); err != nil {
 		return errors.Wrap(err, "failed to add operator manifests")
 	}
 	return nil

--- a/internal/cluster/refresh_status_preprocessor.go
+++ b/internal/cluster/refresh_status_preprocessor.go
@@ -27,15 +27,15 @@ type refreshPreprocessor struct {
 	log          logrus.FieldLogger
 	validations  []validation
 	conditions   []condition
-	operatorsApi operators.API
+	operatorsAPI operators.API
 }
 
-func newRefreshPreprocessor(log logrus.FieldLogger, hostAPI host.API, operatorsApi operators.API) *refreshPreprocessor {
+func newRefreshPreprocessor(log logrus.FieldLogger, hostAPI host.API, operatorsAPI operators.API) *refreshPreprocessor {
 	return &refreshPreprocessor{
 		log:          log,
 		validations:  newValidations(log, hostAPI),
 		conditions:   newConditions(),
-		operatorsApi: operatorsApi,
+		operatorsAPI: operatorsAPI,
 	}
 }
 
@@ -65,7 +65,7 @@ func (r *refreshPreprocessor) preprocess(ctx context.Context, c *clusterPreproce
 		})
 	}
 	// Validate operators
-	results, err := r.operatorsApi.ValidateCluster(ctx, c.cluster)
+	results, err := r.operatorsAPI.ValidateCluster(ctx, c.cluster)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -305,9 +305,9 @@ func (v *clusterValidator) sufficientMastersCount(c *clusterPreprocessContext) v
 	}
 
 	hosts := make([]*models.Host, 0)
-	for k, v := range MapHostsByStatus(c.cluster) {
+	for k, h := range MapHostsByStatus(c.cluster) {
 		if k != models.HostStatusDisabled {
-			hosts = append(hosts, v...)
+			hosts = append(hosts, h...)
 		}
 	}
 	masters := make([]*models.Host, 0)

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -93,7 +93,7 @@ var _ = Describe("hardware_validator", func() {
 		host3 = &models.Host{ID: &id3, ClusterID: clusterID, Status: &status, RequestedHostname: "reqhostname3"}
 		inventory = &models.Inventory{
 			CPU:    &models.CPU{Count: 16},
-			Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+			Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB), UsableBytes: int64(32 * units.GiB)},
 			Interfaces: []*models.Interface{
 				{
 					IPV4Addresses: []string{

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -95,7 +95,7 @@ func GenerateMasterInventoryWithHostname(hostname string) string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16)},
+		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16), UsableBytes: hardware.GibToBytes(16)},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
@@ -122,7 +122,34 @@ func GenerateMasterInventoryWithHostnameV6(hostname string) string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16)},
+		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16), UsableBytes: hardware.GibToBytes(16)},
+		Hostname:     hostname,
+		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
+		Timestamp:    1601835002,
+	}
+	b, err := json.Marshal(&inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
+func GenerateInventoryWithResources(cpu, memory int64, hostname string) string {
+	inventory := models.Inventory{
+		CPU: &models.CPU{Count: cpu},
+		Disks: []*models.Disk{
+			{
+				SizeBytes: 128849018880,
+				DriveType: "HDD",
+			},
+		},
+		Interfaces: []*models.Interface{
+			{
+				Name: "eth0",
+				IPV4Addresses: []string{
+					"1.2.3.4/24",
+				},
+			},
+		},
+		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(memory), UsableBytes: hardware.GibToBytes(memory)},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -59,6 +59,8 @@ var _ = Describe("monitor_disconnection", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 		}, nil)
+		mockOperators.EXPECT().GetCPURequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockOperators.EXPECT().GetMemoryRequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -151,6 +153,8 @@ var _ = Describe("TestHostMonitoring", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 		}, nil)
+		mockOperators.EXPECT().GetCPURequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockOperators.EXPECT().GetMemoryRequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -27,7 +27,7 @@ type refreshPreprocessor struct {
 func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator, operatorsApi operators.API) *refreshPreprocessor {
 	return &refreshPreprocessor{
 		log:          log,
-		validations:  newValidations(log, hwValidatorCfg, hwValidator),
+		validations:  newValidations(log, hwValidatorCfg, hwValidator, operatorsApi),
 		operatorsApi: operatorsApi,
 	}
 }
@@ -77,11 +77,12 @@ func (r *refreshPreprocessor) preprocess(c *validationContext) (map[validationID
 	return stateMachineInput, validationsOutput, nil
 }
 
-func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator) []validation {
+func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator, operatorsAPI operators.API) []validation {
 	v := validator{
 		log:            log,
 		hwValidatorCfg: hwValidatorCfg,
 		hwValidator:    hwValidator,
+		operatorsAPI:   operatorsAPI,
 	}
 	ret := []validation{
 		{
@@ -116,8 +117,8 @@ func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCf
 		},
 		{
 			id:        HasCPUCoresForRole,
-			condition: v.hasCpuCoresForRole,
-			formatter: v.printHasCpuCoresForRole,
+			condition: v.hasCPUCoresForRole,
+			formatter: v.printHasCPUCoresForRole,
 		},
 		{
 			id:        HasMemoryForRole,

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -35,19 +35,19 @@ type Operator interface {
 	// ValidateCluster verifies whether this operator is valid for given cluster
 	ValidateCluster(ctx context.Context, cluster *common.Cluster) (ValidationResult, error)
 	// ValidateHost verifies whether this operator is valid for given host
-	ValidateHost(context.Context, *common.Cluster, *models.Host) (ValidationResult, error)
+	ValidateHost(ctx context.Context, cluster *common.Cluster, hosts *models.Host) (ValidationResult, error)
 	// GenerateManifests generates manifests for the operator
 	GenerateManifests(*common.Cluster) (map[string][]byte, error)
 	// GetCPURequirementForWorker provides worker CPU requirements for the operator
-	GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error)
+	GetCPURequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetCPURequirementForMaster provides master CPU requirements for the operator
-	GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error)
+	GetCPURequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
 	GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetMemoryRequirementForMaster provides master memory requirements for the operator in MB
 	GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetDisksRequirementForMaster provides a number of disks required in a master
-	GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error)
+	GetDisksRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetDisksRequirementForWorker provides a number of disks required in a worker
 	GetDisksRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
 	// GetClusterValidationID returns cluster validation ID for the Operator

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -60,7 +60,7 @@ func (o *operator) GetHostValidationID() string {
 }
 
 // ValidateCluster always return "valid" result
-func (o *operator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+func (o *operator) ValidateCluster(_ context.Context, _ *common.Cluster) (api.ValidationResult, error) {
 	// No need to validate cluster because it will be validate on per host basis
 	return api.ValidationResult{Status: api.Success, ValidationId: o.GetClusterValidationID()}, nil
 }
@@ -100,22 +100,22 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 }
 
 // GetCPURequirementForWorker provides worker CPU requirements for the operator
-func (o *operator) GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (o *operator) GetCPURequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return workerCPU, nil
 }
 
 // GetCPURequirementForMaster provides master CPU requirements for the operator
-func (o *operator) GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (o *operator) GetCPURequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return masterCPU, nil
 }
 
 // GetMemoryRequirementForWorker provides worker memory requirements for the operator
-func (o *operator) GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error) {
+func (o *operator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return hardware.MibToBytes(workerMemory), nil
 }
 
 // GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (o *operator) GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error) {
+func (o *operator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return hardware.MibToBytes(masterMemory), nil
 }
 
@@ -125,12 +125,12 @@ func (o *operator) GenerateManifests(c *common.Cluster) (map[string][]byte, erro
 }
 
 // GetDisksRequirementForMaster provides a number of disks required in a master
-func (o *operator) GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (o *operator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetDisksRequirementForWorker provides a number of disks required in a worker
-func (o *operator) GetDisksRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (o *operator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -44,32 +44,32 @@ func (l *lsOperator) GetHostValidationID() string {
 }
 
 // ValidateCluster always return "valid" result
-func (l *lsOperator) ValidateCluster(ctx context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+func (l *lsOperator) ValidateCluster(_ context.Context, _ *common.Cluster) (api.ValidationResult, error) {
 	return api.ValidationResult{Status: api.Success, ValidationId: l.GetClusterValidationID(), Reasons: []string{}}, nil
 }
 
 // ValidateHost always return "valid" result
-func (l *lsOperator) ValidateHost(context.Context, *common.Cluster, *models.Host) (api.ValidationResult, error) {
+func (l *lsOperator) ValidateHost(_ context.Context, _ *common.Cluster, _ *models.Host) (api.ValidationResult, error) {
 	return api.ValidationResult{Status: api.Success, ValidationId: l.GetHostValidationID(), Reasons: []string{}}, nil
 }
 
 // GetCPURequirementForWorker provides worker CPU requirements for the operator
-func (l *lsOperator) GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetCPURequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetCPURequirementForMaster provides master CPU requirements for the operator
-func (l *lsOperator) GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetCPURequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetMemoryRequirementForWorker provides worker memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
@@ -79,12 +79,12 @@ func (l *lsOperator) GenerateManifests(c *common.Cluster) (map[string][]byte, er
 }
 
 // GetDisksRequirementForMaster provides a number of disks required in a master
-func (l *lsOperator) GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetDisksRequirementForWorker provides a number of disks required in a worker
-func (l *lsOperator) GetDisksRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (l *lsOperator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 1, nil
 }
 

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -49,6 +49,10 @@ type API interface {
 	GetSupportedOperators() []string
 	// GetOperatorProperties provides description of properties of an operator
 	GetOperatorProperties(operatorName string) (models.OperatorProperties, error)
+	// GetCPURequirementForWorker provides worker CPU requirements for the operator
+	GetCPURequirementForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (int64, error)
+	// GetMemoryRequirementForWorker provides worker memory requirements for the operator in Bytes
+	GetMemoryRequirementForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (int64, error)
 }
 
 // GenerateManifests generates manifests for all enabled operators.
@@ -129,9 +133,9 @@ func (mgr *Manager) ValidateHost(ctx context.Context, cluster *common.Cluster, h
 
 	// To track operators that are disabled or not present in the cluster configuration, but have to be present
 	// in the validation results and marked as valid.
-	pendingOperators := make(map[string]bool)
+	pendingOperators := make(map[string]struct{})
 	for k := range mgr.olmOperators {
-		pendingOperators[k] = true
+		pendingOperators[k] = struct{}{}
 	}
 
 	for _, clusterOperator := range cluster.MonitoredOperators {
@@ -176,9 +180,9 @@ func (mgr *Manager) ValidateCluster(ctx context.Context, cluster *common.Cluster
 
 	results := make([]api.ValidationResult, 0, len(mgr.olmOperators))
 
-	pendingOperators := make(map[string]bool)
+	pendingOperators := make(map[string]struct{})
 	for k := range mgr.olmOperators {
-		pendingOperators[k] = true
+		pendingOperators[k] = struct{}{}
 	}
 
 	for _, clusterOperator := range cluster.MonitoredOperators {
@@ -333,4 +337,112 @@ func (mgr *Manager) GetSupportedOperatorsByType(operatorType models.OperatorType
 	}
 
 	return operators
+}
+
+// GetMemoryRequirementForRole returns the amount of usable memory required in Bytes in the host to be able to install all the enabled operators and their dependencies.
+// The value is determined by the sum of each of the enabled operators.
+func (mgr *Manager) GetMemoryRequirementForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (int64, error) {
+	switch role {
+	case models.HostRoleMaster:
+		m, err := mgr.getMemoryRequirementForMaster(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		return m, nil
+	case models.HostRoleWorker:
+		m, err := mgr.getMemoryRequirementForWorker(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		return m, nil
+	default:
+		return 0, nil
+
+	}
+}
+
+func (mgr *Manager) getMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error) {
+
+	var t int64
+	for _, o := range cluster.MonitoredOperators {
+		if o.OperatorType != models.OperatorTypeOlm {
+			continue
+		}
+		m, err := mgr.olmOperators[o.Name].GetMemoryRequirementForMaster(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		t += m
+	}
+	return t, nil
+}
+
+func (mgr *Manager) getMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error) {
+
+	var t int64
+	for _, o := range cluster.MonitoredOperators {
+		if o.OperatorType != models.OperatorTypeOlm {
+			continue
+		}
+		m, err := mgr.olmOperators[o.Name].GetMemoryRequirementForWorker(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		t += m
+	}
+	return t, nil
+}
+
+// GetCPURequirementForRole returns the CPU core count available the host must have to install all the enabled operators and their dependencies.
+// The value is determined by the sum of each of the enabled operators.
+func (mgr *Manager) GetCPURequirementForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (int64, error) {
+
+	switch role {
+	case models.HostRoleMaster:
+		m, err := mgr.getCPURequirementForMaster(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		return m, nil
+	case models.HostRoleWorker:
+		m, err := mgr.getCPURequirementForWorker(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		return m, nil
+	default:
+		return 0, nil
+	}
+}
+
+func (mgr *Manager) getCPURequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error) {
+
+	var t int64
+	for _, o := range cluster.MonitoredOperators {
+		if o.OperatorType != models.OperatorTypeOlm {
+			continue
+		}
+		m, err := mgr.olmOperators[o.Name].GetCPURequirementForMaster(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		t += m
+	}
+	return t, nil
+}
+
+func (mgr *Manager) getCPURequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error) {
+
+	var t int64
+	for _, o := range cluster.MonitoredOperators {
+		if o.OperatorType != models.OperatorTypeOlm {
+			continue
+		}
+		m, err := mgr.olmOperators[o.Name].GetCPURequirementForWorker(ctx, cluster)
+		if err != nil {
+			return 0, err
+		}
+		t += m
+	}
+	return t, nil
 }

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -64,6 +64,36 @@ func (mr *MockAPIMockRecorder) GenerateManifests(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifests", reflect.TypeOf((*MockAPI)(nil).GenerateManifests), arg0, arg1)
 }
 
+// GetCPURequirementForRole mocks base method
+func (m *MockAPI) GetCPURequirementForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCPURequirementForRole", arg0, arg1, arg2)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCPURequirementForRole indicates an expected call of GetCPURequirementForRole
+func (mr *MockAPIMockRecorder) GetCPURequirementForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPURequirementForRole", reflect.TypeOf((*MockAPI)(nil).GetCPURequirementForRole), arg0, arg1, arg2)
+}
+
+// GetMemoryRequirementForRole mocks base method
+func (m *MockAPI) GetMemoryRequirementForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemoryRequirementForRole", arg0, arg1, arg2)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMemoryRequirementForRole indicates an expected call of GetMemoryRequirementForRole
+func (mr *MockAPIMockRecorder) GetMemoryRequirementForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemoryRequirementForRole", reflect.TypeOf((*MockAPI)(nil).GetMemoryRequirementForRole), arg0, arg1, arg2)
+}
+
 // GetMonitoredOperatorsList mocks base method
 func (m *MockAPI) GetMonitoredOperatorsList() map[string]*models.MonitoredOperator {
 	m.ctrl.T.Helper()

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -72,7 +72,7 @@ func (o *ocsOperator) ValidateCluster(_ context.Context, cluster *common.Cluster
 }
 
 // ValidateHost verifies whether this operator is valid for given host
-func (o *ocsOperator) ValidateHost(context.Context, *common.Cluster, *models.Host) (api.ValidationResult, error) {
+func (o *ocsOperator) ValidateHost(_ context.Context, _ *common.Cluster, _ *models.Host) (api.ValidationResult, error) {
 	return api.ValidationResult{Status: api.Success, ValidationId: o.GetHostValidationID(), Reasons: []string{}}, nil
 }
 
@@ -83,32 +83,32 @@ func (o *ocsOperator) GenerateManifests(cluster *common.Cluster) (map[string][]b
 }
 
 // GetCPURequirementForWorker provides worker CPU requirements for the operator
-func (o *ocsOperator) GetCPURequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetCPURequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetCPURequirementForMaster provides master CPU requirements for the operator
-func (o *ocsOperator) GetCPURequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetCPURequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
-func (o *ocsOperator) GetMemoryRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (o *ocsOperator) GetMemoryRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetDisksRequirementForMaster provides a number of disks required in a master
-func (o *ocsOperator) GetDisksRequirementForMaster(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 
 // GetDisksRequirementForWorker provides a number of disks required in a worker
-func (o *ocsOperator) GetDisksRequirementForWorker(context.Context, *common.Cluster) (int64, error) {
+func (o *ocsOperator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
 	return 0, nil
 }
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -55,7 +55,7 @@ const (
 var (
 	validWorkerHwInfo = &models.Inventory{
 		CPU:    &models.CPU{Count: 2},
-		Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB)},
+		Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB), UsableBytes: int64(8 * units.GiB)},
 		Disks: []*models.Disk{
 			{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
 			{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
@@ -67,7 +67,7 @@ var (
 	}
 	validHwInfo = &models.Inventory{
 		CPU:    &models.CPU{Count: 16},
-		Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+		Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB), UsableBytes: int64(32 * units.GiB)},
 		Disks: []*models.Disk{
 			{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
 			{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},
@@ -2452,7 +2452,7 @@ var _ = Describe("cluster install", func() {
 		By("set host with log hw info for master")
 		hwInfo := &models.Inventory{
 			CPU:    &models.CPU{Count: 2},
-			Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB)},
+			Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB), UsableBytes: int64(8 * units.GiB)},
 			Disks: []*models.Disk{
 				{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize},
 			},

--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Host tests", func() {
 			},
 			Memory: &models.Memory{
 				PhysicalBytes: int64(16) * (int64(1) << 30),
+				UsableBytes:   int64(16) * (int64(1) << 30),
 			},
 			SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 			Timestamp:    1601845851,

--- a/subsystem/ipv6_test.go
+++ b/subsystem/ipv6_test.go
@@ -18,7 +18,7 @@ import (
 var (
 	validHwInfoV6 = &models.Inventory{
 		CPU:    &models.CPU{Count: 16},
-		Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB)},
+		Memory: &models.Memory{PhysicalBytes: int64(32 * units.GiB), UsableBytes: int64(32 * units.GiB)},
 		Disks: []*models.Disk{
 			{DriveType: "SSD", Name: "loop0", SizeBytes: validDiskSize},
 			{DriveType: "HDD", Name: "sdb", SizeBytes: validDiskSize}},

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -188,7 +188,7 @@ func generateValidInventoryWithInterface(networkInterface string) string {
 
 	inventory := models.Inventory{
 		CPU:          &models.CPU{Count: 4},
-		Memory:       &models.Memory{PhysicalBytes: int64(16 * units.GiB)},
+		Memory:       &models.Memory{PhysicalBytes: int64(16 * units.GiB), UsableBytes: int64(16 * units.GiB)},
 		Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Interfaces:   []*models.Interface{{IPV4Addresses: []string{networkInterface}}},
@@ -331,7 +331,7 @@ var _ = Describe("Metrics tests", func() {
 			// create a validation failure
 			nonValidInventory := &models.Inventory{
 				CPU:          &models.CPU{Count: 1},
-				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB), UsableBytes: int64(4 * units.GiB)},
 				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
 				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
@@ -373,7 +373,7 @@ var _ = Describe("Metrics tests", func() {
 			h := &registerHost(clusterID).Host
 			nonValidInventory := &models.Inventory{
 				CPU:          &models.CPU{Count: 1},
-				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB)},
+				Memory:       &models.Memory{PhysicalBytes: int64(4 * units.GiB), UsableBytes: int64(4 * units.GiB)},
 				Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
 				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},


### PR DESCRIPTION
This PR updates the CPU and memory validations for the host to add the resources request for the enabled operators to check that the cluster's CPU and usable memory are sufficient to deploy the selected operators (LSO, CNV or OCS) in that node.

@machacekondra @masayag @pkliczewski @jakub-dzon @gamli75 can you take a look in the meanwhile?

/Jordi
