### PR TITLE
OCPBUGSM-26541 Verify file name does not include folder

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -60,6 +61,10 @@ func (m *Manifests) CreateClusterManifest(ctx context.Context, params operations
 		return common.GenerateErrorResponder(apierr)
 	}
 
+	if strings.ContainsRune(*params.CreateManifestParams.FileName, os.PathSeparator) {
+		log.Errorf("Cluster manifest %s for cluster %s should not include a directory in its name.", *params.CreateManifestParams.FileName, cluster.ID)
+		return common.GenerateErrorResponderWithDefault(errors.New("Manifest should not include a directory in its name"), http.StatusBadRequest)
+	}
 	fileName := filepath.Join(*params.CreateManifestParams.Folder, *params.CreateManifestParams.FileName)
 	manifestContent, err := base64.StdEncoding.DecodeString(*params.CreateManifestParams.Content)
 	if err != nil {

--- a/models/create_manifest_params.go
+++ b/models/create_manifest_params.go
@@ -23,9 +23,9 @@ type CreateManifestParams struct {
 	// Required: true
 	Content *string `json:"content"`
 
-	// The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.
+	// The name of the manifest to customize the installed OCP cluster.
 	// Required: true
-	// Pattern: ^.*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -70,7 +70,7 @@ func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", string(*m.FileName), `^.*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", string(*m.FileName), `^[^/]*\.(yaml|yml|json)$`); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5570,9 +5570,9 @@ func init() {
           "type": "string"
         },
         "file_name": {
-          "description": "The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.",
+          "description": "The name of the manifest to customize the installed OCP cluster.",
           "type": "string",
-          "pattern": "^.*\\.(yaml|yml|json)$"
+          "pattern": "^[^/]*\\.(yaml|yml|json)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",
@@ -12891,9 +12891,9 @@ func init() {
           "type": "string"
         },
         "file_name": {
-          "description": "The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.",
+          "description": "The name of the manifest to customize the installed OCP cluster.",
           "type": "string",
-          "pattern": "^.*\\.(yaml|yml|json)$"
+          "pattern": "^[^/]*\\.(yaml|yml|json)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4946,9 +4946,9 @@ definitions:
         enum: [manifests,openshift]
         default: manifests
       file_name:
-        description: The name of the manifest to be stored on S3 and to be created on '{folder}/{file_name}' at ignition generation using openshift-install.
+        description: The name of the manifest to customize the installed OCP cluster.
         type: string
-        pattern: '^.*\.(yaml|yml|json)$'
+        pattern: '^[^/]*\.(yaml|yml|json)$'
       content:
         description: base64 encoded manifest content.
         type: string


### PR DESCRIPTION
According to the manfiest API the target folder for the manifest should
be provided via a dedicated parameter. Thefore the file-name needs to be
verified not to include it.

Signed-off-by: Moti Asayag <masayag@redhat.com>