### PR TITLE
MGMT-3512 Skip garbage collection jobs in operator deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -326,7 +326,7 @@ func main() {
 	} else {
 		crdUtils = controllers.NewDummyCRDUtils()
 	}
-	if Options.EnableDeregisterInactiveGC || Options.EnableDeletedUnregisteredGC {
+	if !Options.EnableKubeAPI && (Options.EnableDeregisterInactiveGC || Options.EnableDeletedUnregisteredGC) {
 		gc := garbagecollector.NewGarbageCollectors(Options.GCConfig, db, log.WithField("pkg", "garbage_collector"), hostApi, clusterApi, objectHandler, lead)
 
 		if Options.EnableDeregisterInactiveGC {


### PR DESCRIPTION
In operator deployment, when cluster entity is removed from the
database by the garbage collector, the clusterdeployment controller
will attempt to reconcile the clusterdeployment CR by re-creating a new
cluster entity in the database for it.
Therefore, the garbage collection job is not useful in operator
deployment and needs to be skipped.

Signed-off-by: Moti Asayag <masayag@redhat.com>