### PR TITLE
MGMT-4463 Support IgnitionConfigOverrides in the Agent

### DIFF
--- a/docs/Kube-API.md
+++ b/docs/Kube-API.md
@@ -189,3 +189,31 @@ metadata:
   namespace: assisted-installer
 spec:
 ```
+
+### Creating host ignition config overrides
+
+In case of failure to apply the overrides the agent conditions will reflect the error and show the relevant error message. 
+
+Add an annotation with the desired options, the bmac controller will update the agent spec with the annotation value.
+Then agent controller will forward it to host configuration.
+Note that this configuration must be applied prior to starting the installation
+```sh
+$ kubectl annotate bmh openshift-worker-0 -n assisted-installer bmac.adi.openshift.io/ignition-config-overrides="{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}"
+baremetalhost.metal3.io/openshift-worker-0 annotated
+```
+
+```sh
+$ oc get bmh openshift-worker-0 -n assisted-installer -o yaml
+```
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  annotations:
+    bmac.adi.openshift.io/ignition-config-overrides: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
+  creationTimestamp: "2021-04-14T10:46:57Z"
+  generation: 1
+  name: openshift-worker-0
+  namespace: assisted-installer
+spec:
+```

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6244,7 +6244,7 @@ var _ = Describe("UpdateHostIgnition", func() {
 			HostIgnitionParams: &models.HostIgnitionParams{Config: override},
 		}
 		response := bm.UpdateHostIgnition(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateHostIgnitionBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 
 	It("returns bad request when provided invalid options", func() {
@@ -6256,7 +6256,7 @@ var _ = Describe("UpdateHostIgnition", func() {
 			HostIgnitionParams: &models.HostIgnitionParams{Config: override},
 		}
 		response := bm.UpdateHostIgnition(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateHostIgnitionBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 
 	It("returns bad request when provided an old version", func() {
@@ -6268,7 +6268,7 @@ var _ = Describe("UpdateHostIgnition", func() {
 			HostIgnitionParams: &models.HostIgnitionParams{Config: override},
 		}
 		response := bm.UpdateHostIgnition(ctx, params)
-		Expect(response).To(BeAssignableToTypeOf(&installer.UpdateHostIgnitionBadRequest{}))
+		verifyApiError(response, http.StatusBadRequest)
 	})
 })
 

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -261,6 +261,21 @@ func (mr *MockInstallerInternalsMockRecorder) UpdateHostApprovedInternal(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostApprovedInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostApprovedInternal), arg0, arg1, arg2, arg3)
 }
 
+// UpdateHostIgnitionInternal mocks base method
+func (m *MockInstallerInternals) UpdateHostIgnitionInternal(arg0 context.Context, arg1 installer.UpdateHostIgnitionParams) (*models.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostIgnitionInternal", arg0, arg1)
+	ret0, _ := ret[0].(*models.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateHostIgnitionInternal indicates an expected call of UpdateHostIgnitionInternal
+func (mr *MockInstallerInternalsMockRecorder) UpdateHostIgnitionInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostIgnitionInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostIgnitionInternal), arg0, arg1)
+}
+
 // UpdateHostInstallerArgsInternal mocks base method
 func (m *MockInstallerInternals) UpdateHostInstallerArgsInternal(arg0 context.Context, arg1 installer.UpdateHostInstallerArgsParams) (*models.Host, error) {
 	m.ctrl.T.Helper()

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -172,7 +172,7 @@ type AgentSpec struct {
 	// Json formatted string containing the user overrides for the host's coreos installer args
 	InstallerArgs string `json:"installerArgs,omitempty"`
 	// Json formatted string containing the user overrides for the host's ignition config
-	IgnitionConfigOverride string `json:"ignitionConfigOverride,omitempty"`
+	IgnitionConfigOverrides string `json:"ignitionConfigOverrides,omitempty"`
 }
 
 type HardwareValidationInfo struct {

--- a/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/internal/controller/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -62,7 +62,7 @@ spec:
                 type: object
               hostname:
                 type: string
-              ignitionConfigOverride:
+              ignitionConfigOverrides:
                 description: Json formatted string containing the user overrides for
                   the host's ignition config
                 type: string

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -53,7 +53,7 @@ spec:
                 type: object
               hostname:
                 type: string
-              ignitionConfigOverride:
+              ignitionConfigOverrides:
                 description: Json formatted string containing the user overrides for the host's ignition config
                 type: string
               installation_disk_id:

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -52,17 +52,17 @@ type BMACReconciler struct {
 }
 
 const (
-	AGENT_BMH_LABEL                    = "agent-install.openshift.io/bmh"
-	BMH_AGENT_ROLE                     = "bmac.agent-install.openshift.io/role"
-	BMH_AGENT_HOSTNAME                 = "bmac.agent-install.openshift.io/hostname"
-	BMH_AGENT_MACHINE_CONFIG_POOL      = "bmac.agent-install.openshift.io/machine-config-pool"
-	BMH_INSTALL_ENV_LABEL              = "infraenvs.agent-install.openshift.io"
-	BMH_AGENT_INSTALLER_ARGS           = "bmac.agent-install.openshift.io/installer-args"
-	BMH_INSPECT_ANNOTATION             = "inspect.metal3.io"
-	BMH_HARDWARE_DETAILS_ANNOTATION    = "inspect.metal3.io/hardwaredetails"
-	BMH_AGENT_IGNITION_CONFIG_OVERRIDE = "bmac.agent-install.openshift.io/ignition-config-overrides"
-	MACHINE_ROLE                       = "machine.openshift.io/cluster-api-machine-role"
-	MACHINE_TYPE                       = "machine.openshift.io/cluster-api-machine-type"
+	AGENT_BMH_LABEL                     = "agent-install.openshift.io/bmh"
+	BMH_AGENT_ROLE                      = "bmac.agent-install.openshift.io/role"
+	BMH_AGENT_HOSTNAME                  = "bmac.agent-install.openshift.io/hostname"
+	BMH_AGENT_MACHINE_CONFIG_POOL       = "bmac.agent-install.openshift.io/machine-config-pool"
+	BMH_INSTALL_ENV_LABEL               = "infraenvs.agent-install.openshift.io"
+	BMH_AGENT_INSTALLER_ARGS            = "bmac.agent-install.openshift.io/installer-args"
+	BMH_INSPECT_ANNOTATION              = "inspect.metal3.io"
+	BMH_HARDWARE_DETAILS_ANNOTATION     = "inspect.metal3.io/hardwaredetails"
+	BMH_AGENT_IGNITION_CONFIG_OVERRIDES = "bmac.agent-install.openshift.io/ignition-config-overrides"
+	MACHINE_ROLE                        = "machine.openshift.io/cluster-api-machine-role"
+	MACHINE_TYPE                        = "machine.openshift.io/cluster-api-machine-type"
 )
 
 // reconcileResult is an interface that encapsulates the result of a Reconcile
@@ -221,8 +221,8 @@ func (r *BMACReconciler) reconcileAgentSpec(bmh *bmh_v1alpha1.BareMetalHost, age
 		agent.Spec.InstallerArgs = val
 	}
 
-	if val, ok := annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDE]; ok {
-		agent.Spec.IgnitionConfigOverride = val
+	if val, ok := annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES]; ok {
+		agent.Spec.IgnitionConfigOverrides = val
 	}
 
 	agent.Spec.Approved = true

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -254,7 +254,7 @@ var _ = Describe("bmac reconcile", func() {
 			annotations[BMH_AGENT_HOSTNAME] = "happy-meal"
 			annotations[BMH_AGENT_MACHINE_CONFIG_POOL] = "number-8"
 			annotations[BMH_AGENT_INSTALLER_ARGS] = `["--args", "aaaa"]`
-			annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDE] = "agent-ignition"
+			annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES] = "agent-ignition"
 			host.ObjectMeta.SetAnnotations(annotations)
 			Expect(c.Create(ctx, host)).To(BeNil())
 
@@ -330,7 +330,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedAgent.Spec.Hostname).To(Equal("happy-meal"))
 				Expect(updatedAgent.Spec.MachineConfigPool).To(Equal("number-8"))
 				Expect(updatedAgent.Spec.InstallerArgs).To(Equal(`["--args", "aaaa"]`))
-				Expect(updatedAgent.Spec.IgnitionConfigOverride).To(Equal("agent-ignition"))
+				Expect(updatedAgent.Spec.IgnitionConfigOverrides).To(Equal("agent-ignition"))
 			})
 
 			It("should keep InstallationDiskID as empty string if not RootDeviceHints match", func() {


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MGMT-4463

This PR adds support for the IgnitionConfigOverrides parameter added in the agent spec (Ref: https://issues.redhat.com/browse/MGMT-4914). The parameter is reconciled and added in the backend (db). To customize IgnitionConfigOverrides, user will need to set annotation in bmh
example:

> bmac.adi.openshift.io/ignition-config-overrides: {"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}

 