### PR TITLE
NO-ISSUE generate random db names for unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/openshift/hive/apis v0.0.0-20210302234131-7026427c0ae5
 	github.com/ory/dockertest/v3 v3.6.3
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/common v0.15.0

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -161,7 +161,7 @@ var _ = Describe("GenerateClusterISO", func() {
 		cfg            Config
 		db             *gorm.DB
 		ctx            = context.Background()
-		dbName         = "generate_cluster_iso"
+		dbName         string
 		ignitionReader = ioutil.NopCloser(strings.NewReader(`{
 				"ignition":{"version":"3.1.0"},
 				"storage":{
@@ -180,7 +180,7 @@ var _ = Describe("GenerateClusterISO", func() {
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		cfg.ServiceBaseURL = FakeServiceBaseURL
 		bm = createInventory(db, cfg)
 
@@ -772,13 +772,13 @@ var _ = Describe("RegisterHost", func() {
 		cfg    Config
 		db     *gorm.DB
 		ctx    = context.Background()
-		dbName = "register_host_api"
+		dbName string
 		hostID strfmt.UUID
 	)
 
 	BeforeEach(func() {
 		hostID = strfmt.UUID(uuid.New().String())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 
@@ -946,13 +946,13 @@ var _ = Describe("GetNextSteps", func() {
 		db                *gorm.DB
 		ctx               = context.Background()
 		defaultNextStepIn int64
-		dbName            = "get_next_steps"
+		dbName            string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		defaultNextStepIn = 60
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 
@@ -1024,12 +1024,12 @@ var _ = Describe("PostStepReply", func() {
 		cfg    Config
 		db     *gorm.DB
 		ctx    = context.Background()
-		dbName = "post_step_reply"
+		dbName string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 
@@ -1441,12 +1441,12 @@ var _ = Describe("GetFreeAddresses", func() {
 		cfg    Config
 		db     *gorm.DB
 		ctx    = context.Background()
-		dbName = "get_free_addresses"
+		dbName string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 
@@ -1581,12 +1581,12 @@ var _ = Describe("UpdateHostInstallProgress", func() {
 		cfg    Config
 		db     *gorm.DB
 		ctx    = context.Background()
-		dbName = "update_host_install_progress"
+		dbName string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 
@@ -1685,14 +1685,14 @@ var _ = Describe("cluster", func() {
 		db             *gorm.DB
 		ctx            = context.Background()
 		clusterID      strfmt.UUID
-		dbName         = "inventory_cluster"
+		dbName         string
 		ignitionReader io.ReadCloser
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		Expect(cfg.IPv6Support).Should(BeTrue())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.ocmClient = nil
 
@@ -3850,12 +3850,12 @@ var _ = Describe("KubeConfig download", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		c         common.Cluster
-		dbName    = "kubeconfig_download"
+		dbName    string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 
 		bm = createInventory(db, cfg)
@@ -3959,12 +3959,12 @@ var _ = Describe("UploadClusterIngressCert test", func() {
 		kubeconfigFile      *os.File
 		kubeconfigNoingress string
 		kubeconfigObject    string
-		dbName              = "upload_cluster_ingress_cert"
+		dbName              string
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ingressCa = "-----BEGIN CERTIFICATE-----\nMIIDozCCAougAwIBAgIULCOqWTF" +
 			"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 			"MQswCQYDVQQHDAJkZDELMAkGA1UECgwCZGQxCzAJBgNVBAsMAmRkMQswCQYDVQQDDAJkZDERMA8GCSqGSIb3DQEJARYCZGQwHhcNMjAwNTI1MTYwNTAwWhcNMzA" +
@@ -4137,13 +4137,13 @@ var _ = Describe("List unregistered clusters", func() {
 		openshiftClusterID = strToUUID("41940ee8-ec99-43de-8766-174381b4921d")
 		c                  common.Cluster
 		kubeconfigFile     *os.File
-		dbName             = "upload_logs"
+		dbName             string
 		host1              models.Host
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		c = common.Cluster{Cluster: models.Cluster{
@@ -4226,13 +4226,13 @@ var _ = Describe("Get unregistered clusters", func() {
 		hostID         strfmt.UUID
 		c              common.Cluster
 		kubeconfigFile *os.File
-		dbName         = "get_unregistered_clusters"
+		dbName         string
 		host1          models.Host
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		clusterID = strfmt.UUID(uuid.New().String())
 		c = common.Cluster{Cluster: models.Cluster{
@@ -4293,7 +4293,7 @@ var _ = Describe("Upload and Download logs test", func() {
 		hostID         strfmt.UUID
 		c              common.Cluster
 		kubeconfigFile *os.File
-		dbName         = "upload_logs"
+		dbName         string
 		request        *http.Request
 		host1          models.Host
 		hostLogsType   = string(models.LogsTypeHost)
@@ -4301,7 +4301,7 @@ var _ = Describe("Upload and Download logs test", func() {
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 
 		bm = createInventory(db, cfg)
@@ -4684,11 +4684,11 @@ var _ = Describe("GetClusterInstallConfig", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		c         common.Cluster
-		dbName    = "get_cluster_install_config"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		c = common.Cluster{Cluster: models.Cluster{
@@ -4752,11 +4752,11 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		c         common.Cluster
-		dbName    = "update_cluster_install_config"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		c = common.Cluster{
@@ -4829,11 +4829,11 @@ var _ = Describe("GetDiscoveryIgnition", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		c         common.Cluster
-		dbName    = "get_discovery_ignition"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		c = common.Cluster{Cluster: models.Cluster{
@@ -4903,11 +4903,11 @@ var _ = Describe("UpdateDiscoveryIgnition", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		c         common.Cluster
-		dbName    = "update_discovery_ignition"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		c = common.Cluster{Cluster: models.Cluster{ID: &clusterID}}
@@ -5085,12 +5085,13 @@ var _ = Describe("Register OCPCluster test", func() {
 		archituctures  []string
 		cfg            Config
 		db             *gorm.DB
+		dbName         string
 		ctx            = context.Background()
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB("register_ocp_cluster")
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		configMap.Data = make(map[string]string)
 		configMap.Data["install-config"] = "baseDomain: redhat.com\nnetworking:\n  machineNetwork:\n  - cidr: 192.168.126.0/24\nplatform:\n  baremetal:\n    apiVIP: 192.168.126.141\n    bootstrapProvisioningIP: 172.22.0.2\nsshKey: ssh-rsa kjfhkefkfsk"
@@ -5106,7 +5107,7 @@ var _ = Describe("Register OCPCluster test", func() {
 	})
 
 	AfterEach(func() {
-		common.DeleteTestDB(db, "register_ocp_cluster")
+		common.DeleteTestDB(db, dbName)
 		ctrl.Finish()
 	})
 
@@ -5208,6 +5209,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 		bm            *bareMetalInventory
 		cfg           Config
 		db            *gorm.DB
+		dbName        string
 		ctx           = context.Background()
 		clusterID     strfmt.UUID
 		clusterName   string
@@ -5217,7 +5219,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB("register_add_hosts_cluster")
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		clusterName = "add-hosts-cluster"
 		apiVIPDnsname = "api-vip.redhat.com"
@@ -5227,7 +5229,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 	})
 
 	AfterEach(func() {
-		common.DeleteTestDB(db, "register_add_hosts_cluster")
+		common.DeleteTestDB(db, dbName)
 		ctrl.Finish()
 	})
 
@@ -5278,13 +5280,13 @@ var _ = Describe("Reset Host test", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "reset_host_cluster"
+		dbName    string
 		request   *http.Request
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		hostID = strfmt.UUID(uuid.New().String())
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{
@@ -5346,13 +5348,13 @@ var _ = Describe("Install Host test", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "reset_host_cluster"
+		dbName    string
 		request   *http.Request
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		hostID = strfmt.UUID(uuid.New().String())
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{
@@ -5458,13 +5460,13 @@ var _ = Describe("Install Hosts test", func() {
 		db        *gorm.DB
 		ctx       = context.Background()
 		clusterID strfmt.UUID
-		dbName    = "inventory_cluster"
+		dbName    string
 		request   *http.Request
 	)
 
 	BeforeEach(func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{
 			ID:               &clusterID,
@@ -5544,14 +5546,14 @@ var _ = Describe("TestRegisterCluster", func() {
 		bm     *bareMetalInventory
 		cfg    Config
 		db     *gorm.DB
-		dbName = "register_cluster_api"
+		dbName string
 		ctx    = context.Background()
 	)
 
 	BeforeEach(func() {
 		cfg.DefaultNTPSource = ""
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
 			db, mockEvents, nil, nil, nil, nil, nil, nil, nil)
@@ -5760,12 +5762,12 @@ var _ = Describe("AMS subscriptions", func() {
 		cfg         = Config{}
 		bm          *bareMetalInventory
 		db          *gorm.DB
-		dbName      = "register_cluster_with_ams_subscription"
+		dbName      string
 		clusterName = "ams-cluster"
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil)
 		bm.ocmClient.Config.WithAMSSubscriptions = true
@@ -6019,13 +6021,13 @@ var _ = Describe("GetHostIgnition and DownloadHostIgnition", func() {
 		cfg       Config
 		db        *gorm.DB
 		ctx       = context.Background()
-		dbName    = "get_download_host_ignition"
+		dbName    string
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 
 		// create a cluster
@@ -6157,11 +6159,11 @@ var _ = Describe("UpdateHostIgnition", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "update_host_ignition"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID}}).Error
@@ -6262,11 +6264,11 @@ var _ = Describe("UpdateHostInstallerArgs", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "update_host_installer_args"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID}}).Error
@@ -6344,11 +6346,11 @@ var _ = Describe("UpdateHostApproved", func() {
 		ctx       = context.Background()
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "update_host_approved"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID}}).Error
@@ -6385,11 +6387,11 @@ var _ = Describe("Calculate host networks", func() {
 		db        *gorm.DB
 		clusterID strfmt.UUID
 		hostID    strfmt.UUID
-		dbName    = "calculate_host_networks"
+		dbName    string
 	)
 	BeforeEach(func() {
 		cfg = &Config{}
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -6443,13 +6445,13 @@ var _ = Describe("Calculate host networks", func() {
 var _ = Describe("Get Cluster by Kube Key", func() {
 	var (
 		db     *gorm.DB
-		dbName = "cluster_by_kube_api"
+		dbName string
 		bm     *bareMetalInventory
 		cfg    Config
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 	})
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2611,7 +2611,7 @@ var _ = Describe("Validation metrics and events", func() {
 		ctrl       *gomock.Controller
 		ctx        = context.Background()
 		db         *gorm.DB
-		dbName     = "validation_metrics_and_events"
+		dbName     = "cluster_validation_metrics_and_events"
 		mockEvents *events.MockHandler
 		mockHost   *host.MockAPI
 		mockMetric *metrics.MockAPI

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -48,13 +48,13 @@ var _ = Describe("stateMachine", func() {
 		cluster          *common.Cluster
 		refreshedCluster *common.Cluster
 		stateErr         error
-		dbName           = "state_machine"
+		dbName           string
 		mockOperators    *operators.MockAPI
 		mockS3Client     *s3wrapper.MockAPI
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators = operators.NewMockAPI(ctrl)
@@ -116,13 +116,13 @@ var _ = Describe("TestClusterMonitoring", func() {
 		ctrl              *gomock.Controller
 		mockHostAPI       *host.MockAPI
 		mockMetric        *metrics.MockAPI
-		dbName            = "cluster_monitor"
+		dbName            string
 		mockEvents        *events.MockHandler
 		mockS3Client      *s3wrapper.MockAPI
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		id = strfmt.UUID(uuid.New().String())
 		ctrl = gomock.NewController(GinkgoT())
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -629,11 +629,11 @@ var _ = Describe("lease timeout event", func() {
 		ctrl        *gomock.Controller
 		mockHostAPI *host.MockAPI
 		mockMetric  *metrics.MockAPI
-		dbName      = "cluster_monitor"
+		dbName      string
 		mockEvents  *events.MockHandler
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		id = strfmt.UUID(uuid.New().String())
 		ctrl = gomock.NewController(GinkgoT())
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -738,11 +738,11 @@ var _ = Describe("Auto assign machine CIDR", func() {
 		ctrl        *gomock.Controller
 		mockHostAPI *host.MockAPI
 		mockMetric  *metrics.MockAPI
-		dbName      = "cluster_monitor"
+		dbName      string
 		mockEvents  *events.MockHandler
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		id = strfmt.UUID(uuid.New().String())
 		ctrl = gomock.NewController(GinkgoT())
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -1101,11 +1101,11 @@ var _ = Describe("VerifyRegisterHost", func() {
 		id          strfmt.UUID
 		clusterApi  *Manager
 		errTemplate = "Cluster %s is in %s state, host can register only in one of [insufficient ready pending-for-input adding-hosts]"
-		dbName      = "verify_register_host"
+		dbName      string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		id = strfmt.UUID(uuid.New().String())
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
@@ -1155,11 +1155,11 @@ var _ = Describe("VerifyClusterUpdatability", func() {
 		id          strfmt.UUID
 		clusterApi  *Manager
 		errTemplate = "Cluster %s is in %s state, cluster can be updated only in one of [insufficient ready pending-for-input adding-hosts]"
-		dbName      = "verify_cluster_updatability"
+		dbName      string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		id = strfmt.UUID(uuid.New().String())
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
@@ -1209,11 +1209,11 @@ var _ = Describe("CancelInstallation", func() {
 		eventsHandler events.Handler
 		ctrl          *gomock.Controller
 		mockMetric    *metrics.MockAPI
-		dbName        = "cluster_cancel_installation"
+		dbName        string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -1284,11 +1284,11 @@ var _ = Describe("ResetCluster", func() {
 		state         API
 		c             common.Cluster
 		eventsHandler events.Handler
-		dbName        = "reset_cluster"
+		dbName        string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		ctrl := gomock.NewController(GinkgoT())
@@ -1504,7 +1504,7 @@ var _ = Describe("PrepareForInstallation", func() {
 		capi      API
 		db        *gorm.DB
 		clusterId strfmt.UUID
-		dbName    = "cluster_prepare_for_installation"
+		dbName    string
 		ctrl      *gomock.Controller
 
 		mockMetric *metrics.MockAPI
@@ -1513,7 +1513,7 @@ var _ = Describe("PrepareForInstallation", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		mockOperators := operators.NewMockAPI(ctrl)
 		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, nil, nil, mockMetric, nil, dummy, mockOperators, nil, nil)
@@ -1602,11 +1602,11 @@ var _ = Describe("HandlePreInstallationError", func() {
 		capi      API
 		db        *gorm.DB
 		clusterId strfmt.UUID
-		dbName    = "handle_preInstallation_error"
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
@@ -1688,7 +1688,7 @@ var _ = Describe("SetVipsData", func() {
 		ctrl       *gomock.Controller
 		db         *gorm.DB
 		clusterId  strfmt.UUID
-		dbName     = "set_vips"
+		dbName     string
 		apiLease   = `lease {
   interface "api";
   renew 0 2020/10/25 14:48:38;
@@ -1716,7 +1716,7 @@ var _ = Describe("SetVipsData", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -1882,7 +1882,7 @@ var _ = Describe("Majority groups", func() {
 		cluster    common.Cluster
 		ctrl       *gomock.Controller
 		mockEvents *events.MockHandler
-		dbName     = "cluster_majority_groups"
+		dbName     string
 	)
 
 	AfterEach(func() {
@@ -1890,7 +1890,7 @@ var _ = Describe("Majority groups", func() {
 	})
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dbIndex++
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
@@ -1986,13 +1986,13 @@ var _ = Describe("ready_state", func() {
 		db         *gorm.DB
 		id         strfmt.UUID
 		cluster    common.Cluster
-		dbName     = "cluster_ready_state"
+		dbName     string
 		ctrl       *gomock.Controller
 		mockEvents *events.MockHandler
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -2058,7 +2058,7 @@ var _ = Describe("insufficient_state", func() {
 		cluster      common.Cluster
 		ctrl         *gomock.Controller
 		mockHostAPI  *host.MockAPI
-		dbName       = "cluster_insufficient_state"
+		dbName       string
 	)
 
 	BeforeEach(func() {
@@ -2066,7 +2066,7 @@ var _ = Describe("insufficient_state", func() {
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockEvents := events.NewMockHandler(ctrl)
 		mockOperators := operators.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil)
@@ -2081,8 +2081,14 @@ var _ = Describe("insufficient_state", func() {
 			BaseDNSDomain:      "test.com",
 			PullSecretSet:      true,
 		}}
-
 		mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("works", func() {
 		replyErr := clusterApi.RegisterCluster(ctx, &cluster)
 		Expect(replyErr).Should(BeNil())
 		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
@@ -2098,12 +2104,12 @@ var _ = Describe("prepare-for-installation refresh status", func() {
 		db          *gorm.DB
 		clusterId   strfmt.UUID
 		cl          common.Cluster
-		dbName      = "cluster_prepare_for_installation"
+		dbName      string
 		ctrl        *gomock.Controller
 		mockHostAPI *host.MockAPI
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		cfg := Config{}
 		Expect(envconfig.Process("myapp", &cfg)).NotTo(HaveOccurred())
 		ctrl = gomock.NewController(GinkgoT())
@@ -2155,7 +2161,7 @@ var _ = Describe("Cluster tarred files", func() {
 		db           *gorm.DB
 		clusterId    strfmt.UUID
 		cl           common.Cluster
-		dbName       = "cluster_tar"
+		dbName       string
 		ctrl         *gomock.Controller
 		mockHostAPI  *host.MockAPI
 		mockS3Client *s3wrapper.MockAPI
@@ -2164,7 +2170,7 @@ var _ = Describe("Cluster tarred files", func() {
 		tarFile      string
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		cfg := Config{}
 		files = []string{"test", "test2"}
 		ctrl = gomock.NewController(GinkgoT())
@@ -2239,7 +2245,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		c                  common.Cluster
 		eventsHandler      events.Handler
 		mockMetric         *metrics.MockAPI
-		dbName             = "generate_additional_manifests"
+		dbName             string
 		manifestsGenerator *network.MockManifestsGeneratorAPI
 		mockOperatorMgr    *operators.MockAPI
 	)
@@ -2248,7 +2254,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
 		manifestsGenerator = network.NewMockManifestsGeneratorAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		mockOperatorMgr = operators.NewMockAPI(ctrl)
@@ -2312,7 +2318,7 @@ var _ = Describe("Deregister inactive clusters", func() {
 		c             common.Cluster
 		eventsHandler events.Handler
 		mockMetric    *metrics.MockAPI
-		dbName        = "deregister_inactive_clusters"
+		dbName        string
 	)
 
 	registerCluster := func() common.Cluster {
@@ -2336,7 +2342,7 @@ var _ = Describe("Deregister inactive clusters", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockOperators := operators.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil)
@@ -2414,7 +2420,7 @@ var _ = Describe("Permanently delete clusters", func() {
 		c3            common.Cluster
 		eventsHandler events.Handler
 		mockMetric    *metrics.MockAPI
-		dbName        = "permanently_delete_clusters"
+		dbName        string
 		mockS3Api     *s3wrapper.MockAPI
 	)
 
@@ -2434,7 +2440,7 @@ var _ = Describe("Permanently delete clusters", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockOperators := operators.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil)
@@ -2512,7 +2518,7 @@ var _ = Describe("Get cluster by Kube key", func() {
 		db               *gorm.DB
 		eventsHandler    events.Handler
 		key              types.NamespacedName
-		dbName           = "get_cluster_by_kube_key"
+		dbName           string
 		kubeKeyName      = "test-kube-name"
 		kubeKeyNamespace = "test-kube-namespace"
 	)
@@ -2520,7 +2526,7 @@ var _ = Describe("Get cluster by Kube key", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, dummy, mockOperators, nil, nil)
@@ -2563,14 +2569,14 @@ var _ = Describe("Update AMS subscription ID", func() {
 		ctrl          *gomock.Controller
 		ctx           = context.Background()
 		db            *gorm.DB
-		dbName        = "update_ams_subscription_id"
+		dbName        string
 		eventsHandler events.Handler
 		api           API
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		api = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, nil, nil, nil, nil)
 	})
@@ -2611,7 +2617,7 @@ var _ = Describe("Validation metrics and events", func() {
 		ctrl       *gomock.Controller
 		ctx        = context.Background()
 		db         *gorm.DB
-		dbName     = "cluster_validation_metrics_and_events"
+		dbName     string
 		mockEvents *events.MockHandler
 		mockHost   *host.MockAPI
 		mockMetric *metrics.MockAPI
@@ -2658,7 +2664,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHost = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)

--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -20,11 +20,11 @@ var _ = Describe("update_cluster_state", func() {
 		cluster         *common.Cluster
 		lastUpdatedTime strfmt.DateTime
 		err             error
-		dbName          string = "common_test"
+		dbName          string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 
 		id := strfmt.UUID(uuid.New().String())
 		cluster = &common.Cluster{Cluster: models.Cluster{

--- a/internal/cluster/installer_test.go
+++ b/internal/cluster/installer_test.go
@@ -22,11 +22,11 @@ var _ = Describe("installer", func() {
 		id               strfmt.UUID
 		cluster          common.Cluster
 		hostsIds         []strfmt.UUID
-		dbName           = "cluster_installer"
+		dbName           string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		installerManager = NewInstaller(common.GetTestLog(), db)
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/cluster/registrar_test.go
+++ b/internal/cluster/registrar_test.go
@@ -22,11 +22,11 @@ var _ = Describe("registrar", func() {
 		updateErr       error
 		cluster         common.Cluster
 		host            models.Host
-		dbName          = "registar"
+		dbName          string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		registerManager = NewRegistrar(common.GetTestLog(), db)
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -36,14 +36,14 @@ var _ = Describe("Transition tests", func() {
 		eventsHandler    events.Handler
 		ctrl             *gomock.Controller
 		mockMetric       *metrics.MockAPI
-		dbName           = "cluster_transition_test"
+		dbName           string
 		operatorsManager *operators.MockAPI
 		mockS3Api        *s3wrapper.MockAPI
 		mockAccountsMgmt *ocm.MockOCMAccountsMgmt
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -329,7 +329,7 @@ var _ = Describe("Transition tests", func() {
 var _ = Describe("Cancel cluster installation", func() {
 	var (
 		ctx               = context.Background()
-		dbName            = "cancel_cluster_installation_test"
+		dbName            string
 		capi              API
 		db                *gorm.DB
 		ctrl              *gomock.Controller
@@ -338,7 +338,7 @@ var _ = Describe("Cancel cluster installation", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -401,7 +401,7 @@ var _ = Describe("Cancel cluster installation", func() {
 var _ = Describe("Reset cluster", func() {
 	var (
 		ctx               = context.Background()
-		dbName            = "reset_cluster_test"
+		dbName            string
 		capi              API
 		db                *gorm.DB
 		ctrl              *gomock.Controller
@@ -409,7 +409,7 @@ var _ = Describe("Reset cluster", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{})
@@ -526,7 +526,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  string = "cluster_transition_test_refresh_host_no_dhcp"
+		dbName                                  string
 		mockS3Api                               *s3wrapper.MockAPI
 	)
 
@@ -543,7 +543,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 	}
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -1171,14 +1171,14 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  string = "cluster_transition_test_refresh_host_no_dhcp"
+		dbName                                  string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
 		mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -2015,7 +2015,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  string = "cluster_transition_test_refresh_host_with_dhcp"
+		dbName                                  string
 		mockS3Api                               *s3wrapper.MockAPI
 	)
 
@@ -2023,7 +2023,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -2527,7 +2527,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  = "cluster_transition_test_refresh_installing_cases"
+		dbName                                  string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
@@ -2538,7 +2538,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 	}
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -2803,7 +2803,7 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 		mockHostAPI *host.MockAPI
 		mockMetric  *metrics.MockAPI
 		ctrl        *gomock.Controller
-		dbName      string = "log_refresh_cluster"
+		dbName      string
 	)
 
 	var (
@@ -2830,7 +2830,7 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 	}
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -2965,14 +2965,14 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  string = "cluster_transition_test_refresh_cluster_with_ntp"
+		dbName                                  string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
 		mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -3323,14 +3323,14 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockHostAPI                             *host.MockAPI
 		mockMetric                              *metrics.MockAPI
 		ctrl                                    *gomock.Controller
-		dbName                                  string = "cluster_transition_test_refresh_cluster_with_ntp"
+		dbName                                  string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
 		mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
@@ -3682,7 +3682,7 @@ var _ = Describe("Single node", func() {
 		mockHostAPI                 *host.MockAPI
 		mockMetric                  *metrics.MockAPI
 		ctrl                        *gomock.Controller
-		dbName                      string = "cluster_transition_test_refresh_cluster_with_ntp"
+		dbName                      string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
@@ -3692,7 +3692,7 @@ var _ = Describe("Single node", func() {
 		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -29,13 +29,13 @@ var _ = Describe("Events library", func() {
 	var (
 		db        *gorm.DB
 		theEvents *events.Events
-		dbName    = "events_test"
+		dbName    string
 		cluster1  = strfmt.UUID("46a8d745-dfce-4fd8-9df0-549ee8eabb3d")
 		cluster2  = strfmt.UUID("60415d9c-7c44-4978-89f5-53d510b03a47")
 		host      = strfmt.UUID("1e45d128-4a69-4e71-9b50-a0c627217f3e")
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		theEvents = events.New(db, logrus.WithField("pkg", "events"))
 	})
 	numOfEvents := func(clusterID strfmt.UUID, hostID *strfmt.UUID) int {

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	. "github.com/onsi/ginkgo"
@@ -16,7 +17,6 @@ import (
 	"github.com/openshift/assisted-service/internal/events"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/requestid"
-	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -109,7 +109,7 @@ var _ = Describe("Events library", func() {
 	Context("events with request ID", func() {
 		It("events with request ID", func() {
 			ctx := context.Background()
-			rid1 := uuid.NewRandom().String()
+			rid1 := uuid.New().String()
 			ctx = requestid.ToContext(ctx, rid1)
 			theEvents.AddEvent(ctx, cluster1, &host, models.EventSeverityInfo, "event1", time.Now())
 			Expect(numOfEvents(cluster1, &host)).Should(Equal(1))

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -47,12 +47,12 @@ var _ = Describe("update_role", func() {
 		state         API
 		host          models.Host
 		id, clusterID strfmt.UUID
-		dbName        = "update_role"
+		dbName        string
 	)
 
 	BeforeEach(func() {
 		dummy := &leader.DummyElector{}
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		state = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
@@ -264,7 +264,7 @@ var _ = Describe("update_progress", func() {
 		ctrl       *gomock.Controller
 		mockEvents *events.MockHandler
 		mockMetric *metrics.MockAPI
-		dbName     = "host_update_progress"
+		dbName     string
 	)
 
 	setDefaultReportHostInstallationMetrics := func(mockMetricApi *metrics.MockAPI) {
@@ -272,7 +272,7 @@ var _ = Describe("update_progress", func() {
 	}
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -494,11 +494,11 @@ var _ = Describe("cancel installation", func() {
 		state         API
 		h             models.Host
 		eventsHandler events.Handler
-		dbName        = "cancel_installation"
+		dbName        string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		dummy := &leader.DummyElector{}
 		state = NewManager(common.GetTestLog(), db, eventsHandler, nil, nil, nil, nil, defaultConfig, dummy, nil)
@@ -576,12 +576,12 @@ var _ = Describe("reset host", func() {
 		state         API
 		h             models.Host
 		eventsHandler events.Handler
-		dbName        = "reset_host"
+		dbName        string
 		config        Config
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, logrus.New())
 		config = *defaultConfig
 		dummy := &leader.DummyElector{}
@@ -700,12 +700,12 @@ var _ = Describe("register host", func() {
 		state         API
 		h             models.Host
 		eventsHandler *events.MockHandler
-		dbName        = "host_tests_register_host"
+		dbName        string
 		config        Config
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		eventsHandler = events.NewMockHandler(ctrl)
 		config = *defaultConfig
@@ -847,11 +847,11 @@ var _ = Describe("UpdateInventory", func() {
 		mockValidator     *hardware.MockValidator
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "update_inventory"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		ctrl = gomock.NewController(GinkgoT())
 		mockValidator = hardware.NewMockValidator(ctrl)
@@ -1134,11 +1134,11 @@ var _ = Describe("Update hostname", func() {
 		db                *gorm.DB
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "update_inventory"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		hapi = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
@@ -1249,12 +1249,12 @@ var _ = Describe("Update disk installation path", func() {
 		host              models.Host
 		ctrl              *gomock.Controller
 		mockValidator     *hardware.MockValidator
-		dbName            = "installation_path_db"
+		dbName            string
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		leader := &leader.DummyElector{}
 		mockValidator = hardware.NewMockValidator(ctrl)
 		logger := common.GetTestLog()
@@ -1401,11 +1401,11 @@ var _ = Describe("SetBootstrap", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "SetBootstrap"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -1462,11 +1462,11 @@ var _ = Describe("UpdateNTP", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "UpdateNTP"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -1524,11 +1524,11 @@ var _ = Describe("UpdateMachineConfigPoolName", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "UpdateMachineConfigPoolName"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -1607,12 +1607,12 @@ var _ = Describe("update logs_info", func() {
 		hapi              API
 		host              models.Host
 		hostId, clusterId strfmt.UUID
-		dbName            = "host_update_logs_info"
+		dbName            string
 	)
 
 	BeforeEach(func() {
 		dummy := &leader.DummyElector{}
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockOperators := operators.NewMockAPI(ctrl)
 		hapi = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, mockOperators)
 		hostId = strfmt.UUID(uuid.New().String())
@@ -1681,11 +1681,11 @@ var _ = Describe("UpdateImageStatus", func() {
 		mockMetric        *metrics.MockAPI
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "UpdateImageStatus"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -1824,11 +1824,11 @@ var _ = Describe("PrepareForInstallation", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "prepare_for_installation"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -1899,14 +1899,14 @@ var _ = Describe("AutoAssignRole", func() {
 		db              *gorm.DB
 		ctrl            *gomock.Controller
 		mockHwValidator *hardware.MockValidator
-		dbName          = "host_auto_assign_role"
+		dbName          string
 	)
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockHwValidator = hardware.NewMockValidator(ctrl)
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterId = strfmt.UUID(uuid.New().String())
 		dummy := &leader.DummyElector{}
 		hapi = NewManager(
@@ -2037,11 +2037,11 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		clusterId strfmt.UUID
 		hapi      API
 		db        *gorm.DB
-		dbName    = "host_is_valid_master_candidate"
+		dbName    string
 		ctrl      *gomock.Controller
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterId = strfmt.UUID(uuid.New().String())
 		dummy := &leader.DummyElector{}
 		testLog := common.GetTestLog()
@@ -2149,7 +2149,7 @@ var _ = Describe("Validation metrics and events", func() {
 		ctrl            *gomock.Controller
 		ctx             = context.Background()
 		db              *gorm.DB
-		dbName          = "validation_metrics_and_events"
+		dbName          string
 		mockEvents      *events.MockHandler
 		mockHwValidator *hardware.MockValidator
 		mockMetric      *metrics.MockAPI
@@ -2202,7 +2202,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator = hardware.NewMockValidator(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
@@ -2249,7 +2249,7 @@ var _ = Describe("SetDiskSpeed", func() {
 		ctrl            *gomock.Controller
 		ctx             = context.Background()
 		db              *gorm.DB
-		dbName          = "validation_metrics_and_events"
+		dbName          string
 		mockEvents      *events.MockHandler
 		mockHwValidator *hardware.MockValidator
 		validatorCfg    *hardware.ValidatorCfg
@@ -2271,7 +2271,7 @@ var _ = Describe("SetDiskSpeed", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator = hardware.NewMockValidator(ctrl)
 		validatorCfg = createValidatorCfg()

--- a/internal/host/hostcommands/api_vip_connectivity_check_cmd_test.go
+++ b/internal/host/hostcommands/api_vip_connectivity_check_cmd_test.go
@@ -22,10 +22,10 @@ var _ = Describe("apivipconnectivitycheckcmd", func() {
 	var id, clusterID strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "apivipconnectivitycheckcmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		apivipConnectivityCheckCmd = NewAPIVIPConnectivityCheckCmd(common.GetTestLog(), db, "quay.io/ocpmetal/assisted-installer-agent:latest", true)
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/connectivity_check_cmd_test.go
+++ b/internal/host/hostcommands/connectivity_check_cmd_test.go
@@ -21,10 +21,10 @@ var _ = Describe("connectivitycheckcmd", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "connectivitycheckcmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		connectivityCheckCmd = NewConnectivityCheckCmd(common.GetTestLog(), db, nil, "quay.io/ocpmetal/connectivity_check:latest")
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -27,7 +27,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 		db            *gorm.DB
 		cmd           *imageAvailabilityCmd
 		id, clusterID strfmt.UUID
-		dbName        = "apivipconnectivitycheckcmd"
+		dbName        string
 		ctrl          *gomock.Controller
 		mockRelease   *oc.MockRelease
 		mockVersions  *versions.MockHandler
@@ -38,7 +38,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 		mockVersions = versions.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		cmd = NewImageAvailabilityCmd(common.GetTestLog(), db, mockRelease, mockVersions, DefaultInstructionConfig)
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/dhcp_allocate_cmd_test.go
+++ b/internal/host/hostcommands/dhcp_allocate_cmd_test.go
@@ -23,10 +23,10 @@ var _ = Describe("dhcpallocate", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "dhcpallocate_cmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		dCmd = NewDhcpAllocateCmd(common.GetTestLog(), "quay.io/ocpmetal/dhcp_lease_allocator:latest", db)
 
 		id = strfmt.UUID("32b4463e-5f94-4245-87cf-a6948014045c")

--- a/internal/host/hostcommands/free_addresses_cmd_test.go
+++ b/internal/host/hostcommands/free_addresses_cmd_test.go
@@ -21,10 +21,10 @@ var _ = Describe("free_addresses", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "freeaddresses_cmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		fCmd = NewFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest")
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -55,13 +55,13 @@ var _ = Describe("installcmd", func() {
 		mockRelease       *oc.MockRelease
 		instructionConfig InstructionConfig
 		disks             []*models.Disk
-		dbName            = "install_cmd"
+		dbName            string
 		validDiskSize     = int64(128849018880)
 		mockEvents        *events.MockHandler
 		mockVersions      *versions.MockHandler
 	)
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockValidator = hardware.NewMockValidator(ctrl)
 		instructionConfig = DefaultInstructionConfig
@@ -258,7 +258,7 @@ var _ = Describe("installcmd arguments", func() {
 		db           *gorm.DB
 		validator    *hardware.MockValidator
 		mockRelease  *oc.MockRelease
-		dbName       = "installcmd_args"
+		dbName       string
 		ctrl         *gomock.Controller
 		mockEvents   *events.MockHandler
 		mockVersions *versions.MockHandler
@@ -270,7 +270,7 @@ var _ = Describe("installcmd arguments", func() {
 	}
 
 	BeforeSuite(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		cluster = createClusterInDb(db, models.ClusterHighAvailabilityModeNone)
 		host = createHostInDb(db, *cluster.ID, models.HostRoleMaster, false, "")
 		disks := []*models.Disk{{Name: "Disk1"}}

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -39,11 +39,11 @@ var _ = Describe("instruction_manager", func() {
 		mockRelease       *oc.MockRelease
 		cnValidator       *connectivity.MockValidator
 		instructionConfig InstructionConfig
-		dbName            = "instruction_manager"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)

--- a/internal/host/hostcommands/inventory_cmd_test.go
+++ b/internal/host/hostcommands/inventory_cmd_test.go
@@ -22,10 +22,10 @@ var _ = Describe("inventory", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "inventorycmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		invCmd = NewInventoryCmd(common.GetTestLog(), "quay.io/ocpmetal/inventory:latest")
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/logs_cmd_test.go
+++ b/internal/host/hostcommands/logs_cmd_test.go
@@ -24,10 +24,10 @@ var _ = Describe("upload_logs", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "logs_cmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		logsCmd = NewLogsCmd(common.GetTestLog(), db, DefaultInstructionConfig)
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/reset_installation_cmd_test.go
+++ b/internal/host/hostcommands/reset_installation_cmd_test.go
@@ -21,10 +21,10 @@ var _ = Describe("reset", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "reset_cmd"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		rstCmd = NewResetInstallationCmd(common.GetTestLog())
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/stop_installation_cmd_test.go
+++ b/internal/host/hostcommands/stop_installation_cmd_test.go
@@ -21,10 +21,10 @@ var _ = Describe("stop-podman", func() {
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
-	dbName := "stop_podman"
+	var dbName string
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		stopCmd = NewStopInstallationCmd(common.GetTestLog())
 
 		id = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostutil/update_host_test.go
+++ b/internal/host/hostutil/update_host_test.go
@@ -28,11 +28,11 @@ var _ = Describe("update_host_state", func() {
 		lastUpdatedTime strfmt.DateTime
 		returnedHost    *models.Host
 		err             error
-		dbName          string = "host_common_test"
+		dbName          string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		id := strfmt.UUID(uuid.New().String())

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -32,11 +32,11 @@ var _ = Describe("monitor_disconnection", func() {
 		host       models.Host
 		ctrl       *gomock.Controller
 		mockEvents *events.MockHandler
-		dbName     = "monitor_disconnection"
+		dbName     string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
@@ -131,12 +131,12 @@ var _ = Describe("TestHostMonitoring", func() {
 		ctrl       *gomock.Controller
 		cfg        Config
 		mockEvents *events.MockHandler
-		dbName     = "host_monitor_tests"
+		dbName     string
 		clusterID  = strfmt.UUID(uuid.New().String())
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockEvents.EXPECT().

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -51,12 +51,12 @@ var _ = Describe("RegisterHost", func() {
 		ctrl              *gomock.Controller
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
-		dbName            = "register_host"
+		dbName            string
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{})
@@ -433,11 +433,11 @@ var _ = Describe("HostInstallationFailed", func() {
 		ctrl              *gomock.Controller
 		mockMetric        *metrics.MockAPI
 		mockEvents        *events.MockHandler
-		dbName            = "host_installation_failed"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockEvents = events.NewMockHandler(ctrl)
@@ -477,11 +477,11 @@ var _ = Describe("RegisterInstalledOCPHost", func() {
 		ctrl              *gomock.Controller
 		mockMetric        *metrics.MockAPI
 		mockEvents        *events.MockHandler
-		dbName            = "register_installed_host"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockEvents = events.NewMockHandler(ctrl)
@@ -507,7 +507,7 @@ var _ = Describe("RegisterInstalledOCPHost", func() {
 var _ = Describe("Cancel host installation", func() {
 	var (
 		ctx               = context.Background()
-		dbName            = "cancel_host_installation_test"
+		dbName            string
 		hapi              API
 		db                *gorm.DB
 		hostId, clusterId strfmt.UUID
@@ -517,7 +517,7 @@ var _ = Describe("Cancel host installation", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
@@ -594,7 +594,7 @@ var _ = Describe("Cancel host installation", func() {
 var _ = Describe("Reset host", func() {
 	var (
 		ctx               = context.Background()
-		dbName            = "reset_host_test"
+		dbName            string
 		hapi              API
 		db                *gorm.DB
 		hostId, clusterId strfmt.UUID
@@ -604,7 +604,7 @@ var _ = Describe("Reset host", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
@@ -688,11 +688,11 @@ var _ = Describe("Install", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "transition_install"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
@@ -843,11 +843,11 @@ var _ = Describe("Disable", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "transition_disable"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
@@ -976,11 +976,11 @@ var _ = Describe("Enable", func() {
 		mockEvents        *events.MockHandler
 		hostId, clusterId strfmt.UUID
 		host              models.Host
-		dbName            = "transition_enable"
+		dbName            string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
@@ -1176,12 +1176,12 @@ var _ = Describe("Refresh Host", func() {
 		cluster           common.Cluster
 		mockEvents        *events.MockHandler
 		ctrl              *gomock.Controller
-		dbName            string = "host_transition_test_refresh_host"
+		dbName            string
 		mockHwValidator   *hardware.MockValidator
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHwValidator = hardware.NewMockValidator(ctrl)

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -60,7 +60,7 @@ var _ = Describe("ClusterManifestTests", func() {
 		ctx           = context.Background()
 		ctrl          *gomock.Controller
 		mockS3Client  *s3wrapper.MockAPI
-		dbName        = "cluster_manifest"
+		dbName        string
 		fileName      = "99-openshift-machineconfig-master-kargs.yaml"
 		validFolder   = "openshift"
 		defaultFolder = "manifests"
@@ -69,7 +69,7 @@ var _ = Describe("ClusterManifestTests", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
 
 		manifestsAPI = manifests.NewManifestsAPI(db, common.GetTestLog(), mockS3Client)

--- a/internal/migrations/20201019194303_change_overrides_to_text_test.go
+++ b/internal/migrations/20201019194303_change_overrides_to_text_test.go
@@ -20,7 +20,7 @@ var _ = Describe("changeOverridesToText", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB("change_overrides_to_text")
+		db, _ = common.PrepareTestDB()
 
 		overrides = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		clusterID = strfmt.UUID(uuid.New().String())

--- a/internal/migrations/20201202140700_change_image_ssh_key_text_test.go
+++ b/internal/migrations/20201202140700_change_image_ssh_key_text_test.go
@@ -21,7 +21,7 @@ var _ = Describe("changeOverridesToText", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB("change_image_ssh_key_to_text")
+		db, _ = common.PrepareTestDB()
 		gm = gormigrate.New(db, gormigrate.DefaultOptions, all())
 
 		// create cluster in order to get rows from DB

--- a/internal/migrations/20210218160100_validations_info_to_text_test.go
+++ b/internal/migrations/20210218160100_validations_info_to_text_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ChangeValidationsInfoToText", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB("change_validations_info_to_text")
+		db, _ = common.PrepareTestDB()
 		clusterID = strfmt.UUID(uuid.New().String())
 		cluster := common.Cluster{Cluster: models.Cluster{
 			ID:              &clusterID,

--- a/internal/migrations/20210223090000_host_validations_info_to_text_test.go
+++ b/internal/migrations/20210223090000_host_validations_info_to_text_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ChangeHostValidationsInfoToText", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB("change_host_validations_info_to_text")
+		db, _ = common.PrepareTestDB()
 		hostID = strfmt.UUID(uuid.New().String())
 		clusterID := strfmt.UUID(uuid.New().String())
 		host := models.Host{

--- a/internal/migrations/migrations_test.go
+++ b/internal/migrations/migrations_test.go
@@ -8,7 +8,8 @@ import (
 
 var _ = Describe("Migrate", func() {
 	It("Succeeds", func() {
-		db := common.PrepareTestDB("migration_test")
+		db, dbName := common.PrepareTestDB()
+		defer common.DeleteTestDB(db, dbName)
 		err := Migrate(db)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -114,7 +114,7 @@ var _ = Describe("chrony manifest", func() {
 			manifestsApi *mocks.MockManifestsAPI
 			ntpUtils     ManifestsGeneratorAPI
 			db           *gorm.DB
-			dbName       = "ntp_utils"
+			dbName       string
 			clusterId    strfmt.UUID
 			cluster      common.Cluster
 		)
@@ -124,7 +124,7 @@ var _ = Describe("chrony manifest", func() {
 			ctrl = gomock.NewController(GinkgoT())
 			manifestsApi = mocks.NewMockManifestsAPI(ctrl)
 			ntpUtils = NewManifestsGenerator(manifestsApi)
-			db = common.PrepareTestDB(dbName)
+			db, dbName = common.PrepareTestDB()
 			clusterId = strfmt.UUID(uuid.New().String())
 
 			hosts := make([]*models.Host, 0)

--- a/internal/operators/handler/handler_test.go
+++ b/internal/operators/handler/handler_test.go
@@ -18,11 +18,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const dbName = "operators_handler"
-
 var _ = Describe("Operators manager", func() {
 	var (
 		db                *gorm.DB
+		dbName            string
 		cluster, cluster2 *common.Cluster
 		log               = logrus.New()
 		ctrl              *gomock.Controller
@@ -31,7 +30,7 @@ var _ = Describe("Operators manager", func() {
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockApi = operators.NewMockAPI(ctrl)
 		handler = hndlr.NewHandler(mockApi, log, db)

--- a/internal/operators/ocs/validation_test.go
+++ b/internal/operators/ocs/validation_test.go
@@ -282,7 +282,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockHostAPI                                   *host.MockAPI
 		mockMetric                                    *metrics.MockAPI
 		ctrl                                          *gomock.Controller
-		dbName                                        = "cluster_transition_test_with_ocs_validations"
+		dbName                                        string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
@@ -292,7 +292,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	}
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = events.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -21,12 +21,12 @@ var _ = Describe("AuthAgentAuth", func() {
 		a       *LocalAuthenticator
 		cluster *common.Cluster
 		db      *gorm.DB
-		dbName  = "local_auth_test"
+		dbName  string
 		token   string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB(dbName)
+		db, dbName = common.PrepareTestDB()
 		clusterID := strfmt.UUID(uuid.New().String())
 		cluster = &common.Cluster{Cluster: models.Cluster{ID: &clusterID}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/tools/migration_generator/migration_generator.go
+++ b/tools/migration_generator/migration_generator.go
@@ -30,13 +30,11 @@ func main() {
 	testFilePath := filepath.Join("internal/migrations", fmt.Sprintf("%s_%s_test.go", id, funcNameSnake))
 
 	data := struct {
-		ID            string
-		FuncName      string
-		FuncNameSnake string
+		ID       string
+		FuncName string
 	}{
-		ID:            id,
-		FuncName:      funcName,
-		FuncNameSnake: funcNameSnake,
+		ID:       id,
+		FuncName: funcName,
 	}
 
 	file, err := os.Create(filePath)
@@ -105,14 +103,15 @@ import (
 var _ = Describe("{{.FuncName}}", func() {
 	var (
 		db        *gorm.DB
+		dbName    string
 	)
 
 	BeforeEach(func() {
-		db = common.PrepareTestDB("{{.FuncNameSnake}}")
+		db, dbName = common.PrepareTestDB()
 	})
 
 	AfterEach(func() {
-		common.DeleteTestDB(db, "{{.FuncNameSnake}}")
+		common.DeleteTestDB(db, dbName)
 	})
 
 	It("Migrates up", func() {


### PR DESCRIPTION
Hoping this will fix test failures in host_test.go
like `pq: database "validation_metrics_and_events" already exists`

Both tests use the same db name so if they get run at the same time
we could see a failure like this.

cc @ybettan 
Looks like this new test was added just a few days ago in https://github.com/openshift/assisted-service/pull/1198

---------
UPDATE:

Instead of just fixing the one test, we decided to fix the issue everywhere and generate a random database name for each test.
This PR changes `common.PrepareTestDB` to return both a database name and db handle to the caller.
Hopefully this will get us a bit closer to being able to run unit tests in parallel as well.