### PR TITLE
OCPBUGSM-27700 Fix NMstate requeue

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -72,6 +72,7 @@ const DefaultUser = "kubeadmin"
 
 // 125 is the generic exit code for cases the error is in podman / docker and not the container we tried to run
 const ContainerAlreadyRunningExitCode = 125
+const WindowBetweenRequestsInSeconds = 10 * time.Second
 
 type Config struct {
 	ignition.IgnitionConfig
@@ -906,7 +907,7 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	*/
 	now := time.Now()
 	previousCreatedAt := time.Time(cluster.ImageInfo.CreatedAt)
-	if previousCreatedAt.Add(10 * time.Second).After(now) {
+	if previousCreatedAt.Add(WindowBetweenRequestsInSeconds).After(now) {
 		log.Error("request came too soon after previous request")
 		return nil, common.NewApiError(
 			http.StatusConflict,

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -195,7 +195,7 @@ var _ = Describe("infraEnv reconcile", func() {
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).ToNot(BeNil())
-		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(res).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeueAfterPerClientError}))
 
 		key := types.NamespacedName{
 			Namespace: testNamespace,
@@ -306,7 +306,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-		Expect(err).ToNot(BeNil())
+		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{Requeue: false}))
 
 		key := types.NamespacedName{
@@ -415,7 +415,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			}).Return(errors.Errorf("error")).Times(1)
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).ToNot(BeNil())
-		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(res).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeueAfterPerClientError}))
 	})
 
 	It("failed to update cluster with proxy", func() {
@@ -434,7 +434,7 @@ var _ = Describe("infraEnv reconcile", func() {
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).ToNot(BeNil())
-		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+		Expect(res).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeueAfterPerClientError}))
 
 		key := types.NamespacedName{
 			Namespace: testNamespace,
@@ -520,7 +520,7 @@ var _ = Describe("infraEnv reconcile", func() {
 			Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil)
-			expectedError := common.NewApiError(http.StatusInternalServerError, errors.New("error")) // TODO: change to http.StatusBadRequest when MGMT-4695 and MGMT-4696 get resolved.
+			expectedError := common.NewApiError(http.StatusBadRequest, errors.New("internal error"))
 			mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
 					Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
@@ -531,8 +531,8 @@ var _ = Describe("infraEnv reconcile", func() {
 			})
 			Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 			res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
-			Expect(err).To(Equal(expectedError))
-			Expect(res).To(Equal(ctrl.Result{Requeue: true}))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{Requeue: false, RequeueAfter: 0}))
 
 			key := types.NamespacedName{
 				Namespace: testNamespace,


### PR DESCRIPTION
To avoid needless requeues (e.g. for `BadRequest`), the InfraEnv controller
will reflect the error in conditions, but will not return it alongside `ctrl.Result`

Additionally, to avoid `http.StatusConflict` (409) coming from the backend[1], in a case of a requeue the
InfraEnv controller will wait a bit longer.

[1] https://github.com/openshift/assisted-service/blob/cf99d1fca3fe29869a9245dc7b0b2400eaf11fc3/internal/bminventory/inventory.go#L903-L914