### PR TITLE
MGMT-4079 change subscription channel to stable

### DIFF
--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -115,7 +115,7 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 
 // GenerateManifests generates manifests for the operator
 func (o *operator) GenerateManifests(c *common.Cluster) (map[string][]byte, error) {
-	return Manifests(c.Cluster.OpenshiftVersion)
+	return Manifests()
 }
 
 // GetProperties provides description of operator properties: none required

--- a/internal/operators/cnv/manifest.go
+++ b/internal/operators/cnv/manifest.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Manifests returns manifests needed to deploy CNV
-func Manifests(OpenShiftVersion string) (map[string][]byte, error) {
-	cnvSubs, err := subscription(OpenShiftVersion)
+func Manifests() (map[string][]byte, error) {
+	cnvSubs, err := subscription()
 	if err != nil {
 		return nil, err
 	}
@@ -20,9 +20,8 @@ func Manifests(OpenShiftVersion string) (map[string][]byte, error) {
 	return manifests, nil
 }
 
-func subscription(OpenShiftVersion string) ([]byte, error) {
+func subscription() ([]byte, error) {
 	data := map[string]string{
-		"OPENSHIFT_VERSION":          OpenShiftVersion,
 		"OPERATOR_NAMESPACE":         Operator.Namespace,
 		"OPERATOR_SUBSCRIPTION_NAME": Operator.SubscriptionName,
 	}
@@ -47,7 +46,7 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   name: kubevirt-hyperconverged
-  channel: "{{.OPENSHIFT_VERSION}}"
+  channel: stable
   installPlanApproval: "Automatic"`
 
 const cnvNamespace = `apiVersion: v1


### PR DESCRIPTION
We need to use `stable` channel when creating cnv subscription. In the past ocp version was used instead.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>