### PR TITLE
OCPBUGSM-26430 - fix dns resolution for bootstrap node configured wit…

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -40,6 +40,22 @@ ipv6.dhcp-duid=ll
 path=/etc/NetworkManager/system-connections-merged
 `
 
+// Configuration of the NM hostname mode in case of static network configuration
+// needed in order to prevent hostname update in bootstrap node, which may cause dns resolution
+// failure due to OCPBUGSM-26430
+const StaticNetworkHostnameConf = `
+[main]
+hostname-mode=none
+`
+
+// NM configuration to be activated (set into discovery ignition) in case we want more logging for NM debugging purposes.
+// This content needs to be set in the /etc/NetworkManager/conf.d/95-nm-debug.conf
+// In addition, the line RateLimitBurst=0 must be uncommented in the /etc/systemd/journald.conf and systemctl restart systemd-journald run.
+const NMDebugModeConf = `
+[logging]
+domains=ALL:DEBUG
+`
+
 // continueOnError is set when running as stream, error is doing nothing when it happens cause we in the middle of stream
 // and 200 was already returned
 func CreateTar(ctx context.Context, w io.Writer, files, tarredFilenames []string, client s3wrapper.API, continueOnError bool) error {

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -241,6 +241,15 @@ const discoveryIgnitionConfigFormat = `{
             "name": "root"
         },
         "contents": { "source": "data:text/plain;base64,{{.PreNetworkConfigScript}}"}
+    },
+    {
+      "overwrite": true,
+      "path": "/etc/NetworkManager/conf.d/02-hostname-mode.conf",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.StaticNMHostnameMode}}" }
     }{{end}}{{range .StaticNetworkConfig}},
     {
       "path": "{{.FilePath}}",
@@ -1279,6 +1288,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(cluster *common.Cluster, 
 		}
 		ignitionParams["StaticNetworkConfig"] = filesList
 		ignitionParams["PreNetworkConfigScript"] = base64.StdEncoding.EncodeToString([]byte(constants.PreNetworkConfigScript))
+		ignitionParams["StaticNMHostnameMode"] = url.PathEscape(common.StaticNetworkHostnameConf)
 	}
 
 	tmpl, err := template.New("ignitionConfig").Parse(discoveryIgnitionConfigFormat)

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1000,11 +1000,11 @@ var _ = Describe("IgnitionBuilder", func() {
 			Expect(report.IsFatal()).To(BeFalse())
 			count := 0
 			for _, f := range config.Storage.Files {
-				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") {
+				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") || strings.HasSuffix(f.Path, "02-hostname-mode.conf") {
 					count += 1
 				}
 			}
-			Expect(count).Should(Equal(3))
+			Expect(count).Should(Equal(4))
 		})
 		It("Doesn't include static network config for minimal isos", func() {
 			formattedInput := staticnetworkconfig.FormatStaticNetworkConfigForDB(staticNetworkConfig)
@@ -1018,7 +1018,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			Expect(report.IsFatal()).To(BeFalse())
 			count := 0
 			for _, f := range config.Storage.Files {
-				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") {
+				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") || strings.HasSuffix(f.Path, "02-hostname-mode.conf") {
 					count += 1
 				}
 			}


### PR DESCRIPTION
…h bond interface

Bonding interface may take a long time to be up, therefore NM will set its transient name
to localhost, since no default link is available. Afterwards, API VIP is set on that interface which causes NM to check if
there is an update to hostame ( and there will be since link is up and it can perform reverse lookup. In case hostname has changed,
NM tries to recalculate the resolv.conf file contents, and it will set it to use the DNS ip provied by configuration( external), and will remove
the local ip 127.0.0.1, set by the prepender script. Since the IP change is external, and the resulting hostname is not valid for hostnamed service,
the prepender script is not run.
Solutuon: set the NM configurion hostname mode to none, which will block Nm from trying to resolve/chec hostname updates. In addition, this configuration
will not be propagated to the RHCOS upon node reboot