### PR TITLE
MGMT-4531 cluster host requirements handler

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/events"
+	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/installcfg"
@@ -77,6 +78,7 @@ var (
 	mockCRDUtils            *MockCRDUtils
 	mockAccountsMgmt        *ocm.MockOCMAccountsMgmt
 	mockOperatorManager     *operators.MockAPI
+	mockHwValidator         *hardware.MockValidator
 	mockIgnitionBuilder     *ignition.MockIgnitionBuilder
 	secondDayWorkerIgnition = []byte(`{
 		"ignition": {
@@ -6469,11 +6471,11 @@ func createInventory(db *gorm.DB, cfg Config) *bareMetalInventory {
 	mockCRDUtils = NewMockCRDUtils(ctrl)
 	mockOperatorManager = operators.NewMockAPI(ctrl)
 	mockIgnitionBuilder = ignition.NewMockIgnitionBuilder(ctrl)
-
+	mockHwValidator = hardware.NewMockValidator(ctrl)
 	return NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterApi, cfg,
 		mockGenerator, mockEvents, mockS3Client, mockMetric, mockOperatorManager,
 		getTestAuthHandler(), mockK8sClient, ocmClient, nil, mockSecretValidator, mockVersions,
-		mockIsoEditorFactory, mockCRDUtils, mockIgnitionBuilder)
+		mockIsoEditorFactory, mockCRDUtils, mockIgnitionBuilder, mockHwValidator)
 }
 
 var _ = Describe("IPv6 support disabled", func() {

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -5,7 +5,9 @@
 package hardware
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
+	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	reflect "reflect"
 )
@@ -60,6 +62,21 @@ func (m *MockValidator) GetHostRequirements(role models.HostRole) models.HostReq
 func (mr *MockValidatorMockRecorder) GetHostRequirements(role interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements), role)
+}
+
+// GetClusterHostRequirements mocks base method
+func (m *MockValidator) GetClusterHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterHostRequirements", ctx, cluster, host)
+	ret0, _ := ret[0].(*models.ClusterHostRequirements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterHostRequirements indicates an expected call of GetClusterHostRequirements
+func (mr *MockValidatorMockRecorder) GetClusterHostRequirements(ctx, cluster, host interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetClusterHostRequirements), ctx, cluster, host)
 }
 
 // DiskIsEligible mocks base method

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -132,7 +132,7 @@ func (v *validator) GetHostRequirements(role models.HostRole) models.HostRequire
 }
 
 func (v *validator) GetClusterHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirements, error) {
-	operatorsRequirements, err := v.operatorsAPI.GetRequirementsBreakdownForRole(ctx, cluster, host.Role)
+	operatorsRequirements, err := v.operatorsAPI.GetRequirementsBreakdownForRoleInCluster(ctx, cluster, host.Role)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -1,16 +1,20 @@
 package hardware
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/alecthomas/units"
 	"github.com/go-openapi/strfmt"
+	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
@@ -32,7 +36,7 @@ var _ = Describe("Disk eligibility", func() {
 	BeforeEach(func() {
 		var cfg ValidatorCfg
 		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
-		hwvalidator = NewValidator(logrus.New(), cfg)
+		hwvalidator = NewValidator(logrus.New(), cfg, nil)
 
 		bigEnoughSize = conversions.GbToBytes(cfg.MinDiskSizeGb) + 1
 		tooSmallSize = conversions.GbToBytes(cfg.MinDiskSizeGb) - 1
@@ -84,7 +88,7 @@ var _ = Describe("hardware_validator", func() {
 	BeforeEach(func() {
 		var cfg ValidatorCfg
 		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
-		hwvalidator = NewValidator(logrus.New(), cfg)
+		hwvalidator = NewValidator(logrus.New(), cfg, nil)
 		id1 := strfmt.UUID(uuid.New().String())
 		id2 := strfmt.UUID(uuid.New().String())
 		id3 := strfmt.UUID(uuid.New().String())
@@ -175,6 +179,120 @@ var _ = Describe("hardware_validator", func() {
 		Expect(disks[0].Name).Should(Equal("xvda"))
 		Expect(len(disks)).Should(Equal(1))
 	})
+})
+
+var _ = Describe("Cluster host requirements", func() {
+
+	var (
+		cfg         ValidatorCfg
+		hwvalidator Validator
+		cluster     *common.Cluster
+		host        *models.Host
+
+		ctrl          *gomock.Controller
+		operatorsMock *operators.MockAPI
+
+		operatorRequirements []*models.OperatorHostRequirements
+		details1, details2   models.ClusterHostRequirementsDetails
+	)
+
+	BeforeEach(func() {
+		clusterID := strfmt.UUID(uuid.New().String())
+		cluster = &common.Cluster{Cluster: models.Cluster{ID: &clusterID}}
+
+		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+
+		details1 = models.ClusterHostRequirementsDetails{
+			InstallationDiskSpeedThresholdMs: 10,
+			RAMMib:                           1024,
+			CPUCores:                         4,
+			DiskSizeGb:                       10,
+		}
+		details2 = models.ClusterHostRequirementsDetails{
+			InstallationDiskSpeedThresholdMs: 5,
+			RAMMib:                           256,
+			CPUCores:                         2,
+			DiskSizeGb:                       5,
+		}
+		operatorRequirements = []*models.OperatorHostRequirements{
+			{OperatorName: "op-one", Requirements: &details1},
+			{OperatorName: "op-two", Requirements: &details2},
+		}
+
+		ctrl = gomock.NewController(GinkgoT())
+		operatorsMock = operators.NewMockAPI(ctrl)
+
+		hwvalidator = NewValidator(logrus.New(), cfg, operatorsMock)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should contain correct requirements for master host", func() {
+		role := models.HostRoleMaster
+		id1 := strfmt.UUID(uuid.New().String())
+		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
+
+		operatorsMock.EXPECT().GetRequirementsBreakdownForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(operatorRequirements, nil)
+
+		result, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+
+		Expect(result.Ocp.DiskSizeGb).To(BeEquivalentTo(cfg.MinDiskSizeGb))
+		Expect(result.Ocp.CPUCores).To(BeEquivalentTo(cfg.MinCPUCoresMaster))
+		Expect(result.Ocp.RAMMib).To(BeEquivalentTo(cfg.MinRamGibMaster * int64(units.KiB)))
+		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(BeZero())
+
+		Expect(result.Operators).To(ConsistOf(operatorRequirements))
+
+		Expect(result.Total.DiskSizeGb).To(Equal(cfg.MinDiskSizeGb + details1.DiskSizeGb + details2.DiskSizeGb))
+		Expect(result.Total.CPUCores).To(Equal(cfg.MinCPUCoresMaster + details1.CPUCores + details2.CPUCores))
+		Expect(result.Total.RAMMib).To(Equal(cfg.MinRamGibMaster*int64(units.KiB) + details1.RAMMib + details2.RAMMib))
+		Expect(result.Total.InstallationDiskSpeedThresholdMs).To(Equal(details2.InstallationDiskSpeedThresholdMs))
+	})
+
+	It("should contain correct requirements for worker host", func() {
+		role := models.HostRoleWorker
+		id1 := strfmt.UUID(uuid.New().String())
+		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
+
+		operatorsMock.EXPECT().GetRequirementsBreakdownForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(operatorRequirements, nil)
+
+		result, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).ToNot(BeNil())
+
+		Expect(result.Ocp.DiskSizeGb).To(BeEquivalentTo(cfg.MinDiskSizeGb))
+		Expect(result.Ocp.CPUCores).To(BeEquivalentTo(cfg.MinCPUCoresWorker))
+		Expect(result.Ocp.RAMMib).To(BeEquivalentTo(cfg.MinRamGibWorker * int64(units.KiB)))
+		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(BeZero())
+
+		Expect(result.Operators).To(ConsistOf(operatorRequirements))
+
+		Expect(result.Total.DiskSizeGb).To(Equal(cfg.MinDiskSizeGb + details1.DiskSizeGb + details2.DiskSizeGb))
+		Expect(result.Total.CPUCores).To(Equal(cfg.MinCPUCoresWorker + details1.CPUCores + details2.CPUCores))
+		Expect(result.Total.RAMMib).To(Equal(cfg.MinRamGibWorker*int64(units.KiB) + details1.RAMMib + details2.RAMMib))
+		Expect(result.Total.InstallationDiskSpeedThresholdMs).To(Equal(details2.InstallationDiskSpeedThresholdMs))
+	})
+
+	It("should fail providing on operator API error", func() {
+		role := models.HostRoleWorker
+		id1 := strfmt.UUID(uuid.New().String())
+		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
+
+		failure := errors.New("boom")
+		operatorsMock.EXPECT().GetRequirementsBreakdownForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(nil, failure)
+
+		_, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(failure))
+	})
+
 })
 
 func isBlockDeviceNameInlist(disks []*models.Disk, name string) bool {

--- a/internal/hardware/virt/virt.go
+++ b/internal/hardware/virt/virt.go
@@ -1,0 +1,15 @@
+package virt
+
+import (
+	"github.com/openshift/assisted-service/models"
+	"github.com/thoas/go-funk"
+)
+
+const (
+	intelVirtCpuFlag = "vmx"
+	amdVirtCpuFlag   = "svm"
+)
+
+func IsVirtSupported(inventory *models.Inventory) bool {
+	return funk.Contains(inventory.CPU.Flags, intelVirtCpuFlag) || funk.Contains(inventory.CPU.Flags, amdVirtCpuFlag)
+}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -328,7 +328,7 @@ func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB
 	if db == nil {
 		db = m.db
 	}
-	vc, err := newValidationContext(h, db)
+	vc, err := newValidationContext(h, db, m.hwValidator)
 	if err != nil {
 		return err
 	}
@@ -917,7 +917,7 @@ func (m *Manager) selectRole(ctx context.Context, h *models.Host, db *gorm.DB) (
 
 	if mastersCount < common.MinMasterHostsNeededForInstallation {
 		h.Role = models.HostRoleMaster
-		vc, err := newValidationContext(h, db)
+		vc, err := newValidationContext(h, db, m.hwValidator)
 		if err != nil {
 			log.WithError(err).Errorf("failed to create new validation context for host %s", h.ID.String())
 			return autoSelectedRole, err
@@ -941,7 +941,7 @@ func (m *Manager) IsValidMasterCandidate(h *models.Host, db *gorm.DB, log logrus
 	}
 
 	h.Role = models.HostRoleMaster
-	vc, err := newValidationContext(h, db)
+	vc, err := newValidationContext(h, db, m.hwValidator)
 	if err != nil {
 		log.WithError(err).Errorf("failed to create new validation context for host %s", h.ID.String())
 		return false, err

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2049,7 +2049,7 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
 		hwValidator := hardware.NewValidator(testLog, *hwValidatorCfg, mockOperators)
-		mockOperators.EXPECT().GetRequirementsBreakdownForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]*models.OperatorHostRequirements{}, nil)
+		mockOperators.EXPECT().GetRequirementsBreakdownForRoleInCluster(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]*models.OperatorHostRequirements{}, nil)
 		hapi = NewManager(
 			common.GetTestLog(),
 			db,

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -42,6 +42,9 @@ var _ = Describe("monitor_disconnection", func() {
 		dummy := &leader.DummyElector{}
 		mockHwValidator := hardware.NewMockValidator(ctrl)
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
+		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
+			Total: &models.ClusterHostRequirementsDetails{},
+		}, nil)
 		mockOperators := operators.NewMockAPI(ctrl)
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, defaultConfig, dummy, mockOperators)
@@ -59,8 +62,6 @@ var _ = Describe("monitor_disconnection", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 		}, nil)
-		mockOperators.EXPECT().GetCPURequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		mockOperators.EXPECT().GetMemoryRequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -144,6 +145,9 @@ var _ = Describe("TestHostMonitoring", func() {
 		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
 		mockHwValidator := hardware.NewMockValidator(ctrl)
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
+		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
+			Total: &models.ClusterHostRequirementsDetails{},
+		}, nil)
 		mockOperators := operators.NewMockAPI(ctrl)
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, &cfg, &leader.DummyElector{}, mockOperators)
@@ -153,8 +157,6 @@ var _ = Describe("TestHostMonitoring", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 		}, nil)
-		mockOperators.EXPECT().GetCPURequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		mockOperators.EXPECT().GetMemoryRequirementForRole(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -38,18 +38,8 @@ type Operator interface {
 	ValidateHost(ctx context.Context, cluster *common.Cluster, hosts *models.Host) (ValidationResult, error)
 	// GenerateManifests generates manifests for the operator
 	GenerateManifests(*common.Cluster) (map[string][]byte, error)
-	// GetCPURequirementForWorker provides worker CPU requirements for the operator
-	GetCPURequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetCPURequirementForMaster provides master CPU requirements for the operator
-	GetCPURequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
-	GetMemoryRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetMemoryRequirementForMaster provides master memory requirements for the operator in MB
-	GetMemoryRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetDisksRequirementForMaster provides a number of disks required in a master
-	GetDisksRequirementForMaster(ctx context.Context, cluster *common.Cluster) (int64, error)
-	// GetDisksRequirementForWorker provides a number of disks required in a worker
-	GetDisksRequirementForWorker(ctx context.Context, cluster *common.Cluster) (int64, error)
+	// GetHostRequirementsForRole provides operator's requirements towards host in a given role
+	GetHostRequirementsForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (*models.ClusterHostRequirementsDetails, error)
 	// GetClusterValidationID returns cluster validation ID for the Operator
 	GetClusterValidationID() string
 	// GetHostValidationID returns host validation ID for the Operator

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -50,36 +50,6 @@ func (mr *MockOperatorMockRecorder) GenerateManifests(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifests", reflect.TypeOf((*MockOperator)(nil).GenerateManifests), arg0)
 }
 
-// GetCPURequirementForMaster mocks base method
-func (m *MockOperator) GetCPURequirementForMaster(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCPURequirementForMaster", arg0, arg1)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCPURequirementForMaster indicates an expected call of GetCPURequirementForMaster
-func (mr *MockOperatorMockRecorder) GetCPURequirementForMaster(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPURequirementForMaster", reflect.TypeOf((*MockOperator)(nil).GetCPURequirementForMaster), arg0, arg1)
-}
-
-// GetCPURequirementForWorker mocks base method
-func (m *MockOperator) GetCPURequirementForWorker(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCPURequirementForWorker", arg0, arg1)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCPURequirementForWorker indicates an expected call of GetCPURequirementForWorker
-func (mr *MockOperatorMockRecorder) GetCPURequirementForWorker(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPURequirementForWorker", reflect.TypeOf((*MockOperator)(nil).GetCPURequirementForWorker), arg0, arg1)
-}
-
 // GetClusterValidationID mocks base method
 func (m *MockOperator) GetClusterValidationID() string {
 	m.ctrl.T.Helper()
@@ -108,34 +78,19 @@ func (mr *MockOperatorMockRecorder) GetDependencies() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDependencies", reflect.TypeOf((*MockOperator)(nil).GetDependencies))
 }
 
-// GetDisksRequirementForMaster mocks base method
-func (m *MockOperator) GetDisksRequirementForMaster(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
+// GetHostRequirementsForRole mocks base method
+func (m *MockOperator) GetHostRequirementsForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDisksRequirementForMaster", arg0, arg1)
-	ret0, _ := ret[0].(int64)
+	ret := m.ctrl.Call(m, "GetHostRequirementsForRole", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*models.ClusterHostRequirementsDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDisksRequirementForMaster indicates an expected call of GetDisksRequirementForMaster
-func (mr *MockOperatorMockRecorder) GetDisksRequirementForMaster(arg0, arg1 interface{}) *gomock.Call {
+// GetHostRequirementsForRole indicates an expected call of GetHostRequirementsForRole
+func (mr *MockOperatorMockRecorder) GetHostRequirementsForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDisksRequirementForMaster", reflect.TypeOf((*MockOperator)(nil).GetDisksRequirementForMaster), arg0, arg1)
-}
-
-// GetDisksRequirementForWorker mocks base method
-func (m *MockOperator) GetDisksRequirementForWorker(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDisksRequirementForWorker", arg0, arg1)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDisksRequirementForWorker indicates an expected call of GetDisksRequirementForWorker
-func (mr *MockOperatorMockRecorder) GetDisksRequirementForWorker(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDisksRequirementForWorker", reflect.TypeOf((*MockOperator)(nil).GetDisksRequirementForWorker), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirementsForRole", reflect.TypeOf((*MockOperator)(nil).GetHostRequirementsForRole), arg0, arg1, arg2)
 }
 
 // GetHostValidationID mocks base method
@@ -150,36 +105,6 @@ func (m *MockOperator) GetHostValidationID() string {
 func (mr *MockOperatorMockRecorder) GetHostValidationID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostValidationID", reflect.TypeOf((*MockOperator)(nil).GetHostValidationID))
-}
-
-// GetMemoryRequirementForMaster mocks base method
-func (m *MockOperator) GetMemoryRequirementForMaster(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemoryRequirementForMaster", arg0, arg1)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemoryRequirementForMaster indicates an expected call of GetMemoryRequirementForMaster
-func (mr *MockOperatorMockRecorder) GetMemoryRequirementForMaster(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemoryRequirementForMaster", reflect.TypeOf((*MockOperator)(nil).GetMemoryRequirementForMaster), arg0, arg1)
-}
-
-// GetMemoryRequirementForWorker mocks base method
-func (m *MockOperator) GetMemoryRequirementForWorker(arg0 context.Context, arg1 *common.Cluster) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemoryRequirementForWorker", arg0, arg1)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemoryRequirementForWorker indicates an expected call of GetMemoryRequirementForWorker
-func (mr *MockOperatorMockRecorder) GetMemoryRequirementForWorker(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemoryRequirementForWorker", reflect.TypeOf((*MockOperator)(nil).GetMemoryRequirementForWorker), arg0, arg1)
 }
 
 // GetMonitoredOperator mocks base method

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -159,7 +159,7 @@ func (o *operator) GetHostRequirementsForRole(_ context.Context, _ *common.Clust
 			CPUCores: masterCPU,
 			RAMMib:   masterMemory,
 		}, nil
-	case models.HostRoleWorker:
+	case models.HostRoleWorker, models.HostRoleAutoAssign:
 		return &models.ClusterHostRequirementsDetails{
 			CPUCores: workerCPU,
 			RAMMib:   workerMemory,

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/hardware"
+	"github.com/openshift/assisted-service/internal/hardware/virt"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/lso"
-	models "github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 )
@@ -80,7 +80,7 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID()}, err
 	}
 
-	if !hardware.IsVirtSupported(&inventory) {
+	if !virt.IsVirtSupported(&inventory) {
 		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{"CPU does not have virtualization support "}}, nil
 	}
 
@@ -141,16 +141,6 @@ func (o *operator) GenerateManifests(c *common.Cluster) (map[string][]byte, erro
 	return Manifests(c.Cluster.OpenshiftVersion)
 }
 
-// GetDisksRequirementForMaster provides a number of disks required in a master
-func (o *operator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetDisksRequirementForWorker provides a number of disks required in a worker
-func (o *operator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
 // GetProperties provides description of operator properties: none required
 func (o *operator) GetProperties() models.OperatorProperties {
 	return models.OperatorProperties{}
@@ -159,4 +149,21 @@ func (o *operator) GetProperties() models.OperatorProperties {
 // GetMonitoredOperator returns MonitoredOperator corresponding to the CNV Operator
 func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
+}
+
+// GetHostRequirementsForRole provides operator's requirements towards host in a given role
+func (o *operator) GetHostRequirementsForRole(_ context.Context, _ *common.Cluster, role models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+	switch role {
+	case models.HostRoleMaster:
+		return &models.ClusterHostRequirementsDetails{
+			CPUCores: masterCPU,
+			RAMMib:   masterMemory,
+		}, nil
+	case models.HostRoleWorker:
+		return &models.ClusterHostRequirementsDetails{
+			CPUCores: workerCPU,
+			RAMMib:   workerMemory,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported role: %s", role)
 }

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -55,39 +55,9 @@ func (l *lsOperator) ValidateHost(_ context.Context, _ *common.Cluster, _ *model
 	return api.ValidationResult{Status: api.Success, ValidationId: l.GetHostValidationID(), Reasons: []string{}}, nil
 }
 
-// GetCPURequirementForWorker provides worker CPU requirements for the operator
-func (l *lsOperator) GetCPURequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetCPURequirementForMaster provides master CPU requirements for the operator
-func (l *lsOperator) GetCPURequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetMemoryRequirementForWorker provides worker memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (l *lsOperator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
 // GenerateManifests generates manifests for the operator
 func (l *lsOperator) GenerateManifests(c *common.Cluster) (map[string][]byte, error) {
 	return Manifests(c.Cluster.OpenshiftVersion)
-}
-
-// GetDisksRequirementForMaster provides a number of disks required in a master
-func (l *lsOperator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetDisksRequirementForWorker provides a number of disks required in a worker
-func (l *lsOperator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 1, nil
 }
 
 // GetProperties provides description of operator properties: none required
@@ -98,4 +68,9 @@ func (l *lsOperator) GetProperties() models.OperatorProperties {
 // GetMonitoredOperator returns MonitoredOperator corresponding to the LSO
 func (l *lsOperator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
+}
+
+// GetHostRequirementsForRole provides operator's requirements towards host in a given role
+func (l *lsOperator) GetHostRequirementsForRole(context.Context, *common.Cluster, models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+	return &models.ClusterHostRequirementsDetails{}, nil
 }

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -50,12 +50,12 @@ type API interface {
 	GetSupportedOperators() []string
 	// GetOperatorProperties provides description of properties of an operator
 	GetOperatorProperties(operatorName string) (models.OperatorProperties, error)
-	// GetRequirementsBreakdownForRole provides host requirements breakdown for each OLM operator
-	GetRequirementsBreakdownForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error)
+	// GetRequirementsBreakdownForRoleInCluster provides host requirements breakdown for each OLM operator in the cluster
+	GetRequirementsBreakdownForRoleInCluster(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error)
 }
 
-// GetRequirementsBreakdownForRole provides host requirements breakdown for each OLM operator
-func (mgr *Manager) GetRequirementsBreakdownForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error) {
+// GetRequirementsBreakdownForRoleInCluster provides host requirements breakdown for each OLM operator in the cluster
+func (mgr *Manager) GetRequirementsBreakdownForRoleInCluster(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error) {
 	logger := logutil.FromContext(ctx, mgr.log)
 	var requirements []*models.OperatorHostRequirements
 	for _, monitoredOperator := range cluster.MonitoredOperators {

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Operators manager", func() {
 			requirements2 := models.ClusterHostRequirementsDetails{CPUCores: 2}
 			operator2.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(&requirements2, nil)
 
-			reqBreakdown, err := manager.GetRequirementsBreakdownForRole(context.TODO(), cluster, role)
+			reqBreakdown, err := manager.GetRequirementsBreakdownForRoleInCluster(context.TODO(), cluster, role)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reqBreakdown).To(HaveLen(2))
@@ -290,7 +290,7 @@ var _ = Describe("Operators manager", func() {
 			theError := errors.New("boom")
 			operator2.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(nil, theError)
 
-			_, err := manager.GetRequirementsBreakdownForRole(context.TODO(), cluster, role)
+			_, err := manager.GetRequirementsBreakdownForRoleInCluster(context.TODO(), cluster, role)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(BeEquivalentTo(theError))

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -3,6 +3,7 @@ package operators_test
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -245,4 +246,63 @@ var _ = Describe("Operators manager", func() {
 			Expect(properties).To(BeEquivalentTo(models.OperatorProperties{}))
 		})
 	})
+
+	Context("Host requirements", func() {
+		const (
+			operatorName1 = "operator-1"
+			operatorName2 = "operator-2"
+		)
+		var (
+			manager              *operators.Manager
+			operator1, operator2 *api.MockOperator
+		)
+
+		BeforeEach(func() {
+			operator1 = mockOperatorBase(operatorName1)
+			operator2 = mockOperatorBase(operatorName2)
+			cluster.MonitoredOperators = models.MonitoredOperatorsList{{Name: operatorName1}, {Name: operatorName2}}
+			manager = operators.NewManagerWithOperators(log, manifestsAPI, operators.Options{}, operator1, operator2)
+		})
+		It("should be provided for configured operators", func() {
+			role := models.HostRoleMaster
+
+			requirements1 := models.ClusterHostRequirementsDetails{CPUCores: 1}
+			operator1.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(&requirements1, nil)
+			requirements2 := models.ClusterHostRequirementsDetails{CPUCores: 2}
+			operator2.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(&requirements2, nil)
+
+			reqBreakdown, err := manager.GetRequirementsBreakdownForRole(context.TODO(), cluster, role)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reqBreakdown).To(HaveLen(2))
+			Expect(reqBreakdown).To(ContainElements(
+				&models.OperatorHostRequirements{OperatorName: operatorName1, Requirements: &requirements1},
+				&models.OperatorHostRequirements{OperatorName: operatorName2, Requirements: &requirements2},
+			))
+		})
+
+		It("should return error", func() {
+			role := models.HostRoleMaster
+
+			requirements1 := models.ClusterHostRequirementsDetails{CPUCores: 1}
+			operator1.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(&requirements1, nil)
+
+			theError := errors.New("boom")
+			operator2.EXPECT().GetHostRequirementsForRole(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(nil, theError)
+
+			_, err := manager.GetRequirementsBreakdownForRole(context.TODO(), cluster, role)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeEquivalentTo(theError))
+		})
+	})
 })
+
+func mockOperatorBase(operatorName string) *api.MockOperator {
+	operator1 := api.NewMockOperator(ctrl)
+	operator1.EXPECT().GetName().AnyTimes().Return(operatorName)
+	monitoredOperator1 := &models.MonitoredOperator{}
+	operator1.EXPECT().GetMonitoredOperator().Return(monitoredOperator1)
+
+	return operator1
+}

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -64,36 +64,6 @@ func (mr *MockAPIMockRecorder) GenerateManifests(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateManifests", reflect.TypeOf((*MockAPI)(nil).GenerateManifests), arg0, arg1)
 }
 
-// GetCPURequirementForRole mocks base method
-func (m *MockAPI) GetCPURequirementForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCPURequirementForRole", arg0, arg1, arg2)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCPURequirementForRole indicates an expected call of GetCPURequirementForRole
-func (mr *MockAPIMockRecorder) GetCPURequirementForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPURequirementForRole", reflect.TypeOf((*MockAPI)(nil).GetCPURequirementForRole), arg0, arg1, arg2)
-}
-
-// GetMemoryRequirementForRole mocks base method
-func (m *MockAPI) GetMemoryRequirementForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemoryRequirementForRole", arg0, arg1, arg2)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemoryRequirementForRole indicates an expected call of GetMemoryRequirementForRole
-func (mr *MockAPIMockRecorder) GetMemoryRequirementForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemoryRequirementForRole", reflect.TypeOf((*MockAPI)(nil).GetMemoryRequirementForRole), arg0, arg1, arg2)
-}
-
 // GetMonitoredOperatorsList mocks base method
 func (m *MockAPI) GetMonitoredOperatorsList() map[string]*models.MonitoredOperator {
 	m.ctrl.T.Helper()
@@ -136,6 +106,21 @@ func (m *MockAPI) GetOperatorProperties(arg0 string) (models.OperatorProperties,
 func (mr *MockAPIMockRecorder) GetOperatorProperties(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorProperties", reflect.TypeOf((*MockAPI)(nil).GetOperatorProperties), arg0)
+}
+
+// GetRequirementsBreakdownForRole mocks base method
+func (m *MockAPI) GetRequirementsBreakdownForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) ([]*models.OperatorHostRequirements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRequirementsBreakdownForRole", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*models.OperatorHostRequirements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRequirementsBreakdownForRole indicates an expected call of GetRequirementsBreakdownForRole
+func (mr *MockAPIMockRecorder) GetRequirementsBreakdownForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequirementsBreakdownForRole", reflect.TypeOf((*MockAPI)(nil).GetRequirementsBreakdownForRole), arg0, arg1, arg2)
 }
 
 // GetSupportedOperators mocks base method

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -108,19 +108,19 @@ func (mr *MockAPIMockRecorder) GetOperatorProperties(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorProperties", reflect.TypeOf((*MockAPI)(nil).GetOperatorProperties), arg0)
 }
 
-// GetRequirementsBreakdownForRole mocks base method
-func (m *MockAPI) GetRequirementsBreakdownForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) ([]*models.OperatorHostRequirements, error) {
+// GetRequirementsBreakdownForRoleInCluster mocks base method
+func (m *MockAPI) GetRequirementsBreakdownForRoleInCluster(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) ([]*models.OperatorHostRequirements, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRequirementsBreakdownForRole", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRequirementsBreakdownForRoleInCluster", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*models.OperatorHostRequirements)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRequirementsBreakdownForRole indicates an expected call of GetRequirementsBreakdownForRole
-func (mr *MockAPIMockRecorder) GetRequirementsBreakdownForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetRequirementsBreakdownForRoleInCluster indicates an expected call of GetRequirementsBreakdownForRoleInCluster
+func (mr *MockAPIMockRecorder) GetRequirementsBreakdownForRoleInCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequirementsBreakdownForRole", reflect.TypeOf((*MockAPI)(nil).GetRequirementsBreakdownForRole), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequirementsBreakdownForRoleInCluster", reflect.TypeOf((*MockAPI)(nil).GetRequirementsBreakdownForRoleInCluster), arg0, arg1, arg2)
 }
 
 // GetSupportedOperators mocks base method

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -81,36 +81,6 @@ func (o *operator) GenerateManifests(cluster *common.Cluster) (map[string][]byte
 	return Manifests(o.config)
 }
 
-// GetCPURequirementForWorker provides worker CPU requirements for the operator
-func (o *operator) GetCPURequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetCPURequirementForMaster provides master CPU requirements for the operator
-func (o *operator) GetCPURequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetMemoryRequirementForWorker provides worker memory requirements for the operator in MB
-func (o *operator) GetMemoryRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetMemoryRequirementForMaster provides master memory requirements for the operator
-func (o *operator) GetMemoryRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetDisksRequirementForMaster provides a number of disks required in a master
-func (o *operator) GetDisksRequirementForMaster(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
-// GetDisksRequirementForWorker provides a number of disks required in a worker
-func (o *operator) GetDisksRequirementForWorker(_ context.Context, _ *common.Cluster) (int64, error) {
-	return 0, nil
-}
-
 // GetProperties provides description of operator properties: none required
 func (o *operator) GetProperties() models.OperatorProperties {
 	return models.OperatorProperties{}
@@ -119,4 +89,9 @@ func (o *operator) GetProperties() models.OperatorProperties {
 // GetMonitoredOperator returns MonitoredOperator corresponding to the OCS Operator
 func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
+}
+
+// GetHostRequirementsForRole provides operator's requirements towards host in a given role
+func (o *operator) GetHostRequirementsForRole(context.Context, *common.Cluster, models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+	return &models.ClusterHostRequirementsDetails{}, nil
 }

--- a/pkg/conversions/conversions.go
+++ b/pkg/conversions/conversions.go
@@ -10,6 +10,14 @@ func GibToBytes(gib int64) int64 {
 	return gib * int64(units.GiB)
 }
 
+func GibToMib(gib int64) int64 {
+	return gib * int64(units.KiB)
+}
+
+func MibToGiB(mib int64) int64 {
+	return mib / int64(units.KiB)
+}
+
 func BytesToGiB(bytes int64) int64 {
 	return bytes / int64(units.GiB)
 }


### PR DESCRIPTION
This PR introduces following changes:
 - Implementation of the `/clusters/{cluster_id}/host-requirements` handler;
 - Validation refactored to use the same code as the mentioned endpoint;
 - Simplified OLM Generic Operator API - separate worker/master CPU/RAM/Disk requirements methods replaced by one (`GetHostRequirementsForRole`)