### PR TITLE
MGMT-4480 Get must-gather image from release

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -124,6 +124,11 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		return "", err
 	}
 
+	mustGatherImage, err := i.ocRelease.GetMustGatherImage(i.log, releaseImage, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
+	if err != nil {
+		return "", err
+	}
+
 	i.log.Infof("Install command releaseImage: %s, mcoImage: %s", releaseImage, mcoImage)
 
 	podmanCmd := podmanBaseCmd[:]
@@ -138,6 +143,7 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		"--mco-image", mcoImage,
 		"--controller-image", i.instructionConfig.ControllerImage,
 		"--agent-image", i.instructionConfig.AgentImage,
+		"--must-gather-image", mustGatherImage,
 	}
 
 	/*

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -232,7 +232,8 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 	mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(disks, nil).AnyTimes()
 	mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).AnyTimes()
-	mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("mcoImage", nil).AnyTimes()
+	mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).AnyTimes()
+	mockRelease.EXPECT().GetMustGatherImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherImage, nil).AnyTimes()
 	if funk.Contains(expectedStepTypes, models.StepTypeConnectivityCheck) {
 		mockConnectivity.EXPECT().GetHostValidInterfaces(gomock.Any()).Return([]*models.Interface{
 			{

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -48,6 +48,21 @@ func (mr *MockReleaseMockRecorder) GetMCOImage(log, releaseImage, releaseImageMi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMCOImage", reflect.TypeOf((*MockRelease)(nil).GetMCOImage), log, releaseImage, releaseImageMirror, pullSecret)
 }
 
+// GetMustGatherImage mocks base method
+func (m *MockRelease) GetMustGatherImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMustGatherImage", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMustGatherImage indicates an expected call of GetMustGatherImage
+func (mr *MockReleaseMockRecorder) GetMustGatherImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImage", reflect.TypeOf((*MockRelease)(nil).GetMustGatherImage), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
 // GetOpenshiftVersion mocks base method
 func (m *MockRelease) GetOpenshiftVersion(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -23,6 +23,7 @@ var (
 	pullSecret         = "pull secret"
 	fullVersion        = "4.6.0-0.nightly-2020-08-31-220837"
 	mcoImage           = "mco_image"
+	mustGatherImage    = "must_gather_image"
 )
 
 var _ = Describe("oc", func() {
@@ -50,8 +51,8 @@ var _ = Describe("oc", func() {
 
 	Context("GetMCOImage", func() {
 		It("mco image from release image", func() {
-			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
-				false, releaseImage, tempPullSecretFile.Name())
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mcoImageName, false, releaseImage, tempPullSecretFile.Name())
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mcoImage, "", 0).Times(1)
 
@@ -61,8 +62,8 @@ var _ = Describe("oc", func() {
 		})
 
 		It("mco image from release image mirror", func() {
-			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
-				true, releaseImageMirror, tempPullSecretFile.Name())
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mcoImageName, true, releaseImageMirror, tempPullSecretFile.Name())
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mcoImage, "", 0).Times(1)
 
@@ -80,13 +81,56 @@ var _ = Describe("oc", func() {
 		It("stdout with new lines", func() {
 			stdout := fmt.Sprintf("\n%s\n", mcoImage)
 
-			command := fmt.Sprintf(templateGetMCOImage+" --registry-config=%s",
-				false, releaseImage, tempPullSecretFile.Name())
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mcoImageName, false, releaseImage, tempPullSecretFile.Name())
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(stdout, "", 0).Times(1)
 
 			mco, err := oc.GetMCOImage(log, releaseImage, "", pullSecret)
 			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("GetMustGatherImage", func() {
+		It("must-gather image from release image", func() {
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mustGatherImageName, false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mustGatherImage, "", 0).Times(1)
+
+			mustGather, err := oc.GetMustGatherImage(log, releaseImage, "", pullSecret)
+			Expect(mustGather).Should(Equal(mustGatherImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("must-gather image from release image mirror", func() {
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mustGatherImageName, true, releaseImageMirror, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mustGatherImage, "", 0).Times(1)
+
+			mustGather, err := oc.GetMustGatherImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mustGather).Should(Equal(mustGatherImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("must-gather image with no release image or mirror", func() {
+			mustGather, err := oc.GetMustGatherImage(log, "", "", pullSecret)
+			Expect(mustGather).Should(BeEmpty())
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("stdout with new lines", func() {
+			stdout := fmt.Sprintf("\n%s\n", mustGatherImage)
+
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mustGatherImageName, false, releaseImage, tempPullSecretFile.Name())
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(stdout, "", 0).Times(1)
+
+			mustGather, err := oc.GetMustGatherImage(log, releaseImage, "", pullSecret)
+			Expect(mustGather).Should(Equal(mustGatherImage))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Extract must-gather image URL from release or release mirror and
send it to installer so that must-gather doesn't have to talk to
the cluster in order to extract the image, and won't use the
global default. Hopefully, it will allow must-gather to run on
broken clusters.