### PR TITLE
MGMT-4822 Skip un-needed cluster status update

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -825,7 +825,8 @@ func (m *Manager) SetConnectivityMajorityGroupsForCluster(clusterID strfmt.UUID,
 	if err != nil {
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
-	err = db.Model(&common.Cluster{}).Where("id = ?", clusterID.String()).Update(&common.Cluster{
+
+	err = db.Model(&common.Cluster{}).Where("id = ? and connectivity_majority_groups <> ?", clusterID.String(), string(b)).Update(&common.Cluster{
 		Cluster: models.Cluster{
 			ConnectivityMajorityGroups: string(b),
 		},

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -452,8 +452,11 @@ func (th *transitionHandler) PostRefreshCluster(reason string) stateswitch.PostT
 			err            error
 			updatedCluster *common.Cluster
 		)
-		updatedCluster, err = updateClusterStatus(logutil.FromContext(params.ctx, th.log), params.db, *sCluster.cluster.ID, sCluster.srcState, *sCluster.cluster.Status,
-			reason)
+		if sCluster.srcState != swag.StringValue(sCluster.cluster.Status) || reason != swag.StringValue(sCluster.cluster.StatusInfo) {
+			updatedCluster, err = updateClusterStatus(logutil.FromContext(params.ctx, th.log), params.db, *sCluster.cluster.ID, sCluster.srcState, *sCluster.cluster.Status,
+				reason)
+		}
+
 		//update hosts status to models.HostStatusResettingPendingUserAction if needed
 		cluster := sCluster.cluster
 		if updatedCluster != nil {


### PR DESCRIPTION
To prevent flusters from being constantly updated this will skip cluster status update in cast the status & info are not changd  