### PR TITLE
MGMT-4184: Use the full version during the deployment

### DIFF
--- a/config/onprem-iso-config.ign
+++ b/config/onprem-iso-config.ign
@@ -29,7 +29,7 @@
         "path": "/etc/assisted-service/environment",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/7SQ326bMBjF73kMrosxlCYMiQuaeClSFpjtdNqV5YGTWALs2SRqVPXdJzd/lkmTpmnaBZLP+cw5n391RegCI/J5yeYFLR4LgnI52JF3nTDezbQuCPlS4XnO214Ot5M1Qfjszh/ZU0VoHsVTAAEEkXPqCtP8IbmPnfj1sgv9qVbFp9tygvBzOUPM7cTWeJnvxlHbLAy5tdKOog24lqBTDe+A0mKwO7kZgVRZmiT33hzVy+orowVeIJqrQRvRe4RWuFigfCM7YY92dNa5ZVawGcKU1QV9ysOWjzwctnJ4CazoNlZuB9GCxoxeVaMVeSo/UvaMMCmrFclf/QRM/OzVb6XVHT+ygffCz5wLotS/843oBLeCyZ5v3eD7nh+BVOF16+B8I2jFIVSNvujsFBG8pBM2SVzSrlH2mnMB0ktjlLmB0Kg+1PtvNwWHJGyFFkMrhkYKG74HhQmYuA+kJx28n89tQScPApzOQFp1bT8IY6Ua3AMnII1BDGMYxfAhSmMYQP/Ot3utlRlZJw6i8zNfG9Xum9H983bnJ2D6W1ZTAP8R1RTA/0ZKG3FpCk9NpgHxFdvF+At2U5DeO3YRjOEHCJPkj+zevHr9uCxnbFataFGuEGYYLUpCcYlIfibl/QgAAP//XoZweNIDAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/7SQ326bMBjF73kMrosxlCYMiQuaeClSFpjtdNqV5YGTWALs2SRqVPXdJzd/lkmTpmnaBZK/c8w5n391RegCI/J5yeYFLR4LgnI52JF3nTDejVsXhHyp8DznbS+HW2dNED6r80f2VBGaR/EUQABB5JS6wjR/SO5jN/x62YX+nFbFp9tygvBzOUPM7cTWeJnvxlHbLAy5tdKOog24lqBTDe+A0mKwO7kZgVRZmiT33hzVy+orowVeIJqrQRvRe4RWuFigfCM7YY92dNK5ZVawGcKU1QV9ysOWjzwctnJ4CazoNlZuB9GCxoxeVaMVeSo/UvaMMCmrFclf/QRMQJT62avfSqs7fmQD74WfXYw734hOcCuY7PnWGd/3/AikCq+LB+cbQSsOoWr0Zc5OEcFLOmGTxCXtGmWvORcmvTRGmRsOjepDvf92U3BIwlZoMbRiaKSw4XtQmICJ+0B6moP387kt6ORBgNMZSKuu7QdhrFSDe+AEpDGIYQyjGD5EaQwD6N/5dq+1MiPrxEF0fuZro9p9M7p/3u78BEwB/C0tp/8brCmA/42VNuLSFJ6aTAPiK7iL8Bf0piC9d/QiGMMPECbJH+m9efX6cVnO2Kxa0aJcIcwwWpSE4hKR/EzK+xEAAP//KS9njdcDAAA="
         },
         "mode": 420
       },
@@ -52,7 +52,7 @@
         "path": "/etc/assisted-service/startup_script.sh",
         "contents": {
           "compression": "gzip",
-          "source": "data:;base64,H4sIAAAAAAAC/0SOwUorQRBF9/0V9/VLiIKT/oGZoEgWsxMDbowknZmaTEFS3XQ1QVD/XXoUU5u7KDjn/P/nDizu4HU0HLWZ3YxBs/gzoWpvTSLfo0qoPDg+pIS6rmFnHNWaISRwBAvs7GP6vt6/fVkDAH3AtOViYskD7FbmCq/KmqmvfOTlKXT+tAyRREce8pLDVuyEt1it4Ch3ruToL1OoNO46bfbUjQGlA5949+lYVqlHRViog7tzx8XeXNWb9fNL+7jetU+bZq4/kkK6iv7KlNKFO3IkF05BziTZfAcAAP//9XIuQCcBAAA="
+          "source": "data:;base64,H4sIAAAAAAAC/0SOwUorQRBF9/0V9/VLiIKT/oGZoEgWsxMDbowknZmaTEFS3XQ1QVD/XXoUU5u7KDjn/P/nDizu4HU0HLWZ3YxBs/gzoWpvTSLfo0qoPDg+pIS6rmFnHNWaISRwBAvs7GP6vt6/fVkDAH2YplxMLHmA3cpc4VVZM/WVj7w8hc6fliGS6MhDXnLYip3oFqsVHOXOlRr9RQqVxF2nzZ66MaBk4BPvPh3LKvWoCAt1cHfuuNibq3qzfn5pH9e79mnTzPVHUkhX0V+ZUrpwR47kwinImSSb7wAAAP//AKg6oiYBAAA="
         },
         "mode": 420
       }

--- a/config/onprem-iso-fcc.yaml
+++ b/config/onprem-iso-fcc.yaml
@@ -26,12 +26,12 @@ systemd:
           contents: |
             [Unit]
             After=network-online.target
-          
+
             [Service]
             Type=forking
             Restart=no
             ExecStart=/bin/bash /etc/assisted-service/startup_script.sh
-          
+
             [Install]
             WantedBy=multi-user.target
         - name: assisted-service-livecd.service
@@ -52,7 +52,7 @@ systemd:
           contents: |
             [Unit]
             After=assisted-service-ip-configuration.service
-            
+
             [Service]
             Type=forking
             Restart=no
@@ -65,13 +65,13 @@ systemd:
           contents: |
             [Unit]
             After=assisted-service-pod.service
-            
+
             [Service]
             Type=forking
             Restart=no
             ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment --authfile /etc/assisted-service/auth.json --name db quay.io/ocpmetal/postgresql-12-centos7
             TimeoutStartSec=300
-          
+
             [Install]
             WantedBy=multi-user.target
         - name: assisted-service-installer.service
@@ -79,13 +79,13 @@ systemd:
           contents: |
             [Unit]
             After=assisted-service-db.service
-          
+
             [Service]
             Type=forking
             Restart=no
             ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment -v /bin/coreos-installer:/data/coreos-installer:z -v /etc/assisted-service/livecd.iso:/data/livecd.iso:z -v /etc/assisted-service/nginx-certs/nginx-selfsigned.crt:/data/nginx-selfsigned.crt:z --restart always --name installer quay.io/ocpmetal/assisted-service:latest
             TimeoutStartSec=300
-          
+
             [Install]
             WantedBy=multi-user.target
         - name: assisted-service-ui.service
@@ -93,13 +93,13 @@ systemd:
           contents: |
             [Unit]
             After=assisted-service-installer.service
-          
+
             [Service]
             Type=forking
             Restart=no
             ExecStart=podman run -dt --pod assisted-installer --env-file /etc/assisted-service/environment -v /etc/assisted-service/nginx-certs:/certs:z -v /etc/assisted-service/nginx.conf:/opt/bitnami/nginx/conf/server_blocks/nginx.conf:z --name ui quay.io/ocpmetal/ocp-metal-ui:latest
             TimeoutStartSec=300
-          
+
             [Install]
             WantedBy=multi-user.target
 storage:
@@ -128,7 +128,7 @@ storage:
                 DEPLOY_TARGET=onprem
                 STORAGE=filesystem
                 SERVICE_CA_CERT_PATH=/data/nginx-selfsigned.crt
-                OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
+                OPENSHIFT_VERSIONS={"4.6.18":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7.0":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
                 PUBLIC_CONTAINER_REGISTRIES=quay.io
         - path: /etc/assisted-service/nginx.conf
           mode: 0644
@@ -165,7 +165,7 @@ storage:
               ips=$(hostname -I)
               read -r -a ipArr <<< "$ips"
               for ip in "${ipArr[@]}"
-                  do 
+                  do
                       printf "\n%s assisted-api.local.openshift.io\n" "$ip" >> /etc/hosts
                   done
               ips_cs=`echo $ips | xargs | sed -e 's/ /,/g'`

--- a/default_ocp_versions.json
+++ b/default_ocp_versions.json
@@ -1,12 +1,12 @@
 {
-        "4.6": {
+        "4.6.18": {
                 "display_name": "4.6.18",
                 "release_image": "quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64",
                 "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso",
                 "rhcos_version": "46.82.202012051820-0",
                 "support_level": "production"
         },
-        "4.7": {
+        "4.7.0": {
                 "display_name": "4.7.0",
                 "release_image": "quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64",
                 "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso",

--- a/onprem-environment
+++ b/onprem-environment
@@ -10,6 +10,6 @@ SERVICE_BASE_URL=http://127.0.0.1:8090
 DEPLOY_TARGET=onprem
 STORAGE=filesystem
 DUMMY_IGNITION=false
-OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
+OPENSHIFT_VERSIONS={"4.6.18":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7.0":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
 PUBLIC_CONTAINER_REGISTRIES=quay.io
 NTP_DEFAULT_SERVER=

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -11,7 +11,7 @@ parameters:
 - name: BASE_DNS_DOMAINS # example: name1:id1/provider1,name2:id2/provider2
   value: ''
 - name: OPENSHIFT_VERSIONS
-  value: '{"4.6":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}' # openshift version
+  value: '{"4.6.18":{"display_name":"4.6.18","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.18-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7.0":{"display_name":"4.7.0","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.7.0-rc.2/rhcos-4.7.0-rc.2-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}' # openshift version
   required: false
 - name: JWKS_URL # example https://example.com/.well-known/jwks.json
   value: ''


### PR DESCRIPTION
By using the full version as key for the available versions in the
OPENSHIFT_VERSIONS input, we' will instruct the assited-installer to use
that version, instead of the short form. This will allow to have more
detailed information in the database (OpenshiftVersion will be set to
the full version in the DB) as well as more granular metrics in
the monitoring tools being used.

We could keep the current json files and data as they are but, by being
explicit, we will also instruct on what we thing is the recommended
thing to do.