### PR TITLE
MGMT-4739: AgentServiceConfig controller cleanup

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,22 @@ spec:
         image: quay.io/ocpmetal/assisted-service:latest
         name: manager
         env:
+          - name: SERVICE_IMAGE
+            value: quay.io/ocpmetal/assisted-service:latest
+          - name: DATABASE_IMAGE
+            value: quay.io/ocpmetal/postgresql-12-centos7:latest
+          - name: AGENT_IMAGE
+            value: quay.io/ocpmetal/assisted-installer-agent:latest
+          - name: CONTROLLER_IMAGE
+            value: quay.io/ocpmetal/assisted-installer-controller:latest
+          - name: INSTALLER_IMAGE
+            value: quay.io/ocpmetal/assisted-installer:latest
+          - name: OPENSHIFT_VERSIONS
+            value: '{"4.6":{"display_name":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.5","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.5-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}'
+          - name: SERVICE_ACCOUNT_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           - name: NAMESPACE
             valueFrom:
               fieldRef:
@@ -49,9 +65,6 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 300Mi
           requests:
             cpu: 100m
             memory: 200Mi

--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
                  ],
                  "resources": {
                     "requests": {
-                       "storage": "20Gi"
+                       "storage": "100Gi"
                     }
                  }
               }
@@ -55,6 +55,10 @@ spec:
       version: v1alpha1
   description: |-
     Assisted Service is used to orchestrate baremetal OpenShift installations.
+
+    When creating the AgentServiceConfig CR. It is important to note that the
+    controller will only ever reconcile an AgentServiceConfig named "agent".
+    No other name will be accepted.
   displayName: Assisted Service Operator
   icon:
     - base64data: >-

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -6,7 +6,11 @@
 2. kustomize <https://github.com/kubernetes-sigs/kustomize/releases>
 3. opm <https://github.com/operator-framework/operator-registry/releases>
 
-## Building the operator
+## Building the operator bundle (optional)
+
+For development and testing purposes it may be beneficial to build the operator
+bundle and index images. If you don't __need__ to build it, just skip to
+[Deploying the Operator](#deploying-the-operator).
 
 ### Background
 
@@ -176,10 +180,6 @@ spec:
   source: assisted-service-manifests
   sourceNamespace: openshift-marketplace
   startingCSV: assisted-service-operator.v0.0.1
-  config:
-    env:
-    - name: ISO_IMAGE_TYPE
-      value: "full-iso"
 EOF
 ```
 

--- a/internal/controller/api/v1alpha1/agentserviceconfig_types.go
+++ b/internal/controller/api/v1alpha1/agentserviceconfig_types.go
@@ -26,10 +26,18 @@ import (
 type AgentServiceConfigSpec struct {
 	// FileSystemStorage defines the spec of the PersistentVolumeClaim to be
 	// created for the assisted-service's filesystem (logs, etc).
+	// With respect to the resource requests, the amount of filesystem storage
+	// consumer will depend largely on the number of clusters you intend to create.
+	// Approximate storage requiremens include:
+	//   - ~200 MB per cluster
+	//   - ~2-3 GB per supported OpenShift version
+	// 20Gi is the recommended minimum for development/testing and 100Gi is recommended
+	// for everything else.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage for service filesystem"
 	FileSystemStorage corev1.PersistentVolumeClaimSpec `json:"filesystemStorage"`
 	// DatabaseStorage defines the spec of the PersistentVolumeClaim to be
 	// created for the database's filesystem.
+	// With respect to the resource requests, a minimum of 10Gi is recommended.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage for database"
 	DatabaseStorage corev1.PersistentVolumeClaimSpec `json:"databaseStorage"`
 }
@@ -63,7 +71,10 @@ type AgentServiceConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 
-// AgentServiceConfig represents an Assisted Service deployment
+// AgentServiceConfig represents an Assisted Service deployment.
+// Only an AgentServiceConfig with name="agent" will be reconciled, for all other
+// names a "Warning" event will be emitted + message logged and it will be ignored
+// forever.
 // +operator-sdk:csv:customresourcedefinitions:displayName="Agent Service Config"
 // +operator-sdk:csv:customresourcedefinitions:order=1
 type AgentServiceConfig struct {

--- a/internal/controller/config/crd/bases/adi.io.my.domain_agentserviceconfigs.yaml
+++ b/internal/controller/config/crd/bases/adi.io.my.domain_agentserviceconfigs.yaml
@@ -19,7 +19,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentServiceConfig represents an Assisted Service deployment
+        description: AgentServiceConfig represents an Assisted Service deployment.
+          Only an AgentServiceConfig with name="agent" will be reconciled, for all
+          other names a "Warning" event will be emitted + message logged and it will
+          be ignored forever.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -38,7 +41,8 @@ spec:
             properties:
               databaseStorage:
                 description: DatabaseStorage defines the spec of the PersistentVolumeClaim
-                  to be created for the database's filesystem.
+                  to be created for the database's filesystem. With respect to the
+                  resource requests, a minimum of 10Gi is recommended.
                 properties:
                   accessModes:
                     description: 'AccessModes contains the desired access modes the
@@ -159,8 +163,14 @@ spec:
                     type: string
                 type: object
               filesystemStorage:
-                description: FileSystemStorage defines the spec of the PersistentVolumeClaim
-                  to be created for the assisted-service's filesystem (logs, etc).
+                description: 'FileSystemStorage defines the spec of the PersistentVolumeClaim
+                  to be created for the assisted-service''s filesystem (logs, etc).
+                  With respect to the resource requests, the amount of filesystem
+                  storage consumer will depend largely on the number of clusters you
+                  intend to create. Approximate storage requiremens include:   - ~200
+                  MB per cluster   - ~2-3 GB per supported OpenShift version 20Gi
+                  is the recommended minimum for development/testing and 100Gi is
+                  recommended for everything else.'
                 properties:
                   accessModes:
                     description: 'AccessModes contains the desired access modes the

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -410,7 +410,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AgentServiceConfig represents an Assisted Service deployment
+        description: AgentServiceConfig represents an Assisted Service deployment. Only an AgentServiceConfig with name="agent" will be reconciled, for all other names a "Warning" event will be emitted + message logged and it will be ignored forever.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -424,7 +424,7 @@ spec:
             description: AgentServiceConfigSpec defines the desired state of AgentServiceConfig
             properties:
               databaseStorage:
-                description: DatabaseStorage defines the spec of the PersistentVolumeClaim to be created for the database's filesystem.
+                description: DatabaseStorage defines the spec of the PersistentVolumeClaim to be created for the database's filesystem. With respect to the resource requests, a minimum of 10Gi is recommended.
                 properties:
                   accessModes:
                     description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
@@ -510,7 +510,7 @@ spec:
                     type: string
                 type: object
               filesystemStorage:
-                description: FileSystemStorage defines the spec of the PersistentVolumeClaim to be created for the assisted-service's filesystem (logs, etc).
+                description: 'FileSystemStorage defines the spec of the PersistentVolumeClaim to be created for the assisted-service''s filesystem (logs, etc). With respect to the resource requests, the amount of filesystem storage consumer will depend largely on the number of clusters you intend to create. Approximate storage requiremens include:   - ~200 MB per cluster   - ~2-3 GB per supported OpenShift version 20Gi is the recommended minimum for development/testing and 100Gi is recommended for everything else.'
                 properties:
                   accessModes:
                     description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -2,6 +2,9 @@ package controllers
 
 import (
 	"context"
+	"crypto/rand"
+	"math/big"
+	"strings"
 
 	adiiov1alpha1 "github.com/openshift/assisted-service/internal/controller/api/v1alpha1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -51,4 +54,49 @@ func addAppLabel(appName string, meta *metav1.ObjectMeta) {
 		meta.Labels = make(map[string]string)
 	}
 	meta.Labels["app"] = appName
+}
+
+// generatePassword generates a password of a given length out of the acceptable
+// ASCII characters suitable for a password
+// taken from https://github.com/CrunchyData/postgres-operator/blob/383dfa95991553352623f14d3d0d4c9193795855/internal/util/secrets.go#L75
+func generatePassword(length int) (string, error) {
+	password := make([]byte, length)
+
+	// passwordCharLower is the lowest ASCII character to use for generating a
+	// password, which is 40
+	passwordCharLower := int64(40)
+	// passwordCharUpper is the highest ASCII character to use for generating a
+	// password, which is 126
+	passwordCharUpper := int64(126)
+	// passwordCharExclude is a map of characters that we choose to exclude from
+	// the password to simplify usage in the shell. There is still enough entropy
+	// that exclusion of these characters is OK.
+	passwordCharExclude := "`\\"
+
+	// passwordCharSelector is a "big int" that we need to select the random ASCII
+	// character for the password. Since the random integer generator looks for
+	// values from [0,X), we need to force this to be [40,126]
+	passwordCharSelector := big.NewInt(passwordCharUpper - passwordCharLower)
+
+	i := 0
+
+	for i < length {
+		val, err := rand.Int(rand.Reader, passwordCharSelector)
+		// if there is an error generating the random integer, return
+		if err != nil {
+			return "", err
+		}
+
+		char := byte(passwordCharLower + val.Int64())
+
+		// if the character is in the exclusion list, continue
+		if idx := strings.IndexAny(string(char), passwordCharExclude); idx > -1 {
+			continue
+		}
+
+		password[i] = char
+		i++
+	}
+
+	return string(password), nil
 }

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -20,6 +20,10 @@ import (
 	"os"
 )
 
+const (
+	OpenshiftVersionsEnvVar string = "OPENSHIFT_VERSIONS"
+)
+
 func ServiceImage() string {
 	return getEnvVar("SERVICE_IMAGE", "quay.io/ocpmetal/assisted-service:latest")
 }
@@ -38,6 +42,17 @@ func ControllerImage() string {
 
 func InstallerImage() string {
 	return getEnvVar("INSTALLER_IMAGE", "quay.io/ocpmetal/assisted-installer:latest")
+}
+
+func ServiceAccountName() string {
+	return getEnvVar("SERVICE_ACCOUNT_NAME", "default")
+}
+
+// This is left blank so that we don't include the json string in source
+// it should always be specified on the CSV (and operator deployment)
+// and is enforced in cmd/operator/main.go
+func OpenshiftVersions() string {
+	return getEnvVar(OpenshiftVersionsEnvVar, "")
 }
 
 func getEnvVar(key, def string) string {


### PR DESCRIPTION
The original PR#1422 left some comments unaddressed. This commit
addresses those comments and other concerns:

- Moving the passwordGenerator to common.go
- Making the error message when NAMESPACE isn't specified more clear
- Documenting that building the bundle+index isn't required
- Simplifying controller constants
- Abstracting the newFilesystemPVC+newDatabasePVC -> newPVC
- Emitting an event when reconcile completes
- Handle OPENSHIFT_VERSIONS
- Set IPV6_SUPPORT to True on assisted-service
- Set requests on assisted-service+postgres containers
- Add some basic guidelines for the filesystem+database PVC requests
- Add SERVICE_ACCOUNT_NAME using d/w API to operator, pass that to
  the assisted-service-deployment
- Add 'http://' to host for `SERVICE_BASE_URL`