### PR TITLE
MGMT-4261 Agent CR and ACI cleanup when deleting CD

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -186,6 +186,12 @@ rules:
 - apiGroups:
   - extensions.hive.openshift.io
   resources:
+  - agentclusterinstalls/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
   - agentclusterinstalls/status
   verbs:
   - get

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -350,6 +350,12 @@ spec:
         - apiGroups:
           - extensions.hive.openshift.io
           resources:
+          - agentclusterinstalls/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - extensions.hive.openshift.io
+          resources:
           - agentclusterinstalls/status
           verbs:
           - get


### PR DESCRIPTION
clusterdeployments_controller:
When a CD CR gets deleted, the controller will place a
finalizer to trigger a pre-deletion cleanup.

The cleanup includes ACI deletion, which will place a finalizer on ACI.

ACI finalizer includes backend-cluster deregister and deletion of the
cluster agent resources.

As for subsystem tests:
1. Tests will now assert for agent deletion per ACI removal.
2. Tests will now assert for agent deletion and ACI per CD removal.
3. Each test will now use a unique CD and ACI CR name - to provide better
   test isolation. This was also done because deletion via finalizers
   takes an additional reconcile to be fully deleted.
4. Per 2, and to avoid any cleanup bugs, the cleanup done for subsystem
   tests (AfterEach) is now followed up by verifyCleanUP

P.S.
Note that this PR does not cover host deregister upon Agent CR deletion,
which was added in #1642