### PR TITLE
MGMT-4526 - Extended Event API

### DIFF
--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -18,13 +18,15 @@ type controllerEventsWrapper struct {
 	log              logrus.FieldLogger
 }
 
+var _ events.Handler = &controllerEventsWrapper{}
+
 func NewControllerEventsWrapper(crdEventsHandler CRDEventsHandler, events *events.Events, db *gorm.DB, log logrus.FieldLogger) *controllerEventsWrapper {
 	return &controllerEventsWrapper{crdEventsHandler: crdEventsHandler,
 		events: events, db: db, log: log}
 }
 
-func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time) {
-	c.events.AddEvent(ctx, clusterID, hostID, severity, msg, eventTime)
+func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{}) {
+	c.events.AddEvent(ctx, clusterID, hostID, severity, msg, eventTime, props)
 	cluster, err := common.GetClusterFromDB(c.db, clusterID, common.SkipEagerLoading)
 	if err != nil {
 		return

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -21,7 +22,7 @@ type Handler interface {
 	//     host added to cluster, we have the host-id as the main entityID and
 	//     the cluster-id as another ID that this event should be related to
 	// otherEntities arguments provides for specifying mor IDs that are relevant for this event
-	AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time)
+	AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	GetEvents(clusterID strfmt.UUID, hostID *strfmt.UUID) ([]*common.Event, error)
 }
 
@@ -39,46 +40,54 @@ func New(db *gorm.DB, log logrus.FieldLogger) *Events {
 	}
 }
 
-func addEventToDB(log logrus.FieldLogger, db *gorm.DB, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, message string, t time.Time, requestID string) error {
+func (e *Events) saveEvent(ctx context.Context, tx *gorm.DB, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, message string, t time.Time, requestID string, props ...interface{}) error {
+	log := logutil.FromContext(ctx, e.log)
 	tt := strfmt.DateTime(t)
 	uid := clusterID
 	rid := strfmt.UUID(requestID)
 
-	e := common.Event{
+	additionalProps, err := toProps(props...)
+	if err != nil {
+		log.WithError(err).Error("failed to parse event's properties field")
+	}
+
+	event := common.Event{
 		Event: models.Event{
 			EventTime: &tt,
 			ClusterID: &uid,
 			Severity:  &severity,
 			Message:   &message,
 			RequestID: rid,
+			Props:     additionalProps,
 		},
 	}
 	if hostID != nil {
-		e.HostID = *hostID
+		event.HostID = *hostID
 	}
 
-	if err := db.Create(&e).Error; err != nil {
+	if err := tx.Create(&event).Error; err != nil {
 		log.WithError(err).Error("Error adding event")
 	}
 	return nil
 }
 
-func (e *Events) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time) {
+func (e *Events) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{}) {
 	log := logutil.FromContext(ctx, e.log)
+	requestID := requestid.FromContext(ctx)
 	var isSuccess bool = false
+
+	//each event is saved in its own embedded transaction
 	tx := e.db.Begin()
 	defer func() {
 		if !isSuccess {
-			log.Warn("Rolling back transaction")
+			log.Warnf("Rolling back event transaction on event=%s cluster_id=%s", msg, clusterID)
 			tx.Rollback()
 		} else {
 			tx.Commit()
 		}
 	}()
 
-	requestID := requestid.FromContext(ctx)
-	err := addEventToDB(log, tx, clusterID, hostID, severity, msg, eventTime, requestID)
-	if err != nil {
+	if err := e.saveEvent(ctx, tx, clusterID, hostID, severity, msg, eventTime, requestID, props...); err != nil {
 		return
 	}
 	isSuccess = true
@@ -97,4 +106,30 @@ func (e Events) GetEvents(clusterID strfmt.UUID, hostID *strfmt.UUID) ([]*common
 	}
 
 	return evs, nil
+}
+
+func toProps(attrs ...interface{}) (result string, err error) {
+	props := make(map[string]interface{})
+	length := len(attrs)
+
+	if length == 1 {
+		if attr, ok := attrs[0].(map[string]interface{}); ok {
+			props = attr
+		}
+	}
+
+	if length > 1 && length%2 == 0 {
+		for i := 0; i < length; i += 2 {
+			props[attrs[i].(string)] = attrs[i+1]
+		}
+	}
+
+	if len(props) > 0 {
+		var b []byte
+		if b, err = json.Marshal(props); err == nil {
+			return string(b), nil
+		}
+	}
+
+	return "", err
 }

--- a/internal/events/mock_event.go
+++ b/internal/events/mock_event.go
@@ -37,15 +37,20 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // AddEvent mocks base method
-func (m *MockHandler) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time) {
+func (m *MockHandler) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddEvent", ctx, clusterID, hostID, severity, msg, eventTime)
+	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
+	for _, a := range props {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "AddEvent", varargs...)
 }
 
 // AddEvent indicates an expected call of AddEvent
-func (mr *MockHandlerMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockHandler)(nil).AddEvent), ctx, clusterID, hostID, severity, msg, eventTime)
+	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockHandler)(nil).AddEvent), varargs...)
 }
 
 // GetEvents mocks base method

--- a/models/event.go
+++ b/models/event.go
@@ -37,13 +37,16 @@ type Event struct {
 	// Required: true
 	Message *string `json:"message" gorm:"type:varchar(4096)"`
 
+	// Additional properties for the event in JSON format.
+	Props string `json:"props,omitempty" gorm:"type:text"`
+
 	// Unique identifier of the request that caused this event to occur.
 	// Format: uuid
 	RequestID strfmt.UUID `json:"request_id,omitempty"`
 
 	// severity
 	// Required: true
-	// Enum: [info warning error critical]
+	// Enum: [info warning error critical internal]
 	Severity *string `json:"severity"`
 }
 
@@ -146,7 +149,7 @@ var eventTypeSeverityPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["info","warning","error","critical"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["info","warning","error","critical","internal"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -167,6 +170,9 @@ const (
 
 	// EventSeverityCritical captures enum value "critical"
 	EventSeverityCritical string = "critical"
+
+	// EventSeverityInternal captures enum value "internal"
+	EventSeverityInternal string = "internal"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6152,6 +6152,11 @@ func init() {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:varchar(4096)\""
         },
+        "props": {
+          "description": "Additional properties for the event in JSON format.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "request_id": {
           "description": "Unique identifier of the request that caused this event to occur.",
           "type": "string",
@@ -6163,7 +6168,8 @@ func init() {
             "info",
             "warning",
             "error",
-            "critical"
+            "critical",
+            "internal"
           ]
         }
       }
@@ -13863,6 +13869,11 @@ func init() {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:varchar(4096)\""
         },
+        "props": {
+          "description": "Additional properties for the event in JSON format.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "request_id": {
           "description": "Unique identifier of the request that caused this event to occur.",
           "type": "string",
@@ -13874,7 +13885,8 @@ func init() {
             "info",
             "warning",
             "error",
-            "critical"
+            "critical",
+            "internal"
           ]
         }
       }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3441,7 +3441,7 @@ definitions:
         description: Unique identifier of the host this event relates to.
       severity:
         type: string
-        enum: [info, warning, error, critical]
+        enum: [info, warning, error, critical, internal]
       message:
         type: string
         x-go-custom-tag: gorm:"type:varchar(4096)"
@@ -3453,7 +3453,11 @@ definitions:
         type: string
         format: uuid
         description: Unique identifier of the request that caused this event to occur.
-
+      props:
+        type: string
+        description: Additional properties for the event in JSON format.
+        x-go-custom-tag: gorm:"type:text"
+        
   image-create-params:
     type: object
     properties:


### PR DESCRIPTION
    Add JSON-formatter properties field to Event to hold free-formatted
    additional properties and optional extra properties parameters to
    Event API for hosting metrics parameters

    additional internal severity filters out internal events from the UI