### PR TITLE
MGMT-5420 Always return 401 for local auth errors

### DIFF
--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -48,26 +48,26 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 	t, err := validateToken(token, a.publicKey)
 	if err != nil {
 		a.log.WithError(err).Error("failed to validate token")
-		return nil, err
+		return nil, common.NewInfraError(401, err)
 	}
 	claims, ok := t.Claims.(jwt.MapClaims)
 	if !ok {
 		err := errors.Errorf("failed to parse JWT token claims")
 		a.log.Error(err)
-		return nil, err
+		return nil, common.NewInfraError(401, err)
 	}
 
 	clusterID, ok := claims["cluster_id"].(string)
 	if !ok {
 		err := errors.Errorf("claims are incorrectly formatted")
 		a.log.Error(err)
-		return nil, err
+		return nil, common.NewInfraError(401, err)
 	}
 
 	if !clusterExists(a.db, clusterID) {
 		err := errors.Errorf("cluster %s does not exist", clusterID)
 		a.log.Error(err)
-		return nil, err
+		return nil, common.NewInfraError(401, err)
 	}
 
 	a.log.Debugf("Authenticating cluster %s JWT", clusterID)
@@ -75,7 +75,7 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 }
 
 func (a *LocalAuthenticator) AuthUserAuth(_ string) (interface{}, error) {
-	return nil, errors.Errorf("User Authentication not allowed for local auth")
+	return nil, common.NewInfraError(401, errors.Errorf("User Authentication not allowed for local auth"))
 }
 
 func (a *LocalAuthenticator) AuthURLAuth(token string) (interface{}, error) {

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -68,6 +68,12 @@ var _ = Describe("AuthAgentAuth", func() {
 		return strings.Join(parts, ".")
 	}
 
+	validateErrorResponse := func(err error) {
+		infraError, ok := err.(*common.InfraErrorResponse)
+		Expect(ok).To(BeTrue())
+		Expect(infraError.StatusCode()).To(Equal(int32(401)))
+	}
+
 	It("Validates a token correctly", func() {
 		_, err := a.AuthAgentAuth(token)
 		Expect(err).ToNot(HaveOccurred())
@@ -76,23 +82,27 @@ var _ = Describe("AuthAgentAuth", func() {
 	It("Fails an invalid token", func() {
 		_, err := a.AuthAgentAuth(token + "asdf")
 		Expect(err).To(HaveOccurred())
+		validateErrorResponse(err)
 	})
 
 	It("Fails all user auth", func() {
 		_, err := a.AuthUserAuth(token)
 		Expect(err).To(HaveOccurred())
+		validateErrorResponse(err)
 	})
 
 	It("Fails a token with invalid signing method", func() {
 		newTok := fakeTokenAlg(token)
 		_, err := a.AuthAgentAuth(newTok)
 		Expect(err).To(HaveOccurred())
+		validateErrorResponse(err)
 	})
 
 	It("Fails with an RSA token", func() {
 		rsaToken, _ := GetTokenAndCert()
 		_, err := a.AuthAgentAuth(rsaToken)
 		Expect(err).To(HaveOccurred())
+		validateErrorResponse(err)
 	})
 
 	It("Fails for a deleted cluster", func() {
@@ -101,5 +111,6 @@ var _ = Describe("AuthAgentAuth", func() {
 
 		_, err := a.AuthAgentAuth(token)
 		Expect(err).To(HaveOccurred())
+		validateErrorResponse(err)
 	})
 })


### PR DESCRIPTION
Previously if we were missing the cluster in the token (or if any of the
other errors occurred) we ended up returning a 500 error because we
didn't specify one here. Now all the authentication errors will be 401

cc @tsorya @avishayt 