### PR TITLE
MGMT-4891 Validate hostNMConnections is not empty

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/executer"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v2"
@@ -99,6 +100,9 @@ func (s *StaticNetworkConfigGenerator) createNMConnectionFiles(nmstateOutput, ho
 	if err != nil {
 		s.log.WithError(err).Errorf("Failed to unmarshal nmstate output")
 		return nil, err
+	}
+	if _, found := hostNMConnections["NetworkManager"]; !found {
+		return nil, errors.Errorf("nmstate generated an empty NetworkManager config file content")
 	}
 	filesList := []StaticNetworkConfigData{}
 	connectionsList := hostNMConnections["NetworkManager"].([]interface{})


### PR DESCRIPTION
A valid YAML, which is an invalid nmstatectl config, will cause assisted-service to crash.
The root cause for this is the fact that nmstatectl returns an empty config {} when it gets flags it does not recognize, and additionally return code=0

This is causing a panic in assisted-service, which won't be recovered until we delete that nmstate config.

nmstatectl returns an empty config and return code 0 here: https://github.com/openshift/assisted-service/blob/0d2c0170ff0ada57c7803246c0c961313baad860/pkg/staticnetworkconfig/generator.go#L76

Next, we have: https://github.com/openshift/assisted-service/blob/0d2c0170ff0ada57c7803246c0c961313baad860/pkg/staticnetworkconfig/generator.go#L96-L104
This empty config is accepted by `yaml.Unmarshal`, thus no error returned, but hostNMConnections["NetworkManager"] (line#104) is empty and the panic happens.

This PR offers a possible solution to avoid the panic, but we need to make sure we indeed want to bail out for the entire cluster if a single nmstate config is invalid.