### PR TITLE
NO-ISSUE: Tests for agentserviceconfig_controller reconcile and

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -482,7 +482,14 @@ func (r *AgentServiceConfigReconciler) newAgentRoute(instance *aiv1beta1.AgentSe
 		if err := controllerutil.SetControllerReference(instance, route, r.Scheme); err != nil {
 			return err
 		}
-		route.Spec = routeSpec
+		// Only update what is specified above in routeSpec.
+		// If we update the entire route.Spec with
+		// route.Spec = routeSpec
+		// it would overwrite any existing values for route.Spec.Host
+		route.Spec.To = routeSpec.To
+		route.Spec.Port = routeSpec.Port
+		route.Spec.WildcardPolicy = routeSpec.WildcardPolicy
+		route.Spec.TLS = routeSpec.TLS
 		return nil
 	}
 


### PR DESCRIPTION
ensureAgentRoute

One of the test for ensureAgentRoute checks that the route.Spec.Host
isn't overwritten by subsequent ensures/reconciles.