### PR TITLE
NO-ISSUE: Use 'bucket-pv-claim' instead of scality

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -48,7 +48,7 @@ metadata:
 EOF
 ```
 
-Create two PVCs, one for postgres and another for s3 (temporary until filesystem implementation is available).
+Create two PVCs, one for postgres and another for bucket (temporary until filesystem implementation is available).
 
 ```bash
 cat <<EOF | kubectl create -f -

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -72,15 +72,15 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app: scality
-  name: scality-pv-claim
+    app: assisted-service
+  name: bucket-pv-claim
   namespace: assisted-installer
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 10Gi
 EOF
 ```
 


### PR DESCRIPTION
### This is a docs update only. 
For the AI operator, now bucket-pv-claim is a pre-requisite and not scality.