### PR TITLE
MGMT-3700 Add dedicated subsystem tests for BMAC day0 

### DIFF
--- a/hack/crds/metal3.io_baremetalhosts.yaml
+++ b/hack/crds/metal3.io_baremetalhosts.yaml
@@ -67,6 +67,13 @@ spec:
           spec:
             description: BareMetalHostSpec defines the desired state of BareMetalHost
             properties:
+              automatedCleaningMode:
+                default: metadata
+                description: When set to disabled, automated cleaning will be avoided during provisioning and deprovisioning.
+                enum:
+                - metadata
+                - disabled
+                type: string
               bmc:
                 description: How do we connect to the BMC?
                 properties:
@@ -589,6 +596,7 @@ spec:
                 - discovered
                 - error
                 - delayed
+                - detached
                 type: string
               poweredOn:
                 description: indicator for whether or not the host is powered on

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -607,7 +607,7 @@ func (r *BMACReconciler) findAgent(ctx context.Context, bmh *bmh_v1alpha1.BareMe
 	agents := []*aiv1beta1.Agent{}
 	for i, agent := range agentList.Items {
 		for _, agentInterface := range agent.Status.Inventory.Interfaces {
-			if strings.EqualFold(bmh.Spec.BootMACAddress, agentInterface.MacAddress) {
+			if agentInterface.MacAddress != "" && strings.EqualFold(bmh.Spec.BootMACAddress, agentInterface.MacAddress) {
 				agents = append(agents, &agentList.Items[i])
 			}
 		}
@@ -637,7 +637,7 @@ func (r *BMACReconciler) findBMH(ctx context.Context, agent *aiv1beta1.Agent) (*
 
 	for _, bmh := range bmhList.Items {
 		for _, agentInterface := range agent.Status.Inventory.Interfaces {
-			if strings.EqualFold(bmh.Spec.BootMACAddress, agentInterface.MacAddress) {
+			if agentInterface.MacAddress != "" && strings.EqualFold(bmh.Spec.BootMACAddress, agentInterface.MacAddress) {
 				return &bmh, nil
 			}
 		}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -92,7 +92,12 @@ var (
 		Memory: &models.Memory{PhysicalBytes: int64(8 * units.GiB), UsableBytes: int64(8 * units.GiB)},
 		Disks:  []*models.Disk{&loop0, &sdb},
 		Interfaces: []*models.Interface{
-			{IPV4Addresses: []string{"1.2.3.4/24"}},
+			{
+				IPV4Addresses: []string{
+					"1.2.3.4/24",
+				},
+				MacAddress: "e6:53:3d:a7:77:b4",
+			},
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
 		Timestamp:    1601853088,
@@ -106,6 +111,7 @@ var (
 				IPV4Addresses: []string{
 					"1.2.3.4/24",
 				},
+				MacAddress: "e6:53:3d:a7:77:b4",
 			},
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},


### PR DESCRIPTION
This PR also fixes an issue with the filtering of agents that have an empty MacAddress https://github.com/openshift/assisted-service/commit/55009fb17a984bfaae79f3cc80bd526345770f88

It is possible to create Agents that have an empty MacAddress. If this happens, and there are BMH's that don't have a BootMACAddress set, then the agent will be associated with that BMH, and hardwaredetails will be set on the resource.

This commit skips Agents that have an empty MacAddress just for extra safety measures

More tests will be added but, at least, this sets the basis to do so in more isolated PRs.

Signed-off-by: Flavio Percoco <flavio@redhat.com>
