### PR TITLE
MGMT-4740 Encrypt traffic to assisted service

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -477,14 +477,21 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(instance *ai
 			},
 		},
 		LivenessProbe: &corev1.Probe{
-			FailureThreshold:    3,
-			SuccessThreshold:    1,
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       10,
-			TimeoutSeconds:      3,
+			InitialDelaySeconds: 30,
 			Handler: corev1.Handler{
-				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(int(servicePort)),
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/health",
+					Port:   intstr.FromInt(int(servicePort)),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/ready",
+					Port:   intstr.FromInt(int(servicePort)),
+					Scheme: corev1.URISchemeHTTPS,
 				},
 			},
 		},


### PR DESCRIPTION
This commit adds an annotation to the service which will cause a
tls secret to be created in the same namespace valid for that service
name. This secret is used to configure assisted-service to start an
https server.

Additionally, the route is configured to use "re-encrypt" tls
termination which will use the router's certificate to communicate
with the client, then re-encrypt the request from the router to the
service using the service cert.

Docs on the service annotation:
https://docs.openshift.com/container-platform/4.7/security/certificates/service-serving-certificate.html#add-service-certificate_service-serving-certificate
https://issues.redhat.com/browse/MGMT-4740

~~Depends on https://github.com/openshift/assisted-service/pull/1495~~ Merged