### PR TITLE
MGMT-4773 Use local auth with kube-api subsystem tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ test:
 	$(MAKE) _run_test AUTH_TYPE=rhsso WITH_AMS_SUBSCRIPTIONS=true
 
 test-kube-api:
-	$(MAKE) _run_test AUTH_TYPE=none ENABLE_KUBE_API=true FOCUS=kube-api
+	$(MAKE) _run_test AUTH_TYPE=local ENABLE_KUBE_API=true FOCUS=kube-api
 
 _run_test:
 	INVENTORY=$(shell $(call get_service,assisted-service) | sed 's/http:\/\///g') \
@@ -325,7 +325,7 @@ _run_test:
 		go test -v ./subsystem/... -count=1 $(GINKGO_FOCUS_FLAG) -ginkgo.v -timeout 120m
 
 enable-kube-api-for-subsystem: $(BUILD_FOLDER)
-	$(MAKE) deploy-service-requirements AUTH_TYPE=none ENABLE_KUBE_API=true
+	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true
 	$(call restart_service_pods)
 	$(MAKE) wait-for-service
 

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -28,7 +28,7 @@ var _ = Describe("test authorization", func() {
 	var capabilityReviewAdminStubID string
 
 	BeforeSuite(func() {
-		if Options.AuthType == auth.TypeNone {
+		if Options.AuthType != auth.TypeRHSSO {
 			return
 		}
 
@@ -46,7 +46,7 @@ var _ = Describe("test authorization", func() {
 	})
 
 	AfterSuite(func() {
-		if Options.AuthType == auth.TypeNone {
+		if Options.AuthType != auth.TypeRHSSO {
 			return
 		}
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -418,7 +418,7 @@ func installCluster(clusterID strfmt.UUID) *models.Cluster {
 
 func completeInstallation(client *client.AssistedInstall, clusterID strfmt.UUID) {
 	ctx := context.Background()
-	rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
+	rep, err := client.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 	Expect(err).NotTo(HaveOccurred())
 
 	status := models.OperatorStatusAvailable

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -51,7 +51,7 @@ func clientcfg(authInfo runtime.ClientAuthInfoWriter) client.Config {
 			Path:   client.DefaultBasePath,
 		},
 	}
-	if Options.AuthType == auth.TypeRHSSO {
+	if Options.AuthType != auth.TypeNone {
 		log.Info("API Key authentication enabled for subsystem tests")
 		cfg.AuthInfo = authInfo
 	}


### PR DESCRIPTION
Now when running subsystem for kube-api all user auth
is rejected and agent auth requires the new local token

cc @filanov 