### PR TITLE
NO-ISSUE: Index build needs to use the publish tag of bundle image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,7 @@ pipeline {
                 // When the index index is being built, the opm tooling pulls the bundle
                 // image from quay, so the index is built after the bundle image has been
                 // published.
-                sh "skipper make operator-index-build"
-                sh "make publish-index"
+                sh "make build-publish-index"
             }
         }
 
@@ -89,8 +88,7 @@ pipeline {
                 // When the index index is being built, the opm tooling pulls the bundle
                 // image from quay, so the index is built after the bundle image has been
                 // published.
-                sh "skipper make operator-index-build"
-                sh "make publish-index PUBLISH_TAG=latest"
+                sh "make build-publish-index PUBLISH_TAG=latest"
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,8 @@ publish:
 	$(call publish_image,docker,${BUNDLE_IMAGE},quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG})
 	skipper make publish-client
 
-publish-index:
+build-publish-index:
+	skipper make operator-index-build BUNDLE_IMAGE=quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG}
 	$(call publish_image,docker,${INDEX_IMAGE},quay.io/ocpmetal/assisted-service-index:${PUBLISH_TAG})
 
 publish-client: generate-python-client


### PR DESCRIPTION
Cannot use BUNDLE_IMAGE, needs to use published tag version:
quay.io/ocpmetal/assisted-service-operator-bundle:${PUBLISH_TAG}