### PR TITLE
MGMT-4930 Add notifications from ClusterDeployment to InfravEnv

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -373,10 +373,31 @@ func (r *InfraEnvReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return reply
 	}
 
+	mapClusterDeploymentToInfraEnv := func(clusterDeployment client.Object) []reconcile.Request {
+		infraEnvs := &aiv1beta1.InfraEnvList{}
+		if err := r.List(context.Background(), infraEnvs, client.InNamespace(clusterDeployment.GetNamespace())); err != nil {
+			r.Log.Debugf("failed to list InfraEnvs")
+			return []reconcile.Request{}
+		}
+
+		reply := make([]reconcile.Request, 0, len(infraEnvs.Items))
+		for _, infraEnv := range infraEnvs.Items {
+			if infraEnv.Spec.ClusterRef.Name == clusterDeployment.GetName() &&
+				infraEnv.Spec.ClusterRef.Namespace == clusterDeployment.GetNamespace() {
+				reply = append(reply, reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: infraEnv.Namespace,
+					Name:      infraEnv.Name,
+				}})
+			}
+		}
+		return reply
+	}
+
 	infraEnvUpdates := r.CRDEventsHandler.GetInfraEnvUpdates()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&aiv1beta1.InfraEnv{}).
 		Watches(&source.Kind{Type: &aiv1beta1.NMStateConfig{}}, handler.EnqueueRequestsFromMapFunc(mapNMStateConfigToInfraEnv)).
+		Watches(&source.Kind{Type: &hivev1.ClusterDeployment{}}, handler.EnqueueRequestsFromMapFunc(mapClusterDeploymentToInfraEnv)).
 		Watches(&source.Channel{Source: infraEnvUpdates}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -240,9 +240,9 @@ func checkClusterCondition(ctx context.Context, key types.NamespacedName, condit
 	}, "2m", "2s").Should(Equal(reason))
 }
 
-func checkInfraEnvCondition(ctx context.Context, key types.NamespacedName, message string) {
+func checkInfraEnvCondition(ctx context.Context, key types.NamespacedName, conditionType conditionsv1.ConditionType, message string) {
 	Eventually(func() string {
-		condition := conditionsv1.FindStatusCondition(getInfraEnvCRD(ctx, kubeClient, key).Status.Conditions, v1beta1.ImageCreatedCondition)
+		condition := conditionsv1.FindStatusCondition(getInfraEnvCRD(ctx, kubeClient, key).Status.Conditions, conditionType)
 		if condition != nil {
 			return condition.Message
 		}
@@ -788,7 +788,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      infraEnvName,
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageStateCreated)
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
 		cluster = getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.ImageGenerated).Should(Equal(true))
 		By("Validate proxy settings.", func() {
@@ -826,9 +826,34 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      infraEnvName,
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageStateCreated)
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
 		cluster = getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.IgnitionConfigOverrides).Should(Equal(fakeIgnitionConfigOverride))
+		Expect(cluster.ImageGenerated).Should(Equal(true))
+	})
+
+	It("deploy infraEnv before clusterDeployment", func() {
+		infraEnvName := "infraenv"
+		secretRef := deployLocalObjectSecretIfNeeded(ctx, kubeClient)
+		clusterDeploymentSpec := getDefaultClusterDeploymentSNOSpec(secretRef)
+		infraEnvSpec := getDefaultInfraEnvSpec(secretRef, clusterDeploymentSpec)
+
+		deployInfraEnvCRD(ctx, kubeClient, infraEnvName, infraEnvSpec)
+		infraEnvKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraEnvName,
+		}
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		clusterKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterName,
+		}
+		checkClusterCondition(ctx, clusterKubeName, controllers.ClusterReadyForInstallationCondition, controllers.ClusterNotReadyReason)
+		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
+		configureLocalAgentClient(cluster.ID.String())
+
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
+		cluster = getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.ImageGenerated).Should(Equal(true))
 	})
 
@@ -854,7 +879,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Namespace: Options.Namespace,
 			Name:      infraEnvName,
 		}
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageStateFailedToCreate+": error parsing ignition: config is not valid")
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateFailedToCreate+": error parsing ignition: config is not valid")
 		cluster = getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.IgnitionConfigOverrides).ShouldNot(Equal(fakeIgnitionConfigOverride))
 		Expect(cluster.ImageGenerated).Should(Equal(false))
@@ -941,7 +966,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      infraEnvName,
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageStateCreated)
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
 		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.ImageInfo.StaticNetworkConfig).Should(ContainSubstring(hostStaticNetworkConfig.NetworkYaml))
 		Expect(cluster.ImageGenerated).Should(Equal(true))
@@ -976,7 +1001,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      infraEnvName,
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, fmt.Sprintf("%s: internal error", v1beta1.ImageStateFailedToCreate))
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, fmt.Sprintf("%s: internal error", v1beta1.ImageStateFailedToCreate))
 		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
 		Expect(cluster.ImageGenerated).Should(Equal(false))
 	})


### PR DESCRIPTION
If the InfravEnv is created before the ClusterDeployment, it will never create the image.
This patch add a notification between the ClusterDeployment to InfraEnv.