### PR TITLE
MGMT-4673 Sort ValidationsOutput to prevent uneeded updates

### DIFF
--- a/internal/cluster/refresh_status_preprocessor.go
+++ b/internal/cluster/refresh_status_preprocessor.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/go-openapi/swag"
@@ -91,7 +92,17 @@ func (r *refreshPreprocessor) preprocess(ctx context.Context, c *clusterPreproce
 	for _, condition := range r.conditions {
 		stateMachineInput[condition.id.String()] = condition.fn(c)
 	}
+	for _, validationResults := range validationsOutput {
+		sortByValidationResultID(validationResults)
+	}
 	return stateMachineInput, validationsOutput, nil
+}
+
+// sortByValidationResultID sorts results by models.ClusterValidationID
+func sortByValidationResultID(validationResults []ValidationResult) {
+	sort.SliceStable(validationResults, func(i, j int) bool {
+		return validationResults[i].ID < validationResults[j].ID
+	})
 }
 
 func newValidations(log logrus.FieldLogger, api host.API) []validation {

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -3980,6 +3980,22 @@ var _ = Describe("Single node", func() {
 	})
 })
 
+var _ = Describe("ValidationResult sort", func() {
+	It("ValidationResult sort", func() {
+		validationResults := []ValidationResult{
+			{ID: "cab", Status: "abc", Message: "abc"},
+			{ID: "bac", Status: "abc", Message: "abc"},
+			{ID: "acb", Status: "abc", Message: "abc"},
+			{ID: "abc", Status: "abc", Message: "abc"},
+		}
+		sortByValidationResultID(validationResults)
+		Expect(validationResults[0].ID.String()).Should(Equal("abc"))
+		Expect(validationResults[1].ID.String()).Should(Equal("acb"))
+		Expect(validationResults[2].ID.String()).Should(Equal("bac"))
+		Expect(validationResults[3].ID.String()).Should(Equal("cab"))
+	})
+})
+
 func getClusterFromDB(clusterId strfmt.UUID, db *gorm.DB) common.Cluster {
 	c, err := common.GetClusterFromDB(db, clusterId, common.UseEagerLoading)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/openshift/assisted-service/internal/hardware"
@@ -17,6 +18,8 @@ type validationResult struct {
 }
 
 type validationsStatus map[string][]validationResult
+
+type validationResults []validationResult
 
 type refreshPreprocessor struct {
 	log          logrus.FieldLogger
@@ -72,9 +75,17 @@ func (r *refreshPreprocessor) preprocess(c *validationContext) (map[validationID
 			Status:  status,
 			Message: strings.Join(result.Reasons, "\n"),
 		})
+		sortByValidationResultID(validationsOutput[category])
 	}
 
 	return stateMachineInput, validationsOutput, nil
+}
+
+// sortByValidationResultID sorts results by models.HostValidationID
+func sortByValidationResultID(validationResults []validationResult) {
+	sort.SliceStable(validationResults, func(i, j int) bool {
+		return validationResults[i].ID < validationResults[j].ID
+	})
 }
 
 func newValidations(log logrus.FieldLogger, hwValidatorCfg *hardware.ValidatorCfg, hwValidator hardware.Validator, operatorsAPI operators.API) []validation {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1139,6 +1139,7 @@ type validationsChecker struct {
 func (j *validationsChecker) check(validationsStr string) {
 	validationRes := make(validationsStatus)
 	Expect(json.Unmarshal([]byte(validationsStr), &validationRes)).ToNot(HaveOccurred())
+	Expect(checkValidationInfoIsSorted(validationRes["operators"])).Should(BeTrue())
 next:
 	for id, checkedResult := range j.expected {
 		category, err := id.category()
@@ -1155,6 +1156,12 @@ next:
 		// Should not reach here
 		Expect(false).To(BeTrue())
 	}
+}
+
+func checkValidationInfoIsSorted(vRes validationResults) bool {
+	return sort.SliceIsSorted(vRes, func(i, j int) bool {
+		return vRes[i].ID < vRes[j].ID
+	})
 }
 
 type validationCheckResult struct {
@@ -3389,6 +3396,22 @@ var _ = Describe("Refresh Host", func() {
 	AfterEach(func() {
 		common.DeleteTestDB(db, dbName)
 		ctrl.Finish()
+	})
+})
+
+var _ = Describe("validationResult sort", func() {
+	It("validationResult sort", func() {
+		validationResults := []validationResult{
+			{ID: "cab", Status: "abc", Message: "abc"},
+			{ID: "bac", Status: "abc", Message: "abc"},
+			{ID: "acb", Status: "abc", Message: "abc"},
+			{ID: "abc", Status: "abc", Message: "abc"},
+		}
+		sortByValidationResultID(validationResults)
+		Expect(validationResults[0].ID.String()).Should(Equal("abc"))
+		Expect(validationResults[1].ID.String()).Should(Equal("acb"))
+		Expect(validationResults[2].ID.String()).Should(Equal("bac"))
+		Expect(validationResults[3].ID.String()).Should(Equal("cab"))
 	})
 })
 


### PR DESCRIPTION
We need to sort `ValidationResults` being stored as part of `ValidationsOutput` to make sure it is not changing (only order of the results).