### PR TITLE
MGMT-4576 Check manifests content on creation

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	operations "github.com/openshift/assisted-service/restapi/operations/manifests"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 var _ restapi.ManifestsAPI = &Manifests{}
@@ -64,6 +66,19 @@ func (m *Manifests) CreateClusterManifest(ctx context.Context, params operations
 		log.WithError(err).Errorf("Cluster manifest %s for cluster %s failed to base64 decode: [%s]",
 			fileName, cluster.ID, *params.CreateManifestParams.Content)
 		return common.GenerateErrorResponderWithDefault(errors.New("failed to base64-decode cluster manifest content"), http.StatusBadRequest)
+	}
+	extension := filepath.Ext(fileName)
+	if extension == ".yaml" || extension == ".yml" {
+		var s map[interface{}]interface{}
+		if yaml.Unmarshal(manifestContent, &s) != nil {
+			return common.GenerateErrorResponderWithDefault(errors.New("Manifest content has an invalid YAML format"), http.StatusBadRequest)
+		}
+	} else if extension == ".json" {
+		if !json.Valid(manifestContent) {
+			return common.GenerateErrorResponderWithDefault(errors.New("Manifest content has an illegal JSON format"), http.StatusBadRequest)
+		}
+	} else {
+		return common.GenerateErrorResponderWithDefault(errors.New("Unsupported manifest extension. Only json, yaml and yml extensions are supported"), http.StatusBadRequest)
 	}
 
 	objectName := GetManifestObjectName(*cluster.ID, fileName)

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -2,6 +2,7 @@ package manifests_test
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,6 +30,29 @@ func TestValidator(t *testing.T) {
 	RunSpecs(t, "manifests_test")
 }
 
+const contentAsYAML = `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+  machineconfiguration.openshift.io/role: master
+  name: 99-openshift-machineconfig-master-kargs
+spec:
+  kernelArguments:
+  - 'loglevel=7'`
+
+const contentAsJSON = `{
+  "apiVersion": "machineconfiguration.openshift.io/v1",
+  "kind": "MachineConfig",
+  "metadata": null,
+  "labels": null,
+  "machineconfiguration.openshift.io/role": "master",
+  "name": "99-openshift-machineconfig-master-kargs",
+  "spec": null,
+  "kernelArguments": [
+    "loglevel=7"
+  ]
+}`
+
 var _ = Describe("ClusterManifestTests", func() {
 	var (
 		manifestsAPI  *manifests.Manifests
@@ -37,10 +61,10 @@ var _ = Describe("ClusterManifestTests", func() {
 		ctrl          *gomock.Controller
 		mockS3Client  *s3wrapper.MockAPI
 		dbName        = "cluster_manifest"
-		content       = "aGVsbG8gd29ybGQhCg=="
-		fileName      = "99-test.yaml"
+		fileName      = "99-openshift-machineconfig-master-kargs.yaml"
 		validFolder   = "openshift"
 		defaultFolder = "manifests"
+		content       = encodeToBase64(contentAsYAML)
 	)
 
 	BeforeEach(func() {
@@ -190,6 +214,155 @@ var _ = Describe("ClusterManifestTests", func() {
 			err := response.(*common.ApiErrorResponse)
 			Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
 			Expect(err.Error()).To(ContainSubstring("failed to base64-decode cluster manifest content"))
+		})
+
+		Context("File extension and format", func() {
+			It("accepts manifest in json format and .json extension", func() {
+				clusterID := registerCluster().ID
+				jsonContent := encodeToBase64(contentAsJSON)
+				fileName := "99-openshift-machineconfig-master-kargs.json"
+				mockUpload(1)
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &jsonContent,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(operations.NewCreateClusterManifestCreated()))
+				responsePayload := response.(*operations.CreateClusterManifestCreated)
+				Expect(responsePayload.Payload).ShouldNot(BeNil())
+				Expect(responsePayload.Payload.FileName).To(Equal(fileName))
+				Expect(responsePayload.Payload.Folder).To(Equal(defaultFolder))
+			})
+
+			It("accepts manifest with .yml extension", func() {
+				clusterID := registerCluster().ID
+				fileName := "99-openshift-machineconfig-master-kargs.yml"
+				mockUpload(1)
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &content,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(operations.NewCreateClusterManifestCreated()))
+				responsePayload := response.(*operations.CreateClusterManifestCreated)
+				Expect(responsePayload.Payload).ShouldNot(BeNil())
+				Expect(responsePayload.Payload.FileName).To(Equal(fileName))
+				Expect(responsePayload.Payload.Folder).To(Equal(defaultFolder))
+			})
+
+			It("accepts manifest with .yml extension and a multi YAML content", func() {
+				clusterID := registerCluster().ID
+				fileName := "99_masters-chrony-configuration.yaml"
+				aContent := encodeToBase64(`---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: masters-chrony-configuration
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,c2VydmVyIGNsb2NrLnJlZGhhdC5jb20gaWJ1cnN0Cg==
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/chrony.conf
+  osImageURL: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: masters-chrony-configuration
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+`)
+				mockUpload(1)
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &aContent,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(operations.NewCreateClusterManifestCreated()))
+				responsePayload := response.(*operations.CreateClusterManifestCreated)
+				Expect(responsePayload.Payload).ShouldNot(BeNil())
+				Expect(responsePayload.Payload.FileName).To(Equal(fileName))
+				Expect(responsePayload.Payload.Folder).To(Equal(defaultFolder))
+			})
+
+			It("fails for manifest with invalid json format", func() {
+				clusterID := registerCluster().ID
+				fileName := "99-test.json"
+				invalidJSONContent := encodeToBase64("not a valid JSON content")
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &invalidJSONContent,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
+				err := response.(*common.ApiErrorResponse)
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+				Expect(err.Error()).To(ContainSubstring("Manifest content has an illegal JSON format"))
+			})
+
+			It("fails for manifest with invalid yaml format", func() {
+				clusterID := registerCluster().ID
+				fileName := "99-test.yml"
+				invalidYAMLContent := encodeToBase64("not a valid YAML content")
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &invalidYAMLContent,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
+				err := response.(*common.ApiErrorResponse)
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+				Expect(err.Error()).To(ContainSubstring("Manifest content has an invalid YAML format"))
+			})
+
+			It("fails for manifest with unsupported extension", func() {
+				clusterID := registerCluster().ID
+				fileName := "99-test.txt"
+				response := manifestsAPI.CreateClusterManifest(ctx, operations.CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &content,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
+				err := response.(*common.ApiErrorResponse)
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+				Expect(err.Error()).To(ContainSubstring("Unsupported manifest extension"))
+			})
 		})
 	})
 
@@ -358,4 +531,8 @@ func (VoidReadCloser) Read(p []byte) (int, error) {
 
 func (VoidReadCloser) Close() error {
 	return nil
+}
+
+func encodeToBase64(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
 }

--- a/models/create_manifest_params.go
+++ b/models/create_manifest_params.go
@@ -25,6 +25,7 @@ type CreateManifestParams struct {
 
 	// The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.
 	// Required: true
+	// Pattern: ^.*\.(yaml|yml|json)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -66,6 +67,10 @@ func (m *CreateManifestParams) validateContent(formats strfmt.Registry) error {
 func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 
 	if err := validate.Required("file_name", "body", m.FileName); err != nil {
+		return err
+	}
+
+	if err := validate.Pattern("file_name", "body", string(*m.FileName), `^.*\.(yaml|yml|json)$`); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5571,7 +5571,8 @@ func init() {
         },
         "file_name": {
           "description": "The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^.*\\.(yaml|yml|json)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",
@@ -12891,7 +12892,8 @@ func init() {
         },
         "file_name": {
           "description": "The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^.*\\.(yaml|yml|json)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -16,10 +16,18 @@ import (
 
 var _ = Describe("manifests tests", func() {
 	var (
-		ctx           = context.Background()
-		cluster       *models.Cluster
-		content       = "hello world!"
-		base64Content = base64.RawStdEncoding.EncodeToString([]byte(content))
+		ctx     = context.Background()
+		cluster *models.Cluster
+		content = `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-openshift-machineconfig-master-kargs
+spec:
+  kernelArguments:
+    - 'loglevel=7'`
+		base64Content = base64.StdEncoding.EncodeToString([]byte(content))
 		manifestFile  models.Manifest
 	)
 
@@ -29,7 +37,7 @@ var _ = Describe("manifests tests", func() {
 
 	BeforeEach(func() {
 		manifestFile = models.Manifest{
-			FileName: "99-test.yaml",
+			FileName: "99-openshift-machineconfig-master-kargs.yaml",
 			Folder:   "openshift",
 		}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4948,6 +4948,7 @@ definitions:
       file_name:
         description: The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.
         type: string
+        pattern: '^.*\.(yaml|yml|json)$'
       content:
         description: base64 encoded manifest content.
         type: string


### PR DESCRIPTION
- Manifests provided by the user should have one of the following extensions: json, yaml or yml.
- Manifests content should be a valid JSON or YAML format.

Signed-off-by: Moti Asayag <masayag@redhat.com>