### PR TITLE
OCPBUGSM-17327 Handle asterisk in NoProxy values

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -404,7 +404,9 @@ var _ = Describe("Proxy validations", func() {
 		})
 		It("'*' bypass proxy for all destinations", func() {
 			err := ValidateNoProxyFormat("*")
-			Expect(err).Should(BeNil())
+			// TODO: Start accepting '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in this release"))
 		})
 		It("invalid format", func() {
 			err := ValidateNoProxyFormat("...")
@@ -412,6 +414,10 @@ var _ = Describe("Proxy validations", func() {
 		})
 		It("invalid format of a single value", func() {
 			err := ValidateNoProxyFormat("domain.com,...")
+			Expect(err).ShouldNot(BeNil())
+		})
+		It("invalid use of asterisk", func() {
+			err := ValidateNoProxyFormat("*,domain.com")
 			Expect(err).ShouldNot(BeNil())
 		})
 	})

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -330,7 +330,8 @@ func ValidateHTTPProxyFormat(proxyURL string) error {
 // Use '*' to bypass proxy for all destinations.
 func ValidateNoProxyFormat(noProxy string) error {
 	if noProxy == "*" {
-		return nil
+		// TODO: Start accepting '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed, return an error until then
+		return errors.Errorf("Sorry, no-proxy value '*' is not supported in this release")
 	}
 	domains := strings.Split(noProxy, ",")
 	for _, s := range domains {
@@ -348,6 +349,8 @@ func ValidateNoProxyFormat(noProxy string) error {
 		}
 		return errors.Errorf("NO Proxy format is not valid: '%s'. "+
 			"NO Proxy is a comma-separated list of destination domain names, domains, IP addresses or other network CIDRs. "+
+			// TODO: Change this to allow '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed
+			// "A domain can be prefaced with '.' to include all subdomains of that domain. Use '*' to bypass proxy for all destinations.", noProxy)
 			"A domain can be prefaced with '.' to include all subdomains of that domain.", noProxy)
 	}
 	return nil

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -179,22 +179,35 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 
 func (i *installCmd) getProxyArguments(clusterName, baseDNSDomain, httpProxy, httpsProxy, noProxy string) []string {
 	cmd := make([]string, 0)
+	if httpProxy == "" && httpsProxy == "" {
+		return cmd
+	}
 
-	if httpProxy != "" || httpsProxy != "" {
-		if httpProxy != "" {
-			cmd = append(cmd, "--http-proxy", httpProxy)
-		}
-		if httpsProxy != "" {
-			cmd = append(cmd, "--https-proxy", httpsProxy)
-		}
+	if httpProxy != "" {
+		cmd = append(cmd, "--http-proxy", httpProxy)
+	}
 
+	if httpsProxy != "" {
+		cmd = append(cmd, "--https-proxy", httpsProxy)
+	}
+
+	noProxyTrim := strings.TrimSpace(noProxy)
+	if noProxyTrim == "*" {
+		cmd = append(cmd, "--no-proxy", noProxyTrim)
+	} else {
+
+		noProxyUpdated := []string{}
+		if noProxyTrim != "" {
+			noProxyUpdated = append(noProxyUpdated, noProxyTrim)
+		}
 		// if we set proxy we need to update assisted installer no proxy with no proxy params as installer.
 		// it must be able to connect to api int. Added this way for not to pass name and base domain
-		noProxyUpdated := []string{noProxy, "127.0.0.1",
+		noProxyUpdated = append(noProxyUpdated,
+			"127.0.0.1",
 			"localhost",
 			".svc",
 			".cluster.local",
-			fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain)}
+			fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain))
 		cmd = append(cmd, "--no-proxy", strings.Join(noProxyUpdated, ","))
 	}
 

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -926,6 +926,17 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).Should(ContainSubstring(`"proxy": { "httpProxy": "http://10.10.1.1:3128", "noProxy": ["quay.io"] }`))
 	})
 
+	It("ignition_file_contains_asterisk_no_proxy", func() {
+		cluster.HTTPProxy = "http://10.10.1.1:3128"
+		cluster.NoProxy = "*"
+		serviceBaseURL := "file://10.56.20.70:7878"
+		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
+		text, err := builder.FormatDiscoveryIgnitionFile(&cluster, config, false, auth.TypeRHSSO)
+
+		Expect(err).Should(BeNil())
+		Expect(text).Should(ContainSubstring(`"proxy": { "httpProxy": "http://10.10.1.1:3128", "noProxy": ["*"] }`))
+	})
+
 	It("produces a valid ignition v3.1 spec by default", func() {
 		text, err := builder.FormatDiscoveryIgnitionFile(&cluster, IgnitionConfig{}, false, auth.TypeRHSSO)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -150,6 +150,10 @@ func getNetworkType(cluster *common.Cluster) string {
 
 func generateNoProxy(cluster *common.Cluster) string {
 	noProxy := strings.TrimSpace(cluster.NoProxy)
+	if noProxy == "*" {
+		return noProxy
+	}
+
 	splitNoProxy := funk.FilterString(strings.Split(noProxy, ","), func(s string) bool { return s != "" })
 	if cluster.MachineNetworkCidr != "" {
 		splitNoProxy = append(splitNoProxy, cluster.MachineNetworkCidr)


### PR DESCRIPTION
Asterisk (*) is a special value and cannot be used in combination
with a list of values (addresses, domains) in NoProxy field.

This value will be blocked until
https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed.