### PR TITLE
OCPBUGSM-28382: Accept cm annotation on ASC

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -136,7 +136,6 @@ cat <<EOF | kubectl create -f -
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
-  namespace: assisted-installer
   name: agent
 spec:
   databaseStorage:
@@ -154,6 +153,14 @@ spec:
 EOF
 ```
 
+**NOTE Unsupported**
+It is possible to specify a ConfigMap to be mounted into the assisted-service
+container as environment variables by adding an
+`"unsupported.agent-install.openshift.io/assisted-service-configmap"`
+annotation to the `AgentServiceConfig` specifying the name of the configmap to be
+used. This ConfigMap must exist in the namespace where the operator is
+installed.
+
 For more details on how to specify the CR, see [AgentServiceConfig CRD](https://github.com/openshift/assisted-service/blob/master/internal/controller/config/crd/bases/agent-install.openshift.io_agentserviceconfigs.yaml).
 
 ## Subscription config
@@ -162,12 +169,11 @@ Subscription configs override any environment variables set in
 the deployment specs and any values from ConfigMaps. They can be
 used to configure the operator deployment.
 
-Here is an example. By default, the operator bundle is configured
-to use minimal-iso for ISO_IMAGE_TYPE. It can be reconfigured to
-full-iso through the Subscription config.
+In the example below, we configure the image that will be used
+when deploying the assisted-service by changing the value of `SERVICE_IMAGE`.
 
 ``` bash
-cat <<EOF | kubectl create -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -179,7 +185,10 @@ spec:
   name: assisted-service-operator
   source: assisted-service-manifests
   sourceNamespace: openshift-marketplace
-  startingCSV: assisted-service-operator.v0.0.1
+  config:
+    env:
+      - name: SERVICE_IMAGE
+        value: "my-custom-assisted-service-image"
 EOF
 ```
 

--- a/internal/controller/controllers/controllers_suite_test.go
+++ b/internal/controller/controllers/controllers_suite_test.go
@@ -6,6 +6,7 @@ import (
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +20,7 @@ func init() {
 	_ = v1beta1.AddToScheme(scheme.Scheme)
 	_ = hivev1.AddToScheme(scheme.Scheme)
 	_ = bmh_v1alpha1.AddToScheme(scheme.Scheme)
-
+	_ = routev1.AddToScheme(scheme.Scheme)
 }
 
 const (


### PR DESCRIPTION
This PR updates the agent service config controller to recognize
"unsupported.agent-install.openshift.io/assisted-service-config"
annotation and use that as EnvFrom on the assisted-service container.

Checklist
- [ ] Manual testing and changes
- [x] Add tests for `ensureAssistedServiceDeployment()` specifically need to cover the handling of the annotation.
- [x] Update operator docs.