### PR TITLE
MGMT-4628 InstallEnv ignitionConfigOverride should be optional

### DIFF
--- a/internal/controller/api/v1alpha1/installenv_types.go
+++ b/internal/controller/api/v1alpha1/installenv_types.go
@@ -84,7 +84,8 @@ type InstallEnvSpec struct {
 	// removed.
 	ClusterRef *ClusterReference `json:"clusterRef"`
 	// Json formatted string containing the user overrides for the initial ignition config
-	IgnitionConfigOverride string `json:"ignitionConfigOverride"`
+	// +optional
+	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
 }
 
 // Proxy defines the proxy settings for agents and clusters that use the InstallEnv.

--- a/internal/controller/config/crd/bases/adi.io.my.domain_installenvs.yaml
+++ b/internal/controller/config/crd/bases/adi.io.my.domain_installenvs.yaml
@@ -192,7 +192,6 @@ spec:
             required:
             - agentLabelSelector
             - clusterRef
-            - ignitionConfigOverride
             - pullSecretRef
             type: object
           status:


### PR DESCRIPTION
Not every cluster will have ignitionConfigOverride.
Therefore, this should be an optional parameter.