### PR TITLE
MGMT-4697 The DownloadClusterKubeconfig API switches kubeconfig-noingress and kubeconfig

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -41,12 +41,12 @@ const DhcpLeaseTimeoutMinutes = 2
 
 var S3FileNames = []string{
 	constants.Kubeconfig,
+	constants.KubeconfigNoIngress,
 	"bootstrap.ign",
 	"master.ign",
 	"worker.ign",
 	"metadata.json",
 	"kubeadmin-password",
-	"kubeconfig-noingress",
 	"install-config.yaml",
 	"discovery.ign",
 }

--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -1,3 +1,4 @@
 package constants
 
 const Kubeconfig = "kubeconfig"
+const KubeconfigNoIngress = "kubeconfig-noingress"

--- a/internal/ignition/dummy.go
+++ b/internal/ignition/dummy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
@@ -54,7 +55,7 @@ func (g *dummyGenerator) Generate(_ context.Context, installConfig []byte) error
 		defer f.Close()
 		data := "data"
 		// use the pre-baked data
-		if fileName == "kubeconfig-noingress" {
+		if fileName == constants.KubeconfigNoIngress {
 			data = kubeconfig
 		} else if fileName == "bootstrap.ign" {
 			data = bootstrapIgnition

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -273,7 +273,7 @@ var fileNames = [...]string{
 	masterIgn,
 	"metadata.json",
 	workerIgn,
-	"kubeconfig-noingress",
+	constants.KubeconfigNoIngress,
 	"kubeadmin-password",
 	"install-config.yaml",
 }
@@ -445,7 +445,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte)
 	}
 	// after installation completes, a new kubeconfig will be created and made
 	// available that includes ingress details, so we rename this one
-	err = os.Rename(filepath.Join(g.workDir, "auth/kubeconfig"), filepath.Join(g.workDir, "kubeconfig-noingress"))
+	err = os.Rename(filepath.Join(g.workDir, "auth/kubeconfig"), filepath.Join(g.workDir, constants.KubeconfigNoIngress))
 	if err != nil {
 		return err
 	}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -27,6 +27,7 @@ import (
 	operatorsClient "github.com/openshift/assisted-service/client/operators"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/models"
 )
@@ -1711,7 +1712,7 @@ var _ = Describe("cluster install", func() {
 				// Download kubeconfig before uploading
 				kubeconfigNoIngress, err := ioutil.TempFile("", "tmp")
 				Expect(err).NotTo(HaveOccurred())
-				_, err = userBMClient.Installer.DownloadClusterFiles(ctx, &installer.DownloadClusterFilesParams{ClusterID: clusterID, FileName: "kubeconfig-noingress"}, kubeconfigNoIngress)
+				_, err = userBMClient.Installer.DownloadClusterFiles(ctx, &installer.DownloadClusterFilesParams{ClusterID: clusterID, FileName: constants.KubeconfigNoIngress}, kubeconfigNoIngress)
 				Expect(err).NotTo(HaveOccurred())
 				sni, err := kubeconfigNoIngress.Stat()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Up until now, the client (i.e. UI) had to manage the logic for when the
kubeconfig file is available (when the cluster is installed). In case
not - the client had to download kubeconfig-noingress directly.

Instead, DownloadClusterKubeconfig API manages that logic.
In case cluster's kubeconfig file is available then it will download it,
otherwise it will try to download the kubeconfig-noingress file.

/cc @tsorya  @rollandf @filanov 