### PR TITLE
MGMT-3512 Report FS usage metrics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,7 +221,7 @@ func main() {
 	isoEditorFactory := isoeditor.NewFactory(Options.ISOEditorConfig, staticNetworkConfig)
 
 	var objectHandler = createStorageClient(Options.DeployTarget, Options.Storage, &Options.S3Config,
-		Options.JobConfig.WorkDir, log, versionHandler, isoEditorFactory)
+		Options.JobConfig.WorkDir, log, versionHandler, isoEditorFactory, metricsManager)
 	createS3Bucket(objectHandler, log)
 
 	manifestsApi := manifests.NewManifestsAPI(db, log.WithField("pkg", "manifests"), objectHandler)
@@ -540,7 +540,7 @@ func createS3Bucket(objectHandler s3wrapper.API, log logrus.FieldLogger) {
 }
 
 func createStorageClient(deployTarget string, storage string, s3cfg *s3wrapper.Config, fsWorkDir string,
-	log logrus.FieldLogger, versionsHandler versions.Handler, isoEditorFactory isoeditor.Factory) s3wrapper.API {
+	log logrus.FieldLogger, versionsHandler versions.Handler, isoEditorFactory isoeditor.Factory, metricsAPI metrics.API) s3wrapper.API {
 	var storageClient s3wrapper.API
 	if storage != "" {
 		switch storage {
@@ -550,7 +550,7 @@ func createStorageClient(deployTarget string, storage string, s3cfg *s3wrapper.C
 				log.Fatal("failed to create S3 client")
 			}
 		case storage_filesystem:
-			storageClient = s3wrapper.NewFSClient(fsWorkDir, log, versionsHandler, isoEditorFactory)
+			storageClient = s3wrapper.NewFSClient(fsWorkDir, log, versionsHandler, isoEditorFactory, metricsAPI)
 			if storageClient == nil {
 				log.Fatal("failed to create filesystem client")
 			}
@@ -566,7 +566,7 @@ func createStorageClient(deployTarget string, storage string, s3cfg *s3wrapper.C
 				log.Fatal("failed to create S3 client")
 			}
 		case deployment_type_onprem, deployment_type_ocp:
-			storageClient = s3wrapper.NewFSClient(fsWorkDir, log, versionsHandler, isoEditorFactory)
+			storageClient = s3wrapper.NewFSClient(fsWorkDir, log, versionsHandler, isoEditorFactory, metricsAPI)
 			if storageClient == nil {
 				log.Fatal("failed to create S3 filesystem client")
 			}

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	go.uber.org/zap v1.15.0 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	gopkg.in/gormigrate.v1 v1.6.0

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -191,3 +191,15 @@ func (mr *MockAPIMockRecorder) ImagePullStatus(clusterID, hostID, imageName, res
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), clusterID, hostID, imageName, resultStatus, downloadRate)
 }
+
+// FileSystemUsage mocks base method
+func (m *MockAPI) FileSystemUsage(usageInPercentage float64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "FileSystemUsage", usageInPercentage)
+}
+
+// FileSystemUsage indicates an expected call of FileSystemUsage
+func (mr *MockAPIMockRecorder) FileSystemUsage(usageInPercentage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileSystemUsage", reflect.TypeOf((*MockAPI)(nil).FileSystemUsage), usageInPercentage)
+}

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -28,11 +28,19 @@ type FSClient struct {
 	basedir          string
 	versionsHandler  versions.Handler
 	isoEditorFactory isoeditor.Factory
-	metricsAPI       metrics.API
 }
 
-func NewFSClient(basedir string, logger logrus.FieldLogger, versionsHandler versions.Handler, isoEditorFactory isoeditor.Factory, metricsAPI metrics.API) *FSClient {
-	return &FSClient{log: logger, basedir: basedir, versionsHandler: versionsHandler, isoEditorFactory: isoEditorFactory, metricsAPI: metricsAPI}
+func NewFSClient(basedir string, logger logrus.FieldLogger, versionsHandler versions.Handler, isoEditorFactory isoeditor.Factory, metricsAPI metrics.API) *FSClientDecorator {
+	return &FSClientDecorator{
+		log:        logger,
+		metricsAPI: metricsAPI,
+		fsClient: FSClient{
+			log:              logger,
+			basedir:          basedir,
+			versionsHandler:  versionsHandler,
+			isoEditorFactory: isoEditorFactory,
+		},
+	}
 }
 
 func (f *FSClient) IsAwsS3() bool {
@@ -60,7 +68,6 @@ func (f *FSClient) Upload(ctx context.Context, data []byte, objectName string) e
 		log.Error(err)
 		return err
 	}
-	f.reportFilesystemUsageMetrics()
 	log.Infof("Successfully uploaded file %s", objectName)
 	return nil
 }
@@ -90,11 +97,7 @@ func (f *FSClient) UploadISO(ctx context.Context, ignitionConfig, srcObject, des
 		return err
 	}
 
-	err = isoeditor.EmbedIgnition(baseFile, resultFile, ignitionConfig)
-	if err == nil {
-		f.reportFilesystemUsageMetrics()
-	}
-	return err
+	return isoeditor.EmbedIgnition(baseFile, resultFile, ignitionConfig)
 }
 
 func (f *FSClient) UploadStream(ctx context.Context, reader io.Reader, objectName string) error {
@@ -145,7 +148,6 @@ func (f *FSClient) UploadStream(ctx context.Context, reader io.Reader, objectNam
 		log.Error(err)
 		return err
 	}
-	f.reportFilesystemUsageMetrics()
 	log.Infof("Successfully uploaded file %s", objectName)
 	return nil
 }
@@ -209,7 +211,6 @@ func (f *FSClient) DeleteObject(ctx context.Context, objectName string) (bool, e
 		}
 		return false, errors.Wrapf(err, "Failed to delete file %s", filePath)
 	}
-	f.reportFilesystemUsageMetrics()
 	log.Infof("Deleted file %s", filePath)
 	return true, nil
 }
@@ -273,7 +274,6 @@ func (f *FSClient) handleFile(ctx context.Context, log logrus.FieldLogger, fileP
 		}
 		return
 	}
-	f.reportFilesystemUsageMetrics()
 	log.Infof("Deleted expired file %s", filePath)
 	callback(ctx, log, filePath)
 }
@@ -375,7 +375,6 @@ func (f *FSClient) UploadBootFiles(ctx context.Context, openshiftVersion, servic
 			return err
 		}
 	}
-	f.reportFilesystemUsageMetrics()
 	return nil
 }
 
@@ -411,15 +410,155 @@ func (f *FSClient) GetMinimalIsoObjectName(openshiftVersion string) (string, err
 	return fmt.Sprintf(rhcosMinimalObjectTemplate, rhcosVersion), nil
 }
 
-func (f *FSClient) reportFilesystemUsageMetrics() {
+type FSClientDecorator struct {
+	log        logrus.FieldLogger
+	fsClient   FSClient
+	metricsAPI metrics.API
+}
+
+func (d *FSClientDecorator) reportFilesystemUsageMetrics() {
+	basedir := d.fsClient.basedir
 	stat := syscall.Statfs_t{}
-	err := syscall.Statfs(f.basedir, &stat)
+	err := syscall.Statfs(basedir, &stat)
 	if err != nil {
-		f.log.WithError(err).Errorf("Failed to collect filesystem stats for %s", f.basedir)
+		d.fsClient.log.WithError(err).Errorf("Failed to collect filesystem stats for %s", basedir)
 		return
 	}
 	percentage := (float64(stat.Blocks-stat.Bfree) / float64(stat.Blocks)) * 100
 	fixedPercentage := math.Floor(percentage*10) / 10
-	f.log.Infof("Filesystem (%s) usage is %f%", f.basedir, fixedPercentage)
-	f.metricsAPI.FileSystemUsage(fixedPercentage)
+	d.log.Infof("Filesystem '%s' usage is %.1f%%", basedir, fixedPercentage)
+	d.metricsAPI.FileSystemUsage(fixedPercentage)
+}
+
+func (d *FSClientDecorator) IsAwsS3() bool {
+	return d.fsClient.IsAwsS3()
+}
+
+func (d *FSClientDecorator) CreateBucket() error {
+	return d.fsClient.CreateBucket()
+}
+
+func (d *FSClientDecorator) Upload(ctx context.Context, data []byte, objectName string) error {
+	err := d.fsClient.Upload(ctx, data, objectName)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) UploadStream(ctx context.Context, reader io.Reader, objectName string) error {
+	err := d.fsClient.UploadStream(ctx, reader, objectName)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) UploadFile(ctx context.Context, filePath, objectName string) error {
+	err := d.fsClient.UploadFile(ctx, filePath, objectName)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) UploadISO(ctx context.Context, ignitionConfig, srcObject, destObjectPrefix string) error {
+	err := d.fsClient.UploadISO(ctx, ignitionConfig, srcObject, destObjectPrefix)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) Download(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
+	return d.fsClient.Download(ctx, objectName)
+}
+
+func (d *FSClientDecorator) DoesObjectExist(ctx context.Context, objectName string) (bool, error) {
+	return d.fsClient.DoesObjectExist(ctx, objectName)
+}
+
+func (d *FSClientDecorator) DeleteObject(ctx context.Context, objectName string) (bool, error) {
+	exists, err := d.fsClient.DeleteObject(ctx, objectName)
+	if exists && err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return exists, err
+}
+
+func (d *FSClientDecorator) GetObjectSizeBytes(ctx context.Context, objectName string) (int64, error) {
+	return d.fsClient.GetObjectSizeBytes(ctx, objectName)
+}
+
+func (d *FSClientDecorator) GeneratePresignedDownloadURL(ctx context.Context, objectName string, downloadFilename string, duration time.Duration) (string, error) {
+	return d.fsClient.GeneratePresignedDownloadURL(ctx, objectName, downloadFilename, duration)
+}
+
+func (d *FSClientDecorator) UpdateObjectTimestamp(ctx context.Context, objectName string) (bool, error) {
+	return d.fsClient.UpdateObjectTimestamp(ctx, objectName)
+}
+
+func (d *FSClientDecorator) ExpireObjects(ctx context.Context, prefix string, deleteTime time.Duration, callback func(ctx context.Context, log logrus.FieldLogger, objectName string)) {
+	d.fsClient.ExpireObjects(ctx, prefix, deleteTime, callback)
+	d.reportFilesystemUsageMetrics()
+}
+
+func (d *FSClientDecorator) ListObjectsByPrefix(ctx context.Context, prefix string) ([]string, error) {
+	return d.fsClient.ListObjectsByPrefix(ctx, prefix)
+}
+
+func (d *FSClientDecorator) UploadBootFiles(ctx context.Context, openshiftVersion, serviceBaseURL string, haveLatestMinimalTemplate bool) error {
+	err := d.fsClient.UploadBootFiles(ctx, openshiftVersion, serviceBaseURL, haveLatestMinimalTemplate)
+	if err != nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) DoAllBootFilesExist(ctx context.Context, isoObjectName string) (bool, error) {
+	return d.fsClient.DoAllBootFilesExist(ctx, isoObjectName)
+}
+
+func (d *FSClientDecorator) DownloadBootFile(ctx context.Context, isoObjectName, fileType string) (io.ReadCloser, string, int64, error) {
+	return d.fsClient.DownloadBootFile(ctx, isoObjectName, fileType)
+}
+
+func (d *FSClientDecorator) GetS3BootFileURL(isoObjectName, fileType string) string {
+	return d.fsClient.GetS3BootFileURL(isoObjectName, fileType)
+}
+
+func (d *FSClientDecorator) GetBaseIsoObject(openshiftVersion string) (string, error) {
+	return d.fsClient.GetBaseIsoObject(openshiftVersion)
+}
+
+func (d *FSClientDecorator) GetMinimalIsoObjectName(openshiftVersion string) (string, error) {
+	return d.fsClient.GetMinimalIsoObjectName(openshiftVersion)
+}
+
+func (d *FSClientDecorator) CreatePublicBucket() error {
+	return d.fsClient.CreatePublicBucket()
+}
+
+func (d *FSClientDecorator) UploadStreamToPublicBucket(ctx context.Context, reader io.Reader, objectName string) error {
+	err := d.fsClient.UploadStreamToPublicBucket(ctx, reader, objectName)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) UploadFileToPublicBucket(ctx context.Context, filePath, objectName string) error {
+	err := d.fsClient.UploadFileToPublicBucket(ctx, filePath, objectName)
+	if err == nil {
+		d.reportFilesystemUsageMetrics()
+	}
+	return err
+}
+
+func (d *FSClientDecorator) DoesPublicObjectExist(ctx context.Context, objectName string) (bool, error) {
+	return d.fsClient.DoesPublicObjectExist(ctx, objectName)
+}
+
+func (d *FSClientDecorator) DownloadPublic(ctx context.Context, objectName string) (io.ReadCloser, int64, error) {
+	return d.fsClient.DownloadPublic(ctx, objectName)
 }

--- a/pkg/s3wrapper/filesystem_test.go
+++ b/pkg/s3wrapper/filesystem_test.go
@@ -43,7 +43,7 @@ var _ = Describe("s3filesystem", func() {
 		mockVersions = versions.NewMockHandler(ctrl)
 		editorFactory := isoeditor.NewFactory(isoeditor.Config{ConcurrentEdits: 10}, nil)
 		mockMetricsAPI = metrics.NewMockAPI(ctrl)
-		client = &FSClient{basedir: baseDir, log: log, versionsHandler: mockVersions, isoEditorFactory: editorFactory, metricsAPI: mockMetricsAPI}
+		client = &FSClient{basedir: baseDir, log: log, versionsHandler: mockVersions, isoEditorFactory: editorFactory}
 		deleteTime, _ = time.ParseDuration("60m")
 		now, _ = time.Parse(time.RFC3339, "2020-01-01T10:00:00+00:00")
 	})


### PR DESCRIPTION
In order to inspect FS usage and allow user to define alert based on
reported metrics, each time FS is being changed (on create/delete file),
the metrics are updated to reflect the actual usage in percentage of the filesystem.

An example of the reported metrics:
```
# HELP service_assisted_installer_filesystem_usage_percentage The percentage of the filesystem usage by the service
# TYPE service_assisted_installer_filesystem_usage_percentage gauge
service_assisted_installer_filesystem_usage_percentage 55
```

Signed-off-by: Moti Asayag <masayag@redhat.com>