### PR TITLE
MGMT-5408 Warning if day 2 host is dual stack

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -189,3 +189,23 @@ func ValidateInstallerArgs(args []string) error {
 func IsDay2Host(h *models.Host) bool {
 	return swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost
 }
+
+// GetAddressFamilies returns if a host has addresses in IPv4, in IPv6 family, or both
+func GetAddressFamilies(host *models.Host) (bool, bool, error) {
+
+	var inventory models.Inventory
+	err := json.Unmarshal([]byte(host.Inventory), &inventory)
+	if err != nil {
+		return false, false, err
+	}
+	v4 := false
+	v6 := false
+	for _, i := range inventory.Interfaces {
+		v4 = v4 || len(i.IPV4Addresses) > 0
+		v6 = v6 || len(i.IPV6Addresses) > 0
+		if v4 && v6 {
+			break
+		}
+	}
+	return v4, v6, nil
+}

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -88,6 +88,126 @@ var _ = Describe("Installation Disk selection", func() {
 	}
 })
 
+var _ = Describe("host IP address families", func() {
+	It("host doesn't have interfaces", func() {
+		host := &models.Host{
+			Inventory: "{}",
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeFalse())
+		Expect(v6).To(BeFalse())
+	})
+	It("error parsing inventory", func() {
+		host := &models.Host{
+			Inventory: "",
+		}
+		_, _, err := GetAddressFamilies(host)
+		Expect(err).Should(HaveOccurred())
+	})
+	It("host has only IPv4 addresses", func() {
+		host := &models.Host{
+			Inventory: `{
+				"interfaces":[
+					{
+						"ipv6_addresses":[],
+						"ipv4_addresses":[
+							"192.186.10.12/24"
+						]
+					}
+				]
+			}`,
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeTrue())
+		Expect(v6).To(BeFalse())
+	})
+	It("host has only IPv6 addresses", func() {
+		host := &models.Host{
+			Inventory: `{
+				"interfaces":
+				[
+					{
+						"ipv6_addresses":[
+							"2002:db8::2/64"
+						],
+						"ipv4_addresses":[]
+					}
+				]
+			}`,
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeFalse())
+		Expect(v6).To(BeTrue())
+	})
+	It("host has both IPv4 and IPv6 addresses on same interface", func() {
+		host := &models.Host{
+			Inventory: `{"interfaces":
+				[
+					{
+						"ipv4_addresses":[
+							"192.186.10.12/24"
+						],
+						"ipv6_addresses":[
+							"2002:db8::1/64"
+						]
+					}
+				]
+			}`,
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeTrue())
+		Expect(v6).To(BeTrue())
+	})
+	It("host has both IPv4 and IPv6 addresses on different interfaces", func() {
+		host := &models.Host{
+			Inventory: `{
+				"interfaces":[
+					{
+						"ipv4_addresses":[
+							"192.186.10.12/24"
+						]
+					},
+					{
+						"ipv6_addresses":[
+							"2002:db8::1/64"
+						]
+					}
+				]
+			}`,
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeTrue())
+		Expect(v6).To(BeTrue())
+	})
+	It("host has both IPv4 and IPv6 addresses on different interfaces, reverse order", func() {
+		host := &models.Host{
+			Inventory: `{
+				"interfaces":[
+					{
+						"ipv6_addresses":[
+							"2002:db8::1/64"
+						]
+					},
+					{
+						"ipv4_addresses":[
+							"192.186.10.12/24"
+						]
+					}
+				]
+			}`,
+		}
+		v4, v6, err := GetAddressFamilies(host)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(v4).To(BeTrue())
+		Expect(v6).To(BeTrue())
+	})
+})
+
 func TestHostUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HostUtil Tests")


### PR DESCRIPTION
In day 2 it's not possible to determing which IP family must be
used to enforce DHCP during reboot. In case a host has both IPv4
and IPv6 addresses, write a warning to the log for easier
troubleshooting.