### PR TITLE
OCPBUGSM-28006 Fix vxlan vmware incorrect checksum in assisted installer

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2297,6 +2297,73 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		Expect(err).To(Not(HaveOccurred()))
 	})
 
+	Context("Vmware", func() {
+		It("Single host", func() {
+			cfg2 := getDefaultConfig()
+			cfg2.EnableSingleNodeDnsmasq = false
+			capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil)
+			manifestsGenerator.EXPECT().AddChronyManifest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			manifestsGenerator.EXPECT().AddDisableVmwareTunnelOffloading(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+
+			c.Hosts = append(c.Hosts, &models.Host{
+				Inventory: common.GenerateTestDefaultVmwareInventory(),
+			})
+			err := capi.GenerateAdditionalManifests(ctx, &c)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("2 hosts", func() {
+			cfg2 := getDefaultConfig()
+			cfg2.EnableSingleNodeDnsmasq = false
+			capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil)
+			manifestsGenerator.EXPECT().AddChronyManifest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			manifestsGenerator.EXPECT().AddDisableVmwareTunnelOffloading(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+
+			for i := 0; i != 2; i++ {
+				c.Hosts = append(c.Hosts, &models.Host{
+					Inventory: common.GenerateTestDefaultVmwareInventory(),
+				})
+			}
+			err := capi.GenerateAdditionalManifests(ctx, &c)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("Mixed", func() {
+			cfg2 := getDefaultConfig()
+			cfg2.EnableSingleNodeDnsmasq = false
+			capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil)
+			manifestsGenerator.EXPECT().AddChronyManifest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			manifestsGenerator.EXPECT().AddDisableVmwareTunnelOffloading(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+
+			c.Hosts = append(c.Hosts, &models.Host{
+				Inventory: common.GenerateTestDefaultVmwareInventory(),
+			})
+			c.Hosts = append(c.Hosts, &models.Host{
+				Inventory: common.GenerateTestDefaultInventory(),
+			})
+			err := capi.GenerateAdditionalManifests(ctx, &c)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("No VMWARE", func() {
+			cfg2 := getDefaultConfig()
+			cfg2.EnableSingleNodeDnsmasq = false
+			capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil)
+			manifestsGenerator.EXPECT().AddChronyManifest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+
+			c.Hosts = append(c.Hosts, &models.Host{
+				Inventory: common.GenerateTestDefaultInventory(),
+			})
+			err := capi.GenerateAdditionalManifests(ctx, &c)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+
 	AfterEach(func() {
 		ctrl.Finish()
 		common.DeleteTestDB(db, dbName)

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -113,6 +113,32 @@ func GenerateTestDefaultInventory() string {
 	return string(b)
 }
 
+func GenerateTestDefaultVmwareInventory() string {
+	inventory := &models.Inventory{
+		Interfaces: []*models.Interface{
+			{
+				Name: "eth0",
+				IPV4Addresses: []string{
+					"1.2.3.4/24",
+				},
+				IPV6Addresses: []string{
+					"1001:db8::10/120",
+				},
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		SystemVendor: &models.SystemVendor{
+			Manufacturer: "vmware",
+		},
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 func GenerateTestDefaultInventoryIPv4Only() string {
 	defaultInventory := GenerateTestDefaultInventory()
 	var inventory models.Inventory

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -23,6 +23,7 @@ import (
 type ManifestsGeneratorAPI interface {
 	AddChronyManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
 	AddDnsmasqForSingleNode(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
+	AddDisableVmwareTunnelOffloading(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
 }
 
 type ManifestsGenerator struct {
@@ -273,4 +274,69 @@ func fillTemplate(manifestParams map[string]string, templateData string, log log
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+const disableTunnelOffloadManifest = `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: %s
+  name: %ss-disable-tunnel-offload
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,%s
+          verification: {}
+        filesystem: root
+        mode: 493
+        path: /etc/NetworkManager/dispatcher.d/05-disable-tunnel-offload
+  osImageURL: ""
+`
+
+const disableTunnelOffloadScript = `#! /bin/bash
+
+if [ "$2" != "up" ] ; then
+	exit 0
+fi
+
+driver=$(ethtool -i "$1" | awk '/driver:/{print $2;}')
+
+if [ "$driver" != "vmxnet3" ] ; then 
+	exit 0
+fi
+
+current=$(ethtool -k "$1" | grep udp_tnl | grep -v '\[fixed\]')
+
+if [ -z "$current" ] ; then
+	exit 0
+fi
+
+nmcli connection modify $CONNECTION_UUID ethtool.feature-tx-udp_tnl-csum-segmentation off ethtool.feature-tx-udp_tnl-segmentation off
+nmcli connection up $CONNECTION_UUID
+`
+
+func createDisableTunnelOffloadingContext(role string) string {
+	return fmt.Sprintf(disableTunnelOffloadManifest, role, role, base64.StdEncoding.EncodeToString([]byte(disableTunnelOffloadScript)))
+}
+
+func (m *ManifestsGenerator) AddDisableVmwareTunnelOffloading(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
+	for _, role := range []string{"master", "worker"} {
+		fname := fmt.Sprintf("%ss-disable-tunnel-offload.yaml", role)
+		if err := m.createManifests(ctx, c, fname, []byte(createDisableTunnelOffloadingContext(role))); err != nil {
+			log.WithError(err).Errorf("Failed to create disable tunnel offloading manifest for role %s", role)
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/network/mock_manifests_generator.go
+++ b/internal/network/mock_manifests_generator.go
@@ -62,3 +62,17 @@ func (mr *MockManifestsGeneratorAPIMockRecorder) AddDnsmasqForSingleNode(ctx, lo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDnsmasqForSingleNode", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddDnsmasqForSingleNode), ctx, log, c)
 }
+
+// AddDisableVmwareTunnelOffloading mocks base method
+func (m *MockManifestsGeneratorAPI) AddDisableVmwareTunnelOffloading(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddDisableVmwareTunnelOffloading", ctx, log, c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddDisableVmwareTunnelOffloading indicates an expected call of AddDisableVmwareTunnelOffloading
+func (mr *MockManifestsGeneratorAPIMockRecorder) AddDisableVmwareTunnelOffloading(ctx, log, c interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDisableVmwareTunnelOffloading", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddDisableVmwareTunnelOffloading), ctx, log, c)
+}


### PR DESCRIPTION
Add manifest to create a bash script file /etc/NetworkManager/dispatcher.d/05-disable-tunnel-offload
The manifest creation is invoked for clusters with vmware hosts only
The script checks if the driver is vmxnet3 and that the settings tx-udp_tnl-csum-segmentation and tx-udp_tnl-segmentation
can be updated, If these settings can be updated, the script sets the to off.
The script is relevant (and checks it) for "up" action only.

/cc @ronniel1 
/cc @tsorya 
/cc @gamli75 