### PR TITLE
WIP - MGMT-4501 - Dockerfile.assisted-service.dev - Patch existing service image binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build
+!build/assisted-installer/assisted-service

--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -5,6 +5,11 @@ COPY swagger.yaml .
 COPY tools/generate_python_client.sh .
 RUN chmod +x ./generate_python_client.sh && SWAGGER_FILE=swagger.yaml OUTPUT=/build ./generate_python_client.sh
 
+# TODO: Find a pure Python3 base image, rather than relying on the golang one
+FROM registry.ci.openshift.org/openshift/release:golang-1.15 as pybuilder
+COPY --from=swagger_py /build build
+RUN cd build && python3 setup.py sdist --dist-dir /assisted-service-client
+
 # Generate go client
 FROM quay.io/goswagger/swagger:v0.25.0 as swagger_go
 COPY swagger.yaml go.* ./
@@ -24,12 +29,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-COPY --from=swagger_py /build build
-COPY --from=swagger_go /build/client client
-COPY --from=swagger_go /build/models models
-COPY --from=swagger_go /build/restapi restapi
 RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service cmd/main.go
-RUN cd build && python3 setup.py sdist --dist-dir /assisted-service-client
 
 # Create final image
 FROM quay.io/centos/centos:centos8
@@ -72,6 +72,6 @@ ARG OC_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/open
 RUN curl -s $OC_URL | tar -xzC /usr/local/bin/ oc
 
 COPY --from=builder /build/assisted-service /assisted-service
-COPY --from=builder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
+COPY --from=pybuilder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
 COPY /config/onprem-iso-config.ign /data/onprem-iso-config.ign
 CMD ["/assisted-service"]

--- a/Dockerfile.assisted-service.dev
+++ b/Dockerfile.assisted-service.dev
@@ -1,0 +1,8 @@
+# Let the `docker build` command caller decide the base image
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+# Simply replace the existing service binary in the base image with a new locally built one
+ARG LOCAL_SERVICE_BINARY
+COPY $LOCAL_SERVICE_BINARY /assisted-service
+


### PR DESCRIPTION
Added service dev dockerfile for fast image build

See commit message:
   This new dockerfile FROMs the existing service image and simply replaces
   the existing service binary with the new locally built one. This allows for
   more quickly deploying modified images during development because it no
   longer requires rebuilding the entire image. Building the new service
   binary locally is done pretty quickly because it makes use of the go build
   cache