### PR TITLE
[BZ-1942521] Revert memory validation for host role to use physical instead of usable

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -290,7 +290,7 @@ func (v *validator) hasMemoryForRole(c *validationContext) ValidationStatus {
 		return ValidationPending
 	}
 	requiredBytes := conversions.MibToBytes(c.clusterHostRequirements.Total.RAMMib)
-	return boolValue(c.inventory.Memory.UsableBytes >= requiredBytes)
+	return boolValue(c.inventory.Memory.PhysicalBytes >= requiredBytes)
 }
 
 func (v *validator) isValidPlatform(c *validationContext) ValidationStatus {
@@ -323,7 +323,7 @@ func (v *validator) printHasMemoryForRole(c *validationContext, status Validatio
 	case ValidationFailure:
 
 		return fmt.Sprintf("Require at least %d GiB RAM role %s, found only %d GiB",
-			conversions.MibToGiB(c.clusterHostRequirements.Total.RAMMib), c.host.Role, conversions.BytesToGiB(c.inventory.Memory.UsableBytes))
+			conversions.MibToGiB(c.clusterHostRequirements.Total.RAMMib), c.host.Role, conversions.BytesToGiB(c.inventory.Memory.PhysicalBytes))
 	case ValidationPending:
 		return "Missing inventory or role"
 	default:


### PR DESCRIPTION
Relates to [BZ-1942521](https://bugzilla.redhat.com/show_bug.cgi?id=1942521)
Reverting back the change to use physical memory when validation host for role. If no operator is selected, it should match the behavior of minimum node requirement validation, which still uses physical memory.

I believe that node memory overall should not make use of the usable memory at this point, that should fall into the specific operator validation to determine if there is sufficient resources for its needs.