### PR TITLE
MGMT-4339 Add indication for discovery image generation

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -240,10 +240,14 @@ var _ = Describe("GenerateClusterISO", func() {
 
 	It("image already exists", func() {
 		clusterId := strfmt.UUID(uuid.New().String())
-		cluster := common.Cluster{Cluster: models.Cluster{
-			ID:            &clusterId,
-			PullSecretSet: true,
-		}, PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"}
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID:            &clusterId,
+				PullSecretSet: true,
+			},
+			PullSecret:     "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+			ImageGenerated: true,
+		}
 		cluster.ProxyHash, _ = computeClusterProxyHash(nil, nil, nil)
 		cluster.ImageInfo = &models.ImageInfo{Type: models.ImageTypeFullIso}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
@@ -265,11 +269,15 @@ var _ = Describe("GenerateClusterISO", func() {
 
 	It("image expired", func() {
 		clusterId := strfmt.UUID(uuid.New().String())
-		cluster := common.Cluster{Cluster: models.Cluster{
-			ID:               &clusterId,
-			PullSecretSet:    true,
-			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
-		}, PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"}
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID:               &clusterId,
+				PullSecretSet:    true,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			},
+			PullSecret:     "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+			ImageGenerated: true,
+		}
 		cluster.ProxyHash, _ = computeClusterProxyHash(nil, nil, nil)
 		cluster.ImageInfo = &models.ImageInfo{Type: models.ImageTypeFullIso}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -35,6 +35,12 @@ type Cluster struct {
 
 	// The ID of the subscription created in AMS
 	AmsSubscriptionID strfmt.UUID `json:"ams_subscription_id"`
+
+	// ImageGenerated indicates if the discovery image was generated successfully. It will be used internally
+	// when an image needs to be generated. In case the user request to generate an image with custom parameters,
+	// and the generation failed, the value of ImageGenerated will be set to 'false'. In that case, providing the
+	// same request with the same custom parameters will re-attempt to generate the image.
+	ImageGenerated bool `json:"image_generated"`
 }
 
 type Event struct {


### PR DESCRIPTION
In order to allow the discovery image to be re-generated, an indication
is added to describe the state of it.
When the discovery image is generated, the indicator will be set to false
and only after successful image generation it will be set to true.

The indicator will prevent the case in which a failed attempt to generate
an image will result with storing the image create parameters on the
cluster. In that case, the next attempt to generate the ISO will falsely
present as the image hasn't been changed without considering the new
parameters of the cluster.

Signed-off-by: Moti Asayag <masayag@redhat.com>