### PR TITLE
MGMT-4587 Allow install-config overrides using annotations

### DIFF
--- a/docs/Kube-API-examples.md
+++ b/docs/Kube-API-examples.md
@@ -10,3 +10,33 @@ You will likely need to adapt those for your own needs.
 * [Hive PullSecret Secret](crds/pullsecret.yaml)
 * [Hive ClusterDeployment](crds/clusterDeployment.yaml)
 * [Hive ClusterDeployment-SNO](crds/clusterDeployment-SNO.yaml)
+
+
+
+###Creating InstallConfig overrides
+
+In order to alter the default install config yaml used when running `openshift-install create` commands.
+More information about install-config overrides is available [here](user/guide/install-customization.md#Install-Config)
+In case of failure to apply the overrides the clusterdeployment conditions will reflect the error and show the relevant error message. 
+
+Add an annotation with the desired options, the clusterdeployment controller will update the install config yaml with the annotation value.
+Note that this configuration must be applied prior to starting the installation
+```
+$kubectl annotate clusterdeployments.hive.openshift.io test-cluster -n assisted-installer adi.io.my.domain/install-config-overrides="{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}"
+clusterdeployment.hive.openshift.io/test-cluster annotated
+
+$kubectl get clusterdeployments.hive.openshift.io test-cluster -n assisted-installer -o yaml
+apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  annotations:
+    adi.io.my.domain/install-config-overrides: '{"controlPlane":{"hyperthreading":"Disabled"}}'
+  creationTimestamp: "2021-04-01T07:04:49Z"
+  generation: 1
+  name: test-cluster
+  namespace: assisted-installer
+  resourceVersion: "183201"
+  selfLink: /apis/hive.openshift.io/v1/namespaces/assisted-installer/clusterdeployments/test-cluster
+  uid: 25769614-52db-448d-8366-05cb38c776fa
+spec:
+```

--- a/docs/user-guide/install-customization.md
+++ b/docs/user-guide/install-customization.md
@@ -60,7 +60,29 @@ curl --header "Authorization: Bearer $TOKEN" "http://$ASSISTED_SERVICE_IP:$ASSIS
 ## Install Config
 
 These endpoints alter the default install config yaml used when running `openshift-install create` commands.
+Install config customization reference is available [here](https://github.com/openshift/installer/blob/master/docs/user/customization.md)
 Some of this content will be pinned to particular values, but most can be edited.
+Note, some of this content will be pinned to particular values by the assisted-installer (can't be overwritten).
+
+You can compose the install-config overrides by creating a json string with the options you wish to set.
+An example install config with disabled hyperthreading for the control plane:
+```
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+  name: master
+  hyperthreading: Disabled
+compute:
+- name: worker
+  replicas: 5
+metadata:
+  name: test-cluster
+platform: ...
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+should look like this:
+```"{\"controlPlane\":{\"hyperthreading\":\"Disabled\"}}"```
 
 ### Patch the install config
 

--- a/go.sum
+++ b/go.sum
@@ -2522,6 +2522,7 @@ k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+
 k8s.io/kubectl v0.17.2/go.mod h1:y4rfLV0n6aPmvbRCqZQjvOp3ezxsFgpqL+zF5jH/lxk=
 k8s.io/kubectl v0.17.3/go.mod h1:NUn4IBY7f7yCMwSop2HCXlw/MVYP4HJBiUmOR3n9w28=
 k8s.io/kubectl v0.17.4/go.mod h1:im5QWmh6fvtmJkkNm4HToLe8z9aM3jihYK5X/wOybcY=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.17.2/go.mod h1:3TkNHET4ROd+NfzNxkjoVfQ0Ob4iZnaHmSEA4vYpwLw=
 k8s.io/metrics v0.17.3/go.mod h1:HEJGy1fhHOjHggW9rMDBJBD3YuGroH3Y1pnIRw9FFaI=

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4929,7 +4929,7 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			InstallConfigParams: override,
 		}
 		response := bm.UpdateClusterInstallConfig(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateClusterInstallConfigNotFound{}))
+		verifyApiError(response, http.StatusNotFound)
 	})
 
 	It("returns bad request when provided invalid json", func() {
@@ -4939,7 +4939,7 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			InstallConfigParams: override,
 		}
 		response := bm.UpdateClusterInstallConfig(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateClusterInstallConfigBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 
 	It("returns bad request when provided invalid options", func() {
@@ -4949,7 +4949,7 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			InstallConfigParams: override,
 		}
 		response := bm.UpdateClusterInstallConfig(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateClusterInstallConfigBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 })
 

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -203,6 +203,21 @@ func (mr *MockInstallerInternalsMockRecorder) RegisterClusterInternal(arg0, arg1
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).RegisterClusterInternal), arg0, arg1, arg2)
 }
 
+// UpdateClusterInstallConfigInternal mocks base method
+func (m *MockInstallerInternals) UpdateClusterInstallConfigInternal(arg0 context.Context, arg1 installer.UpdateClusterInstallConfigParams) (*common.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterInstallConfigInternal", arg0, arg1)
+	ret0, _ := ret[0].(*common.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateClusterInstallConfigInternal indicates an expected call of UpdateClusterInstallConfigInternal
+func (mr *MockInstallerInternalsMockRecorder) UpdateClusterInstallConfigInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterInstallConfigInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateClusterInstallConfigInternal), arg0, arg1)
+}
+
 // UpdateClusterInternal mocks base method
 func (m *MockInstallerInternals) UpdateClusterInternal(arg0 context.Context, arg1 installer.UpdateClusterParams) (*common.Cluster, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Support install-config patching using annotations on cluster-deployment CRD.
annotation key: "hive.openshift.io/install-config-overrides"
Adding, updating, or removing this annotation will trigger a call for UpdateClusterInstallConfigOverrides with the given string

The current implementation doesn't cover invalid configuration

