### PR TITLE
Mgmt 4843 clusterdeployment api and console urls

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -70,7 +70,6 @@ import (
 )
 
 const DefaultUser = "kubeadmin"
-const ConsoleUrlPrefix = "https://console-openshift-console.apps"
 
 // 125 is the generic exit code for cases the error is in podman / docker and not the container we tried to run
 const ContainerAlreadyRunningExitCode = 125
@@ -3445,7 +3444,7 @@ func (b *bareMetalInventory) GetCredentialsInternal(ctx context.Context, params 
 	return &models.Credentials{
 		Username:   DefaultUser,
 		Password:   string(password),
-		ConsoleURL: fmt.Sprintf("%s.%s.%s", ConsoleUrlPrefix, cluster.Name, cluster.BaseDNSDomain),
+		ConsoleURL: common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain),
 	}, nil
 }
 

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -27,10 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	consoleUrlPrefix = "https://console-openshift-console.apps"
-)
-
 var resetLogsField = []interface{}{"logs_info", "", "controller_logs_started_at", strfmt.DateTime(time.Time{}), "controller_logs_collected_at", strfmt.DateTime(time.Time{})}
 
 type transitionHandler struct {
@@ -356,7 +352,7 @@ func (th *transitionHandler) PostUpdateFinalizingAMSConsoleUrl(sw stateswitch.St
 	}
 	log := logutil.FromContext(params.ctx, th.log)
 	subscriptionID := sCluster.cluster.AmsSubscriptionID
-	consoleUrl := fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, sCluster.cluster.Name, sCluster.cluster.BaseDNSDomain)
+	consoleUrl := common.GetConsoleUrl(sCluster.cluster.Name, sCluster.cluster.BaseDNSDomain)
 	if err := params.ocmClient.AccountsMgmt.UpdateSubscriptionConsoleUrl(params.ctx, subscriptionID, consoleUrl); err != nil {
 		log.WithError(err).Error("Failed to updated console-url in OCM")
 		return err

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -3143,7 +3143,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 				}
 				if t.requiresAMSUpdate {
 					subscriptionID := cluster.AmsSubscriptionID
-					consoleUrl := fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, cluster.Name, cluster.BaseDNSDomain)
+					consoleUrl := common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain)
 					mockAccountsMgmt.EXPECT().UpdateSubscriptionConsoleUrl(ctx, subscriptionID, consoleUrl)
 				}
 				Expect(cluster.ValidationsInfo).To(BeEmpty())

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
 )
@@ -13,6 +15,8 @@ const AllowedNumberOfWorkersInNoneHaMode = 0
 const IllegalWorkerHostsCount = 1
 
 const HostCACertPath = "/etc/assisted-service/service-ca-cert.crt"
+
+const consoleUrlPrefix = "https://console-openshift-console.apps"
 
 // Configuration to be injected by discovery ignition.  It will cause IPv6 DHCP client identifier to be the same
 // after reboot.  This will cause the DHCP server to provide the same IP address after reboot.
@@ -69,4 +73,8 @@ func GetBootstrapHost(cluster *Cluster) *models.Host {
 // IsSingleNodeCluster if this cluster is single-node or not
 func IsSingleNodeCluster(cluster *Cluster) bool {
 	return swag.StringValue(cluster.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone
+}
+
+func GetConsoleUrl(clusterName, baseDomain string) string {
+	return fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, clusterName, baseDomain)
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -208,7 +208,6 @@ func (r *ClusterDeploymentsReconciler) updateClusterMetadata(ctx context.Context
 	cluster.Spec.Installed = true
 	cluster.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
 		ClusterID: c.OpenshiftClusterID.String(),
-		InfraID:   c.ID.String(),
 		AdminPasswordSecretRef: corev1.LocalObjectReference{
 			Name: s.Name,
 		},
@@ -583,6 +582,12 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, cluster
 	} else {
 		setClusterConditionsUnknown(cluster)
 	}
+
+	if cluster.Spec.Installed {
+		cluster.Status.APIURL = fmt.Sprintf("https://api.%s.%s:6443", cluster.Spec.ClusterName, cluster.Spec.BaseDomain)
+		cluster.Status.WebConsoleURL = common.GetConsoleUrl(cluster.Spec.ClusterName, cluster.Spec.BaseDomain)
+	}
+
 	if updateErr := r.Status().Update(ctx, cluster); updateErr != nil {
 		r.Log.WithError(updateErr).Error("failed to update ClusterDeployment Status")
 		return ctrl.Result{Requeue: true}, nil

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1538,8 +1538,7 @@ var _ = Describe("cluster install", func() {
 				creds, err := userBMClient.Installer.GetCredentials(ctx, &installer.GetCredentialsParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(creds.GetPayload().Username).To(Equal(bminventory.DefaultUser))
-				Expect(creds.GetPayload().ConsoleURL).To(Equal(
-					fmt.Sprintf("%s.%s.%s", bminventory.ConsoleUrlPrefix, cluster.Name, cluster.BaseDNSDomain)))
+				Expect(creds.GetPayload().ConsoleURL).To(Equal(common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain)))
 				Expect(len(creds.GetPayload().Password)).NotTo(Equal(0))
 			}
 		})

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1054,6 +1054,8 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		Eventually(func() bool {
 			return getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Spec.Installed
 		}, "1m", "2s").Should(BeTrue())
+		Expect(getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.APIURL).Should(Equal("https://api.test-cluster-sno.hive.example.com:6443"))
+		Expect(getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.WebConsoleURL).Should(Equal("https://console-openshift-console.apps.test-cluster-sno.hive.example.com"))
 		passwordSecretRef := getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Spec.ClusterMetadata.AdminPasswordSecretRef
 		Expect(passwordSecretRef).NotTo(BeNil())
 		passwordkey := types.NamespacedName{


### PR DESCRIPTION
 - Remove InfraID: was populated by mistake with cluster rest api uuid
 - Update in CD CR status api and console url
