### PR TITLE
NO-ISSUE Pin k8s.io/api to v0.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,4 +82,5 @@ require (
 replace (
 	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20210309203657-2c1aca867039 // Use OpenShift fork
 	k8s.io/client-go => k8s.io/client-go v0.20.0
+	k8s.io/api => k8s.io/api v0.20.0
 )


### PR DESCRIPTION
This PR aims to fix the current CI problemby pinning the k8s.io/api package to version v0.20.0 to prevent the lint job from [failing](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/1476/pull-ci-openshift-assisted-service-master-lint/1380620849509306368) by pulling the latest version (v0.21.0), which is incompatible with the other libraries we use.

Related to #1479 

@osherdp @YuviGold @nmagnezi can you take a look?