### PR TITLE
NO-ISSUE allow GitHub-created reverts to be used

### DIFF
--- a/tools/check-commit-message.sh
+++ b/tools/check-commit-message.sh
@@ -4,7 +4,7 @@ set -o nounset
 
 commit_file=${1}
 commit_message="$(cat ${commit_file})"
-valid_commit_regex='([A-Z]+-[0-9]+|#[0-9]+|merge|no-issue)'
+valid_commit_regex='([A-Z]+-[0-9]+|#[0-9]+|merge|no-issue|revert)'
 
 error_msg="""Aborting commit.
 Your commit message is missing either a JIRA issue ('JIRA-1111'), a GitHub issue ('#39').


### PR DESCRIPTION
It's really frustrating to create reverts from GitHub only to find out that CI doesn't like the selected commit message
So it will enable reverts to be considered with legal commit messages.
/cc @YuviGold @eranco74 