### PR TITLE
MGMT-5408 Fix kernel arg for dhcp in none-platform

### DIFF
--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -225,6 +225,7 @@ func GetMachineCidrForUserManagedNetwork(cluster *common.Cluster, log logrus.Fie
 
 	bootstrap := common.GetBootstrapHost(cluster)
 	if bootstrap == nil {
+		log.Warnf("No bootstrap found in cluster %s", cluster.ID)
 		return ""
 	}
 


### PR DESCRIPTION
Set `ip=dhcp` or `ip=dhcp6`, according to address family of the
machine network, for reliable interface initialization in dracut mode.

In none-platform, determining the machine network relies on bootstrap
node. When the install command of a node is being generated, we need
to read the bootstrap host of the cluster from the DB.

We return an error if an address family cannot be determined:
1. A host cannot exist without an IP address, therefore not finding
   one means a bug.
2. Situations when this kernel argument remains unset (i.e. default
   value) may result in failed installations, and are very difficult
   to detect and troubleshoot.
3. Having said that, it's not possible to tell the right address
   family in day 2 scenario, so we have to leave the flag unset