### PR TITLE
MGMT-4386: Use latest available rhcos for onprem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ BUNDLE_IMAGE := $(or ${BUNDLE_IMAGE},${ASSISTED_ORG}/assisted-service-operator-b
 CONTAINER_BUILD_PARAMS = --network=host --label git_revision=${GIT_REVISION} ${CONTAINER_BUILD_EXTRA_PARAMS}
 
 # RHCOS_VERSION should be consistent with BaseObjectName in pkg/s3wrapper/client.go
-RHCOS_BASE_ISO := $(or ${RHCOS_BASE_ISO},https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/latest/rhcos-live.x86_64.iso)
 OPENSHIFT_VERSIONS := $(or ${OPENSHIFT_VERSIONS}, $(shell hack/get_ocp_versions_for_testing.sh))
+RHCOS_BASE_ISO := $(shell (jq -n '$(OPENSHIFT_VERSIONS)' | jq '[.[].rhcos_image]|max'))
 DUMMY_IGNITION := $(or ${DUMMY_IGNITION},False)
 GIT_REVISION := $(shell git rev-parse HEAD)
 PUBLISH_TAG := $(or ${GIT_REVISION})


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MGMT-4386
Instead of setting the RHCOS_BASE_ISO value from user env var or hardcoding it, the value is extracted from the OPENSHIFT_VERSIONS. For on-prem, the latest value of rhcos image is extracted from the OPENSHIFT_VERSIONS.