### PR TITLE
OCPBUGSM-24075 - Fix spelling of `canceled` in both american and british

### DIFF
--- a/docs/ClusterStatus.dot
+++ b/docs/ClusterStatus.dot
@@ -14,7 +14,7 @@ digraph ClusterStateMachine {
     }
     installed [shape = doublecircle, color = chartreuse];
     error [shape = doublecircle, color = crimson];
-    cancelled [shape = doublecircle, color = slategray];
+    canceled [shape = doublecircle, color = slategray];
 
     start -> insufficient [label = "cluster\ncreated", color=lightpink3, fontcolor=lightpink3];
 
@@ -23,7 +23,7 @@ digraph ClusterStateMachine {
     ready -> insufficient [label = "min reqs\nnot met", color=lightpink3, fontcolor=lightpink3];
     ready -> "preparing-for-installation" [label = "installation started", color=darkolivegreen3, fontcolor=darkolivegreen4];
 
-    cancelled -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
+    canceled -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
 
     "preparing-for-installation" -> installing [color=darkolivegreen4];
 
@@ -32,11 +32,11 @@ digraph ClusterStateMachine {
     installing -> "installing-pending-user-action" [label = "hosts in wrong boot order", color=cornsilk4, fontcolor=cornsilk4];
 
     "installing-pending-user-action" -> installing [label = "fixed wrong boot order", fontcolor=darkolivegreen4, color=darkolivegreen4];
-    "installing-pending-user-action" -> cancelled [label = "cancel", color=slategray, fontcolor=slategray];
+    "installing-pending-user-action" -> canceled [label = "cancel", color=slategray, fontcolor=slategray];
     "installing-pending-user-action" -> error [label = "error\n", color=crimson, fontcolor=crimson];
 
     finalizing -> error [label = "installation\nerror\n", color=crimson, fontcolor=crimson, ltail = cluster_level1];
-    finalizing -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level1];
+    finalizing -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level1];
     finalizing -> installed [label = "installation\ncompleted", color=chartreuse4, fontcolor=chartreuse4];
 
     error -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
@@ -44,5 +44,5 @@ digraph ClusterStateMachine {
     {rank=min; start}
     {rank=max; installed}
     {rank=same; start; insufficient; ready}
-    {rank=same; installed; error; cancelled}
+    {rank=same; installed; error; canceled}
 }

--- a/docs/HostStatus.dot
+++ b/docs/HostStatus.dot
@@ -21,7 +21,7 @@ digraph HostStateMachine {
     "installing-pending-user-action" [color = cornsilk]
     installed [shape = doublecircle, color = chartreuse];
     error [shape = doublecircle, color = crimson];
-    cancelled [shape = doublecircle, color = slategray];
+    canceled [shape = doublecircle, color = slategray];
     subgraph cluster_level3 {
         resetting [color = aquamarine3]
         "resetting-pending-user-action" [color = yellow]
@@ -50,7 +50,7 @@ digraph HostStateMachine {
 
     "preparing-for-installation" -> installing [color=darkolivegreen3];
     "preparing-for-installation" -> error [label = "installation\nerror", color=crimson, fontcolor=crimson, ltail = cluster_level2];
-    "preparing-for-installation" -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    "preparing-for-installation" -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
     installing -> "installing-in-progress" [color=darkolivegreen3];
 
@@ -59,15 +59,15 @@ digraph HostStateMachine {
 
     "installing-pending-user-action" -> installed [label = "boot from\ninstall disk", color=chartreuse4, fontcolor=chartreuse4];
 
-    cancelled -> resetting [label = "reset", color=aquamarine4, fontcolor=aquamarine4];
+    canceled -> resetting [label = "reset", color=aquamarine4, fontcolor=aquamarine4];
 
     resetting -> discovering [color=goldenrod, fontcolor=goldenrod, ltail = cluster_level3];
     resetting -> "resetting-pending-user-action" [label = "wrong boot\norder", color=yellow3, fontcolor=yellow3];
  
     installed -> error [label = "installation", color=crimson, fontcolor=crimson, ltail = cluster_level2];
-    installed-> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    installed-> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
-    error -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    error -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
     {rank=min; start}
     {rank=max; installed}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -418,7 +418,7 @@ func (m *Manager) autoAssignMachineNetworkCidrs() error {
 }
 
 func (m *Manager) shouldTriggerLeaseTimeoutEvent(c *common.Cluster, curMonitorInvokedAt time.Time) bool {
-	notAllowedStates := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCancelled}
+	notAllowedStates := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCanceled}
 	if funk.Contains(notAllowedStates, *c.Status) {
 		return false
 	}
@@ -437,7 +437,7 @@ func (m *Manager) SkipMonitoring(c *common.Cluster) bool {
 	// or remote controllers reports that their log colection has been completed. Then, monitoring should be
 	// stopped to avoid excessive computation
 	skipMonitoringStates := []string{string(models.LogsStateCompleted), string(models.LogsStateTimeout)}
-	result := ((swag.StringValue(c.Status) == models.ClusterStatusError || swag.StringValue(c.Status) == models.ClusterStatusCancelled) &&
+	result := ((swag.StringValue(c.Status) == models.ClusterStatusError || swag.StringValue(c.Status) == models.ClusterStatusCanceled) &&
 		funk.Contains(skipMonitoringStates, c.LogsInfo))
 	return result
 }
@@ -518,7 +518,7 @@ func CanDownloadFiles(c *common.Cluster) (err error) {
 		models.ClusterStatusInstalled,
 		models.ClusterStatusError,
 		models.ClusterStatusAddingHosts,
-		models.ClusterStatusCancelled,
+		models.ClusterStatusCanceled,
 	}
 	if !funk.Contains(allowedStatuses, clusterStatus) {
 		err = errors.Errorf("cluster %s is in %s state, files can be downloaded only when status is one of: %s",

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -514,7 +514,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 				Expect(updateTime).Should(BeTemporally(">=", before))
 				Expect(updateTime).Should(BeTemporally("<=", after))
 
-				installationCompletedStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCancelled}
+				installationCompletedStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCanceled}
 				if funk.ContainsString(installationCompletedStatuses, expectedState) {
 					Expect(c.InstallCompletedAt).Should(Equal(c.StatusUpdatedAt))
 				}
@@ -1264,7 +1264,7 @@ var _ = Describe("CancelInstallation", func() {
 
 		AfterEach(func() {
 			db.First(&c, "id = ?", c.ID)
-			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 		})
 	})
 

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -47,7 +47,7 @@ func updateClusterStatus(log logrus.FieldLogger, db *gorm.DB, clusterId strfmt.U
 		now := strfmt.DateTime(time.Now())
 		extra = append(extra, "status_updated_at", now)
 
-		installationCompletedStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCancelled}
+		installationCompletedStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusCanceled}
 		if funk.ContainsString(installationCompletedStatuses, swag.StringValue(&newStatus)) {
 			extra = append(extra, "install_completed_at", now)
 		}

--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -26,7 +26,7 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.ClusterStatusError),
 			stateswitch.State(models.ClusterStatusFinalizing),
 		},
-		DestinationState: stateswitch.State(models.ClusterStatusCancelled),
+		DestinationState: stateswitch.State(models.ClusterStatusCanceled),
 		PostTransition:   th.PostCancelInstallation,
 	})
 
@@ -37,7 +37,7 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.ClusterStatusInstalling),
 			stateswitch.State(models.ClusterStatusInstallingPendingUserAction),
 			stateswitch.State(models.ClusterStatusError),
-			stateswitch.State(models.ClusterStatusCancelled),
+			stateswitch.State(models.ClusterStatusCanceled),
 			stateswitch.State(models.ClusterStatusFinalizing),
 		},
 		DestinationState: stateswitch.State(models.ClusterStatusInsufficient),
@@ -278,7 +278,7 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	// check timeout of log collection
 	for _, state := range []stateswitch.State{
 		stateswitch.State(models.ClusterStatusError),
-		stateswitch.State(models.ClusterStatusCancelled)} {
+		stateswitch.State(models.ClusterStatusCanceled)} {
 		sm.AddTransition(stateswitch.TransitionRule{
 			TransitionType:   TransitionTypeRefreshStatus,
 			SourceStates:     []stateswitch.State{state},
@@ -294,7 +294,7 @@ func NewClusterStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		stateswitch.State(models.ClusterStatusFinalizing),
 		stateswitch.State(models.ClusterStatusInstalled),
 		stateswitch.State(models.ClusterStatusError),
-		stateswitch.State(models.ClusterStatusCancelled),
+		stateswitch.State(models.ClusterStatusCanceled),
 		stateswitch.State(models.ClusterStatusAddingHosts)} {
 		sm.AddTransition(stateswitch.TransitionRule{
 			TransitionType:   TransitionTypeRefreshStatus,

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Transition tests", func() {
 			Expect(capi.CancelInstallation(ctx, &c, "", db)).ShouldNot(HaveOccurred())
 
 			Expect(db.First(&c, "id = ?", c.ID).Error).ShouldNot(HaveOccurred())
-			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 		})
 
 		It("cancel_installation_conflict", func() {
@@ -96,7 +96,7 @@ var _ = Describe("Transition tests", func() {
 			Expect(capi.CancelInstallation(ctx, &c, "", db)).ShouldNot(HaveOccurred())
 
 			Expect(db.First(&c, "id = ?", c.ID).Error).ShouldNot(HaveOccurred())
-			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+			Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 			Expect(swag.StringValue(c.StatusInfo)).ShouldNot(Equal("original error"))
 		})
 	})
@@ -2988,8 +2988,8 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 	Context("refresh on cancel state", func() {
 
 		BeforeEach(func() {
-			srcState = models.ClusterStatusCancelled
-			srcStatusInfo = "cancelled"
+			srcState = models.ClusterStatusCanceled
+			srcStatusInfo = "canceled"
 		})
 
 		It("logs not requested when cluster enter cancel -> mark as timeout to signal that we do not wait for them", func() {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -540,7 +540,7 @@ var _ = Describe("cancel installation", func() {
 
 		AfterEach(func() {
 			db.First(&h, "id = ? and cluster_id = ?", h.ID, h.ClusterID)
-			Expect(*h.Status).Should(Equal(models.HostStatusCancelled))
+			Expect(*h.Status).Should(Equal(models.HostStatusCanceled))
 		})
 	})
 

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -85,7 +85,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusDisabled:                 {[]CommandGetter{}, defaultBackedOffInstructionInSec},
 			models.HostStatusResetting:                {[]CommandGetter{resetCmd}, defaultBackedOffInstructionInSec},
 			models.HostStatusError:                    {[]CommandGetter{logsCmd, stopCmd}, defaultBackedOffInstructionInSec},
-			models.HostStatusCancelled:                {[]CommandGetter{logsCmd, stopCmd}, defaultBackedOffInstructionInSec},
+			models.HostStatusCanceled:                 {[]CommandGetter{logsCmd, stopCmd}, defaultBackedOffInstructionInSec},
 		},
 		addHostsClusterToSteps: stateToStepsMap{
 			models.HostStatusKnown:                {[]CommandGetter{connectivityCmd, apivipConnectivityCmd, inventoryCmd, ntpSynchronizerCmd}, defaultNextInstructionInSec},
@@ -98,7 +98,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusDisabled:             {[]CommandGetter{}, defaultBackedOffInstructionInSec},
 			models.HostStatusResetting:            {[]CommandGetter{resetCmd}, defaultBackedOffInstructionInSec},
 			models.HostStatusError:                {[]CommandGetter{stopCmd}, defaultBackedOffInstructionInSec},
-			models.HostStatusCancelled:            {[]CommandGetter{stopCmd}, defaultBackedOffInstructionInSec},
+			models.HostStatusCanceled:             {[]CommandGetter{stopCmd}, defaultBackedOffInstructionInSec},
 		},
 	}
 }

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -116,8 +116,8 @@ var _ = Describe("instruction_manager", func() {
 					models.StepTypeExecute,
 				})
 			})
-			It("cancelled", func() {
-				checkStep(models.HostStatusCancelled, []models.StepType{
+			It("canceled", func() {
+				checkStep(models.HostStatusCanceled, []models.StepType{
 					models.StepTypeExecute, models.StepTypeExecute,
 				})
 			})
@@ -181,8 +181,8 @@ var _ = Describe("instruction_manager", func() {
 					models.StepTypeExecute, models.StepTypeExecute,
 				})
 			})
-			It("cancelled", func() {
-				checkStep(models.HostStatusCancelled, []models.StepType{
+			It("canceled", func() {
+				checkStep(models.HostStatusCanceled, []models.StepType{
 					models.StepTypeExecute, models.StepTypeExecute,
 				})
 			})

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -11,7 +11,7 @@ import (
 
 func (m *Manager) SkipMonitoring(h *models.Host) bool {
 	skipMonitoringStates := []string{string(models.LogsStateCompleted), string(models.LogsStateTimeout), ""}
-	result := ((swag.StringValue(h.Status) == models.HostStatusError || swag.StringValue(h.Status) == models.HostStatusCancelled) &&
+	result := ((swag.StringValue(h.Status) == models.HostStatusError || swag.StringValue(h.Status) == models.HostStatusCanceled) &&
 		funk.Contains(skipMonitoringStates, h.LogsInfo))
 	return result
 }
@@ -42,8 +42,8 @@ func (m *Manager) HostMonitoring() {
 		models.HostStatusInstalled,
 		models.HostStatusInstallingPendingUserAction,
 		models.HostStatusResettingPendingUserAction,
-		models.HostStatusCancelled, // for limited time, until log collection finished or timed-out
-		models.HostStatusError,     // for limited time, until log collection finished or timed-out
+		models.HostStatusCanceled, // for limited time, until log collection finished or timed-out
+		models.HostStatusError,    // for limited time, until log collection finished or timed-out
 	}
 	for {
 		hosts := make([]*models.Host, 0, limit)

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -143,7 +143,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.HostStatusInstalled),
 			stateswitch.State(models.HostStatusError),
 		},
-		DestinationState: stateswitch.State(models.HostStatusCancelled),
+		DestinationState: stateswitch.State(models.HostStatusCanceled),
 		PostTransition:   th.PostCancelInstallation,
 	})
 
@@ -166,7 +166,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.HostStatusInstallingInProgress),
 			stateswitch.State(models.HostStatusInstalled),
 			stateswitch.State(models.HostStatusError),
-			stateswitch.State(models.HostStatusCancelled),
+			stateswitch.State(models.HostStatusCanceled),
 			stateswitch.State(models.HostStatusAddedToExistingCluster),
 		},
 		DestinationState: stateswitch.State(models.HostStatusResetting),
@@ -240,7 +240,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.HostStatusInstallingInProgress),
 			stateswitch.State(models.HostStatusInstalled),
 			stateswitch.State(models.HostStatusError),
-			stateswitch.State(models.HostStatusCancelled),
+			stateswitch.State(models.HostStatusCanceled),
 			stateswitch.State(models.HostStatusAddedToExistingCluster),
 		},
 		DestinationState: stateswitch.State(models.HostStatusResettingPendingUserAction),
@@ -479,7 +479,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	// check timeout of log collection
 	for _, state := range []stateswitch.State{
 		stateswitch.State(models.HostStatusError),
-		stateswitch.State(models.HostStatusCancelled)} {
+		stateswitch.State(models.HostStatusCanceled)} {
 		sm.AddTransition(stateswitch.TransitionRule{
 			TransitionType:   TransitionTypeRefresh,
 			SourceStates:     []stateswitch.State{state},
@@ -493,7 +493,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	for _, state := range []stateswitch.State{
 		stateswitch.State(models.HostStatusDisabled),
 		stateswitch.State(models.HostStatusError),
-		stateswitch.State(models.HostStatusCancelled),
+		stateswitch.State(models.HostStatusCanceled),
 		stateswitch.State(models.HostStatusResetting),
 	} {
 		sm.AddTransition(stateswitch.TransitionRule{

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -543,7 +543,7 @@ var _ = Describe("Cancel host installation", func() {
 		{state: models.HostStatusPendingForInput, success: false, statusCode: http.StatusConflict, changeState: false},
 		{state: models.HostStatusResettingPendingUserAction, success: false, statusCode: http.StatusConflict, changeState: false},
 		{state: models.HostStatusDisconnected, success: false, statusCode: http.StatusConflict, changeState: false},
-		{state: models.HostStatusCancelled, success: false, statusCode: http.StatusConflict, changeState: false},
+		{state: models.HostStatusCanceled, success: false, statusCode: http.StatusConflict, changeState: false},
 	}
 
 	acceptNewEvents := func(times int) {
@@ -571,7 +571,7 @@ var _ = Describe("Cancel host installation", func() {
 			if t.success {
 				Expect(err).ShouldNot(HaveOccurred())
 
-				expectedState := models.HostStatusCancelled
+				expectedState := models.HostStatusCanceled
 				if !t.changeState {
 					expectedState = t.state
 				}
@@ -625,7 +625,7 @@ var _ = Describe("Reset host", func() {
 		{state: models.HostStatusError, success: true, changeState: true},
 		{state: models.HostStatusDisabled, success: true, changeState: false},
 		{state: models.HostStatusInstallingPendingUserAction, success: true, changeState: true},
-		{state: models.HostStatusCancelled, success: true, changeState: true},
+		{state: models.HostStatusCanceled, success: true, changeState: true},
 		{state: models.HostStatusAddedToExistingCluster, success: true, changeState: true},
 		{state: models.HostStatusDiscovering, success: false, statusCode: http.StatusConflict, changeState: false},
 		{state: models.HostStatusKnown, success: false, statusCode: http.StatusConflict, changeState: false},

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -179,7 +179,7 @@ type Cluster struct {
 
 	// Status of the OpenShift cluster.
 	// Required: true
-	// Enum: [insufficient ready error preparing-for-installation pending-for-input installing finalizing installed adding-hosts cancelled installing-pending-user-action]
+	// Enum: [insufficient ready error preparing-for-installation pending-for-input installing finalizing installed adding-hosts canceled installing-pending-user-action]
 	Status *string `json:"status"`
 
 	// Additional information pertaining to the status of the OpenShift cluster.
@@ -810,7 +810,7 @@ var clusterTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["insufficient","ready","error","preparing-for-installation","pending-for-input","installing","finalizing","installed","adding-hosts","cancelled","installing-pending-user-action"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["insufficient","ready","error","preparing-for-installation","pending-for-input","installing","finalizing","installed","adding-hosts","canceled","installing-pending-user-action"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -847,8 +847,8 @@ const (
 	// ClusterStatusAddingHosts captures enum value "adding-hosts"
 	ClusterStatusAddingHosts string = "adding-hosts"
 
-	// ClusterStatusCancelled captures enum value "cancelled"
-	ClusterStatusCancelled string = "cancelled"
+	// ClusterStatusCanceled captures enum value "canceled"
+	ClusterStatusCanceled string = "canceled"
 
 	// ClusterStatusInstallingPendingUserAction captures enum value "installing-pending-user-action"
 	ClusterStatusInstallingPendingUserAction string = "installing-pending-user-action"

--- a/models/host.go
+++ b/models/host.go
@@ -130,7 +130,7 @@ type Host struct {
 
 	// status
 	// Required: true
-	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled]
+	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster canceled]
 	Status *string `json:"status"`
 
 	// status info
@@ -481,7 +481,7 @@ var hostTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","canceled"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -539,8 +539,8 @@ const (
 	// HostStatusAddedToExistingCluster captures enum value "added-to-existing-cluster"
 	HostStatusAddedToExistingCluster string = "added-to-existing-cluster"
 
-	// HostStatusCancelled captures enum value "cancelled"
-	HostStatusCancelled string = "cancelled"
+	// HostStatusCanceled captures enum value "canceled"
+	HostStatusCanceled string = "canceled"
 )
 
 // prop value enum

--- a/pkg/leader/leaderelector.go
+++ b/pkg/leader/leaderelector.go
@@ -88,7 +88,7 @@ func (l *Elector) waitForLeader(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done(): // Done returns a channel that's closed when work done on behalf of this context is canceled
-			return errors.Errorf("cancelled while waiting for leader")
+			return errors.Errorf("canceled while waiting for leader")
 		case <-ticker.C:
 			if l.isLeader {
 				l.log.Infof("Got leader, stop waiting")
@@ -120,12 +120,12 @@ func (l *Elector) StartLeaderElection(ctx context.Context) error {
 	l.log.Infof("Attempting to acquire leader lease")
 	// Running loop cause leaderElector.Run is blocking
 	// and needs to be restarted while leader is lost
-	// will exit if context was cancelled
+	// will exit if context was canceled
 	go func() {
 		for {
 			l.log.Infof("Starting leader elections process")
 			if ctx.Err() != nil {
-				l.log.Infof("Given context was cancelled, exiting leader elector")
+				l.log.Infof("Given context was canceled, exiting leader elector")
 				return
 			}
 			leaderElector.Run(ctx)

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5064,7 +5064,7 @@ func init() {
             "finalizing",
             "installed",
             "adding-hosts",
-            "cancelled",
+            "canceled",
             "installing-pending-user-action"
           ]
         },
@@ -6388,7 +6388,7 @@ func init() {
             "error",
             "resetting",
             "added-to-existing-cluster",
-            "cancelled"
+            "canceled"
           ]
         },
         "status_info": {
@@ -12706,7 +12706,7 @@ func init() {
             "finalizing",
             "installed",
             "adding-hosts",
-            "cancelled",
+            "canceled",
             "installing-pending-user-action"
           ]
         },
@@ -13954,7 +13954,7 @@ func init() {
             "error",
             "resetting",
             "added-to-existing-cluster",
-            "cancelled"
+            "canceled"
           ]
         },
         "status_info": {

--- a/site/ClusterStatus.dot
+++ b/site/ClusterStatus.dot
@@ -14,7 +14,7 @@ digraph ClusterStateMachine {
     }
     installed [shape = doublecircle, color = chartreuse];
     error [shape = doublecircle, color = crimson];
-    cancelled [shape = doublecircle, color = slategray];
+    canceled [shape = doublecircle, color = slategray];
 
     start -> insufficient [label = "cluster\ncreated", color=lightpink3, fontcolor=lightpink3];
 
@@ -23,7 +23,7 @@ digraph ClusterStateMachine {
     ready -> insufficient [label = "min reqs\nnot met", color=lightpink3, fontcolor=lightpink3];
     ready -> "preparing-for-installation" [label = "installation started", color=darkolivegreen3, fontcolor=darkolivegreen4];
 
-    cancelled -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
+    canceled -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
 
     "preparing-for-installation" -> installing [color=darkolivegreen4];
 
@@ -32,11 +32,11 @@ digraph ClusterStateMachine {
     installing -> "installing-pending-user-action" [label = "hosts in wrong boot order", color=cornsilk4, fontcolor=cornsilk4];
 
     "installing-pending-user-action" -> installing [label = "fixed wrong boot order", fontcolor=darkolivegreen4, color=darkolivegreen4];
-    "installing-pending-user-action" -> cancelled [label = "cancel", color=slategray, fontcolor=slategray];
+    "installing-pending-user-action" -> canceled [label = "cancel", color=slategray, fontcolor=slategray];
     "installing-pending-user-action" -> error [label = "error\n", color=crimson, fontcolor=crimson];
 
     finalizing -> error [label = "installation\nerror\n", color=crimson, fontcolor=crimson, ltail = cluster_level1];
-    finalizing -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level1];
+    finalizing -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level1];
     finalizing -> installed [label = "installation\ncompleted", color=chartreuse4, fontcolor=chartreuse4];
 
     error -> insufficient [label = "reset", color=lightpink3, fontcolor=lightpink3];
@@ -44,5 +44,5 @@ digraph ClusterStateMachine {
     {rank=min; start}
     {rank=max; installed}
     {rank=same; start; insufficient; ready}
-    {rank=same; installed; error; cancelled}
+    {rank=same; installed; error; canceled}
 }

--- a/site/HostStatus.dot
+++ b/site/HostStatus.dot
@@ -21,7 +21,7 @@ digraph HostStateMachine {
     "installing-pending-user-action" [color = cornsilk]
     installed [shape = doublecircle, color = chartreuse];
     error [shape = doublecircle, color = crimson];
-    cancelled [shape = doublecircle, color = slategray];
+    canceled [shape = doublecircle, color = slategray];
     subgraph cluster_level3 {
         resetting [color = aquamarine3]
         "resetting-pending-user-action" [color = yellow]
@@ -50,7 +50,7 @@ digraph HostStateMachine {
 
     "preparing-for-installation" -> installing [color=darkolivegreen3];
     "preparing-for-installation" -> error [label = "installation\nerror", color=crimson, fontcolor=crimson, ltail = cluster_level2];
-    "preparing-for-installation" -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    "preparing-for-installation" -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
     installing -> "installing-in-progress" [color=darkolivegreen3];
 
@@ -59,15 +59,15 @@ digraph HostStateMachine {
 
     "installing-pending-user-action" -> installed [label = "boot from\ninstall disk", color=chartreuse4, fontcolor=chartreuse4];
 
-    cancelled -> resetting [label = "reset", color=aquamarine4, fontcolor=aquamarine4];
+    canceled -> resetting [label = "reset", color=aquamarine4, fontcolor=aquamarine4];
 
     resetting -> discovering [color=goldenrod, fontcolor=goldenrod, ltail = cluster_level3];
     resetting -> "resetting-pending-user-action" [label = "wrong boot\norder", color=yellow3, fontcolor=yellow3];
  
     installed -> error [label = "installation", color=crimson, fontcolor=crimson, ltail = cluster_level2];
-    installed-> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    installed-> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
-    error -> cancelled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
+    error -> canceled [label = "cancel", color=slategray, fontcolor=slategray, ltail = cluster_level2];
 
     {rank=min; start}
     {rank=max; installed}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1762,13 +1762,13 @@ var _ = Describe("cluster install", func() {
 				}
 				_, err := userBMClient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
-				waitForClusterState(ctx, clusterID, models.ClusterStatusCancelled, defaultWaitForClusterStateTimeout, clusterCanceledInfo)
+				waitForClusterState(ctx, clusterID, models.ClusterStatusCanceled, defaultWaitForClusterStateTimeout, clusterCanceledInfo)
 				rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				c = rep.GetPayload()
-				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 				for _, host := range c.Hosts {
-					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCancelled))
+					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCanceled))
 				}
 
 				Expect(c.InstallCompletedAt).Should(Equal(c.StatusUpdatedAt))
@@ -1800,9 +1800,9 @@ var _ = Describe("cluster install", func() {
 				rep, err = userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 				Expect(err).ShouldNot(HaveOccurred())
 				c = rep.GetPayload()
-				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 				for _, host := range c.Hosts {
-					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCancelled))
+					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCanceled))
 				}
 			})
 			It("cancel cluster with various hosts states", func() {
@@ -1820,7 +1820,7 @@ var _ = Describe("cluster install", func() {
 				_, err := userBMClient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
 				Expect(err).ShouldNot(HaveOccurred())
 				for _, host := range c.Hosts {
-					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCancelled,
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCanceled,
 						defaultWaitForClusterStateTimeout)
 				}
 			})
@@ -1867,13 +1867,13 @@ var _ = Describe("cluster install", func() {
 				Expect(err).NotTo(HaveOccurred())
 				c = rep.GetPayload()
 				Expect(len(c.Hosts)).Should(Equal(6))
-				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCancelled))
+				Expect(swag.StringValue(c.Status)).Should(Equal(models.ClusterStatusCanceled))
 				for _, host := range c.Hosts {
 					if host.ID.String() == disabledHost.ID.String() {
 						Expect(*host.Status).Should(Equal(models.HostStatusDisabled))
 						continue
 					}
-					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCancelled))
+					Expect(swag.StringValue(host.Status)).Should(Equal(models.HostStatusCanceled))
 				}
 			})
 			It("cancel host - wrong boot order", func() {
@@ -1903,7 +1903,7 @@ var _ = Describe("cluster install", func() {
 				_, err = userBMClient.Installer.CancelInstallation(ctx, &installer.CancelInstallationParams{ClusterID: clusterID})
 				Expect(err).ShouldNot(HaveOccurred())
 				for _, host := range c.Hosts {
-					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCancelled,
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCanceled,
 						defaultWaitForHostStateTimeout)
 				}
 			})
@@ -1918,7 +1918,7 @@ var _ = Describe("cluster install", func() {
 				Expect(c).NotTo(BeNil())
 
 				for _, host := range c.Hosts {
-					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCancelled,
+					waitForHostState(ctx, clusterID, *host.ID, models.HostStatusCanceled,
 						defaultWaitForHostStateTimeout)
 				}
 			})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3470,7 +3470,7 @@ definitions:
           - error
           - resetting
           - added-to-existing-cluster
-          - cancelled
+          - canceled
       status_info:
         type: string
         x-go-custom-tag: gorm:"type:varchar(2048)"
@@ -4069,7 +4069,7 @@ definitions:
           - finalizing
           - installed
           - adding-hosts
-          - cancelled
+          - canceled
           - installing-pending-user-action
       status_info:
         type: string


### PR DESCRIPTION
Both spellings canceled(Americans) and canceled(British) are in use.
This patch changes all `cancelled` to `canceled`.

https://bugzilla.redhat.com/show_bug.cgi?id=1923268