### PR TITLE
NO-ISSUE - attempt to logout from problematic registries before running CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,11 +28,17 @@ pipeline {
         stage('Init') {
             steps {
                 sh 'make clear-all || true'
-                sh 'make ci-lint'
+
+                // Logout from problematic registries
+                sh 'docker logout registry.svc.ci.openshift.org || true'
+                sh 'podman logout --all || true'
+                sh 'oc logout || true'
 
                 // Login to quay.io
                 sh "docker login quay.io -u ${QUAY_IO_CREDS_USR} -p ${QUAY_IO_CREDS_PSW}"
                 sh "podman login quay.io -u ${QUAY_IO_CREDS_USR} -p ${QUAY_IO_CREDS_PSW}"
+
+                sh 'make ci-lint'
             }
         }
 


### PR DESCRIPTION
We've recently seen some issues with the registry.svc.ci.openshift.org registry. It seems that someone might have logged in to those registries in some job and it affected future CI jobs that came after it. This commit makes it so there's a more 'clean slate' before trying to run the CI