### PR TITLE
MGMT-4554 API for supporting a custom OCP version

### DIFF
--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -39,6 +39,21 @@ func (m *MockInstallerInternals) EXPECT() *MockInstallerInternalsMockRecorder {
 	return m.recorder
 }
 
+// AddOpenshiftVersion mocks base method
+func (m *MockInstallerInternals) AddOpenshiftVersion(arg0 context.Context, arg1, arg2 string) (*models.OpenshiftVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOpenshiftVersion", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*models.OpenshiftVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddOpenshiftVersion indicates an expected call of AddOpenshiftVersion
+func (mr *MockInstallerInternalsMockRecorder) AddOpenshiftVersion(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOpenshiftVersion", reflect.TypeOf((*MockInstallerInternals)(nil).AddOpenshiftVersion), arg0, arg1, arg2)
+}
+
 // DeregisterClusterInternal mocks base method
 func (m *MockInstallerInternals) DeregisterClusterInternal(arg0 context.Context, arg1 installer.DeregisterClusterParams) error {
 	m.ctrl.T.Helper()

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -11,7 +11,14 @@ import (
 )
 
 type TestConfiguration struct {
-	OpenShiftVersion  string
+	OpenShiftVersion string
+	ReleaseVersion   string
+	ReleaseImage     string
+	RhcosImage       string
+	RhcosVersion     string
+	SupportLevel     string
+	Version          *models.OpenshiftVersion
+
 	Status            string
 	StatusInfo        string
 	HostProgressStage models.HostStage
@@ -25,9 +32,28 @@ type TestConfiguration struct {
 const TestDiskId = "/dev/disk/by-id/test-disk-id"
 const TestDiskPath = "/dev/test-disk"
 
+var (
+	OpenShiftVersion string = "4.6"
+	ReleaseVersion          = "4.6.0"
+	ReleaseImage            = "quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64"
+	RhcosImage              = "rhcos_4.6.0"
+	RhcosVersion            = "version-46.123-0"
+	SupportLevel            = "beta"
+)
+
 // Defaults to be used by all testing modules
 var TestDefaultConfig = &TestConfiguration{
-	OpenShiftVersion:  "4.6",
+	OpenShiftVersion: OpenShiftVersion,
+	ReleaseVersion:   ReleaseVersion,
+	ReleaseImage:     ReleaseImage,
+	Version: &models.OpenshiftVersion{
+		DisplayName:    &OpenShiftVersion,
+		ReleaseImage:   &ReleaseImage,
+		ReleaseVersion: &ReleaseVersion,
+		RhcosImage:     &RhcosImage,
+		RhcosVersion:   &RhcosVersion,
+		SupportLevel:   &SupportLevel,
+	},
 	Status:            "status",
 	StatusInfo:        "statusInfo",
 	HostProgressStage: models.HostStage("default progress stage"),

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -134,9 +134,20 @@ var _ = Describe("cluster reconcile", func() {
 		mockClusterApi        *cluster.MockAPI
 		mockHostApi           *host.MockAPI
 		mockCRDEventsHandler  *MockCRDEventsHandler
+		defaultClusterSpec    hivev1.ClusterDeploymentSpec
 		clusterName           = "test-cluster"
 		pullSecretName        = "pull-secret"
-		defaultClusterSpec    hivev1.ClusterDeploymentSpec
+		imageSetName          = "openshift-v4.8.0"
+		releaseImage          = "quay.io/openshift-release-dev/ocp-release:4.8.0-x86_64"
+		ocpReleaseVersion     = "4.8.0"
+		openshiftVersion      = &models.OpenshiftVersion{
+			DisplayName:    new(string),
+			ReleaseImage:   new(string),
+			ReleaseVersion: &ocpReleaseVersion,
+			RhcosImage:     new(string),
+			RhcosVersion:   new(string),
+			SupportLevel:   new(string),
+		}
 	)
 
 	getTestCluster := func() *hivev1.ClusterDeployment {
@@ -187,6 +198,8 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
+			imageSet := getDefaultTestImageSet(imageSetName, releaseImage)
+			Expect(c.Create(ctx, imageSet)).To(BeNil())
 		})
 
 		Context("successful creation", func() {
@@ -218,7 +231,11 @@ var _ = Describe("cluster reconcile", func() {
 
 			It("create new cluster", func() {
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(clusterReply, nil)
+					Do(func(arg1, arg2 interface{}, params installer.RegisterClusterParams) {
+						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*openshiftVersion.ReleaseVersion))
+						Expect(params.NewClusterParams.OcpReleaseImage).To(Equal(*openshiftVersion.ReleaseImage))
+					}).Return(clusterReply, nil)
+				mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -229,8 +246,9 @@ var _ = Describe("cluster reconcile", func() {
 			It("create sno cluster", func() {
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(arg1, arg2 interface{}, params installer.RegisterClusterParams) {
-						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal("4.8"))
+						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(ocpReleaseVersion))
 					}).Return(clusterReply, nil)
+				mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace,
 					getDefaultSNOClusterDeploymentSpec(clusterName, pullSecretName))
@@ -245,6 +263,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HighAvailabilityMode)).
 							To(Equal(HighAvailabilityModeNone))
 					}).Return(clusterReply, nil)
+				mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 				cluster.Spec.Provisioning.InstallStrategy.Agent.ProvisionRequirements.WorkerAgents = 0
@@ -259,6 +278,7 @@ var _ = Describe("cluster reconcile", func() {
 			errString := "internal error"
 			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -280,7 +300,7 @@ var _ = Describe("cluster reconcile", func() {
 		spec := hivev1.ClusterDeploymentSpec{
 			ClusterName: clusterName,
 			Provisioning: &hivev1.Provisioning{
-				ImageSetRef:            &hivev1.ClusterImageSetReference{Name: "openshift-v4.8.0"},
+				ImageSetRef:            &hivev1.ClusterImageSetReference{Name: imageSetName},
 				InstallConfigSecretRef: &corev1.LocalObjectReference{Name: "cluster-install-config"},
 			},
 			Platform: hivev1.Platform{
@@ -333,6 +353,8 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
+			imageSet := getDefaultTestImageSet(imageSetName, releaseImage)
+			Expect(c.Create(ctx, imageSet)).To(BeNil())
 		})
 
 		It("cluster resource deleted - verify call to deregister cluster", func() {
@@ -378,6 +400,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 			Expect(c.Delete(ctx, cluster)).ShouldNot(HaveOccurred())
 			request := newClusterDeploymentRequest(cluster)
@@ -408,6 +431,8 @@ var _ = Describe("cluster reconcile", func() {
 		BeforeEach(func() {
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
+			imageSet := getDefaultTestImageSet(imageSetName, releaseImage)
+			Expect(c.Create(ctx, imageSet)).To(BeNil())
 			cluster = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			id := uuid.New()
 			sId = strfmt.UUID(id.String())
@@ -493,6 +518,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().DownloadClusterKubeconfigInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockInstallerInternal.EXPECT().RegisterAddHostsClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(clusterReply, nil)
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
@@ -601,6 +627,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().DownloadClusterKubeconfigInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockInstallerInternal.EXPECT().RegisterAddHostsClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(expectedErr))
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
@@ -625,6 +652,7 @@ var _ = Describe("cluster reconcile", func() {
 				},
 			}
 			mockInstallerInternal.EXPECT().RegisterAddHostsClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(clusterReply, nil)
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 			cluster.Spec.Installed = true
 			Expect(c.Update(ctx, cluster)).Should(BeNil())
 			request := newClusterDeploymentRequest(cluster)

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -100,3 +100,16 @@ func generatePassword(length int) (string, error) {
 
 	return string(password), nil
 }
+
+func getReleaseImage(ctx context.Context, c client.Client, imageSetName string) (string, error) {
+	clusterImageSet := &hivev1.ClusterImageSet{}
+	key := types.NamespacedName{
+		Namespace: "",
+		Name:      imageSetName,
+	}
+	if err := c.Get(ctx, key, clusterImageSet); err != nil {
+		return "", errors.Wrapf(err, "failed to get cluster image set %s", key)
+	}
+
+	return clusterImageSet.Spec.ReleaseImage, nil
+}

--- a/internal/controller/controllers/controllers_suite_test.go
+++ b/internal/controller/controllers/controllers_suite_test.go
@@ -74,3 +74,25 @@ func newBMHRequest(host *bmh_v1alpha1.BareMetalHost) ctrl.Request {
 	}
 	return ctrl.Request{NamespacedName: namespacedName}
 }
+
+func newImageSet(name, releaseImage string) *hivev1.ClusterImageSet {
+	imageSet := &hivev1.ClusterImageSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterImageSet",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "",
+		},
+		Spec: hivev1.ClusterImageSetSpec{
+			ReleaseImage: releaseImage,
+		},
+	}
+
+	return imageSet
+}
+
+func getDefaultTestImageSet(name, releaseImage string) *hivev1.ClusterImageSet {
+	return newImageSet(name, releaseImage)
+}

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -268,6 +268,12 @@ func (r *InfraEnvReconciler) ensureISO(ctx context.Context, infraEnv *aiv1beta1.
 		isoParams.ImageCreateParams.StaticNetworkConfig = staticNetworkConfig
 	}
 
+	// Add openshift version to ensure it isn't missing in versions cache
+	_, err = r.Installer.AddOpenshiftVersion(ctx, cluster.OcpReleaseImage, cluster.PullSecret)
+	if err != nil {
+		return r.handleEnsureISOErrors(ctx, infraEnv, err)
+	}
+
 	// GenerateClusterISOInternal will generate an ISO only if there it was not generated before,
 	// or something has changed in isoParams.
 	updatedCluster, inventoryErr = r.Installer.GenerateClusterISOInternal(ctx, isoParams)

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -73,6 +73,14 @@ var _ = Describe("infraEnv reconcile", func() {
 		ctx                   = context.Background()
 		sId                   strfmt.UUID
 		backEndCluster        = &common.Cluster{Cluster: models.Cluster{ID: &sId}}
+		ocpDisplayName        = "4.8.0"
+		openshiftVersion      = &models.OpenshiftVersion{
+			DisplayName:  &ocpDisplayName,
+			ReleaseImage: new(string),
+			RhcosImage:   new(string),
+			RhcosVersion: new(string),
+			SupportLevel: new(string),
+		}
 	)
 
 	BeforeEach(func() {
@@ -114,6 +122,7 @@ var _ = Describe("infraEnv reconcile", func() {
 				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
 				Expect(params.ImageCreateParams.ImageType).To(Equal(models.ImageTypeMinimalIso))
 			}).Return(&common.Cluster{Cluster: models.Cluster{ImageInfo: &imageInfo}}, nil).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
 		})
@@ -146,6 +155,7 @@ var _ = Describe("infraEnv reconcile", func() {
 				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
 				Expect(params.ImageCreateParams.ImageType).To(Equal(models.ImageTypeFullIso))
 			}).Return(&common.Cluster{Cluster: models.Cluster{ImageInfo: &imageInfo}}, nil).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
 		})
@@ -176,6 +186,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
 				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
 			}).Return(nil, expectedError).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
@@ -257,6 +268,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
 				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
 			}).Return(nil, expectedError).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
@@ -287,6 +299,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
 				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
 			}).Return(nil, expectedError).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
 		})
@@ -353,6 +366,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			}).Return(nil, nil).Times(1)
 		mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
 			Return(&common.Cluster{Cluster: models.Cluster{ImageInfo: &imageInfo}}, nil).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(BeNil())
@@ -377,6 +391,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			}).Return(nil).Times(1)
 		mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
 			Return(&common.Cluster{Cluster: models.Cluster{ImageInfo: &imageInfo}}, nil).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(BeNil())
@@ -463,6 +478,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "pull-secret"))
 			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 			mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
 					Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
@@ -503,6 +519,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "pull-secret"))
 			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
 			expectedError := common.NewApiError(http.StatusInternalServerError, errors.New("error")) // TODO: change to http.StatusBadRequest when MGMT-4695 and MGMT-4696 get resolved.
 			mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -139,7 +139,8 @@ func (r *release) getOpenshiftVersionFromRelease(log logrus.FieldLogger, release
 		log.WithError(err).Errorf("error running \"oc adm release info\" for release %s", releaseImage)
 		return "", err
 	}
-	return version, nil
+	// Trimming as output is retrieved wrapped with single quotes.
+	return strings.Trim(version, "'"), nil
 }
 
 // Extract openshift-baremetal-install binary from releaseImageMirror if provided.

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
+	models "github.com/openshift/assisted-service/models"
 	versions "github.com/openshift/assisted-service/restapi/operations/versions"
 	reflect "reflect"
 )
@@ -33,6 +34,36 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
+}
+
+// AddOpenshiftVersion mocks base method
+func (m *MockHandler) AddOpenshiftVersion(arg0, arg1 string) (*models.OpenshiftVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOpenshiftVersion", arg0, arg1)
+	ret0, _ := ret[0].(*models.OpenshiftVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddOpenshiftVersion indicates an expected call of AddOpenshiftVersion
+func (mr *MockHandlerMockRecorder) AddOpenshiftVersion(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOpenshiftVersion", reflect.TypeOf((*MockHandler)(nil).AddOpenshiftVersion), arg0, arg1)
+}
+
+// GetKey mocks base method
+func (m *MockHandler) GetKey(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKey", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKey indicates an expected call of GetKey
+func (mr *MockHandlerMockRecorder) GetKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKey", reflect.TypeOf((*MockHandler)(nil).GetKey), arg0)
 }
 
 // GetRHCOSImage mocks base method
@@ -80,19 +111,34 @@ func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0)
 }
 
-// GetSupportedVersionFormat mocks base method
-func (m *MockHandler) GetSupportedVersionFormat(arg0 string) (string, error) {
+// GetReleaseVersion mocks base method
+func (m *MockHandler) GetReleaseVersion(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSupportedVersionFormat", arg0)
+	ret := m.ctrl.Call(m, "GetReleaseVersion", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSupportedVersionFormat indicates an expected call of GetSupportedVersionFormat
-func (mr *MockHandlerMockRecorder) GetSupportedVersionFormat(arg0 interface{}) *gomock.Call {
+// GetReleaseVersion indicates an expected call of GetReleaseVersion
+func (mr *MockHandlerMockRecorder) GetReleaseVersion(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedVersionFormat", reflect.TypeOf((*MockHandler)(nil).GetSupportedVersionFormat), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseVersion", reflect.TypeOf((*MockHandler)(nil).GetReleaseVersion), arg0)
+}
+
+// GetVersion mocks base method
+func (m *MockHandler) GetVersion(arg0 string) (*models.OpenshiftVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersion", arg0)
+	ret0, _ := ret[0].(*models.OpenshiftVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVersion indicates an expected call of GetVersion
+func (mr *MockHandlerMockRecorder) GetVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockHandler)(nil).GetVersion), arg0)
 }
 
 // IsOpenshiftVersionSupported mocks base method

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -23,30 +23,39 @@ type Versions struct {
 	ReleaseTag      string `envconfig:"RELEASE_TAG" default:""`
 }
 
-//go:generate mockgen -package versions -destination mock_versions.go . Handler
+//go:generate mockgen -package versions -destination mock_versions.go -self_package github.com/openshift/assisted-service/internal/versions . Handler
 type Handler interface {
 	restapi.VersionsAPI
 	GetReleaseImage(openshiftVersion string) (string, error)
 	GetRHCOSImage(openshiftVersion string) (string, error)
 	GetRHCOSVersion(openshiftVersion string) (string, error)
-	IsOpenshiftVersionSupported(openshiftVersion string) bool
-	GetSupportedVersionFormat(openshiftVersion string) (string, error)
+	GetReleaseVersion(openshiftVersion string) (string, error)
+	GetKey(openshiftVersion string) (string, error)
+	GetVersion(openshiftVersion string) (*models.OpenshiftVersion, error)
+	IsOpenshiftVersionSupported(versionKey string) bool
+	AddOpenshiftVersion(ocpReleaseImage, pullSecret string) (*models.OpenshiftVersion, error)
 }
 
 func NewHandler(log logrus.FieldLogger, releaseHandler oc.Release,
 	versions Versions, openshiftVersions models.OpenshiftVersions,
 	releaseImageMirror string) *handler {
 	return &handler{
-		versions:          versions,
-		openshiftVersions: openshiftVersions,
+		versions:           versions,
+		openshiftVersions:  openshiftVersions,
+		releaseHandler:     releaseHandler,
+		releaseImageMirror: releaseImageMirror,
+		log:                log,
 	}
 }
 
 var _ restapi.VersionsAPI = (*handler)(nil)
 
 type handler struct {
-	versions          Versions
-	openshiftVersions models.OpenshiftVersions
+	versions           Versions
+	openshiftVersions  models.OpenshiftVersions
+	releaseHandler     oc.Release
+	releaseImageMirror string
+	log                logrus.FieldLogger
 }
 
 func (h *handler) ListComponentVersions(ctx context.Context, params operations.ListComponentVersionsParams) middleware.Responder {
@@ -73,53 +82,158 @@ func (h *handler) ListSupportedOpenshiftVersions(ctx context.Context, params ope
 }
 
 func (h *handler) GetReleaseImage(openshiftVersion string) (pullSpec string, err error) {
-	if !h.IsOpenshiftVersionSupported(openshiftVersion) {
-		return "", errors.Errorf("No release image for unsupported openshift version %s", openshiftVersion)
+	versionKey, err := h.GetKey(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+	if !h.IsOpenshiftVersionSupported(versionKey) {
+		return "", errors.Errorf("No release image for unsupported openshift version %s", versionKey)
 	}
 
-	if h.openshiftVersions[openshiftVersion].ReleaseImage == nil {
-		return "", errors.Errorf("Release image was missing for openshift version %s", openshiftVersion)
+	if h.openshiftVersions[versionKey].ReleaseImage == nil {
+		return "", errors.Errorf("Release image was missing for openshift version %s", versionKey)
 	}
 
-	return *h.openshiftVersions[openshiftVersion].ReleaseImage, nil
+	return *h.openshiftVersions[versionKey].ReleaseImage, nil
 }
 
 func (h *handler) GetRHCOSImage(openshiftVersion string) (string, error) {
-	if !h.IsOpenshiftVersionSupported(openshiftVersion) {
-		return "", errors.Errorf("No rhcos image for unsupported openshift version %s", openshiftVersion)
+	versionKey, err := h.GetKey(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+	if !h.IsOpenshiftVersionSupported(versionKey) {
+		return "", errors.Errorf("No rhcos image for unsupported openshift version %s", versionKey)
 	}
 
-	if h.openshiftVersions[openshiftVersion].RhcosImage == nil {
-		return "", errors.Errorf("RHCOS image was missing for openshift version %s", openshiftVersion)
+	if h.openshiftVersions[versionKey].RhcosImage == nil {
+		return "", errors.Errorf("RHCOS image was missing for openshift version %s", versionKey)
 	}
 
-	return *h.openshiftVersions[openshiftVersion].RhcosImage, nil
+	return *h.openshiftVersions[versionKey].RhcosImage, nil
 }
 
 func (h *handler) GetRHCOSVersion(openshiftVersion string) (string, error) {
-	if !h.IsOpenshiftVersionSupported(openshiftVersion) {
-		return "", errors.Errorf("No rhcos version for unsupported openshift version %s", openshiftVersion)
+	versionKey, err := h.GetKey(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+	if !h.IsOpenshiftVersionSupported(versionKey) {
+		return "", errors.Errorf("No rhcos version for unsupported openshift version %s", versionKey)
 	}
 
-	if h.openshiftVersions[openshiftVersion].RhcosVersion == nil {
-		return "", errors.Errorf("RHCOS version was missing for openshift version %s", openshiftVersion)
+	if h.openshiftVersions[versionKey].RhcosVersion == nil {
+		return "", errors.Errorf("RHCOS version was missing for openshift version %s", versionKey)
 	}
 
-	return *h.openshiftVersions[openshiftVersion].RhcosVersion, nil
+	return *h.openshiftVersions[versionKey].RhcosVersion, nil
 }
 
-func (h *handler) IsOpenshiftVersionSupported(openshiftVersion string) bool {
-	if _, ok := h.openshiftVersions[openshiftVersion]; !ok {
+func (h *handler) IsOpenshiftVersionSupported(versionKey string) bool {
+	if _, ok := h.openshiftVersions[versionKey]; !ok {
 		return false
 	}
 
 	return true
 }
 
-func (h *handler) GetSupportedVersionFormat(openshiftVersion string) (string, error) {
+// Should return release version (as fetched from 'oc adm release info')
+func (h *handler) GetReleaseVersion(openshiftVersion string) (string, error) {
+	versionKey, err := h.GetKey(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+	if !h.IsOpenshiftVersionSupported(versionKey) {
+		return "", errors.Errorf("No release version for unsupported openshift version %s", versionKey)
+	}
+
+	if h.openshiftVersions[versionKey].ReleaseVersion == nil {
+		return h.GetOCPSemVer(openshiftVersion)
+	}
+
+	return *h.openshiftVersions[versionKey].ReleaseVersion, nil
+}
+
+// Returns the OpenshiftVersion entity
+func (h *handler) GetVersion(openshiftVersion string) (*models.OpenshiftVersion, error) {
+	versionKey, err := h.GetKey(openshiftVersion)
+	if err != nil {
+		return nil, err
+	}
+	if !h.IsOpenshiftVersionSupported(versionKey) {
+		return nil, errors.Errorf("No release version for unsupported openshift version %s", versionKey)
+	}
+
+	releaseVersion, err := h.GetReleaseVersion(openshiftVersion)
+	if err != nil {
+		return nil, err
+	}
+	version := h.openshiftVersions[versionKey]
+	version.ReleaseVersion = &releaseVersion
+	return &version, nil
+}
+
+// Returns version in major.minor format
+func (h *handler) GetKey(openshiftVersion string) (string, error) {
 	v, err := version.NewVersion(openshiftVersion)
 	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1]), nil
+}
+
+// Returns version in major.minor.patch format
+func (h *handler) GetOCPSemVer(openshiftVersion string) (string, error) {
+	v, err := version.NewVersion(openshiftVersion)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%d.%d.%d", v.Segments()[0], v.Segments()[1], v.Segments()[2]), nil
+}
+
+func (h *handler) AddOpenshiftVersion(ocpReleaseImage, pullSecret string) (*models.OpenshiftVersion, error) {
+	// Get openshift version from release image metadata (oc adm release info)
+	ocpVersion, err := h.releaseHandler.GetOpenshiftVersion(h.log, ocpReleaseImage, h.releaseImageMirror, pullSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return if version is not speficied in OPENSHIFT_VERSIONS
+	ocpVersionKey, err := h.GetKey(ocpVersion)
+	if err != nil {
+		return nil, err
+	}
+	versionFromCache, ok := h.openshiftVersions[ocpVersionKey]
+	if !ok {
+		return nil, errors.Errorf("OCP version is not specified in OPENSHIFT_VERSIONS: %s", ocpVersionKey)
+	}
+
+	// Get version in major.minor.patch format
+	ocpSemVer, err := h.GetOCPSemVer(ocpVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get SupportLevel or default to 'custom'
+	var supportLevel string
+	if versionFromCache.SupportLevel != nil {
+		supportLevel = *versionFromCache.SupportLevel
+	}
+	supportLevel = models.OpenshiftVersionSupportLevelCustom
+
+	// Create OpenshiftVersion according to fetched data
+	openshiftVersion := &models.OpenshiftVersion{
+		DisplayName:    &ocpVersion,
+		ReleaseImage:   &ocpReleaseImage,
+		ReleaseVersion: &ocpSemVer,
+		RhcosImage:     versionFromCache.RhcosImage,
+		RhcosVersion:   versionFromCache.RhcosVersion,
+		SupportLevel:   &supportLevel,
+	}
+
+	// Store in map
+	h.openshiftVersions[ocpVersionKey] = *openshiftVersion
+	h.log.Infof("Stored OCP version: %s", ocpSemVer)
+
+	return openshiftVersion, nil
 }


### PR DESCRIPTION
Added an internal API for dynamically supporting a new custom OCP version,
and upload boot files according to specified OCP/RHCOS version/image.

In order to allow hive ClusterDeployment creation with custom OCP version, supporting the following flow:
* Set OPENSHIFT_VERSIONS env var only with RHCOS image/version and
   OCP version in major.minor format as a key. I.e. {"4.8":{"rhcos_image":...,"rhcos_version":...}}
* Set the release image within an ImageSet referenced in the ClusterDeployment.
* Upon creating a new cluster in ClusterDeploymentsReconciler, use 'oc adm release info' to fetch the OCP version (in major.minor.patch format).
* Fetch stored OpenshiftVersion entity according to major.minor version.
* Update OpenshiftVersion with missing data (ReleaseImage and DisplayName), and cache in versionHandler.
* Store in cluster model:
  * ocp_release_image: needed for ISO generation, to add OpenshiftVersion if missing.
  * openshift_version: in major.minor.patch format.
* Upload boot files for the new OCP version (create/upload ISO template).