### PR TITLE
Moving conversion helpers to separate package

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/units"
 	"github.com/dustin/go-humanize"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 )
@@ -57,26 +57,6 @@ func (v *validator) GetHostValidDisks(host *models.Host) ([]*models.Disk, error)
 	return v.ListEligibleDisks(&inventory), nil
 }
 
-func GbToBytes(gb int64) int64 {
-	return gb * int64(units.GB)
-}
-
-func GibToBytes(gib int64) int64 {
-	return gib * int64(units.GiB)
-}
-
-func BytesToGiB(bytes int64) int64 {
-	return bytes / int64(units.GiB)
-}
-
-func MibToBytes(mib int64) int64 {
-	return mib * int64(units.MiB)
-}
-
-func BytesToMib(bytes int64) int64 {
-	return bytes / int64(units.MiB)
-}
-
 func isNvme(name string) bool {
 	return strings.HasPrefix(name, "nvme")
 }
@@ -88,7 +68,7 @@ func isNvme(name string) bool {
 func (v *validator) DiskIsEligible(disk *models.Disk) []string {
 	var notEligibleReasons []string
 
-	if minSizeBytes := GbToBytes(v.MinDiskSizeGb); disk.SizeBytes < minSizeBytes {
+	if minSizeBytes := conversions.GbToBytes(v.MinDiskSizeGb); disk.SizeBytes < minSizeBytes {
 		notEligibleReasons = append(notEligibleReasons,
 			fmt.Sprintf(
 				"Disk is too small (disk only has %s, but %s are required)",

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,8 +34,8 @@ var _ = Describe("Disk eligibility", func() {
 		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
 		hwvalidator = NewValidator(logrus.New(), cfg)
 
-		bigEnoughSize = GbToBytes(cfg.MinDiskSizeGb) + 1
-		tooSmallSize = GbToBytes(cfg.MinDiskSizeGb) - 1
+		bigEnoughSize = conversions.GbToBytes(cfg.MinDiskSizeGb) + 1
+		tooSmallSize = conversions.GbToBytes(cfg.MinDiskSizeGb) - 1
 
 		// Start off with an eligible default
 		testDisk = models.Disk{

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/openshift/assisted-service/pkg/leader"
 	"github.com/sirupsen/logrus"
 )
@@ -802,7 +803,7 @@ func inventoryWithUnauthorizedVendor() string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16), UsableBytes: hardware.GibToBytes(16)},
+		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(16), UsableBytes: conversions.GibToBytes(16)},
 		Hostname:     "master-hostname",
 		SystemVendor: &models.SystemVendor{Manufacturer: "RDO", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 		Timestamp:    1601835002,
@@ -829,7 +830,7 @@ func workerInventory() string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(8), UsableBytes: hardware.GibToBytes(8)},
+		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(8), UsableBytes: conversions.GibToBytes(8)},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 	}
 	b, err := json.Marshal(&inventory)

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -9,8 +9,8 @@ import (
 	"github.com/jinzhu/gorm"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 )
 
 func GetHostFromDB(hostId, clusterId strfmt.UUID, db *gorm.DB) *models.Host {
@@ -95,7 +95,7 @@ func GenerateMasterInventoryWithHostname(hostname string) string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16), UsableBytes: hardware.GibToBytes(16)},
+		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(16), UsableBytes: conversions.GibToBytes(16)},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
@@ -122,7 +122,7 @@ func GenerateMasterInventoryWithHostnameV6(hostname string) string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(16), UsableBytes: hardware.GibToBytes(16)},
+		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(16), UsableBytes: conversions.GibToBytes(16)},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
@@ -149,7 +149,7 @@ func GenerateInventoryWithResources(cpu, memory int64, hostname string) string {
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: hardware.GibToBytes(memory), UsableBytes: hardware.GibToBytes(memory)},
+		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(memory), UsableBytes: conversions.GibToBytes(memory)},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/internal/operators/ocs"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/thoas/go-funk"
 )
 
@@ -1188,7 +1189,7 @@ var _ = Describe("Refresh Host", func() {
 			// Mock the hwValidator behavior of performing simple filtering according to disk size, because these tests
 			// rely on small disks to get filtered out.
 			return funk.Filter(inventory.Disks, func(disk *models.Disk) bool {
-				return disk.SizeBytes >= hardware.GibToBytes(validatorCfg.MinDiskSizeGb)
+				return disk.SizeBytes >= conversions.GibToBytes(validatorCfg.MinDiskSizeGb)
 			}).([]*models.Disk)
 		}).AnyTimes()
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil)
@@ -1587,7 +1588,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient worker cpu",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, hardware.GibToBytes(16), "worker"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(16), "worker"),
 				role:          models.HostRoleWorker,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,
@@ -1617,7 +1618,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient master cpu",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, hardware.GibToBytes(17), "master"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(17), "master"),
 				role:          models.HostRoleMaster,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
@@ -193,7 +194,7 @@ func (v *validator) hasMinMemory(c *validationContext) ValidationStatus {
 	if c.inventory == nil {
 		return ValidationPending
 	}
-	return boolValue(c.inventory.Memory.PhysicalBytes >= hardware.GibToBytes(v.hwValidatorCfg.MinRamGib))
+	return boolValue(c.inventory.Memory.PhysicalBytes >= conversions.GibToBytes(v.hwValidatorCfg.MinRamGib))
 }
 
 func (v *validator) printHasMinMemory(c *validationContext, status ValidationStatus) string {
@@ -202,7 +203,7 @@ func (v *validator) printHasMinMemory(c *validationContext, status ValidationSta
 		return "Sufficient minimum RAM"
 	case ValidationFailure:
 		return fmt.Sprintf("The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is %d GiB, found only %d GiB", v.hwValidatorCfg.MinRamGib,
-			hardware.BytesToGiB(c.inventory.Memory.PhysicalBytes))
+			conversions.BytesToGiB(c.inventory.Memory.PhysicalBytes))
 	case ValidationPending:
 		return "Missing inventory"
 	default:
@@ -352,11 +353,11 @@ func (v *validator) getMemoryForRole(cluster *common.Cluster, role models.HostRo
 	}
 	switch role {
 	case models.HostRoleMaster:
-		return hardware.GibToBytes(v.hwValidatorCfg.MinRamGibMaster) + opReqs, nil
+		return conversions.GibToBytes(v.hwValidatorCfg.MinRamGibMaster) + opReqs, nil
 	case models.HostRoleWorker, models.HostRoleAutoAssign:
-		return hardware.GibToBytes(v.hwValidatorCfg.MinRamGibWorker) + opReqs, nil
+		return conversions.GibToBytes(v.hwValidatorCfg.MinRamGibWorker) + opReqs, nil
 	default:
-		return hardware.GibToBytes(v.hwValidatorCfg.MinRamGib) + opReqs, nil
+		return conversions.GibToBytes(v.hwValidatorCfg.MinRamGib) + opReqs, nil
 	}
 }
 
@@ -371,7 +372,7 @@ func (v *validator) printHasMemoryForRole(c *validationContext, status Validatio
 			return fmt.Sprintf("Unable to determine host memory requirements: %s", err)
 		}
 		return fmt.Sprintf("Require at least %d GiB RAM role %s, found only %d GiB",
-			hardware.BytesToGiB(mem), c.host.Role, hardware.BytesToGiB(c.inventory.Memory.UsableBytes))
+			conversions.BytesToGiB(mem), c.host.Role, conversions.BytesToGiB(c.inventory.Memory.UsableBytes))
 	case ValidationPending:
 		return "Missing inventory or role"
 	default:

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	models "github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -82,8 +82,8 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 		}
 		mem, _ := o.GetMemoryRequirementForWorker(ctx, cluster)
 		if inventory.Memory.UsableBytes < mem {
-			usableMemory := hardware.BytesToMib(inventory.Memory.UsableBytes)
-			memBytes := hardware.BytesToMib(mem)
+			usableMemory := conversions.BytesToMib(inventory.Memory.UsableBytes)
+			memBytes := conversions.BytesToMib(mem)
 			return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{fmt.Sprintf("Insufficient memory to deploy CNV. Required memory is %d MiB but found %d MiB", memBytes, usableMemory)}}, nil
 		}
 	} else if host.Role == models.HostRoleMaster {
@@ -93,8 +93,8 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 		}
 		mem, _ := o.GetMemoryRequirementForMaster(ctx, cluster)
 		if inventory.Memory.UsableBytes < mem {
-			usableMemory := hardware.BytesToMib(inventory.Memory.UsableBytes)
-			memBytes := hardware.BytesToMib(mem)
+			usableMemory := conversions.BytesToMib(inventory.Memory.UsableBytes)
+			memBytes := conversions.BytesToMib(mem)
 			return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{fmt.Sprintf("Insufficient memory to deploy CNV. Required memory is %d MiB but found %d MiB", memBytes, usableMemory)}}, nil
 		}
 	}
@@ -113,12 +113,12 @@ func (o *operator) GetCPURequirementForMaster(_ context.Context, _ *common.Clust
 
 // GetMemoryRequirementForWorker provides worker memory requirements for the operator
 func (o *operator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return hardware.MibToBytes(workerMemory), nil
+	return conversions.MibToBytes(workerMemory), nil
 }
 
 // GetMemoryRequirementForMaster provides master memory requirements for the operator
 func (o *operator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return hardware.MibToBytes(masterMemory), nil
+	return conversions.MibToBytes(masterMemory), nil
 }
 
 // GenerateManifests generates manifests for the operator

--- a/pkg/conversions/conversions.go
+++ b/pkg/conversions/conversions.go
@@ -1,0 +1,23 @@
+package conversions
+
+import "github.com/alecthomas/units"
+
+func GbToBytes(gb int64) int64 {
+	return gb * int64(units.GB)
+}
+
+func GibToBytes(gib int64) int64 {
+	return gib * int64(units.GiB)
+}
+
+func BytesToGiB(bytes int64) int64 {
+	return bytes / int64(units.GiB)
+}
+
+func MibToBytes(mib int64) int64 {
+	return mib * int64(units.MiB)
+}
+
+func BytesToMib(bytes int64) int64 {
+	return bytes / int64(units.MiB)
+}


### PR DESCRIPTION
This PR moves existing size conversion functions to a separate package to avoid cyclic imports in other changes.