### PR TITLE
NO-ISSUE - Jenkins slack message distinction between failure and user abort

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
             script {
                 if ((env.BRANCH_NAME == 'master') && (currentBuild.currentResult == "ABORTED" || currentBuild.currentResult == "FAILURE")){
                     script {
-                        def data = [text: "Attention! ${BUILD_TAG} job failed, see: ${BUILD_URL}"]
+                        def data = [text: "Attention! ${BUILD_TAG} job ${currentBuild.currentResult}, see: ${BUILD_URL}"]
                         writeJSON(file: 'data.txt', json: data, pretty: 4)
                     }
 


### PR DESCRIPTION
Users may abort Jenkins jobs, it would be nice to know whether a job was
aborted or whether it actually failed in the Slack message.

This is what it looked like before:
![image](https://user-images.githubusercontent.com/10882062/113503923-94fbb680-953d-11eb-8b53-ebe387638b96.png)

Hopefully, after it would say either `"Attention! ... job ABORTED", ..."` or `"Attention! ... job FAILURE, ..."`