### PR TITLE
MGMT-5391 - Expose http and https from the service and configure BMH against http

### DIFF
--- a/pkg/app/app_suite_test.go
+++ b/pkg/app/app_suite_test.go
@@ -1,0 +1,13 @@
+package app_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "app suite")
+}

--- a/pkg/app/middleware_test.go
+++ b/pkg/app/middleware_test.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("WithPathAllowListMiddleware", func() {
+	var successHandler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	It("fails for non-matching methods", func() {
+		req, err := http.NewRequest(http.MethodPatch, "/testing", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+
+		allowList := []*RequestMatch{
+			{
+				Path:    regexp.MustCompile(`/testing$`),
+				Methods: []string{http.MethodGet, http.MethodHead},
+			},
+		}
+
+		WithPathAllowListMiddleware(successHandler, allowList).ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusForbidden))
+	})
+
+	It("fails for non-matching paths", func() {
+		req, err := http.NewRequest(http.MethodPatch, "/testing", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+
+		allowList := []*RequestMatch{
+			{
+				Path:    regexp.MustCompile(`/update$`),
+				Methods: []string{http.MethodPatch},
+			},
+		}
+
+		WithPathAllowListMiddleware(successHandler, allowList).ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusForbidden))
+	})
+
+	It("succeeds with matching requests", func() {
+		req, err := http.NewRequest(http.MethodPatch, "/testing", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+
+		allowList := []*RequestMatch{
+			{
+				Path:    regexp.MustCompile(`/testing`),
+				Methods: []string{http.MethodGet, http.MethodPatch},
+			},
+		}
+
+		WithPathAllowListMiddleware(successHandler, allowList).ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusOK))
+	})
+
+	It("succeeds when the request matches only one list entry", func() {
+		req, err := http.NewRequest(http.MethodPatch, "/testing", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+
+		allowList := []*RequestMatch{
+			{
+				Path:    regexp.MustCompile(`/health`),
+				Methods: []string{http.MethodGet},
+			},
+			{
+				Path:    regexp.MustCompile(`/testing$`),
+				Methods: []string{http.MethodPatch},
+			},
+			{
+				Path:    regexp.MustCompile(`/clusters/.*$`),
+				Methods: []string{http.MethodGet},
+			},
+		}
+
+		WithPathAllowListMiddleware(successHandler, allowList).ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusOK))
+	})
+
+	It("succeeds with more complicated regex", func() {
+		req, err := http.NewRequest(http.MethodGet, "/clusters/f4db0f5b-a93e-434b-a270-43665cfbae63/downloads/image", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		rr := httptest.NewRecorder()
+
+		allowList := []*RequestMatch{
+			{
+				Path:    regexp.MustCompile(`/clusters/[\w-]+/downloads/image$`),
+				Methods: []string{http.MethodGet, http.MethodHead},
+			},
+		}
+
+		WithPathAllowListMiddleware(successHandler, allowList).ServeHTTP(rr, req)
+		Expect(rr.Code).To(Equal(http.StatusOK))
+	})
+})


### PR DESCRIPTION
Ironic can't easily be configured to trust our default certificate so we need to expose an http api internal to the cluster for it to pull the iso from and configure the BMH to point to the http service rather than the https route.

Both ports are exposed on the same service object and the route is configured to only expose https.

This internal API is limited to just serving GET and HEAD for `/clusters/[\w-]+/downloads/image` by a new middleware.