### PR TITLE
MGMT-4693 Make minimal iso boot with UEFI

### DIFF
--- a/internal/isoeditor/rhcos.go
+++ b/internal/isoeditor/rhcos.go
@@ -331,10 +331,12 @@ func (e *rhcosEditor) create() (string, error) {
 
 func (e *rhcosEditor) fixTemplateConfigs(serviceBaseURL string) error {
 	// Add the rootfs url
-	replacement := fmt.Sprintf("$1 $2 coreos.live.rootfs_url=%s", e.getRootFSURL(serviceBaseURL))
+	rootFSURL := e.getRootFSURL(serviceBaseURL)
+	replacement := fmt.Sprintf("$1 $2 'coreos.live.rootfs_url=%s'", rootFSURL)
 	if err := editFile(e.isoHandler.ExtractedPath("EFI/redhat/grub.cfg"), `(?m)^(\s+linux) (.+| )+$`, replacement); err != nil {
 		return err
 	}
+	replacement = fmt.Sprintf("$1 $2 coreos.live.rootfs_url=%s", rootFSURL)
 	if err := editFile(e.isoHandler.ExtractedPath("isolinux/isolinux.cfg"), `(?m)^(\s+append) (.+| )+$`, replacement); err != nil {
 		return err
 	}

--- a/internal/isoeditor/rhcos_test.go
+++ b/internal/isoeditor/rhcos_test.go
@@ -119,7 +119,7 @@ var _ = Context("with test files", func() {
 			err = editor.(*rhcosEditor).fixTemplateConfigs(defaultTestServiceBaseURL)
 			Expect(err).ToNot(HaveOccurred())
 
-			newLine := "	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal coreos.live.rootfs_url=%s"
+			newLine := "	linux /images/pxeboot/vmlinuz random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=%s'"
 			grubCfg := fmt.Sprintf(newLine, rootfsURL)
 			validateFileContainsLine(isoHandler.ExtractedPath("EFI/redhat/grub.cfg"), grubCfg)
 

--- a/internal/isoutil/isoutil_test.go
+++ b/internal/isoutil/isoutil_test.go
@@ -151,6 +151,17 @@ var _ = Context("with test files", func() {
 			Expect(id).To(Equal(volumeID))
 		})
 	})
+
+	Describe("efiLoadSectors", func() {
+		It("returns the correct value", func() {
+			p, err := filepath.Abs(filepath.Join(filesDir, "boot_files"))
+			Expect(err).ToNot(HaveOccurred())
+			h := NewHandler("", p).(*installerHandler)
+			sectors, err := h.efiLoadSectors()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sectors).To(Equal(uint16(3997)))
+		})
+	})
 })
 
 func createIsoViaGenisoimage(volumeID string) (string, string, string) {
@@ -173,7 +184,10 @@ func createIsoViaGenisoimage(volumeID string) (string, string, string) {
 	Expect(err).ToNot(HaveOccurred())
 	err = os.Mkdir(filepath.Join(filesDir, "boot_files", "images"), 0755)
 	Expect(err).ToNot(HaveOccurred())
-	err = ioutil.WriteFile(filepath.Join(filesDir, "boot_files", "images", "efiboot.img"), []byte(""), 0600)
+	// Create a file with some size to test load sector calculation
+	f, err := os.Create(filepath.Join(filesDir, "boot_files", "images", "efiboot.img"))
+	Expect(err).ToNot(HaveOccurred())
+	err = f.Truncate(8184422)
 	Expect(err).ToNot(HaveOccurred())
 	err = os.Mkdir(filepath.Join(filesDir, "boot_files", "isolinux"), 0755)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	minimalTemplatesVersionFileName = "minimal_templates_version.json"
-	minimalTemplatesVersionLatest   = 1 // increase if templates update is needed
+	minimalTemplatesVersionLatest   = 2 // increase if templates update is needed
 )
 
 type templatesVersion struct {


### PR DESCRIPTION
There were two issues preventing the image from booting properly with UEFI. Each is handled by a commit in this PR.

1. We need to compute the correct size for the number of sectors to load for the boot image
Load Sectors * 2048 should be the size of efiboot.img rounded up to a multiple of 2048.
This was preventing the uefi system from finding the boot image.
ref:
https://fedoraproject.org/wiki/User:Pjones/BootableCDsForBIOSAndUEFI#Testing_the_image

2. We need to quote the rootfs url parameter in grub.cfg
Some special characters which are legal in a url are used as separators in grub's syntax so we need quotes.
ref:
https://www.gnu.org/software/grub/manual/grub/html_node/Shell_002dlike-scripting.html