### PR TITLE
MGMT-5281: Handle conflicts in CRDs status updates

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -26,6 +26,7 @@ import (
 	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	controllers "github.com/openshift/assisted-service/internal/controller/controllers"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -106,7 +107,7 @@ func main() {
 
 	if err = (&controllers.AgentServiceConfigReconciler{
 		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controllers").WithName("AgentServiceConfig"),
+		Log:       logrus.New(),
 		Scheme:    mgr.GetScheme(),
 		Recorder:  mgr.GetEventRecorderFor("agentserviceconfig-controller"),
 		Namespace: ns,

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.5
 	k8s.io/apimachinery v0.20.5
+	k8s.io/apiserver v0.19.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kubectl v0.20.5
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -129,9 +129,8 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, agent *aiv1beta1.Age
 	} else {
 		setConditionsUnknown(agent)
 	}
-	if updateErr := r.Status().Update(ctx, agent); updateErr != nil {
-		r.Log.WithError(updateErr).Error("failed to update agent Status")
-		return ctrl.Result{Requeue: true}, nil
+	if updated, result, _ := UpdateStatus(r.Log, r.Status().Update, ctx, agent); !updated {
+		return result, nil
 	}
 	if internal {
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -6,13 +6,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -27,7 +27,7 @@ func newTestReconciler(initObjs ...runtime.Object) *AgentServiceConfigReconciler
 	return &AgentServiceConfigReconciler{
 		Client:    c,
 		Scheme:    scheme.Scheme,
-		Log:       ctrl.Log.WithName("testLog"),
+		Log:       logrus.New(),
 		Namespace: testNamespace,
 	}
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -734,9 +734,8 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, cluster
 		cluster.Status.WebConsoleURL = common.GetConsoleUrl(cluster.Spec.ClusterName, cluster.Spec.BaseDomain)
 	}
 
-	if updateErr := r.Status().Update(ctx, cluster); updateErr != nil {
-		r.Log.WithError(updateErr).Error("failed to update ClusterDeployment Status")
-		return ctrl.Result{Requeue: true}, nil
+	if updated, result, _ := UpdateStatus(r.Log, r.Status().Update, ctx, cluster); !updated {
+		return result, nil
 	}
 	if syncErr != nil && !IsHTTP4XXError(syncErr) {
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil


### PR DESCRIPTION
In the time between getting the resource to reconcile
and updating its status, the object can become out of
date (if edited by user for example).
When it happens we will attempt to reconcile this crd
again immediately with the up-to-date data.

```
time="2021-04-20T08:04:50Z" level=error msg="failed to update agent Status" func="github.com/openshift/assisted-service/internal/controller/controllers.(*AgentReconciler).updateStatus" file="/go/src/github.com/openshift/origin/internal/controller/controllers/agent_controller.go:132" error="Operation cannot be fulfilled on agents.agent-install.openshift.io \"a72237e3-f7f5-46d4-965e-ea644056917a\": the object has been modified; please apply your changes to the latest version and try again"

time="2021-04-20T08:05:01Z" level=error msg="failed to update ClusterDeployment Status" func="github.com/openshift/assisted-service/internal/controller/controllers.(*ClusterDeploymentsReconciler).updateStatus" file="/go/src/github.com/openshift/origin/internal/controller/controllers/clusterdeployments_controller.go:599" error="Operation cannot be fulfilled on clusterdeployments.hive.openshift.io \"test-cluster\": the object has been modified; please apply your changes to the latest version and try again"

```
