### PR TITLE
MGMT-4165 handle minimal iso templates update

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -367,6 +367,9 @@ func main() {
 		//cancel the context in case this method ends
 		defer cancel()
 
+		// Checks whether latest version of minimal ISO templates already exists
+		haveLatestMinimalTemplate := s3wrapper.HaveLatestMinimalTemplate(context.Background(), log, objectHandler)
+
 		switch Options.DeployTarget {
 		case deployment_type_k8s:
 			baseISOUploadLeader := leader.NewElector(k8sClient, leader.Config{LeaseDuration: 5 * time.Second,
@@ -378,7 +381,7 @@ func main() {
 				currVresion := version
 				errs.Go(func() error {
 					return errors.Wrapf(baseISOUploadLeader.RunWithLeader(context.Background(), func() error {
-						return objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL)
+						return objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL, haveLatestMinimalTemplate)
 					}), "Failed uploading boot files for OCP version %s", currVresion)
 				})
 			}
@@ -386,7 +389,7 @@ func main() {
 			for version := range openshiftVersionsMap {
 				currVresion := version
 				errs.Go(func() error {
-					return errors.Wrapf(objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL),
+					return errors.Wrapf(objectHandler.UploadBootFiles(context.Background(), currVresion, Options.BMConfig.ServiceBaseURL, haveLatestMinimalTemplate),
 						"Failed uploading boot files for OCP version %s", currVresion)
 				})
 			}

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -307,7 +307,7 @@ func (f *FSClient) ListObjectsByPrefix(ctx context.Context, prefix string) ([]st
 	return matches, nil
 }
 
-func (f *FSClient) UploadBootFiles(ctx context.Context, openshiftVersion, serviceBaseURL string) error {
+func (f *FSClient) UploadBootFiles(ctx context.Context, openshiftVersion, serviceBaseURL string, haveLatestMinimalTemplate bool) error {
 	log := logutil.FromContext(ctx, f.log)
 	isoObjectName, err := f.GetBaseIsoObject(openshiftVersion)
 	if err != nil {

--- a/pkg/s3wrapper/filesystem_test.go
+++ b/pkg/s3wrapper/filesystem_test.go
@@ -175,13 +175,13 @@ var _ = Describe("s3filesystem", func() {
 			Expect(err).Should(BeNil())
 
 			mockVersions.EXPECT().GetRHCOSImage(defaultTestOpenShiftVersion).Return(defaultTestRhcosURL, nil).Times(1)
-			err = client.UploadBootFiles(ctx, defaultTestOpenShiftVersion, defaultTestServiceBaseURL)
+			err = client.UploadBootFiles(ctx, defaultTestOpenShiftVersion, defaultTestServiceBaseURL, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("unsupported openshift version", func() {
 			unsupportedVersion := "999"
 			mockVersions.EXPECT().GetRHCOSImage(unsupportedVersion).Return("", errors.New("unsupported")).Times(1)
-			err := client.UploadBootFiles(ctx, unsupportedVersion, defaultTestServiceBaseURL)
+			err := client.UploadBootFiles(ctx, unsupportedVersion, defaultTestServiceBaseURL, false)
 			Expect(err).To(HaveOccurred())
 		})
 		It("iso exists", func() {
@@ -215,7 +215,7 @@ var _ = Describe("s3filesystem", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			mockVersions.EXPECT().GetRHCOSImage(defaultTestOpenShiftVersion).Return(defaultTestRhcosURL, nil).Times(1)
-			err = client.UploadBootFiles(ctx, defaultTestOpenShiftVersion, defaultTestServiceBaseURL)
+			err = client.UploadBootFiles(ctx, defaultTestOpenShiftVersion, defaultTestServiceBaseURL, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			srcObject, err = client.GetBaseIsoObject(defaultTestOpenShiftVersion)

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -318,17 +318,17 @@ func (mr *MockAPIMockRecorder) Upload(arg0, arg1, arg2 interface{}) *gomock.Call
 }
 
 // UploadBootFiles mocks base method
-func (m *MockAPI) UploadBootFiles(arg0 context.Context, arg1, arg2 string) error {
+func (m *MockAPI) UploadBootFiles(arg0 context.Context, arg1, arg2 string, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UploadBootFiles", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UploadBootFiles", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UploadBootFiles indicates an expected call of UploadBootFiles
-func (mr *MockAPIMockRecorder) UploadBootFiles(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) UploadBootFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBootFiles", reflect.TypeOf((*MockAPI)(nil).UploadBootFiles), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadBootFiles", reflect.TypeOf((*MockAPI)(nil).UploadBootFiles), arg0, arg1, arg2, arg3)
 }
 
 // UploadFile mocks base method

--- a/pkg/s3wrapper/util_test.go
+++ b/pkg/s3wrapper/util_test.go
@@ -1,15 +1,24 @@
 package s3wrapper
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/isoeditor"
+	"github.com/openshift/assisted-service/internal/versions"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,3 +104,92 @@ var _ = Describe("UploadBootFiles", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 })
+
+var _ = Describe("HaveLatestMinimalTemplate", func() {
+	var (
+		ctx            = context.Background()
+		log            logrus.FieldLogger
+		ctrl           *gomock.Controller
+		isoUploader    *ISOUploader
+		client         *S3Client
+		mockAPI        *MockS3API
+		publicMockAPI  *MockS3API
+		uploader       *MockUploaderAPI
+		publicUploader *MockUploaderAPI
+		mockVersions   *versions.MockHandler
+
+		bucket       string
+		publicBucket string
+	)
+
+	BeforeEach(func() {
+		log = logrus.New()
+		ctrl = gomock.NewController(GinkgoT())
+		mockAPI = NewMockS3API(ctrl)
+		publicMockAPI = NewMockS3API(ctrl)
+		uploader = NewMockUploaderAPI(ctrl)
+		publicUploader = NewMockUploaderAPI(ctrl)
+		mockVersions = versions.NewMockHandler(ctrl)
+		bucket = "test"
+		publicBucket = "pub-test"
+		editorFactory := isoeditor.NewFactory(isoeditor.Config{ConcurrentEdits: 10}, nil)
+		cfg := Config{S3Bucket: bucket, PublicS3Bucket: publicBucket}
+		isoUploader = &ISOUploader{log: log, bucket: bucket, publicBucket: publicBucket, s3client: mockAPI}
+		client = &S3Client{log: log, session: nil, client: mockAPI, publicClient: publicMockAPI, uploader: uploader,
+			publicUploader: publicUploader, cfg: &cfg, isoUploader: isoUploader, versionsHandler: mockVersions,
+			isoEditorFactory: editorFactory}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("latest version already exists", func() {
+		mockTemplatesVersions(mockAPI, bucket, minimalTemplatesVersionLatest)
+		latestExists := HaveLatestMinimalTemplate(ctx, log, client)
+		Expect(latestExists).To(Equal(true))
+	})
+
+	It("latest version missing", func() {
+		mockTemplatesVersions(mockAPI, bucket, minimalTemplatesVersionLatest-1)
+		latestExists := HaveLatestMinimalTemplate(ctx, log, client)
+		Expect(latestExists).To(Equal(false))
+	})
+
+	It("version file missing", func() {
+		mockAPI.EXPECT().HeadObject(&s3.HeadObjectInput{
+			Bucket: &bucket,
+			Key:    aws.String(minimalTemplatesVersionFileName)}).
+			Return(nil, awserr.New("NotFound", "NotFound", errors.New("NotFound")))
+
+		latestExists := HaveLatestMinimalTemplate(ctx, log, client)
+		Expect(latestExists).To(Equal(false))
+	})
+})
+
+func getMockTemplatesVersion(version int) ([]byte, error) {
+	versionInBucket := &templatesVersion{
+		Version: version,
+	}
+	b, err := json.Marshal(versionInBucket)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func mockTemplatesVersions(mockAPI *MockS3API, bucket string, version int) {
+	templatesVersions, err := getMockTemplatesVersion(version)
+	Expect(err).ToNot(HaveOccurred())
+	mockAPI.EXPECT().HeadObject(&s3.HeadObjectInput{
+		Bucket: &bucket,
+		Key:    aws.String(minimalTemplatesVersionFileName)}).
+		Return(&s3.HeadObjectOutput{
+			ETag:          aws.String("etag"),
+			ContentLength: aws.Int64(int64(len(templatesVersions)))}, nil)
+	mockAPI.EXPECT().GetObject(&s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    aws.String(minimalTemplatesVersionFileName)}).
+		Return(&s3.GetObjectOutput{
+			Body: ioutil.NopCloser(bytes.NewReader(templatesVersions))}, nil)
+}


### PR DESCRIPTION
On service startup, need to ensure that the minimal ISO templates
aren't stale. Hence, using the following approach to upload latest version:
* Fetch template versions file from s3/fs that includes the latest revision number.
* If version is lower than the one hardcoded in code, force upload (overwrite) template.
* Update version in the file to latest (or create the file if doesn't exist).