### PR TITLE
MGMT-6067 Add a cache for the local authenticator

### DIFF
--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -79,6 +79,17 @@ var _ = Describe("AuthAgentAuth", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("Caches the response", func() {
+		_, err := a.AuthAgentAuth(token)
+		Expect(err).ToNot(HaveOccurred())
+
+		resp := db.Delete(cluster)
+		Expect(resp.Error).ToNot(HaveOccurred())
+
+		_, err = a.AuthAgentAuth(token)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	It("Fails an invalid token", func() {
 		_, err := a.AuthAgentAuth(token + "asdf")
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
We will now only go to the database to check for presence of the cluster
from the token claim once every 10 minutes.

We don't store any data in the cache because the presence of the key is
enough to authenticate the request. We also don't cache failed responses
as we don't want it to take 10 minutes for a request to succeed if a
cluster is somehow not present, but will be in the future.

cc @tsorya 