### PR TITLE
OCPBUGSM-28762 cd controller: trim ssh key before update

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -380,7 +380,10 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context, clust
 
 	updateString(spec.Platform.AgentBareMetal.APIVIP, cluster.APIVip, &params.APIVip)
 	updateString(spec.Platform.AgentBareMetal.IngressVIP, cluster.IngressVip, &params.IngressVip)
-	updateString(spec.Provisioning.InstallStrategy.Agent.SSHPublicKey, cluster.SSHPublicKey, &params.SSHPublicKey)
+
+	// Trim key before comapring as done in RegisterClusterInternal
+	sshPublicKey := strings.TrimSpace(spec.Provisioning.InstallStrategy.Agent.SSHPublicKey)
+	updateString(sshPublicKey, cluster.SSHPublicKey, &params.SSHPublicKey)
 
 	if userManagedNetwork := isUserManagedNetwork(clusterDeployment); userManagedNetwork != swag.BoolValue(cluster.UserManagedNetworking) {
 		params.UserManagedNetworking = swag.Bool(userManagedNetwork)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1063,6 +1063,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		By("Create cluster")
 		secretRef := deployLocalObjectSecretIfNeeded(ctx, kubeClient)
 		spec := getDefaultClusterDeploymentSNOSpec(secretRef)
+
+		// Add space suffix to SSHPublicKey to validate proper install
+		sshPublicKeySuffixSpace := fmt.Sprintf("%s ",
+			spec.Provisioning.InstallStrategy.Agent.SSHPublicKey)
+		spec.Provisioning.InstallStrategy.Agent.SSHPublicKey = sshPublicKeySuffixSpace
+
 		deployClusterDeploymentCRD(ctx, kubeClient, spec)
 		clusterKey := types.NamespacedName{
 			Namespace: Options.Namespace,


### PR DESCRIPTION
As SSHPublicKey string is trimmed on RegisterClusterInternal,
same behaviour should be applied on ClusterDeploymentsReconciler (updateIfNeeded)
That way, we can avoid repeating the unnecessary cluster updating.