### PR TITLE
MGMT-4743 Assisted installer clusterDeployment uses same netmask to parse all networks (machine/service/cluster)

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1776,7 +1776,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 	userManagedNetworking := swag.BoolValue(cluster.UserManagedNetworking)
 
 	if params.ClusterUpdateParams.ClusterNetworkCidr != nil {
-		if err = network.VerifySubnetCIDR(*params.ClusterUpdateParams.ClusterNetworkCidr); err != nil {
+		if err = network.VerifyClusterOrServiceCIDR(*params.ClusterUpdateParams.ClusterNetworkCidr); err != nil {
 			return common.NewApiError(http.StatusBadRequest, errors.Wrap(err, "Cluster network CIDR"))
 		}
 		clusterCidr = *params.ClusterUpdateParams.ClusterNetworkCidr
@@ -1796,7 +1796,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 		}
 	}
 	if params.ClusterUpdateParams.ServiceNetworkCidr != nil {
-		if err = network.VerifySubnetCIDR(*params.ClusterUpdateParams.ServiceNetworkCidr); err != nil {
+		if err = network.VerifyClusterOrServiceCIDR(*params.ClusterUpdateParams.ServiceNetworkCidr); err != nil {
 			return common.NewApiError(http.StatusBadRequest, errors.Wrap(err, "Service network CIDR"))
 		}
 		serviceCidr = *params.ClusterUpdateParams.ServiceNetworkCidr
@@ -1837,7 +1837,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 
 	if params.ClusterUpdateParams.MachineNetworkCidr != nil && common.IsSingleNodeCluster(cluster) {
 		machineCidr = swag.StringValue(params.ClusterUpdateParams.MachineNetworkCidr)
-		if err = network.VerifySubnetCIDR(machineCidr); err != nil {
+		if err = network.VerifyMachineCIDR(machineCidr); err != nil {
 			log.WithError(err).Warningf("Given machine cidr %q is not valid", machineCidr)
 			return common.NewApiError(http.StatusBadRequest, err)
 		}

--- a/internal/network/cidr_validations_test.go
+++ b/internal/network/cidr_validations_test.go
@@ -23,4 +23,21 @@ var _ = Describe("CIDR validations", func() {
 			Expect(VerifyClusterCidrSize(66, "8::/64", 4)).ToNot(HaveOccurred())
 		})
 	})
+	Context("Verify CIDRs", func() {
+		It("Machine CIDR 24 OK", func() {
+			Expect(VerifyMachineCIDR("1.2.3.0/24")).ToNot(HaveOccurred())
+		})
+		It("Machine CIDR 26 OK", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/26")).ToNot(HaveOccurred())
+		})
+		It("Machine CIDR 27 Fail", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/27")).To(HaveOccurred())
+		})
+		It("Service CIDR 26 Fail", func() {
+			Expect(VerifyClusterOrServiceCIDR("1.2.3.0/26")).To(HaveOccurred())
+		})
+		It("Service CIDR 25 OK", func() {
+			Expect(VerifyClusterOrServiceCIDR("1.2.3.0/25")).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -3,7 +3,6 @@ package network
 import (
 	"encoding/json"
 	"net"
-	"net/http"
 	"strings"
 
 	"github.com/go-openapi/strfmt"
@@ -115,18 +114,6 @@ func VerifyVips(hosts []*models.Host, machineNetworkCidr string, apiVip string, 
 		err = VerifyDifferentVipAddresses(apiVip, ingressVip)
 	}
 	return err
-}
-
-func VerifyMachineCIDR(machineCidr string) error {
-	ip, ipNet, err := net.ParseCIDR(machineCidr)
-	if err != nil {
-		return err
-	}
-
-	if !ip.Equal(ipNet.IP) {
-		return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s is not a valid machine CIDR", machineCidr))
-	}
-	return nil
 }
 
 func findMatchingIPForFamily(ipnet *net.IPNet, addresses []string) (bool, string) {


### PR DESCRIPTION


- Use /26 for machine CIDR and /25 for Service and Cluster CIDR

/cc @tsorya 