### PR TITLE
MGMT-4733 provide host in Operator requirements API

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -132,7 +132,7 @@ func (v *validator) GetHostRequirements(role models.HostRole) models.HostRequire
 }
 
 func (v *validator) GetClusterHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirements, error) {
-	operatorsRequirements, err := v.operatorsAPI.GetRequirementsBreakdownForRoleInCluster(ctx, cluster, host.Role)
+	operatorsRequirements, err := v.operatorsAPI.GetRequirementsBreakdownForHostInCluster(ctx, cluster, host)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Cluster host requirements", func() {
 		id1 := strfmt.UUID(uuid.New().String())
 		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
 
-		operatorsMock.EXPECT().GetRequirementsBreakdownForRoleInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(operatorRequirements, nil)
+		operatorsMock.EXPECT().GetRequirementsBreakdownForHostInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(host)).Return(operatorRequirements, nil)
 
 		result, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
 
@@ -269,7 +269,7 @@ var _ = Describe("Cluster host requirements", func() {
 		id1 := strfmt.UUID(uuid.New().String())
 		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
 
-		operatorsMock.EXPECT().GetRequirementsBreakdownForRoleInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(operatorRequirements, nil)
+		operatorsMock.EXPECT().GetRequirementsBreakdownForHostInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(host)).Return(operatorRequirements, nil)
 
 		result, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
 
@@ -295,7 +295,7 @@ var _ = Describe("Cluster host requirements", func() {
 		host = &models.Host{ID: &id1, ClusterID: *cluster.ID, Role: role}
 
 		failure := errors.New("boom")
-		operatorsMock.EXPECT().GetRequirementsBreakdownForRoleInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(role)).Return(nil, failure)
+		operatorsMock.EXPECT().GetRequirementsBreakdownForHostInCluster(gomock.Any(), gomock.Eq(cluster), gomock.Eq(host)).Return(nil, failure)
 
 		_, err := hwvalidator.GetClusterHostRequirements(context.TODO(), cluster, host)
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2049,7 +2049,7 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
 		hwValidator := hardware.NewValidator(testLog, *hwValidatorCfg, mockOperators)
-		mockOperators.EXPECT().GetRequirementsBreakdownForRoleInCluster(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]*models.OperatorHostRequirements{}, nil)
+		mockOperators.EXPECT().GetRequirementsBreakdownForHostInCluster(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]*models.OperatorHostRequirements{}, nil)
 		hapi = NewManager(
 			common.GetTestLog(),
 			db,

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -38,8 +38,8 @@ type Operator interface {
 	ValidateHost(ctx context.Context, cluster *common.Cluster, hosts *models.Host) (ValidationResult, error)
 	// GenerateManifests generates manifests for the operator
 	GenerateManifests(*common.Cluster) (map[string][]byte, error)
-	// GetHostRequirementsForRole provides operator's requirements towards host in a given role
-	GetHostRequirementsForRole(ctx context.Context, cluster *common.Cluster, role models.HostRole) (*models.ClusterHostRequirementsDetails, error)
+	// GetHostRequirements provides operator's requirements towards the host
+	GetHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error)
 	// GetClusterValidationID returns cluster validation ID for the Operator
 	GetClusterValidationID() string
 	// GetHostValidationID returns host validation ID for the Operator

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -78,19 +78,19 @@ func (mr *MockOperatorMockRecorder) GetDependencies() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDependencies", reflect.TypeOf((*MockOperator)(nil).GetDependencies))
 }
 
-// GetHostRequirementsForRole mocks base method
-func (m *MockOperator) GetHostRequirementsForRole(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+// GetHostRequirements mocks base method
+func (m *MockOperator) GetHostRequirements(arg0 context.Context, arg1 *common.Cluster, arg2 *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostRequirementsForRole", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetHostRequirements", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*models.ClusterHostRequirementsDetails)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetHostRequirementsForRole indicates an expected call of GetHostRequirementsForRole
-func (mr *MockOperatorMockRecorder) GetHostRequirementsForRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetHostRequirements indicates an expected call of GetHostRequirements
+func (mr *MockOperatorMockRecorder) GetHostRequirements(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirementsForRole", reflect.TypeOf((*MockOperator)(nil).GetHostRequirementsForRole), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockOperator)(nil).GetHostRequirements), arg0, arg1, arg2)
 }
 
 // GetHostValidationID mocks base method

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -90,7 +90,7 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 		o.log.Info("Validate Requirements status ", status)
 		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{status}}, nil
 	}
-	requirements, err := o.GetHostRequirementsForRole(ctx, cluster, host.Role)
+	requirements, err := o.GetHostRequirements(ctx, cluster, host)
 	if err != nil {
 		message := fmt.Sprintf("Failed to get host requirements for host with id %s", host.ID)
 		o.log.Error(message)
@@ -128,9 +128,9 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
 }
 
-// GetHostRequirementsForRole provides operator's requirements towards host in a given role
-func (o *operator) GetHostRequirementsForRole(_ context.Context, _ *common.Cluster, role models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
-	switch role {
+// GetHostRequirements provides operator's requirements towards the host
+func (o *operator) GetHostRequirements(_ context.Context, _ *common.Cluster, host *models.Host) (*models.ClusterHostRequirementsDetails, error) {
+	switch host.Role {
 	case models.HostRoleMaster:
 		return &models.ClusterHostRequirementsDetails{
 			CPUCores: masterCPU,
@@ -142,5 +142,5 @@ func (o *operator) GetHostRequirementsForRole(_ context.Context, _ *common.Clust
 			RAMMib:   workerMemory,
 		}, nil
 	}
-	return nil, fmt.Errorf("unsupported role: %s", role)
+	return nil, fmt.Errorf("unsupported role: %s", host.Role)
 }

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -70,7 +70,7 @@ func (l *lsOperator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
 }
 
-// GetHostRequirementsForRole provides operator's requirements towards host in a given role
-func (l *lsOperator) GetHostRequirementsForRole(context.Context, *common.Cluster, models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+// GetHostRequirements provides operator's requirements towards the host
+func (l *lsOperator) GetHostRequirements(context.Context, *common.Cluster, *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	return &models.ClusterHostRequirementsDetails{}, nil
 }

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -50,19 +50,19 @@ type API interface {
 	GetSupportedOperators() []string
 	// GetOperatorProperties provides description of properties of an operator
 	GetOperatorProperties(operatorName string) (models.OperatorProperties, error)
-	// GetRequirementsBreakdownForRoleInCluster provides host requirements breakdown for each OLM operator in the cluster
-	GetRequirementsBreakdownForRoleInCluster(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error)
+	// GetRequirementsBreakdownForHostInCluster provides host requirements breakdown for each OLM operator in the cluster
+	GetRequirementsBreakdownForHostInCluster(ctx context.Context, cluster *common.Cluster, host *models.Host) ([]*models.OperatorHostRequirements, error)
 }
 
 // GetRequirementsBreakdownForRoleInCluster provides host requirements breakdown for each OLM operator in the cluster
-func (mgr *Manager) GetRequirementsBreakdownForRoleInCluster(ctx context.Context, cluster *common.Cluster, role models.HostRole) ([]*models.OperatorHostRequirements, error) {
+func (mgr *Manager) GetRequirementsBreakdownForHostInCluster(ctx context.Context, cluster *common.Cluster, host *models.Host) ([]*models.OperatorHostRequirements, error) {
 	logger := logutil.FromContext(ctx, mgr.log)
 	var requirements []*models.OperatorHostRequirements
 	for _, monitoredOperator := range cluster.MonitoredOperators {
 		operatorName := monitoredOperator.Name
 		operator := mgr.olmOperators[operatorName]
 		if operator != nil {
-			reqs, err := operator.GetHostRequirementsForRole(ctx, cluster, role)
+			reqs, err := operator.GetHostRequirements(ctx, cluster, host)
 			if err != nil {
 				logger.WithError(err).Errorf("Cannot get host requirements for %s operator", operatorName)
 				return nil, err

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -108,19 +108,19 @@ func (mr *MockAPIMockRecorder) GetOperatorProperties(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorProperties", reflect.TypeOf((*MockAPI)(nil).GetOperatorProperties), arg0)
 }
 
-// GetRequirementsBreakdownForRoleInCluster mocks base method
-func (m *MockAPI) GetRequirementsBreakdownForRoleInCluster(arg0 context.Context, arg1 *common.Cluster, arg2 models.HostRole) ([]*models.OperatorHostRequirements, error) {
+// GetRequirementsBreakdownForHostInCluster mocks base method
+func (m *MockAPI) GetRequirementsBreakdownForHostInCluster(arg0 context.Context, arg1 *common.Cluster, arg2 *models.Host) ([]*models.OperatorHostRequirements, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRequirementsBreakdownForRoleInCluster", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRequirementsBreakdownForHostInCluster", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*models.OperatorHostRequirements)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRequirementsBreakdownForRoleInCluster indicates an expected call of GetRequirementsBreakdownForRoleInCluster
-func (mr *MockAPIMockRecorder) GetRequirementsBreakdownForRoleInCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetRequirementsBreakdownForHostInCluster indicates an expected call of GetRequirementsBreakdownForHostInCluster
+func (mr *MockAPIMockRecorder) GetRequirementsBreakdownForHostInCluster(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequirementsBreakdownForRoleInCluster", reflect.TypeOf((*MockAPI)(nil).GetRequirementsBreakdownForRoleInCluster), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequirementsBreakdownForHostInCluster", reflect.TypeOf((*MockAPI)(nil).GetRequirementsBreakdownForHostInCluster), arg0, arg1, arg2)
 }
 
 // GetSupportedOperators mocks base method

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -91,7 +91,7 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 	return &Operator
 }
 
-// GetHostRequirementsForRole provides operator's requirements towards host in a given role
-func (o *operator) GetHostRequirementsForRole(context.Context, *common.Cluster, models.HostRole) (*models.ClusterHostRequirementsDetails, error) {
+// GetHostRequirements provides operator's requirements towards the host
+func (o *operator) GetHostRequirements(context.Context, *common.Cluster, *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	return &models.ClusterHostRequirementsDetails{}, nil
 }


### PR DESCRIPTION
Interface change is required to allow the OLM operator plugins to access inventory information while calculating host requirements.