### PR TITLE
Allow patching of controlPlane.workloads in install-config.yaml

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -79,6 +79,10 @@ type InstallerConfigBaremetal struct {
 		Hyperthreading string `yaml:"hyperthreading"`
 		Name           string `yaml:"name"`
 		Replicas       int    `yaml:"replicas"`
+		Workloads      []struct {
+			Name   string `yaml:"name"`
+			CPUIds string `yaml:"cpuIDs"`
+		} `yaml:"workloads,omitempty"`
 	} `yaml:"controlPlane"`
 	Platform              platform         `yaml:"platform"`
 	BootstrapInPlace      bootstrapInPlace `yaml:"bootstrapInPlace,omitempty"`
@@ -207,6 +211,10 @@ func getBasicInstallConfig(log logrus.FieldLogger, cluster *common.Cluster) *Ins
 			Hyperthreading string `yaml:"hyperthreading"`
 			Name           string `yaml:"name"`
 			Replicas       int    `yaml:"replicas"`
+			Workloads      []struct {
+				Name   string `yaml:"name"`
+				CPUIds string `yaml:"cpuIDs"`
+			} `yaml:"workloads,omitempty"`
 		}{
 			Hyperthreading: "Enabled",
 			Name:           string(models.HostRoleMaster),


### PR DESCRIPTION
This feature is needed for the SNO "workload-partitioning" feature
outlined in https://github.com/openshift/enhancements/pull/703

Implemented as something we can only apply via a patch now. As this
feature undergoes further development, we could consider better
user-facing API integration.

Note: This is related to the install-config.yaml changes implemented in https://github.com/openshift/installer/pull/4802, and we should postpone merging this until that PR completes review and commit.