### PR TITLE
Mgmt 4967 Create a standard way to run a debugger on the service

### DIFF
--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -3,8 +3,9 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS download_dlv
 RUN go get github.com/go-delve/delve/cmd/dlv
 
 FROM $SERVICE
+ARG DEBUG_PORT=40000
 COPY --from=download_dlv /go/bin/dlv /
-EXPOSE 8090 40000
+EXPOSE 8090 $DEBUG_PORT
 COPY assisted-service /assisted-service
 COPY assisted-service-operator /assisted-service-operator
 CMD ["/dlv", "--listen=:40000", "--headless=true", "--continue", "--api-version=2", "--accept-multiclient", "exec", "/assisted-service"]

--- a/debug.md
+++ b/debug.md
@@ -1,0 +1,59 @@
+# assisted-service
+
+## Debug Setup
+
+To debug the application first set the `DEBUG` environment variable to any nonempty value
+
+```shell
+export DEBUG=true
+```
+
+The default remote debug port is 40000 but its configurable by setting the `DEBUG_PORT` env variable:
+
+```shell
+export DEBUG_PORT=8765
+```
+
+Compile the code with debug information, patch the image and push to your local k8s:
+
+```shell
+skipper make _update-local-image
+```
+Note! This target updates the existing assisted-service image with the latest assisted-service, but you are responsible to update the image
+if the Dockerfile has been changed before patching it.\
+You have two options to update the image:
+1. Pulling the latest assisted-service image:\
+   This option is faster, but it pulls the latest master image
+    * For a local minikube k8s:
+        ```shell
+        eval $(minikube docker-env) && docker pull IMAGE_NAME
+        ```
+    * For a local k3d k8s:
+        ```shell
+        docker pull IMAGE_NAME
+        k3d image import IMAGE_NAME
+        ```
+2. Build the image locally(Recommended)
+    ```shell
+    unset DEBUG
+    skipper make _update-local-image
+    ```
+
+Deploy the service to your local k8s:
+
+```shell
+skipper make deploy-all
+```
+
+Compile the code with debug information and patch the image:
+
+```shell
+skipper make update-debug-minimal
+```
+
+
+
+
+
+
+

--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -23,7 +23,7 @@ spec:
               cpu: 300m
               memory: 400Mi
           image: REPLACE_IMAGE
-          imagePullPolicy: Always
+          imagePullPolicy: REPLACE_IMAGE_PULL_POLICY
           ports:
             - containerPort: 8090
           livenessProbe:

--- a/skipper-mac.yaml
+++ b/skipper-mac.yaml
@@ -31,5 +31,6 @@ env_file:
   - skipper.env
 env:
   GOCACHE: "/go/pkg/mod"
+  SKIPPER_PLATFORM: "darwin"
   DOCKER_CONFIG: $DOCKER_CONFIG
   KUBECONFIG: $CONTAINER_KUBE_CONFIG

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -57,6 +57,10 @@ def load_deployment_options(parser=None):
 
     parser.add_argument("--apply-manifest", type=lambda x: (str(x).lower() == 'true'), default=True)
     parser.add_argument("--persistent-storage", type=lambda x: (str(x).lower() == 'true'), default=True)
+    parser.add_argument('-p', '--port', action="append", nargs=2,
+                        metavar=('port', 'name'),  help="Expose a port")
+    parser.add_argument("--image-pull-policy", help='Determine if the image should be pulled prior to starting the container.',
+                    type=str, choices=["Always", "IfNotPresent", "Never"], default="Always")
 
     deploy_options = parser.add_mutually_exclusive_group()
     deploy_options.add_argument("--deploy-tag", help='Tag for all deployment images', type=str)


### PR DESCRIPTION
[MGMT-4967](https://issues.redhat.com/browse/MGMT-4967) Create a standard way to run a debugger on the service
Document how to debug deploy the service with debug information 
Open the debug ports on our k8s resources
Change the debug port to be configureable
 
 Fixing skipper make deploy-test command on a macos