### PR TITLE
NO-ISSUE remove redundant call to upload files

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4295,12 +4295,5 @@ func (b *bareMetalInventory) AddOpenshiftVersion(ctx context.Context, ocpRelease
 		return nil, err
 	}
 
-	// Upload relevant boot files according to the specified version
-	haveLatestMinimalTemplate := s3wrapper.HaveLatestMinimalTemplate(ctx, b.log, b.objectHandler)
-	if err := b.objectHandler.UploadBootFiles(ctx, *openshiftVersion.DisplayName, b.Config.ServiceBaseURL, haveLatestMinimalTemplate); err != nil {
-		log.WithError(err).Errorf("Failed uploading boot files for OCP version %s", *openshiftVersion.DisplayName)
-		return nil, err
-	}
-
 	return openshiftVersion, nil
 }

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6680,3 +6680,35 @@ var _ = Describe("GetCredentials", func() {
 		verifyApiError(reply, http.StatusConflict)
 	})
 })
+
+var _ = Describe("AddOpenshiftVersion", func() {
+	var (
+		cfg          = Config{}
+		ctx          = context.Background()
+		bm           *bareMetalInventory
+		db           *gorm.DB
+		dbName       string
+		pullSecret   = "test_pull_secret"
+		releaseImage = "releaseImage"
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB(dbName)
+		bm = createInventory(db, cfg)
+	})
+
+	It("successfully added version", func() {
+		mockVersions.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+
+		version, err := bm.AddOpenshiftVersion(ctx, releaseImage, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(version).Should(Equal(common.TestDefaultConfig.Version))
+	})
+
+	It("failed to added version", func() {
+		mockVersions.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).Times(1)
+
+		_, err := bm.AddOpenshiftVersion(ctx, releaseImage, pullSecret)
+		Expect(err).Should(HaveOccurred())
+	})
+})


### PR DESCRIPTION
* No need to invoke UploadBootFiles on AddOpenshiftVersion func
  as it's already called on service startup (main.go).
  Hence, removed the redundant call.
  Note: the function already checks files existence before trying
  to upload, so there's no change in behaviour.
* Added unit-tests to AddOpenshiftVersion to ensure it's only
  invoking the add version API.