### PR TITLE
Bug 1953586 - Assisted installer fails to allocate VIPs

### DIFF
--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -9,8 +9,8 @@ import (
 // Minimum mask size to allow 128 addresses for cluster or service CIDRs
 const MinMaskDelta = 7
 
-// Minimum mask size for Machine CIDR to allow at least 64 addresses
-const MinMachineMaskDelta = 6
+// Minimum mask size for Machine CIDR to allow at least 16 addresses
+const MinMachineMaskDelta = 4
 
 // VerifyCIDRsNotOverlap returns true if one of the CIDRs is a subset of the other.
 func verifyCIDRsNotOverlap(acidr, bcidr *net.IPNet) error {

--- a/internal/network/cidr_validations_test.go
+++ b/internal/network/cidr_validations_test.go
@@ -39,9 +39,13 @@ var _ = Describe("CIDR validations", func() {
 		It("Machine CIDR 26 OK", func() {
 			Expect(VerifyMachineCIDR("1.2.3.128/26")).ToNot(HaveOccurred())
 		})
-		It("Machine CIDR 27 Fail", func() {
-			Expect(VerifyMachineCIDR("1.2.3.128/27")).To(HaveOccurred())
+		It("Machine CIDR 29 Fail", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/29")).To(HaveOccurred())
 		})
+		It("Machine CIDR 27 OK", func() {
+			Expect(VerifyMachineCIDR("1.2.3.128/27")).ToNot(HaveOccurred())
+		})
+
 		It("Service CIDR 26 Fail", func() {
 			Expect(VerifyClusterOrServiceCIDR("1.2.3.0/26")).To(HaveOccurred())
 		})


### PR DESCRIPTION
Updated MinMachineMaskDelta to 4, it should allow /28 for machine network CIDR