### PR TITLE
NO-ISSUE Increase operator resource limit/requests

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -51,8 +51,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Limit of 30Mi and request of 20Mi made the operator undeployable on
cluster-bot clusters. Resulting in "FailedCreatePodSandBox" errors.