### PR TITLE
MGMT-4502 - Improve unit test performance by putting DB data in RAM rather than disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ deploy-monitoring: deploy-olm deploy-prometheus deploy-grafana
 
 unit-test: $(REPORTS)
 	docker ps -q --filter "name=postgres" | xargs -r docker kill && sleep 3
-	docker run -d  --rm --name postgres -e POSTGRES_PASSWORD=admin -e POSTGRES_USER=admin -p 127.0.0.1:5432:5432 \
+	docker run -d  --rm --tmpfs /var/lib/postgresql/data --name postgres -e POSTGRES_PASSWORD=admin -e POSTGRES_USER=admin -p 127.0.0.1:5432:5432 \
 		quay.io/ocpmetal/postgres:12.3-alpine -c 'max_connections=10000'
 	timeout 5m ./hack/wait_for_postgres.sh
 	SKIP_UT_DB=1 gotestsum --format=pkgname $(TEST_PUBLISH_FLAGS) -- -cover -coverprofile=$(REPORTS)/coverage.out $(or ${TEST},${TEST},$(shell go list ./... | grep -v subsystem)) $(GINKGO_FOCUS_FLAG) \


### PR DESCRIPTION
Unit tests that make use of the postgres database container are
typically very slow because that postgres container uses the disk
for storage. 

This commit mounts a tmpfs in the container in the directory where this postgres image
stores its data, causing significant performance improvement relative to
a regular disk filesystem

 