### PR TITLE
MGMT-5174 Subsystem tests for epic MGMT-3563

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -387,7 +387,7 @@ func setupNewHost(ctx context.Context, hostname string, clusterID strfmt.UUID) *
 	host := registerNode(ctx, clusterID, hostname)
 	generateHWPostStepReply(ctx, host, validHwInfo, hostname)
 	generateFAPostStepReply(ctx, host, validFreeAddresses)
-	generateDiskSpeedResponses(ctx, sdbId, host)
+	generateSuccessfulDiskSpeedResponses(ctx, sdbId, host)
 	return host
 }
 

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -274,7 +274,7 @@ func generateFAPostStepReply(ctx context.Context, h *models.Host, freeAddresses 
 	Expect(err).To(BeNil())
 }
 
-func generateDiskSppedChekResponse(ctx context.Context, h *models.Host, path string) {
+func generateDiskSpeedChekResponse(ctx context.Context, h *models.Host, path string, exitCode int64) {
 	result := models.DiskSpeedCheckResponse{
 		IoSyncDuration: 10,
 		Path:           path,
@@ -285,7 +285,7 @@ func generateDiskSppedChekResponse(ctx context.Context, h *models.Host, path str
 		ClusterID: h.ClusterID,
 		HostID:    *h.ID,
 		Reply: &models.StepReply{
-			ExitCode: 0,
+			ExitCode: exitCode,
 			Output:   string(b),
 			StepID:   string(models.StepTypeInstallationDiskSpeedCheck),
 			StepType: models.StepTypeInstallationDiskSpeedCheck,
@@ -294,9 +294,15 @@ func generateDiskSppedChekResponse(ctx context.Context, h *models.Host, path str
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func generateDiskSpeedResponses(ctx context.Context, path string, hosts ...*models.Host) {
+func generateSuccessfulDiskSpeedResponses(ctx context.Context, path string, hosts ...*models.Host) {
 	for _, h := range hosts {
-		generateDiskSppedChekResponse(ctx, h, path)
+		generateDiskSpeedChekResponse(ctx, h, path, 0)
+	}
+}
+
+func generateFailedDiskSpeedResponses(ctx context.Context, path string, hosts ...*models.Host) {
+	for _, h := range hosts {
+		generateDiskSpeedChekResponse(ctx, h, path, -1)
 	}
 }
 


### PR DESCRIPTION
    Tests that are validating the effect of successful or failed disk-speed-check response
    on the flow of the installation. In case of failed response, the host should
    return to insufficint as well as the cluster.  In case the all hosts succeeded preparing (successful disk-speed-check response),
    installation should continue. The successful flow is already tested as part of the other installation tests.
