### PR TITLE
OCPBUGSM-25356 Handle net prefix for single node

### DIFF
--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -86,12 +86,17 @@ func VerifyClusterCidrSize(hostNetworkPrefix int, clusterNetworkCIDR string, num
 	if hostNetworkPrefix > bits-MinMaskDelta {
 		return errors.Errorf("Host prefix, now %d, must be less than or equal to %d to allow at least 128 addresses", hostNetworkPrefix, bits-MinMaskDelta)
 	}
-	requestedNumHosts := max(4, numberOfHosts)
+	var requestedNumHosts int
+	if numberOfHosts == 1 {
+		requestedNumHosts = 1
+	} else {
+		requestedNumHosts = max(4, numberOfHosts)
+	}
 	// 63 to avoid overflow
 	possibleNumHosts := uint64(1) << min(63, max(hostNetworkPrefix-clusterNetworkPrefix, 0))
 	if uint64(requestedNumHosts) > possibleNumHosts {
 		return errors.Errorf("Cluster network CIDR prefix %d does not contain enough addresses for %d hosts each one with %d prefix (%d addresses)",
-			clusterNetworkPrefix, requestedNumHosts, hostNetworkPrefix, uint64(1)<<min(63, bits-hostNetworkPrefix))
+			clusterNetworkPrefix, numberOfHosts, hostNetworkPrefix, uint64(1)<<min(63, bits-hostNetworkPrefix))
 	}
 	return nil
 }

--- a/internal/network/cidr_validations_test.go
+++ b/internal/network/cidr_validations_test.go
@@ -22,6 +22,15 @@ var _ = Describe("CIDR validations", func() {
 		It("IPv6 just enough", func() {
 			Expect(VerifyClusterCidrSize(66, "8::/64", 4)).ToNot(HaveOccurred())
 		})
+		It("single-node not enough", func() {
+			Expect(VerifyClusterCidrSize(26, "192.168.1.0/25", 1)).To(HaveOccurred())
+		})
+		It("single-node just enough", func() {
+			Expect(VerifyClusterCidrSize(25, "192.168.1.0/25", 1)).ToNot(HaveOccurred())
+		})
+		It("single-node more than enough", func() {
+			Expect(VerifyClusterCidrSize(25, "192.168.1.0/24", 1)).ToNot(HaveOccurred())
+		})
 	})
 	Context("Verify CIDRs", func() {
 		It("Machine CIDR 24 OK", func() {


### PR DESCRIPTION
Handle network prefix in case a cluster has a single node. In such
case the entire machine CIDR or its part (but no less than 128
addresses) can be allocated to the node.