### PR TITLE
MGMT-4568 Block IPv6 input when not supported

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -325,6 +325,11 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		}
 	}()
 
+	if err = validations.ValidateIPAddressFamily(b.IPv6Support, params.NewClusterParams.ClusterNetworkCidr, params.NewClusterParams.ServiceNetworkCidr,
+		&params.NewClusterParams.IngressVip); err != nil {
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
 	if params.NewClusterParams.HTTPProxy != nil &&
 		(params.NewClusterParams.HTTPSProxy == nil || *params.NewClusterParams.HTTPSProxy == "") {
 		params.NewClusterParams.HTTPSProxy = params.NewClusterParams.HTTPProxy
@@ -1464,6 +1469,11 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 		if err := validations.ValidateClusterNameFormat(*params.ClusterUpdateParams.Name); err != nil {
 			return installer.UpdateClusterParams{}, err
 		}
+	}
+
+	if err := validations.ValidateIPAddressFamily(b.IPv6Support, params.ClusterUpdateParams.ClusterNetworkCidr, params.ClusterUpdateParams.ServiceNetworkCidr,
+		params.ClusterUpdateParams.MachineNetworkCidr, params.ClusterUpdateParams.APIVip, params.ClusterUpdateParams.IngressVip); err != nil {
+		return installer.UpdateClusterParams{}, common.NewApiError(http.StatusBadRequest, err)
 	}
 
 	if sshPublicKey := swag.StringValue(params.ClusterUpdateParams.SSHPublicKey); sshPublicKey != "" {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -425,3 +425,20 @@ func ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation bool, machineNetworkCID
 	}
 	return nil
 }
+
+//ValidateIPAddressFamily returns an error if the argument contains an IP address
+// or CIDR of IPv6 family, and IPv6 support is turned off
+func ValidateIPAddressFamily(ipV6Supported bool, elements ...*string) error {
+	if ipV6Supported {
+		return nil
+	}
+	for _, e := range elements {
+		if e == nil {
+			continue
+		}
+		if strings.Contains(*e, ":") {
+			return errors.Errorf("IPv6 is not supported in this setup")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
In deployments where IPv6 support is turned off, block
IPv6 addresses and CIDRs in input fields.