### PR TITLE
MGMT-4425 Add presigned url authentication

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -360,6 +360,7 @@ func main() {
 	h, err := restapi.Handler(restapi.Config{
 		AuthAgentAuth:         authHandler.AuthAgentAuth,
 		AuthUserAuth:          authHandler.AuthUserAuth,
+		AuthURLAuth:           authHandler.AuthURLAuth,
 		APIKeyAuthenticator:   authHandler.CreateAuthenticator(),
 		Authorizer:            authzHandler.CreateAuthorizer(),
 		InstallerAPI:          bm,

--- a/internal/cluster/auth.go
+++ b/internal/cluster/auth.go
@@ -1,11 +1,9 @@
 package cluster
 
 import (
-	"os"
-
-	"github.com/dgrijalva/jwt-go"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/pkg/errors"
 )
@@ -15,7 +13,7 @@ func AgentToken(c *common.Cluster, authType auth.AuthType) (token string, err er
 	case auth.TypeRHSSO:
 		token, err = cloudPullSecretToken(c.PullSecret)
 	case auth.TypeLocal:
-		token, err = localJWT(c.ID.String())
+		token, err = gencrypto.LocalJWT(c.ID.String())
 	case auth.TypeNone:
 		token = ""
 	default:
@@ -34,27 +32,4 @@ func cloudPullSecretToken(pullSecret string) (string, error) {
 		return "", errors.Errorf("Pull secret does not contain auth for cloud.openshift.com")
 	}
 	return r.AuthRaw, nil
-}
-
-func localJWT(id string) (string, error) {
-	key, ok := os.LookupEnv("EC_PRIVATE_KEY_PEM")
-	if !ok || key == "" {
-		return "", errors.Errorf("EC_PRIVATE_KEY_PEM not found")
-	}
-
-	priv, err := jwt.ParseECPrivateKeyFromPEM([]byte(key))
-	if err != nil {
-		return "", err
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"cluster_id": id,
-	})
-
-	tokenString, err := token.SignedString(priv)
-	if err != nil {
-		return "", err
-	}
-
-	return tokenString, nil
 }

--- a/internal/cluster/auth_test.go
+++ b/internal/cluster/auth_test.go
@@ -1,16 +1,6 @@
 package cluster
 
 import (
-	"bytes"
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"encoding/pem"
-	"os"
-
-	"github.com/dgrijalva/jwt-go"
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
@@ -77,61 +67,5 @@ var _ = Describe("AgentToken", func() {
 		_, err := AgentToken(c, auth.TypeLocal)
 
 		Expect(err).To(HaveOccurred())
-	})
-
-	Context("with a private key set", func() {
-		var (
-			publicKey crypto.PublicKey
-		)
-
-		BeforeEach(func() {
-			priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-			Expect(err).NotTo(HaveOccurred())
-
-			publicKey = priv.Public()
-
-			privBytes, err := x509.MarshalECPrivateKey(priv)
-			Expect(err).NotTo(HaveOccurred())
-
-			block := &pem.Block{
-				Type:  "EC PRIVATE KEY",
-				Bytes: privBytes,
-			}
-			var out bytes.Buffer
-			Expect(pem.Encode(&out, block)).To(Succeed())
-
-			os.Setenv("EC_PRIVATE_KEY_PEM", out.String())
-		})
-
-		AfterEach(func() {
-			os.Unsetenv("EC_PRIVATE_KEY_PEM")
-		})
-
-		validateToken := func(token string, pub crypto.PublicKey) *jwt.Token {
-			parser := &jwt.Parser{ValidMethods: []string{jwt.SigningMethodES256.Alg()}}
-			parsed, err := parser.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(parsed.Valid).To(BeTrue())
-
-			return parsed
-		}
-
-		It("creates a valid token", func() {
-			c := &common.Cluster{
-				Cluster:    models.Cluster{ID: &id},
-				PullSecret: "{\"auths\":{\"registry.redhat.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
-			}
-			tokenString, err := AgentToken(c, auth.TypeLocal)
-			Expect(err).ToNot(HaveOccurred())
-
-			tok := validateToken(tokenString, publicKey)
-			claims, ok := tok.Claims.(jwt.MapClaims)
-			Expect(ok).To(BeTrue())
-
-			clusterID, ok := claims["cluster_id"].(string)
-			Expect(ok).To(BeTrue())
-			Expect(clusterID).To(Equal(id.String()))
-		})
 	})
 })

--- a/internal/gencrypto/gencrypto_suite_test.go
+++ b/internal/gencrypto/gencrypto_suite_test.go
@@ -1,0 +1,13 @@
+package gencrypto_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "gencrypto tests")
+}

--- a/internal/gencrypto/keys.go
+++ b/internal/gencrypto/keys.go
@@ -1,0 +1,53 @@
+package gencrypto
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+)
+
+func ECDSAKeyPairPEM() (string, string, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	// encode private key to PEM string
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return "", "", err
+	}
+
+	block := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: privBytes,
+	}
+
+	var privKeyPEM bytes.Buffer
+	err = pem.Encode(&privKeyPEM, block)
+	if err != nil {
+		return "", "", err
+	}
+
+	// encode public key to PEM string
+	pubBytes, err := x509.MarshalPKIXPublicKey(priv.Public())
+	if err != nil {
+		return "", "", err
+	}
+
+	block = &pem.Block{
+		Type:  "EC PUBLIC KEY",
+		Bytes: pubBytes,
+	}
+
+	var pubKeyPEM bytes.Buffer
+	err = pem.Encode(&pubKeyPEM, block)
+	if err != nil {
+		return "", "", err
+	}
+
+	return pubKeyPEM.String(), privKeyPEM.String(), nil
+}

--- a/internal/gencrypto/token.go
+++ b/internal/gencrypto/token.go
@@ -1,0 +1,34 @@
+package gencrypto
+
+import (
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
+)
+
+func LocalJWT(cluster_id string) (string, error) {
+	key, ok := os.LookupEnv("EC_PRIVATE_KEY_PEM")
+	if !ok || key == "" {
+		return "", errors.Errorf("EC_PRIVATE_KEY_PEM not found")
+	}
+	return LocalJWTForKey(cluster_id, key)
+}
+
+func LocalJWTForKey(cluster_id string, private_key_pem string) (string, error) {
+	priv, err := jwt.ParseECPrivateKeyFromPEM([]byte(private_key_pem))
+	if err != nil {
+		return "", err
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"cluster_id": cluster_id,
+	})
+
+	tokenString, err := token.SignedString(priv)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenString, nil
+}

--- a/internal/gencrypto/token.go
+++ b/internal/gencrypto/token.go
@@ -1,6 +1,7 @@
 package gencrypto
 
 import (
+	"net/url"
 	"os"
 
 	"github.com/dgrijalva/jwt-go"
@@ -31,4 +32,22 @@ func LocalJWTForKey(cluster_id string, private_key_pem string) (string, error) {
 	}
 
 	return tokenString, nil
+}
+
+func SignURL(urlString string, cluster_id string) (string, error) {
+	u, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	tok, err := LocalJWT(cluster_id)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("api_key", tok)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
 }

--- a/internal/gencrypto/token_test.go
+++ b/internal/gencrypto/token_test.go
@@ -1,0 +1,84 @@
+package gencrypto
+
+import (
+	"crypto"
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWT creation", func() {
+	It("LocalJWT fails when EC_PRIVATE_KEY_PEM is unset", func() {
+		os.Unsetenv("EC_PRIVATE_KEY_PEM")
+		_, err := LocalJWT(uuid.New().String())
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("LocalJWT fails when EC_PRIVATE_KEY_PEM is empty", func() {
+		os.Setenv("EC_PRIVATE_KEY_PEM", "")
+		_, err := LocalJWT(uuid.New().String())
+		Expect(err).To(HaveOccurred())
+		os.Unsetenv("EC_PRIVATE_KEY_PEM")
+	})
+
+	Context("with a private key", func() {
+		var (
+			publicKey     crypto.PublicKey
+			privateKeyPEM string
+		)
+
+		BeforeEach(func() {
+			var err error
+			var publicKeyPEM string
+			publicKeyPEM, privateKeyPEM, err = ECDSAKeyPairPEM()
+			Expect(err).NotTo(HaveOccurred())
+			publicKey, err = jwt.ParseECPublicKeyFromPEM([]byte(publicKeyPEM))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		validateToken := func(token string, pub crypto.PublicKey) *jwt.Token {
+			parser := &jwt.Parser{ValidMethods: []string{jwt.SigningMethodES256.Alg()}}
+			parsed, err := parser.Parse(token, func(t *jwt.Token) (interface{}, error) { return pub, nil })
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsed.Valid).To(BeTrue())
+
+			return parsed
+		}
+
+		It("LocalJWT creates a valid token with EC_PRIVATE_KEY_PEM set", func() {
+			os.Setenv("EC_PRIVATE_KEY_PEM", privateKeyPEM)
+
+			id := uuid.New().String()
+			tokenString, err := LocalJWT(id)
+			Expect(err).ToNot(HaveOccurred())
+
+			tok := validateToken(tokenString, publicKey)
+			claims, ok := tok.Claims.(jwt.MapClaims)
+			Expect(ok).To(BeTrue())
+
+			clusterID, ok := claims["cluster_id"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(clusterID).To(Equal(id))
+
+			os.Unsetenv("EC_PRIVATE_KEY_PEM")
+		})
+
+		It("LocalJWTForKey creates a valid token", func() {
+			id := uuid.New().String()
+			tokenString, err := LocalJWTForKey(id, privateKeyPEM)
+			Expect(err).ToNot(HaveOccurred())
+
+			tok := validateToken(tokenString, publicKey)
+			claims, ok := tok.Claims.(jwt.MapClaims)
+			Expect(ok).To(BeTrue())
+
+			clusterID, ok := claims["cluster_id"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(clusterID).To(Equal(id))
+		})
+	})
+})

--- a/pkg/auth/auth_handler_test_utils.go
+++ b/pkg/auth/auth_handler_test_utils.go
@@ -1,15 +1,10 @@
 package auth
 
 import (
-	"bytes"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/base32"
-	"encoding/pem"
 	"fmt"
 
 	"github.com/dgrijalva/jwt-go"
@@ -85,37 +80,4 @@ func GenJSJWKS(privKey crypto.PublicKey, pubKey crypto.PublicKey) ([]byte, []byt
 		fmt.Printf("pubJSJWKS Marshaling error: %v\n", err)
 	}
 	return pubJSJWKS, privJSJWKS, kid, nil
-}
-
-func ECDSATokenAndKey(clusterID string) (string, string, error) {
-	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return "", "", err
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
-		"cluster_id": clusterID,
-	})
-	tokenString, err := token.SignedString(priv)
-	if err != nil {
-		return "", "", err
-	}
-
-	pubBytes, err := x509.MarshalPKIXPublicKey(priv.Public())
-	if err != nil {
-		return "", "", err
-	}
-
-	block := &pem.Block{
-		Type:  "EC PUBLIC KEY",
-		Bytes: pubBytes,
-	}
-
-	var out bytes.Buffer
-	err = pem.Encode(&out, block)
-	if err != nil {
-		return "", "", err
-	}
-
-	return tokenString, out.String(), nil
 }

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -23,6 +23,7 @@ type Authenticator interface {
 	CreateAuthenticator() func(name, in string, authenticate security.TokenAuthentication) runtime.Authenticator
 	AuthUserAuth(token string) (interface{}, error)
 	AuthAgentAuth(token string) (interface{}, error)
+	AuthURLAuth(token string) (interface{}, error)
 	AuthType() AuthType
 }
 
@@ -47,5 +48,7 @@ func NewAuthenticator(cfg *Config, ocmClient *ocm.Client, log logrus.FieldLogger
 	default:
 		err = fmt.Errorf("invalid authenticator type %v", cfg.AuthType)
 	}
+
+	log.Infof("Created %s authenticator", cfg.AuthType)
 	return
 }

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,11 +37,11 @@ var _ = Describe("NewAuthenticator", func() {
 		Expect(ok).To(BeTrue())
 
 		// LocalAuthenticator
-		_, ecdsaPubKey, err := ECDSATokenAndKey("")
+		pubKey, _, err := gencrypto.ECDSAKeyPairPEM()
 		Expect(err).ToNot(HaveOccurred())
 		config = &Config{
 			AuthType:       TypeLocal,
-			ECPublicKeyPEM: ecdsaPubKey,
+			ECPublicKeyPEM: pubKey,
 		}
 
 		a, err = NewAuthenticator(config, nil, logrus.New(), nil)

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -80,6 +80,10 @@ func (a *LocalAuthenticator) AuthUserAuth(_ string) (interface{}, error) {
 	return nil, errors.Errorf("User Authentication not allowed for local auth")
 }
 
+func (a *LocalAuthenticator) AuthURLAuth(token string) (interface{}, error) {
+	return a.AuthAgentAuth(token)
+}
+
 func (a *LocalAuthenticator) CreateAuthenticator() func(_, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
 	return func(name string, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
 		return security.HttpAuthenticator(func(r *http.Request) (bool, interface{}, error) {

--- a/pkg/auth/none_authenticator.go
+++ b/pkg/auth/none_authenticator.go
@@ -33,6 +33,11 @@ func (a *NoneAuthenticator) AuthUserAuth(_ string) (interface{}, error) {
 	return ocm.AdminPayload(), nil
 }
 
+func (a *NoneAuthenticator) AuthURLAuth(_ string) (interface{}, error) {
+	a.log.Debug("URL Authentication Disabled")
+	return ocm.AdminPayload(), nil
+}
+
 func (a *NoneAuthenticator) CreateAuthenticator() func(_, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
 	return func(_ string, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
 		return security.HttpAuthenticator(func(_ *http.Request) (bool, interface{}, error) {

--- a/pkg/auth/rhsso_authenticator.go
+++ b/pkg/auth/rhsso_authenticator.go
@@ -261,6 +261,10 @@ func (a *RHSSOAuthenticator) isClusterOwnedByUser(clusterID string, payload *ocm
 	return true, nil
 }
 
+func (a *RHSSOAuthenticator) AuthURLAuth(_ string) (interface{}, error) {
+	return nil, errors.Errorf("URL Authentication not allowed for rhsso auth")
+}
+
 func (a *RHSSOAuthenticator) CreateAuthenticator() func(name, in string, authenticate security.TokenAuthentication) runtime.Authenticator {
 	return func(name string, _ string, authenticate security.TokenAuthentication) runtime.Authenticator {
 		getToken := func(r *http.Request) string { return r.Header.Get(name) }

--- a/restapi/configure_assisted_install.go
+++ b/restapi/configure_assisted_install.go
@@ -283,6 +283,9 @@ type Config struct {
 	// AuthAgentAuth Applies when the "X-Secret-Key" header is set
 	AuthAgentAuth func(token string) (interface{}, error)
 
+	// AuthURLAuth Applies when the "api_key" query is set
+	AuthURLAuth func(token string) (interface{}, error)
+
 	// AuthUserAuth Applies when the "Authorization" header is set
 	AuthUserAuth func(token string) (interface{}, error)
 
@@ -332,6 +335,13 @@ func HandlerAPI(c Config) (http.Handler, *operations.AssistedInstallAPI, error) 
 			return token, nil
 		}
 		return c.AuthAgentAuth(token)
+	}
+
+	api.URLAuthAuth = func(token string) (interface{}, error) {
+		if c.AuthURLAuth == nil {
+			return token, nil
+		}
+		return c.AuthURLAuth(token)
 	}
 
 	api.UserAuthAuth = func(token string) (interface{}, error) {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1278,6 +1278,9 @@ func init() {
           },
           {
             "agentAuth": []
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads files relating to the installed/installing cluster.",
@@ -1504,6 +1507,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads the OpenShift per-cluster Discovery ISO.",
@@ -1659,6 +1665,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads the kubeconfig file for this cluster.",
@@ -3038,6 +3047,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Download host logs.",
@@ -3513,6 +3525,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Download cluster logs.",
@@ -7181,6 +7196,11 @@ func init() {
       "name": "X-Secret-Key",
       "in": "header"
     },
+    "urlAuth": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "query"
+    },
     "userAuth": {
       "type": "apiKey",
       "name": "Authorization",
@@ -8495,6 +8515,9 @@ func init() {
           },
           {
             "agentAuth": []
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads files relating to the installed/installing cluster.",
@@ -8721,6 +8744,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads the OpenShift per-cluster Discovery ISO.",
@@ -8876,6 +8902,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Downloads the kubeconfig file for this cluster.",
@@ -10255,6 +10284,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Download host logs.",
@@ -10730,6 +10762,9 @@ func init() {
               "read-only-admin",
               "user"
             ]
+          },
+          {
+            "urlAuth": []
           }
         ],
         "description": "Download cluster logs.",
@@ -14455,6 +14490,11 @@ func init() {
       "type": "apiKey",
       "name": "X-Secret-Key",
       "in": "header"
+    },
+    "urlAuth": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "query"
     },
     "userAuth": {
       "type": "apiKey",

--- a/restapi/operations/assisted_install_api.go
+++ b/restapi/operations/assisted_install_api.go
@@ -250,6 +250,10 @@ func NewAssistedInstallAPI(spec *loads.Document) *AssistedInstallAPI {
 		AgentAuthAuth: func(token string) (interface{}, error) {
 			return nil, errors.NotImplemented("api key auth (agentAuth) X-Secret-Key from header param [X-Secret-Key] has not yet been implemented")
 		},
+		// Applies when the "api_key" query is set
+		URLAuthAuth: func(token string) (interface{}, error) {
+			return nil, errors.NotImplemented("api key auth (urlAuth) api_key from query param [api_key] has not yet been implemented")
+		},
 		// Applies when the "Authorization" header is set
 		UserAuthAuth: func(token string) (interface{}, error) {
 			return nil, errors.NotImplemented("api key auth (userAuth) Authorization from header param [Authorization] has not yet been implemented")
@@ -299,6 +303,10 @@ type AssistedInstallAPI struct {
 	// AgentAuthAuth registers a function that takes a token and returns a principal
 	// it performs authentication based on an api key X-Secret-Key provided in the header
 	AgentAuthAuth func(string) (interface{}, error)
+
+	// URLAuthAuth registers a function that takes a token and returns a principal
+	// it performs authentication based on an api key api_key provided in the query
+	URLAuthAuth func(string) (interface{}, error)
 
 	// UserAuthAuth registers a function that takes a token and returns a principal
 	// it performs authentication based on an api key Authorization provided in the header
@@ -520,6 +528,9 @@ func (o *AssistedInstallAPI) Validate() error {
 	if o.AgentAuthAuth == nil {
 		unregistered = append(unregistered, "XSecretKeyAuth")
 	}
+	if o.URLAuthAuth == nil {
+		unregistered = append(unregistered, "APIKeyAuth")
+	}
 	if o.UserAuthAuth == nil {
 		unregistered = append(unregistered, "AuthorizationAuth")
 	}
@@ -737,6 +748,10 @@ func (o *AssistedInstallAPI) AuthenticatorsFor(schemes map[string]spec.SecurityS
 		case "agentAuth":
 			scheme := schemes[name]
 			result[name] = o.APIKeyAuthenticator(scheme.Name, scheme.In, o.AgentAuthAuth)
+
+		case "urlAuth":
+			scheme := schemes[name]
+			result[name] = o.APIKeyAuthenticator(scheme.Name, scheme.In, o.URLAuthAuth)
 
 		case "userAuth":
 			scheme := schemes[name]

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -45,6 +45,10 @@ securityDefinitions:
     type: apiKey
     in: header
     name: Authorization
+  urlAuth:
+    type: apiKey
+    in: query
+    name: api_key
 
 security:
   - userAuth: [admin, user]
@@ -343,6 +347,7 @@ paths:
       description: Downloads the OpenShift per-cluster Discovery ISO.
       security:
         - userAuth: [admin, read-only-admin, user]
+        - urlAuth: []
       operationId: DownloadClusterISO
       produces:
         # application/vnd.efi.iso is not supported
@@ -394,6 +399,7 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
+        - urlAuth: []
       description: Downloads files relating to the installed/installing cluster.
       operationId: DownloadClusterFiles
       produces:
@@ -573,6 +579,7 @@ paths:
         - installer
       security:
         - userAuth: [admin, read-only-admin, user]
+        - urlAuth: []
       description: Downloads the kubeconfig file for this cluster.
       operationId: DownloadClusterKubeconfig
       produces:
@@ -2128,6 +2135,7 @@ paths:
       deprecated: true
       security:
         - userAuth: [admin, read-only-admin, user]
+        - urlAuth: []
       operationId: DownloadHostLogs
       produces:
         - application/octet-stream
@@ -2451,6 +2459,7 @@ paths:
       description: Download cluster logs.
       security:
         - userAuth: [admin, read-only-admin, user]
+        - urlAuth: []
       operationId: DownloadClusterLogs
       produces:
         - 'application/octet-stream'


### PR DESCRIPTION
Add a new authentication method which validates a token in the query params of the url.
This method will only be used on a small number of endpoints where the intended client both cannot provide an alternate form of authentication (in headers) and is already considered trusted (the token is a form of password).

Specifically this will be used in the kube-api use case when we need to post a download link to some artifact in a CR. Authentication using this method is only enabled when we are already using the new "local" auth handler which disables the header-based userAuth entirely.

This enables the new auth on the following endpoints:
- GET /clusters/{cluster_id}/downloads/files
- GET /clusters/{cluster_id}/downloads/image
- GET /clusters/{cluster_id}/downloads/kubeconfig
- GET /clusters/{cluster_id}/hosts/{host_id}/logs
- GET /clusters/{cluster_id}/logs

This also signs the cluster discovery iso url saved to the image info if we're using local auth. The plan is to expand this functionality to other embedded urls in the future.