### PR TITLE
Mgmt 5282 kubeapi info log on reconcile entering

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -59,6 +59,8 @@ type AgentReconciler struct {
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents/status,verbs=get;update;patch
 
 func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Infof("Reconcile has been called for Agent name=%s namespace=%s", req.Name, req.Namespace)
+
 	agent := &aiv1beta1.Agent{}
 
 	err := r.Get(ctx, req.NamespacedName, agent)

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -83,6 +83,8 @@ type ClusterDeploymentsReconciler struct {
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterimagesets,verbs=get;list;watch
 
 func (r *ClusterDeploymentsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Infof("Reconcile has been called for ClusterDeployment name=%s namespace=%s", req.Name, req.Namespace)
+
 	clusterDeployment := &hivev1.ClusterDeployment{}
 	err := r.Get(ctx, req.NamespacedName, clusterDeployment)
 	if err != nil {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -63,8 +63,7 @@ type InfraEnvReconciler struct {
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs/status,verbs=get;update;patch
 
 func (r *InfraEnvReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log.Debugf("InfraEnv Reconcile start for InfraEnv: %s, Namespace %s",
-		req.NamespacedName.Name, req.NamespacedName.Name)
+	r.Log.Infof("Reconcile has been called for InfraEnv name=%s namespace=%s", req.Name, req.Namespace)
 
 	infraEnv := &aiv1beta1.InfraEnv{}
 	if err := r.Get(ctx, req.NamespacedName, infraEnv); err != nil {


### PR DESCRIPTION
It will help us to find bugs in Reconcile loops and give more visibility.
The log should include the resource name and namespace.