### PR TITLE
NO-ISSUE: kubeapi_test.go fixed secret deployment

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -40,7 +40,7 @@ func deployLocalObjectSecretIfNeeded(ctx context.Context, client k8sclient.Clien
 }
 
 func deployPullSecretResource(ctx context.Context, client k8sclient.Client, name, secret string) {
-	data := map[string]string{corev1.DockerConfigJsonKey: secret}
+	data := map[string][]byte{corev1.DockerConfigJsonKey: []byte(secret)}
 	s := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -50,8 +50,8 @@ func deployPullSecretResource(ctx context.Context, client k8sclient.Client, name
 			Namespace: Options.Namespace,
 			Name:      name,
 		},
-		StringData: data,
-		Type:       corev1.SecretTypeDockerConfigJson,
+		Data: data,
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 	Expect(client.Create(ctx, s)).To(BeNil())
 }


### PR DESCRIPTION
ClusterDeployment controller does not look for StringData
in its pull secret as the old Cluster did. As a result the
subsystem for kube-api failed, it didn't manage to extract
the pull secret from the Secret resource.