### PR TITLE
MGMT-4966 Map the /run/media/iso directory to the next_step agent com…

### DIFF
--- a/internal/host/hostcommands/next_step_runner_cmd.go
+++ b/internal/host/hostcommands/next_step_runner_cmd.go
@@ -22,7 +22,8 @@ func GetNextStepRunnerCommand(config *NextStepRunnerConfig) (string, *[]string) 
 	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--net=host",
 		"-v", "/dev:/dev:rw", "-v", "/opt:/opt:rw",
 		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-		"-v", "/var/log:/var/log:rw"}
+		"-v", "/var/log:/var/log:rw",
+		"-v", "/run/media/iso:/run/media/iso:ro"}
 
 	if config.UseCustomCACert {
 		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", common.HostCACertPath, common.HostCACertPath))


### PR DESCRIPTION
…ponent

When a media disconnection error occurred the system became unstable and the step execution might be stuck on IO errors or failed with an unfriendly message.
Media disconnection occurred when a network drive (mostly PXE) has any errors (Network issue) and the controller disconnects it automatically.
Since this error is common to all the steps, we add this verification to the agent.
/run/media/iso is the ISO directory which mounted from the CDROM drive