### PR TITLE
OCPBUGSM-28144 fix reconcile error of installed SNO cluster

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -108,6 +108,8 @@ func (r *ClusterDeploymentsReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if !r.isSNO(clusterDeployment) {
 			return r.createNewDay2Cluster(ctx, req.NamespacedName, clusterDeployment)
 		}
+		// cluster  is installed and SNO nothing to do
+		return ctrl.Result{Requeue: false}, nil
 	}
 	if err != nil {
 		return r.updateState(ctx, clusterDeployment, nil, err)

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -780,6 +780,18 @@ var _ = Describe("cluster reconcile", func() {
 
 	})
 
+	It("reconcile on installed sno cluster should not return an error or requeue", func() {
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
+		cluster := newClusterDeployment(clusterName, testNamespace,
+			getDefaultSNOClusterDeploymentSpec(clusterName, pullSecretName))
+		cluster.Spec.Installed = true
+		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+		request := newClusterDeploymentRequest(cluster)
+		result, err := cr.Reconcile(ctx, request)
+		Expect(err).To(BeNil())
+		Expect(result.Requeue).To(BeFalse())
+	})
+
 	Context("cluster update", func() {
 		var (
 			sId     strfmt.UUID


### PR DESCRIPTION
After SNO cluster is installed it will be deleted, the next reconcile
loop will return Not Found and should not update cluster deployment with
an error and just return and stop requeue