### PR TITLE
NO-ISSUE: use swagger-codegen-cli from quay.io instead of docker hub

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -34,7 +34,7 @@ function generate_python_client() {
         -v "${__root}"/swagger.yaml:/swagger.yaml:ro,Z \
         -v "${__root}"/tools/generate_python_client.sh:/script.sh:ro,Z \
         -e SWAGGER_FILE=/swagger.yaml -e OUTPUT=/local/assisted-service-client/ \
-        swaggerapi/swagger-codegen-cli:2.4.15 /script.sh
+        quay.io/ocpmetal/swagger-codegen-cli:2.4.15 /script.sh
      cd "${dest}"/assisted-service-client/ && python3 setup.py sdist --dist-dir "${dest}"
      cd "${dest}"/assisted-service-client/ && python3 "${__root}"/tools/client_package_initializer.py "${dest}"/assisted-service-client/  https://github.com/openshift/assisted-service --build
 }


### PR DESCRIPTION
Using the quay.io image
/cc @YuviGold @omertuc 