### PR TITLE
MGMT-4274 Make ENABLE_AUTH optional in the openshift template

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -21,6 +21,7 @@ parameters:
   required: true
 - name: ENABLE_AUTH
   value: ''
+  required: false
 - name: AUTH_TYPE
   value: ''
   required: false


### PR DESCRIPTION
This will allow our tests to pass when we switch over to `AUTH_TYPE`