### PR TITLE
MGMT-4274 Make AUTH_TYPE optional

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -23,7 +23,7 @@ parameters:
   value: ''
 - name: AUTH_TYPE
   value: ''
-  required: true
+  required: false
 - name: WITH_AMS_SUBSCRIPTIONS
   value: ''
   required: true


### PR DESCRIPTION
At least until we can add it to the parameters on the deploy side