### PR TITLE
MGMT-4929 Add Agent Approval event

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4221,7 +4221,7 @@ func (b *bareMetalInventory) GetCommonHostInternal(_ context.Context, clusterId,
 func (b *bareMetalInventory) UpdateHostApprovedInternal(ctx context.Context, clusterId, hostId string, approved bool) error {
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Updating Approved to %t Host %s Cluster %s", approved, hostId, clusterId)
-	_, err := b.GetCommonHostInternal(ctx, clusterId, hostId)
+	dbHost, err := b.GetCommonHostInternal(ctx, clusterId, hostId)
 	if err != nil {
 		return err
 	}
@@ -4230,6 +4230,8 @@ func (b *bareMetalInventory) UpdateHostApprovedInternal(ctx context.Context, clu
 		log.WithError(err).Errorf("failed to update 'approved' in host: %s", hostId)
 		return err
 	}
+	b.eventsHandler.AddEvent(ctx, strfmt.UUID(clusterId), dbHost.ID, models.EventSeverityInfo,
+		fmt.Sprintf("Host %s: updated approved to %t", hostutil.GetHostnameForMsg(&dbHost.Host), approved), time.Now())
 	return nil
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6539,6 +6539,9 @@ var _ = Describe("UpdateHostApproved", func() {
 	})
 
 	It("update approved value", func() {
+		mockEvents.EXPECT().AddEvent(gomock.Any(), clusterID, &hostID, models.EventSeverityInfo,
+			fmt.Sprintf("Host %s: updated approved to %t", hostID.String(), true),
+			gomock.Any()).Times(1)
 		err := bm.UpdateHostApprovedInternal(ctx, string(clusterID), string(hostID), true)
 		Expect(err).ShouldNot(HaveOccurred())
 		h, err := bm.GetCommonHostInternal(ctx, string(clusterID), string(hostID))

--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -30,11 +30,9 @@ func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt
 		return
 	}
 
-	// Notifying cluster deployment in case host id is nil -> cluster event
-	if hostID == nil {
-		c.log.Debugf("Pushing cluster event %s %s", cluster.KubeKeyName, cluster.KubeKeyNamespace)
-		c.crdEventsHandler.NotifyClusterDeploymentUpdates(cluster.KubeKeyName, cluster.KubeKeyNamespace)
-	} else {
+	c.log.Debugf("Pushing cluster event %s %s", cluster.KubeKeyName, cluster.KubeKeyNamespace)
+	c.crdEventsHandler.NotifyClusterDeploymentUpdates(cluster.KubeKeyName, cluster.KubeKeyNamespace)
+	if hostID != nil {
 		// TODO once host will have installenv params we need to use common.GetHostFromDB()
 		// till then we will use same namespace as cluster deployment
 		c.log.Debugf("Pushing event for host %q %s %s", hostID, cluster.KubeKeyName, cluster.KubeKeyNamespace)


### PR DESCRIPTION
This comes as a followup to [MGMT-4834](https://issues.redhat.com/browse/MGMT-4834) Reconcile on backend events
We need an event so we can reconcile when it happens.

Also, this PR will change AddEvent log to Info, so we can better track those events.
Lastly, always push clusterDeployment updates, so we reconcile changes in clusterDeployment.