### PR TITLE
NO-ISSUE Remove minikube code and PROFILE variable

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -20,9 +20,6 @@ RUN go get -u github.com/onsi/ginkgo/ginkgo@v1.14.2 \
 RUN pip3 install --upgrade pip
 RUN pip3 install boto3==1.13.14 waiting==1.4.1 requests==2.22.0 mkdocs==1.1.2 \
     vcversioner==2.16.0.0 twine==3.3.0 wheel==0.36.2 setuptools==53.0.0
-RUN curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.10.1/minikube-linux-amd64 \
-  && chmod +x minikube && mkdir -p /usr/local/bin/ && install minikube /usr/local/bin/
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
   && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.4.2 \

--- a/hack/update_local_image.sh
+++ b/hack/update_local_image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
+
+CLUSTER_CONTEXT=$(${KUBECTL} config current-context | cut -d'-' -f1)
+
+case "${CLUSTER_CONTEXT}" in
+  "minikube")
+    eval $(SHELL=${SHELL:-/bin/sh} minikube docker-env) && \
+        docker build ${CONTAINER_BUILD_PARAMS} -f Dockerfile.assisted-service . -t ${SERVICE}
+    ;;
+
+  "k3d")
+    docker build ${CONTAINER_BUILD_PARAMS} -f Dockerfile.assisted-service . -t ${SERVICE}
+    k3d image import ${SERVICE}
+    ;;
+
+  *)
+    echo "Unknown cluster context ${CLUSTER_CONTEXT}"
+    ;;
+esac

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -82,7 +82,7 @@ func (k *kubeJob) getJob(ctx context.Context, job *batch.Job, name, namespace st
 		}
 		return err
 	}
-	//using retry for get job api because sometimes k8s (minikube) api service is not reachable
+	//using retry for get job api because sometimes k8s api service is not reachable
 	if err := retry(func() error {
 		return k.kube.Get(ctx, client.ObjectKey{
 			Namespace: namespace,

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -4,6 +4,12 @@ build-container-image: assisted-service-build
 containers:
   assisted-service-build: Dockerfile.assisted-service-build
 volumes:
+  # programs
+  - /usr/bin/minikube:/usr/bin/minikube
+  - /usr/local/bin/minikube:/usr/local/bin/minikube
+  - /usr/bin/kubectl:/usr/bin/kubectl
+  - /usr/local/bin/kubectl:/usr/local/bin/kubectl
+
   # config
   - $HOME/.minikube:$HOME/.minikube
   - $HOME/.kube/:$HOME/.kube

--- a/tools/clear_deployment.py
+++ b/tools/clear_deployment.py
@@ -10,10 +10,7 @@ def main():
 
     utils.verify_build_directory(deploy_options.namespace)
 
-    kubectl_cmd = utils.get_kubectl_command(
-        target=deploy_options.target,
-        profile=deploy_options.profile
-    )
+    kubectl_cmd = utils.get_kubectl_command(target=deploy_options.target)
     print(utils.check_output(f'{kubectl_cmd} delete all --all -n {deploy_options.namespace} --force --grace-period=0 1> /dev/null ; true'))
     # configmaps are not deleted with `delete all`
     print(utils.check_output(f"{kubectl_cmd} get configmap -o name -n {deploy_options.namespace} | " +

--- a/tools/debug/minikube_postgres.sh
+++ b/tools/debug/minikube_postgres.sh
@@ -5,26 +5,23 @@
 
 function print_usage() {
     [[ -n "$1" ]] && echo "$1" && echo
-    echo "usage: minikube_postgres.sh [-u <username>] [-p <password>] [-t <table-name>] [-m <minikube-profile] <db-service-name>"
+    echo "usage: minikube_postgres.sh [-u <username>] [-p <password>] [-t <table-name>] <db-service-name>"
     echo
     echo "    -u  - username"
     echo "    -p  - password"
     echo "    -t  - table"
-    echo "    -m  - minikube profile"
     exit 1
 }
 
 USER="admin"
 PWD="admin"
 TABLE="installer"
-PROFILE="minikube"
 
 while getopts ':t:u:p:m:h:' flag; do
   case "${flag}" in
     t) TABLE=${OPTARG} ;;
     u) USER=${OPTARG} ;;
     p) PWD=${OPTARG} ;;
-    m) PROFILE=${OPTARG} ;;
     h) print_usage ;;
     ?) print_usage "invalid flag ${OPTARG}" ;;
   esac
@@ -33,7 +30,8 @@ done
 DB_SERVICE=${@:$OPTIND:1}
 [[ -z "${DB_SERVICE}" ]] && print_usage "pod-name-filter is missing"
 
-SERVICE_URL=$(minikube -p $PROFILE service list | grep ${DB_SERVICE} | awk -F"|" '{print $5}' | tr -d '[:space:]')
+# TODO: Support kubectl
+SERVICE_URL=$(minikube service list | grep ${DB_SERVICE} | awk -F"|" '{print $5}' | tr -d '[:space:]')
 PORT=$(echo  ${SERVICE_URL}| awk -F"://|:" '{print $3}')
 SERVER=$(echo  ${SERVICE_URL}| awk -F"://|:" '{print $2}')
 PGPASSWORD=admin psql -U ${USER} --dbname ${TABLE} --host ${SERVER} --port ${PORT} -w

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -52,14 +52,15 @@ def main():
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_ID', 'value': 'mock-ocm-client-id'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'OCM_SERVICE_CLIENT_SECRET', 'value': 'mock-ocm-client-secret'})
 
-            if deploy_options.profile == utils.OPENSHIFT_CI:
+            if deploy_options.target == deployment_options.OPENSHIFT_TARGET:
                 # Images built on infra cluster but needed on ephemeral cluster
                 data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "IfNotPresent"
             else:
                 data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Never"
         else:
             data["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
-        if deploy_options.target == utils.OCP_TARGET:
+
+        if deploy_options.target == deployment_options.OCP_TARGET:
             data["spec"]["replicas"] = 1 # force single replica
             spec = data["spec"]["template"]["spec"]
             service_container = spec["containers"][0]
@@ -79,7 +80,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=DST_FILE
     )
 

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -58,7 +58,6 @@ def main():
                                                                             target=deploy_options.target,
                                                                             domain=deploy_options.domain,
                                                                             namespace=deploy_options.namespace,
-                                                                            profile=deploy_options.profile,
                                                                             disable_tls=deploy_options.disable_tls))
 
             data = data.replace('REPLACE_NAMESPACE', f'"{deploy_options.namespace}"')
@@ -120,7 +119,6 @@ def main():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=DST_FILE
         )
 

--- a/tools/deploy_crd.py
+++ b/tools/deploy_crd.py
@@ -17,7 +17,6 @@ def main():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=file_path
         )
 
@@ -27,7 +26,6 @@ def main():
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,
-                profile=deploy_options.profile,
                 file=file_path
             )
 

--- a/tools/deploy_grafana.py
+++ b/tools/deploy_grafana.py
@@ -16,7 +16,6 @@ utils.verify_build_directory(deploy_options.namespace)
 if deploy_options.target != "oc-ingress":
     CMD_BIN = utils.get_kubectl_command(
         target=deploy_options.target,
-        profile=deploy_options.profile
     )
 else:
     CMD_BIN = 'oc'
@@ -31,7 +30,6 @@ def deploy_oauth_reqs():
             k8s_object_name=secret_name,
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
             ):
         cmd = "{} -n {} create secret generic {} --from-literal=session_secret={}"\
         .format(CMD_BIN, deploy_options.namespace, secret_name, session_secret)
@@ -44,7 +42,6 @@ def deploy_oauth_reqs():
             k8s_object_name=sa_name,
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
         ):
         cmd = "{} -n {} create serviceaccount {} ".format(CMD_BIN, deploy_options.namespace, sa_name)
         utils.check_output(cmd)
@@ -60,7 +57,6 @@ def deploy_oauth_reqs():
             k8s_object_name='openshift-custom-ca',
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
             ):
         secret_name = 'router-certs-default'
         namespace = 'openshift-ingress'
@@ -84,7 +80,6 @@ def deploy_oauth_reqs():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
 
@@ -101,7 +96,6 @@ def deployer(src_file, topic):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -117,7 +111,6 @@ def deploy_grafana_route():
         ingress_domain = utils.get_domain(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
         )
     except:
         # I have not permissions, yes it's ugly...
@@ -141,7 +134,6 @@ def deploy_grafana_route():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -160,7 +152,6 @@ def deploy_grafana_ds():
             k8s_object_name=secret_name,
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
             ):
         print("Creating Grafana Datasource")
         cmd = "{} create secret generic {} --namespace={} --from-file=prometheus.yaml={}".format(CMD_BIN, secret_name, deploy_options.namespace, dst_file)
@@ -182,7 +173,6 @@ def deploy_grafana_config(conf_file):
             k8s_object_name=secret_name,
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
             ):
         print("Creating Grafana Configuration")
         cmd = "{} create secret generic {} --namespace={} --from-file=grafana.ini={}".format(CMD_BIN, secret_name, deploy_options.namespace, dst_file)
@@ -218,7 +208,6 @@ def main():
             k8s_object_name='grafana',
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
         )
     else:
         # Deploy Oauth Pre-reqs for OCP integration
@@ -243,7 +232,6 @@ def main():
             k8s_object_name='grafana',
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile
         )
         # Deploy grafana Route
         deploy_grafana_route()

--- a/tools/deploy_inventory_service.py
+++ b/tools/deploy_inventory_service.py
@@ -24,7 +24,6 @@ def main():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
     # in case of OpenShift deploy ingress as well
@@ -33,8 +32,7 @@ def main():
             'assisted-installer',
             deploy_options.target,
             deploy_options.domain,
-            deploy_options.namespace,
-            deploy_options.profile
+            deploy_options.namespace
         )
 
         if deploy_options.disable_tls:
@@ -65,7 +63,6 @@ def deploy_ingress(hostname, namespace, template_file):
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
 

--- a/tools/deploy_local_auth_secret.py
+++ b/tools/deploy_local_auth_secret.py
@@ -37,8 +37,7 @@ def main():
         "secret",
         secret_name,
         target=deploy_options.target,
-        namespace=deploy_options.namespace,
-        profile=deploy_options.profile
+        namespace=deploy_options.namespace
     )
 
     if exists:
@@ -57,7 +56,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=secret_file
     )
 

--- a/tools/deploy_mariadb.py
+++ b/tools/deploy_mariadb.py
@@ -18,7 +18,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -33,7 +32,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -46,8 +44,7 @@ def main():
             try:
                 kubectl_cmd = utils.get_kubectl_command(
                     target=deploy_options.target,
-                    namespace=deploy_options.namespace,
-                    profile=deploy_options.profile
+                    namespace=deploy_options.namespace
                 )
                 size = utils.check_output(
                     f'{kubectl_cmd} get persistentvolumeclaims mariadb-pv-claim ' +
@@ -63,7 +60,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_namespace.py
+++ b/tools/deploy_namespace.py
@@ -26,7 +26,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_olm.py
+++ b/tools/deploy_olm.py
@@ -18,8 +18,7 @@ def check_deployment():
             k8s_object='deployment',
             k8s_object_name=deployment,
             target=deploy_options.target,
-            namespace='olm',
-            profile=deploy_options.profile
+            namespace='olm'
         )
 
 
@@ -33,8 +32,7 @@ def main():
             k8s_object='namespace',
             k8s_object_name='olm',
             target=deploy_options.target,
-            namespace='olm',
-            profile=deploy_options.profile
+            namespace='olm'
         )
         if not deployed:
             olm_manifests = [ 
@@ -53,7 +51,6 @@ def main():
                 utils.apply(
                     target=deploy_options.target,
                     namespace=None,
-                    profile=deploy_options.profile,
                     file=dst_file
                 )
 

--- a/tools/deploy_postgres.py
+++ b/tools/deploy_postgres.py
@@ -15,7 +15,7 @@ def main():
 
     deploy_postgres_secret(deploy_options)
     deploy_postgres(deploy_options)
-    if deploy_options.target != utils.OCP_TARGET:
+    if deploy_options.target != deployment_options.OCP_TARGET:
         deploy_postgres_storage(deploy_options)
 
     log.info('Completed postgres deployment')
@@ -37,7 +37,6 @@ def deploy_postgres_secret(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -62,7 +61,6 @@ def deploy_postgres(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -76,7 +74,6 @@ def deploy_postgres_storage(deploy_options):
     pvc_size_utils.update_size_in_yaml_docs(
         target=deploy_options.target,
         ns=deploy_options.namespace,
-        profile=deploy_options.profile,
         name='postgres-pv-claim',
         docs=docs
     )
@@ -92,7 +89,6 @@ def deploy_postgres_storage(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_prometheus.py
+++ b/tools/deploy_prometheus.py
@@ -15,8 +15,7 @@ utils.verify_build_directory(deploy_options.namespace)
 
 if deploy_options.target != "oc-ingress":
     CMD_BIN = utils.get_kubectl_command(
-        target=deploy_options.target,
-        profile=deploy_options.profile
+        target=deploy_options.target
     )
     OLM_NS = 'olm'
     CAT_SRC = 'operatorhubio-catalog'
@@ -34,8 +33,7 @@ def deploy_oauth_reqs():
             k8s_object='secret',
             k8s_object_name=secret_name,
             target=deploy_options.target,
-            namespace=deploy_options.namespace,
-            profile=deploy_options.profile
+            namespace=deploy_options.namespace
             ):
         cmd = "{} -n {} create secret generic {} --from-literal=session_secret={}" \
                 .format(CMD_BIN, deploy_options.namespace, secret_name, session_secret)
@@ -78,7 +76,6 @@ def deploy_oauth_reqs():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
     else:
@@ -96,8 +93,7 @@ def deploy_prometheus_route():
         # I have permissions
         ingress_domain = utils.get_domain(
             target=deploy_options.target,
-            namespace=deploy_options.namespace,
-            profile=deploy_options.profile
+            namespace=deploy_options.namespace
         )
     except:
         # I have not permissions, yes it's ugly...
@@ -121,7 +117,6 @@ def deploy_prometheus_route():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -143,15 +138,13 @@ def deploy_prometheus_sub(olm_ns, cat_src):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
     utils.wait_for_rollout(
         k8s_object='deployment',
         k8s_object_name='prometheus-operator',
         target=deploy_options.target,
-        namespace=deploy_options.namespace,
-        profile=deploy_options.profile
+        namespace=deploy_options.namespace
     )
 
 
@@ -168,7 +161,6 @@ def deployer(src_file, topic):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -192,8 +184,7 @@ def main():
             k8s_object='statefulset',
             k8s_object_name='prometheus-assisted-installer-prometheus',
             target=deploy_options.target,
-            namespace=deploy_options.namespace,
-            profile=deploy_options.profile
+            namespace=deploy_options.namespace
         )
         # Deploy Prom svc Monitor
         deployer('deploy/monitoring/prometheus/assisted-installer-prometheus-svc-monitor.yaml',
@@ -226,8 +217,7 @@ def main():
             k8s_object='statefulset',
             k8s_object_name='prometheus-assisted-installer-prometheus',
             target=deploy_options.target,
-            namespace=deploy_options.namespace,
-            profile=deploy_options.profile
+            namespace=deploy_options.namespace
         )
         # Deploy Prom svc Monitor
         deployer('deploy/monitoring/prometheus/assisted-installer-prometheus-svc-monitor.yaml',

--- a/tools/deploy_role.py
+++ b/tools/deploy_role.py
@@ -9,7 +9,7 @@ def main():
 
     utils.verify_build_directory(deploy_options.namespace)
 
-    if deploy_options.target == 'ocp':
+    if deploy_options.target == deployment_options.OCP_TARGET:
         src_file = os.path.join(os.getcwd(), 'deploy/roles/ocp_role.yaml')
         dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'ocp_role.yaml')
     else:
@@ -27,7 +27,6 @@ def main():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
 
@@ -46,7 +45,6 @@ def main():
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,
-                profile=deploy_options.profile,
                 file=dst_file
             )
 
@@ -58,7 +56,6 @@ def main():
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,
-                profile=deploy_options.profile,
                 file=dst_file,
             )
 

--- a/tools/deploy_route53.py
+++ b/tools/deploy_route53.py
@@ -26,7 +26,6 @@ def deploy_secret():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_s3.py
+++ b/tools/deploy_s3.py
@@ -33,7 +33,6 @@ def deploy_scality(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 
@@ -47,7 +46,6 @@ def deploy_scality_storage(deploy_options):
     pvc_size_utils.update_size_in_yaml_docs(
         target=deploy_options.target,
         ns=deploy_options.namespace,
-        profile=deploy_options.profile,
         name='scality-pv-claim',
         docs=docs
     )
@@ -61,7 +59,6 @@ def deploy_scality_storage(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_scality_configmap.py
+++ b/tools/deploy_scality_configmap.py
@@ -23,7 +23,6 @@ def deploy(src_file):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_sso_secret.py
+++ b/tools/deploy_sso_secret.py
@@ -36,7 +36,6 @@ def main():
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deploy_ui.py
+++ b/tools/deploy_ui.py
@@ -41,7 +41,6 @@ def main():
         utils.apply(
             target=deploy_options.target,
             namespace=deploy_options.namespace,
-            profile=deploy_options.profile,
             file=dst_file
         )
 
@@ -57,8 +56,7 @@ def main():
                     'assisted-installer-ui',
                     deploy_options.target,
                     deploy_options.domain,
-                    deploy_options.namespace,
-                    deploy_options.profile
+                    deploy_options.namespace
                 ))
                 dst.write(data)
         if deploy_options.apply_manifest:
@@ -66,7 +64,6 @@ def main():
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,
-                profile=deploy_options.profile,
                 file=dst_file
             )
 

--- a/tools/deploy_wiremock.py
+++ b/tools/deploy_wiremock.py
@@ -21,7 +21,6 @@ def deploy_wiremock(deploy_options):
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,
-        profile=deploy_options.profile,
         file=dst_file
     )
 

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -5,7 +5,11 @@ import requests
 import yaml
 
 
+LOCAL_TARGET = 'local'
+INGRESS_REMOTE_TARGET = 'oc-ingress'
 IMAGE_FQDN_TEMPLATE = "quay.io/ocpmetal/{}:{}"
+OCP_TARGET = 'ocp'
+OPENSHIFT_TARGET = 'oc'
 
 
 def load_deployment_options(parser=None):
@@ -19,16 +23,10 @@ def load_deployment_options(parser=None):
         default='assisted-installer'
     )
     parser.add_argument(
-        '--profile',
-        help='Profile for all deployment images',
-        type=str,
-        default='minikube'
-    )
-    parser.add_argument(
         '--target',
         help='Target kubernetes distribution',
-        choices=['minikube', 'oc', 'oc-ingress', 'ocp'],
-        default='minikube'
+        choices=[LOCAL_TARGET, OPENSHIFT_TARGET, INGRESS_REMOTE_TARGET, OCP_TARGET],
+        default=LOCAL_TARGET
     )
     parser.add_argument(
         '--domain',
@@ -60,7 +58,7 @@ def load_deployment_options(parser=None):
     deploy_options.add_argument('--disable-tls', action='store_true', help='Disable TLS for assisted service transport', default=False)
 
     parsed_arguments = parser.parse_args()
-    if parsed_arguments.target != 'oc-ingress':
+    if parsed_arguments.target != INGRESS_REMOTE_TARGET:
         parsed_arguments.disable_tls = True
 
     return parsed_arguments

--- a/tools/pvc_size_utils.py
+++ b/tools/pvc_size_utils.py
@@ -63,9 +63,9 @@ class DecBytesSuffix(BytesSuffix):
     }
 
 
-def update_size_in_yaml_docs(target, ns, profile, name, docs):
+def update_size_in_yaml_docs(target, ns, name, docs):
     req = extract_requested_size_from_yaml_docs(name, docs)
-    cur = get_current_size_if_exist(target, ns, profile, name)
+    cur = get_current_size_if_exist(target, ns, name)
     size = determine_which_size_to_deploy(req, cur)
     set_size_in_yaml_docs(name, size, docs)
 
@@ -85,8 +85,8 @@ def extract_requested_size_from_yaml_docs(name, docs):
     )
 
 
-def get_current_size_if_exist(target, ns, profile, name):
-    kubectl_cmd = utils.get_kubectl_command(target, ns, profile)
+def get_current_size_if_exist(target, ns, name):
+    kubectl_cmd = utils.get_kubectl_command(target, ns)
     p = sp.Popen(
         f'{kubectl_cmd} get persistentvolumeclaims {name} '
         '-o=jsonpath="{.status.capacity.storage}"',

--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -29,8 +29,7 @@ def main():
         return
 
     service_url = utils.get_service_url(service=SERVICE, target=deploy_options.target, domain=deploy_options.domain,
-                                        namespace=deploy_options.namespace, profile=deploy_options.profile,
-                                        disable_tls=deploy_options.disable_tls)
+                                        namespace=deploy_options.namespace, disable_tls=deploy_options.disable_tls)
     health_url = f'{service_url}/ready'
 
     print(f'Wait for {health_url}')


### PR DESCRIPTION
Our Python scripts were dependent on `minikube` tool. Minikube requires a host with a KVM.

Making our scripts work regardless of the cluster. A simple `kubectl` command approach that is configured to some cluster. That cluster could be local or remote.
Some lightweight approaches like k3d and kind deploy a cluster on top of dockers, would be able to work as well.