### PR TITLE
MGMT-4513: Don't do anything if we update host with unchanged info.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3511,22 +3511,23 @@ func (b *bareMetalInventory) UpdateHostInstallProgress(ctx context.Context, para
 		return installer.NewUpdateHostInstallProgressNotFound().
 			WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
-	if err := b.hostApi.UpdateInstallProgress(ctx, &host, params.HostProgress); err != nil {
-		log.WithError(err).Errorf("failed to update host %s progress", params.HostID)
-		return installer.NewUpdateHostInstallProgressInternalServerError().
-			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+
+	if params.HostProgress.CurrentStage != host.Progress.CurrentStage || params.HostProgress.ProgressInfo != host.Progress.ProgressInfo {
+		if err := b.hostApi.UpdateInstallProgress(ctx, &host, params.HostProgress); err != nil {
+			log.WithError(err).Errorf("failed to update host %s progress", params.HostID)
+			return installer.NewUpdateHostInstallProgressInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+		}
+
+		event := fmt.Sprintf("reached installation stage %s", params.HostProgress.CurrentStage)
+		if params.HostProgress.ProgressInfo != "" {
+			event += fmt.Sprintf(": %s", params.HostProgress.ProgressInfo)
+		}
+
+		log.Info(fmt.Sprintf("Host %s in cluster %s: %s", host.ID, host.ClusterID, event))
+		msg := fmt.Sprintf("Host %s: %s", hostutil.GetHostnameForMsg(&host), event)
+		b.eventsHandler.AddEvent(ctx, host.ClusterID, host.ID, models.EventSeverityInfo, msg, time.Now())
 	}
 
-	event := fmt.Sprintf("reached installation stage %s", params.HostProgress.CurrentStage)
-
-	if params.HostProgress.ProgressInfo != "" {
-		event += fmt.Sprintf(": %s", params.HostProgress.ProgressInfo)
-	}
-
-	log.Info(fmt.Sprintf("Host %s in cluster %s: %s", host.ID, host.ClusterID, event))
-	msg := fmt.Sprintf("Host %s: %s", hostutil.GetHostnameForMsg(&host), event)
-
-	b.eventsHandler.AddEvent(ctx, host.ClusterID, host.ID, models.EventSeverityInfo, msg, time.Now())
 	return installer.NewUpdateHostInstallProgressOK()
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1679,14 +1679,27 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 		})
 
 		It("success", func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), clusterID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any())
-			mockHostApi.EXPECT().UpdateInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			reply := bm.UpdateHostInstallProgress(ctx, installer.UpdateHostInstallProgressParams{
-				ClusterID:    clusterID,
-				HostProgress: progressParams,
-				HostID:       hostID,
+
+			By("update with new data", func() {
+				mockEvents.EXPECT().AddEvent(gomock.Any(), clusterID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any())
+				mockHostApi.EXPECT().UpdateInstallProgress(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				reply := bm.UpdateHostInstallProgress(ctx, installer.UpdateHostInstallProgressParams{
+					ClusterID:    clusterID,
+					HostProgress: progressParams,
+					HostID:       hostID,
+				})
+				Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressOK()))
 			})
-			Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressOK()))
+
+			By("update with no changes", func() {
+				// We used an hostmock so DB wasn't updated after first step.
+				reply := bm.UpdateHostInstallProgress(ctx, installer.UpdateHostInstallProgressParams{
+					ClusterID:    clusterID,
+					HostProgress: &models.HostProgress{},
+					HostID:       hostID,
+				})
+				Expect(reply).Should(BeAssignableToTypeOf(installer.NewUpdateHostInstallProgressOK()))
+			})
 		})
 
 		It("update_failed", func() {


### PR DESCRIPTION
The controller keeps updating host installation progress until all hosts
are installed or they are all in error.

In case the user is resetting the cluster, there is a time window in
which the controller still runs and continues to update the hosts,
therefore events are spammed until k8s kills the controller once 2
masters aren't part of the cluster anymore.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>