### PR TITLE
MGMT-6284 install hive without OLM

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -4,7 +4,7 @@ ENV GO111MODULE=on
 ENV GOFLAGS=""
 
 COPY ./hack/setup_env.sh ./dev-requirements.txt ./
-RUN ./setup_env.sh
+RUN ./setup_env.sh assisted_service
 
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo
 all: build
 
 init:
-	./hack/setup_env.sh
+	./hack/setup_env.sh assisted_service
 
 ci-lint:
 ifdef SKIPPER_USERNAME

--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -13,5 +13,6 @@ if [ "${INSTALL_LSO:-true}" == "true" ]; then
 fi
 
 ${__dir}/setup_lso.sh create_local_volume
-${__dir}/setup_hive.sh
+${__dir}/setup_hive.sh install_dependencies
+${__dir}/setup_hive.sh with_olm
 ${__dir}/setup_assisted_operator.sh

--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -13,6 +13,5 @@ if [ "${INSTALL_LSO:-true}" == "true" ]; then
 fi
 
 ${__dir}/setup_lso.sh create_local_volume
-${__dir}/setup_hive.sh install_dependencies
 ${__dir}/setup_hive.sh with_olm
 ${__dir}/setup_assisted_operator.sh

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -1,7 +1,10 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/utils.sh
 
-set -xeo pipefail
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
 
 DISCONNECTED="${DISCONNECTED:-false}"
 HIVE_IMAGE="${HIVE_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"
@@ -54,14 +57,15 @@ EOCR
 
 function from_upstream() {
   HIVE_DIR="${HIVE_DIR:-${HOME}/go/src/github.com/openshift/hive}"
+  HIVE_BRANCH="${HIVE_BRANCH:-master}"
 
   if [ ! -d "${HIVE_DIR}" ]; then
     git clone https://github.com/openshift/hive.git "${HIVE_DIR}"
   fi
 
-  pushd $HOME/go/src/github.com/openshift/hive
-  git fetch origin
-  git pull origin master
+  pushd ${HIVE_DIR}
+  git fetch origin "${HIVE_BRANCH}"
+  git reset --hard FETCH_HEAD
 
   if [ "${DISCONNECTED}" = "true" ]; then
     export IMG="${LOCAL_REGISTRY}/localimages/hive:latest"

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -10,7 +10,7 @@ DISCONNECTED="${DISCONNECTED:-false}"
 HIVE_IMAGE="${HIVE_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"
 
 function print_help() {
-  ALL_FUNCS="with_olm|from_upstream|install_dependencies|print_help"
+  ALL_FUNCS="with_olm|from_upstream|print_help"
   if [ "${DISCONNECTED}" == "true" ]; then
     echo "Usage: DISCONNECTED=true AUTHFILE=... LOCAL_REGISTRY=... bash ${0} (${ALL_FUNCS})"
   else
@@ -19,15 +19,15 @@ function print_help() {
 }
 
 if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE:-}" ]; then
-    echo "On disconnected mode, you must provide AUTHFILE env-var."
-    print_help
-    exit 1
+  echo "On disconnected mode, you must provide AUTHFILE env-var."
+  print_help
+  exit 1
 fi
 
 if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY:-}" ]; then
-    echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
-    print_help
-    exit 1
+  echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
+  print_help
+  exit 1
 fi
 
 function with_olm() {
@@ -82,23 +82,6 @@ function from_upstream() {
   wait_for_pod "hive-controllers" "hive" "control-plane=controller-manager"
 
   popd
-}
-
-function install_dependencies() {
-  echo "Installing kustomize..."
-  (cd /usr/local/bin && curl -s "https://raw.githubusercontent.com/\
-kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash)
-
-  echo "Installing golang..."
-  curl -L https://storage.googleapis.com/golang/getgo/installer_linux -o /tmp/golang_installer
-  chmod u+x /tmp/golang_installer
-  /tmp/golang_installer
-  rm /tmp/golang_installer
-
-  echo "Activating go command on current shell..."
-  set +u
-  source /root/.bash_profile
-  set -u
 }
 
 declare -F $@ || (print_help && exit 1)

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -3,7 +3,37 @@ source ${__dir}/utils.sh
 
 set -xeo pipefail
 
-cat <<EOCR | oc apply -f -
+DISCONNECTED="${DISCONNECTED:-false}"
+HIVE_IMAGE="${HIVE_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"
+
+function print_help() {
+  ALL_FUNCS="with_olm|from_upstream|install_dependencies|print_help"
+  if [ "${DISCONNECTED}" == "true" ]; then
+    echo "Usage: DISCONNECTED=true AUTHFILE=... LOCAL_REGISTRY=... bash ${0} (${ALL_FUNCS})"
+  else
+    echo "Usage: bash ${0} (${ALL_FUNCS})"
+  fi
+}
+
+if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE:-}" ]; then
+    echo "On disconnected mode, you must provide AUTHFILE env-var."
+    print_help
+    exit 1
+fi
+
+if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY:-}" ]; then
+    echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
+    print_help
+    exit 1
+fi
+
+function with_olm() {
+  if [ "${DISCONNECTED}" = "true" ]; then
+    echo "Not yet implemented"
+    return 1
+  fi
+
+  cat <<EOCR | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -16,7 +46,57 @@ spec:
   sourceNamespace: openshift-marketplace
 EOCR
 
-wait_for_operator "hive-operator" "openshift-operators"
-wait_for_crd "clusterdeployments.hive.openshift.io"
+  wait_for_operator "hive-operator" "openshift-operators"
+  wait_for_crd "clusterdeployments.hive.openshift.io"
 
-echo "Hive installed successfully!"
+  echo "Hive installed successfully!"
+}
+
+function from_upstream() {
+  HIVE_DIR="${HIVE_DIR:-${HOME}/go/src/github.com/openshift/hive}"
+
+  if [ ! -d "${HIVE_DIR}" ]; then
+    git clone https://github.com/openshift/hive.git "${HIVE_DIR}"
+  fi
+
+  pushd $HOME/go/src/github.com/openshift/hive
+  git fetch origin
+  git pull origin master
+
+  if [ "${DISCONNECTED}" = "true" ]; then
+    export IMG="${LOCAL_REGISTRY}/localimages/hive:latest"
+    oc image mirror \
+       -a ${AUTHFILE} \
+       ${HIVE_IMAGE} \
+       ${IMG}
+  else
+    export IMG="${HIVE_IMAGE}"
+  fi
+
+  make deploy
+  wait_for_pod "hive-operator" "hive" "control-plane=hive-operator"
+  wait_for_pod "hive-controllers" "hive" "control-plane=controller-manager"
+
+  popd
+}
+
+function install_dependencies() {
+  echo "Installing kustomize..."
+  (cd /usr/local/bin && curl -s "https://raw.githubusercontent.com/\
+kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash)
+
+  echo "Installing golang..."
+  curl -L https://storage.googleapis.com/golang/getgo/installer_linux -o /tmp/golang_installer
+  chmod u+x /tmp/golang_installer
+  /tmp/golang_installer
+  rm /tmp/golang_installer
+
+  echo "Activating go command on current shell..."
+  set +u
+  source /root/.bash_profile
+  set -u
+}
+
+declare -F $@ || (print_help && exit 1)
+
+"$@"

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -5,24 +5,53 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-curl --retry 5 -L "https://dl.k8s.io/release/$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
+function print_help() {
+  ALL_FUNCS="kustomize|golang|assisted_service|hive_from_upstream|print_help"
+  echo "Usage: bash ${0} (${ALL_FUNCS})"
+}
+
+function kustomize() {
+  (cd /usr/bin &&
+    curl --retry 5 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
+      | bash -s -- 3.8.8)
+}
+
+function golang() {
+  echo "Installing golang..."
+  curl -L https://storage.googleapis.com/golang/getgo/installer_linux -o /tmp/golang_installer
+  chmod u+x /tmp/golang_installer
+  /tmp/golang_installer
+  rm /tmp/golang_installer
+
+  echo "Activating go command on current shell..."
+  set +u
+  source /root/.bash_profile
+  set -u
+}
+
+function assisted_service() {
+  latest_kubectl_version=$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)
+  curl --retry 5 -L "https://dl.k8s.io/release/${latest_kubectl_version}/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
     install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
     rm -f /tmp/kubectl
-yum install -y docker libvirt-clients awscli python3-pip postgresql genisoimage && \
+  yum install -y docker libvirt-clients awscli python3-pip postgresql genisoimage && \
     yum clean all
-curl --retry 5 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | \
-    bash -s -- 3.8.8 && mv kustomize /usr/bin/
-curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.36.0
-curl --retry 5 -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
 
-ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
-OS=$(uname | awk '{print tolower($0)}')
-OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.6.2
-curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
-chmod +x operator-sdk_${OS}_${ARCH}
-install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+  kustomize
 
-go get -u github.com/onsi/ginkgo/ginkgo@v1.16.1 \
+  curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+    | sh -s -- -b $(go env GOPATH)/bin v1.36.0
+
+  curl --retry 5 -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
+
+  ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
+  OS=$(uname | awk '{print tolower($0)}')
+  OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.6.2
+  curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+  chmod +x operator-sdk_${OS}_${ARCH}
+  install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+
+  go get -u github.com/onsi/ginkgo/ginkgo@v1.16.1 \
     golang.org/x/tools/cmd/goimports@v0.1.0 \
     github.com/golang/mock/mockgen@v1.4.3 \
     github.com/vektra/mockery/.../@v1.1.2 \
@@ -31,5 +60,15 @@ go get -u github.com/onsi/ginkgo/ginkgo@v1.16.1 \
     sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 \
     github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 
-python3 -m pip install --upgrade pip
-python3 -m pip install -r ./dev-requirements.txt
+  python3 -m pip install --upgrade pip
+  python3 -m pip install -r ./dev-requirements.txt
+}
+
+function hive_from_upstream() {
+  kustomize
+  golang
+}
+
+declare -F $@ || (print_help && exit 1)
+
+"$@"


### PR DESCRIPTION
This enables hive installation with the upstream image, without OLM mechanism.
We're doing it to keep running forwards with disconnected environment testing, as hive operator doesn't currently refers to hive image using an image digest (but by a regular tag). Soon we'll fix hive operator bundle with the correct behavior.

Hive installation now supports two modes:
* ``bash setup_hive.sh with_olm`` currently not supporting disconnected environment
* ``bash setup_hive.sh from_upstream`` currently supporting both disconnected and connected environments

The flow of the new ``from_upstream`` mode:
* Clone or pull ``openshift/hive`` repo, that includes most of the internal logic for installation from upstream images
* On disconnected environment, mirror the image to a local registry. Also overriding ``IMG`` env-var to make use of the mirrored image
* Run ``make deploy`` in the ``hive`` repo. This requires ``kustomize`` and ``golang`` to be installed

Installation of the requirements is possible via ``bash setup_hive.sh install_dependencies``

/cc @YuviGold @lranjbar 