### PR TITLE
NO-ISSUE Replace envconfig prefix in-line string with a const

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -145,7 +145,7 @@ func InitLogs() *logrus.Entry {
 }
 
 func main() {
-	err := envconfig.Process("myapp", &Options)
+	err := envconfig.Process(common.EnvConfigPrefix, &Options)
 	log := InitLogs()
 
 	if err != nil {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -37,7 +37,7 @@ import (
 
 func getDefaultConfig() Config {
 	var cfg Config
-	Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+	Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 	return cfg
 }
 
@@ -2142,7 +2142,7 @@ var _ = Describe("prepare-for-installation refresh status", func() {
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
 		cfg := Config{}
-		Expect(envconfig.Process("myapp", &cfg)).NotTo(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).NotTo(HaveOccurred())
 		ctrl = gomock.NewController(GinkgoT())
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockEvents := events.NewMockHandler(ctrl)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const EnvConfigPrefix = "myapp"
+
 const MinMasterHostsNeededForInstallation = 3
 const AllowedNumberOfMasterHostsInNoneHaMode = 1
 const AllowedNumberOfWorkersInNoneHaMode = 0

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Disk eligibility", func() {
 
 	BeforeEach(func() {
 		var cfg ValidatorCfg
-		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		hwvalidator = NewValidator(logrus.New(), cfg, nil)
 
 		bigEnoughSize = conversions.GbToBytes(cfg.MinDiskSizeGb) + 1
@@ -89,7 +89,7 @@ var _ = Describe("hardware_validator", func() {
 	)
 	BeforeEach(func() {
 		var cfg ValidatorCfg
-		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		hwvalidator = NewValidator(logrus.New(), cfg, nil)
 		id1 := strfmt.UUID(uuid.New().String())
 		id2 := strfmt.UUID(uuid.New().String())
@@ -250,7 +250,7 @@ var _ = Describe("Cluster host requirements", func() {
 		versionRequirements, err := json.Marshal(versionRequirementsSource)
 		Expect(err).ToNot(HaveOccurred())
 		_ = os.Setenv(prefixedRequirementsEnv, string(versionRequirements))
-		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		Expect(cfg.VersionedRequirements).ToNot(HaveKey(openShiftVersionNotInJSON))
 		details1 = models.ClusterHostRequirementsDetails{
 			InstallationDiskSpeedThresholdMs: 10,

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -143,7 +143,7 @@ var _ = Describe("TestHostMonitoring", func() {
 		mockEvents.EXPECT().
 			AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			AnyTimes()
-		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		mockHwValidator := hardware.NewMockValidator(ctrl)
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
 		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -28,7 +28,7 @@ var Operator = models.MonitoredOperator{
 // NewOcsOperator creates new OCSOperator
 func NewOcsOperator(log logrus.FieldLogger) *operator {
 	cfg := Config{}
-	err := envconfig.Process("myapp", &cfg)
+	err := envconfig.Process(common.EnvConfigPrefix, &cfg)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/internal/operators/ocs/validation_test.go
+++ b/internal/operators/ocs/validation_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{})
 		var cfg clust.Config
-		Expect(envconfig.Process("myapp", &cfg)).ShouldNot(HaveOccurred())
+		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		clusterApi = clust.NewManager(cfg, common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil)
 


### PR DESCRIPTION
"myapp" prefix parameter for envconfig appears in-line in many places and this PR defines a const that should be used instead.
