### PR TITLE
MGMT-5176 - Fix support for disabling hyperthrreading

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -412,7 +412,7 @@ func getHypethreadingConfiguration(cluster *common.Cluster, machineType string) 
 			return "Enabled"
 		}
 	}
-	return ""
+	return "Disabled"
 }
 
 func getCAContents(cluster *common.Cluster, rhRootCA string, installRHRootCAFlag bool) string {

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -315,8 +315,8 @@ var _ = Describe("installcfg", func() {
 		cluster.Hyperthreading = "none"
 		data, err := getBasicInstallConfig(logrus.New(), &cluster)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(data.ControlPlane.Hyperthreading).Should(Equal(""))
-		Expect(data.Compute[0].Hyperthreading).Should(Equal(""))
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal("Disabled"))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal("Disabled"))
 		cluster.Hyperthreading = "all"
 		data, err = getBasicInstallConfig(logrus.New(), &cluster)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -325,13 +325,13 @@ var _ = Describe("installcfg", func() {
 		cluster.Hyperthreading = "workers"
 		data, err = getBasicInstallConfig(logrus.New(), &cluster)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(data.ControlPlane.Hyperthreading).Should(Equal(""))
+		Expect(data.ControlPlane.Hyperthreading).Should(Equal("Disabled"))
 		Expect(data.Compute[0].Hyperthreading).Should(Equal("Enabled"))
 		cluster.Hyperthreading = "masters"
 		data, err = getBasicInstallConfig(logrus.New(), &cluster)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(data.ControlPlane.Hyperthreading).Should(Equal("Enabled"))
-		Expect(data.Compute[0].Hyperthreading).Should(Equal(""))
+		Expect(data.Compute[0].Hyperthreading).Should(Equal("Disabled"))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
hypethreading configuration is set in the install-config and is used
    by the installer code to produce ignition kernel param for RHCOS.
    by default hypethreading is enabled by the RCHOS, so installer code needs
    to configure kernel arg only in case of hyperthreading disabling. the valid values
    for hyperthreading parameter in ignition is Enabled and Disabled. In case the value is missing,
    it is Enabled by default