### PR TITLE
NO-ISSUE Rename InfraEnv sshAuthorizedKey to sshAuthorizedKeys

### DIFF
--- a/docs/crds/infraEnv.yaml
+++ b/docs/crds/infraEnv.yaml
@@ -14,7 +14,7 @@ spec:
   proxy:
     httpProxy: http://11.11.11.33
     httpsProxy: http://22.22.22.55
-  sshAuthorizedKey: 'your_pub_key_here'
+  sshAuthorizedKeys: 'your_pub_keys_here'
   ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/someconfig", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
   nmStateConfigLabelSelector:
     matchLabels:

--- a/internal/controller/api/v1beta1/infraenv_types.go
+++ b/internal/controller/api/v1beta1/infraenv_types.go
@@ -55,9 +55,9 @@ type InfraEnvSpec struct {
 	// +optional
 	AdditionalNTPSources []string `json:"additionalNTPSources,omitempty"`
 
-	// SSHAuthorizedKey is a SSH public keys that will be added to all agents for use in debugging.
+	// SSHAuthorizedKeys are the SSH public keys that will be added to all agents for use in debugging.
 	// +optional
-	SSHAuthorizedKey string `json:"sshAuthorizedKey,omitempty"`
+	SSHAuthorizedKeys string `json:"sshAuthorizedKeys,omitempty"`
 
 	// PullSecretRef is the reference to the secret to use when pulling images.
 	PullSecretRef *corev1.LocalObjectReference `json:"pullSecretRef"`

--- a/internal/controller/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/internal/controller/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -183,9 +183,9 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              sshAuthorizedKey:
-                description: SSHAuthorizedKey is a SSH public keys that will be added
-                  to all agents for use in debugging.
+              sshAuthorizedKeys:
+                description: SSHAuthorizedKeys are the SSH public keys that will be
+                  added to all agents for use in debugging.
                 type: string
             required:
             - agentLabelSelector

--- a/internal/controller/config/crd/resources.yaml
+++ b/internal/controller/config/crd/resources.yaml
@@ -778,8 +778,8 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
-              sshAuthorizedKey:
-                description: SSHAuthorizedKey is a SSH public keys that will be added to all agents for use in debugging.
+              sshAuthorizedKeys:
+                description: SSHAuthorizedKeys are the SSH public keys that will be added to all agents for use in debugging.
                 type: string
             required:
             - agentLabelSelector

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -256,7 +256,7 @@ func (r *InfraEnvReconciler) ensureISO(ctx context.Context, infraEnv *aiv1beta1.
 		ClusterID: *cluster.ID,
 		ImageCreateParams: &models.ImageCreateParams{
 			ImageType:    r.Config.ImageType,
-			SSHPublicKey: infraEnv.Spec.SSHAuthorizedKey,
+			SSHPublicKey: infraEnv.Spec.SSHAuthorizedKeys,
 		},
 	}
 

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -376,8 +376,8 @@ func getDefaultInfraEnvSpec(secretRef *corev1.LocalObjectReference,
 			Name:      clusterDeployment.ClusterName,
 			Namespace: Options.Namespace,
 		},
-		PullSecretRef:    secretRef,
-		SSHAuthorizedKey: sshPublicKey,
+		PullSecretRef:     secretRef,
+		SSHAuthorizedKeys: sshPublicKey,
 	}
 }
 


### PR DESCRIPTION
Renaming to better reflect the fact we support multiple keys, as a single string.