### PR TITLE
NO-ISSUE use a specific k8s.io/api vesion to fix the build

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -25,6 +25,7 @@ go get -u github.com/onsi/ginkgo/ginkgo@v1.16.1 \
     github.com/vektra/mockery/.../@v1.1.2 \
     gotest.tools/gotestsum@v1.6.3 \
     github.com/axw/gocov/gocov \
+    k8s.io/api@v0.20.5 \
     sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 \
     github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 


### PR DESCRIPTION
Seems like we get with latest version of ``k8s.io/api``:
```
github.com/openshift/assisted-service/cmd imports
	k8s.io/client-go/kubernetes/scheme imports
	k8s.io/api/batch/v2alpha1: module k8s.io/api@latest found (v0.21.0), but does not contain package k8s.io/api/batch/v2alpha1
github.com/openshift/assisted-service/cmd imports
	k8s.io/client-go/kubernetes/scheme imports
	k8s.io/api/discovery/v1alpha1: module k8s.io/api@latest found (v0.21.0), but does not contain package k8s.io/api/discovery/v1alpha1
```

which we didn't get on v0.20.5.
/hold