### PR TITLE
OCPBUGSM-27559 - fix pip install of the pycairo package. previously i…

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -45,7 +45,7 @@ RUN dnf install -y libvirt-libs python3 && \
     dnf install -y NetworkManager-config-server && \
     dnf install -y openvswitch2.11 && \
     dnf install -y python3-openvswitch2.11 && \
-    pip3 install --user pycairo && \
+    pip3 install pycairo && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all
 


### PR DESCRIPTION
…t was using --user flag, which during build cuases it to be installed as a root user package. When running in non-root container, it cannot be accessed by the executable started by a non-root user.