### PR TITLE
MGMT-4834 Reconcile on backend events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ deploy-onprem-for-subsystem:
 
 deploy-on-openshift-ci:
 	ln -s $(shell which oc) $(shell dirname $(shell which oc))/kubectl
-	export TARGET='oc' && export ENABLE_KUBE_API='true' && export GENERATE_CRD='false' && unset GOFLAGS && \
+	export TARGET='oc' && export GENERATE_CRD='false' && unset GOFLAGS && \
 	$(MAKE) ci-deploy-for-subsystem
 	oc get pods
 

--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -1,0 +1,47 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/events"
+	"github.com/sirupsen/logrus"
+)
+
+type controllerEventsWrapper struct {
+	events           *events.Events
+	crdEventsHandler CRDEventsHandler
+	db               *gorm.DB
+	log              logrus.FieldLogger
+}
+
+func NewControllerEventsWrapper(crdEventsHandler CRDEventsHandler, events *events.Events, db *gorm.DB, log logrus.FieldLogger) *controllerEventsWrapper {
+	return &controllerEventsWrapper{crdEventsHandler: crdEventsHandler,
+		events: events, db: db, log: log}
+}
+
+func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time) {
+	c.events.AddEvent(ctx, clusterID, hostID, severity, msg, eventTime)
+	cluster, err := common.GetClusterFromDB(c.db, clusterID, common.SkipEagerLoading)
+	if err != nil {
+		return
+	}
+
+	// Notifying cluster deployment in case host id is nil -> cluster event
+	if hostID == nil {
+		c.log.Debugf("Pushing cluster event %s %s", cluster.KubeKeyName, cluster.KubeKeyNamespace)
+		c.crdEventsHandler.NotifyClusterDeploymentUpdates(cluster.KubeKeyName, cluster.KubeKeyNamespace)
+	} else {
+		// TODO once host will have installenv params we need to use common.GetHostFromDB()
+		// till then we will use same namespace as cluster deployment
+		c.log.Debugf("Pushing event for host %q %s %s", hostID, cluster.KubeKeyName, cluster.KubeKeyNamespace)
+		c.crdEventsHandler.NotifyAgentUpdates(hostID.String(), cluster.KubeKeyNamespace)
+	}
+}
+
+func (c *controllerEventsWrapper) GetEvents(clusterID strfmt.UUID, hostID *strfmt.UUID) ([]*common.Event, error) {
+	return c.events.GetEvents(clusterID, hostID)
+}

--- a/internal/controller/controllers/controller_event_wrapper_test.go
+++ b/internal/controller/controllers/controller_event_wrapper_test.go
@@ -1,0 +1,120 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/events"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Controller events wrapper", func() {
+	var (
+		db                   *gorm.DB
+		cluster1             *common.Cluster
+		cluster2             *common.Cluster
+		theEvents            *events.Events
+		cEventsWrapper       *controllerEventsWrapper
+		mockCtrl             *gomock.Controller
+		mockCRDEventsHandler *MockCRDEventsHandler
+		dbName               string
+		host                 = strfmt.UUID("1e45d128-4a69-4e71-9b50-a0c627217f3e")
+	)
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		mockCtrl = gomock.NewController(GinkgoT())
+		theEvents = events.New(db, logrus.WithField("pkg", "events"))
+		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
+		cEventsWrapper = NewControllerEventsWrapper(mockCRDEventsHandler, theEvents, db, logrus.New())
+		// create simple cluster
+		clusterID1 := strfmt.UUID(uuid.New().String())
+		cluster1 = &common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID1,
+			},
+			KubeKeyName:      "cluster1",
+			KubeKeyNamespace: "cluster1Nm",
+		}
+
+		clusterID2 := strfmt.UUID(uuid.New().String())
+		cluster2 = &common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID2,
+			},
+			KubeKeyName:      "cluster2",
+			KubeKeyNamespace: "cluster2Nm",
+		}
+
+	})
+	numOfEvents := func(clusterID strfmt.UUID, hostID *strfmt.UUID) int {
+		evs, err := cEventsWrapper.GetEvents(clusterID, hostID)
+		Expect(err).Should(BeNil())
+		return len(evs)
+	}
+
+	Context("Initially", func() {
+		It("No events for cluster1 ", func() {
+			nEvents := numOfEvents(*cluster1.ID, nil)
+			Expect(nEvents).Should(Equal(0))
+		})
+		It("No events for cluster2 ", func() {
+			nEvents := numOfEvents(*cluster2.ID, nil)
+			Expect(nEvents).Should(Equal(0))
+		})
+
+	})
+
+	Context("With events", func() {
+		It("Adding a cluster event", func() {
+			mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(cluster1.KubeKeyName, cluster1.KubeKeyNamespace).Times(1)
+			cEventsWrapper.AddEvent(context.TODO(), *cluster1.ID, nil, models.EventSeverityInfo, "the event1", time.Now())
+			Expect(numOfEvents(*cluster1.ID, nil)).Should(Equal(1))
+			Expect(numOfEvents(*cluster2.ID, nil)).Should(Equal(0))
+
+			evs, err := cEventsWrapper.GetEvents(*cluster1.ID, nil)
+			Expect(err).Should(BeNil())
+			Expect(evs[0]).Should(WithMessage(swag.String("the event1")))
+			Expect(evs[0]).Should(WithSeverity(swag.String(models.EventSeverityInfo)))
+
+			mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(cluster2.KubeKeyName, cluster2.KubeKeyNamespace).Times(1)
+			cEventsWrapper.AddEvent(context.TODO(), *cluster2.ID, nil, models.EventSeverityInfo, "event2", time.Now())
+			Expect(numOfEvents(*cluster1.ID, nil)).Should(Equal(1))
+			Expect(numOfEvents(*cluster2.ID, nil)).Should(Equal(1))
+		})
+
+		It("Adding a host event ", func() {
+			mockCRDEventsHandler.EXPECT().NotifyAgentUpdates(&host, cluster1.KubeKeyNamespace).Times(1)
+			cEventsWrapper.AddEvent(context.TODO(), *cluster1.ID, &host, models.EventSeverityInfo, "event2", time.Now())
+			Expect(numOfEvents(*cluster1.ID, nil)).Should(Equal(1))
+			Expect(numOfEvents(*cluster1.ID, &host)).Should(Equal(1))
+		})
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+})
+
+func WithMessage(msg *string) types.GomegaMatcher {
+	return WithTransform(func(e *common.Event) *string {
+		return e.Message
+	}, Equal(msg))
+}
+
+func WithSeverity(severity *string) types.GomegaMatcher {
+	return WithTransform(func(e *common.Event) *string {
+		return e.Severity
+	}, Equal(severity))
+}

--- a/internal/controller/controllers/crd_events_handler.go
+++ b/internal/controller/controllers/crd_events_handler.go
@@ -9,21 +9,23 @@ import (
 type CRDEventsHandler interface {
 	NotifyClusterDeploymentUpdates(clusterDeploymentName string, clusterDeploymentNamespace string)
 	NotifyInstallEnvUpdates(installEnvName string, installEnvNamespace string)
+	NotifyAgentUpdates(agentName string, agentNamespace string)
 	GetInstallEnvUpdates() chan event.GenericEvent
 	GetClusterDeploymentUpdates() chan event.GenericEvent
+	GetAgentUpdates() chan event.GenericEvent
 }
 
 type CRDEventsHandlerChannels struct {
-	ClusterDeploymentUpdates chan event.GenericEvent
-	InstallEnvUpdates        chan event.GenericEvent
+	clusterDeploymentUpdates chan event.GenericEvent
+	installEnvUpdates        chan event.GenericEvent
+	agentUpdates             chan event.GenericEvent
 }
 
 func NewCRDEventsHandler() CRDEventsHandler {
-	clusterDeploymentUpdates := make(chan event.GenericEvent)
-	installEnvUpdates := make(chan event.GenericEvent)
 	return &CRDEventsHandlerChannels{
-		ClusterDeploymentUpdates: clusterDeploymentUpdates,
-		InstallEnvUpdates:        installEnvUpdates,
+		clusterDeploymentUpdates: make(chan event.GenericEvent),
+		installEnvUpdates:        make(chan event.GenericEvent),
+		agentUpdates:             make(chan event.GenericEvent),
 	}
 }
 
@@ -37,16 +39,25 @@ func (h *CRDEventsHandlerChannels) NotifyUpdates(ch chan<- event.GenericEvent, n
 }
 
 func (h *CRDEventsHandlerChannels) NotifyClusterDeploymentUpdates(clusterDeploymentName string, clusterDeploymentNamespace string) {
-	h.NotifyUpdates(h.ClusterDeploymentUpdates, clusterDeploymentName, clusterDeploymentNamespace)
+	h.NotifyUpdates(h.clusterDeploymentUpdates, clusterDeploymentName, clusterDeploymentNamespace)
+}
+
+func (h *CRDEventsHandlerChannels) NotifyAgentUpdates(agentName string, agentNamespace string) {
+	h.NotifyUpdates(h.agentUpdates, agentName, agentNamespace)
 }
 
 func (h *CRDEventsHandlerChannels) NotifyInstallEnvUpdates(installEnvName string, installEnvNamespace string) {
-	h.NotifyUpdates(h.InstallEnvUpdates, installEnvName, installEnvNamespace)
+	h.NotifyUpdates(h.installEnvUpdates, installEnvName, installEnvNamespace)
 }
 
 func (h *CRDEventsHandlerChannels) GetInstallEnvUpdates() chan event.GenericEvent {
-	return h.InstallEnvUpdates
+	return h.installEnvUpdates
 }
+
 func (h *CRDEventsHandlerChannels) GetClusterDeploymentUpdates() chan event.GenericEvent {
-	return h.ClusterDeploymentUpdates
+	return h.clusterDeploymentUpdates
+}
+
+func (h *CRDEventsHandlerChannels) GetAgentUpdates() chan event.GenericEvent {
+	return h.agentUpdates
 }

--- a/internal/controller/controllers/mock_crd_events_handler.go
+++ b/internal/controller/controllers/mock_crd_events_handler.go
@@ -34,6 +34,20 @@ func (m *MockCRDEventsHandler) EXPECT() *MockCRDEventsHandlerMockRecorder {
 	return m.recorder
 }
 
+// GetAgentUpdates mocks base method
+func (m *MockCRDEventsHandler) GetAgentUpdates() chan event.GenericEvent {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAgentUpdates")
+	ret0, _ := ret[0].(chan event.GenericEvent)
+	return ret0
+}
+
+// GetAgentUpdates indicates an expected call of GetAgentUpdates
+func (mr *MockCRDEventsHandlerMockRecorder) GetAgentUpdates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentUpdates", reflect.TypeOf((*MockCRDEventsHandler)(nil).GetAgentUpdates))
+}
+
 // GetClusterDeploymentUpdates mocks base method
 func (m *MockCRDEventsHandler) GetClusterDeploymentUpdates() chan event.GenericEvent {
 	m.ctrl.T.Helper()
@@ -60,6 +74,18 @@ func (m *MockCRDEventsHandler) GetInstallEnvUpdates() chan event.GenericEvent {
 func (mr *MockCRDEventsHandlerMockRecorder) GetInstallEnvUpdates() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallEnvUpdates", reflect.TypeOf((*MockCRDEventsHandler)(nil).GetInstallEnvUpdates))
+}
+
+// NotifyAgentUpdates mocks base method
+func (m *MockCRDEventsHandler) NotifyAgentUpdates(arg0, arg1 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyAgentUpdates", arg0, arg1)
+}
+
+// NotifyAgentUpdates indicates an expected call of NotifyAgentUpdates
+func (mr *MockCRDEventsHandlerMockRecorder) NotifyAgentUpdates(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyAgentUpdates", reflect.TypeOf((*MockCRDEventsHandler)(nil).NotifyAgentUpdates), arg0, arg1)
 }
 
 // NotifyClusterDeploymentUpdates mocks base method


### PR DESCRIPTION
Currently we reconcile every few seconds regardless if there was a change on the resource.
The reconcile should be based on two things, changes in the spec and based on changed from the backend. the important changes are state and validations. for both we have events.
So we should have a wrapper for the events interface that will notify host/cluster about the changes.
If the event contain host-id then agent resource should get a notification, otherwise cluster resource.
Both cluster and host have a kube key (namespace name) so a generic event can be used to notify the controller
The controllers will listen to channel that will get those events and call for a reconcile loop according to it.