### PR TITLE
NO-ISSUE Use a ClusterIP service rather than LoadBalancer

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -536,7 +536,7 @@ func (r *AgentServiceConfigReconciler) newAgentService(instance *aiv1beta1.Agent
 		svc.Spec.Ports[0].TargetPort = intstr.IntOrString{Type: intstr.Int, IntVal: servicePort}
 		svc.Spec.Ports[0].Protocol = corev1.ProtocolTCP
 		svc.Spec.Selector = map[string]string{"app": serviceName}
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
 		return nil
 	}
 


### PR DESCRIPTION
A LoadBalancer type service exposes a port on the node.
We only want the service accessible through the route.