### PR TITLE
MGMT-5430 -  use the nmstate RPM

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -32,7 +32,7 @@ RUN dnf install -y libvirt-libs python3 && \
     dnf install -b -y  dnf-plugins-core && \
     dnf copr enable -y networkmanager/NetworkManager-master && \
     dnf copr enable -y nmstate/ovs-el8 && \
-    dnf copr enable -y nmstate/nmstate-0.3&& \
+    dnf copr enable -y nmstate/nmstate-1.0&& \
     dnf copr enable -y nmstate/nispor && \
     dnf install -y pkg-config && \
     dnf install -y glib2-devel && \
@@ -47,14 +47,10 @@ RUN dnf install -y libvirt-libs python3 && \
     dnf install -y NetworkManager-config-server && \
     dnf install -y openvswitch2.11 && \
     dnf install -y python3-openvswitch2.11 && \
+    dnf install -y nmstate &&\
     pip3 install pycairo && \
     dnf remove -y dnf-plugins-core && \
     dnf clean all
-
-RUN mkdir nmstate
-RUN curl --retry 5 -SL https://github.com/nmstate/nmstate/releases/download/v1.0.2/nmstate-1.0.2.tar.gz | tar -xz -C nmstate
-RUN cd /nmstate/nmstate-1.0.2 && python3 setup.py build
-RUN cd /nmstate/nmstate-1.0.2 && python3 setup.py install
 
 ARG WORK_DIR=/data
 


### PR DESCRIPTION
Based on the current `Dockerfile` it looks like the minimum required version is `1.0.2`. With this change we will be installing `1.0.3`

```
[root@b44e2acbacd8 /]# nmstatectl --version
1.0.3
[root@b44e2acbacd8 /]# dnf info nmstate
Failed to set locale, defaulting to C.UTF-8
CentOS Linux 8 - AppStream                                                                                                                                                                                                                       3.0 MB/s | 6.3 MB     00:02
CentOS Linux 8 - BaseOS                                                                                                                                                                                                                          1.0 MB/s | 2.3 MB     00:02
CentOS Linux 8 - Extras                                                                                                                                                                                                                           20 kB/s | 9.6 kB     00:00
Copr repo for NetworkManager-master owned by networkmanager                                                                                                                                                                                       35 kB/s |  22 kB     00:00
Copr repo for nispor owned by nmstate                                                                                                                                                                                                             20 kB/s |  11 kB     00:00
Copr repo for nmstate-1.0 owned by nmstate                                                                                                                                                                                                       8.7 kB/s | 3.6 kB     00:00
Copr repo for ovs-el8 owned by nmstate                                                                                                                                                                                                            87 kB/s |  36 kB     00:00
Installed Packages
Name         : nmstate
Version      : 1.0.3
Release      : 1.el8
Architecture : noarch
Size         : 66 k
Source       : nmstate-1.0.3-1.el8.src.rpm
Repository   : @System
From repo    : copr:copr.fedorainfracloud.org:nmstate:nmstate-1.0
Summary      : Declarative network manager API
URL          : https://github.com/nmstate/nmstate
License      : LGPLv2+
Description  : Nmstate is a library with an accompanying command line tool that manages host
             : networking settings in a declarative manner and aimed to satisfy enterprise
             : needs to manage host networking through a northbound declarative API and multi
             : provider support on the southbound.

Available Packages
Name         : nmstate
Version      : 1.0.3
Release      : 1.el8
Architecture : src
Size         : 142 k
Source       : None
Repository   : copr:copr.fedorainfracloud.org:nmstate:nmstate-1.0
Summary      : Declarative network manager API
URL          : https://github.com/nmstate/nmstate
License      : LGPLv2+
Description  : Nmstate is a library with an accompanying command line tool that manages host
             : networking settings in a declarative manner and aimed to satisfy enterprise
             : needs to manage host networking through a northbound declarative API and multi
             : provider support on the southbound.

[root@b44e2acbacd8 /]#
```
Signed-off-by: Flavio Percoco <flavio@redhat.com>