### PR TITLE
NO-ISSUE Fix apiVersion for AgentServiceConfig

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -161,7 +161,7 @@ Add the annotation to the AgentServiceConfig:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
   name: agent


### PR DESCRIPTION
This PR fixes the incorrect API version for AgentServiceConfig resource
mentioned in the Operator deployment documentation.

The currently used `operators.coreos.com/v1alpha1` does not define
`AgentServiceConfig` causing the following error to be thrown

```
error: unable to recognize "STDIN": no matches for kind "AgentServiceConfig" in version "operators.coreos.com/v1alpha1"
```

Instead, `agent-install.openshift.io/v1beta1` should be used.