### PR TITLE
Bug 1957227: Allow overriding defaults via provided ConfigMap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -126,6 +126,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -288,6 +288,18 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - persistentvolumeclaims
           verbs:
           - create

--- a/deploy/olm-catalog/metadata/annotations.yaml
+++ b/deploy/olm-catalog/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: assisted-service-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,ocm-2.3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -201,6 +201,14 @@ metadata:
 EOF
 ```
 
+**NOTE**
+
+After modifying content of the ConfigMap a new rollout of the Deployment has to be forced. This can be done with
+
+```bash
+oc rollout restart deployment/assisted-service
+```
+
 ### Mirror Registry Configuration
 
 In case user wants to create an installation that uses mirror registry, the following must be executed:
@@ -225,19 +233,19 @@ data:
 
   registries.conf: |
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
-    
+
     [[registry]]
        prefix = ""
        location = "quay.io/ocpmetal"
        mirror-by-digest-only = false
-    
+
        [[registry.mirror]]
        location = "bm-cluster-1-hyper.e2e.bos.redhat.com:5000/ocpmetal"
 EOF
 ```
 
    Note1: ConfigMap should be installed in the same namespace as the assisted-service-operator (ie. `assisted-installer`).
-   
+
    Note2: registry.conf supplied should use "mirror-by-digest-only = false" mode
 
 2. set the mirrorRegistryRef in the spec of AgentServiceConfig to the name of uploaded ConfigMap. Example:


### PR DESCRIPTION
This PR fixes a bug where a custom ConfigMap configured via the
annotation
`unsupported.agent-install.openshift.io/assisted-service-configmap`
allowed to define additional variables, but did not allow to override
the ones provided by default by the service. This was causing a
confusion in scenario when custom ConfigMap contained e.g.

```
SERVE_HTTPS: 'False'
```

but the real state of the deployment was not reflecting it correctly

```
oc rsh deployment/assisted-service
env | grep SERVE_HTTPS

SERVE_HTTPS=True
```

With this PR we are creating a ConfigMap with all the service defaults.
When creating a service container, EnvFrom field will be populated with
both default ConfigMap as well as the one created manually (if present).
In order to simplify the logic, service secrets are not mounted via
EnvFrom but via Env.

This change gives customer an ability to override an arbitrary value
without taking ownership of the whole configuration.

The initial issue was caused by the order of applying variables by
Kubernetes, i.e. Env always taking precedence over EnvFrom.

Closes: [OCPBUGSM-28781](https://issues.redhat.com/browse/OCPBUGSM-28781)