### PR TITLE
NO-ISSUE Render a file for the local secret

### DIFF
--- a/deploy/assisted-installer-local-auth.yaml
+++ b/deploy/assisted-installer-local-auth.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: assisted-installer-local-auth-key
+  namespace: REPLACE_NAMESPACE
+type: Opaque
+data:
+  ec-private-key.pem: REPLACE_PRIVATE_KEY
+  ec-public-key.pem: REPLACE_PUBLIC_KEY


### PR DESCRIPTION
Even though we can't use it for the operator case, we still need
the secret object as the service references it unconditionally

Without this the operator deployment was failing with:
`Error: secret "assisted-installer-local-auth-key" not found`