### PR TITLE
MGMT-6281 mirror LSO packages to local registry

### DIFF
--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -1,6 +1,10 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/utils.sh
 
+function print_help() {
+  echo "Usage: DISKS=\$(echo sd{b..f}) bash ${0} (create|destroy|print_help)"
+}
+
 if [ -z "${NODES:-}" ]; then
     export NODES=$(virsh list --name | grep worker || virsh list --name | grep master)
 fi

--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -1,0 +1,72 @@
+function mirror_package() {
+  # e.g. "local-storage-operator"
+  package="${1}"
+
+  # e.g. "redhat-operator-index", "certified-operator-index",
+  # "community-operator-index", "redhat-marketplace-index"
+  catalog="${2}"
+
+  # e.g. "4.8"
+  ocp_release="${3}"
+
+  # e.g. "virthost.ostest.test.metalkube.org:5000"
+  local_registry="${4}"
+
+  # e.g. "/run/user/0/containers/auth.json", "~/.docker/config.json"
+  # should have authentication information for both official registry
+  # (pull-secret) and for the local registry
+  authfile="${5}"
+
+  remote_index="registry.redhat.io/redhat/${catalog}:v${ocp_release}"
+  local_registry_index_tag="${local_registry}/olm-index/${catalog}:v${ocp_release}"
+  local_registry_image_tag="${local_registry}/olm"
+
+  opm index prune \
+        --from-index "${remote_index}" \
+        --packages "${package}" \
+        --tag "${local_registry_index_tag}"
+
+  GODEBUG=x509ignoreCN=0 podman push \
+        --tls-verify=false \
+        "${local_registry_index_tag}" \
+        --authfile "${authfile}"
+
+  manifests_dir=$(mktemp -d -t manifests-XXXXXXXXXX)
+  GODEBUG=x509ignoreCN=0 oc adm catalog mirror \
+        "${local_registry_index_tag}" \
+        "${local_registry_image_tag}" \
+        --registry-config="${authfile}" \
+        --to-manifests="${manifests_dir}"
+
+  cat > "${manifests_dir}/catalogSource.yaml" << EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: mirror-catalog-for-${package}
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: ${local_registry_index_tag}
+  displayName: Mirror Index to package ${package} on ${catalog}
+  publisher: Local
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+EOF
+
+  oc apply -f "${manifests_dir}/imageContentSourcePolicy.yaml"
+  oc apply -f "${manifests_dir}/catalogSource.yaml"
+}
+
+function disable_default_indexes() {
+  oc patch OperatorHub cluster --type json \
+        -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+}
+
+function merge_authfiles() {
+  jq -s '.[0] * .[1]' "${1}" "${2}" > "${3}"
+}
+
+function install_opm() {
+  curl -s https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.7/opm-linux.tar.gz | tar xvz -C /usr/local/bin/
+}

--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -8,7 +8,7 @@ DISCONNECTED="${DISCONNECTED:-false}"
 function print_help() {
   ALL_FUNCS="install_lso|create_local_volume|print_help"
   if [ "${DISCONNECTED}" == "true" ]; then
-    echo "Usage: DISKS=\$(echo sd{b..f}) DISCONNECTED=true AUTHFILE=... bash ${0} (${ALL_FUNCS})"
+    echo "Usage: DISKS=\$(echo sd{b..f}) DISCONNECTED=true LOCAL_REGISTRY=... AUTHFILE=... bash ${0} (${ALL_FUNCS})"
   else
     echo "Usage: DISKS=\$(echo sd{b..f}) bash ${0} (${ALL_FUNCS})"
   fi
@@ -22,6 +22,12 @@ fi
 
 if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE}" ]; then
     echo "On disconnected mode, you must provide AUTHFILE env-var."
+    print_help
+    exit 1
+fi
+
+if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY}" ]; then
+    echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
     print_help
     exit 1
 fi

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -48,8 +48,3 @@ function wait_for_pod() {
   echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to become ready..."
   oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=10m
 }
-
-function print_help() {
-  ALL_FUNCS=$(compgen -A "function" | grep -Ev "(help|wait_for)" | paste -s -d'|')
-  echo "Usage: DISKS=\$(echo sd{b..f}) bash ${0} (${ALL_FUNCS})"
-}


### PR DESCRIPTION
This is the first step towards working on top of a disconnected environment. Next steps:
* Hive installation, at first without using OLM as hive bundle reference hive image using tag instead of digest. Next we will use OLM when it's fixed
* Assisted Installer Operator installation via OLM. This also waits for the fix by @lranjbar that will allow that
* Going afterwards HubCluster scope, allowing full SNO installation on disconnected environment.

``mirror_utils.sh`` module enables:
* mirroring relevant operator package from the relevant catalog
* disabling default indexes that are usually connected to the external registries
* merging auth files, to allow accessing both external registries and internal registries
* ``opm`` installation which is required for the mirroring process