### PR TITLE
NO-ISSUE: Fixing update of console URL in OCM.

### DIFF
--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -232,6 +232,16 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		PostTransition:   th.PostRefreshCluster(statusInfoInstalling),
 	})
 
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRefreshStatus,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.ClusterStatusFinalizing),
+		},
+		DestinationState: stateswitch.State(models.ClusterStatusFinalizing),
+		Condition:        th.WithAMSSubscriptions,
+		PostTransition:   th.PostUpdateFinalizingAMSConsoleUrl,
+	})
+
 	// This transition is fired when the cluster is in finalizing
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeRefreshStatus,
@@ -252,16 +262,6 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.Not(th.IsInstalling)),
 		DestinationState: stateswitch.State(models.ClusterStatusError),
 		PostTransition:   th.PostRefreshCluster(statusInfoError),
-	})
-
-	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType: TransitionTypeRefreshStatus,
-		SourceStates: []stateswitch.State{
-			stateswitch.State(models.ClusterStatusFinalizing),
-		},
-		DestinationState: stateswitch.State(models.ClusterStatusFinalizing),
-		Condition:        th.WithAMSSubscriptions,
-		PostTransition:   th.PostUpdateFinalizingAMSConsoleUrl,
 	})
 
 	for _, state := range []stateswitch.State{

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -364,7 +364,8 @@ func (th *transitionHandler) WithAMSSubscriptions(sw stateswitch.StateSwitch, ar
 	if !ok {
 		return false, errors.New("WithAMSSubscriptions invalid argument")
 	}
-	if params.ocmClient != nil && params.ocmClient.Config.WithAMSSubscriptions && !sCluster.cluster.IsAmsSubscriptionConsoleUrlSet {
+	if params.ocmClient != nil && params.ocmClient.Config.WithAMSSubscriptions &&
+		!sCluster.cluster.IsAmsSubscriptionConsoleUrlSet && params.clusterAPI.IsOperatorAvailable(sCluster.cluster, operators.OperatorConsole.Name) {
 		return true, nil
 	}
 	return false, nil
@@ -380,9 +381,6 @@ func (th *transitionHandler) PostUpdateFinalizingAMSConsoleUrl(sw stateswitch.St
 		return errors.New("PostUpdateFinalizingAMSConsoleUrl invalid argument")
 	}
 	log := logutil.FromContext(params.ctx, th.log)
-	if !params.clusterAPI.IsOperatorAvailable(sCluster.cluster, operators.OperatorConsole.Name) {
-		return nil
-	}
 	subscriptionID := sCluster.cluster.AmsSubscriptionID
 	consoleUrl := fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, sCluster.cluster.Name, sCluster.cluster.BaseDNSDomain)
 	if err := params.ocmClient.AccountsMgmt.UpdateSubscriptionConsoleUrl(params.ctx, subscriptionID, consoleUrl); err != nil {

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -270,6 +270,7 @@ var _ = Describe("Transition tests", func() {
 						Status:             swag.String(models.ClusterStatusFinalizing),
 						MonitoredOperators: t.operators,
 					},
+					IsAmsSubscriptionConsoleUrlSet: true,
 				}
 				Expect(common.LoadTableFromDB(db, common.MonitoredOperatorsTable).Create(&c).Error).ShouldNot(HaveOccurred())
 
@@ -2842,7 +2843,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(),
 						gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 				}
-				if t.srcState == models.ClusterStatusFinalizing {
+				if t.srcState == models.ClusterStatusFinalizing && !t.requiresAMSUpdate {
 					mockS3Api.EXPECT().DoesObjectExist(ctx, fmt.Sprintf("%s/%s", cluster.ID, constants.Kubeconfig)).Return(false, nil)
 				}
 				reportInstallationCompleteStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError}


### PR DESCRIPTION
Reordered the transitions in such why updating the console URL in OCM
won't be skipped and also added a condition to the transition so the
console URL is updated only when the console operator gets available.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>