### PR TITLE
MGMT-4471 Generate an agent auth token for local auth

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -396,19 +396,10 @@ func (b *bareMetalInventory) updatePullSecret(pullSecret string, log logrus.Fiel
 }
 
 func (b *bareMetalInventory) formatIgnitionFile(cluster *common.Cluster, params installer.GenerateClusterISOParams, logger logrus.FieldLogger, safeForLogs bool) (string, error) {
-	creds, err := validations.ParsePullSecret(cluster.PullSecret)
+	pullSecretToken, err := clusterPkg.AgentToken(cluster, b.authHandler.AuthType())
 	if err != nil {
 		return "", err
 	}
-	pullSecretToken := ""
-	if b.authHandler.AuthType() == auth.TypeRHSSO {
-		r, ok := creds["cloud.openshift.com"]
-		if !ok {
-			return "", errors.Errorf("Pull secret does not contain auth for cloud.openshift.com")
-		}
-		pullSecretToken = r.AuthRaw
-	}
-
 	proxySettings, err := proxySettingsForIgnition(cluster.HTTPProxy, cluster.HTTPSProxy, cluster.NoProxy)
 	if err != nil {
 		return "", err

--- a/internal/cluster/auth.go
+++ b/internal/cluster/auth.go
@@ -1,25 +1,60 @@
 package cluster
 
 import (
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/pkg/errors"
 )
 
-func AgentToken(c *common.Cluster, authType auth.AuthType) (string, error) {
-	creds, err := validations.ParsePullSecret(c.PullSecret)
+func AgentToken(c *common.Cluster, authType auth.AuthType) (token string, err error) {
+	switch authType {
+	case auth.TypeRHSSO:
+		token, err = cloudPullSecretToken(c.PullSecret)
+	case auth.TypeLocal:
+		token, err = localJWT(c.ID.String())
+	case auth.TypeNone:
+		token = ""
+	default:
+		err = errors.Errorf("invalid authentication type %v", authType)
+	}
+	return
+}
+
+func cloudPullSecretToken(pullSecret string) (string, error) {
+	creds, err := validations.ParsePullSecret(pullSecret)
 	if err != nil {
 		return "", err
 	}
-	pullSecretToken := ""
-	if authType == auth.TypeRHSSO {
-		r, ok := creds["cloud.openshift.com"]
-		if !ok {
-			return "", errors.Errorf("Pull secret does not contain auth for cloud.openshift.com")
-		}
-		pullSecretToken = r.AuthRaw
+	r, ok := creds["cloud.openshift.com"]
+	if !ok {
+		return "", errors.Errorf("Pull secret does not contain auth for cloud.openshift.com")
+	}
+	return r.AuthRaw, nil
+}
+
+func localJWT(id string) (string, error) {
+	key, ok := os.LookupEnv("EC_PRIVATE_KEY_PEM")
+	if !ok || key == "" {
+		return "", errors.Errorf("EC_PRIVATE_KEY_PEM not found")
 	}
 
-	return pullSecretToken, nil
+	priv, err := jwt.ParseECPrivateKeyFromPEM([]byte(key))
+	if err != nil {
+		return "", err
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"cluster_id": id,
+	})
+
+	tokenString, err := token.SignedString(priv)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenString, nil
 }

--- a/internal/cluster/auth.go
+++ b/internal/cluster/auth.go
@@ -1,0 +1,25 @@
+package cluster
+
+import (
+	"github.com/openshift/assisted-service/internal/cluster/validations"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/pkg/auth"
+	"github.com/pkg/errors"
+)
+
+func AgentToken(c *common.Cluster, authType auth.AuthType) (string, error) {
+	creds, err := validations.ParsePullSecret(c.PullSecret)
+	if err != nil {
+		return "", err
+	}
+	pullSecretToken := ""
+	if authType == auth.TypeRHSSO {
+		r, ok := creds["cloud.openshift.com"]
+		if !ok {
+			return "", errors.Errorf("Pull secret does not contain auth for cloud.openshift.com")
+		}
+		pullSecretToken = r.AuthRaw
+	}
+
+	return pullSecretToken, nil
+}

--- a/internal/cluster/auth_test.go
+++ b/internal/cluster/auth_test.go
@@ -1,6 +1,16 @@
 package cluster
 
 import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
@@ -10,7 +20,7 @@ import (
 	"github.com/openshift/assisted-service/pkg/auth"
 )
 
-var _ = FDescribe("AgentToken", func() {
+var _ = Describe("AgentToken", func() {
 	var (
 		id strfmt.UUID
 	)
@@ -47,5 +57,81 @@ var _ = FDescribe("AgentToken", func() {
 		token, err := AgentToken(c, auth.TypeNone)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(token).To(Equal(""))
+	})
+
+	It("returns an error if an invalid auth type is configured", func() {
+		c := &common.Cluster{
+			Cluster:    models.Cluster{ID: &id},
+			PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+		}
+		_, err := AgentToken(c, auth.AuthType("asdf"))
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error for local auth with no private key", func() {
+		c := &common.Cluster{
+			Cluster:    models.Cluster{ID: &id},
+			PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+		}
+		_, err := AgentToken(c, auth.TypeLocal)
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	Context("with a private key set", func() {
+		var (
+			publicKey crypto.PublicKey
+		)
+
+		BeforeEach(func() {
+			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			Expect(err).NotTo(HaveOccurred())
+
+			publicKey = priv.Public()
+
+			privBytes, err := x509.MarshalECPrivateKey(priv)
+			Expect(err).NotTo(HaveOccurred())
+
+			block := &pem.Block{
+				Type:  "EC PRIVATE KEY",
+				Bytes: privBytes,
+			}
+			var out bytes.Buffer
+			Expect(pem.Encode(&out, block)).To(Succeed())
+
+			os.Setenv("EC_PRIVATE_KEY_PEM", out.String())
+		})
+
+		AfterEach(func() {
+			os.Unsetenv("EC_PRIVATE_KEY_PEM")
+		})
+
+		validateToken := func(token string, pub crypto.PublicKey) *jwt.Token {
+			parser := &jwt.Parser{ValidMethods: []string{jwt.SigningMethodES256.Alg()}}
+			parsed, err := parser.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsed.Valid).To(BeTrue())
+
+			return parsed
+		}
+
+		It("creates a valid token", func() {
+			c := &common.Cluster{
+				Cluster:    models.Cluster{ID: &id},
+				PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+			}
+			tokenString, err := AgentToken(c, auth.TypeLocal)
+			Expect(err).ToNot(HaveOccurred())
+
+			tok := validateToken(tokenString, publicKey)
+			claims, ok := tok.Claims.(jwt.MapClaims)
+			Expect(ok).To(BeTrue())
+
+			clusterID, ok := claims["cluster_id"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(clusterID).To(Equal(id.String()))
+		})
 	})
 })

--- a/internal/cluster/auth_test.go
+++ b/internal/cluster/auth_test.go
@@ -1,0 +1,51 @@
+package cluster
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/auth"
+)
+
+var _ = FDescribe("AgentToken", func() {
+	var (
+		id strfmt.UUID
+	)
+
+	BeforeEach(func() {
+		id = strfmt.UUID(uuid.New().String())
+	})
+
+	It("fails with rhsso auth when the cloud.openshift.com pull secret is missing", func() {
+		c := &common.Cluster{
+			Cluster:    models.Cluster{ID: &id},
+			PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+		}
+		_, err := AgentToken(c, auth.TypeRHSSO)
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("succeeds with rhsso auth when cloud.openshift.com pull secret is present", func() {
+		c := &common.Cluster{
+			Cluster:    models.Cluster{ID: &id},
+			PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+		}
+		_, err := AgentToken(c, auth.TypeRHSSO)
+
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("returns empty when no auth is configured", func() {
+		c := &common.Cluster{
+			Cluster:    models.Cluster{ID: &id},
+			PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
+		}
+		token, err := AgentToken(c, auth.TypeNone)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token).To(Equal(""))
+	})
+})

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -7,9 +7,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/security"
-	"github.com/go-openapi/strfmt"
 	"github.com/jinzhu/gorm"
-	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/common"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/pkg/ocm"
@@ -68,7 +66,7 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 		return nil, err
 	}
 
-	if !cluster.ClusterExists(a.db, strfmt.UUID(clusterID)) {
+	if !clusterExists(a.db, clusterID) {
 		err := errors.Errorf("cluster %s does not exist", clusterID)
 		a.log.Error(err)
 		return nil, err
@@ -112,4 +110,9 @@ func validateToken(token string, pub crypto.PublicKey) (*jwt.Token, error) {
 	}
 
 	return parsed, nil
+}
+
+func clusterExists(db *gorm.DB, clusterID string) bool {
+	var c common.Cluster
+	return db.Select("id").Take(&c, map[string]interface{}{"id": clusterID}).Error == nil
 }


### PR DESCRIPTION
This PR implements the token generation side of the new local auth for agents.

Instead of embedding the pull secret auth into the agent command in the discovery ignition this PR switches what we use based on the the authentication type.

Behavior is unchanged with rhsso and none authentication types, but will require `EC_PRIVATE_KEY_PEM` to be set to use local auth.

~~Built on https://github.com/openshift/assisted-service/pull/1228 which adds the local auth type.~~
Merged