### PR TITLE
OCPBUGSM-28683: Enable pprof when running in debug mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,8 +20,8 @@ run:
   # default value is empty list, but default dirs are skipped independently
   # from this option's value (see skip-dirs-use-default).
   skip-dirs:
-    - build 
-    - client 
+    - build
+    - client
     - docs
     - models
     - restapi
@@ -48,6 +48,7 @@ issues:
   exclude:
     - G107
     - G402  # support object store DisableSSL
+    - G108
 
 linters:
   enable:

--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -42,4 +42,6 @@ COPY --from=builder /build/assisted-service /assisted-service
 COPY --from=builder /build/assisted-service-operator /assisted-service-operator
 COPY --from=pybuilder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
 COPY /config/onprem-iso-config.ign /data/onprem-iso-config.ign
+ENV GODEBUG=madvdontneed=1
+ENV GOGC=50
 CMD ["/assisted-service"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strings"
 	"time"
@@ -452,6 +453,12 @@ func main() {
 		}
 
 		apiEnabler.Enable()
+	}()
+
+	go func() {
+		if log.Level == logrus.DebugLevel {
+			log.Println(http.ListenAndServe("localhost:6060", nil))
+		}
 	}()
 
 	go func() {


### PR DESCRIPTION
Enable pprof when running in `DEBUG` mode so that it's possible to inspect the traces, heap data, as well as other profile data from assisted-service.

This has proven to be useful when doing scale test and needing to debug performance issues.

This PR also adds the following flags to the `Dockerfile`

```
GODEBUG=madvdontneed=1
GOGC=50
```

These two flags instruct the GC to free memory more often. These flags have a cost in terms of CPU resources but it's not as significant to prevent us from using them. More testing will be done.

Signed-off-by: Flavio Percoco <flavio@redhat.com>