### PR TITLE
NO-ISSUE remove dependency of common in s3wrapper

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4069,7 +4069,7 @@ func (b *bareMetalInventory) DownloadClusterLogs(ctx context.Context, params ins
 	}
 	respBody, contentLength, err := b.objectHandler.Download(ctx, fileName)
 	if err != nil {
-		if _, ok := err.(s3wrapper.NotFound); ok {
+		if _, ok := err.(common.NotFound); ok {
 			log.WithError(err).Warnf("File not found %s", fileName)
 			return common.NewApiError(http.StatusNotFound, errors.Errorf("Logs of type %s for cluster %s "+
 				"were not found", swag.StringValue(params.LogsType), params.ClusterID))
@@ -4099,7 +4099,7 @@ func (b *bareMetalInventory) DownloadHostLogs(ctx context.Context, params instal
 
 	respBody, contentLength, err := b.objectHandler.Download(ctx, fileName)
 	if err != nil {
-		if _, ok := err.(s3wrapper.NotFound); ok {
+		if _, ok := err.(common.NotFound); ok {
 			log.WithError(err).Warnf("File not found %s", fileName)
 			return common.NewApiError(http.StatusNotFound, errors.Errorf("Logs for host %s were not found", params.HostID))
 		}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4527,7 +4527,7 @@ var _ = Describe("Upload and Download logs test", func() {
 		host1.LogsCollectedAt = strfmt.DateTime(time.Now())
 		db.Save(&host1)
 		fileName := bm.getLogsFullName(clusterID.String(), hostID.String())
-		mockS3Client.EXPECT().Download(ctx, fileName).Return(nil, int64(0), s3wrapper.NotFound(fileName))
+		mockS3Client.EXPECT().Download(ctx, fileName).Return(nil, int64(0), common.NotFound(fileName))
 		verifyApiError(bm.DownloadHostLogs(ctx, params), http.StatusNotFound)
 	})
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -786,7 +786,7 @@ func (m *Manager) CreateTarredClusterLogs(ctx context.Context, c *common.Cluster
 	}
 
 	log.Debugf("List of files to include into %s is %s", fileName, files)
-	err = common.TarAwsFiles(ctx, fileName, files, tarredFilenames, objectHandler, log)
+	err = s3wrapper.TarAwsFiles(ctx, fileName, files, tarredFilenames, objectHandler, log)
 	if err != nil {
 		log.WithError(err).Errorf("failed to download file %s", fileName)
 		return "", common.NewApiError(http.StatusInternalServerError, err)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,17 +1,8 @@
 package common
 
 import (
-	"archive/tar"
-	"context"
-	"io"
-	"sync"
-	"time"
-
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/s3wrapper"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const EnvConfigPrefix = "myapp"
@@ -55,93 +46,6 @@ const NMDebugModeConf = `
 [logging]
 domains=ALL:DEBUG
 `
-
-// continueOnError is set when running as stream, error is doing nothing when it happens cause we in the middle of stream
-// and 200 was already returned
-func CreateTar(ctx context.Context, w io.Writer, files, tarredFilenames []string, client s3wrapper.API, continueOnError bool) error {
-	var rdr io.ReadCloser
-	tarWriter := tar.NewWriter(w)
-	defer func() {
-		if rdr != nil {
-			rdr.Close()
-		}
-		tarWriter.Close()
-
-	}()
-	var err error
-	var objectSize int64
-
-	// Create tar headers from s3 files
-	for i, file := range files {
-		// Read file from S3, log any errors
-		rdr, objectSize, err = client.Download(ctx, file)
-		if err != nil {
-			if continueOnError {
-				continue
-			}
-			return errors.Wrapf(err, "Failed to open reader for %s", file)
-		}
-
-		header := tar.Header{
-			Name:    tarredFilenames[i],
-			Size:    objectSize,
-			Mode:    0644,
-			ModTime: time.Now(),
-		}
-		err = tarWriter.WriteHeader(&header)
-		if err != nil && !continueOnError {
-			return errors.Wrapf(err, "Failed to write tar header with file %s details", file)
-		}
-		_, err = io.Copy(tarWriter, rdr)
-		if err != nil && !continueOnError {
-			return errors.Wrapf(err, "Failed to write file %s to tar", file)
-		}
-		_ = rdr.Close()
-	}
-
-	return nil
-}
-
-// Tar given files in s3 bucket.
-// We open pipe for reading from aws and writing archived back to it while archiving them.
-// It creates stream by using io.pipe
-func TarAwsFiles(ctx context.Context, tarName string, files, tarredFilenames []string, client s3wrapper.API, log logrus.FieldLogger) error {
-	// Create pipe
-	var err error
-	pr, pw := io.Pipe()
-	wg := sync.WaitGroup{}
-	// Wait for downloader and uploader
-	wg.Add(2)
-	// Run 'downloader'
-	go func() {
-		defer func() {
-			wg.Done()
-			// closing pipe will stop uploading
-			pw.Close()
-		}()
-		downloadError := CreateTar(ctx, pw, files, tarredFilenames, client, false)
-		if downloadError != nil && err == nil {
-			err = errors.Wrapf(downloadError, "Failed to download files while creating archive %s", tarName)
-			log.Error(err)
-		}
-	}()
-	go func() {
-		defer func() {
-			wg.Done()
-			// if upload fails close pipe
-			// will fail download too
-			pr.Close()
-		}()
-		// Upload the file, body is `io.Reader` from pipe
-		uploadError := client.UploadStream(ctx, pr, tarName)
-		if uploadError != nil && err == nil {
-			err = errors.Wrapf(uploadError, "Failed to upload archive %s", tarName)
-			log.Error(err)
-		}
-	}()
-	wg.Wait()
-	return err
-}
 
 func AllStrings(vs []string, f func(string) bool) bool {
 	for _, v := range vs {

--- a/internal/common/error_utils.go
+++ b/internal/common/error_utils.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -10,8 +11,13 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/jinzhu/gorm"
 	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/s3wrapper"
 )
+
+type NotFound string
+
+func (f NotFound) Error() string {
+	return fmt.Sprintf("object %s was not found", string(f))
+}
 
 func GenerateError(id int32, err error) *models.Error {
 	return &models.Error{
@@ -108,7 +114,7 @@ func GenerateErrorResponder(err error) middleware.Responder {
 		return errValue
 	case *InfraErrorResponse:
 		return errValue
-	case s3wrapper.NotFound:
+	case NotFound:
 		return NewApiError(http.StatusNotFound, err)
 	default:
 		return NewApiError(http.StatusInternalServerError, err)

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/versions"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -403,7 +404,7 @@ func (c *S3Client) GeneratePresignedDownloadURL(ctx context.Context, objectName 
 func (c S3Client) transformErrorIfNeeded(err error, objectName string) (bool, error) {
 	if aerr, ok := err.(awserr.Error); ok {
 		if aerr.Code() == s3.ErrCodeNoSuchKey || aerr.Code() == "NotFound" {
-			return true, NotFound(objectName)
+			return true, common.NotFound(objectName)
 		}
 	}
 	return false, err

--- a/pkg/s3wrapper/errors.go
+++ b/pkg/s3wrapper/errors.go
@@ -1,9 +1,0 @@
-package s3wrapper
-
-import "fmt"
-
-type NotFound string
-
-func (f NotFound) Error() string {
-	return fmt.Sprintf("object %s was not found", string(f))
-}

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/renameio"
 	"github.com/moby/moby/pkg/ioutils"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/versions"
@@ -162,7 +163,7 @@ func (f *FSClient) Download(ctx context.Context, objectName string) (io.ReadClos
 	fp, err := os.Open(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, 0, NotFound(objectName)
+			return nil, 0, common.NotFound(objectName)
 		}
 		err = errors.Wrapf(err, "Unable to open file %s", filePath)
 		log.Error(err)

--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -1,6 +1,7 @@
 package s3wrapper
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -10,6 +11,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/isoutil"
@@ -214,4 +217,91 @@ func updateISOTemplatesVersion(ctx context.Context, log logrus.FieldLogger, api 
 	}
 	reader := bytes.NewReader(b)
 	return api.UploadStream(ctx, reader, minimalTemplatesVersionFileName)
+}
+
+// continueOnError is set when running as stream, error is doing nothing when it happens cause we in the middle of stream
+// and 200 was already returned
+func CreateTar(ctx context.Context, w io.Writer, files, tarredFilenames []string, client API, continueOnError bool) error {
+	var rdr io.ReadCloser
+	tarWriter := tar.NewWriter(w)
+	defer func() {
+		if rdr != nil {
+			rdr.Close()
+		}
+		tarWriter.Close()
+
+	}()
+	var err error
+	var objectSize int64
+
+	// Create tar headers from s3 files
+	for i, file := range files {
+		// Read file from S3, log any errors
+		rdr, objectSize, err = client.Download(ctx, file)
+		if err != nil {
+			if continueOnError {
+				continue
+			}
+			return errors.Wrapf(err, "Failed to open reader for %s", file)
+		}
+
+		header := tar.Header{
+			Name:    tarredFilenames[i],
+			Size:    objectSize,
+			Mode:    0644,
+			ModTime: time.Now(),
+		}
+		err = tarWriter.WriteHeader(&header)
+		if err != nil && !continueOnError {
+			return errors.Wrapf(err, "Failed to write tar header with file %s details", file)
+		}
+		_, err = io.Copy(tarWriter, rdr)
+		if err != nil && !continueOnError {
+			return errors.Wrapf(err, "Failed to write file %s to tar", file)
+		}
+		_ = rdr.Close()
+	}
+
+	return nil
+}
+
+// Tar given files in s3 bucket.
+// We open pipe for reading from aws and writing archived back to it while archiving them.
+// It creates stream by using io.pipe
+func TarAwsFiles(ctx context.Context, tarName string, files, tarredFilenames []string, client API, log logrus.FieldLogger) error {
+	// Create pipe
+	var err error
+	pr, pw := io.Pipe()
+	wg := sync.WaitGroup{}
+	// Wait for downloader and uploader
+	wg.Add(2)
+	// Run 'downloader'
+	go func() {
+		defer func() {
+			wg.Done()
+			// closing pipe will stop uploading
+			pw.Close()
+		}()
+		downloadError := CreateTar(ctx, pw, files, tarredFilenames, client, false)
+		if downloadError != nil && err == nil {
+			err = errors.Wrapf(downloadError, "Failed to download files while creating archive %s", tarName)
+			log.Error(err)
+		}
+	}()
+	go func() {
+		defer func() {
+			wg.Done()
+			// if upload fails close pipe
+			// will fail download too
+			pr.Close()
+		}()
+		// Upload the file, body is `io.Reader` from pipe
+		uploadError := client.UploadStream(ctx, pr, tarName)
+		if uploadError != nil && err == nil {
+			err = errors.Wrapf(uploadError, "Failed to upload archive %s", tarName)
+			log.Error(err)
+		}
+	}()
+	wg.Wait()
+	return err
 }


### PR DESCRIPTION
s3wrapper depends on metric API which is a high level package and creates cyclic dependencies for the effort to migrate metric to events