### PR TITLE
MGMT-5441 assisted-service should use oc client with ICSP support

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -22,6 +22,8 @@ COPY . .
 RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service cmd/main.go
 RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-operator cmd/operator/main.go
 
+FROM quay.io/ocpmetal/oc-image:bug-1823143 as oc-image
+
 # Create final image
 FROM quay.io/centos/centos:centos8
 
@@ -58,9 +60,8 @@ ARG WORK_DIR=/data
 
 RUN mkdir $WORK_DIR && chmod 775 $WORK_DIR
 
-# downstream this can be installed as an RPM
-ARG OC_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
-RUN curl -s $OC_URL | tar -xzC /usr/local/bin/ oc
+#TODO: Use official oc client once it has ICSP support https://bugzilla.redhat.com/show_bug.cgi?id=1823143
+COPY --from=oc-image /oc /usr/local/bin/
 
 COPY --from=builder /build/assisted-service /assisted-service
 COPY --from=builder /build/assisted-service-operator /assisted-service-operator


### PR DESCRIPTION
Note that this is a temporary patch to mitigate the issue and there is a blocker bug for moving back to official oc client once it supports ICSP

Verified it works for release image from mirror registry and nightly images

Mirror:
```
[root@edge-01 openshift]# ./new-oc adm release extract --command openshift-install -a ./pull-secret-update.txt edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp:4.8.0-0.nightly-2021-03-16-221720 -v=2
I0504 04:14:49.455269 2185657 simplelookup.go:99] edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 04:14:49.455339 2185657 simplelookup.go:130] Found sources: [edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp] for image: edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp
I0504 04:14:49.458322 2185657 simplelookup.go:99] edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 04:14:49.458332 2185657 simplelookup.go:130] Found sources: [edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp] for image: edge-01.edge.lab.eng.rdu2.redhat.com:5000/ocp
I0504 04:14:49.659949 2185657 extract_tools.go:314] Skipping openshift-install-mac-%s.tar.gz, does not match current OS darwin
I0504 04:14:49.659974 2185657 extract_tools.go:326] Will extract usr/bin/openshift-install from quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3edf2979e2534ba58b9801893c5ec0f4757b4056f6cc67d3743ca89a2f5b98fd
I0504 04:14:49.660173 2185657 simplelookup.go:99] quay.io/openshift-release-dev/ocp-v4.0-art-dev ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 04:14:49.660181 2185657 simplelookup.go:130] Found sources: [quay.io/openshift-release-dev/ocp-v4.0-art-dev] for image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
I0504 04:14:49.774190 2185657 simplelookup.go:99] quay.io/openshift-release-dev/ocp-v4.0-art-dev ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 04:14:49.774201 2185657 simplelookup.go:130] Found sources: [quay.io/openshift-release-dev/ocp-v4.0-art-dev] for image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
I0504 04:14:51.997630 2185657 extract_tools.go:680] Found match for release version at 1945 (len=4096, offset=327, n=3769)
I0504 04:14:52.004700 2185657 extract_tools.go:680] Found match for release image at 3740 (len=4096, offset=327, n=3769)
```

Nightly:
```
./new-oc adm release extract --command=openshift-baremetal-install --to=./ --insecure=false registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-04-30-201824 -v=2
I0504 11:17:49.059505 1181756 simplelookup.go:99] registry.ci.openshift.org/ocp/release ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 11:17:49.059721 1181756 simplelookup.go:130] Found sources: [registry.ci.openshift.org/ocp/release] for image: registry.ci.openshift.org/ocp/release
I0504 11:17:49.448406 1181756 simplelookup.go:99] registry.ci.openshift.org/ocp/release ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 11:17:49.448451 1181756 simplelookup.go:130] Found sources: [registry.ci.openshift.org/ocp/release] for image: registry.ci.openshift.org/ocp/release
I0504 11:17:57.443801 1181756 extract_tools.go:326] Will extract usr/bin/openshift-install from quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:42c947cfb0b1e1b0222de72c85aa6439b784ecc8bfbce65f81493191fa5ccc78
I0504 11:17:57.594160 1181756 simplelookup.go:99] quay.io/openshift-release-dev/ocp-v4.0-art-dev ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 11:17:57.594193 1181756 simplelookup.go:130] Found sources: [quay.io/openshift-release-dev/ocp-v4.0-art-dev] for image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
I0504 11:17:58.307024 1181756 simplelookup.go:99] quay.io/openshift-release-dev/ocp-v4.0-art-dev ImageReference added to potential ImageSourcePrefixes from ImageContentSourcePolicy
I0504 11:17:58.307065 1181756 simplelookup.go:130] Found sources: [quay.io/openshift-release-dev/ocp-v4.0-art-dev] for image: quay.io/openshift-release-dev/ocp-v4.0-art-dev
I0504 11:18:03.636300 1181756 extract_tools.go:680] Found match for release version at 461 (len=4096, offset=327, n=3769)
I0504 11:18:03.645492 1181756 extract_tools.go:680] Found match for release image at 1566 (len=4096, offset=327, n=3769)

```