### PR TITLE
Igal/support installer args

### DIFF
--- a/docs/Kube-API-examples.md
+++ b/docs/Kube-API-examples.md
@@ -109,3 +109,33 @@ metadata:
   uid: 25769614-52db-448d-8366-05cb38c776fa
 spec:
 ```
+
+### Creating host installer args overrides
+
+In order to alter the default coreos-installer arguments used when running `coreos-installer`openshift-install create command.
+List of supported args can be found here https://github.com/openshift/assisted-service/blob/master/internal/host/hostutil/host_utils.go#L165
+In case of failure to apply the overrides the agent conditions will reflect the error and show the relevant error message. 
+
+Add an annotation with the desired options, the bmac controller will update the agent spec with the annotation value.
+Then agent controller will forward it to host configuration.
+Note that this configuration must be applied prior to starting the installation
+```sh
+$ kubectl annotate bmh openshift-worker-0 -n assisted-installer bmac.agent-install.openshift.io/installer-args="[\"--append-karg\", \"ip=192.0.2.2::192.0.2.254:255.255.255.0:core0.example.com:enp1s0:none\", \"--save-partindex\", \"1\", \"-n\"]"
+baremetalhost.metal3.io/openshift-worker-0 annotated
+```
+
+```sh
+$ oc get bmh openshift-worker-0 -n assisted-installer -o yaml
+```
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  annotations:
+    bmac.agent-install.openshift.io/installer-args: '["--append-karg", "ip=192.0.2.2::192.0.2.254:255.255.255.0:core0.example.com:enp1s0:none", "--save-partindex", "1", "-n"]'
+  creationTimestamp: "2021-04-13T10:46:57Z"
+  generation: 1
+  name: openshift-worker-0
+  namespace: assisted-installer
+spec:
+```

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-openapi/swag v0.19.9
 	github.com/go-openapi/validate v0.19.10
 	github.com/golang-collections/go-datastructures v0.0.0-20150211160725-59788d5eb259
-	github.com/golang/mock v1.4.4
+	github.com/golang/mock v1.5.0
 	github.com/google/renameio v0.1.0
 	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,8 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
-github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6502,7 +6502,7 @@ var _ = Describe("UpdateHostInstallerArgs", func() {
 			InstallerArgsParams: &models.InstallerArgsParams{Args: args},
 		}
 		response := bm.UpdateHostInstallerArgs(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateHostInstallerArgsBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 })
 

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -260,3 +260,18 @@ func (mr *MockInstallerInternalsMockRecorder) UpdateHostApprovedInternal(arg0, a
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostApprovedInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostApprovedInternal), arg0, arg1, arg2, arg3)
 }
+
+// UpdateHostInstallerArgsInternal mocks base method
+func (m *MockInstallerInternals) UpdateHostInstallerArgsInternal(arg0 context.Context, arg1 installer.UpdateHostInstallerArgsParams) (*models.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostInstallerArgsInternal", arg0, arg1)
+	ret0, _ := ret[0].(*models.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateHostInstallerArgsInternal indicates an expected call of UpdateHostInstallerArgsInternal
+func (mr *MockInstallerInternalsMockRecorder) UpdateHostInstallerArgsInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallerArgsInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostInstallerArgsInternal), arg0, arg1)
+}

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -135,6 +135,8 @@ type AgentSpec struct {
 	Approved              bool              `json:"approved"`
 	// InstallationDiskID defines the installation destination disk (must be equal to the inventory disk id).
 	InstallationDiskID string `json:"installation_disk_id,omitempty"`
+	// Json formatted string containing the user overrides for the host's coreos installer args
+	InstallerArgs string `json:"installerArgs,omitempty"`
 }
 
 type HardwareValidationInfo struct {

--- a/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -66,6 +66,10 @@ spec:
                 description: InstallationDiskID defines the installation destination
                   disk (must be equal to the inventory disk id).
                 type: string
+              installerArgs:
+                description: Json formatted string containing the user overrides for
+                  the host's coreos installer args
+                type: string
               machineConfigPool:
                 type: string
               role:

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -56,6 +56,9 @@ spec:
               installation_disk_id:
                 description: InstallationDiskID defines the installation destination disk (must be equal to the inventory disk id).
                 type: string
+              installerArgs:
+                description: Json formatted string containing the user overrides for the host's coreos installer args
+                type: string
               machineConfigPool:
                 type: string
               role:

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -51,6 +51,7 @@ const (
 	BMH_AGENT_HOSTNAME              = "bmac.agent-install.openshift.io/hostname"
 	BMH_AGENT_MACHINE_CONFIG_POOL   = "bmac.agent-install.openshift.io/machine-config-pool"
 	BMH_INSTALL_ENV_LABEL           = "installenvs.agent-install.openshift.io"
+	BMH_AGENT_INSTALLER_ARGS        = "bmac.agent-install.openshift.io/installer-args"
 	BMH_INSPECT_ANNOTATION          = "inspect.metal3.io"
 	BMH_HARDWARE_DETAILS_ANNOTATION = "inspect.metal3.io/hardwaredetails"
 )
@@ -208,6 +209,10 @@ func (r *BMACReconciler) reconcileAgentSpec(bmh *bmh_v1alpha1.BareMetalHost, age
 		agent.Spec.MachineConfigPool = val
 	}
 
+	if val, ok := annotations[BMH_AGENT_INSTALLER_ARGS]; ok {
+		agent.Spec.InstallerArgs = val
+	}
+
 	agent.Spec.Approved = true
 	if agent.ObjectMeta.Labels == nil {
 		agent.ObjectMeta.Labels = make(map[string]string)
@@ -216,7 +221,7 @@ func (r *BMACReconciler) reconcileAgentSpec(bmh *bmh_v1alpha1.BareMetalHost, age
 	// Label the agent with the reference to this BMH
 	agent.ObjectMeta.Labels[AGENT_BMH_LABEL] = bmh.Name
 
-	// findInstalltionDiskID will return an empty string
+	// findInstallationDiskID will return an empty string
 	// if no disk is found from the list. Should be find
 	// to "overwrite" this value everytime as the default
 	// is ""

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -241,6 +241,7 @@ var _ = Describe("bmac reconcile", func() {
 			annotations[BMH_AGENT_ROLE] = "master"
 			annotations[BMH_AGENT_HOSTNAME] = "happy-meal"
 			annotations[BMH_AGENT_MACHINE_CONFIG_POOL] = "number-8"
+			annotations[BMH_AGENT_INSTALLER_ARGS] = `["--args", "aaaa"]`
 			host.ObjectMeta.SetAnnotations(annotations)
 			Expect(c.Create(ctx, host)).To(BeNil())
 
@@ -315,6 +316,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedAgent.Spec.Role).To(Equal(models.HostRoleMaster))
 				Expect(updatedAgent.Spec.Hostname).To(Equal("happy-meal"))
 				Expect(updatedAgent.Spec.MachineConfigPool).To(Equal("number-8"))
+				Expect(updatedAgent.Spec.InstallerArgs).To(Equal(`["--args", "aaaa"]`))
 			})
 
 			It("should keep InstallationDiskID as empty string if not RootDeviceHints match", func() {

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/kelseyhightower/envconfig"
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client"
@@ -70,6 +71,10 @@ func setupKubeClient() {
 	}
 	if addErr := hivev1.AddToScheme(scheme.Scheme); addErr != nil {
 		logrus.Fatalf("Fail adding kubernetes hivev1 scheme: %s", addErr)
+	}
+
+	if addErr := bmh_v1alpha1.AddToScheme(scheme.Scheme); addErr != nil {
+		logrus.Fatalf("Fail adding kubernetes bmh scheme: %s", addErr)
 	}
 
 	var err error


### PR DESCRIPTION
Adding support for core os installer args customization
To customize installer args user will need to set annotation in bmh
example:
bmac.agent-install.openshift.io/installer-args: `["--append-karg", "ip=192.0.2.2::192.0.2.254:255.255.255.0:core0.example.com:enp1s0:none", "--save-partindex", "1", "-n"]`

To delete installer args user will need to set:
bmac.agent-install.openshift.io/installer-args: ""