### PR TITLE
NO-ISSUE Update RBAC for controller

### DIFF
--- a/internal/controller/config/rbac/role.yaml
+++ b/internal/controller/config/rbac/role.yaml
@@ -71,6 +71,12 @@ rules:
 - apiGroups:
   - hive.openshift.io
   resources:
+  - clusterdeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - hive.openshift.io
+  resources:
   - clusterdeployments/status
   verbs:
   - get

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -77,6 +77,7 @@ type ClusterDeploymentsReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;create
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/finalizers,verbs=update
 
 func (r *ClusterDeploymentsReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
@@ -475,6 +476,7 @@ func (r *ClusterDeploymentsReconciler) updateState(ctx context.Context, clusterD
 	}
 
 	if err != nil {
+		r.Log.WithError(err).Errorf("Updating state with error for %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
 		setClusterApiError(err, clusterDeployment)
 		reply.RequeueAfter = defaultRequeueAfterOnError
 	}


### PR DESCRIPTION
In order to be able to set OwnerReference of the secrets to the ClusterDeployments, the controller need RBAC to `clusterdeployments/finalizers`