### PR TITLE
MGMT-4275 Add local JWT authentication

### DIFF
--- a/pkg/auth/auth_handler_test_utils.go
+++ b/pkg/auth/auth_handler_test_utils.go
@@ -1,10 +1,15 @@
 package auth
 
 import (
+	"bytes"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base32"
+	"encoding/pem"
 	"fmt"
 
 	"github.com/dgrijalva/jwt-go"
@@ -80,4 +85,37 @@ func GenJSJWKS(privKey crypto.PublicKey, pubKey crypto.PublicKey) ([]byte, []byt
 		fmt.Printf("pubJSJWKS Marshaling error: %v\n", err)
 	}
 	return pubJSJWKS, privJSJWKS, kid, nil
+}
+
+func ECDSATokenAndKey() (string, string, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"cluster_id": "6c7aec2b-c7c9-415b-b153-6dbb1f290f40",
+	})
+	tokenString, err := token.SignedString(priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(priv.Public())
+	if err != nil {
+		return "", "", err
+	}
+
+	block := &pem.Block{
+		Type:  "EC PUBLIC KEY",
+		Bytes: pubBytes,
+	}
+
+	var out bytes.Buffer
+	err = pem.Encode(&out, block)
+	if err != nil {
+		return "", "", err
+	}
+
+	return tokenString, out.String(), nil
 }

--- a/pkg/auth/auth_handler_test_utils.go
+++ b/pkg/auth/auth_handler_test_utils.go
@@ -87,14 +87,14 @@ func GenJSJWKS(privKey crypto.PublicKey, pubKey crypto.PublicKey) ([]byte, []byt
 	return pubJSJWKS, privJSJWKS, kid, nil
 }
 
-func ECDSATokenAndKey() (string, string, error) {
+func ECDSATokenAndKey(clusterID string) (string, string, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return "", "", err
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"cluster_id": "6c7aec2b-c7c9-415b-b153-6dbb1f290f40",
+		"cluster_id": clusterID,
 	})
 	tokenString, err := token.SignedString(priv)
 	if err != nil {

--- a/pkg/auth/auth_suite_test.go
+++ b/pkg/auth/auth_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
 )
 
 func TestCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
+	common.InitializeDBTest()
+	defer common.TerminateDBTest()
 	RunSpecs(t, "auth tests")
 }

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -57,7 +57,7 @@ func NewAuthenticator(cfg *Config, ocmClient *ocm.Client, log logrus.FieldLogger
 	case TypeNone:
 		a = NewNoneAuthenticator(log)
 	case TypeLocal:
-		a, err = NewLocalAuthenticator(cfg, log)
+		a, err = NewLocalAuthenticator(cfg, log, db)
 	default:
 		err = fmt.Errorf("invalid authenticator type %v", t)
 	}

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -16,6 +16,7 @@ const (
 	TypeEmpty AuthType = ""
 	TypeNone  AuthType = "none"
 	TypeRHSSO AuthType = "rhsso"
+	TypeLocal AuthType = "local"
 )
 
 type Authenticator interface {
@@ -26,10 +27,11 @@ type Authenticator interface {
 }
 
 type Config struct {
-	EnableAuth bool     `envconfig:"ENABLE_AUTH" default:"false"`
-	AuthType   AuthType `envconfig:"AUTH_TYPE" default:""`
-	JwkCert    string   `envconfig:"JWKS_CERT"`
-	JwkCertURL string   `envconfig:"JWKS_URL" default:"https://api.openshift.com/.well-known/jwks.json"`
+	EnableAuth     bool     `envconfig:"ENABLE_AUTH" default:"false"`
+	AuthType       AuthType `envconfig:"AUTH_TYPE" default:""`
+	JwkCert        string   `envconfig:"JWKS_CERT"`
+	JwkCertURL     string   `envconfig:"JWKS_URL" default:"https://api.openshift.com/.well-known/jwks.json"`
+	ECPublicKeyPEM string   `envconfig:"EC_PUBLIC_KEY_PEM"`
 	// Will be split with "," as separator
 	AllowedDomains string   `envconfig:"ALLOWED_DOMAINS" default:""`
 	AdminUsers     []string `envconfig:"ADMIN_USERS" default:""`
@@ -54,6 +56,8 @@ func NewAuthenticator(cfg *Config, ocmClient *ocm.Client, log logrus.FieldLogger
 		a = NewRHSSOAuthenticator(cfg, ocmClient, log, db)
 	case TypeNone:
 		a = NewNoneAuthenticator(log)
+	case TypeLocal:
+		a, err = NewLocalAuthenticator(cfg, log)
 	default:
 		err = fmt.Errorf("invalid authenticator type %v", t)
 	}

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -63,7 +63,7 @@ var _ = Describe("NewAuthenticator", func() {
 		Expect(ok).To(BeTrue())
 
 		// LocalAuthenticator
-		_, ecdsaPubKey, err := ECDSATokenAndKey()
+		_, ecdsaPubKey, err := ECDSATokenAndKey("")
 		Expect(err).ToNot(HaveOccurred())
 		config = &Config{
 			AuthType:       TypeLocal,

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -19,6 +19,8 @@ var _ = Describe("ResolvedAuth", func() {
 			{authType: TypeNone, enabled: true, res: TypeNone},
 			{authType: TypeRHSSO, enabled: false, res: TypeRHSSO},
 			{authType: TypeRHSSO, enabled: true, res: TypeRHSSO},
+			{authType: TypeLocal, enabled: false, res: TypeLocal},
+			{authType: TypeLocal, enabled: true, res: TypeLocal},
 		}
 
 		for _, c := range cases {
@@ -39,21 +41,38 @@ var _ = Describe("NewAuthenticator", func() {
 	})
 
 	It("returns the correct type based on the config", func() {
+		// NoneAuthenticator
 		config := &Config{AuthType: TypeNone}
+
 		a, err := NewAuthenticator(config, nil, logrus.New(), nil)
 		Expect(err).ToNot(HaveOccurred())
 		_, ok := a.(*NoneAuthenticator)
 		Expect(ok).To(BeTrue())
 
+		// RHSSOAuthenticator
 		_, cert := GetTokenAndCert()
 		config = &Config{
 			AuthType:   TypeRHSSO,
 			JwkCertURL: "",
 			JwkCert:    string(cert),
 		}
+
 		a, err = NewAuthenticator(config, nil, logrus.New(), nil)
 		Expect(err).ToNot(HaveOccurred())
 		_, ok = a.(*RHSSOAuthenticator)
+		Expect(ok).To(BeTrue())
+
+		// LocalAuthenticator
+		_, ecdsaPubKey, err := ECDSATokenAndKey()
+		Expect(err).ToNot(HaveOccurred())
+		config = &Config{
+			AuthType:       TypeLocal,
+			ECPublicKeyPEM: ecdsaPubKey,
+		}
+
+		a, err = NewAuthenticator(config, nil, logrus.New(), nil)
+		Expect(err).ToNot(HaveOccurred())
+		_, ok = a.(*LocalAuthenticator)
 		Expect(ok).To(BeTrue())
 	})
 })

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -42,6 +42,8 @@ func NewLocalAuthenticator(cfg *Config, log logrus.FieldLogger, db *gorm.DB) (*L
 	return a, nil
 }
 
+var _ Authenticator = &LocalAuthenticator{}
+
 func (a *LocalAuthenticator) AuthType() AuthType {
 	return TypeLocal
 }

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"crypto"
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/security"
+	"github.com/openshift/assisted-service/internal/common"
+	logutil "github.com/openshift/assisted-service/pkg/log"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type LocalAuthenticator struct {
+	log       logrus.FieldLogger
+	publicKey crypto.PublicKey
+}
+
+func NewLocalAuthenticator(cfg *Config, log logrus.FieldLogger) (*LocalAuthenticator, error) {
+	if cfg.ECPublicKeyPEM == "" {
+		return nil, errors.Errorf("local authentication requires an ecdsa Public Key")
+	}
+
+	key, err := jwt.ParseECPublicKeyFromPEM([]byte(cfg.ECPublicKeyPEM))
+	if err != nil {
+		return nil, err
+	}
+
+	a := &LocalAuthenticator{
+		log:       log,
+		publicKey: key,
+	}
+
+	return a, nil
+}
+
+func (a *LocalAuthenticator) AuthType() AuthType {
+	return TypeLocal
+}
+
+func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
+	_, err := validateToken(token, a.publicKey)
+	if err != nil {
+		a.log.WithError(err).Error("failed to validate token")
+		return nil, err
+	}
+	return ocm.AdminPayload(), nil
+}
+
+func (a *LocalAuthenticator) AuthUserAuth(_ string) (interface{}, error) {
+	return nil, errors.Errorf("User Authentication not allowed for local auth")
+}
+
+func (a *LocalAuthenticator) CreateAuthenticator() func(_, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
+	return func(name string, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
+		return security.HttpAuthenticator(func(r *http.Request) (bool, interface{}, error) {
+			log := logutil.FromContext(r.Context(), a.log)
+
+			p, err := authenticate(r.Header.Get(name))
+			if err != nil {
+				log.WithError(err).Error("failed to authenticate")
+				if common.IsKnownError(err) {
+					return true, nil, err
+				}
+				return true, nil, common.NewInfraError(http.StatusUnauthorized, err)
+			}
+			return true, p, nil
+		})
+	}
+}
+
+func validateToken(token string, pub crypto.PublicKey) (*jwt.Token, error) {
+	parsed, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
+
+	if err != nil {
+		return nil, errors.Errorf("Failed to parse token: %v\n", err)
+	}
+	if jwt.SigningMethodES256.Alg() != parsed.Header["alg"] {
+		return nil, errors.Errorf("Signing algorithm mismatch. Expected %s, token has %s", jwt.SigningMethodES256.Alg(), parsed.Header["alg"])
+	}
+	if !parsed.Valid {
+		return nil, errors.Errorf("Invalid token")
+	}
+
+	return parsed, nil
+}

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -73,13 +73,11 @@ func (a *LocalAuthenticator) CreateAuthenticator() func(_, _ string, authenticat
 }
 
 func validateToken(token string, pub crypto.PublicKey) (*jwt.Token, error) {
-	parsed, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
+	parser := &jwt.Parser{ValidMethods: []string{jwt.SigningMethodES256.Alg()}}
+	parsed, err := parser.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
 
 	if err != nil {
 		return nil, errors.Errorf("Failed to parse token: %v\n", err)
-	}
-	if jwt.SigningMethodES256.Alg() != parsed.Header["alg"] {
-		return nil, errors.Errorf("Signing algorithm mismatch. Expected %s, token has %s", jwt.SigningMethodES256.Alg(), parsed.Header["alg"])
 	}
 	if !parsed.Valid {
 		return nil, errors.Errorf("Invalid token")

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("AuthAgentAuth", func() {
+	var (
+		token string
+		key   string
+		a     *LocalAuthenticator
+	)
+
+	BeforeEach(func() {
+		var err error
+		token, key, err = ECDSATokenAndKey()
+		Expect(err).ToNot(HaveOccurred())
+
+		cfg := &Config{ECPublicKeyPEM: key}
+
+		a, err = NewLocalAuthenticator(cfg, logrus.New())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Validates a token correctly", func() {
+		_, err := a.AuthAgentAuth(token)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Fails an invalid token", func() {
+		_, err := a.AuthAgentAuth(token + "asdf")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Fails all user auth", func() {
+		_, err := a.AuthUserAuth(token)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -1,6 +1,10 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -24,6 +28,27 @@ var _ = Describe("AuthAgentAuth", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	fakeTokenAlg := func(t string) string {
+		parts := strings.Split(t, ".")
+
+		headerJSON, err := base64.RawStdEncoding.DecodeString(parts[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		header := &map[string]interface{}{}
+		err = json.Unmarshal(headerJSON, header)
+		Expect(err).ToNot(HaveOccurred())
+
+		// change the algorithm in an otherwise valid token
+		(*header)["alg"] = "RS256"
+
+		headerBytes, err := json.Marshal(header)
+		Expect(err).ToNot(HaveOccurred())
+		newHeaderString := base64.RawStdEncoding.EncodeToString(headerBytes)
+
+		parts[0] = newHeaderString
+		return strings.Join(parts, ".")
+	}
+
 	It("Validates a token correctly", func() {
 		_, err := a.AuthAgentAuth(token)
 		Expect(err).ToNot(HaveOccurred())
@@ -36,6 +61,18 @@ var _ = Describe("AuthAgentAuth", func() {
 
 	It("Fails all user auth", func() {
 		_, err := a.AuthUserAuth(token)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Fails a token with invalid signing method", func() {
+		newTok := fakeTokenAlg(token)
+		_, err := a.AuthAgentAuth(newTok)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Fails with an RSA token", func() {
+		rsaToken, _ := GetTokenAndCert()
+		_, err := a.AuthAgentAuth(rsaToken)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/auth/none_authenticator.go
+++ b/pkg/auth/none_authenticator.go
@@ -17,6 +17,8 @@ func NewNoneAuthenticator(log logrus.FieldLogger) *NoneAuthenticator {
 	return &NoneAuthenticator{log: log}
 }
 
+var _ Authenticator = &NoneAuthenticator{}
+
 func (a *NoneAuthenticator) AuthType() AuthType {
 	return TypeNone
 }

--- a/pkg/auth/rhsso_authenticator.go
+++ b/pkg/auth/rhsso_authenticator.go
@@ -46,6 +46,8 @@ func NewRHSSOAuthenticator(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldL
 	return a
 }
 
+var _ Authenticator = &RHSSOAuthenticator{}
+
 func (a *RHSSOAuthenticator) AuthType() AuthType {
 	return TypeRHSSO
 }


### PR DESCRIPTION
This uses ecdsa keys to keep the resulting token signing string small.
This will make it a better fit for using in urls later.

~~This *can* be merged as is, but I'm debating adding the token creation here as well.
Let me know if you think we'd rather merge this separately.~~
Did token creation in https://github.com/openshift/assisted-service/pull/1269

cc @nmagnezi @danielerez @mhrivnak @avishayt 