### PR TITLE
MGMT-4477 Preflight hardware requirements handler

### DIFF
--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -51,17 +51,17 @@ func (mr *MockValidatorMockRecorder) GetHostValidDisks(host interface{}) *gomock
 }
 
 // GetHostRequirements mocks base method
-func (m *MockValidator) GetHostRequirements(role models.HostRole) models.HostRequirementsRole {
+func (m *MockValidator) GetHostRequirements() *models.VersionedHostRequirements {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostRequirements", role)
-	ret0, _ := ret[0].(models.HostRequirementsRole)
+	ret := m.ctrl.Call(m, "GetHostRequirements")
+	ret0, _ := ret[0].(*models.VersionedHostRequirements)
 	return ret0
 }
 
 // GetHostRequirements indicates an expected call of GetHostRequirements
-func (mr *MockValidatorMockRecorder) GetHostRequirements(role interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) GetHostRequirements() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements), role)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements))
 }
 
 // GetHostInstallationPath mocks base method
@@ -133,4 +133,19 @@ func (m *MockValidator) GetInstallationDiskSpeedThresholdMs() int64 {
 func (mr *MockValidatorMockRecorder) GetInstallationDiskSpeedThresholdMs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallationDiskSpeedThresholdMs", reflect.TypeOf((*MockValidator)(nil).GetInstallationDiskSpeedThresholdMs))
+}
+
+// GetPreflightHardwareRequirements mocks base method
+func (m *MockValidator) GetPreflightHardwareRequirements(ctx context.Context, cluster *common.Cluster) (*models.PreflightHardwareRequirements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPreflightHardwareRequirements", ctx, cluster)
+	ret0, _ := ret[0].(*models.PreflightHardwareRequirements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPreflightHardwareRequirements indicates an expected call of GetPreflightHardwareRequirements
+func (mr *MockValidatorMockRecorder) GetPreflightHardwareRequirements(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreflightHardwareRequirements", reflect.TypeOf((*MockValidator)(nil).GetPreflightHardwareRequirements), ctx, cluster)
 }

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -26,6 +26,9 @@ type Validator interface {
 	DiskIsEligible(disk *models.Disk) []string
 	ListEligibleDisks(inventory *models.Inventory) []*models.Disk
 	GetInstallationDiskSpeedThresholdMs() int64
+	// GetPreflightHardwareRequirements provides hardware (host) requirements that can be calculated only using cluster information.
+	// Returned information describe requirements coming from OCP and OLM operators.
+	// It should replace GetHostRequirements when its endpoint is not used anymore.
 	GetPreflightHardwareRequirements(ctx context.Context, cluster *common.Cluster) (*models.PreflightHardwareRequirements, error)
 }
 

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -20,12 +20,13 @@ import (
 //go:generate mockgen -source=validator.go -package=hardware -destination=mock_validator.go
 type Validator interface {
 	GetHostValidDisks(host *models.Host) ([]*models.Disk, error)
-	GetHostRequirements(role models.HostRole) models.HostRequirementsRole
+	GetHostRequirements() *models.VersionedHostRequirements
 	GetHostInstallationPath(host *models.Host) string
 	GetClusterHostRequirements(ctx context.Context, cluster *common.Cluster, host *models.Host) (*models.ClusterHostRequirements, error)
 	DiskIsEligible(disk *models.Disk) []string
 	ListEligibleDisks(inventory *models.Inventory) []*models.Disk
 	GetInstallationDiskSpeedThresholdMs() int64
+	GetPreflightHardwareRequirements(ctx context.Context, cluster *common.Cluster) (*models.PreflightHardwareRequirements, error)
 }
 
 func NewValidator(log logrus.FieldLogger, cfg ValidatorCfg, operatorsAPI operators.API) Validator {
@@ -124,40 +125,20 @@ func (v *validator) ListEligibleDisks(inventory *models.Inventory) []*models.Dis
 	return eligibleDisks
 }
 
-func (v *validator) GetHostRequirements(role models.HostRole) models.HostRequirementsRole {
-	if role == models.HostRoleMaster {
-		return models.HostRequirementsRole{
+func (v *validator) GetHostRequirements() *models.VersionedHostRequirements {
+	return &models.VersionedHostRequirements{
+		MasterRequirements: &models.ClusterHostRequirementsDetails{
 			CPUCores:                         v.ValidatorCfg.MinCPUCoresMaster,
-			RAMGib:                           v.ValidatorCfg.MinRamGibMaster,
+			RAMMib:                           conversions.GibToMib(v.ValidatorCfg.MinRamGibMaster),
 			DiskSizeGb:                       v.ValidatorCfg.MinDiskSizeGb,
 			InstallationDiskSpeedThresholdMs: v.InstallationDiskSpeedThresholdMs,
-		}
-	}
-	return models.HostRequirementsRole{
-		CPUCores:                         v.ValidatorCfg.MinCPUCoresWorker,
-		RAMGib:                           v.ValidatorCfg.MinRamGibWorker,
-		DiskSizeGb:                       v.ValidatorCfg.MinDiskSizeGb,
-		InstallationDiskSpeedThresholdMs: v.InstallationDiskSpeedThresholdMs,
-	}
-}
-
-func (v *validator) GetHostRequirementsForVersion(role models.HostRole, openShiftVersion string) models.HostRequirementsRole {
-	requirements, err := v.VersionedRequirements.GetVersionedHostRequirements(openShiftVersion)
-	if err != nil {
-		return v.GetHostRequirements(role)
-	}
-	if role == models.HostRoleMaster {
-		return fromRequirements(requirements.MasterRequirements)
-	}
-	return fromRequirements(requirements.WorkerRequirements)
-}
-
-func fromRequirements(nodeRequirements *models.ClusterHostRequirementsDetails) models.HostRequirementsRole {
-	return models.HostRequirementsRole{
-		CPUCores:                         nodeRequirements.CPUCores,
-		RAMGib:                           conversions.MibToGiB(nodeRequirements.RAMMib),
-		DiskSizeGb:                       nodeRequirements.DiskSizeGb,
-		InstallationDiskSpeedThresholdMs: nodeRequirements.InstallationDiskSpeedThresholdMs,
+		},
+		WorkerRequirements: &models.ClusterHostRequirementsDetails{
+			CPUCores:                         v.ValidatorCfg.MinCPUCoresWorker,
+			RAMMib:                           conversions.GibToMib(v.ValidatorCfg.MinRamGibWorker),
+			DiskSizeGb:                       v.ValidatorCfg.MinDiskSizeGb,
+			InstallationDiskSpeedThresholdMs: v.InstallationDiskSpeedThresholdMs,
+		},
 	}
 }
 
@@ -167,13 +148,7 @@ func (v *validator) GetClusterHostRequirements(ctx context.Context, cluster *com
 		return nil, err
 	}
 
-	hostRequirements := v.GetHostRequirementsForVersion(host.Role, cluster.OpenshiftVersion)
-	ocpRequirements := models.ClusterHostRequirementsDetails{
-		CPUCores:                         hostRequirements.CPUCores,
-		RAMMib:                           conversions.GibToMib(hostRequirements.RAMGib),
-		DiskSizeGb:                       hostRequirements.DiskSizeGb,
-		InstallationDiskSpeedThresholdMs: hostRequirements.InstallationDiskSpeedThresholdMs,
-	}
+	ocpRequirements := v.getOCPHostRoleRequirementsForVersion(host.Role, cluster.OpenshiftVersion)
 	total := totalizeRequirements(ocpRequirements, operatorsRequirements)
 	return &models.ClusterHostRequirements{
 		HostID:    *host.ID,
@@ -181,6 +156,26 @@ func (v *validator) GetClusterHostRequirements(ctx context.Context, cluster *com
 		Operators: operatorsRequirements,
 		Total:     &total,
 	}, nil
+}
+
+func (v *validator) GetPreflightHardwareRequirements(ctx context.Context, cluster *common.Cluster) (*models.PreflightHardwareRequirements, error) {
+	operatorsRequirements, err := v.operatorsAPI.GetPreflightRequirementsBreakdownForCluster(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	ocpRequirements, err := v.getPreflightOCPRequirements(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.PreflightHardwareRequirements{
+		Operators: operatorsRequirements,
+		Ocp:       ocpRequirements,
+	}, nil
+}
+
+func (v *validator) GetInstallationDiskSpeedThresholdMs() int64 {
+	return v.InstallationDiskSpeedThresholdMs
 }
 
 func totalizeRequirements(ocpRequirements models.ClusterHostRequirementsDetails, operatorRequirements []*models.OperatorHostRequirements) models.ClusterHostRequirementsDetails {
@@ -201,6 +196,30 @@ func totalizeRequirements(ocpRequirements models.ClusterHostRequirementsDetails,
 	return total
 }
 
-func (v *validator) GetInstallationDiskSpeedThresholdMs() int64 {
-	return v.InstallationDiskSpeedThresholdMs
+func (v *validator) getOCPHostRoleRequirementsForVersion(role models.HostRole, openShiftVersion string) models.ClusterHostRequirementsDetails {
+	requirements := v.getOCPRequirementsForVersion(openShiftVersion)
+	if role == models.HostRoleMaster {
+		return *requirements.MasterRequirements
+	}
+	return *requirements.WorkerRequirements
+}
+
+func (v *validator) getPreflightOCPRequirements(cluster *common.Cluster) (*models.HostTypeHardwareRequirementsWrapper, error) {
+	requirements := v.getOCPRequirementsForVersion(cluster.OpenshiftVersion)
+	return &models.HostTypeHardwareRequirementsWrapper{
+		Master: &models.HostTypeHardwareRequirements{
+			Quantitative: requirements.MasterRequirements,
+		},
+		Worker: &models.HostTypeHardwareRequirements{
+			Quantitative: requirements.WorkerRequirements,
+		},
+	}, nil
+}
+
+func (v *validator) getOCPRequirementsForVersion(openShiftVersion string) *models.VersionedHostRequirements {
+	requirements, err := v.VersionedRequirements.GetVersionedHostRequirements(openShiftVersion)
+	if err != nil {
+		requirements = v.GetHostRequirements()
+	}
+	return requirements
 }

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -125,7 +125,6 @@ type API interface {
 	IsValidMasterCandidate(h *models.Host, db *gorm.DB, log logrus.FieldLogger) (bool, error)
 	SetUploadLogsAt(ctx context.Context, h *models.Host, db *gorm.DB) error
 	UpdateLogsProgress(ctx context.Context, h *models.Host, progress string) error
-	GetHostRequirements(role models.HostRole) models.HostRequirementsRole
 	PermanentHostsDeletion(olderThan strfmt.DateTime) error
 	ReportValidationFailedMetrics(ctx context.Context, h *models.Host, ocpVersion, emailDomain string) error
 
@@ -937,10 +936,6 @@ func (m *Manager) canBeMaster(conditions map[string]bool) bool {
 		return true
 	}
 	return false
-}
-
-func (m *Manager) GetHostRequirements(role models.HostRole) models.HostRequirementsRole {
-	return m.hwValidator.GetHostRequirements(role)
 }
 
 func (m *Manager) GetHostValidDisks(host *models.Host) ([]*models.Disk, error) {

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -94,20 +94,6 @@ func (mr *MockAPIMockRecorder) EnableHost(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableHost", reflect.TypeOf((*MockAPI)(nil).EnableHost), arg0, arg1, arg2)
 }
 
-// GetHostRequirements mocks base method
-func (m *MockAPI) GetHostRequirements(arg0 models.HostRole) models.HostRequirementsRole {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostRequirements", arg0)
-	ret0, _ := ret[0].(models.HostRequirementsRole)
-	return ret0
-}
-
-// GetHostRequirements indicates an expected call of GetHostRequirements
-func (mr *MockAPIMockRecorder) GetHostRequirements(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockAPI)(nil).GetHostRequirements), arg0)
-}
-
 // GetHostValidDisks mocks base method
 func (m *MockAPI) GetHostValidDisks(arg0 *models.Host) ([]*models.Disk, error) {
 	m.ctrl.T.Helper()

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -813,13 +813,6 @@ var _ = Describe("Install", func() {
 			cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 			cluster.Status = swag.String(models.ClusterStatusInstalling)
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
-			hostRequirements := models.HostRequirementsRole{
-				CPUCores:                         2,
-				DiskSizeGb:                       80,
-				InstallationDiskSpeedThresholdMs: 10,
-				RAMGib:                           8,
-			}
-			mockHwValidator.EXPECT().GetHostRequirements(gomock.Any()).Return(hostRequirements).AnyTimes()
 			clusterRequirements := models.ClusterHostRequirements{
 				Total: &models.ClusterHostRequirementsDetails{
 					CPUCores:   1,

--- a/internal/operators/api/api.go
+++ b/internal/operators/api/api.go
@@ -48,4 +48,6 @@ type Operator interface {
 	GetProperties() models.OperatorProperties
 	// GetMonitoredOperator returns MonitoredOperator corresponding to the Operator implementation
 	GetMonitoredOperator() *models.MonitoredOperator
+	// GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
+	GetPreflightRequirements(ctx context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error)
 }

--- a/internal/operators/api/mock_operator_api.go
+++ b/internal/operators/api/mock_operator_api.go
@@ -135,6 +135,21 @@ func (mr *MockOperatorMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockOperator)(nil).GetName))
 }
 
+// GetPreflightRequirements mocks base method
+func (m *MockOperator) GetPreflightRequirements(arg0 context.Context, arg1 *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPreflightRequirements", arg0, arg1)
+	ret0, _ := ret[0].(*models.OperatorHardwareRequirements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPreflightRequirements indicates an expected call of GetPreflightRequirements
+func (mr *MockOperatorMockRecorder) GetPreflightRequirements(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreflightRequirements", reflect.TypeOf((*MockOperator)(nil).GetPreflightRequirements), arg0, arg1)
+}
+
 // GetProperties mocks base method
 func (m *MockOperator) GetProperties() models.OperatorProperties {
 	m.ctrl.T.Helper()

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/cnv"
+	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 )
@@ -129,6 +130,24 @@ var _ = Describe("CNV operator", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(requirements).ToNot(BeNil())
 			Expect(requirements).To(BeEquivalentTo(newRequirements(cnv.WorkerCPU, cnv.WorkerMemory+2*1024)))
+		})
+	})
+
+	Context("preflight hardware requirements", func() {
+		It("should be returned", func() {
+			requirements, err := operator.GetPreflightRequirements(context.TODO(), nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(requirements.Dependencies).To(ConsistOf(lso.Operator.Name))
+			Expect(requirements.OperatorName).To(BeEquivalentTo(cnv.Operator.Name))
+
+			Expect(requirements.Requirements.Worker.Qualitative).To(HaveLen(2))
+			Expect(requirements.Requirements.Worker.Quantitative).To(BeEquivalentTo(newRequirements(cnv.WorkerCPU, cnv.WorkerMemory)))
+
+			Expect(requirements.Requirements.Master.Qualitative).To(HaveLen(2))
+			Expect(requirements.Requirements.Master.Quantitative).To(BeEquivalentTo(newRequirements(cnv.MasterCPU, cnv.MasterMemory)))
+
+			Expect(requirements.Requirements.Master.Qualitative).To(BeEquivalentTo(requirements.Requirements.Worker.Qualitative))
 		})
 	})
 })

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -74,3 +74,19 @@ func (l *lsOperator) GetMonitoredOperator() *models.MonitoredOperator {
 func (l *lsOperator) GetHostRequirements(context.Context, *common.Cluster, *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	return &models.ClusterHostRequirementsDetails{}, nil
 }
+
+// GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
+func (l *lsOperator) GetPreflightRequirements(context.Context, *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+	return &models.OperatorHardwareRequirements{
+		OperatorName: l.GetName(),
+		Dependencies: l.GetDependencies(),
+		Requirements: &models.HostTypeHardwareRequirementsWrapper{
+			Master: &models.HostTypeHardwareRequirements{
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+			},
+			Worker: &models.HostTypeHardwareRequirements{
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+			},
+		},
+	}, nil
+}

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -52,6 +52,27 @@ type API interface {
 	GetOperatorProperties(operatorName string) (models.OperatorProperties, error)
 	// GetRequirementsBreakdownForHostInCluster provides host requirements breakdown for each OLM operator in the cluster
 	GetRequirementsBreakdownForHostInCluster(ctx context.Context, cluster *common.Cluster, host *models.Host) ([]*models.OperatorHostRequirements, error)
+	// GetPreflightRequirementsBreakdownForCluster provides host requirements breakdown for each OLM operator in the cluster
+	GetPreflightRequirementsBreakdownForCluster(ctx context.Context, cluster *common.Cluster) ([]*models.OperatorHardwareRequirements, error)
+}
+
+// GetPreflightRequirementsBreakdownForCluster provides host requirements breakdown for each OLM operator in the cluster
+func (mgr Manager) GetPreflightRequirementsBreakdownForCluster(ctx context.Context, cluster *common.Cluster) ([]*models.OperatorHardwareRequirements, error) {
+	logger := logutil.FromContext(ctx, mgr.log)
+	var requirements []*models.OperatorHardwareRequirements
+	for _, monitoredOperator := range cluster.MonitoredOperators {
+		operatorName := monitoredOperator.Name
+		operator := mgr.olmOperators[operatorName]
+		if operator != nil {
+			reqs, err := operator.GetPreflightRequirements(ctx, cluster)
+			if err != nil {
+				logger.WithError(err).Errorf("Cannot get preflight requirements for %s operator", operatorName)
+				return nil, err
+			}
+			requirements = append(requirements, reqs)
+		}
+	}
+	return requirements, nil
 }
 
 // GetRequirementsBreakdownForRoleInCluster provides host requirements breakdown for each OLM operator in the cluster

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -308,7 +308,6 @@ var _ = Describe("Operators manager", func() {
 		BeforeEach(func() {
 			operator1 = mockOperatorBase(operatorName1)
 			operator2 = mockOperatorBase(operatorName2)
-			cluster.MonitoredOperators = models.MonitoredOperatorsList{{Name: operatorName1}, {Name: operatorName2}}
 			manager = operators.NewManagerWithOperators(log, manifestsAPI, operators.Options{}, operator1, operator2)
 		})
 		It("should be provided for configured operators", func() {
@@ -328,11 +327,9 @@ var _ = Describe("Operators manager", func() {
 		})
 
 		It("should return error", func() {
-			requirements1 := models.OperatorHardwareRequirements{OperatorName: operatorName1}
-			operator1.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(&requirements1, nil)
-
 			theError := errors.New("boom")
-			operator2.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(nil, theError)
+			operator1.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(nil, theError).AnyTimes()
+			operator2.EXPECT().GetPreflightRequirements(gomock.Any(), gomock.Eq(cluster)).Return(nil, theError).AnyTimes()
 
 			_, err := manager.GetPreflightRequirementsBreakdownForCluster(context.TODO(), cluster)
 

--- a/internal/operators/mock_operators_api.go
+++ b/internal/operators/mock_operators_api.go
@@ -108,6 +108,21 @@ func (mr *MockAPIMockRecorder) GetOperatorProperties(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOperatorProperties", reflect.TypeOf((*MockAPI)(nil).GetOperatorProperties), arg0)
 }
 
+// GetPreflightRequirementsBreakdownForCluster mocks base method
+func (m *MockAPI) GetPreflightRequirementsBreakdownForCluster(arg0 context.Context, arg1 *common.Cluster) ([]*models.OperatorHardwareRequirements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPreflightRequirementsBreakdownForCluster", arg0, arg1)
+	ret0, _ := ret[0].([]*models.OperatorHardwareRequirements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPreflightRequirementsBreakdownForCluster indicates an expected call of GetPreflightRequirementsBreakdownForCluster
+func (mr *MockAPIMockRecorder) GetPreflightRequirementsBreakdownForCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreflightRequirementsBreakdownForCluster", reflect.TypeOf((*MockAPI)(nil).GetPreflightRequirementsBreakdownForCluster), arg0, arg1)
+}
+
 // GetRequirementsBreakdownForHostInCluster mocks base method
 func (m *MockAPI) GetRequirementsBreakdownForHostInCluster(arg0 context.Context, arg1 *common.Cluster, arg2 *models.Host) ([]*models.OperatorHostRequirements, error) {
 	m.ctrl.T.Helper()

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -106,6 +106,10 @@ func (o *operator) GetPreflightRequirements(context.Context, *common.Cluster) (*
 			Master: &models.HostTypeHardwareRequirements{
 				// TODO: adjust when https://github.com/openshift/assisted-service/pull/1456 is merged
 				Quantitative: &models.ClusterHostRequirementsDetails{},
+				Qualitative: []string{
+					"At least 3 hosts in case of masters-only cluster",
+					"At least 1 non-boot disk on 3 hosts",
+				},
 			},
 			Worker: &models.HostTypeHardwareRequirements{
 				// TODO: adjust when https://github.com/openshift/assisted-service/pull/1456 is merged
@@ -113,6 +117,8 @@ func (o *operator) GetPreflightRequirements(context.Context, *common.Cluster) (*
 				Qualitative: []string{
 					fmt.Sprintf("%v GiB of additional RAM for each non-boot disk", o.config.OCSRequiredDiskRAMGB),
 					fmt.Sprintf("%v additional CPUs for each non-boot disk", o.config.OCSRequiredDiskCPUCount),
+					"At least 3 hosts in case of cluster with workers",
+					"At least 1 non-boot disk on 3 hosts",
 				},
 			},
 		},

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -2,6 +2,7 @@ package ocs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift/assisted-service/internal/common"
@@ -94,4 +95,26 @@ func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
 // GetHostRequirements provides operator's requirements towards the host
 func (o *operator) GetHostRequirements(context.Context, *common.Cluster, *models.Host) (*models.ClusterHostRequirementsDetails, error) {
 	return &models.ClusterHostRequirementsDetails{}, nil
+}
+
+// GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
+func (o *operator) GetPreflightRequirements(context.Context, *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+	return &models.OperatorHardwareRequirements{
+		OperatorName: o.GetName(),
+		Dependencies: o.GetDependencies(),
+		Requirements: &models.HostTypeHardwareRequirementsWrapper{
+			Master: &models.HostTypeHardwareRequirements{
+				// TODO: adjust when https://github.com/openshift/assisted-service/pull/1456 is merged
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+			},
+			Worker: &models.HostTypeHardwareRequirements{
+				// TODO: adjust when https://github.com/openshift/assisted-service/pull/1456 is merged
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+				Qualitative: []string{
+					fmt.Sprintf("%v GiB of additional RAM for each non-boot disk", o.config.OCSRequiredDiskRAMGB),
+					fmt.Sprintf("%v additional CPUs for each non-boot disk", o.config.OCSRequiredDiskCPUCount),
+				},
+			},
+		},
+	}, nil
 }


### PR DESCRIPTION
Changes contained within this PR add implementation of `/clusters/{cluster_id}/preflight-requirements` endpoint handler that provides information about pre-flight hardware requirements - coming from OCP and supported OLM operators.