### PR TITLE
MGMT-4204 Rename prefix_name to subscription_name

### DIFF
--- a/models/monitored_operator.go
+++ b/models/monitored_operator.go
@@ -30,9 +30,6 @@ type MonitoredOperator struct {
 	// operator type
 	OperatorType OperatorType `json:"operator_type,omitempty"`
 
-	// Prefix of the operator to be searched by.
-	PrefixName string `json:"prefix_name,omitempty"`
-
 	// Blob of operator-dependent parameters that are required for installation.
 	Properties string `json:"properties,omitempty" gorm:"type:text"`
 
@@ -45,6 +42,9 @@ type MonitoredOperator struct {
 	// Time at which the operator was last updated.
 	// Format: date-time
 	StatusUpdatedAt strfmt.DateTime `json:"status_updated_at,omitempty" gorm:"type:timestamp with time zone"`
+
+	// The name of the subscription of the operator.
+	SubscriptionName string `json:"subscription_name,omitempty"`
 
 	// Positive number represents a timeout in seconds for the operator to be available.
 	TimeoutSeconds int64 `json:"timeout_seconds,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6679,10 +6679,6 @@ func init() {
         "operator_type": {
           "$ref": "#/definitions/operator-type"
         },
-        "prefix_name": {
-          "description": "Prefix of the operator to be searched by.",
-          "type": "string"
-        },
         "properties": {
           "description": "Blob of operator-dependent parameters that are required for installation.",
           "type": "string",
@@ -6700,6 +6696,10 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
+        "subscription_name": {
+          "description": "The name of the subscription of the operator.",
+          "type": "string"
         },
         "timeout_seconds": {
           "description": "Positive number represents a timeout in seconds for the operator to be available.",
@@ -13790,10 +13790,6 @@ func init() {
         "operator_type": {
           "$ref": "#/definitions/operator-type"
         },
-        "prefix_name": {
-          "description": "Prefix of the operator to be searched by.",
-          "type": "string"
-        },
         "properties": {
           "description": "Blob of operator-dependent parameters that are required for installation.",
           "type": "string",
@@ -13811,6 +13807,10 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
+        "subscription_name": {
+          "description": "The name of the subscription of the operator.",
+          "type": "string"
         },
         "timeout_seconds": {
           "description": "Positive number represents a timeout in seconds for the operator to be available.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3047,9 +3047,9 @@ definitions:
       namespace:
         type: string
         description: Namespace where to deploy an operator. Only some operators require a namespace.
-      prefix_name:
+      subscription_name:
         type: string
-        description: Prefix of the operator to be searched by.
+        description: The name of the subscription of the operator.
       operator_type:
         $ref: '#/definitions/operator-type'
       properties:


### PR DESCRIPTION
This PR changes the prefix_name of the MonitoredOperator to the
subscription_name, which reflect the meaning of the attribute clearer.