### PR TITLE
NO-ISSUE - Operator SDK should have a pinned version to make sure the environment is consistent across dev machines

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -25,7 +25,7 @@ RUN curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.10.1/m
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
-  && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/latest/download \
+  && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2 \
   && curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} \
   && chmod +x operator-sdk_${OS}_${ARCH} \
   && install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk


### PR DESCRIPTION
/cc @rwsu

EDIT: I pinned it to 1.4.2 instead of 1.5.0 by mistake, but turns out it was a lucky mistake because 1.5.0 is broken (`make operator-bundle` doesn't work with 1.5.0 right now), so I'm keeping it 1.4.2 for now