### PR TITLE
MGMT-4261 Deregister Host on agent CR deletion

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,12 @@ rules:
 - apiGroups:
   - agent-install.openshift.io
   resources:
+  - agents/ai-deprovision
+  verbs:
+  - update
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
   - agents/status
   verbs:
   - get

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -114,6 +114,7 @@ type InstallerInternals interface {
 	GetClusterByKubeKey(key types.NamespacedName) (*common.Cluster, error)
 	InstallClusterInternal(ctx context.Context, params installer.InstallClusterParams) (*common.Cluster, error)
 	DeregisterClusterInternal(ctx context.Context, params installer.DeregisterClusterParams) error
+	DeregisterHostInternal(ctx context.Context, params installer.DeregisterHostParams) error
 	GetCommonHostInternal(ctx context.Context, clusterId string, hostId string) (*common.Host, error)
 	UpdateHostApprovedInternal(ctx context.Context, clusterId string, hostId string, approved bool) error
 	UpdateHostInstallerArgsInternal(ctx context.Context, params installer.UpdateHostInstallerArgsParams) (*models.Host, error)
@@ -124,6 +125,7 @@ type InstallerInternals interface {
 	InstallSingleDay2HostInternal(ctx context.Context, clusterId strfmt.UUID, hostId strfmt.UUID) error
 	UpdateClusterInstallConfigInternal(ctx context.Context, params installer.UpdateClusterInstallConfigParams) (*common.Cluster, error)
 	AddOpenshiftVersion(ctx context.Context, ocpReleaseImage, pullSecret string) (*models.OpenshiftVersion, error)
+	GetHostById(hostId string) (*common.Host, error)
 }
 
 //go:generate mockgen -package bminventory -destination mock_crd_utils.go . CRDUtils
@@ -2568,19 +2570,25 @@ func isRegisterHostForbiddenDueWrongBootOrder(err error) bool {
 }
 
 func (b *bareMetalInventory) DeregisterHost(ctx context.Context, params installer.DeregisterHostParams) middleware.Responder {
+	if err := b.DeregisterHostInternal(ctx, params); err != nil {
+		return common.GenerateErrorResponder(err)
+	}
+	return installer.NewDeregisterHostNoContent()
+}
+
+func (b *bareMetalInventory) DeregisterHostInternal(ctx context.Context, params installer.DeregisterHostParams) error {
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Deregister host: %s cluster %s", params.HostID, params.ClusterID)
 
 	if err := b.db.Where("id = ? and cluster_id = ?", params.HostID, params.ClusterID).Delete(&common.Host{}).Error; err != nil {
 		// TODO: check error type
-		return installer.NewDeregisterHostBadRequest().
-			WithPayload(common.GenerateError(http.StatusBadRequest, err))
+		return common.NewApiError(http.StatusBadRequest, err)
 	}
 
 	// TODO: need to check that host can be deleted from the cluster
 	b.eventsHandler.AddEvent(ctx, params.ClusterID, &params.HostID, models.EventSeverityInfo,
 		fmt.Sprintf("Host %s: deregistered from cluster", params.HostID.String()), time.Now())
-	return installer.NewDeregisterHostNoContent()
+	return nil
 }
 
 func (b *bareMetalInventory) GetHost(_ context.Context, params installer.GetHostParams) middleware.Responder {
@@ -2598,6 +2606,19 @@ func (b *bareMetalInventory) GetHost(_ context.Context, params installer.GetHost
 	// Clear this field as it is not needed to be sent via API
 	host.FreeAddresses = ""
 	return installer.NewGetHostOK().WithPayload(&host.Host)
+}
+
+func (b *bareMetalInventory) GetHostById(hostId string) (*common.Host, error) {
+	host, err := common.GetHostByIdFromDB(b.db, hostId)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = b.customizeHost(&host.Host); err != nil {
+		return nil, err
+	}
+
+	return host, nil
 }
 
 func (b *bareMetalInventory) ListHosts(ctx context.Context, params installer.ListHostsParams) middleware.Responder {

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -68,6 +68,20 @@ func (mr *MockInstallerInternalsMockRecorder) DeregisterClusterInternal(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).DeregisterClusterInternal), arg0, arg1)
 }
 
+// DeregisterHostInternal mocks base method
+func (m *MockInstallerInternals) DeregisterHostInternal(arg0 context.Context, arg1 installer.DeregisterHostParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterHostInternal", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterHostInternal indicates an expected call of DeregisterHostInternal
+func (mr *MockInstallerInternalsMockRecorder) DeregisterHostInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).DeregisterHostInternal), arg0, arg1)
+}
+
 // DownloadClusterKubeconfigInternal mocks base method
 func (m *MockInstallerInternals) DownloadClusterKubeconfigInternal(arg0 context.Context, arg1 installer.DownloadClusterKubeconfigParams) (io.ReadCloser, int64, error) {
 	m.ctrl.T.Helper()
@@ -157,6 +171,21 @@ func (m *MockInstallerInternals) GetCredentialsInternal(arg0 context.Context, ar
 func (mr *MockInstallerInternalsMockRecorder) GetCredentialsInternal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsInternal", reflect.TypeOf((*MockInstallerInternals)(nil).GetCredentialsInternal), arg0, arg1)
+}
+
+// GetHostById mocks base method
+func (m *MockInstallerInternals) GetHostById(arg0 string) (*common.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHostById", arg0)
+	ret0, _ := ret[0].(*common.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHostById indicates an expected call of GetHostById
+func (mr *MockInstallerInternalsMockRecorder) GetHostById(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostById", reflect.TypeOf((*MockInstallerInternals)(nil).GetHostById), arg0)
 }
 
 // InstallClusterInternal mocks base method

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -156,6 +156,16 @@ func GetHostFromDB(db *gorm.DB, clusterId, hostId string) (*Host, error) {
 	return &host, nil
 }
 
+func GetHostByIdFromDB(db *gorm.DB, hostId string) (*Host, error) {
+	var host Host
+
+	err := db.First(&host, "id = ?", hostId).Error
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get host %s", hostId)
+	}
+	return &host, nil
+}
+
 func DeleteRecordsByClusterID(db *gorm.DB, clusterID strfmt.UUID, value interface{}, where ...interface{}) error {
 	return db.Where("cluster_id = ?", clusterID).Delete(value, where...).Error
 }

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -114,12 +114,7 @@ var _ = Describe("agent reconcile", func() {
 			Namespace: testNamespace,
 			Name:      "host",
 		}
-		Expect(c.Get(ctx, key, agent)).To(BeNil())
-		expectedState := fmt.Sprintf("%s failed to get clusterDeployment with name clusterDeployment in namespace test-namespace: clusterdeployments.hive.openshift.io \"clusterDeployment\" not found", InputErrorMsg)
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Message).To(Equal(expectedState))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Reason).To(Equal(InputErrorReason))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
-
+		Expect(c.Get(ctx, key, agent).Error()).To(Equal("agents.agent-install.openshift.io \"host\" not found"))
 	})
 
 	It("cluster not found in database", func() {
@@ -137,11 +132,7 @@ var _ = Describe("agent reconcile", func() {
 			Namespace: testNamespace,
 			Name:      "host",
 		}
-		Expect(c.Get(ctx, key, agent)).To(BeNil())
-		expectedState := fmt.Sprintf("%s record not found", InputErrorMsg)
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Message).To(Equal(expectedState))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Reason).To(Equal(InputErrorReason))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
+		Expect(c.Get(ctx, key, agent).Error()).To(Equal("agents.agent-install.openshift.io \"host\" not found"))
 	})
 
 	It("error getting cluster from database", func() {
@@ -183,11 +174,7 @@ var _ = Describe("agent reconcile", func() {
 			Namespace: testNamespace,
 			Name:      "host",
 		}
-		Expect(c.Get(ctx, key, agent)).To(BeNil())
-		expectedState := fmt.Sprintf("%s host not found in cluster", InputErrorMsg)
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Message).To(Equal(expectedState))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Reason).To(Equal(InputErrorReason))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, SpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
+		Expect(c.Get(ctx, key, agent).Error()).To(Equal("agents.agent-install.openshift.io \"host\" not found"))
 	})
 
 	It("Agent update", func() {


### PR DESCRIPTION
This change implements a finalizer in the agent controller.
Pre-deletion logic includes host deregistration from the backend.

The same logic gets invoked when the controller attempts to reconcile
for an agent that is not found. That ensures that the backend does
not hold a DB record for a host with no agent to represent it.

The controller will also place a deletion Finalizer when:
1. `clusterDeployment` cannot be retrieved for the reconciled agent.
2. Backend cluster cannot be retrieved for the reconciled agent.
3. The agent (host) is no longer a part of the  backend cluster (day2 scenario)

Lastly, to fetch a host when we have no information about its cluster,
I added a method to query it by host ID. Once we implement [MGMT-6006](https://issues.redhat.com/browse/MGMT-6006)
we may change it to kubeKey.