### PR TITLE
MGMT-4531 change ram_mib to ram_gib in cluster-host-requirements-details

### DIFF
--- a/models/cluster_host_requirements_details.go
+++ b/models/cluster_host_requirements_details.go
@@ -24,8 +24,8 @@ type ClusterHostRequirementsDetails struct {
 	// Required installation disk speed in ms
 	InstallationDiskSpeedThresholdMs int64 `json:"installation_disk_speed_threshold_ms,omitempty"`
 
-	// Required number of RAM in GiB
-	RAMGib int64 `json:"ram_gib,omitempty"`
+	// Required number of RAM in MiB
+	RAMMib int64 `json:"ram_mib,omitempty"`
 }
 
 // Validate validates this cluster host requirements details

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5129,8 +5129,8 @@ func init() {
           "description": "Required installation disk speed in ms",
           "type": "integer"
         },
-        "ram_gib": {
-          "description": "Required number of RAM in GiB",
+        "ram_mib": {
+          "description": "Required number of RAM in MiB",
           "type": "integer"
         }
       }
@@ -12489,8 +12489,8 @@ func init() {
           "description": "Required installation disk speed in ms",
           "type": "integer"
         },
-        "ram_gib": {
-          "description": "Required number of RAM in GiB",
+        "ram_mib": {
+          "description": "Required number of RAM in MiB",
           "type": "integer"
         }
       }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1892,7 +1892,7 @@ func init() {
       "get": {
         "security": [
           {
-            "agentAuth": [
+            "userAuth": [
               "admin",
               "read-only-admin",
               "user"
@@ -9108,7 +9108,7 @@ func init() {
       "get": {
         "security": [
           {
-            "agentAuth": [
+            "userAuth": [
               "admin",
               "read-only-admin",
               "user"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3228,9 +3228,9 @@ definitions:
       cpu_cores:
         type: integer
         description: Required number of CPU cores
-      ram_gib:
+      ram_mib:
         type: integer
-        description: Required number of RAM in GiB
+        description: Required number of RAM in MiB
       disk_size_gb:
         type: integer
         description: Required disk size in GB

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2719,7 +2719,7 @@ paths:
       tags:
         - installer
       security:
-        - agentAuth: [admin, read-only-admin, user]
+        - userAuth: [admin, read-only-admin, user]
       description: Get host requirements of a cluster.
       operationId: GetClusterHostRequirements
       parameters:


### PR DESCRIPTION
Changing `cluster-host-requirements-details'` `ram_gib` to `ram_mib` because CNV has its requirements defined in MiB (150 MiB for master and 360 MiB for worker).

Signed-off-by: Jakub Dzon <jdzon@redhat.com>