### PR TITLE
MGMT-5390 Improve host monitoring performance (to master)

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -164,7 +164,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 			BeforeEach(func() {
 				c = createCluster(&id, "installing", statusInfoInstalling)
 				mockMetric.EXPECT().ClusterInstallationFinished(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 			})
 
 			It("installing -> installing", func() {
@@ -537,7 +537,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 			mockEvents.EXPECT().
 				AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
-			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).
+			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(true, nil).AnyTimes()
 
 			for i := 0; i < nClusters; i++ {
@@ -600,7 +600,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).Times(0)
-				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(0)
+				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(0)
 			})
 
 			It("empty log info (no logs expected or arrived)", func() {
@@ -1085,7 +1085,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			}
 			if len(t.hosts) > 0 {
-				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			}
 			if t.userActionResetExpected {
 				mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).AnyTimes()

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -541,7 +541,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 
 	checkMasterCandidates := func(times int) candidateChecker {
 		return func() {
-			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(times)
+			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(times)
 		}
 	}
 
@@ -1191,7 +1191,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
 			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi)
 
-		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
 		hid3 = strfmt.UUID(uuid.New().String())
@@ -3148,6 +3148,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 				}
 				Expect(cluster.ValidationsInfo).To(BeEmpty())
 				clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
+				Expect(clusterAfterRefresh).ToNot(BeNil())
 				Expect(clusterAfterRefresh.ValidationsInfo).To(BeEmpty())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterAfterRefresh.Status).To(Equal(&t.dstState))
@@ -4058,7 +4059,7 @@ var _ = Describe("Single node", func() {
 		mockHostAPI.EXPECT().IsRequireUserActionReset(gomock.Any()).Return(false).AnyTimes()
 	}
 	mockIsValidMasterCandidate := func() {
-		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	}
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -323,7 +323,7 @@ func (v *clusterValidator) sufficientMastersCount(c *clusterPreprocessContext) V
 		//if allocated masters count is less than the desired count, find eligable hosts
 		//from the candidate pool to match the master count criteria, up to 3
 		if len(masters) < minMastersNeededForInstallation {
-			if isValid, err := v.hostAPI.IsValidMasterCandidate(h, c.db, v.log); isValid && err == nil {
+			if isValid, err := v.hostAPI.IsValidMasterCandidate(h, c.cluster, c.db, v.log); isValid && err == nil {
 				masters = append(masters, h)
 				continue
 			}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -124,7 +124,7 @@ type API interface {
 	IsInstallable(h *models.Host) bool
 	// auto assign host role
 	AutoAssignRole(ctx context.Context, h *models.Host, db *gorm.DB) error
-	IsValidMasterCandidate(h *models.Host, db *gorm.DB, log logrus.FieldLogger) (bool, error)
+	IsValidMasterCandidate(h *models.Host, c *common.Cluster, db *gorm.DB, log logrus.FieldLogger) (bool, error)
 	SetUploadLogsAt(ctx context.Context, h *models.Host, db *gorm.DB) error
 	UpdateLogsProgress(ctx context.Context, h *models.Host, progress string) error
 	PermanentHostsDeletion(olderThan strfmt.DateTime) error
@@ -313,15 +313,21 @@ func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventory
 	}).Error
 }
 
-func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB) error {
+func (m *Manager) refreshStatusInternal(ctx context.Context, h *models.Host, c *common.Cluster, db *gorm.DB) error {
 	if db == nil {
 		db = m.db
 	}
-	vc, err := newValidationContext(h, db, m.hwValidator)
+	var (
+		vc               *validationContext
+		err              error
+		conditions       map[string]bool
+		newValidationRes ValidationsStatus
+	)
+	vc, err = newValidationContext(h, c, db, m.hwValidator)
 	if err != nil {
 		return err
 	}
-	conditions, newValidationRes, err := m.rp.preprocess(vc)
+	conditions, newValidationRes, err = m.rp.preprocess(vc)
 	if err != nil {
 		return err
 	}
@@ -335,7 +341,8 @@ func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB
 		// For changes to be detected and reported correctly, the comparison needs to be
 		// performed before the new validations are updated to the DB.
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
-		if _, err = m.updateValidationsInDB(ctx, db, h, newValidationRes); err != nil {
+		_, err = m.updateValidationsInDB(ctx, db, h, newValidationRes)
+		if err != nil {
 			return err
 		}
 	}
@@ -351,6 +358,13 @@ func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB
 		return common.NewApiError(http.StatusConflict, err)
 	}
 	return nil
+}
+
+func (m *Manager) RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB) error {
+	if db == nil {
+		db = m.db
+	}
+	return m.refreshStatusInternal(ctx, h, nil, db)
 }
 
 func (m *Manager) Install(ctx context.Context, h *models.Host, db *gorm.DB) error {
@@ -869,6 +883,8 @@ func (m *Manager) selectRole(ctx context.Context, h *models.Host, db *gorm.DB) (
 	var (
 		autoSelectedRole = models.HostRoleWorker
 		log              = logutil.FromContext(ctx, m.log)
+		err              error
+		vc               *validationContext
 	)
 
 	if hostutil.IsDay2Host(h) {
@@ -877,7 +893,7 @@ func (m *Manager) selectRole(ctx context.Context, h *models.Host, db *gorm.DB) (
 
 	// count already existing masters
 	mastersCount := 0
-	if err := db.Model(&models.Host{}).Where("cluster_id = ? and status != ? and role = ?",
+	if err = db.Model(&models.Host{}).Where("cluster_id = ? and status != ? and role = ?",
 		h.ClusterID, models.HostStatusDisabled, models.HostRoleMaster).Count(&mastersCount).Error; err != nil {
 		log.WithError(err).Errorf("failed to count masters in cluster %s", h.ClusterID.String())
 		return autoSelectedRole, err
@@ -885,7 +901,7 @@ func (m *Manager) selectRole(ctx context.Context, h *models.Host, db *gorm.DB) (
 
 	if mastersCount < common.MinMasterHostsNeededForInstallation {
 		h.Role = models.HostRoleMaster
-		vc, err := newValidationContext(h, db, m.hwValidator)
+		vc, err = newValidationContext(h, nil, db, m.hwValidator)
 		if err != nil {
 			log.WithError(err).Errorf("failed to create new validation context for host %s", h.ID.String())
 			return autoSelectedRole, err
@@ -903,13 +919,14 @@ func (m *Manager) selectRole(ctx context.Context, h *models.Host, db *gorm.DB) (
 	return autoSelectedRole, nil
 }
 
-func (m *Manager) IsValidMasterCandidate(h *models.Host, db *gorm.DB, log logrus.FieldLogger) (bool, error) {
+func (m *Manager) IsValidMasterCandidate(h *models.Host, c *common.Cluster, db *gorm.DB, log logrus.FieldLogger) (bool, error) {
 	if h.Role == models.HostRoleWorker {
 		return false, nil
 	}
 
 	h.Role = models.HostRoleMaster
-	vc, err := newValidationContext(h, db, m.hwValidator)
+
+	vc, err := newValidationContext(h, c, db, m.hwValidator)
 	if err != nil {
 		log.WithError(err).Errorf("failed to create new validation context for host %s", h.ID.String())
 		return false, err

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2075,7 +2075,9 @@ var _ = Describe("IsValidMasterCandidate", func() {
 				h.Inventory = t.inventory
 				h.Role = t.srcRole
 				Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
-				isValidReply, err := hapi.IsValidMasterCandidate(&h, db, common.GetTestLog())
+				var cluster common.Cluster
+				Expect(db.Preload("Hosts").Take(&cluster, "id = ?", clusterId.String()).Error).ToNot(HaveOccurred())
+				isValidReply, err := hapi.IsValidMasterCandidate(&h, &cluster, db, common.GetTestLog())
 				Expect(isValidReply).Should(Equal(t.isValid))
 				Expect(err).ShouldNot(HaveOccurred())
 			})

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -207,18 +207,18 @@ func (mr *MockAPIMockRecorder) IsRequireUserActionReset(arg0 interface{}) *gomoc
 }
 
 // IsValidMasterCandidate mocks base method
-func (m *MockAPI) IsValidMasterCandidate(arg0 *models.Host, arg1 *gorm.DB, arg2 logrus.FieldLogger) (bool, error) {
+func (m *MockAPI) IsValidMasterCandidate(arg0 *models.Host, arg1 *common.Cluster, arg2 *gorm.DB, arg3 logrus.FieldLogger) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValidMasterCandidate", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "IsValidMasterCandidate", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // IsValidMasterCandidate indicates an expected call of IsValidMasterCandidate
-func (mr *MockAPIMockRecorder) IsValidMasterCandidate(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) IsValidMasterCandidate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidMasterCandidate", reflect.TypeOf((*MockAPI)(nil).IsValidMasterCandidate), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidMasterCandidate", reflect.TypeOf((*MockAPI)(nil).IsValidMasterCandidate), arg0, arg1, arg2, arg3)
 }
 
 // PermanentHostsDeletion mocks base method

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -201,5 +201,4 @@ var _ = Describe("TestHostMonitoring", func() {
 			registerAndValidateDisconnected(765)
 		})
 	})
-
 })

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -400,8 +400,7 @@ func (th *transitionHandler) IsPreparingTimedOut(sw stateswitch.StateSwitch, arg
 		return false, errors.New("IsPreparingTimedOut invalid argument")
 	}
 	var cluster common.Cluster
-	err := params.db.Select("status").Take(&cluster, "id = ?", sHost.host.ClusterID.String()).Error
-	if err != nil {
+	if err := params.db.Select("status").Take(&cluster, "id = ?", sHost.host.ClusterID.String()).Error; err != nil {
 		return false, err
 	}
 	return swag.StringValue(cluster.Status) != models.ClusterStatusPreparingForInstallation, nil
@@ -434,7 +433,8 @@ func (th *transitionHandler) PostRefreshLogsProgress(progress string) stateswitc
 		if !ok {
 			return errors.New("Host PostRefreshLogsProgress invalid argument")
 		}
-		_, err := hostutil.UpdateLogsProgress(params.ctx, logutil.FromContext(params.ctx, th.log),
+		var err error
+		_, err = hostutil.UpdateLogsProgress(params.ctx, logutil.FromContext(params.ctx, th.log),
 			params.db, th.eventsHandler, sHost.host.ClusterID, *sHost.host.ID, sHost.srcState, progress)
 		return err
 	}
@@ -518,8 +518,7 @@ func (th *transitionHandler) ShouldIgnoreInstallingInProgressTimeout(
 
 func IsClusterInstallationPendingUserAction(clusterID strfmt.UUID, db *gorm.DB) (bool, error) {
 	var cluster common.Cluster
-	err := db.Select("status").Take(&cluster, "id = ?", clusterID.String()).Error
-	if err != nil {
+	if err := db.Select("status").Take(&cluster, "id = ?", clusterID.String()).Error; err != nil {
 		return false, err
 	}
 	return swag.StringValue(cluster.Status) == models.ClusterStatusInstallingPendingUserAction, nil
@@ -554,8 +553,11 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 			template = strings.Replace(template, "$FAILING_VALIDATIONS", strings.Join(failedValidations, " ; "), 1)
 		}
 
-		_, err = hostutil.UpdateHostStatus(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, th.eventsHandler, sHost.host.ClusterID, *sHost.host.ID,
-			sHost.srcState, swag.StringValue(sHost.host.Status), template)
+		if sHost.srcState != swag.StringValue(sHost.host.Status) || swag.StringValue(sHost.host.StatusInfo) != template {
+			_, err = hostutil.UpdateHostStatus(params.ctx, logutil.FromContext(params.ctx, th.log), params.db,
+				th.eventsHandler, sHost.host.ClusterID, *sHost.host.ID,
+				sHost.srcState, swag.StringValue(sHost.host.Status), template)
+		}
 		return err
 	}
 	return ret
@@ -617,7 +619,8 @@ func (th *transitionHandler) PostRefreshHostRefreshStageUpdateTime(
 	if time.Minute > time.Since(time.Time(sHost.host.Progress.StageUpdatedAt)) {
 		return nil
 	}
-	_, err := refreshHostStageUpdateTime(
+	var err error
+	_, err = refreshHostStageUpdateTime(
 		logutil.FromContext(params.ctx, th.log),
 		params.db,
 		sHost.host.ClusterID,

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -68,9 +68,9 @@ type validation struct {
 }
 
 func (c *validationContext) loadCluster() error {
-	clusterFromDB, err := common.GetClusterFromDBWithoutDisabledHosts(c.db, c.host.ClusterID)
-	if err == nil {
-		c.cluster = clusterFromDB
+	var err error
+	if c.cluster == nil {
+		c.cluster, err = common.GetClusterFromDBWithoutDisabledHosts(c.db, c.host.ClusterID)
 	}
 	return err
 }
@@ -125,10 +125,11 @@ func (c *validationContext) loadClusterHostRequirements(hwValidator hardware.Val
 	return err
 }
 
-func newValidationContext(host *models.Host, db *gorm.DB, hwValidator hardware.Validator) (*validationContext, error) {
+func newValidationContext(host *models.Host, c *common.Cluster, db *gorm.DB, hwValidator hardware.Validator) (*validationContext, error) {
 	ret := &validationContext{
-		host: host,
-		db:   db,
+		host:    host,
+		db:      db,
+		cluster: c,
 	}
 	err := ret.loadCluster()
 	if err == nil {

--- a/internal/operators/ocs/validation_test.go
+++ b/internal/operators/ocs/validation_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 	}
 
 	mockIsValidMasterCandidate := func() {
-		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	}
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()


### PR DESCRIPTION
- Let host monitoring query clusters and hosts and use them, instead query cluster again for each host
- In PostRefreshHost update database only if status or status-info changed
- In hostApi.IsValidMasterCandidate, get cluster as parameter instead of query from database.  This is used by cluster monitoring

/cc @tsorya 
/cc @filanov 
/cc @ronniel1 