### PR TITLE
OCPBUGSM-26546 Validate length of base DNS domain

### DIFF
--- a/internal/dns/mock_dns.go
+++ b/internal/dns/mock_dns.go
@@ -78,6 +78,20 @@ func (mr *MockDNSApiMockRecorder) GetDNSDomain(clusterName, baseDNSDomainName in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSDomain", reflect.TypeOf((*MockDNSApi)(nil).GetDNSDomain), clusterName, baseDNSDomainName)
 }
 
+// ValidateDNSName mocks base method
+func (m *MockDNSApi) ValidateDNSName(clusterName, baseDNSDomainName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateDNSName", clusterName, baseDNSDomainName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateDNSName indicates an expected call of ValidateDNSName
+func (mr *MockDNSApiMockRecorder) ValidateDNSName(clusterName, baseDNSDomainName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateDNSName", reflect.TypeOf((*MockDNSApi)(nil).ValidateDNSName), clusterName, baseDNSDomainName)
+}
+
 // ValidateBaseDNS mocks base method
 func (m *MockDNSApi) ValidateBaseDNS(domain *DNSDomain) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Validate the length of base DNS doman and its labels.

The lenght must adhere to the 255-bytes limitation while
allowing also for auto-generated DNS names that an OCP cluster
needs, which are created by concatenating a reserved application name,
a cluster name, and a base domain.

Example:
'alertmanager-main-openshift-monitoring.apps.test-cluster.example.com'
where 'test-cluster' is the cluster name and 'example.com' is the base
domain.