### PR TITLE
MGMT-5372 added scripts for operator installation

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -1,0 +1,3 @@
+source ./setup_lso.sh
+source ./setup_hive.sh
+source ./setup_assisted_operator.sh

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -1,0 +1,134 @@
+source utils.sh
+
+set -xeo pipefail
+
+SERVICE_IMAGE="${SERVICE_IMAGE:-}"
+INSTALLER_IMAGE="${INSTALLER_IMAGE:-}"
+AGENT_IMAGE="${AGENT_IMAGE:-}"
+DATABASE_IMAGE="${DATABASE_IMAGE:-}"
+CONTROLLER_IMAGE="${CONTROLLER_IMAGE:-}"
+OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-}"
+
+ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
+INDEX_IMAGE="${INDEX_IMAGE:-quay.io/ocpmetal/assisted-service-index:latest}"
+STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-assisted-service}"
+
+function subscription_config() {
+    if [ -n "${SERVICE_IMAGE}" ]; then
+cat <<EOF
+    - name: SERVICE_IMAGE
+      value: '$SERVICE_IMAGE'
+EOF
+    fi
+
+    if [ -n "${INSTALLER_IMAGE}" ]; then
+cat <<EOF
+    - name: INSTALLER_IMAGE
+      value: '$INSTALLER_IMAGE'
+EOF
+    fi
+
+    if [ -n "${AGENT_IMAGE}" ]; then
+cat <<EOF
+    - name: AGENT_IMAGE
+      value: '$AGENT_IMAGE'
+EOF
+    fi
+
+    if [ -n "${DATABASE_IMAGE}" ]; then
+cat <<EOF
+    - name: DATABASE_IMAGE
+      value: '$DATABASE_IMAGE'
+EOF
+    fi
+
+    if [ -n "${CONTROLLER_IMAGE}" ]; then
+cat <<EOF
+    - name: CONTROLLER_IMAGE
+      value: '$CONTROLLER_IMAGE'
+EOF
+    fi
+
+    if [ -n "${OPENSHIFT_VERSIONS}" ]; then
+cat <<EOF
+    - name: OPENSHIFT_VERSIONS
+      value: '$OPENSHIFT_VERSIONS'
+EOF
+    fi
+}
+
+cat <<EOCR | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: assisted-service-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: ${INDEX_IMAGE}
+  displayName: Assisted Test Registry
+  publisher: Assisted Developer
+EOCR
+
+cat <<EOCR | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ASSISTED_NAMESPACE}
+  labels:
+    name: ${ASSISTED_NAMESPACE}
+EOCR
+
+cat <<EOCR | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: assisted-installer-group
+  namespace: ${ASSISTED_NAMESPACE}
+spec:
+  targetNamespaces:
+    - ${ASSISTED_NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: assisted-service-operator
+  namespace: ${ASSISTED_NAMESPACE}
+spec:
+  config:
+    env:
+$(subscription_config)
+  installPlanApproval: Automatic
+  name: assisted-service-operator
+  source: assisted-service-catalog
+  sourceNamespace: openshift-marketplace
+EOCR
+
+wait_for_crd "agentserviceconfigs.agent-install.openshift.io"
+
+cat <<EOCR | oc apply -f -
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+ name: agent
+spec:
+ databaseStorage:
+  storageClassName: ${STORAGE_CLASS_NAME}
+  accessModes:
+  - ReadWriteOnce
+  resources:
+   requests:
+    storage: 8Gi
+ filesystemStorage:
+  storageClassName: ${STORAGE_CLASS_NAME}
+  accessModes:
+  - ReadWriteOnce
+  resources:
+   requests:
+    storage: 8Gi
+EOCR
+
+wait_for_operator "assisted-service-operator" "${ASSISTED_NAMESPACE}"
+wait_for_pod "assisted-service" "${ASSISTED_NAMESPACE}" "app=assisted-service"
+
+echo "Installation of Assisted Installer operator passed successfully!"

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -1,0 +1,21 @@
+source utils.sh
+
+set -xeo pipefail
+
+cat <<EOCR | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hive-operator
+  namespace: openshift-operators
+spec:
+  installPlanApproval: Automatic
+  name: hive-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+EOCR
+
+wait_for_operator "hive-operator" "openshift-operators"
+wait_for_crd "clusterdeployments.hive.openshift.io"
+
+echo "Hive installed successfully!"

--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -1,0 +1,61 @@
+source utils.sh
+
+set -xeo pipefail
+
+function install_lso() {
+    oc adm new-project openshift-local-storage || true
+
+    oc annotate project openshift-local-storage openshift.io/node-selector='' --overwrite=true
+
+    cat <<EOCR | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: local-operator-group
+  namespace: openshift-local-storage
+spec:
+  targetNamespaces:
+  - openshift-local-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: openshift-local-storage
+spec:
+  installPlanApproval: Automatic
+  name: local-storage-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOCR
+
+    wait_for_operator "local-storage-operator" "openshift-local-storage"
+}
+
+function create_local_volume() {
+    wait_for_crd "localvolumes.local.storage.openshift.io" "openshift-local-storage"
+
+    cat <<EOCR | oc apply -f -
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: assisted-service
+  namespace: openshift-local-storage
+spec:
+  logLevel: Normal
+  managementState: Managed
+  storageClassDevices:
+    - devicePaths:
+        - /dev/sdb
+        - /dev/sdc
+        - /dev/sdd
+        - /dev/sde
+        - /dev/sdf
+      storageClassName: assisted-service
+      volumeMode: Filesystem
+EOCR
+}
+
+install_lso
+create_local_volume
+echo "Done configuring local-storage-operator!"

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -1,0 +1,46 @@
+function wait_for_crd() {
+  crd="$1"
+  namespace="$2"
+  echo "Waiting for CRD (${crd}) on namespace (${namespace}) to be defined..."
+  for i in {1..40}; do
+    oc get "crd/${crd}" -n "${namespace}" && break || sleep 10
+  done
+
+  echo "Waiting for CRD (${crd}) on namespace (${namespace}) to become ready..."
+  oc wait --for condition=established --timeout=60s "crd/${crd}" -n "${namespace}" || return 1
+}
+
+function wait_for_operator() {
+  subscription="$1"
+  namespace="$2"
+  echo "Waiting for operator ${subscription} to get installed on namespace ${namespace}..."
+
+  for _ in $(seq 1 60); do
+    csv=$(oc -n "${namespace}" get subscription "${subscription}" -o jsonpath='{.status.installedCSV}' || true)
+    if [[ -n "${csv}" ]]; then
+      if [[ "$(oc -n "${namespace}" get csv "${csv}" -o jsonpath='{.status.phase}')" == "Succeeded" ]]; then
+	echo "ClusterServiceVersion (${csv}) is ready"
+        return 0
+      fi
+    fi
+
+    sleep 10
+  done
+
+  echo "Timed out waiting for csv to become ready!"
+  return 1
+}
+
+function wait_for_pod() {
+  pod="$1"
+  namespace="${2:-}"
+  selector="${3:-}"
+
+  echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to be created..."
+  for i in {1..40}; do
+    oc get pod --selector=${selector} --namespace=${namespace} |& grep -ivE "(no resources found|not found)" && break || sleep 10
+  done
+
+  echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to become ready..."
+  oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=180s
+}


### PR DESCRIPTION
Moving operator installation scripts to assisted-service, just like other operators are doing.
Those scripts configure local-storage-operator (assumes several disks already existing), hive and assisted-service operator.
It allows for customizing several components' images, as well as referring to a specific catalog source.