### PR TITLE
NO-ISSUE Download specific version of operator-sdk, turn on publish

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -11,7 +11,7 @@ RUN pip3 install waiting==1.4.1 mkdocs==1.1.2
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 RUN go get -u sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
-  && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/latest/download \
+  && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2 \
   && curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} \
   && chmod +x operator-sdk_${OS}_${ARCH} \
   && install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ generate-%: ${BUILD_FOLDER}
 .PHONY: build docs
 build: lint $(UNIT_TEST_TARGET) build-minimal
 
-build-all: build-in-docker
+build-all: build-in-docker operator-bundle-build
 
 build-in-docker:
 	skipper make build-image
@@ -147,6 +147,7 @@ endef # publish_image
 
 publish:
 	$(call publish_image,docker,${SERVICE},quay.io/ocpmetal/assisted-service:${PUBLISH_TAG})
+	$(call publish_image,podman,${BUNDLE_IMAGE},quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG})
 	skipper make publish-client
 
 publish-client: generate-python-client


### PR DESCRIPTION
and build of bundle-image.

Previously we were downloading from latest. The latest URL has
disappeared and returns "Not Found" as the contents of the file
from curl.

This PR also turns back on bundle image build and publish.

Signed-off-by: Richard Su <rwsu@redhat.com>