### PR TITLE
MGMT-4204 Return subscription data in monitor operators

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2237,11 +2237,13 @@ var _ = Describe("cluster", func() {
 					actual := reply.(*installer.RegisterClusterCreated)
 
 					expectedMonitoredOperator := models.MonitoredOperator{
-						Name:           newOperatorName,
-						Properties:     newProperties,
-						OperatorType:   lso.Operator.OperatorType,
-						TimeoutSeconds: lso.Operator.TimeoutSeconds,
-						ClusterID:      *actual.Payload.ID,
+						Name:             newOperatorName,
+						Properties:       newProperties,
+						OperatorType:     lso.Operator.OperatorType,
+						TimeoutSeconds:   lso.Operator.TimeoutSeconds,
+						Namespace:        lso.Operator.Namespace,
+						SubscriptionName: lso.Operator.SubscriptionName,
+						ClusterID:        *actual.Payload.ID,
 					}
 
 					Expect(actual.Payload.MonitoredOperators).To(ContainElement(&common.TestDefaultConfig.MonitoredOperator))

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -27,9 +27,11 @@ type operator struct {
 }
 
 var Operator = models.MonitoredOperator{
-	Name:           "cnv",
-	OperatorType:   models.OperatorTypeOlm,
-	TimeoutSeconds: 60 * 60,
+	Name:             "cnv",
+	OperatorType:     models.OperatorTypeOlm,
+	Namespace:        "openshift-cnv",
+	SubscriptionName: "hco-operatorhub",
+	TimeoutSeconds:   60 * 60,
 }
 
 // NewCNVOperator creates new instance of a Container Native Virtualization installation plugin

--- a/internal/operators/cnv/manifest.go
+++ b/internal/operators/cnv/manifest.go
@@ -22,7 +22,9 @@ func Manifests(OpenShiftVersion string) (map[string][]byte, error) {
 
 func subscription(OpenShiftVersion string) ([]byte, error) {
 	data := map[string]string{
-		"OPENSHIFT_VERSION": OpenShiftVersion,
+		"OPENSHIFT_VERSION":          OpenShiftVersion,
+		"OPERATOR_NAMESPACE":         Operator.Namespace,
+		"OPERATOR_SUBSCRIPTION_NAME": Operator.SubscriptionName,
 	}
 	tmpl, err := template.New("cnvSubscription").Parse(cnvSubscription)
 	if err != nil {
@@ -39,8 +41,8 @@ func subscription(OpenShiftVersion string) ([]byte, error) {
 const cnvSubscription = `apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: hco-operatorhub
-  namespace: openshift-cnv
+  name: "{{.OPERATOR_SUBSCRIPTION_NAME}}"
+  namespace: "{{.OPERATOR_NAMESPACE}}"
 spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -13,9 +13,11 @@ type lsOperator struct {
 }
 
 var Operator = models.MonitoredOperator{
-	Name:           "lso",
-	OperatorType:   models.OperatorTypeOlm,
-	TimeoutSeconds: 60 * 60,
+	Name:             "lso",
+	OperatorType:     models.OperatorTypeOlm,
+	Namespace:        "openshift-local-storage",
+	SubscriptionName: "local-storage-operator",
+	TimeoutSeconds:   70 * 60,
 }
 
 // New LSOperator creates new instance of a Local Storage Operator installation plugin

--- a/internal/operators/lso/manifest.go
+++ b/internal/operators/lso/manifest.go
@@ -7,14 +7,16 @@ import (
 
 func lsoSubscription(OpenShiftVersion string) ([]byte, error) {
 	data := map[string]string{
-		"OPENSHIFT_VERSION": OpenShiftVersion,
+		"OPENSHIFT_VERSION":          OpenShiftVersion,
+		"OPERATOR_NAMESPACE":         Operator.Namespace,
+		"OPERATOR_SUBSCRIPTION_NAME": Operator.SubscriptionName,
 	}
 
 	const lsoSubscription = `apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: local-storage-operator
-  namespace: openshift-local-storage
+  name: "{{.OPERATOR_SUBSCRIPTION_NAME}}"
+  namespace: "{{.OPERATOR_NAMESPACE}}"
 spec:
   channel: "{{.OPENSHIFT_VERSION}}"
   installPlanApproval: Automatic

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -316,9 +316,11 @@ func (mgr *Manager) GetOperatorByName(operatorName string) (*models.MonitoredOpe
 	}
 
 	return &models.MonitoredOperator{
-		Name:           operator.Name,
-		OperatorType:   operator.OperatorType,
-		TimeoutSeconds: operator.TimeoutSeconds,
+		Name:             operator.Name,
+		OperatorType:     operator.OperatorType,
+		TimeoutSeconds:   operator.TimeoutSeconds,
+		Namespace:        operator.Namespace,
+		SubscriptionName: operator.SubscriptionName,
 	}, nil
 }
 

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -19,9 +19,11 @@ type ocsOperator struct {
 }
 
 var Operator = models.MonitoredOperator{
-	Name:           "ocs",
-	OperatorType:   models.OperatorTypeOlm,
-	TimeoutSeconds: 30 * 60,
+	Name:             "ocs",
+	OperatorType:     models.OperatorTypeOlm,
+	Namespace:        "openshift-storage",
+	SubscriptionName: "ocs-operator",
+	TimeoutSeconds:   30 * 60,
 }
 
 // NewOcsOperator creates new OCSOperator


### PR DESCRIPTION
This PR fill the monitored_operator data with subscription_name and
namespace data.

Signed-off-by: Ondra Machacek <omachace@redhat.com>