### PR TITLE
OCPBUGSM-24075 - Correct the spelling of 'canceled' on "canceled by user" event

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3622,11 +3622,11 @@ func (b *bareMetalInventory) CancelInstallation(ctx context.Context, params inst
 	}
 
 	// cancellation is made by setting the cluster and and hosts states to error.
-	if err := b.clusterApi.CancelInstallation(ctx, cluster, "Installation was canceled by user", tx); err != nil {
+	if err := b.clusterApi.CancelInstallation(ctx, cluster, "Installation was cancelled by user", tx); err != nil {
 		return common.GenerateErrorResponder(err)
 	}
 	for _, h := range cluster.Hosts {
-		if err := b.hostApi.CancelInstallation(ctx, h, "Installation was canceled by user", tx); err != nil {
+		if err := b.hostApi.CancelInstallation(ctx, h, "Installation was cancelled by user", tx); err != nil {
 			return common.GenerateErrorResponder(err)
 		}
 		if err := b.customizeHost(h); err != nil {


### PR DESCRIPTION
Both spellings canceled(Americans) and canceled(British) are in use.
This patch changes all `canceled` to `cancelled`.

https://bugzilla.redhat.com/show_bug.cgi?id=1923268