### PR TITLE
MGMT-4523: Exposing ams_subscription_id field in API cluster model.

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -38,9 +38,6 @@ type Cluster struct {
 	// Namespace of the KubeAPI resource
 	KubeKeyNamespace string `json:"kube_key_namespace"`
 
-	// The ID of the subscription created in AMS
-	AmsSubscriptionID strfmt.UUID `json:"ams_subscription_id"`
-
 	// Indication if we updated console_url in AMS subscription
 	IsAmsSubscriptionConsoleUrlSet bool `json:"is_ams_subscription_console_url_set"`
 

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -23,6 +23,10 @@ type Cluster struct {
 	// A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
 	AdditionalNtpSource string `json:"additional_ntp_source,omitempty"`
 
+	// Unique identifier of the AMS subscription in OCM.
+	// Format: uuid
+	AmsSubscriptionID strfmt.UUID `json:"ams_subscription_id,omitempty"`
+
 	// The virtual IP used to reach the OpenShift cluster's API.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))$
 	APIVip string `json:"api_vip,omitempty"`
@@ -206,6 +210,10 @@ type Cluster struct {
 func (m *Cluster) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAmsSubscriptionID(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateAPIVip(formats); err != nil {
 		res = append(res, err)
 	}
@@ -317,6 +325,19 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Cluster) validateAmsSubscriptionID(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.AmsSubscriptionID) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("ams_subscription_id", "body", "uuid", m.AmsSubscriptionID.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4747,6 +4747,11 @@ func init() {
           "description": "A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.",
           "type": "string"
         },
+        "ams_subscription_id": {
+          "description": "Unique identifier of the AMS subscription in OCM.",
+          "type": "string",
+          "format": "uuid"
+        },
         "api_vip": {
           "description": "The virtual IP used to reach the OpenShift cluster's API.",
           "type": "string",
@@ -12272,6 +12277,11 @@ func init() {
         "additional_ntp_source": {
           "description": "A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.",
           "type": "string"
+        },
+        "ams_subscription_id": {
+          "description": "Unique identifier of the AMS subscription in OCM.",
+          "type": "string",
+          "format": "uuid"
         },
         "api_vip": {
           "description": "The virtual IP used to reach the OpenShift cluster's API.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4130,6 +4130,10 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/monitored-operator'
+      ams_subscription_id:
+        type: string
+        format: uuid
+        description: Unique identifier of the AMS subscription in OCM.
 
   image_info:
     type: object


### PR DESCRIPTION
UI needs it so they can query clusters from the service using
ams_subscription_id, therefore, it should be exposed for the user.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>