### PR TITLE
NO-ISSUE: Fixing validations dashboards name.

### DIFF
--- a/dashboards/grafana-dashboard-assisted-installer-validations.configmap.yaml
+++ b/dashboards/grafana-dashboard-assisted-installer-validations.configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: assisted-installer-ocm-operations
+  name: assisted-installer-validations
   labels:
     grafana_dashboard: "true"
   annotations:


### PR DESCRIPTION
I have set the wrong name to the configmap (copy paste) and it is
failing on app-sre because this name already exist in another dashboard.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>