### PR TITLE
MGMT-3512 Reduce disk space taken by assisted service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -344,7 +344,7 @@ func main() {
 		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi)
 
 	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"))
-	expirer := imgexpirer.NewManager(objectHandler, eventsHandler, Options.BMConfig.ImageExpirationTime, lead)
+	expirer := imgexpirer.NewManager(objectHandler, eventsHandler, Options.BMConfig.ImageExpirationTime, lead, Options.EnableKubeAPI)
 	imageExpirationMonitor := thread.New(
 		log.WithField("pkg", "image-expiration-monitor"), "Image Expiration Monitor", Options.ImageExpirationInterval, expirer.ExpirationTask)
 	imageExpirationMonitor.Start()

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5829,6 +5829,10 @@ var _ = Describe("AMS subscriptions", func() {
 		})
 
 		It("deregister cluster that don't have 'Reserved' subscriptions", func() {
+			mockS3Client = s3wrapper.NewMockAPI(ctrl)
+			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
+				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil)
 			mockClusterRegisterSuccess(bm, true)
 			mockAMSSubscription(ctx)
 
@@ -5983,6 +5987,10 @@ var _ = Describe("AMS subscriptions", func() {
 		})
 
 		It("register and deregister cluster happy flow - nil OCM client", func() {
+			mockS3Client = s3wrapper.NewMockAPI(ctrl)
+			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
+				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil)
 			bm.ocmClient = nil
 			mockClusterRegisterSuccess(bm, true)
 

--- a/internal/garbagecollector/garbageCollector.go
+++ b/internal/garbagecollector/garbageCollector.go
@@ -15,8 +15,8 @@ import (
 )
 
 type Config struct {
-	DeletedUnregisteredAfter time.Duration `envconfig:"DELETED_UNREGISTERED_AFTER" default:"168h"` // 7d
-	DeregisterInactiveAfter  time.Duration `envconfig:"DELETED_INACTIVE_AFTER" default:"720h"`     // 20d
+	DeletedUnregisteredAfter time.Duration `envconfig:"DELETED_UNREGISTERED_AFTER" default:"24h"` // 1d
+	DeregisterInactiveAfter  time.Duration `envconfig:"DELETED_INACTIVE_AFTER" default:"720h"`    // 20d
 	MaxGCClustersPerInterval int           `envconfig:"MAX_GC_CLUSTERS_PER_INTERVAL" default:"100"`
 }
 

--- a/internal/imgexpirer/imgexpirer.go
+++ b/internal/imgexpirer/imgexpirer.go
@@ -28,14 +28,16 @@ type Manager struct {
 	eventsHandler events.Handler
 	deleteTime    time.Duration
 	leaderElector leader.Leader
+	enableKubeAPI bool
 }
 
-func NewManager(objectHandler s3wrapper.API, eventsHandler events.Handler, deleteTime time.Duration, leaderElector leader.ElectorInterface) *Manager {
+func NewManager(objectHandler s3wrapper.API, eventsHandler events.Handler, deleteTime time.Duration, leaderElector leader.ElectorInterface, enableKubeAPI bool) *Manager {
 	return &Manager{
 		objectHandler: objectHandler,
 		eventsHandler: eventsHandler,
 		deleteTime:    deleteTime,
 		leaderElector: leaderElector,
+		enableKubeAPI: enableKubeAPI,
 	}
 }
 
@@ -44,7 +46,9 @@ func (m *Manager) ExpirationTask() {
 		return
 	}
 	ctx := requestid.ToContext(context.Background(), requestid.NewID())
-	m.objectHandler.ExpireObjects(ctx, imagePrefix, m.deleteTime, m.DeletedImageCallback)
+	if !m.enableKubeAPI {
+		m.objectHandler.ExpireObjects(ctx, imagePrefix, m.deleteTime, m.DeletedImageCallback)
+	}
 	m.objectHandler.ExpireObjects(ctx, AssistedServiceLiveISOPrefix, m.deleteTime, m.DeletedImageNoCallback)
 }
 

--- a/internal/imgexpirer/imgexpirer_test.go
+++ b/internal/imgexpirer/imgexpirer_test.go
@@ -39,7 +39,7 @@ var _ = Describe("imgexpirer", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		deleteTime, _ := time.ParseDuration("60m")
 		leaderMock = leader.NewMockElectorInterface(ctrl)
-		imgExp = NewManager(nil, mockEvents, deleteTime, leaderMock)
+		imgExp = NewManager(nil, mockEvents, deleteTime, leaderMock, false)
 	})
 	It("callback_valid_objname", func() {
 		clusterId := "53116787-3eb0-4211-93ac-611d5cedaa30"


### PR DESCRIPTION
The PR is responsible for reducing the amount of disk-space taken by the assisted-service and informing the user about exceeding a threshold in can kube-api is enabled:

* Delete discovery-image of deregistered clusters
* Shorten the lifetime of unregistered clusters

Signed-off-by: Moti Asayag <masayag@redhat.com>