### PR TITLE
Bug 1941606: WIP Assisted service bundle digest

### DIFF
--- a/hack/update_image_digests.sh
+++ b/hack/update_image_digests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Get latest digest SHAs
+service="quay.io/ocpmetal/assisted-service@"$(curl -G https://quay.io/api/v1/repository/ocpmetal/assisted-service/tag/ | jq -r '.tags[] | select(.name=="latest" and (has("expiration") | not)) | .manifest_digest')
+agent="quay.io/ocpmetal/assisted-installer-agent@"$(curl -G https://quay.io/api/v1/repository/ocpmetal/assisted-installer-agent/tag/ | jq -r '.tags[] | select(.name=="latest" and (has("expiration") | not)) | .manifest_digest')
+controller="quay.io/ocpmetal/assisted-installer-controller@"$(curl -G https://quay.io/api/v1/repository/ocpmetal/assisted-installer-controller/tag/ | jq -r '.tags[] | select(.name=="latest" and (has("expiration") | not)) | .manifest_digest')
+installer="quay.io/ocpmetal/assisted-installer@"$(curl -G https://quay.io/api/v1/repository/ocpmetal/assisted-installer/tag/ | jq -r '.tags[] | select(.name=="latest" and (has("expiration") | not)) | .manifest_digest')
+postgres="quay.io/ocpmetal/postgresql-12-centos7@"$(curl -G https://quay.io/api/v1/repository/ocpmetal/postgresql-12-centos7/tag/ | jq -r '.tags[] | select(.name=="latest" and (has("expiration") | not)) | .manifest_digest')
+
+# Echo Current digest shas:
+echo "Current digest SHAs:"
+echo "$service"
+echo "$agent"
+echo "$controller"
+echo "$installer"
+echo "$postgres"
+
+# Replace digest SHAs before bundle build
+sed -i "s%quay.io/ocpmetal/assisted-service:latest%${service}%g" config/manager/manager.yaml
+sed -i "s%quay.io/ocpmetal/assisted-installer-agent:latest%${agent}%g" config/manager/manager.yaml
+sed -i "s%quay.io/ocpmetal/assisted-installer-controller:latest%${controller}%g" config/manager/manager.yaml
+sed -i "s%quay.io/ocpmetal/assisted-installer:latest%${installer}%g" config/manager/manager.yaml
+sed -i "s%quay.io/ocpmetal/postgresql-12-centos7:latest%${postgres}%g" config/manager/manager.yaml


### PR DESCRIPTION
Replaces image tags with digest SHA in configurations using kustomize.

- [X] Create kustomization for changing images
- [X] End up using hack script with sed. Couldn't figure out how to get kustomize to update the env variables 
- [X] Create script to pipe in the digest sha using curl and jq
- [X] Update manifest with digest sha
- [X] Update makefile targets to generate csv with digest sha
