### PR TITLE
MGMT-4517 Update static network config in  RESTful API user guide

### DIFF
--- a/docs/user-guide/restful-api-guide.md
+++ b/docs/user-guide/restful-api-guide.md
@@ -5,42 +5,59 @@ The purpose of this guide is to assist users in using the RESTful API for intera
 # Setting Static Network Config
 
 User may provide static network configurations when generating the discovery ISO.
-The input for the static network configurations is a set of [nmstate](https://www.nmstate.io/) files in YAML format, each file contains the desired network configuration of a single node.
+The static network configurations per each host should contain:
+* [nmstate](https://www.nmstate.io/) file in YAML format, specifying the desired network configuration for the host
+  * The file will contain interface logical names that will be replaced with host's actual interface name at discovery time
+* A map (mac-interface-mapping) containing the mapping of mac-address to the logical interface name
 
 In the following example `server-a.yaml` and `server-b.yaml` files contain the nmstate configuration in YAML format for two nodes.
 Here is an example of the content of `server-a.yaml`, setting network configuration for two of its network interfaces:
 ```
+dns-resolver:
+  config:
+    server:
+    - 192.168.126.1
 interfaces:
-- name: 020000e7f670
-  type: ethernet
-  state: up
-  ethernet:
-    auto-negotiation: true
-    duplex: full
-    speed: 1000
-  ipv4:
+- ipv4:
     address:
-    - ip: 192.168.126.10
+    - ip: 192.168.126.30
       prefix-length: 24
-    auto-dns: true
-    auto-gateway: true
-    auto-routes: true
-    dhcp: true
+    dhcp: false
     enabled: true
-  mac-address: 02:00:00:e7:f6:70
-  mtu: 1500
-- name: 020000242e01
-  type: ethernet
+  name: eth0
   state: up
-  ethernet:
-    auto-negotiation: true
-    duplex: full
-    speed: 1000
-  ipv4:
-    enabled: false
-  mac-address: 02:00:00:24:2e:01
-  mtu: 1500
+  type: ethernet
+- ipv4:
+    address:
+    - ip: 192.168.141.30
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  name: eth1
+  state: up
+  type: ethernet
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.168.126.1
+    next-hop-interface: eth0
+    table-id: 254
 ```
+
+The `mac-interface-mapping` attribute should map the MAC Addresses of the host to the logical interface name as used in the `network_yaml` element (nmstate files):
+```
+mac_interface_map: [
+    {
+      mac_address: 02:00:00:2c:23:a5,
+      logical_nic_name: eth0
+    },
+    {
+      mac_address: 02:00:00:68:73:dc,
+      logical_nic_name: eth1
+    }
+]
+```
+
 In order to use `curl` to send a request for setting static network configuration, there is a need to JSON-encode the content of those files.
 This can be achieved using the `jq` tool as shown below:
 
@@ -54,7 +71,16 @@ jq -n --arg SSH_KEY "$NODE_SSH_KEY" --arg NMSTATE_YAML1 "$(cat server-a.yaml)" -
 '{
   "ssh_public_key": $SSH_KEY,
   "image_type": "full-iso",
-  "static_network_config": [ $NMSTATE_YAML1, $NMSTATE_YAML2 ]
+  "static_network_config": [
+    {
+      "network_yaml": $NMSTATE_YAML1,
+      "mac_interface_map": [{"mac_address": "02:00:00:2c:23:a5", "logical_nic_name": "eth0"}, {"mac_address": "02:00:00:68:73:dc", "logical_nic_name": "eth1"}]
+    },
+    {
+      "network_yaml": $NMSTATE_YAML2,
+      "mac_interface_map": [{"mac_address": "02:00:00:9f:85:eb", "logical_nic_name": "eth1"}, {"mac_address": "02:00:00:c8:be:9b", "logical_nic_name": "eth0"}]
+     }
+  ]
 }' >> $request_body
 ```
 The request will be stored in a temporary file `$request_body` and will be used as the request body of the `curl` command:


### PR DESCRIPTION
The static network config API expects a network_yaml along with a mapping file in order to set the static network configuration.
The example is updated accordingly.

Signed-off-by: Moti Asayag <masayag@redhat.com>