### PR TITLE
MGMT-3811 KubeAPI Minimal ISO support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -108,6 +108,7 @@ var Options struct {
 	ValidationsConfig           validations.Config
 	AssistedServiceISOConfig    assistedserviceiso.Config
 	EnableKubeAPI               bool `envconfig:"ENABLE_KUBE_API" default:"false"`
+	InstallEnvConfig            controllers.InstallEnvConfig
 	ISOEditorConfig             isoeditor.Config
 }
 
@@ -412,6 +413,7 @@ func main() {
 			crdEventsHandler := controllers.NewCRDEventsHandler()
 			failOnError((&controllers.InstallEnvReconciler{
 				Client:           ctrlMgr.GetClient(),
+				Config:           Options.InstallEnvConfig,
 				Log:              log,
 				Installer:        bm,
 				CRDEventsHandler: crdEventsHandler,

--- a/internal/controller/controllers/installenv_controller.go
+++ b/internal/controller/controllers/installenv_controller.go
@@ -44,9 +44,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+type InstallEnvConfig struct {
+	ImageType models.ImageType `envconfig:"ISO_IMAGE_TYPE" default:"minimal-iso"`
+}
+
 // InstallEnvReconciler reconciles a InstallEnv object
 type InstallEnvReconciler struct {
 	client.Client
+	Config           InstallEnvConfig
 	Log              logrus.FieldLogger
 	Installer        bminventory.InstallerInternals
 	CRDEventsHandler CRDEventsHandler
@@ -209,10 +214,11 @@ func (r *InstallEnvReconciler) ensureISO(ctx context.Context, installEnv *adiiov
 		return r.handleEnsureISOErrors(ctx, installEnv, err)
 	}
 
-	// Generate ISO
 	isoParams := installer.GenerateClusterISOParams{
-		ClusterID:         *cluster.ID,
-		ImageCreateParams: &models.ImageCreateParams{},
+		ClusterID: *cluster.ID,
+		ImageCreateParams: &models.ImageCreateParams{
+			ImageType: r.Config.ImageType,
+		},
 	}
 	if len(installEnv.Spec.SSHAuthorizedKeys) > 0 {
 		isoParams.ImageCreateParams.SSHPublicKey = installEnv.Spec.SSHAuthorizedKeys[0]

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -385,10 +385,16 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return ""
 		}, "2m", "2s").Should(Equal(v1alpha1.ImageStateCreated))
 		cluster = getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
-		Expect(cluster.NoProxy).Should(Equal("192.168.1.1"))
-		Expect(cluster.HTTPProxy).Should(Equal("http://192.168.1.2"))
-		Expect(cluster.HTTPSProxy).Should(Equal("http://192.168.1.3"))
+		Expect(cluster.ImageGenerated).Should(Equal(true))
+		By("Validate proxy settings.", func() {
+			Expect(cluster.NoProxy).Should(Equal("192.168.1.1"))
+			Expect(cluster.HTTPProxy).Should(Equal("http://192.168.1.2"))
+			Expect(cluster.HTTPSProxy).Should(Equal("http://192.168.1.3"))
+		})
+		By("Validate additional NTP settings.")
 		Expect(cluster.AdditionalNtpSource).Should(ContainSubstring("192.168.1.4"))
+		By("InstallEnv image type defaults to minimal-iso.")
+		Expect(cluster.ImageInfo.Type).Should(Equal(models.ImageTypeMinimalIso))
 	})
 
 	It("deploy clusterDeployment and installEnv with ignition override", func() {


### PR DESCRIPTION
Adds ImageType Config to InstallEnvReconciler.
Same as in done in the operator, the config will read env variable `ISO_IMAGE_TYPE` which can
either be: `minimal-iso` (default) or `full-iso`