### PR TITLE
MGMT-4356: Deploy only single openshift version

### DIFF
--- a/hack/get_ocp_versions_for_testing.sh
+++ b/hack/get_ocp_versions_for_testing.sh
@@ -10,12 +10,13 @@ PROJECT_ROOT_DIR="$(cd "$(dirname "${__dir}")" && pwd)"
 # The code is still kept around behind this gate to provide an example of how we can do
 # a similar override in the future.
 OVERRIDE_4_8_WITH_SINGLE_NODE=0
+SINGLE_VERSION_ONLY=${SINGLE_VERSION_ONLY:-false}
 
 if [[ ${OVERRIDE_4_8_WITH_SINGLE_NODE} == 1 ]]; then
     OPENSHIFT_SNO_IMAGE="quay.io/openshift-release-dev/ocp-release-nightly:4.8.0-0.nightly-2021-03-16-221720"
 
     # Append single node image as 4.8 for local deployments
-    "${PROJECT_ROOT_DIR}"/tools/handle_ocp_versions.py --src ./default_ocp_versions.json --ocp-override ${OPENSHIFT_SNO_IMAGE} --name-override single-node-4.8-alpha --version-override 4.8 --skip-verify | tr -d "\n\t "
+    "${PROJECT_ROOT_DIR}"/tools/handle_ocp_versions.py --src ./default_ocp_versions.json --ocp-override ${OPENSHIFT_SNO_IMAGE} --name-override single-node-4.8-alpha --version-override 4.8 --skip-verify --single-version-only=${SINGLE_VERSION_ONLY} | tr -d "\n\t "
 else
     tr -d "\n\t " < ./default_ocp_versions.json
 fi

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Cluster", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -189,7 +189,7 @@ var _ = Describe("Cluster", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -204,7 +204,7 @@ var _ = Describe("Cluster", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -530,13 +530,14 @@ var _ = Describe("cluster install - DHCP", func() {
 	})
 
 	BeforeEach(func() {
+
 		registerClusterReply, err := userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				BaseDNSDomain:            "example.com",
 				ClusterNetworkCidr:       &clusterCIDR,
 				ClusterNetworkHostPrefix: 23,
 				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion:         swag.String(openshiftVersion),
 				PullSecret:               swag.String(pullSecret),
 				ServiceNetworkCidr:       &serviceCIDR,
 				SSHPublicKey:             sshPublicKey,
@@ -686,7 +687,7 @@ var _ = Describe("cluster update - BaseDNS", func() {
 				ClusterNetworkCidr:       &clusterCIDR,
 				ClusterNetworkHostPrefix: 23,
 				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion:         swag.String(openshiftVersion),
 				PullSecret:               swag.String(pullSecret),
 				ServiceNetworkCidr:       &serviceCIDR,
 				SSHPublicKey:             sshPublicKey,
@@ -747,7 +748,7 @@ var _ = Describe("cluster install", func() {
 				ClusterNetworkCidr:       &clusterCIDR,
 				ClusterNetworkHostPrefix: 23,
 				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion:         swag.String(openshiftVersion),
 				PullSecret:               swag.String(pullSecret),
 				ServiceNetworkCidr:       &serviceCIDR,
 				SSHPublicKey:             sshPublicKey,
@@ -2914,7 +2915,7 @@ var _ = Describe("cluster install, with default network params", func() {
 			NewClusterParams: &models.ClusterCreateParams{
 				BaseDNSDomain:    "example.com",
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 				SSHPublicKey:     sshPublicKey,
 			},

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/internal/bminventory"
-	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -30,7 +29,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		cluster, err = userBMClient.Installer.RegisterAddHostsCluster(ctx, &installer.RegisterAddHostsClusterParams{
 			NewAddHostsClusterParams: &models.AddHostsClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				APIVipDnsname:    swag.String("api_vip_dnsname"),
 				ID:               strToUUID(uuid.New().String()),
 			},

--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Host tests", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -578,7 +578,7 @@ var _ = Describe("Host tests", func() {
 		cluster2, err := userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("another-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -146,7 +146,7 @@ var _ = Describe("image tests", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -192,7 +192,7 @@ var _ = Describe("image tests", func() {
 		cluster, err := userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})
@@ -234,7 +234,7 @@ var _ = Describe("system-test proxy update tests", func() {
 		cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 			},
 		})

--- a/subsystem/ipv6_test.go
+++ b/subsystem/ipv6_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
-	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -51,7 +50,7 @@ var _ = Describe("IPv6 installation", func() {
 				ClusterNetworkCidr:       &clusterCIDR,
 				ClusterNetworkHostPrefix: 64,
 				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion:         swag.String(openshiftVersion),
 				PullSecret:               swag.String(pullSecret),
 				ServiceNetworkCidr:       &serviceCIDR,
 				SSHPublicKey:             sshPublicKey,

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/client/manifests"
-	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -44,7 +43,7 @@ spec:
 		registerClusterReply, err := userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
 				Name:             swag.String("test-cluster"),
-				OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftVersion: swag.String(openshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 				SSHPublicKey:     sshPublicKey,
 			},

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -224,7 +224,7 @@ func registerDay2Cluster(ctx context.Context) strfmt.UUID {
 	c, err := userBMClient.Installer.RegisterAddHostsCluster(ctx, &installer.RegisterAddHostsClusterParams{
 		NewAddHostsClusterParams: &models.AddHostsClusterCreateParams{
 			Name:             swag.String("test-metrics-day2-cluster"),
-			OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+			OpenshiftVersion: swag.String(openshiftVersion),
 			APIVipDnsname:    swag.String("api_vip_dnsname"),
 			ID:               strToUUID(uuid.New().String()),
 		},

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			reply, err := userBMClient.Installer.RegisterCluster(context.TODO(), &installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					Name:             swag.String("test-cluster"),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					OpenshiftVersion: swag.String(openshiftVersion),
 					PullSecret:       swag.String(pullSecret),
 				},
 			})
@@ -72,7 +72,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			reply, err := userBMClient.Installer.RegisterCluster(context.TODO(), &installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					Name:             swag.String("test-cluster"),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					OpenshiftVersion: swag.String(openshiftVersion),
 					PullSecret:       swag.String(pullSecret),
 					OlmOperators: []*models.OperatorCreateParams{
 						{
@@ -98,7 +98,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			registerClusterReply, err := userBMClient.Installer.RegisterCluster(context.TODO(), &installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					Name:             swag.String("test-cluster"),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					OpenshiftVersion: swag.String(openshiftVersion),
 					PullSecret:       swag.String(pullSecret),
 				},
 			})
@@ -158,7 +158,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			cluster, err = userBMClient.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					Name:             swag.String("test-cluster"),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					OpenshiftVersion: swag.String(openshiftVersion),
 					PullSecret:       swag.String(pullSecret),
 					OlmOperators: []*models.OperatorCreateParams{
 						{Name: ocs.Operator.Name},

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -1,6 +1,7 @@
 package subsystem
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client"
+	"github.com/openshift/assisted-service/client/versions"
 	"github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	"github.com/openshift/assisted-service/pkg/auth"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -28,6 +30,7 @@ var agentBMClient, badAgentBMClient, userBMClient, readOnlyAdminUserBMClient, un
 var log *logrus.Logger
 var wiremock *WireMock
 var kubeClient k8sclient.Client
+var openshiftVersion string = "4.6"
 
 const (
 	pollDefaultInterval = 1 * time.Millisecond
@@ -126,6 +129,15 @@ func init() {
 
 		if err = wiremock.CreateWiremockStubsForOCM(); err != nil {
 			logrus.Fatal("Failed to init wiremock stubs, ", err)
+		}
+	}
+
+	// Test on first openshift version. We can't test on latest because quay.io/openshift-release-dev/ocp-release-nightly
+	// is not public, so we would have to add PULL_SECRET env var as mandatory to access the quay.
+	if reply, err := userBMClient.Versions.ListSupportedOpenshiftVersions(context.Background(),
+		&versions.ListSupportedOpenshiftVersionsParams{}); err == nil {
+		for openshiftVersion = range reply.GetPayload() {
+			break
 		}
 	}
 }

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -61,7 +61,7 @@ func registerCluster(ctx context.Context, client *client.AssistedInstall, cluste
 	var cluster, err = client.Installer.RegisterCluster(ctx, &installer.RegisterClusterParams{
 		NewClusterParams: &models.ClusterCreateParams{
 			Name:             swag.String(clusterName),
-			OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+			OpenshiftVersion: swag.String(openshiftVersion),
 			PullSecret:       swag.String(pullSecret),
 			BaseDNSDomain:    "example.com",
 		},

--- a/subsystem/versions_test.go
+++ b/subsystem/versions_test.go
@@ -22,8 +22,6 @@ var _ = Describe("[minimal-set]test versions", func() {
 		reply, err := userBMClient.Versions.ListSupportedOpenshiftVersions(context.Background(),
 			&versions.ListSupportedOpenshiftVersionsParams{})
 		Expect(err).ShouldNot(HaveOccurred())
-
-		// 4.6, 4.7, 4.8
-		Expect(reply.GetPayload()).To(HaveLen(3))
+		Expect(len(reply.GetPayload())).To(BeNumerically(">=", 1))
 	})
 })


### PR DESCRIPTION
This PR add a switch to tools/handle_ocp_versions.py script, that can
decide to deploy only single OCP version. If user pass the env var
SINGLE_VERSION_ONLY=1 it will first take --ocp-override version image,
and use it, if not set it will use OPENSHIFT_VERSION env var, if not set
it will take the latest version in the OPENSHIFT_VERSIONS definition.

Example with OPENSHIFT_VERSION set:
```
$ OPENSHIFT_VERSION=4.7 SINGLE_VERSION_ONLY=true hack/get_ocp_versions_for_testing.sh
Using only single version of the RHCOS ISO
{"4.7":{"display_name":"4.7.5","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.5-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
```

Example with ocp-override:
```
$ SINGLE_VERSION_ONLY=true hack/get_ocp_versions_for_testing.sh
Using only single version of the RHCOS ISO
Getting release version of quay.io/openshift-release-dev/ocp-release-nightly:4.8.0-0.nightly-2021-03-16-221720...
{"4.8":{"display_name":"single-node-4.8-alpha","release_image":"quay.io/openshift-release-dev/ocp-release-nightly:4.8.0-0.nightly-2021-03-16-221720","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
```

Example with SINGLE_VERSION_ONLY=false (default):
```
$ SINGLE_VERSION_ONLY=false hack/get_ocp_versions_for_testing.sh
{"4.6":{"display_name":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.5","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.5-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"},"4.8":{"display_name":"single-node-4.8-alpha","release_image":"quay.io/openshift-release-dev/ocp-release-nightly:4.8.0-0.nightly-2021-03-16-221720","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
```

Signed-off-by: Ondra Machacek <omachace@redhat.com>