### PR TITLE
NO-ISSUE Update ocp-metal-ui proxy-pass URI with service route URI in operator

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -56,6 +56,10 @@ patchesStrategicMerge:
 # as the DEPLOY_TARGET.
 - assisted-service-patch-deploy-target.yaml
 
+# An init container that updates proxy-pass in nginx.conf in the
+# ocp-metal-ui ConfigMap to match the assisted-service's service route URL.
+- ui-patch-init-containers.yaml
+
 ###################
 # Optional patches
 ###################

--- a/config/default/ui-patch-init-containers.yaml
+++ b/config/default/ui-patch-init-containers.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ocp-metal-ui
+  namespace: assisted-installer
+spec:
+  template:
+    metadata:
+      labels:
+        app: ocp-metal-ui
+    spec:
+      initContainers:
+      - name: init-wait-for-route
+        image: quay.io/openshift/origin-cli:latest
+        command: ['sh', '-c', "until oc get routes -n $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) assisted-service; do echo waiting for assisted-service route; sleep 2; done"]
+      - name: init-update-proxy-pass-in-ngnix-conf-config-map
+        image: quay.io/openshift/origin-cli:latest
+        command: ['sh', '-c', 'export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) && export ROUTE_URL=$(oc get routes -n $NAMESPACE assisted-service -o jsonpath={.spec.host}) && if [ "$ROUTE_URL" != "" ] ; then oc get configmap -n $NAMESPACE ocp-metal-ui -o yaml | sed -e "s|assisted-service.assisted-installer.svc.cluster.local|$ROUTE_URL|" | oc apply -f - ; fi']


### PR DESCRIPTION
The service can potentially be installed in any namespace. The
proxy-pass URL in the ocp-metal-ui ConfigMap needs to be updated
if the operator is installed in a namespace not named
"assisted-installer". This patch creates init containers to update
the proxy-pass.

Signed-off-by: Richard Su <rwsu@redhat.com>