### PR TITLE
MGMT-4910 - set hyperthreading configuration to install-config based on cluster configuration. User can set the following options: all (default), none, masters(only masters have hyperthreading enabled), workers(only workers have hyperthreading enabled)

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -303,6 +303,9 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 	if params.NewClusterParams.UserManagedNetworking == nil {
 		params.NewClusterParams.UserManagedNetworking = swag.Bool(false)
 	}
+	if params.NewClusterParams.Hyperthreading == nil {
+		params.NewClusterParams.Hyperthreading = swag.String(models.ClusterHyperthreadingAll)
+	}
 
 	return params
 }
@@ -434,6 +437,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			AdditionalNtpSource:      swag.StringValue(params.NewClusterParams.AdditionalNtpSource),
 			MonitoredOperators:       monitoredOperators,
 			HighAvailabilityMode:     params.NewClusterParams.HighAvailabilityMode,
+			Hyperthreading:           swag.StringValue(params.NewClusterParams.Hyperthreading),
 		},
 		KubeKeyName:      kubeKey.Name,
 		KubeKeyNamespace: kubeKey.Namespace,
@@ -1836,6 +1840,7 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 	optionalParam(params.ClusterUpdateParams.HTTPSProxy, "https_proxy", updates)
 	optionalParam(params.ClusterUpdateParams.NoProxy, "no_proxy", updates)
 	optionalParam(params.ClusterUpdateParams.SSHPublicKey, "ssh_public_key", updates)
+	optionalParam(params.ClusterUpdateParams.Hyperthreading, "hyperthreading", updates)
 
 	if err = b.updateNetworkParams(params, cluster, updates, log); err != nil {
 		return err

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -310,6 +310,25 @@ var _ = Describe("installcfg", func() {
 		Expect(result.Networking.NetworkType).Should(Equal(OvnKubernetes))
 	})
 
+	It("Hyperthreading config", func() {
+		cluster.Hyperthreading = "none"
+		data := getBasicInstallConfig(logrus.New(), &cluster)
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal(""))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal(""))
+		cluster.Hyperthreading = "all"
+		data = getBasicInstallConfig(logrus.New(), &cluster)
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal("Enabled"))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal("Enabled"))
+		cluster.Hyperthreading = "workers"
+		data = getBasicInstallConfig(logrus.New(), &cluster)
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal(""))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal("Enabled"))
+		cluster.Hyperthreading = "masters"
+		data = getBasicInstallConfig(logrus.New(), &cluster)
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal("Enabled"))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal(""))
+	})
+
 	AfterEach(func() {
 		// cleanup
 		ctrl.Finish()


### PR DESCRIPTION
…on cluster configuration