### PR TITLE
MGMT-4760: Updating cluster.GetCredentials function.

### DIFF
--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -281,18 +281,18 @@ func (mr *MockAPIMockRecorder) ClusterMonitoring() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterMonitoring", reflect.TypeOf((*MockAPI)(nil).ClusterMonitoring))
 }
 
-// GetCredentials mocks base method
-func (m *MockAPI) GetCredentials(c *common.Cluster) error {
+// IsOperatorAvailable mocks base method
+func (m *MockAPI) IsOperatorAvailable(c *common.Cluster, operatorName string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCredentials", c)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "IsOperatorAvailable", c, operatorName)
+	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// GetCredentials indicates an expected call of GetCredentials
-func (mr *MockAPIMockRecorder) GetCredentials(c interface{}) *gomock.Call {
+// IsOperatorAvailable indicates an expected call of IsOperatorAvailable
+func (mr *MockAPIMockRecorder) IsOperatorAvailable(c, operatorName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockAPI)(nil).GetCredentials), c)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOperatorAvailable", reflect.TypeOf((*MockAPI)(nil).IsOperatorAvailable), c, operatorName)
 }
 
 // UploadIngressCert mocks base method

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1491,20 +1491,21 @@ var _ = Describe("cluster install", func() {
 		})
 
 		It("Get credentials", func() {
-			By("Test getting kubeadmin password for not found cluster")
+			By("Test getting credentials for not found cluster")
 			{
 				missingClusterId := strfmt.UUID(uuid.New().String())
 				_, err := userBMClient.Installer.GetCredentials(ctx, &installer.GetCredentialsParams{ClusterID: missingClusterId})
 				Expect(reflect.TypeOf(err)).Should(Equal(reflect.TypeOf(installer.NewGetCredentialsNotFound())))
 			}
-			By("Test getting kubeadmin password in wrong state")
+			By("Test getting credentials before console operator is available")
 			{
 				_, err := userBMClient.Installer.GetCredentials(ctx, &installer.GetCredentialsParams{ClusterID: clusterID})
 				Expect(reflect.TypeOf(err)).To(Equal(reflect.TypeOf(installer.NewGetCredentialsConflict())))
 			}
 			By("Test happy flow")
 			{
-				installCluster(clusterID)
+				setClusterAsFinalizing(ctx, clusterID)
+				completeInstallationAndVerify(ctx, agentBMClient, clusterID, true)
 				creds, err := userBMClient.Installer.GetCredentials(ctx, &installer.GetCredentialsParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(creds.GetPayload().Username).To(Equal(bminventory.DefaultUser))


### PR DESCRIPTION
Changing its name to `IsConsoleUrlReady` and changing the implementation
to return the results only once console operator is ready and error
otherwise.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>