### PR TITLE
MGMT-6011 Add monitoring for duration and number of clusters/hosts fr host/cluster monitors

### DIFF
--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -203,3 +203,27 @@ func (mr *MockAPIMockRecorder) FileSystemUsage(usageInPercentage interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileSystemUsage", reflect.TypeOf((*MockAPI)(nil).FileSystemUsage), usageInPercentage)
 }
+
+// MonitoredHostsCount mocks base method
+func (m *MockAPI) MonitoredHostsCount(monitoredHosts int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MonitoredHostsCount", monitoredHosts)
+}
+
+// MonitoredHostsCount indicates an expected call of MonitoredHostsCount
+func (mr *MockAPIMockRecorder) MonitoredHostsCount(monitoredHosts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredHostsCount", reflect.TypeOf((*MockAPI)(nil).MonitoredHostsCount), monitoredHosts)
+}
+
+// MonitoredClusterCount mocks base method
+func (m *MockAPI) MonitoredClusterCount(monitoredClusters int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MonitoredClusterCount", monitoredClusters)
+}
+
+// MonitoredClusterCount indicates an expected call of MonitoredClusterCount
+func (mr *MockAPIMockRecorder) MonitoredClusterCount(monitoredClusters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitoredClusterCount", reflect.TypeOf((*MockAPI)(nil).MonitoredClusterCount), monitoredClusters)
+}

--- a/pkg/commonutils/common_utils.go
+++ b/pkg/commonutils/common_utils.go
@@ -11,7 +11,7 @@ func MeasureOperation(operation string, log logrus.FieldLogger, metricsApi metri
 	start := time.Now()
 	return func() {
 		duration := time.Since(start)
-		log.Infof("%s took : %v", operation, duration)
+		log.Debugf("%s took : %v", operation, duration)
 		if metricsApi != nil {
 			metricsApi.Duration(operation, duration)
 		}


### PR DESCRIPTION
We want to have graph that will allow us to see how much time takes for cluster/host monitors to finish and how many hosts/clusters they monitor in each loop
