### PR TITLE
MGMT-4072: Remove coreos-installer dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,17 +277,9 @@ podman-pull-service-from-docker-daemon:
 deploy-onprem:
 	# Format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
 	podman pod create --name assisted-installer -p 5432:5432,8000:8000,8090:8090,8080:8080
-	# These are required because when running on RHCOS livecd, the coreos-installer binary and
-	# livecd are bind-mounted from the host into the assisted-service container at runtime.
-	[ -f livecd.iso ] || ./hack/retry.sh 5 1 "curl $(RHCOS_BASE_ISO) -o livecd.iso"
-	[ -f coreos-installer ] || podman run --privileged --pull=always -it --rm \
-		-v .:/data -w /data --entrypoint /bin/bash \
-		quay.io/coreos/coreos-installer:v0.7.0 -c 'cp /usr/sbin/coreos-installer /data/coreos-installer'
 	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always --name db quay.io/ocpmetal/postgresql-12-centos7
 	podman run -dt --pod assisted-installer --env-file onprem-environment --pull always -v $(PWD)/deploy/ui/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest
 	podman run -dt --pod assisted-installer --env-file onprem-environment ${PODMAN_PULL_FLAG} --env DUMMY_IGNITION=$(DUMMY_IGNITION) \
-		-v ./livecd.iso:/data/livecd.iso:z \
-		-v ./coreos-installer:/data/coreos-installer:z \
 		--restart always --name installer $(SERVICE)
 	./hack/retry.sh 90 2 "curl http://127.0.0.1:8090/ready"
 
@@ -408,8 +400,6 @@ clear-images:
 
 clean-onprem:
 	podman pod rm -f assisted-installer || true
-	rm livecd.iso || true
-	rm coreos-installer || true
 
 delete-minikube-profile:
 	minikube delete -p $(PROFILE)

--- a/docs/installer-stand-alone.md
+++ b/docs/installer-stand-alone.md
@@ -11,35 +11,6 @@ stand-alone mode via `podman`.
 You will need a valid OpenShift user pull secret. Copy or download the pull
 secret from https://cloud.redhat.com/openshift/install/pull-secret
 
-## Download CoreOS Installer
-
-This is used by the assisted-service to generate the discovery ISO. You can grab
-it from a released container image by:
-
-```
-podman run --privileged --pull=always -it --rm \
-  -v .:/data --entrypoint /bin/cp \
-  quay.io/coreos/coreos-installer:v0.7.0 /usr/sbin/coreos-installer /data/coreos-installer
-```
-
-## Download RHCOS Live ISO
-
-The RHCOS Live ISO is used as the base when building discovery ISOs. These
-images can be found at https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos
-Later on, in this document, you will see it referred to as `livecd.iso`.
-
-To pull the latest RHCOS Live ISO for OpenShift 4.6 and save it as `livecd.iso`.
-
-```
-curl https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/latest/rhcos-live.x86_64.iso -o livecd.iso
-```
-
-**NOTE** 
-The RHCOS images might not change with every release of OpenShift Container Platform.
-You must download images with the highest version that is less than or equal to the
-OpenShift Container Platform version that you install. Use the image versions that
-match your OpenShift Container Platform version if they are available.
-
 # Running the Assisted Installer using Podman
 
 ## Environment
@@ -114,18 +85,12 @@ podman run -dt --pod assisted-installer \
   --name installer \
   --env-file onprem-environment \
   --pull always \
-  -v ${PWD}/livecd.iso:/data/livecd.iso:z \
-  -v ${PWD}/coreos-installer:/data/coreos-installer:z \
   --restart always \
   quay.io/ocpmetal/assisted-service:latest /assisted-service
 ```
 
 **NOTE**
 * `onprem-environment` is the file downloaded and modified previously
-* `$(PWD)/livecd.iso` should be updated to reflect the RHCOS Live ISO previously
-    downloaded.
-* `$(PWD)/coreos-installer` is referencing the coreos-installer binary
-    previously downloaded.
 * If you modified the port for `SERVICE_BASE_URL` you would add `--port ${SERVICE_API_PORT}`
 
 ## Start Assisted Installer UI

--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -29,14 +29,17 @@ Environment=HTTP_PROXY={{.HTTP_PROXY}}
 Environment=HTTPS_PROXY={{.HTTPS_PROXY}}
 Environment=NO_PROXY={{.NO_PROXY}}`
 
-const RamDiskPaddingLength = uint64(1024 * 1024) // 1MB
-const IgnitionPaddingLength = uint64(256 * 1024) // 256KB
-
-const ignitionImagePath = "/images/ignition.img"
-const ramDiskImagePath = "/images/assisted_installer_custom.img"
-const ignitionHeaderKey = "coreiso+"
-const ramdiskHeaderKey = "ramdisk+"
-const headerLength = int64(32768) // first 32KB in ISO
+const (
+	RamDiskPaddingLength  = uint64(1024 * 1024) // 1MB
+	IgnitionPaddingLength = uint64(256 * 1024)  // 256KB
+	ignitionImagePath     = "/images/ignition.img"
+	ramDiskImagePath      = "/images/assisted_installer_custom.img"
+	ignitionHeaderKey     = "coreiso+"
+	ramdiskHeaderKey      = "ramdisk+"
+	isoSystemAreaSize     = 32768
+	ignitionHeaderSize    = 24
+	headerLength          = int64(32768) // first 32KB in ISO
+)
 
 type ClusterProxyInfo struct {
 	HTTPProxy  string
@@ -403,6 +406,8 @@ func writeAt(b []byte, offset int64, clusterISOPath string) error {
 	return nil
 }
 
+// IgnitionImageArchive takes an ignitionConfig and returns a gzipped CPIO
+// archive (in bytes) or err on failure.
 func IgnitionImageArchive(ignitionConfig string) ([]byte, error) {
 	ignitionBytes := []byte(ignitionConfig)
 
@@ -556,4 +561,51 @@ func ParseOffsetInfo(headerBytes []byte) (*OffsetInfo, error) {
 		return nil, err
 	}
 	return offsetInfo, nil
+}
+
+func EmbedIgnition(inputISOPath, outputISOPath, ignitionConfig string) error {
+	coreosIgnitionHeader := make([]byte, ignitionHeaderSize)
+
+	inputISO, err := os.Open(inputISOPath)
+	if err != nil {
+		return err
+	}
+	defer inputISO.Close()
+
+	// Reading the last 24 bytes at the end of the system area)
+	if _, err = inputISO.ReadAt(coreosIgnitionHeader, isoSystemAreaSize-ignitionHeaderSize); err != nil {
+		return err
+	}
+	ignitionOffsetInfo, err := GetIgnitionArea(coreosIgnitionHeader)
+	if err != nil {
+		return err
+	}
+
+	cpio, err := IgnitionImageArchive(ignitionConfig)
+	if err != nil {
+		return err
+	}
+
+	if uint64(len(cpio)) > ignitionOffsetInfo.Length {
+		return errors.Errorf("Compressed Ignition config is too large: %v > %v", len(cpio), int(ignitionOffsetInfo.Length))
+	}
+
+	resultISO, err := os.Create(outputISOPath)
+	if err != nil {
+		return err
+	}
+	defer resultISO.Close()
+
+	if _, err = io.Copy(resultISO, inputISO); err != nil {
+		return err
+	}
+
+	// clear out the embed area
+	embedArea := make([]byte, ignitionOffsetInfo.Length)
+	copy(embedArea, cpio)
+	if _, err = resultISO.WriteAt(embedArea, int64(ignitionOffsetInfo.Offset)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -1,13 +1,11 @@
 package s3wrapper
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -86,19 +84,7 @@ func (f *FSClient) UploadISO(ctx context.Context, ignitionConfig, srcObject, des
 		return err
 	}
 
-	installerCommand := filepath.Join(f.basedir, "coreos-installer")
-	cmd := exec.Command(installerCommand, "iso", "ignition", "embed", "-o", resultFile, baseFile, "-f")
-	var out bytes.Buffer
-	cmd.Stdin = strings.NewReader(ignitionConfig)
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err = cmd.Run()
-	if err != nil {
-		err = errors.Wrapf(err, "coreos-installer failed: %s", out.String())
-		log.Error(err)
-		return err
-	}
-	return nil
+	return isoeditor.EmbedIgnition(baseFile, resultFile, ignitionConfig)
 }
 
 func (f *FSClient) UploadStream(ctx context.Context, reader io.Reader, objectName string) error {


### PR DESCRIPTION
With this change we should be able to embed ignition configurations into
ISOs without using the coreos-installer binary directly.