### PR TITLE
NO-ISSUE: Document the need for an extra PVC

### DIFF
--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -40,6 +40,23 @@ spec:
         requests: {storage: 10Gi}
     EOF
     ````
+
+    A PersistentVolumeClaim named bucket-pv-claim is required for the filesystem storage.
+
+    ````
+    cat <<EOF | oc create -f -
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels: {app: assisted-service}
+      name: bucket-pv-claim
+      namespace: assisted-installer
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests: {storage: 10Gi}
+    EOF
+    ````
   displayName: Assisted Service Operator
   icon:
   - base64data: ""


### PR DESCRIPTION
The operator currentlty mentions the need of a PVC for postgress but it doesn't
mention that it requires another one for the fs storage. This commit adds that text to
the docs