### PR TITLE
MGMT-4914: BMAC sets IgnitionConfigOverride to agent

### DIFF
--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -171,6 +171,8 @@ type AgentSpec struct {
 	InstallationDiskID string `json:"installation_disk_id,omitempty"`
 	// Json formatted string containing the user overrides for the host's coreos installer args
 	InstallerArgs string `json:"installerArgs,omitempty"`
+	// Json formatted string containing the user overrides for the host's ignition config
+	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
 }
 
 type HardwareValidationInfo struct {

--- a/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -62,6 +62,10 @@ spec:
                 type: object
               hostname:
                 type: string
+              ignitionConfigOverride:
+                description: Json formatted string containing the user overrides for
+                  the host's ignition config
+                type: string
               installation_disk_id:
                 description: InstallationDiskID defines the installation destination
                   disk (must be equal to the inventory disk id).

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -53,6 +53,9 @@ spec:
                 type: object
               hostname:
                 type: string
+              ignitionConfigOverride:
+                description: Json formatted string containing the user overrides for the host's ignition config
+                type: string
               installation_disk_id:
                 description: InstallationDiskID defines the installation destination disk (must be equal to the inventory disk id).
                 type: string

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -52,16 +52,17 @@ type BMACReconciler struct {
 }
 
 const (
-	AGENT_BMH_LABEL                 = "agent-install.openshift.io/bmh"
-	BMH_AGENT_ROLE                  = "bmac.agent-install.openshift.io/role"
-	BMH_AGENT_HOSTNAME              = "bmac.agent-install.openshift.io/hostname"
-	BMH_AGENT_MACHINE_CONFIG_POOL   = "bmac.agent-install.openshift.io/machine-config-pool"
-	BMH_INSTALL_ENV_LABEL           = "infraenvs.agent-install.openshift.io"
-	BMH_AGENT_INSTALLER_ARGS        = "bmac.agent-install.openshift.io/installer-args"
-	BMH_INSPECT_ANNOTATION          = "inspect.metal3.io"
-	BMH_HARDWARE_DETAILS_ANNOTATION = "inspect.metal3.io/hardwaredetails"
-	MACHINE_ROLE                    = "machine.openshift.io/cluster-api-machine-role"
-	MACHINE_TYPE                    = "machine.openshift.io/cluster-api-machine-type"
+	AGENT_BMH_LABEL                    = "agent-install.openshift.io/bmh"
+	BMH_AGENT_ROLE                     = "bmac.agent-install.openshift.io/role"
+	BMH_AGENT_HOSTNAME                 = "bmac.agent-install.openshift.io/hostname"
+	BMH_AGENT_MACHINE_CONFIG_POOL      = "bmac.agent-install.openshift.io/machine-config-pool"
+	BMH_INSTALL_ENV_LABEL              = "infraenvs.agent-install.openshift.io"
+	BMH_AGENT_INSTALLER_ARGS           = "bmac.agent-install.openshift.io/installer-args"
+	BMH_INSPECT_ANNOTATION             = "inspect.metal3.io"
+	BMH_HARDWARE_DETAILS_ANNOTATION    = "inspect.metal3.io/hardwaredetails"
+	BMH_AGENT_IGNITION_CONFIG_OVERRIDE = "bmac.agent-install.openshift.io/ignition-config-overrides"
+	MACHINE_ROLE                       = "machine.openshift.io/cluster-api-machine-role"
+	MACHINE_TYPE                       = "machine.openshift.io/cluster-api-machine-type"
 )
 
 // reconcileResult is an interface that encapsulates the result of a Reconcile
@@ -219,6 +220,10 @@ func (r *BMACReconciler) reconcileAgentSpec(bmh *bmh_v1alpha1.BareMetalHost, age
 
 	if val, ok := annotations[BMH_AGENT_INSTALLER_ARGS]; ok {
 		agent.Spec.InstallerArgs = val
+	}
+
+	if val, ok := annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDE]; ok {
+		agent.Spec.IgnitionConfigOverride = val
 	}
 
 	agent.Spec.Approved = true

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -242,6 +242,7 @@ var _ = Describe("bmac reconcile", func() {
 			annotations[BMH_AGENT_HOSTNAME] = "happy-meal"
 			annotations[BMH_AGENT_MACHINE_CONFIG_POOL] = "number-8"
 			annotations[BMH_AGENT_INSTALLER_ARGS] = `["--args", "aaaa"]`
+			annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDE] = "agent-ignition"
 			host.ObjectMeta.SetAnnotations(annotations)
 			Expect(c.Create(ctx, host)).To(BeNil())
 
@@ -317,6 +318,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedAgent.Spec.Hostname).To(Equal("happy-meal"))
 				Expect(updatedAgent.Spec.MachineConfigPool).To(Equal("number-8"))
 				Expect(updatedAgent.Spec.InstallerArgs).To(Equal(`["--args", "aaaa"]`))
+				Expect(updatedAgent.Spec.IgnitionConfigOverride).To(Equal("agent-ignition"))
 			})
 
 			It("should keep InstallationDiskID as empty string if not RootDeviceHints match", func() {


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MGMT-4914

This PR is for the BMAC to read the annotation from BMH and set the IgnitionConfigOverride in the agent's spec, similar to role and hostname. This PR adds support for IgnitionConfigOverride customization. To customize ignition config override user will need to set annotation in bmh
example:
bmac.agent-install.openshift.io/ignition-config-overrides: {"storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}