### PR TITLE
MGMT-4217: Run subsystem test for kube-api after rest-api tests

### DIFF
--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -51,7 +51,6 @@ def main():
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_TOKEN_URL', 'value': WIREMOCK_SERVICE + '/token'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_ID', 'value': 'mock-ocm-client-id'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_SECRET', 'value': 'mock-ocm-client-secret'})
-            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'ENABLE_KUBE_API', 'value': str(deploy_options.enable_kube_api).lower()})
 
             if deploy_options.profile == utils.OPENSHIFT_CI:
                 # Images built on infra cluster but needed on ephemeral cluster


### PR DESCRIPTION
Assisted-service needs to be deployed without auth before running
kube-api tests. Therefore it will be run after all the other tests
finished running and the service redeployed with the proper config.