### PR TITLE
Revert "MGMT-4428 Adds operator-bundle to build-all and publish (#1285)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ generate-%: ${BUILD_FOLDER}
 .PHONY: build docs
 build: lint $(UNIT_TEST_TARGET) build-minimal
 
-build-all: build-in-docker operator-bundle-build
+build-all: build-in-docker
 
 build-in-docker:
 	skipper make build-image
@@ -147,7 +147,6 @@ endef # publish_image
 
 publish:
 	$(call publish_image,docker,${SERVICE},quay.io/ocpmetal/assisted-service:${PUBLISH_TAG})
-	$(call publish_image,podman,${BUNDLE_IMAGE},quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG})
 	skipper make publish-client
 
 publish-client: generate-python-client


### PR DESCRIPTION
This reverts commit f30d42d8d76f66bec73f9e830b8f0b27996eb2b5.

Due CI Errors:
"01:43:23  /usr/local/bin/operator-sdk: line 1: Not: command not found"