### PR TITLE
NO-ISSUE: Adding debug info for failing validations subsystem tests.

### DIFF
--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -145,6 +145,8 @@ func getValidationMetricCounter(validationID, expectedMetric string) int {
 	cmd := exec.Command("curl", "-s", url)
 	output, err := cmd.Output()
 	Expect(err).NotTo(HaveOccurred())
+	_, err = GinkgoWriter.Write(output)
+	Expect(err).NotTo(HaveOccurred())
 
 	metrics := strings.Split(string(output), "\n")
 	filteredMetrics := filterMetrics(metrics, expectedMetric, fmt.Sprintf("ValidationType=\"%s\"", validationID))


### PR DESCRIPTION
GinkgoWriter is an io.Writer that emit its content to the console if a
specific test fails.

In our case, we have some flaky tests due to the fact that multiple
metrics are filtered instead of a single one as part of the test. This
new info will help us understand why more than a single metric was
filtered.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>