### PR TITLE
MGMT-4468 update cluster from installenv

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/common"
-	adiiov1alpha1 "github.com/openshift/assisted-service/internal/controller/api/v1alpha1"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
@@ -134,7 +133,6 @@ var _ = Describe("cluster reconcile", func() {
 	var (
 		c                     client.Client
 		cr                    *ClusterDeploymentsReconciler
-		ir                    *InstallEnvReconciler
 		ctx                   = context.Background()
 		mockCtrl              *gomock.Controller
 		mockInstallerInternal *bminventory.MockInstallerInternals
@@ -171,12 +169,6 @@ var _ = Describe("cluster reconcile", func() {
 			Installer:        mockInstallerInternal,
 			ClusterApi:       mockClusterApi,
 			HostApi:          mockHostApi,
-			CRDEventsHandler: mockCRDEventsHandler,
-		}
-		ir = &InstallEnvReconciler{
-			Client:           c,
-			Log:              common.GetTestLog(),
-			Installer:        mockInstallerInternal,
 			CRDEventsHandler: mockCRDEventsHandler,
 		}
 	})
@@ -225,44 +217,6 @@ var _ = Describe("cluster reconcile", func() {
 				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
 
 				validateCreation(cluster)
-			})
-
-			It("create cluster and validate installEnv updates", func() {
-				updateReply := &common.Cluster{
-					Cluster: models.Cluster{
-						ID:         clusterReply.ID,
-						Status:     swag.String(models.ClusterStatusInsufficient),
-						StatusInfo: swag.String(models.ClusterStatusInsufficient),
-					},
-					PullSecret: testPullSecretVal,
-				}
-
-				// Create Cluster
-				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(clusterReply, nil).AnyTimes()
-				clusterDeployment := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
-				Expect(c.Create(ctx, clusterDeployment)).ShouldNot(HaveOccurred())
-				validateCreation(clusterDeployment)
-				//Create InstallEnv
-				mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(gomock.Any(), gomock.Any()).Times(1)
-				installEnvImage := newInstallEnvImage("installEnvImage", testNamespace, adiiov1alpha1.InstallEnvSpec{
-					ClusterRef: &adiiov1alpha1.ClusterReference{Name: clusterDeployment.Name, Namespace: clusterDeployment.Namespace},
-					Proxy: &adiiov1alpha1.Proxy{ // These changes are expected to trigger a notification to clusterDeployments controller to Reconcile.
-						NoProxy:    "http://192.168.1.1",
-						HTTPProxy:  "http://192.168.1.2",
-						HTTPSProxy: "http://192.168.1.3",
-					},
-				})
-				Expect(c.Create(ctx, installEnvImage)).To(BeNil())
-				res, err := ir.Reconcile(newInstallEnvRequest(installEnvImage))
-				mockCRDEventsHandler.EXPECT().NotifyInstallEnvUpdates(gomock.Any(), gomock.Any()).Times(1)
-				Expect(err).To(BeNil())
-				Expect(res).To(Equal(ctrl.Result{}))
-				// Reconcile clusterDeployment to get the updates
-				mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).Return(updateReply, nil)
-				res, err = cr.Reconcile(newClusterDeploymentRequest(clusterDeployment))
-				Expect(err).To(BeNil())
-				Expect(res).To(Equal(ctrl.Result{}))
 			})
 
 			It("create sno cluster", func() {


### PR DESCRIPTION
Update cluster from InstallEnv when setting Proxy and NTP conficution
Those parameters are reletaed only to discovery phase so they should not affect the cluster
Instead of having a ping-pong between cluster deployment controller and install env controller it is done once via InstallEnv controller.
Later when image will be separate from the cluster it will make things simple.