### PR TITLE
MGMT-5348 cluster specific disk eligibility check

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1501,7 +1501,7 @@ func (b *bareMetalInventory) refreshClusterHosts(ctx context.Context, cluster *c
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	dbCluster, err := common.GetClusterFromDB(tx, *cluster.ID, true)
+	dbCluster, err := common.GetClusterFromDB(tx, *cluster.ID, common.UseEagerLoading)
 	if err != nil {
 		log.WithError(err).Errorf("not refreshing cluster hosts - failed to find cluster %s", *cluster.ID)
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2203,7 +2203,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 				ClusterID: clusterID,
@@ -2259,7 +2259,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			addHost(masterHostId1, models.HostRoleMaster, models.HostStatusKnown, models.HostKindHost, clusterID,
 				getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 			wrongMachineCidr := "2.2.3.0/24"
@@ -2878,7 +2878,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2897,7 +2897,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2970,7 +2970,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3002,7 +3002,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3079,7 +3079,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3099,7 +3099,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3135,7 +3135,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(times * 3) // Number of hosts
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times * 3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(times * 1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times * 3)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times * 3)
 				mockSetConnectivityMajorityGroupsForClusterTimes(mockClusterApi, times)
 			}
 
@@ -6015,6 +6015,40 @@ var _ = Describe("AMS subscriptions", func() {
 
 			reply = bm.DeregisterCluster(ctx, installer.DeregisterClusterParams{ClusterID: clusterID})
 			Expect(reply).Should(BeAssignableToTypeOf(&installer.DeregisterClusterNoContent{}))
+		})
+
+		It("cluster update failure on inventory refresh failure", func() {
+			mockOperators := operators.NewMockAPI(ctrl)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
+
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String(clusterName),
+					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+
+			clusterId := *actual.Payload.ID
+			addHost(strfmt.UUID(uuid.New().String()), models.HostRoleMaster, "known", models.HostKindHost, clusterId, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
+			newClusterName := "new-cluster-name"
+
+			refreshError := errors.New("boom!")
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(refreshError)
+
+			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: clusterId,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					Name: &newClusterName,
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+			Expect(reply.(*common.ApiErrorResponse).Error()).To(BeEquivalentTo(refreshError.Error()))
 		})
 	})
 })

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2203,6 +2203,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 				ClusterID: clusterID,
@@ -2258,6 +2259,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			addHost(masterHostId1, models.HostRoleMaster, models.HostStatusKnown, models.HostKindHost, clusterID,
 				getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 			wrongMachineCidr := "2.2.3.0/24"
@@ -2876,6 +2878,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2894,6 +2897,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2966,6 +2970,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2997,6 +3002,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3073,6 +3079,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3092,6 +3099,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3127,6 +3135,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(times * 3) // Number of hosts
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times * 3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(times * 1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(times * 3)
 				mockSetConnectivityMajorityGroupsForClusterTimes(mockClusterApi, times)
 			}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2203,7 +2203,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 				ClusterID: clusterID,
@@ -2259,7 +2259,7 @@ var _ = Describe("cluster", func() {
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			addHost(masterHostId1, models.HostRoleMaster, models.HostStatusKnown, models.HostKindHost, clusterID,
 				getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 			wrongMachineCidr := "2.2.3.0/24"
@@ -2878,7 +2878,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2897,7 +2897,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -2970,7 +2970,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3002,7 +3002,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3079,7 +3079,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3099,7 +3099,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Cluster{}, nil).Times(1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(3)
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3135,7 +3135,7 @@ var _ = Describe("cluster", func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(times * 3) // Number of hosts
 				mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times * 3)
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(times * 1)
-				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any()).Times(times * 3)
+				mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(times * 3)
 				mockSetConnectivityMajorityGroupsForClusterTimes(mockClusterApi, times)
 			}
 

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -94,17 +94,18 @@ func (mr *MockValidatorMockRecorder) GetClusterHostRequirements(ctx, cluster, ho
 }
 
 // DiskIsEligible mocks base method
-func (m *MockValidator) DiskIsEligible(disk *models.Disk) []string {
+func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, cluster *common.Cluster, host *models.Host) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiskIsEligible", disk)
+	ret := m.ctrl.Call(m, "DiskIsEligible", ctx, disk, cluster, host)
 	ret0, _ := ret[0].([]string)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DiskIsEligible indicates an expected call of DiskIsEligible
-func (mr *MockValidatorMockRecorder) DiskIsEligible(disk interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) DiskIsEligible(ctx, disk, cluster, host interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), disk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), ctx, disk, cluster, host)
 }
 
 // ListEligibleDisks mocks base method

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -28,14 +28,14 @@ var (
 )
 
 func init() {
-	tmp := compile(tooSmallDiskTemplate, ".*", ".*")
+	tmp := compileDiskReasonTemplate(tooSmallDiskTemplate, ".*", ".*")
 	diskEligibilityMatchers = append(diskEligibilityMatchers, tmp)
 
-	tmp = compile(wrongDriveTypeTemplate, ".*", ".*")
+	tmp = compileDiskReasonTemplate(wrongDriveTypeTemplate, ".*", ".*")
 	diskEligibilityMatchers = append(diskEligibilityMatchers, tmp)
 }
 
-func compile(template string, wildcards ...string) *regexp.Regexp {
+func compileDiskReasonTemplate(template string, wildcards ...string) *regexp.Regexp {
 	tmp, err := regexp.Compile(fmt.Sprintf(regexp.QuoteMeta(template), wildcards))
 	if err != nil {
 		panic(err)

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -120,6 +120,29 @@ var _ = Describe("Disk eligibility", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 	})
+
+	It("Check that existing non-eligibility reasons are preserved", func() {
+		existingReasons := []string{"Reason 1", "Reason 2"}
+		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, &cluster, &host)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(ConsistOf(existingReasons))
+	})
+
+	It("Check that a small size reason is added to existing reasons", func() {
+		existingReasons := []string{"Reason 1", "Reason 2"}
+		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
+
+		testDisk.SizeBytes = tooSmallSize
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, &cluster, &host)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(ContainElements(existingReasons))
+		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
+	})
 })
 
 var _ = Describe("hardware_validator", func() {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -234,7 +234,7 @@ func (m *Manager) HandleInstallationFailure(ctx context.Context, h *models.Host)
 func (m *Manager) populateDisksEligibility(ctx context.Context, inventory *models.Inventory, cluster *common.Cluster, host *models.Host) error {
 	for _, disk := range inventory.Disks {
 		if !hardware.DiskEligibilityInitialized(disk) {
-			// for backwards compatibility, pretend that the agent has decided that this disk is reasons
+			// for backwards compatibility, pretend that the agent has decided that this disk is eligible
 			disk.InstallationEligibility.Eligible = true
 			disk.InstallationEligibility.NotEligibleReasons = make([]string, 0)
 		}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -283,7 +283,7 @@ func (m *Manager) RefreshInventory(ctx context.Context, cluster *common.Cluster,
 
 func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventoryStr string) error {
 	log := logutil.FromContext(ctx, m.log)
-	cluster, err := common.GetClusterFromDB(m.db, h.ClusterID, true)
+	cluster, err := common.GetClusterFromDB(m.db, h.ClusterID, common.UseEagerLoading)
 	if err != nil {
 		log.WithError(err).Errorf("not updating inventory - failed to find cluster %s", h.ClusterID)
 		return common.NewApiError(http.StatusNotFound, err)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -863,6 +863,8 @@ var _ = Describe("UpdateInventory", func() {
 			nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		cluster := hostutil.GenerateTestCluster(clusterId, "10.0.0.1/24")
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -902,7 +904,7 @@ var _ = Describe("UpdateInventory", func() {
 			It(test.testName, func() {
 				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-				mockValidator.EXPECT().DiskIsEligible(gomock.Any())
+				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
 				inventoryStr, err := hostutil.MarshalInventory(&test.inventory)
 				Expect(err).ToNot(HaveOccurred())
@@ -962,7 +964,7 @@ var _ = Describe("UpdateInventory", func() {
 		} {
 			test := test
 			It(test.testName, func() {
-				mockValidator.EXPECT().DiskIsEligible(gomock.Any()).Return(test.serviceReasons)
+				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.serviceReasons, nil)
 
 				testInventory := models.Inventory{Disks: []*models.Disk{
 					{InstallationEligibility: models.DiskInstallationEligibility{
@@ -978,7 +980,7 @@ var _ = Describe("UpdateInventory", func() {
 						Eligible: test.expectedDecision, NotEligibleReasons: test.expectedReasons}},
 				}
 
-				hapi.(*Manager).populateDisksEligibility(&testInventory)
+				Expect(hapi.(*Manager).populateDisksEligibility(ctx, &testInventory, nil, nil)).ShouldNot(HaveOccurred())
 				Expect(testInventory.Disks).Should(Equal(expectedDisks))
 			})
 		}
@@ -996,7 +998,7 @@ var _ = Describe("UpdateInventory", func() {
 			host.Inventory = common.GenerateTestDefaultInventory()
 			host.InstallationDiskPath = ""
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		})
 
@@ -1012,7 +1014,7 @@ var _ = Describe("UpdateInventory", func() {
 			Expect(h.InstallationDiskID).To(Equal(diskId))
 
 			// Now make sure it gets removed if the disk is no longer in the inventory
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{},
 			)
@@ -1035,7 +1037,7 @@ var _ = Describe("UpdateInventory", func() {
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			)
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
 			h = hostutil.GetHostFromDB(hostId, clusterId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))
@@ -1050,7 +1052,7 @@ var _ = Describe("UpdateInventory", func() {
 			// Create an inventory that is slightly arbitrarily different than the default one
 			// so we can make sure an update actually occurred.
 			newInventoryBytes = alternativeInventory()
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any()).AnyTimes()
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(nil).AnyTimes()
 		})
 

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -236,17 +236,17 @@ func (mr *MockAPIMockRecorder) PermanentHostsDeletion(arg0 interface{}) *gomock.
 }
 
 // RefreshInventory mocks base method
-func (m *MockAPI) RefreshInventory(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
+func (m *MockAPI) RefreshInventory(arg0 context.Context, arg1 *common.Cluster, arg2 *models.Host, arg3 *gorm.DB) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshInventory", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RefreshInventory", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RefreshInventory indicates an expected call of RefreshInventory
-func (mr *MockAPIMockRecorder) RefreshInventory(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) RefreshInventory(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshInventory", reflect.TypeOf((*MockAPI)(nil).RefreshInventory), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshInventory", reflect.TypeOf((*MockAPI)(nil).RefreshInventory), arg0, arg1, arg2, arg3)
 }
 
 // RefreshStatus mocks base method

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -235,6 +235,20 @@ func (mr *MockAPIMockRecorder) PermanentHostsDeletion(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PermanentHostsDeletion", reflect.TypeOf((*MockAPI)(nil).PermanentHostsDeletion), arg0)
 }
 
+// RefreshInventory mocks base method
+func (m *MockAPI) RefreshInventory(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshInventory", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshInventory indicates an expected call of RefreshInventory
+func (mr *MockAPIMockRecorder) RefreshInventory(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshInventory", reflect.TypeOf((*MockAPI)(nil).RefreshInventory), arg0, arg1, arg2)
+}
+
 // RefreshStatus mocks base method
 func (m *MockAPI) RefreshStatus(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -503,6 +503,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 			stateswitch.State(models.HostStatusDisconnected),
 			stateswitch.State(models.HostStatusDiscovering),
 			stateswitch.State(models.HostStatusInsufficient),
+			stateswitch.State(models.HostStatusKnown),
 		},
 		Condition: stateswitch.And(If(IsConnected), If(HasInventory),
 			stateswitch.Not(hasMinRequiredHardware)),

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2378,14 +2378,19 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected:     true,
 			},
 			{
-				name:              "known to insufficient (1)",
-				role:              models.HostRoleAutoAssign,
-				validCheckInTime:  true,
-				srcState:          models.HostStatusKnown,
-				dstState:          models.HostStatusKnown,
-				statusInfoChecker: makeValueChecker(""),
-				inventory:         insufficientHWInventory(),
-				errorExpected:     true,
+				name:             "known to insufficient (1)",
+				role:             models.HostRoleAutoAssign,
+				validCheckInTime: true,
+				srcState:         models.HostStatusKnown,
+				dstState:         models.HostStatusInsufficient,
+				statusInfoChecker: makeValueChecker("Host does not meet the minimum hardware requirements: " +
+					"Host couldn't synchronize with any NTP server ; Machine Network CIDR is undefined; the Machine " +
+					"Network CIDR can be defined by setting either the API or Ingress virtual IPs ; Require a disk of at " +
+					"least 120 GB ; Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes ; " +
+					"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for " +
+					"any role is 8.00 GiB, found only 130 bytes"),
+				inventory:     insufficientHWInventory(),
+				errorExpected: false,
 			},
 			{
 				name:             "known to pending",

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1213,6 +1213,9 @@ func makeJsonChecker(expected map[validationID]validationCheckResult) *validatio
 }
 
 var _ = Describe("Refresh Host", func() {
+	const (
+		minDiskSizeGb = 120
+	)
 	var (
 		supportedGPU      = models.Gpu{VendorID: "10de", DeviceID: "1db6"}
 		ctx               = context.Background()
@@ -1239,7 +1242,7 @@ var _ = Describe("Refresh Host", func() {
 			// Mock the hwValidator behavior of performing simple filtering according to disk size, because these tests
 			// rely on small disks to get filtered out.
 			return funk.Filter(inventory.Disks, func(disk *models.Disk) bool {
-				return disk.SizeBytes >= conversions.GibToBytes(validatorCfg.MinDiskSizeGb)
+				return disk.SizeBytes >= conversions.GibToBytes(minDiskSizeGb)
 			}).([]*models.Disk)
 		}).AnyTimes()
 		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -250,7 +250,7 @@ func (v *validator) printHasMinValidDisks(c *validationContext, status Validatio
 	case ValidationSuccess:
 		return "Sufficient disk capacity"
 	case ValidationFailure:
-		return fmt.Sprintf("Require a disk of at least %d GB", v.hwValidatorCfg.MinDiskSizeGb)
+		return fmt.Sprintf("Require a disk of at least %d GB", c.clusterHostRequirements.Total.DiskSizeGb)
 	case ValidationPending:
 		return "Missing inventory"
 	default:


### PR DESCRIPTION
Now, when host/hardware requirements are calculated based on cluster and host details, it is possible to check disk eligibility based on those requirements. 

That check will be more accurate, as it takes into account additional operator requirements.