### PR TITLE
Multiple changes for epic MGMT-3563

### DIFF
--- a/internal/cluster/conditions.go
+++ b/internal/cluster/conditions.go
@@ -1,6 +1,10 @@
 package cluster
 
-import "github.com/go-openapi/swag"
+import (
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+)
 
 type conditionId string
 type condition struct {
@@ -9,7 +13,11 @@ type condition struct {
 }
 
 const (
-	VipDhcpAllocationSet = conditionId("vip-dhcp-allocation-set")
+	VipDhcpAllocationSet         = conditionId("vip-dhcp-allocation-set")
+	AllHostsPreparedSuccessfully = conditionId("all-hosts-prepared-successfully")
+	InsufficientHostExists       = conditionId("insufficient-host-exists")
+	ClusterPreparationSucceeded  = conditionId("cluster-preparation-succeeded")
+	ClusterPreparationFailed     = conditionId("cluster-preparation-failed")
 )
 
 func (c conditionId) String() string {
@@ -18,4 +26,30 @@ func (c conditionId) String() string {
 
 func isVipDhcpAllocationSet(c *clusterPreprocessContext) bool {
 	return swag.BoolValue(c.cluster.VipDhcpAllocation)
+}
+
+func areAllHostsPreparedSuccessfully(c *clusterPreprocessContext) bool {
+	for _, h := range c.cluster.Hosts {
+		if swag.StringValue(h.Status) != models.HostStatusPreparingSuccessful {
+			return false
+		}
+	}
+	return true
+}
+
+func isInsufficientHostExists(c *clusterPreprocessContext) bool {
+	for _, h := range c.cluster.Hosts {
+		if swag.StringValue(h.Status) == models.HostStatusInsufficient {
+			return true
+		}
+	}
+	return false
+}
+
+func isClusterPreparationSucceeded(c *clusterPreprocessContext) bool {
+	return c.cluster.InstallationPreparationCompletionStatus == common.InstallationPreparationSucceeded
+}
+
+func isClusterPreparationFailed(c *clusterPreprocessContext) bool {
+	return c.cluster.InstallationPreparationCompletionStatus == common.InstallationPreparationFailed
 }

--- a/internal/cluster/refresh_status_preprocessor.go
+++ b/internal/cluster/refresh_status_preprocessor.go
@@ -196,5 +196,21 @@ func newConditions() []condition {
 			id: VipDhcpAllocationSet,
 			fn: isVipDhcpAllocationSet,
 		},
+		{
+			id: AllHostsPreparedSuccessfully,
+			fn: areAllHostsPreparedSuccessfully,
+		},
+		{
+			id: InsufficientHostExists,
+			fn: isInsufficientHostExists,
+		},
+		{
+			id: ClusterPreparationSucceeded,
+			fn: isClusterPreparationSucceeded,
+		},
+		{
+			id: ClusterPreparationFailed,
+			fn: isClusterPreparationFailed,
+		},
 	}
 }

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -9,6 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	InstallationPreparationSucceeded = "success"
+	InstallationPreparationFailed    = "failed"
+)
+
 type Cluster struct {
 	models.Cluster
 	// The pull secret that obtained from the Pull Secret page on the Red Hat OpenShift Cluster Manager site.
@@ -35,6 +40,9 @@ type Cluster struct {
 
 	// The ID of the subscription created in AMS
 	AmsSubscriptionID strfmt.UUID `json:"ams_subscription_id"`
+
+	// Indication if installation preparation succeeded or failed
+	InstallationPreparationCompletionStatus string
 
 	// ImageGenerated indicates if the discovery image was generated successfully. It will be used internally
 	// when an image needs to be generated. In case the user request to generate an image with custom parameters,

--- a/internal/hardware/boot_device.go
+++ b/internal/hardware/boot_device.go
@@ -1,0 +1,34 @@
+package hardware
+
+import (
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	models "github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func GetBootDevice(log logrus.FieldLogger, hwValidator Validator, host *models.Host) (string, error) {
+	if host.InstallationDiskPath != "" {
+		return host.InstallationDiskPath, nil
+	}
+
+	// TODO: We generally shouldn't reach this point on any version containing this comment.
+	//  It might happen a few times while this version is first rolled out. Remove the call to GetHostValidDisks when
+	//  that new version has been running for a sufficiently long time.
+	//  Note that instead of a call to GetHostValidDisks, an error should occur. That's because if the installation disk
+	//  path is empty, it means there are no valid disks to install on.
+	disks, err := hwValidator.GetHostValidDisks(host)
+	if err != nil || len(disks) == 0 {
+		log.Errorf("Failed to get valid disks on host with id %s", host.ID)
+
+		var newErr error
+		if err != nil {
+			newErr = errors.Wrapf(err, "failed to get valid disks on host with id %s", host.ID)
+		} else {
+			newErr = errors.Errorf("host has no valid disks id %s", host.ID)
+		}
+
+		return "", newErr
+	}
+	return hostutil.GetDeviceFullName(disks[0]), nil
+}

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -36,14 +36,15 @@ func NewValidator(log logrus.FieldLogger, cfg ValidatorCfg, operatorsAPI operato
 }
 
 type ValidatorCfg struct {
-	MinCPUCores                   int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES" default:"2"`
-	MinCPUCoresWorker             int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES_WORKER" default:"2"`
-	MinCPUCoresMaster             int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES_MASTER" default:"4"`
-	MinRamGib                     int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB" default:"8"`
-	MinRamGibWorker               int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB_WORKER" default:"8"`
-	MinRamGibMaster               int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB_MASTER" default:"16"`
-	MinDiskSizeGb                 int64 `envconfig:"HW_VALIDATOR_MIN_DISK_SIZE_GIB" default:"120"` // Env variable is GIB to not break infra
-	MaximumAllowedTimeDiffMinutes int64 `envconfig:"HW_VALIDATOR_MAX_TIME_DIFF_MINUTES" default:"4"`
+	MinCPUCores                      int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES" default:"2"`
+	MinCPUCoresWorker                int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES_WORKER" default:"2"`
+	MinCPUCoresMaster                int64 `envconfig:"HW_VALIDATOR_MIN_CPU_CORES_MASTER" default:"4"`
+	MinRamGib                        int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB" default:"8"`
+	MinRamGibWorker                  int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB_WORKER" default:"8"`
+	MinRamGibMaster                  int64 `envconfig:"HW_VALIDATOR_MIN_RAM_GIB_MASTER" default:"16"`
+	MinDiskSizeGb                    int64 `envconfig:"HW_VALIDATOR_MIN_DISK_SIZE_GIB" default:"120"` // Env variable is GIB to not break infra
+	MaximumAllowedTimeDiffMinutes    int64 `envconfig:"HW_VALIDATOR_MAX_TIME_DIFF_MINUTES" default:"4"`
+	InstallationDiskSpeedThresholdMs int64 `envconfig:"HW_INSTALLATION_DISK_SPEED_THRESHOLD_MS" default:"10"`
 }
 
 type validator struct {
@@ -124,15 +125,17 @@ func (v *validator) ListEligibleDisks(inventory *models.Inventory) []*models.Dis
 func (v *validator) GetHostRequirements(role models.HostRole) models.HostRequirementsRole {
 	if role == models.HostRoleMaster {
 		return models.HostRequirementsRole{
-			CPUCores:   v.ValidatorCfg.MinCPUCoresMaster,
-			RAMGib:     v.ValidatorCfg.MinRamGibMaster,
-			DiskSizeGb: v.ValidatorCfg.MinDiskSizeGb,
+			CPUCores:                         v.ValidatorCfg.MinCPUCoresMaster,
+			RAMGib:                           v.ValidatorCfg.MinRamGibMaster,
+			DiskSizeGb:                       v.ValidatorCfg.MinDiskSizeGb,
+			InstallationDiskSpeedThresholdMs: v.InstallationDiskSpeedThresholdMs,
 		}
 	} else {
 		return models.HostRequirementsRole{
-			CPUCores:   v.ValidatorCfg.MinCPUCoresWorker,
-			RAMGib:     v.ValidatorCfg.MinRamGibWorker,
-			DiskSizeGb: v.ValidatorCfg.MinDiskSizeGb,
+			CPUCores:                         v.ValidatorCfg.MinCPUCoresWorker,
+			RAMGib:                           v.ValidatorCfg.MinRamGibWorker,
+			DiskSizeGb:                       v.ValidatorCfg.MinDiskSizeGb,
+			InstallationDiskSpeedThresholdMs: v.InstallationDiskSpeedThresholdMs,
 		}
 	}
 }

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Cluster host requirements", func() {
 		Expect(result.Ocp.DiskSizeGb).To(BeEquivalentTo(cfg.MinDiskSizeGb))
 		Expect(result.Ocp.CPUCores).To(BeEquivalentTo(cfg.MinCPUCoresMaster))
 		Expect(result.Ocp.RAMMib).To(BeEquivalentTo(cfg.MinRamGibMaster * int64(units.KiB)))
-		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(BeZero())
+		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(Equal(cfg.InstallationDiskSpeedThresholdMs))
 
 		Expect(result.Operators).To(ConsistOf(operatorRequirements))
 
@@ -279,7 +279,7 @@ var _ = Describe("Cluster host requirements", func() {
 		Expect(result.Ocp.DiskSizeGb).To(BeEquivalentTo(cfg.MinDiskSizeGb))
 		Expect(result.Ocp.CPUCores).To(BeEquivalentTo(cfg.MinCPUCoresWorker))
 		Expect(result.Ocp.RAMMib).To(BeEquivalentTo(cfg.MinRamGibWorker * int64(units.KiB)))
-		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(BeZero())
+		Expect(result.Ocp.InstallationDiskSpeedThresholdMs).To(Equal(cfg.InstallationDiskSpeedThresholdMs))
 
 		Expect(result.Operators).To(ConsistOf(operatorRequirements))
 

--- a/internal/host/conditions.go
+++ b/internal/host/conditions.go
@@ -1,0 +1,30 @@
+package host
+
+import (
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/models"
+)
+
+type conditionId string
+type condition struct {
+	id conditionId
+	fn func(c *validationContext) bool
+}
+
+const (
+	InstallationDiskSpeedCheckSuccessful = conditionId("installation-disk-speed-check-successful")
+	ClusterInsufficient                  = conditionId("cluster-insufficient")
+)
+
+func (c conditionId) String() string {
+	return string(c)
+}
+
+func (v *validator) isInstallationDiskSpeedCheckSuccessful(c *validationContext) bool {
+	info, err := v.getBootDeviceInfo(c.host)
+	return err == nil && info != nil && info.DiskSpeed != nil && info.DiskSpeed.Tested && info.DiskSpeed.ExitCode == 0
+}
+
+func (v *validator) isClusterInsufficient(c *validationContext) bool {
+	return swag.StringValue(c.cluster.Status) == models.ClusterStatusInsufficient
+}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -948,8 +948,8 @@ func (m *Manager) IsValidMasterCandidate(h *models.Host, db *gorm.DB, log logrus
 	return false, nil
 }
 
-func (m *Manager) canBeMaster(conditions map[validationID]bool) bool {
-	if conditions[HasCPUCoresForRole] && conditions[HasMemoryForRole] {
+func (m *Manager) canBeMaster(conditions map[string]bool) bool {
+	if conditions[HasCPUCoresForRole.String()] && conditions[HasMemoryForRole.String()] {
 		return true
 	}
 	return false

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1921,6 +1921,7 @@ var _ = Describe("AutoAssignRole", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockHwValidator = hardware.NewMockValidator(ctrl)
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
+		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)
 		db, dbName = common.PrepareTestDB()
 		clusterId = strfmt.UUID(uuid.New().String())

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -45,6 +45,7 @@ var _ = Describe("monitor_disconnection", func() {
 		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
 			Total: &models.ClusterHostRequirementsDetails{},
 		}, nil)
+		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, defaultConfig, dummy, mockOperators)
@@ -148,6 +149,7 @@ var _ = Describe("TestHostMonitoring", func() {
 		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
 			Total: &models.ClusterHostRequirementsDetails{},
 		}, nil)
+		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			nil, &cfg, &leader.DummyElector{}, mockOperators)

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -384,18 +384,18 @@ func (th *transitionHandler) updateTransitionHost(ctx context.Context, log logru
 type TransitionArgsRefreshHost struct {
 	ctx               context.Context
 	eventHandler      events.Handler
-	conditions        map[validationID]bool
+	conditions        map[string]bool
 	validationResults validationsStatus
 	db                *gorm.DB
 }
 
-func If(id validationID) stateswitch.Condition {
+func If(id stringer) stateswitch.Condition {
 	ret := func(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
 		params, ok := args.(*TransitionArgsRefreshHost)
 		if !ok {
 			return false, errors.Errorf("If(%s) invalid argument", id.String())
 		}
-		b, ok := params.conditions[id]
+		b, ok := params.conditions[id.String()]
 		if !ok {
 			return false, errors.Errorf("If(%s) no such condition", id.String())
 		}

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1200,7 +1200,7 @@ var _ = Describe("Refresh Host", func() {
 				return disk.SizeBytes >= conversions.GibToBytes(validatorCfg.MinDiskSizeGb)
 			}).([]*models.Disk)
 		}).AnyTimes()
-
+		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{})
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, nil, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -11,25 +11,26 @@ import (
 type validationID models.HostValidationID
 
 const (
-	IsConnected                 = validationID(models.HostValidationIDConnected)
-	HasInventory                = validationID(models.HostValidationIDHasInventory)
-	IsMachineCidrDefined        = validationID(models.HostValidationIDMachineCidrDefined)
-	BelongsToMachineCidr        = validationID(models.HostValidationIDBelongsToMachineCidr)
-	HasMinCPUCores              = validationID(models.HostValidationIDHasMinCPUCores)
-	HasMinValidDisks            = validationID(models.HostValidationIDHasMinValidDisks)
-	HasMinMemory                = validationID(models.HostValidationIDHasMinMemory)
-	HasCPUCoresForRole          = validationID(models.HostValidationIDHasCPUCoresForRole)
-	HasMemoryForRole            = validationID(models.HostValidationIDHasMemoryForRole)
-	IsHostnameUnique            = validationID(models.HostValidationIDHostnameUnique)
-	IsHostnameValid             = validationID(models.HostValidationIDHostnameValid)
-	IsAPIVipConnected           = validationID(models.HostValidationIDAPIVipConnected)
-	BelongsToMajorityGroup      = validationID(models.HostValidationIDBelongsToMajorityGroup)
-	IsPlatformValid             = validationID(models.HostValidationIDValidPlatform)
-	IsNTPSynced                 = validationID(models.HostValidationIDNtpSynced)
-	AreContainerImagesAvailable = validationID(models.HostValidationIDContainerImagesAvailable)
-	AreLsoRequirementsSatisfied = validationID(models.HostValidationIDLsoRequirementsSatisfied)
-	AreOcsRequirementsSatisfied = validationID(models.HostValidationIDOcsRequirementsSatisfied)
-	AreCnvRequirementsSatisfied = validationID(models.HostValidationIDCnvRequirementsSatisfied)
+	IsConnected                              = validationID(models.HostValidationIDConnected)
+	HasInventory                             = validationID(models.HostValidationIDHasInventory)
+	IsMachineCidrDefined                     = validationID(models.HostValidationIDMachineCidrDefined)
+	BelongsToMachineCidr                     = validationID(models.HostValidationIDBelongsToMachineCidr)
+	HasMinCPUCores                           = validationID(models.HostValidationIDHasMinCPUCores)
+	HasMinValidDisks                         = validationID(models.HostValidationIDHasMinValidDisks)
+	HasMinMemory                             = validationID(models.HostValidationIDHasMinMemory)
+	HasCPUCoresForRole                       = validationID(models.HostValidationIDHasCPUCoresForRole)
+	HasMemoryForRole                         = validationID(models.HostValidationIDHasMemoryForRole)
+	IsHostnameUnique                         = validationID(models.HostValidationIDHostnameUnique)
+	IsHostnameValid                          = validationID(models.HostValidationIDHostnameValid)
+	IsAPIVipConnected                        = validationID(models.HostValidationIDAPIVipConnected)
+	BelongsToMajorityGroup                   = validationID(models.HostValidationIDBelongsToMajorityGroup)
+	IsPlatformValid                          = validationID(models.HostValidationIDValidPlatform)
+	IsNTPSynced                              = validationID(models.HostValidationIDNtpSynced)
+	AreContainerImagesAvailable              = validationID(models.HostValidationIDContainerImagesAvailable)
+	AreLsoRequirementsSatisfied              = validationID(models.HostValidationIDLsoRequirementsSatisfied)
+	AreOcsRequirementsSatisfied              = validationID(models.HostValidationIDOcsRequirementsSatisfied)
+	AreCnvRequirementsSatisfied              = validationID(models.HostValidationIDCnvRequirementsSatisfied)
+	SufficientOrUnknownInstallationDiskSpeed = validationID(models.HostValidationIDSufficientOrUnknownInstallationDiskSpeed)
 )
 
 func (v validationID) category() (string, error) {
@@ -37,7 +38,7 @@ func (v validationID) category() (string, error) {
 	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr,
 		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, AreContainerImagesAvailable:
 		return "network", nil
-	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory,
+	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory, SufficientOrUnknownInstallationDiskSpeed,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid:
 		return "hardware", nil
 	case AreLsoRequirementsSatisfied, AreOcsRequirementsSatisfied, AreCnvRequirementsSatisfied:

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -74,8 +74,8 @@ const (
 	// HostValidationIDOcsRequirementsSatisfied captures enum value "ocs-requirements-satisfied"
 	HostValidationIDOcsRequirementsSatisfied HostValidationID = "ocs-requirements-satisfied"
 
-	// HostValidationIDSufficientInstallationDiskSpeed captures enum value "sufficient-installation-disk-speed"
-	HostValidationIDSufficientInstallationDiskSpeed HostValidationID = "sufficient-installation-disk-speed"
+	// HostValidationIDSufficientOrUnknownInstallationDiskSpeed captures enum value "sufficient-or-unknown-installation-disk-speed"
+	HostValidationIDSufficientOrUnknownInstallationDiskSpeed HostValidationID = "sufficient-or-unknown-installation-disk-speed"
 
 	// HostValidationIDCnvRequirementsSatisfied captures enum value "cnv-requirements-satisfied"
 	HostValidationIDCnvRequirementsSatisfied HostValidationID = "cnv-requirements-satisfied"
@@ -86,7 +86,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-or-unknown-installation-disk-speed","cnv-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6442,7 +6442,7 @@ func init() {
         "container-images-available",
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
-        "sufficient-installation-disk-speed",
+        "sufficient-or-unknown-installation-disk-speed",
         "cnv-requirements-satisfied"
       ]
     },
@@ -13838,7 +13838,7 @@ func init() {
         "container-images-available",
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
-        "sufficient-installation-disk-speed",
+        "sufficient-or-unknown-installation-disk-speed",
         "cnv-requirements-satisfied"
       ]
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4813,7 +4813,7 @@ definitions:
       - 'container-images-available'
       - 'lso-requirements-satisfied'
       - 'ocs-requirements-satisfied'
-      - 'sufficient-installation-disk-speed'
+      - 'sufficient-or-unknown-installation-disk-speed'
       - 'cnv-requirements-satisfied'
 
   dhcp_allocation_request:


### PR DESCRIPTION
[MGMT-3453](https://issues.redhat.com/browse/MGMT-3453) - Add support in requirement API to retrieve the value of installation_disk_speed_threshold_ms

[MGMT-4674](https://issues.redhat.com/browse/MGMT-4674) - Add validations and conditions for new state.  These include the disk FIO validations and conditions, and
            installation preparations conditions.  These will be used in a later commit affecting cluster and host
            state machines.