### PR TITLE
MGMT-4358 Deploy the local secret with a make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ deploy-inventory-service-file: deploy-namespace
 	sleep 5;  # wait for service to get an address
 
 deploy-service-requirements: | deploy-namespace deploy-inventory-service-file
+	python3 ./tools/deploy_local_auth_secret.py --namespace "$(NAMESPACE)" --profile "$(PROFILE)" --target "$(TARGET)" --apply-manifest $(APPLY_MANIFEST)
 	python3 ./tools/deploy_assisted_installer_configmap.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" \
 		--base-dns-domains "$(BASE_DNS_DOMAINS)" --namespace "$(NAMESPACE)" --profile "$(PROFILE)" \
 		$(INSTALLATION_TIMEOUT_FLAG) $(DEPLOY_TAG_OPTION) --auth-type "$(AUTH_TYPE)" --with-ams-subscriptions "$(WITH_AMS_SUBSCRIPTIONS)" $(TEST_FLAGS) \

--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -124,6 +124,16 @@ spec:
                 secretKeyRef:
                   key: endpoint
                   name: assisted-installer-public-s3
+            - name: EC_PUBLIC_KEY_PEM
+              valueFrom:
+                secretKeyRef:
+                  key: ec-public-key.pem
+                  name: assisted-installer-local-auth-key
+            - name: EC_PRIVATE_KEY_PEM
+              valueFrom:
+                secretKeyRef:
+                  key: ec-private-key.pem
+                  name: assisted-installer-local-auth-key
             - name: S3_USE_SSL
               value: "false"
             - name: LOG_LEVEL

--- a/tools/deploy_local_auth_secret.py
+++ b/tools/deploy_local_auth_secret.py
@@ -1,0 +1,41 @@
+import os
+
+import deployment_options
+import tempfile
+import utils
+
+def main():
+    secret_name = 'assisted-installer-local-auth-key'
+    deploy_options = deployment_options.load_deployment_options()
+
+    # NO OP if we don't apply manifests as we don't want the secret included in the operator bundle
+    if not deploy_options.apply_manifest:
+        return
+
+    exists = utils.check_if_exists(
+        "secret",
+        secret_name,
+        target=deploy_options.target,
+        namespace=deploy_options.namespace,
+        profile=deploy_options.profile
+    )
+
+    if exists:
+        print(f'Secret {secret_name} already exists in namespace {deploy_options.namespace}')
+        return
+
+    utils.verify_build_directory(deploy_options.namespace)
+
+    output_dir = tempfile.TemporaryDirectory()
+    priv_path = os.path.join(output_dir.name, f'ec-private-key.pem')
+    pub_path = os.path.join(output_dir.name, f'ec-public-key.pem')
+
+    print(utils.check_output(f'openssl ecparam -name prime256v1 -genkey -noout -out {priv_path}'))
+    print(utils.check_output(f'openssl ec -in {priv_path} -pubout -out {pub_path}'))
+
+    kubectl = utils.get_kubectl_command(deploy_options.target, deploy_options.namespace, deploy_options.profile)
+    print(utils.check_output(f'{kubectl} create secret generic {secret_name} --from-file={priv_path} --from-file={pub_path}'))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit adds a python tool to create the local
auth key pair secret and adds the keys to env vars
in the service.

This will be created on every deployment, but will
only be used if AUTH_TYPE=local