### PR TITLE
MGMT-4450 Operator bundle should not include experimental ISOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ deploy-ui-on-ocp-cluster:
 create-ocp-manifests:
 	export APPLY_MANIFEST=False && export APPLY_NAMESPACE=False && \
 	export ENABLE_KUBE_API=true && export TARGET=ocp && \
+	export OPENSHIFT_VERSIONS="$(subst ",\", $(shell cat default_ocp_versions.json | tr -d "\n\t "))" && \
 	$(MAKE) deploy-postgres deploy-ocm-secret deploy-s3-secret deploy-service deploy-ui
 
 jenkins-deploy-for-subsystem: ci-deploy-for-subsystem


### PR DESCRIPTION
The operator should only include the versions in
default_ocp_versions.json and not include experimental ISOs used
in development that are included by hack/get_ocp_versions_for_testing.sh.

Signed-off-by: Richard Su <rwsu@redhat.com>