### PR TITLE
NO-ISSUE Add cluster and approved columns to Agent CRDs list

### DIFF
--- a/internal/controller/api/v1alpha1/agent_types.go
+++ b/internal/controller/api/v1alpha1/agent_types.go
@@ -222,6 +222,8 @@ type AgentStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterDeploymentName.name",description="The name of the cluster the Agent registered to."
+// +kubebuilder:printcolumn:name="Approved",type="boolean",JSONPath=".spec.approved",description="The `Approve` state of the Agent."
 
 // Agent is the Schema for the hosts API
 type Agent struct {

--- a/internal/controller/config/crd/bases/adi.io.my.domain_agents.yaml
+++ b/internal/controller/config/crd/bases/adi.io.my.domain_agents.yaml
@@ -16,7 +16,16 @@ spec:
     singular: agent
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The name of the cluster the Agent registered to.
+      jsonPath: .spec.clusterDeploymentName.name
+      name: Cluster
+      type: string
+    - description: The `Approve` state of the Agent.
+      jsonPath: .spec.approved
+      name: Approved
+      type: boolean
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Agent is the Schema for the hosts API

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -14,7 +14,16 @@ spec:
     singular: agent
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The name of the cluster the Agent registered to.
+      jsonPath: .spec.clusterDeploymentName.name
+      name: Cluster
+      type: string
+    - description: The `Approve` state of the Agent.
+      jsonPath: .spec.approved
+      name: Approved
+      type: boolean
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Agent is the Schema for the hosts API


### PR DESCRIPTION
```
$ kubectl get agents.adi.io.my.domain -A
NAMESPACE            NAME                                   CLUSTER            APPROVED
assisted-installer   22fb988d-ae7f-46a7-a4e2-7b0351e60de6   test-cluster-sno   true
assisted-installer   40fc9f70-5959-4043-8d93-0dc0316c5be7   test-cluster       true
assisted-installer   4aea9478-672b-4d8f-ad6b-d29a50cf709c   test-cluster       false
```