### PR TITLE
WIP NO-ISSUE add workers to cluster monitor

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -94,6 +94,7 @@ type Config struct {
 	EnableAutoReset         bool                    `envconfig:"ENABLE_AUTO_RESET" default:"false"`
 	ResetTimeout            time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
 	MonitorBatchSize        int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
+	MonitorWorkersNum       int                     `envconfig:"HOST_MONITOR_WORKERS_NUM" default:"10"`
 	DisabledHostvalidations DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:"container-images-available"` // Disable container image validation to fix BZ-1937293
 }
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -39,6 +39,7 @@ var (
 		ResetTimeout:            3 * time.Minute,
 		EnableAutoReset:         true,
 		MonitorBatchSize:        100,
+		MonitorWorkersNum:       10,
 		DisabledHostvalidations: defaultDisabledHostValidations,
 	}
 	defaultNTPSources = []*models.NtpSource{common.TestNTPSourceSynced}

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -7,7 +7,9 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/commonutils"
+	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/pkg/requestid"
+	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 )
 
@@ -26,14 +28,56 @@ func (m *Manager) HostMonitoring() {
 	m.log.Debugf("Running HostMonitoring")
 	defer commonutils.MeasureOperation("HostMonitoring", m.log, m.metricApi)()
 	var (
-		offset    int
 		limit     = m.Config.MonitorBatchSize
-		monitored int64
 		requestID = requestid.NewID()
 		ctx       = requestid.ToContext(context.Background(), requestID)
 		log       = requestid.RequestIDLogger(m.log, requestID)
-		err       error
+		monitored int64
 	)
+
+	jobs := make(chan *common.Cluster, limit)
+	monitorRes := make(chan int64, m.Config.MonitorWorkersNum)
+
+	for i := 0; i < m.Config.MonitorWorkersNum; i++ {
+		go m.monitorWorker(ctx, jobs, monitorRes)
+	}
+
+	m.monitorWorkManager(log, jobs)
+
+	// closing the channel will make sure that works will stop.
+	// it will not break the flow and workers will complete all the tasks until the channel is empty.
+	close(jobs)
+	// using results channel as a wait group for the workers
+	for i := 0; i < m.Config.MonitorWorkersNum; i++ {
+		monitored += <-monitorRes
+	}
+	m.metricApi.MonitoredHostsCount(monitored)
+}
+
+// consume clusters from the jobs channel and perform refresh status on each host in a cluster
+func (m *Manager) monitorWorker(ctx context.Context, jobs chan *common.Cluster, monitorRes chan int64) {
+	var monitored int64
+	log := logutil.FromContext(ctx, m.log)
+	defer func() { monitorRes <- monitored }()
+	// pull jobs until channel is closed
+	for c := range jobs {
+		// can't use leader election, it will cause a deadlock on the work manager
+		// workers need to clean the jobs channel
+		for _, host := range c.Hosts {
+			if !m.SkipMonitoring(host) {
+				monitored += 1
+				if err := m.refreshStatusInternal(ctx, host, c, m.db); err != nil {
+					log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
+				}
+			}
+		}
+	}
+}
+
+// iterate over clusters in batches and push them to a jobs channel for the workers to consume
+func (m *Manager) monitorWorkManager(log logrus.FieldLogger, jobs chan *common.Cluster) {
+	var offset int
+	var limit = m.Config.MonitorBatchSize
 
 	monitorStates := []string{
 		models.HostStatusDiscovering,
@@ -51,32 +95,23 @@ func (m *Manager) HostMonitoring() {
 		models.HostStatusCancelled, // for limited time, until log collection finished or timed-out
 		models.HostStatusError,     // for limited time, until log collection finished or timed-out
 	}
+
 	for {
 		var clusters []*common.Cluster
-		if err = m.db.Preload("Hosts", "status in (?)", monitorStates).Preload(common.MonitoredOperatorsTable).
-			Offset(offset).Limit(limit).Order("id").Find(&clusters, "exists (select 1 from hosts where clusters.id = hosts.cluster_id)").Error; err != nil {
+		if err := m.db.Preload("Hosts", "status in (?)", monitorStates).
+			Preload(common.MonitoredOperatorsTable).
+			Offset(offset).Limit(limit).Order("id").
+			Find(&clusters, "exists (select 1 from hosts where clusters.id = hosts.cluster_id)").Error; err != nil {
 			log.WithError(err).Errorf("failed to get clusters for host monitoring")
 			return
 		}
 		if len(clusters) == 0 {
-			break
+			return
 		}
-		for _, c := range clusters {
-			for _, host := range c.Hosts {
-				if !m.leaderElector.IsLeader() {
-					m.log.Debugf("Not a leader, exiting HostMonitoring")
-					return
-				}
-				if !m.SkipMonitoring(host) {
-					monitored += 1
-					err = m.refreshStatusInternal(ctx, host, c, m.db)
-					if err != nil {
-						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
-					}
-				}
-			}
+		for i := range clusters {
+			jobs <- clusters[i]
 		}
+
 		offset += limit
 	}
-	m.metricApi.MonitoredHostsCount(monitored)
 }

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -125,7 +125,7 @@ var _ = Describe("monitor_disconnection", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
-		db.Close()
+		common.DeleteTestDB(db, dbName)
 	})
 })
 


### PR DESCRIPTION
Works will watch a jobs channel and work in paralel on cluster monitoring
By default there will be 10 workers, could be customized with CLUSTER_MONITOR_WORKERS_NUM env
A unit test that run over 1K cluster with 2 hosts each impvoved from ~8 sec to ~2 sec