### PR TITLE
NO-ISSUE - Remove erezalster from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@
 aliases:
   approvers:
     - eranco74
-    - erezalster
     - filanov
     - gamli75
     - ronniel1
@@ -20,7 +19,6 @@ aliases:
     - tsorya
     - yevgeny-shnaidman
     - yuvigold
-    - erezalster
     - nmagnezi
     - carbonin
     - rollandf


### PR DESCRIPTION
This will prevent him from being automatically selected for PR review