### PR TITLE
MGMT-4765 Bugfix Resolve OLM dependencies on cluster creation and update

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2094,7 +2094,7 @@ func (b *bareMetalInventory) getOLMOperators(newOperators []*models.OperatorCrea
 		monitoredOperators = append(monitoredOperators, operator)
 	}
 
-	return monitoredOperators, nil
+	return b.operatorManagerApi.ResolveDependencies(monitoredOperators)
 }
 
 func (b *bareMetalInventory) updateHostsAndClusterStatus(ctx context.Context, cluster *common.Cluster, db *gorm.DB, log logrus.FieldLogger) error {

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -151,18 +151,19 @@ func (mr *MockAPIMockRecorder) GetSupportedOperatorsByType(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedOperatorsByType", reflect.TypeOf((*MockAPI)(nil).GetSupportedOperatorsByType), arg0)
 }
 
-// UpdateDependencies mocks base method
-func (m *MockAPI) UpdateDependencies(arg0 *common.Cluster) error {
+// ResolveDependencies mocks base method
+func (m *MockAPI) ResolveDependencies(arg0 []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDependencies", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ResolveDependencies", arg0)
+	ret0, _ := ret[0].([]*models.MonitoredOperator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// UpdateDependencies indicates an expected call of UpdateDependencies
-func (mr *MockAPIMockRecorder) UpdateDependencies(arg0 interface{}) *gomock.Call {
+// ResolveDependencies indicates an expected call of ResolveDependencies
+func (mr *MockAPIMockRecorder) ResolveDependencies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDependencies", reflect.TypeOf((*MockAPI)(nil).UpdateDependencies), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveDependencies", reflect.TypeOf((*MockAPI)(nil).ResolveDependencies), arg0)
 }
 
 // ValidateCluster mocks base method


### PR DESCRIPTION
Until now, we resolved dependencies on the validation level only.
Hence, the user was unable to install a cluster with OCS/CNV requirements but without LSO requirements.
But still, LSO wasn't monitored and the UI is unable to show its status.

Now, moving the cluster OLM operators dependencies to be resolved on cluster
creation or cluster update operation level.