### PR TITLE
MGMT-4428 Adds operator-bundle to build-all and publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ generate-%: ${BUILD_FOLDER}
 .PHONY: build docs
 build: lint $(UNIT_TEST_TARGET) build-minimal
 
-build-all: build-in-docker
+build-all: build-in-docker operator-bundle-build
 
 build-in-docker:
 	skipper make build-image
@@ -147,6 +147,7 @@ endef # publish_image
 
 publish:
 	$(call publish_image,docker,${SERVICE},quay.io/ocpmetal/assisted-service:${PUBLISH_TAG})
+	$(call publish_image,podman,${BUNDLE_IMAGE},quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG})
 	skipper make publish-client
 
 publish-client: generate-python-client


### PR DESCRIPTION
https://github.com/openshift/assisted-service/pull/1230 omitted the operator-bundle from build-all which caused
the master builds to fail because it was attempting to publish
an image that hadn't been build.