### PR TITLE
MGMT-4070 Capture network latency between hosts

### DIFF
--- a/models/l3_connectivity.go
+++ b/models/l3_connectivity.go
@@ -15,8 +15,14 @@ import (
 // swagger:model l3-connectivity
 type L3Connectivity struct {
 
+	// Average round trip time in milliseconds.
+	AverageRTTMs float64 `json:"average_rtt_ms,omitempty"`
+
 	// outgoing nic
 	OutgoingNic string `json:"outgoing_nic,omitempty"`
+
+	// Percentage of packets lost during connectivity check.
+	PacketLossPercentage float64 `json:"packet_loss_percentage,omitempty"`
 
 	// remote ip address
 	RemoteIPAddress string `json:"remote_ip_address,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6728,8 +6728,19 @@ func init() {
     "l3-connectivity": {
       "type": "object",
       "properties": {
+        "average_rtt_ms": {
+          "description": "Average round trip time in milliseconds.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "AverageRTTMs"
+        },
         "outgoing_nic": {
           "type": "string"
+        },
+        "packet_loss_percentage": {
+          "description": "Percentage of packets lost during connectivity check.",
+          "type": "number",
+          "format": "double"
         },
         "remote_ip_address": {
           "type": "string"
@@ -14112,8 +14123,19 @@ func init() {
     "l3-connectivity": {
       "type": "object",
       "properties": {
+        "average_rtt_ms": {
+          "description": "Average round trip time in milliseconds.",
+          "type": "number",
+          "format": "double",
+          "x-go-name": "AverageRTTMs"
+        },
         "outgoing_nic": {
           "type": "string"
+        },
+        "packet_loss_percentage": {
+          "description": "Percentage of packets lost during connectivity check.",
+          "type": "number",
+          "format": "double"
         },
         "remote_ip_address": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4231,6 +4231,15 @@ definitions:
         type: string
       successful:
         type: boolean
+      average_rtt_ms:
+        type: number
+        format: double
+        description: Average round trip time in milliseconds.
+        x-go-name: "AverageRTTMs"
+      packet_loss_percentage:
+        type: number
+        format: double
+        description: Percentage of packets lost during connectivity check.
 
   connectivity-remote-host:
     type: object


### PR DESCRIPTION
This PR adds the model details in swagger to extend the L3 connectivity structure to capture the network latency (average RTT and packet loss) between hosts. This information will be used next to validate whether a node is a good candidate to be a member of the etcd cluster based on its average RTT and packet losses captured during the node discovery phase.

I need to have the swagger model updated before I can import the new structure into the agent project and progress into capturing the extra details. Once I have that information, I can proceed to add a new validation that uses the new information to determine if a host that has role Master fits the etcd latency requirements.

@avishayt @jakub-dzon @pkliczewski @masayag @machacekondra please review at your discretion.

/Jordi