### PR TITLE
OCPBUGSM-24075 - fix events using English spelling canceled

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -635,7 +635,7 @@ func (m *Manager) CancelInstallation(ctx context.Context, c *common.Cluster, rea
 	log := logutil.FromContext(ctx, m.log)
 
 	eventSeverity := models.EventSeverityInfo
-	eventInfo := "Canceled cluster installation"
+	eventInfo := "Cancelled cluster installation"
 	defer func() {
 		m.eventsHandler.AddEvent(ctx, *c.ID, nil, eventSeverity, eventInfo, time.Now())
 	}()

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1247,7 +1247,7 @@ var _ = Describe("CancelInstallation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			Expect(*cancelEvent.Message).Should(Equal("Canceled cluster installation"))
+			Expect(*cancelEvent.Message).Should(Equal("Cancelled cluster installation"))
 		})
 		It("cancel_failed_installation", func() {
 			c.Status = swag.String(models.ClusterStatusError)
@@ -1260,7 +1260,7 @@ var _ = Describe("CancelInstallation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			Expect(*cancelEvent.Message).Should(Equal("Canceled cluster installation"))
+			Expect(*cancelEvent.Message).Should(Equal("Cancelled cluster installation"))
 		})
 
 		AfterEach(func() {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -629,7 +629,7 @@ func (m *Manager) UpdateInstallationDisk(ctx context.Context, db *gorm.DB, h *mo
 
 func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason string, db *gorm.DB) *common.ApiErrorResponse {
 	eventSeverity := models.EventSeverityInfo
-	eventInfo := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(h))
+	eventInfo := fmt.Sprintf("Installation cancelled for host %s", hostutil.GetHostnameForMsg(h))
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -525,7 +525,7 @@ var _ = Describe("cancel installation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("Installation cancelled for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*cancelEvent.Message).Should(Equal(eventMessage))
 		})
 
@@ -538,7 +538,7 @@ var _ = Describe("cancel installation", func() {
 			Expect(len(events)).ShouldNot(Equal(0))
 			cancelEvent := events[len(events)-1]
 			Expect(*cancelEvent.Severity).Should(Equal(models.EventSeverityInfo))
-			eventMessage := fmt.Sprintf("Installation canceled for host %s", hostutil.GetHostnameForMsg(&h))
+			eventMessage := fmt.Sprintf("Installation cancelled for host %s", hostutil.GetHostnameForMsg(&h))
 			Expect(*cancelEvent.Message).Should(Equal(eventMessage))
 		})
 


### PR DESCRIPTION
At some events, the cluster state was spelled canceled and not canceled .