### PR TITLE
MGMT-4563 Skip host connection validation when host is installed or p…

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -46,7 +46,7 @@ var WorkerStages = [...]models.HostStage{
 	models.HostStageJoined, models.HostStageDone,
 }
 
-var manualRebootStages = [...]models.HostStage{
+var manualRebootStages = []models.HostStage{
 	models.HostStageRebooting,
 	models.HostStageWaitingForIgnition,
 	models.HostStageConfiguring,
@@ -797,11 +797,6 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 	for vCategory, vRes := range newValidationRes {
 		for _, v := range vRes {
 			if currentStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
-				// after reboot there is no agent, therefore, the host validation for 'connected' will constantly fail.
-				// this is the expected behaviour and we don't need to generate event/metric for it.
-				if v.ID == IsConnected && funk.Contains(manualRebootStages, h.Progress.CurrentStage) {
-					continue
-				}
 				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
 					m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
 					eventMsg := fmt.Sprintf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -58,6 +58,12 @@ func (r *refreshPreprocessor) preprocess(c *validationContext) (map[string]bool,
 		st := v.condition(c)
 		stateMachineInput[v.id.String()] = st == ValidationSuccess
 		message := v.formatter(c, st)
+
+		// skip the validations per states
+		if funk.Contains(v.skippedStates, c.host.Progress.CurrentStage) {
+			continue
+		}
+
 		category, err := v.id.category()
 		if err != nil {
 			logrus.WithError(err).Warn("id.category()")
@@ -111,9 +117,10 @@ func sortByValidationResultID(validationResults []ValidationResult) {
 func newValidations(v *validator, disabledHostValidations []string) []validation {
 	baseValidations := []validation{
 		{
-			id:        IsConnected,
-			condition: v.isConnected,
-			formatter: v.printConnected,
+			id:            IsConnected,
+			condition:     v.isConnected,
+			formatter:     v.printConnected,
+			skippedStates: manualRebootStages,
 		},
 		{
 			id:        HasInventory,
@@ -181,9 +188,10 @@ func newValidations(v *validator, disabledHostValidations []string) []validation
 			formatter: v.printValidPlatform,
 		},
 		{
-			id:        IsNTPSynced,
-			condition: v.isNTPSynced,
-			formatter: v.printNTPSynced,
+			id:            IsNTPSynced,
+			condition:     v.isNTPSynced,
+			formatter:     v.printNTPSynced,
+			skippedStates: manualRebootStages,
 		},
 		{
 			id:        AreContainerImagesAvailable,

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -60,9 +60,10 @@ type validationConditon func(context *validationContext) ValidationStatus
 type validationStringFormatter func(context *validationContext, status ValidationStatus) string
 
 type validation struct {
-	id        validationID
-	condition validationConditon
-	formatter validationStringFormatter
+	id            validationID
+	condition     validationConditon
+	formatter     validationStringFormatter
+	skippedStates []models.HostStage
 }
 
 func (c *validationContext) loadCluster() error {

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Metrics tests", func() {
 				},
 			}).Error
 			Expect(err).NotTo(HaveOccurred())
-			waitForHostValidationStatus(clusterID, *h.ID, "failure", models.HostValidationIDConnected)
+			waitForHostValidationStatus(clusterID, *h.ID, "success", models.HostValidationIDConnected)
 
 			// check no generated events
 			assertNoValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDConnected)


### PR DESCRIPTION
At this point after rebooting the validation is still running so there is an option a user will get a disconnection or NTP validation fail post-installation, see [MGMT-4563](https://issues.redhat.com/browse/MGMT-4563) bug. 
This PR will skip connection validation checks post-reboot stage. 