### PR TITLE
MGMT-4878 Add host validation for network latency

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -745,15 +745,16 @@ var _ = Describe("lease timeout event", func() {
 
 var _ = Describe("Auto assign machine CIDR", func() {
 	var (
-		db          *gorm.DB
-		c           common.Cluster
-		id          strfmt.UUID
-		clusterApi  *Manager
-		ctrl        *gomock.Controller
-		mockHostAPI *host.MockAPI
-		mockMetric  *metrics.MockAPI
-		dbName      string
-		mockEvents  *events.MockHandler
+		db                 *gorm.DB
+		c                  common.Cluster
+		id                 strfmt.UUID
+		clusterApi         *Manager
+		ctrl               *gomock.Controller
+		mockHostAPI        *host.MockAPI
+		mockMetric         *metrics.MockAPI
+		dbName             string
+		mockEvents         *events.MockHandler
+		defaultIPv4Address = common.NetAddress{IPv4Address: []string{"1.2.3.0/24"}}
 	)
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
@@ -809,7 +810,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			hosts: []*models.Host{
 				{
 					Status:    swag.String(models.HostStatusInsufficient),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 			},
 			userActionResetExpected: true,
@@ -834,11 +835,11 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			hosts: []*models.Host{
 				{
 					Status:    swag.String(models.HostStatusPendingForInput),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 				{
 					Status:    swag.String(models.HostStatusPendingForInput),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 			},
 			userActionResetExpected: true,
@@ -917,7 +918,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			hosts: []*models.Host{
 				{
 					Status:    swag.String(models.HostStatusInsufficient),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 			},
 			userActionResetExpected: true,
@@ -983,11 +984,11 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			hosts: []*models.Host{
 				{
 					Status:    swag.String(models.HostStatusPendingForInput),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 				{
 					Status:    swag.String(models.HostStatusPendingForInput),
-					Inventory: common.GenerateTestDefaultInventoryIPv4Only(),
+					Inventory: common.GenerateTestInventoryWithNetwork(defaultIPv4Address),
 				},
 			},
 			userActionResetExpected: true,

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -223,6 +225,20 @@ func totalizeRequirements(ocpRequirements models.ClusterHostRequirementsDetails,
 		if details.InstallationDiskSpeedThresholdMs > 0 {
 			if total.InstallationDiskSpeedThresholdMs == 0 || details.InstallationDiskSpeedThresholdMs < total.InstallationDiskSpeedThresholdMs {
 				total.InstallationDiskSpeedThresholdMs = details.InstallationDiskSpeedThresholdMs
+			}
+		}
+		if details.NetworkLatencyThresholdMs != nil && *details.NetworkLatencyThresholdMs >= 0 {
+			if total.NetworkLatencyThresholdMs == nil {
+				total.NetworkLatencyThresholdMs = details.NetworkLatencyThresholdMs
+			} else {
+				total.NetworkLatencyThresholdMs = pointer.Float64Ptr(math.Min(*total.NetworkLatencyThresholdMs, *details.NetworkLatencyThresholdMs))
+			}
+		}
+		if details.PacketLossPercentage != nil && *details.PacketLossPercentage >= 0 {
+			if total.PacketLossPercentage == nil {
+				total.PacketLossPercentage = details.PacketLossPercentage
+			} else {
+				total.PacketLossPercentage = pointer.Float64Ptr(math.Min(*total.PacketLossPercentage, *details.PacketLossPercentage))
 			}
 		}
 	}

--- a/internal/hardware/versioned-requirements.go
+++ b/internal/hardware/versioned-requirements.go
@@ -84,5 +84,7 @@ func copyClusterHostRequirementsDetails(details *models.ClusterHostRequirementsD
 		DiskSizeGb:                       details.DiskSizeGb,
 		InstallationDiskSpeedThresholdMs: details.InstallationDiskSpeedThresholdMs,
 		RAMMib:                           details.RAMMib,
+		NetworkLatencyThresholdMs:        details.NetworkLatencyThresholdMs,
+		PacketLossPercentage:             details.PacketLossPercentage,
 	}
 }

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -94,7 +94,7 @@ type Config struct {
 	EnableAutoReset         bool                    `envconfig:"ENABLE_AUTO_RESET" default:"false"`
 	ResetTimeout            time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
 	MonitorBatchSize        int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
-	DisabledHostvalidations DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS"` // Which host validations to disable (should not run in preprocess)
+	DisabledHostvalidations DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:"sufficient-network-latency-requirement-for-role,sufficient-packet-loss-requirement-for-role"` // Which host validations to disable (should not run in preprocess)
 }
 
 //go:generate mockgen -package=host -aux_files=github.com/openshift/assisted-service/internal/host/hostcommands=instruction_manager.go -destination=mock_host_api.go . API

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -207,3 +207,19 @@ func GetAddressFamilies(host *models.Host) (bool, bool, error) {
 	}
 	return v4, v6, nil
 }
+func MarshalConnectivityReport(report *models.ConnectivityReport) (string, error) {
+	if data, err := json.Marshal(report); err != nil {
+		return "", err
+	} else {
+		return string(data), nil
+	}
+}
+
+func UnmarshalConnectivityReport(reportStr string) (*models.ConnectivityReport, error) {
+	var report models.ConnectivityReport
+
+	if err := json.Unmarshal([]byte(reportStr), &report); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -215,6 +215,15 @@ func newValidations(v *validator) []validation {
 			condition: v.sufficientOrUnknownInstallationDiskSpeed,
 			formatter: v.printSufficientOrUnknownInstallationDiskSpeed,
 		},
+		{
+			id:        HasSufficientNetworkLatencyRequirementForRole,
+			condition: v.hasSufficientNetworkLatencyRequirementForRole,
+			formatter: v.printSufficientNetworkLatencyRequirementForRole,
+		}, {
+			id:        HasSufficientPacketLossRequirementForRole,
+			condition: v.hasSufficientPacketLossRequirementForRole,
+			formatter: v.printSufficientPacketLossRequirementForRole,
+		},
 	}
 }
 

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -507,7 +507,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr), If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup),
-		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability))
+		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -31,12 +31,14 @@ const (
 	AreOcsRequirementsSatisfied                    = validationID(models.HostValidationIDOcsRequirementsSatisfied)
 	AreCnvRequirementsSatisfied                    = validationID(models.HostValidationIDCnvRequirementsSatisfied)
 	SufficientOrUnknownInstallationDiskSpeed       = validationID(models.HostValidationIDSufficientInstallationDiskSpeed)
+	HasSufficientNetworkLatencyRequirementForRole  = validationID(models.HostValidationIDSufficientNetworkLatencyRequirementForRole)
+	HasSufficientPacketLossRequirementForRole      = validationID(models.HostValidationIDSufficientPacketLossRequirementForRole)
 )
 
 func (v validationID) category() (string, error) {
 	switch v {
 	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr,
-		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability:
+		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole:
 		return "network", nil
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory, SufficientOrUnknownInstallationDiskSpeed,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid:

--- a/models/cluster_host_requirements_details.go
+++ b/models/cluster_host_requirements_details.go
@@ -24,6 +24,12 @@ type ClusterHostRequirementsDetails struct {
 	// Required installation disk speed in ms
 	InstallationDiskSpeedThresholdMs int64 `json:"installation_disk_speed_threshold_ms,omitempty"`
 
+	// Maximum network average latency (RTT) at L3 for role.
+	NetworkLatencyThresholdMs *float64 `json:"network_latency_threshold_ms,omitempty"`
+
+	// Maximum packet loss allowed at L3 for role.
+	PacketLossPercentage *float64 `json:"packet_loss_percentage,omitempty"`
+
 	// Required number of RAM in MiB
 	RAMMib int64 `json:"ram_mib,omitempty"`
 }

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -79,6 +79,12 @@ const (
 
 	// HostValidationIDCnvRequirementsSatisfied captures enum value "cnv-requirements-satisfied"
 	HostValidationIDCnvRequirementsSatisfied HostValidationID = "cnv-requirements-satisfied"
+
+	// HostValidationIDSufficientNetworkLatencyRequirementForRole captures enum value "sufficient-network-latency-requirement-for-role"
+	HostValidationIDSufficientNetworkLatencyRequirementForRole HostValidationID = "sufficient-network-latency-requirement-for-role"
+
+	// HostValidationIDSufficientPacketLossRequirementForRole captures enum value "sufficient-packet-loss-requirement-for-role"
+	HostValidationIDSufficientPacketLossRequirementForRole HostValidationID = "sufficient-packet-loss-requirement-for-role"
 )
 
 // for schema
@@ -86,7 +92,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5367,6 +5367,18 @@ func init() {
           "description": "Required installation disk speed in ms",
           "type": "integer"
         },
+        "network_latency_threshold_ms": {
+          "description": "Maximum network average latency (RTT) at L3 for role.",
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
+        "packet_loss_percentage": {
+          "description": "Maximum packet loss allowed at L3 for role.",
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
         "ram_mib": {
           "description": "Required number of RAM in MiB",
           "type": "integer"
@@ -6699,7 +6711,9 @@ func init() {
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
         "sufficient-installation-disk-speed",
-        "cnv-requirements-satisfied"
+        "cnv-requirements-satisfied",
+        "sufficient-network-latency-requirement-for-role",
+        "sufficient-packet-loss-requirement-for-role"
       ]
     },
     "host_network": {
@@ -13140,6 +13154,18 @@ func init() {
           "description": "Required installation disk speed in ms",
           "type": "integer"
         },
+        "network_latency_threshold_ms": {
+          "description": "Maximum network average latency (RTT) at L3 for role.",
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
+        "packet_loss_percentage": {
+          "description": "Maximum packet loss allowed at L3 for role.",
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
         "ram_mib": {
           "description": "Required number of RAM in MiB",
           "type": "integer"
@@ -14396,7 +14422,9 @@ func init() {
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
         "sufficient-installation-disk-speed",
-        "cnv-requirements-satisfied"
+        "cnv-requirements-satisfied",
+        "sufficient-network-latency-requirement-for-role",
+        "sufficient-packet-loss-requirement-for-role"
       ]
     },
     "host_network": {

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		steps := getNextSteps(clusterID, *host.ID)
 		checkStepsInList(steps, []models.StepType{models.StepTypeInventory}, 1)
 
-		By("checking insufficient state state - one host, no conenctivity check")
+		By("checking insufficient state state - one host, no connectivity check")
 		generateEssentialHostSteps(ctx, h, "h1host")
 		waitForHostState(ctx, clusterID, *h.ID, "insufficient", 60*time.Second)
 		steps = getNextSteps(clusterID, *host.ID)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3410,6 +3410,16 @@ definitions:
       installation_disk_speed_threshold_ms:
         type: integer
         description: Required installation disk speed in ms
+      network_latency_threshold_ms:
+        type: number
+        format: double
+        x-nullable: true
+        description: Maximum network average latency (RTT) at L3 for role.
+      packet_loss_percentage:
+        type: number
+        format: double
+        x-nullable: true
+        description: Maximum packet loss allowed at L3 for role.
 
   versioned-host-requirements:
     type: object
@@ -4994,6 +5004,8 @@ definitions:
       - 'ocs-requirements-satisfied'
       - 'sufficient-installation-disk-speed'
       - 'cnv-requirements-satisfied'
+      - 'sufficient-network-latency-requirement-for-role'
+      - 'sufficient-packet-loss-requirement-for-role'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
*Update:*
* ~~The code now incorporates a new environment variable that specifies which hosts validations to disable. This change allows this new 2 validations to be added to the code as disabled, and avoid the potential impact in production environments.~~
* ~~This PR contains the commit from #1528~~  

--------------8<-----------------------8<------------------------8<-----------------------8<------------------------------

* Adds 2 new network validations to the host profile as disabled:

  * Network latency for role: Leverages on the L3 connectivity remote host object to validate that each connection between the given host and any other host with the same role has a latency lower or equal than the threshold defined in the given role (master or worker). 
  * Packet loss for role: Also leverages on the L3 connectivity remote host object to validate that the packet loss between hosts is lower or equal than the reported one by the agent.

These validations don't have any predefined threshold values,  pending from analyzing the telemetry in production deployments and to avoid such environments from failing day 2 cluster management operations. 

This [PR](https://github.com/openshift/assisted-installer-agent/pull/187) is the counterpart in the assisted-installer-agent.

@pkliczewski @jakub-dzon @machacekondra @masayag @YuviGold @avishayt please review at your discretion.

Thanks,

/Jordi

Signed-off-by: Jordi Gil <jgil@redhat.com>