### PR TITLE
MGMT-5274 Adjust operator scripts for test-infra usage

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -1,8 +1,17 @@
-if [ -z "${DISKS}" ]; then
+#!/usr/bin/env bash
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${DISKS:-}" ]; then
     export DISKS=$(echo sd{b..f})
 fi
 
-source ./libvirt_disks.sh create
-source ./setup_lso.sh
-source ./setup_hive.sh
-source ./setup_assisted_operator.sh
+${__dir}/libvirt_disks.sh create
+
+if [ "${INSTALL_LSO:-true}" == "true" ]; then
+    ${__dir}/setup_lso.sh install_lso
+fi
+
+${__dir}/setup_lso.sh create_local_volume
+${__dir}/setup_hive.sh
+${__dir}/setup_assisted_operator.sh

--- a/deploy/operator/destroy.sh
+++ b/deploy/operator/destroy.sh
@@ -1,0 +1,15 @@
+
+#!/usr/bin/env bash
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -z "${DISKS:-}" ]; then
+    export DISKS=$(echo sd{b..f})
+fi
+
+kubectl delete namespace assisted-installer
+kubectl delete agentserviceconfigs.agent-install.openshift.io agent
+kubectl delete localvolume -n openshift-local-storage assisted-service
+
+${__dir}/libvirt_disks.sh destroy
+kubectl get pv -o=name | xargs -r kubectl delete

--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -1,10 +1,13 @@
-if [ -z "${NODES}" ]; then
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/utils.sh
+
+if [ -z "${NODES:-}" ]; then
     export NODES=$(virsh list --name | grep worker || virsh list --name | grep master)
 fi
 
-if [ -z "${DISKS}" ]; then
-    echo "You must provide DISKS env-var. For example:"
-    echo "    DISKS=\$(echo sd{b..f}) bash ./libvirt_disks.sh create"
+if [ -z "${DISKS:-}" ]; then
+    echo "You must provide DISKS env-var."
+    print_help
     exit 1
 fi
 
@@ -44,9 +47,6 @@ function destroy() {
     echo "Done destroying libvirt disks!"
 }
 
-ALL_FUNCS=$(compgen -A function)
-case "$@" in
-    create)  create;;
-    destroy) destroy;;
-    *)       echo "Usage: DISKS=<disk names> bash ./libvirt_disks.sh ($(echo $ALL_FUNCS | tr ' ' '|'))" && exit 1;;
-esac
+declare -F $@ || (print_help && exit 1)
+
+"$@"

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -1,4 +1,5 @@
-source utils.sh
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/utils.sh
 
 set -xeo pipefail
 

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -1,6 +1,10 @@
+set -o nounset
+set -o pipefail
+set -o errexit
+
 function wait_for_crd() {
   crd="$1"
-  namespace="$2"
+  namespace="${2:-}"
   echo "Waiting for CRD (${crd}) on namespace (${namespace}) to be defined..."
   for i in {1..40}; do
     oc get "crd/${crd}" -n "${namespace}" && break || sleep 10
@@ -12,7 +16,7 @@ function wait_for_crd() {
 
 function wait_for_operator() {
   subscription="$1"
-  namespace="$2"
+  namespace="${2:-}"
   echo "Waiting for operator ${subscription} to get installed on namespace ${namespace}..."
 
   for _ in $(seq 1 60); do
@@ -43,4 +47,9 @@ function wait_for_pod() {
 
   echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to become ready..."
   oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=10m
+}
+
+function print_help() {
+  ALL_FUNCS=$(compgen -A "function" | grep -Ev "(help|wait_for)" | paste -s -d'|')
+  echo "Usage: DISKS=\$(echo sd{b..f}) bash ${0} (${ALL_FUNCS})"
 }


### PR DESCRIPTION
- Add destroy.sh script deleting the assisted-installer namespace, service
  config and the assisted-service localvolume.
- Fix destroy of PVs from k8s.
- Add a generic print_help function to utils.sh
- Print k8s manifestes before applying them.
/cc @osherdp 