### PR TITLE
NO-ISSUE: Fix ClusterDeployment example

### DIFF
--- a/docs/crds/clusterDeployment-SNO.yaml
+++ b/docs/crds/clusterDeployment-SNO.yaml
@@ -16,8 +16,6 @@ spec:
   provisioning:
     imageSetRef:
       name: openshift-v4.8.0
-    installConfigSecretRef:
-      name: mycluster-install-config
     sshPrivateKeySecretRef:
       name: mycluster-ssh-key
     installStrategy:

--- a/docs/crds/clusterDeployment.yaml
+++ b/docs/crds/clusterDeployment.yaml
@@ -16,8 +16,6 @@ spec:
   provisioning:
     imageSetRef:
       name: openshift-v4.7.0
-    installConfigSecretRef:
-      name: mycluster-install-config
     sshPrivateKeySecretRef:
       name: mycluster-ssh-key
     installStrategy:


### PR DESCRIPTION
The `installConfigSecretRef` is forbidden by hive in case of agent install
strategy.

'# kubectl create -f  snocluster.yaml
The ClusterDeployment "test-infra-cluster-assisted-installer" is
invalid: spec.provisioning.installConfigSecretRef: Forbidden: custom
install config cannot be used with agent install strategy'