### PR TITLE
MGMT-4414: Adding DB update for each change in validations status.

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	reflect "reflect"
 	"strconv"
 	"time"
 
@@ -312,6 +313,24 @@ func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventory
 	}).Error
 }
 
+func (m *Manager) checkValidationChanged(ctx context.Context, h *models.Host, newValidationRes validationsStatus) (validationsStatus, bool, error) {
+	var currentValidationRes validationsStatus
+	if h.ValidationsInfo != "" {
+		if err := json.Unmarshal([]byte(h.ValidationsInfo), &currentValidationRes); err != nil {
+			return validationsStatus{}, false, errors.Wrapf(err, "Failed to unmarshal validations info from host %s in cluster %s", h.ID, h.ClusterID)
+		}
+	}
+	return currentValidationRes, !reflect.DeepEqual(newValidationRes, currentValidationRes), nil
+}
+
+func (m *Manager) updateValidationsInDB(ctx context.Context, db *gorm.DB, h *models.Host, newValidationRes validationsStatus) (*models.Host, error) {
+	b, err := json.Marshal(newValidationRes)
+	if err != nil {
+		return nil, err
+	}
+	return hostutil.UpdateHost(logutil.FromContext(ctx, m.log), db, h.ClusterID, *h.ID, *h.Status, "validations_info", string(b))
+}
+
 func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB) error {
 	if db == nil {
 		db = m.db
@@ -320,19 +339,30 @@ func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB
 	if err != nil {
 		return err
 	}
-	conditions, validationsResults, err := m.rp.preprocess(vc)
+	conditions, newValidationRes, err := m.rp.preprocess(vc)
 	if err != nil {
 		return err
 	}
-	if err = m.reportValidationStatusChanged(ctx, vc, h, validationsResults); err != nil {
+	currentValidationRes, validationsChanged, err := m.checkValidationChanged(ctx, h, newValidationRes)
+	if err != nil {
 		return err
+	}
+	if validationsChanged {
+		// Validation status changes are detected when new validations are different from the
+		// current validations in the DB.
+		// For changes to be detected and reported correctly, the comparison needs to be
+		// performed before the new validations are updated to the DB.
+		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
+		if _, err = m.updateValidationsInDB(ctx, db, h, newValidationRes); err != nil {
+			return err
+		}
 	}
 	err = m.sm.Run(TransitionTypeRefresh, newStateHost(h), &TransitionArgsRefreshHost{
 		ctx:               ctx,
 		db:                db,
 		eventHandler:      m.eventsHandler,
 		conditions:        conditions,
-		validationResults: validationsResults,
+		validationResults: newValidationRes,
 	})
 	if err != nil {
 		return common.NewApiError(http.StatusConflict, err)
@@ -762,7 +792,7 @@ func (m *Manager) reportInstallationMetrics(ctx context.Context, h *models.Host,
 
 func (m *Manager) ReportValidationFailedMetrics(ctx context.Context, h *models.Host, ocpVersion, emailDomain string) error {
 	log := logutil.FromContext(ctx, m.log)
-	var validationRes map[string][]validationResult
+	var validationRes validationsStatus
 	if h.ValidationsInfo != "" {
 		if err := json.Unmarshal([]byte(h.ValidationsInfo), &validationRes); err != nil {
 			log.WithError(err).Errorf("Failed to unmarshal validations info from host %s in cluster %s", h.ID, h.ClusterID)
@@ -779,32 +809,26 @@ func (m *Manager) ReportValidationFailedMetrics(ctx context.Context, h *models.H
 	return nil
 }
 
-func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validationContext, h *models.Host, newValidationRes map[string][]validationResult) error {
-	var currentValidationRes map[string][]validationResult
-	if h.ValidationsInfo != "" {
-		if err := json.Unmarshal([]byte(h.ValidationsInfo), &currentValidationRes); err != nil {
-			return errors.Wrapf(err, "Failed to unmarshal validations info from host %s in cluster %s", h.ID, h.ClusterID)
-		}
-		for vCategory, vRes := range currentValidationRes {
-			for i, v := range vRes {
-				// after reboot there is no agent, therefore, the host validation for 'connected' will constantly fail.
-				// this is the expected behaviour and we don't need to generate event/metric for it.
-				if v.ID == IsConnected && funk.Contains(manualRebootStages, h.Progress.CurrentStage) {
-					continue
-				}
-				if newValidationRes[vCategory][i].Status == ValidationFailure && v.Status == ValidationSuccess {
-					m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
-					eventMsg := fmt.Sprintf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)
-					m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityWarning, eventMsg, time.Now())
-				}
-				if newValidationRes[vCategory][i].Status == ValidationSuccess && v.Status == ValidationFailure {
-					eventMsg := fmt.Sprintf("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
-					m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo, eventMsg, time.Now())
-				}
+func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validationContext, h *models.Host,
+	newValidationRes, currentValidationRes validationsStatus) {
+	for vCategory, vRes := range currentValidationRes {
+		for i, v := range vRes {
+			// after reboot there is no agent, therefore, the host validation for 'connected' will constantly fail.
+			// this is the expected behaviour and we don't need to generate event/metric for it.
+			if v.ID == IsConnected && funk.Contains(manualRebootStages, h.Progress.CurrentStage) {
+				continue
+			}
+			if newValidationRes[vCategory][i].Status == ValidationFailure && v.Status == ValidationSuccess {
+				m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
+				eventMsg := fmt.Sprintf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)
+				m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityWarning, eventMsg, time.Now())
+			}
+			if newValidationRes[vCategory][i].Status == ValidationSuccess && v.Status == ValidationFailure {
+				eventMsg := fmt.Sprintf("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
+				m.eventsHandler.AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo, eventMsg, time.Now())
 			}
 		}
 	}
-	return nil
 }
 
 func (m *Manager) AutoAssignRole(ctx context.Context, h *models.Host, db *gorm.DB) error {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2059,3 +2059,109 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		}
 	})
 })
+
+var _ = Describe("Validation metrics and events", func() {
+
+	const (
+		openshiftVersion = "dummyVersion"
+		emailDomain      = "dummy.com"
+	)
+
+	var (
+		ctrl            *gomock.Controller
+		ctx             = context.Background()
+		db              *gorm.DB
+		dbName          = "validation_metrics_and_events"
+		mockEvents      *events.MockHandler
+		mockHwValidator *hardware.MockValidator
+		mockMetric      *metrics.MockAPI
+		validatorCfg    *hardware.ValidatorCfg
+		m               *Manager
+		h               *models.Host
+	)
+
+	generateTestValidationResult := func(status ValidationStatus) validationsStatus {
+		validationRes := validationsStatus{
+			"hw": {
+				{
+					ID:     HasMinCPUCores,
+					Status: status,
+				},
+			},
+		}
+		return validationRes
+	}
+
+	registerTestHostWithValidations := func(clusterID strfmt.UUID) *models.Host {
+
+		hostID := strfmt.UUID(uuid.New().String())
+		h := hostutil.GenerateTestHost(hostID, clusterID, models.HostStatusInsufficient)
+
+		validationRes := generateTestValidationResult(ValidationFailure)
+		bytes, err := json.Marshal(validationRes)
+		Expect(err).ToNot(HaveOccurred())
+		h.ValidationsInfo = string(bytes)
+
+		h.Inventory = hostutil.GenerateMasterInventory()
+
+		err = m.RegisterHost(ctx, &h, db)
+		Expect(err).ToNot(HaveOccurred())
+
+		return &h
+	}
+
+	generateValidationCtx := func() *validationContext {
+		vc := validationContext{
+			cluster: &common.Cluster{
+				Cluster: models.Cluster{
+					OpenshiftVersion: openshiftVersion,
+					EmailDomain:      emailDomain,
+				},
+			},
+		}
+		return &vc
+	}
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		db = common.PrepareTestDB(dbName)
+		mockEvents = events.NewMockHandler(ctrl)
+		mockHwValidator = hardware.NewMockValidator(ctrl)
+		mockMetric = metrics.NewMockAPI(ctrl)
+		validatorCfg = createValidatorCfg()
+		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil)
+		h = registerTestHostWithValidations(strfmt.UUID(uuid.New().String()))
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Test ReportValidationFailedMetrics", func() {
+
+		mockMetric.EXPECT().HostValidationFailed(openshiftVersion, emailDomain, models.HostValidationIDHasMinCPUCores)
+
+		err := m.ReportValidationFailedMetrics(ctx, h, openshiftVersion, emailDomain)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Test reportValidationStatusChanged", func() {
+
+		mockEvents.EXPECT().AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityInfo, gomock.Any(), gomock.Any())
+
+		vc := generateValidationCtx()
+		newValidationRes := generateTestValidationResult(ValidationSuccess)
+		var currentValidationRes validationsStatus
+		err := json.Unmarshal([]byte(h.ValidationsInfo), &currentValidationRes)
+		Expect(err).ToNot(HaveOccurred())
+		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
+
+		mockMetric.EXPECT().HostValidationChanged(openshiftVersion, emailDomain, models.HostValidationIDHasMinCPUCores)
+		mockEvents.EXPECT().AddEvent(ctx, h.ClusterID, h.ID, models.EventSeverityWarning, gomock.Any(), gomock.Any())
+
+		currentValidationRes = newValidationRes
+		newValidationRes = generateTestValidationResult(ValidationFailure)
+		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
+	})
+})

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -16,6 +16,8 @@ type validationResult struct {
 	Message string           `json:"message"`
 }
 
+type validationsStatus map[string][]validationResult
+
 type refreshPreprocessor struct {
 	log          logrus.FieldLogger
 	validations  []validation
@@ -30,9 +32,9 @@ func newRefreshPreprocessor(log logrus.FieldLogger, hwValidatorCfg *hardware.Val
 	}
 }
 
-func (r *refreshPreprocessor) preprocess(c *validationContext) (map[validationID]bool, map[string][]validationResult, error) {
+func (r *refreshPreprocessor) preprocess(c *validationContext) (map[validationID]bool, validationsStatus, error) {
 	stateMachineInput := make(map[validationID]bool)
-	validationsOutput := make(map[string][]validationResult)
+	validationsOutput := make(validationsStatus)
 	for _, v := range r.validations {
 		st := v.condition(c)
 		stateMachineInput[v.id] = st == ValidationSuccess

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -385,7 +385,7 @@ type TransitionArgsRefreshHost struct {
 	ctx               context.Context
 	eventHandler      events.Handler
 	conditions        map[validationID]bool
-	validationResults map[string][]validationResult
+	validationResults validationsStatus
 	db                *gorm.DB
 }
 
@@ -502,13 +502,8 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 			return errors.New("PostRefreshHost invalid argument")
 		}
 		var (
-			b   []byte
 			err error
 		)
-		b, err = json.Marshal(&params.validationResults)
-		if err != nil {
-			return err
-		}
 		if sHost.host.Progress.CurrentStage == models.HostStageWritingImageToDisk &&
 			reason == statusInfoInstallationInProgressTimedOut {
 			template = statusInfoInstallationInProgressWritingImageToDiskTimedOut
@@ -523,7 +518,7 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 		}
 
 		_, err = hostutil.UpdateHostStatus(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, th.eventsHandler, sHost.host.ClusterID, *sHost.host.ID,
-			sHost.srcState, swag.StringValue(sHost.host.Status), template, "validations_info", string(b))
+			sHost.srcState, swag.StringValue(sHost.host.Status), template)
 		return err
 	}
 	return ret


### PR DESCRIPTION
On each host status refresh, we will now update the DB with the new
validations results if they changed regardless of the matching
transition.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>