### PR TITLE
MGMT-5359 High CPU usage of Assisted-Service with 500 clusters and not hosts

### DIFF
--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -141,6 +141,7 @@ func (th *transitionHandler) PostCompleteInstallation(sw stateswitch.StateSwitch
 		return err
 	} else {
 		sCluster.cluster = cluster
+		params.updatedCluster = cluster
 		return nil
 	}
 }
@@ -276,6 +277,7 @@ type TransitionArgsRefreshCluster struct {
 	clusterAPI        API
 	ocmClient         *ocm.Client
 	dnsApi            dns.DNSApi
+	updatedCluster    *common.Cluster
 }
 
 func If(id stringer) stateswitch.Condition {
@@ -362,10 +364,15 @@ func (th *transitionHandler) PostUpdateFinalizingAMSConsoleUrl(sw stateswitch.St
 		return err
 	}
 	isAmsSubscriptionConsoleUrlSetField := "is_ams_subscription_console_url_set"
-	if _, err := UpdateCluster(log, th.db, *sCluster.cluster.ID, sCluster.srcState, isAmsSubscriptionConsoleUrlSetField, true); err != nil {
+	var (
+		updatedCluster *common.Cluster
+		err            error
+	)
+	if updatedCluster, err = UpdateCluster(log, th.db, *sCluster.cluster.ID, sCluster.srcState, isAmsSubscriptionConsoleUrlSetField, true); err != nil {
 		log.WithError(err).Errorf("Failed to update %s in cluster DB", isAmsSubscriptionConsoleUrlSetField)
 		return err
 	}
+	params.updatedCluster = updatedCluster
 	log.Infof("Updated console-url in AMS subscription with id %s", subscriptionID)
 	return nil
 }
@@ -433,6 +440,7 @@ func (th *transitionHandler) PostRefreshCluster(reason string) stateswitch.PostT
 		cluster := sCluster.cluster
 		if updatedCluster != nil {
 			cluster = updatedCluster
+			params.updatedCluster = updatedCluster
 		}
 		setPendingUserResetIfNeeded(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, params.hostApi, cluster)
 

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -50,24 +50,12 @@ type validation struct {
 	formatter validationStringFormatter
 }
 
-func (c *clusterPreprocessContext) loadCluster() error {
-	cluster, err := common.GetClusterFromDBWithoutDisabledHosts(c.db, c.clusterId)
-	if err == nil {
-		c.cluster = cluster
-	}
-	return err
-}
-
-func newClusterValidationContext(clusterId strfmt.UUID, db *gorm.DB) (*clusterPreprocessContext, error) {
-	ret := &clusterPreprocessContext{
-		clusterId: clusterId,
+func newClusterValidationContext(c *common.Cluster, db *gorm.DB) *clusterPreprocessContext {
+	return &clusterPreprocessContext{
+		clusterId: *c.ID,
+		cluster:   c,
 		db:        db,
 	}
-	err := ret.loadCluster()
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
 }
 
 func isDhcpLeaseAllocationTimedOut(c *clusterPreprocessContext) bool {


### PR DESCRIPTION

The change handles the flow when there are many clusters that do not need to be updated during RefreshStatus.
This flow should be fast as possible.  Testing showed that many db queries cause high CPU usage and latency in cluster monitoring.
So during the above flow the aim for clusters that do not need to change - to query the database much less than
the number of clusters.  Currently we use 100 clusters batch.
The solution is in cluster monitoring to query one per batch for all cluster operations in the loop (connectivity-groups, refresh-status).
This data should be used without additional database query unless update is attempted.
The main idea for the change is that clusters are queried only once in the monitoring loop with all the details needed (hosts,
operators etc.).  These clusters are used for all the monitoring flow in case that no update is attempted.  Basically it contains the following changes:

- The refresh status cluster uses cluster from the initial query.
- In case cluster is updated during refresh status, the result of the update is taken from the update function.
- The loadCluster was removed when preparing cluster.  The cluster is taken from the initial query.
- The clusters for connectivity check calculation are taken from the initial query.


/cc @filanov 
/cc @tsorya 