### PR TITLE
MGMT-4647 Remove HTTP409 event for `GenerateClusterISOInternal`

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -831,8 +831,6 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	previousCreatedAt := time.Time(cluster.ImageInfo.CreatedAt)
 	if previousCreatedAt.Add(10 * time.Second).After(now) {
 		log.Error("request came too soon after previous request")
-		msg := "Failed to generate image: another request to generate an image has been recently submitted - please wait a few seconds and try again"
-		b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityError, msg, time.Now())
 		return nil, common.NewApiError(
 			http.StatusConflict,
 			errors.New("Another request to generate an image has been recently submitted. Please wait a few seconds and try again."))


### PR DESCRIPTION
This change will partially resolve [MGMT-4647](https://issues.redhat.com/browse/MGMT-4647).
We will also need to follow up with backend notifications, which will not be included in this PR.

This will prevent the following:
![Screenshot from 2021-03-18 11-55-16](https://user-images.githubusercontent.com/2920292/113507590-2413c900-9554-11eb-92f0-7f37d548d290.png)
