### PR TITLE
NO-ISSUE Use logging instead of print in tools scripts

### DIFF
--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -8,6 +8,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--subsystem-test", help='deploy in subsystem mode',
                     action='store_true')
 deploy_options = deployment_options.load_deployment_options(parser)
+log = utils.get_logger('deploy-assisted-installer')
 
 SRC_FILE = os.path.join(os.getcwd(), 'deploy/assisted-service.yaml')
 DST_FILE = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'assisted-service.yaml')
@@ -23,7 +24,7 @@ def load_key():
         with open(KEY_FILE, "r") as f:
             return f.read()
     except Exception as e:
-        print("Got exception {}, when tried to read key file at {}."
+        log.warn("Got exception {}, when tried to read key file at {}."
               "Make sure you used tools/auth_keys_generator.go before running subsystem tests".format(e, KEY_FILE))
         return ""
 
@@ -76,7 +77,7 @@ def main():
     if not deploy_options.apply_manifest:
         return
 
-    print("Deploying {}".format(DST_FILE))
+    log.info(f"Deploying {DST_FILE}")
     utils.apply(
         target=deploy_options.target,
         namespace=deploy_options.namespace,

--- a/tools/deploy_namespace.py
+++ b/tools/deploy_namespace.py
@@ -4,6 +4,9 @@ import argparse
 import deployment_options
 
 
+log = utils.get_logger('deploy-namespace')
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--deploy-namespace", type=lambda x: (str(x).lower() == 'true'), default=True)
@@ -12,7 +15,7 @@ def main():
     utils.verify_build_directory(deploy_options.namespace)
 
     if deploy_options.deploy_namespace is False:
-        print("Not deploying namespace")
+        log.info("Not deploying namespace")
         return
     src_file = os.path.join(os.getcwd(), 'deploy/namespace/namespace.yaml')
     dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'namespace.yaml')
@@ -20,7 +23,7 @@ def main():
         with open(dst_file, "w+") as dst:
             data = src.read()
             data = data.replace('REPLACE_NAMESPACE', f'"{deploy_options.namespace}"')
-            print("Deploying {}".format(dst_file))
+            log.info(f"Deploying {dst_file}")
             dst.write(data)
 
     utils.apply(

--- a/tools/deploy_role.py
+++ b/tools/deploy_role.py
@@ -4,6 +4,9 @@ import utils
 import deployment_options
 
 
+log = utils.get_logger('deploy-role')
+
+
 def main():
     deploy_options = deployment_options.load_deployment_options()
 
@@ -20,7 +23,7 @@ def main():
         with open(dst_file, "w+") as dst:
             data = src.read()
             data = data.replace('REPLACE_NAMESPACE', f'"{deploy_options.namespace}"')
-            print("Deploying {}".format(dst_file))
+            log.info(f"Deploying {dst_file}")
             dst.write(data)
 
     if deploy_options.apply_manifest:
@@ -41,7 +44,7 @@ def main():
                 dst.write(data)
 
         if deploy_options.apply_manifest:
-            print("Deploying {}".format(dst_file))
+            log.info(f"Deploying {dst_file}")
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,
@@ -52,7 +55,7 @@ def main():
         dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'controller_roles.yaml')
         shutil.copy(src_file, dst_file)
         if deploy_options.apply_manifest:
-            print("Deploying {}".format(dst_file))
+            log.info(f"Deploying {dst_file}")
             utils.apply(
                 target=deploy_options.target,
                 namespace=deploy_options.namespace,


### PR DESCRIPTION
This PR changes the python print method to logging. It's needed because
we can see the time of the logging printed and the output and compare
the time of the execution in CI.

Signed-off-by: Ondra Machacek <omachace@redhat.com>