### PR TITLE
MGMT-4981: crds and dependencies for custom version support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -230,7 +230,11 @@ func main() {
 	}
 
 	for _, ocpVersion := range openshiftVersionsMap {
-		images = append(images, *ocpVersion.ReleaseImage)
+		// ReleaseImage is not necessarily specified when using the operator
+		// (fetched from ClusterImageSet instead)
+		if ocpVersion.ReleaseImage != nil {
+			images = append(images, *ocpVersion.ReleaseImage)
+		}
 	}
 
 	pullSecretValidator, err := validations.NewPullSecretValidator(Options.ValidationsConfig, images...)

--- a/docs/crds/clusterImageSet.yaml
+++ b/docs/crds/clusterImageSet.yaml
@@ -1,0 +1,6 @@
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: openshift-v4.7.0
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64

--- a/hack/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/hack/crds/hive.openshift.io_clusterimagesets.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterimagesets.hive.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.releaseImage
+    name: Release
+    type: string
+  group: hive.openshift.io
+  names:
+    kind: ClusterImageSet
+    listKind: ClusterImageSetList
+    plural: clusterimagesets
+    shortNames:
+    - imgset
+    singular: clusterimageset
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterImageSet is the Schema for the clusterimagesets API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ClusterImageSetSpec defines the desired state of ClusterImageSet
+          properties:
+            releaseImage:
+              description: ReleaseImage is the image that contains the payload to
+                use when installing a cluster.
+              type: string
+          required:
+          - releaseImage
+          type: object
+        status:
+          description: ClusterImageSetStatus defines the observed state of ClusterImageSet
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/internal/controller/config/rbac/role.yaml
+++ b/internal/controller/config/rbac/role.yaml
@@ -172,6 +172,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterimagesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - metal3.io
   resources:
   - baremetalhosts

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -79,6 +79,7 @@ type ClusterDeploymentsReconciler struct {
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch
 
 func (r *ClusterDeploymentsReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -151,6 +151,9 @@ type Cluster struct {
 	// A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy string `json:"no_proxy,omitempty"`
 
+	// OpenShift release image URI.
+	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
+
 	// Cluster ID on OCP system.
 	// Format: uuid
 	OpenshiftClusterID strfmt.UUID `json:"openshift_cluster_id,omitempty"`

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -68,6 +68,9 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
+	// OpenShift release image URI.
+	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
+
 	// List of OLM operators to be installed.
 	OlmOperators []*OperatorCreateParams `json:"olm_operators"`
 

--- a/models/openshift_version.go
+++ b/models/openshift_version.go
@@ -30,6 +30,10 @@ type OpenshiftVersion struct {
 	// Required: true
 	ReleaseImage *string `json:"release_image"`
 
+	// OCP version from the release metadata.
+	// Required: true
+	ReleaseVersion *string `json:"release_version"`
+
 	// The base RHCOS image used for the discovery iso.
 	// Required: true
 	RhcosImage *string `json:"rhcos_image"`
@@ -40,7 +44,7 @@ type OpenshiftVersion struct {
 
 	// Level of support of the version.
 	// Required: true
-	// Enum: [beta production]
+	// Enum: [beta production custom]
 	SupportLevel *string `json:"support_level"`
 }
 
@@ -53,6 +57,10 @@ func (m *OpenshiftVersion) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateReleaseImage(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateReleaseVersion(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -92,6 +100,15 @@ func (m *OpenshiftVersion) validateReleaseImage(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *OpenshiftVersion) validateReleaseVersion(formats strfmt.Registry) error {
+
+	if err := validate.Required("release_version", "body", m.ReleaseVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (m *OpenshiftVersion) validateRhcosImage(formats strfmt.Registry) error {
 
 	if err := validate.Required("rhcos_image", "body", m.RhcosImage); err != nil {
@@ -114,7 +131,7 @@ var openshiftVersionTypeSupportLevelPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["beta","production"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["beta","production","custom"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -129,6 +146,9 @@ const (
 
 	// OpenshiftVersionSupportLevelProduction captures enum value "production"
 	OpenshiftVersionSupportLevelProduction string = "production"
+
+	// OpenshiftVersionSupportLevelCustom captures enum value "custom"
+	OpenshiftVersionSupportLevelCustom string = "custom"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5016,6 +5016,10 @@ func init() {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string"
         },
+        "ocp_release_image": {
+          "description": "OpenShift release image URI.",
+          "type": "string"
+        },
         "openshift_cluster_id": {
           "description": "Cluster ID on OCP system.",
           "type": "string",
@@ -5186,6 +5190,10 @@ func init() {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
+        },
+        "ocp_release_image": {
+          "description": "OpenShift release image URI.",
+          "type": "string"
         },
         "olm_operators": {
           "description": "List of OLM operators to be installed.",
@@ -7154,6 +7162,7 @@ func init() {
       "required": [
         "display_name",
         "release_image",
+        "release_version",
         "rhcos_image",
         "rhcos_version",
         "support_level"
@@ -7171,6 +7180,10 @@ func init() {
           "description": "The installation image of the OpenShift cluster.",
           "type": "string"
         },
+        "release_version": {
+          "description": "OCP version from the release metadata.",
+          "type": "string"
+        },
         "rhcos_image": {
           "description": "The base RHCOS image used for the discovery iso.",
           "type": "string"
@@ -7184,7 +7197,8 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production"
+            "production",
+            "custom"
           ]
         }
       }
@@ -12658,6 +12672,10 @@ func init() {
           "description": "A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string"
         },
+        "ocp_release_image": {
+          "description": "OpenShift release image URI.",
+          "type": "string"
+        },
         "openshift_cluster_id": {
           "description": "Cluster ID on OCP system.",
           "type": "string",
@@ -12828,6 +12846,10 @@ func init() {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
+        },
+        "ocp_release_image": {
+          "description": "OpenShift release image URI.",
+          "type": "string"
         },
         "olm_operators": {
           "description": "List of OLM operators to be installed.",
@@ -14710,6 +14732,7 @@ func init() {
       "required": [
         "display_name",
         "release_image",
+        "release_version",
         "rhcos_image",
         "rhcos_version",
         "support_level"
@@ -14727,6 +14750,10 @@ func init() {
           "description": "The installation image of the OpenShift cluster.",
           "type": "string"
         },
+        "release_version": {
+          "description": "OCP version from the release metadata.",
+          "type": "string"
+        },
         "rhcos_image": {
           "description": "The base RHCOS image used for the discovery iso.",
           "type": "string"
@@ -14740,7 +14767,8 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production"
+            "production",
+            "custom"
           ]
         }
       }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3720,6 +3720,9 @@ definitions:
       openshift_version:
         type: string
         description: Version of the OpenShift cluster.
+      ocp_release_image:
+        type: string
+        description: OpenShift release image URI.
       base_dns_domain:
         type: string
         description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
@@ -4000,6 +4003,9 @@ definitions:
       openshift_version:
         type: string
         description: Version of the OpenShift cluster.
+      ocp_release_image:
+        type: string
+        description: OpenShift release image URI.
       openshift_cluster_id:
         type: string
         format: uuid
@@ -5155,6 +5161,7 @@ definitions:
     required:
       - display_name
       - release_image
+      - release_version
       - rhcos_image
       - rhcos_version
       - support_level
@@ -5165,6 +5172,9 @@ definitions:
       release_image:
         type: string
         description: The installation image of the OpenShift cluster.
+      release_version:
+        type: string
+        description: OCP version from the release metadata.
       rhcos_image:
         type: string
         description: The base RHCOS image used for the discovery iso.
@@ -5173,7 +5183,7 @@ definitions:
         description: Build ID of the RHCOS image.
       support_level:
         type: string
-        enum: [beta, production]
+        enum: [beta, production, custom]
         description: Level of support of the version.
       default:
         type: boolean

--- a/tools/handle_ocp_versions.py
+++ b/tools/handle_ocp_versions.py
@@ -65,6 +65,9 @@ def update_openshift_versions_hashmap(ocp_versions: dict, release_image: str, na
 
 def verify_ocp_versions(ocp_versions: dict):
     for key, metadata in ocp_versions.items():
+        if "release_image" not in metadata:
+            # in hive cluster deployment scenario, the release image is specified within an imageset
+            continue
         verify_image_version(key, metadata["release_image"])
 
 


### PR DESCRIPTION
Added the following crds and apis as preliminary dependencies for: https://github.com/openshift/assisted-service/pull/1319

* Added ClusterImageSet CRD
   - Copied from:
   https://github.com/openshift/hive/blob/34d28c1d6e001687fae2d0fc3ac722fe173f0c8c/config/crds/hive.openshift.io_clusterimagesets.yaml
  - Added relevant roles to clusterdeployments_controller.
  - Added an example to docs/crds.
* 'ocp_release_image' property in cluster entity and create params:
  used for storing the release image URI.
* 'release_version' property in openshift-version:
  used for storing the version in major.minor.patch format.
* Modified main and handle_ocp_version to handle missing release_image
  (would be feteched from the cluster image set).