### PR TITLE
NO-ISSUE Increase timeout for assisted-service pod in operator deployment

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -46,7 +46,7 @@ function wait_for_pod() {
   done
 
   echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to become ready..."
-  oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=10m
+  oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=20m
 }
 
 function print_help() {


### PR DESCRIPTION
Not sure why I'm seeing this timeout now. Did something change with the assisted-service pod? @YuviGold @osherdp 

Timeouts here:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/17966/rehearse-17966-pull-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-bmh/1389357728454938624