### PR TITLE
MGMT-4261 Agent CR cleanup

### DIFF
--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -53,6 +53,20 @@ func (mr *MockInstallerInternalsMockRecorder) DeregisterClusterInternal(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).DeregisterClusterInternal), arg0, arg1)
 }
 
+// DeregisterHostInternal mocks base method
+func (m *MockInstallerInternals) DeregisterHostInternal(arg0 context.Context, arg1 installer.DeregisterHostParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterHostInternal", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterHostInternal indicates an expected call of DeregisterHostInternal
+func (mr *MockInstallerInternalsMockRecorder) DeregisterHostInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).DeregisterHostInternal), arg0, arg1)
+}
+
 // DownloadClusterKubeconfigInternal mocks base method
 func (m *MockInstallerInternals) DownloadClusterKubeconfigInternal(arg0 context.Context, arg1 installer.DownloadClusterKubeconfigParams) (io.ReadCloser, int64, error) {
 	m.ctrl.T.Helper()
@@ -142,6 +156,21 @@ func (m *MockInstallerInternals) GetCredentialsInternal(arg0 context.Context, ar
 func (mr *MockInstallerInternalsMockRecorder) GetCredentialsInternal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsInternal", reflect.TypeOf((*MockInstallerInternals)(nil).GetCredentialsInternal), arg0, arg1)
+}
+
+// GetHostByKubeKey mocks base method
+func (m *MockInstallerInternals) GetHostByKubeKey(arg0 types.NamespacedName) (*common.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostByKubeKey", arg0)
+	ret0, _ := ret[0].(*common.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostByKubeKey indicates an expected call of GetHostByKubeKey
+func (mr *MockInstallerInternalsMockRecorder) GetHostByKubeKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostByKubeKey", reflect.TypeOf((*MockInstallerInternals)(nil).GetHostByKubeKey), arg0)
 }
 
 // InstallClusterInternal mocks base method
@@ -289,4 +318,18 @@ func (m *MockInstallerInternals) UpdateHostInstallerArgsInternal(arg0 context.Co
 func (mr *MockInstallerInternalsMockRecorder) UpdateHostInstallerArgsInternal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostInstallerArgsInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostInstallerArgsInternal), arg0, arg1)
+}
+
+// UpdateHostKubeKeyInternal mocks base method
+func (m *MockInstallerInternals) UpdateHostKubeKeyInternal(arg0 context.Context, arg1, arg2, arg3 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateHostKubeKeyInternal", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateHostKubeKeyInternal indicates an expected call of UpdateHostKubeKeyInternal
+func (mr *MockInstallerInternalsMockRecorder) UpdateHostKubeKeyInternal(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHostKubeKeyInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateHostKubeKeyInternal), arg0, arg1, arg2, arg3)
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -12,6 +12,7 @@ import (
 	common "github.com/openshift/assisted-service/internal/common"
 	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
+	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 )
 
@@ -92,6 +93,21 @@ func (m *MockAPI) EnableHost(arg0 context.Context, arg1 *models.Host, arg2 *gorm
 func (mr *MockAPIMockRecorder) EnableHost(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableHost", reflect.TypeOf((*MockAPI)(nil).EnableHost), arg0, arg1, arg2)
+}
+
+// GetHostByKubeKey mocks base method
+func (m *MockAPI) GetHostByKubeKey(arg0 types.NamespacedName) (*common.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostByKubeKey", arg0)
+	ret0, _ := ret[0].(*common.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostByKubeKey indicates an expected call of GetHostByKubeKey
+func (mr *MockAPIMockRecorder) GetHostByKubeKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostByKubeKey", reflect.TypeOf((*MockAPI)(nil).GetHostByKubeKey), arg0)
 }
 
 // GetHostValidDisks mocks base method


### PR DESCRIPTION
This change handles cases in which the agent CR(s) should be removed.

clusterdeployments_controller:
When a clusterDeployment CR gets deleted, the controller detects the
relevant agents and pushes updates to the agent_controller, which
in turn will reconcile and delete them.

agent_controller:
Agent CR deletion will now deregister the host from the backend.
The controller will delete agent CR if one of the following scenarios
takes place during reconcile:
- No clusterDeployment was found for the agent.
- No cluster (backend) was found for the agent.
- Agent does not belong to the cluster retrieved from the backend,
  which may happen with newly created day2 clusters.