### PR TITLE
OCPBUGSM-27182 Backward-compatible IsOperatorAvailable function

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -541,6 +541,14 @@ func CanDownloadKubeconfig(c *common.Cluster) (err error) {
 }
 
 func (m *Manager) IsOperatorAvailable(c *common.Cluster, operatorName string) bool {
+	// TODO: MGMT-4458
+	// Backward-compatible solution for clusters that don't have monitored operators data
+	if len(c.MonitoredOperators) == 0 {
+		clusterStatus := swag.StringValue(c.Status)
+		allowedStatuses := []string{models.ClusterStatusInstalling, models.ClusterStatusFinalizing, models.ClusterStatusInstalled}
+		return funk.ContainsString(allowedStatuses, clusterStatus)
+	}
+
 	for _, o := range c.MonitoredOperators {
 		if o.Name == operatorName {
 			return o.Status == models.OperatorStatusAvailable


### PR DESCRIPTION
On https://github.com/openshift/assisted-service/pull/1384
GetCredentials function logic changed to support looking on the
operator's status instead of on the cluster status. Hence when asking
for credentials the console operator status will be checked.

This change wasn't backward-compatible for clusters that don't weren't
registered and initialized with monitored operators' data. Hence, need to
keep checking the previous way for the cluster status for clusters that
don't have monitored operators at all.

/cc @gamli75 @ybettan 