### PR TITLE
OCPBUGSM-25828 Use ubi for assisted-service init container

### DIFF
--- a/config/default/assisted-service-patch-init-containers.yaml
+++ b/config/default/assisted-service-patch-init-containers.yaml
@@ -11,8 +11,8 @@ spec:
     spec:
       initContainers:
       - name: init-wait-for-service
-        image: busybox:1.28
-        command: ['sh', '-c', "until nslookup assisted-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for assisted-service; sleep 2; done"]
+        image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+        command: ['sh', '-c', "until getent hosts assisted-service.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for assisted-service; sleep 2; done"]
       - name: init-add-route-and-update-config-map
         image: quay.io/openshift/origin-cli:latest
         command: ['sh', '-c', 'export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) && export HAS_ROUTE=$(oc get routes -n $NAMESPACE assisted-service) && if [ "$HAS_ROUTE" == "" ] ; then oc expose service -n $NAMESPACE assisted-service ; fi && export ROUTE_URL=$(oc get routes -n $NAMESPACE assisted-service -o jsonpath={.spec.host}) && oc get configmap -n $NAMESPACE assisted-service-config -o yaml | sed -e "s|REPLACE_BASE_URL|http\:\/\/$ROUTE_URL|" | oc apply -f - ']


### PR DESCRIPTION
Changes assisted-service init container base image to ubi-minimal from
busybox.

The init container waits for the assisted-service service to be
created.

Also change service checks to using "getent hosts" from "nslookup".
nslookup is not available in ubi.