### PR TITLE
MGMT-6023 kubeAPI subsystem test - wait for URLs

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1112,8 +1112,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		Eventually(func() bool {
 			return getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Spec.Installed
 		}, "1m", "2s").Should(BeTrue())
-		Expect(getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.APIURL).Should(Equal("https://api.test-cluster-sno.hive.example.com:6443"))
-		Expect(getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.WebConsoleURL).Should(Equal("https://console-openshift-console.apps.test-cluster-sno.hive.example.com"))
+		Eventually(func() string {
+			return getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.APIURL
+		}, "1m", "2s").Should(Equal(fmt.Sprintf("https://api.%s.hive.example.com:6443", spec.ClusterName)))
+		Eventually(func() string {
+			return getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Status.WebConsoleURL
+		}, "1m", "2s").Should(Equal(fmt.Sprintf("https://console-openshift-console.apps.%s.hive.example.com", spec.ClusterName)))
 		passwordSecretRef := getClusterDeploymentCRD(ctx, kubeClient, clusterKey).Spec.ClusterMetadata.AdminPasswordSecretRef
 		Expect(passwordSecretRef).NotTo(BeNil())
 		passwordkey := types.NamespacedName{


### PR DESCRIPTION
`WebConsoleURL` and `APIURL` may take several seconds to update.
We should not fail the test immidiatly but wait to see if the
expected URLs show up.