### PR TITLE
MGMT-6034 fix enabling mirror registry certificate in Assisted Service…

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -19,7 +19,7 @@ const (
 
 	consoleUrlPrefix = "https://console-openshift-console.apps"
 
-	MirrorRegistriesCertificateFile = "mirror_ca.pem"
+	MirrorRegistriesCertificateFile = "tls-ca-bundle.pem"
 	MirrorRegistriesCertificatePath = "/etc/pki/ca-trust/extracted/pem/" + MirrorRegistriesCertificateFile
 	MirrorRegistriesConfigDir       = "/etc/containers"
 	MirrorRegistriesConfigFile      = "registries.conf"

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -253,14 +253,6 @@ func (i *installConfigBuilder) getBasicInstallConfig(cluster *common.Cluster) (*
 		}
 	}
 
-	/*
-		if cluster.ImageInfo.MirrorRegistriesConfig != "" {
-			err := i.setImageContentSources(cluster.ImageInfo.MirrorRegistriesConfig, cfg)
-			if err != nil {
-				return nil, err
-			}
-		}
-	*/
 	return cfg, nil
 }
 
@@ -445,9 +437,11 @@ func (i *installConfigBuilder) getHypethreadingConfiguration(cluster *common.Clu
 
 func (i *installConfigBuilder) getCAContents(cluster *common.Cluster, rhRootCA string, installRHRootCAFlag bool) string {
 	// CA for mirror registries and RH CA are mutually exclusive
-	caContents, err := i.mirrorRegistriesBuilder.GetMirrorCA()
-	if err == nil {
-		return "\n" + string(caContents)
+	if i.mirrorRegistriesBuilder.IsMirrorRegistriesConfigured() {
+		caContents, err := i.mirrorRegistriesBuilder.GetMirrorCA()
+		if err == nil {
+			return "\n" + string(caContents)
+		}
 	}
 	if installRHRootCAFlag {
 		return rhRootCA

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -2,7 +2,6 @@ package installcfg
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -77,8 +76,7 @@ var _ = Describe("installcfg", func() {
 
 	It("create_configuration_with_all_hosts", func() {
 		var result InstallerConfigBaremetal
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -89,8 +87,7 @@ var _ = Describe("installcfg", func() {
 	It("create_configuration_with_one_host_disabled", func() {
 		var result InstallerConfigBaremetal
 		host3.Status = swag.String(models.HostStatusDisabled)
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -99,13 +96,24 @@ var _ = Describe("installcfg", func() {
 		Expect(result.Proxy).Should(BeNil())
 	})
 
+	It("create_configuration_with_mirror_registries", func() {
+		var result InstallerConfigBaremetal
+		regData := []mirrorregistries.RegistriesConf{{Location: "location1", Mirror: "mirror1"}, {Location: "location2", Mirror: "mirror2"}}
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(true).Times(2)
+		mockMirrorRegistriesConfigBuilder.EXPECT().ExtractLocationMirrorDataFromRegistries().Return(regData, nil).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return([]byte("some sa data"), nil).Times(1)
+		data, err := installConfig.GetInstallConfig(&cluster, false, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = yaml.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
 	It("create_configuration_with_proxy", func() {
 		var result InstallerConfigBaremetal
 		proxyURL := "http://proxyserver:3218"
 		cluster.HTTPProxy = proxyURL
 		cluster.HTTPSProxy = proxyURL
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -128,8 +136,7 @@ var _ = Describe("installcfg", func() {
 		cluster.HTTPSProxy = proxyURL
 		cluster.NoProxy = "no-proxy.com"
 		cluster.MachineNetworkCidr = ""
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -147,8 +154,7 @@ var _ = Describe("installcfg", func() {
 
 	It("correctly applies cluster overrides", func() {
 		var result InstallerConfigBaremetal
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -164,8 +170,7 @@ var _ = Describe("installcfg", func() {
 	It("doesn't fail with empty overrides", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -177,8 +182,7 @@ var _ = Describe("installcfg", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
 		cluster.MachineNetworkCidr = "1001:db8::/120"
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -190,8 +194,7 @@ var _ = Describe("installcfg", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
 		cluster.ClusterNetworkCidr = "1001:db8::/120"
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -203,8 +206,7 @@ var _ = Describe("installcfg", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
 		cluster.ServiceNetworkCidr = "1001:db8::/120"
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -218,8 +220,7 @@ var _ = Describe("installcfg", func() {
 		ca := "-----BEGIN CERTIFICATE-----\nMIIDozCCAougAwIBAgIULCOqWTF" +
 			"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 			"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, true, ca)
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -232,8 +233,7 @@ var _ = Describe("installcfg", func() {
 	It("CA AdditionalTrustBundle not added", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "CA-CERT")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -245,8 +245,7 @@ var _ = Describe("installcfg", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
 		cluster.UserManagedNetworking = swag.Bool(true)
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -262,8 +261,7 @@ var _ = Describe("installcfg", func() {
 		cluster.UserManagedNetworking = swag.Bool(true)
 		cluster.MachineNetworkCidr = ""
 		host1.Bootstrap = true
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -281,8 +279,7 @@ var _ = Describe("installcfg", func() {
 		cluster.MachineNetworkCidr = ""
 		host1.Bootstrap = true
 		host1.Inventory = getInventoryStr("hostname0", "bootMode", true)
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -298,8 +295,7 @@ var _ = Describe("installcfg", func() {
 		var result InstallerConfigBaremetal
 		cluster.InstallConfigOverrides = ""
 		cluster.UserManagedNetworking = swag.Bool(false)
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -317,8 +313,7 @@ var _ = Describe("installcfg", func() {
 		cluster.Hosts[0].Bootstrap = true
 		cluster.Hosts[0].InstallationDiskPath = "/dev/test"
 		cluster.MachineNetworkCidr = "10.35.20.0/24"
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
@@ -337,8 +332,7 @@ var _ = Describe("installcfg", func() {
 		cluster.MachineNetworkCidr = "fe80::/64"
 		host1.Bootstrap = true
 		host1.Inventory = getInventoryStr("hostname0", "bootMode", true)
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
 		Expect(err).ShouldNot(HaveOccurred())
 		err = yaml.Unmarshal(data, &result)
@@ -407,24 +401,21 @@ var _ = Describe("ValidateInstallConfigPatch", func() {
 
 	It("Succeeds when provided valid json", func() {
 		s := `{"apiVersion": "v3", "baseDomain": "example.com", "metadata": {"name": "things"}}`
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		err := installConfigBuilder.ValidateInstallConfigPatch(cluster, s)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	It("Fails when provided invalid json", func() {
 		s := `{"apiVersion": 3, "baseDomain": "example.com", "metadata": {"name": "things"}}`
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		err := installConfigBuilder.ValidateInstallConfigPatch(cluster, s)
 		Expect(err).Should(HaveOccurred())
 	})
 
 	It("Fails with an invalid cert", func() {
 		s := `{"additionalTrustBundle":  "-----BEGIN CERTIFICATE-----\nMIIFozCCA4ugAwIBAgIUVlT4eKQQ43HN31jQzsez+iEmpw8wDQYJKoZIhvcNAQEL\nBQAwYTELMAkGA1UEBhMCQUExFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE\nCgwTRGVmYXVsdCBDb21wYW55IEx0ZDEdMBsGA1UEAwwUcmVnaXN0cnkuZXhhbXBs\nZS5jb20wHhcNMjAxMDI3MTI0OTEwWhcNMjExMDI3MTI0OTEwWjBhMQswCQYDVQQG\nEwJBQTEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZhdWx0IENv\nbXBhbnkgTHRkMR0wGwYDVQQDDBRyZWdpc3RyeS5leGFtcGxlLmNvbTCCAiIwDQYJ\nKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKm/wEl5B6lDOwYtkOxoLHQySA5RySEU\nkEMoGxBtGewLjLRMS9zp5pgYNcRenOTfUeyx6n4vE+lLn6p4laSig6QGDK0mmPl/\nt8OVZGBNE/dOZEoGe3I+gQux0oErhzjNxrf1EGfeBRVVuSqmgQnFaeLq2mGsbb5+\nyz114seD7u0Vb6OIX5sA+ytvr+jV3HK0jf5H9AHvSnNzF0UE+S7CHTJSDqQNUPxp\n8rAtfOvWyndDJBBmA0fdnDRYNtUqKcj/YBSntuZAmSJ0Woq9NrE+H3e61kvF0AP8\nHz21FSD/GqCn97Q8Mh8uTKx8jas2XBLyWdi0OCIV+a4jTadez1zPCWT+zgD5rHAk\np5RyXgkRU3guJydNMlpRPsGur3pUM4Q3zQfArZ+OxTkU/SLZbBmAVMPDI2pwL6qE\n2F8So4JdysH1MiwtYDYVIxKChrpBtTVunIe+Jyl/w8a3xR77r++3MFauobGLpeCL\nptbSz0aFZIIIwoLw2JVaWe7BWryjk8fDYrlPkLWqgQ956lcZppqiUzvEVv3p7wC2\nmfWkXJBGZZ0CZcYUoEE7zQ5T0RHLXqf0lSMf8I1SPzBF+Wl6G2gUOaZtYT5s0LA5\nid+gSDtKqyDH1HwPGO0eQB1LGeXOCLBA3cgmxYXtIMLfds0LgcJF+vRV3868abpD\n+yVMxGQRzRZFAgMBAAGjUzBRMB0GA1UdDgQWBBTUHUuivG1L6rTHS9v8KHTtOVpL\ncjAfBgNVHSMEGDAWgBTUHUuivG1L6rTHS9v8KHTtOVpLcjAPBgNVHRMBAf8EBTAD\nAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQAFTmSriXnTJ/9cbO2lJmH7OFcrgKWdsycU\ngc9aeLSpnlYPuMjRHgXpq0X5iZzJaOXu8WKmbxTItxfd7MD/9rsaDMo7uDs6cZhC\nsdpWDVzZlP1PRcy1uT3+g12QmMmt89WBtauKEMukI3mOlx6y1VzPj9Vw5gfBKYjS\nh2NJPSVzgkLlLTOsY6bHesXVWrHVtCS5fUiE2xNkE6hXS0hZWYZlzLwn55wIrchx\nB3G++mPnNL3SbH62lXyWcrc1M/+gNl3F3jSd5WfxZQVllZ9vK1DnBKDisTUax5fR\nqK/D7vgkvHJa0USzGhcYV3DEdbgP/COgWrpbA0TTFcasWWYQdBk+2EUPcWKAh0JB\nVgql3o0pmyzfqQtuRRMC4D6Ip6y6IE2opK2c7ipXT4iEyPqr4uk4IeVFXghCYW92\nkCI+FyRJgbSu9ZuIug8AUlea7UOLTC4mxAayXvTwA6bNlGoSLmojgQHG7GlGj+E8\n57AHM2sD9Qi1VYyLuMVhJB3DzlQKtEFuvZsvi/rSIGqT8UfNbxk7OCtxceyzECqW\n2ptIv7tDhQeAGqkGqhTj1WdH+16+QZpsfmkwt5+hAaOeZfQ/nOCP7CGwbl4nYc3X\narDiqhVUXlv84/7XrOyoDJo3AVGidq902h6MYenX9T//XYbWkUK7nkvYMVoxu/Ek\nx/aT+8yOHQ==\n", "imageContentSources": [{"mirrors": ["registry.example.com:5000/ocp4"], "source": "quay.io/openshift-release-dev/ocp-release"}, {"mirrors": ["registry.example.com:5000/ocp4"], "source": "quay.io/openshift-release-dev/ocp-release-nightly"}, {"mirrors": ["registry.example.com:5000/ocp4"], "source": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"}]}`
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		err := installConfigBuilder.ValidateInstallConfigPatch(cluster, s)
 		Expect(err).Should(HaveOccurred())
 	})
@@ -434,8 +425,7 @@ var _ = Describe("ValidateInstallConfigPatch", func() {
 		cluster.UserManagedNetworking = swag.Bool(true)
 		mode := models.ClusterHighAvailabilityModeNone
 		cluster.HighAvailabilityMode = &mode
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return(nil, fmt.Errorf("file not present")).Times(1)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		err := installConfigBuilder.ValidateInstallConfigPatch(cluster, s)
 		Expect(err).ShouldNot(HaveOccurred())
 	})


### PR DESCRIPTION
… pod

In order for ssl to actualy see the contents of the certificate, we need
to upload it into /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem