### PR TITLE
NO-ISSUE Fix incomplete Hive installation manifest

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -50,6 +50,7 @@ spec:
   name: hive-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
+EOF
 ```
 
 Deploy the operator using the operator-sdk:


### PR DESCRIPTION
The PR fixes the missing "EOF" in the Hive installation manifest.