### PR TITLE
MGMT-4558 adding joined state for workers and bootstrap

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -31,7 +31,8 @@ import (
 var BootstrapStages = [...]models.HostStage{
 	models.HostStageStartingInstallation, models.HostStageInstalling,
 	models.HostStageWritingImageToDisk, models.HostStageWaitingForControlPlane,
-	models.HostStageRebooting, models.HostStageConfiguring, models.HostStageDone,
+	models.HostStageRebooting, models.HostStageConfiguring, models.HostStageJoined,
+	models.HostStageDone,
 }
 var MasterStages = [...]models.HostStage{
 	models.HostStageStartingInstallation, models.HostStageInstalling,
@@ -41,7 +42,8 @@ var MasterStages = [...]models.HostStage{
 var WorkerStages = [...]models.HostStage{
 	models.HostStageStartingInstallation, models.HostStageInstalling,
 	models.HostStageWritingImageToDisk, models.HostStageRebooting,
-	models.HostStageWaitingForIgnition, models.HostStageConfiguring, models.HostStageDone,
+	models.HostStageWaitingForIgnition, models.HostStageConfiguring,
+	models.HostStageJoined, models.HostStageDone,
 }
 
 var manualRebootStages = [...]models.HostStage{


### PR DESCRIPTION
Controller will send joined state for hosts that joined but are not ready yet. That's why we need to allow joined state for all the types.
Currently we are missing joined state in bootstrap role and workers and it spams logs.