### PR TITLE
MGMT-5415: Adding filter to GET /clusters API.

### DIFF
--- a/client/installer/list_clusters_parameters.go
+++ b/client/installer/list_clusters_parameters.go
@@ -73,6 +73,11 @@ for the list clusters operation typically these are written to a http.Request
 */
 type ListClustersParams struct {
 
+	/*AmsSubscriptionIds
+	  If non-empty, returned Clusters are filtered to those with matching subscription IDs.
+
+	*/
+	AmsSubscriptionIds []string
 	/*GetUnregisteredClusters
 	  Whether to return clusters that have been unregistered.
 
@@ -122,6 +127,17 @@ func (o *ListClustersParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAmsSubscriptionIds adds the amsSubscriptionIds to the list clusters params
+func (o *ListClustersParams) WithAmsSubscriptionIds(amsSubscriptionIds []string) *ListClustersParams {
+	o.SetAmsSubscriptionIds(amsSubscriptionIds)
+	return o
+}
+
+// SetAmsSubscriptionIds adds the amsSubscriptionIds to the list clusters params
+func (o *ListClustersParams) SetAmsSubscriptionIds(amsSubscriptionIds []string) {
+	o.AmsSubscriptionIds = amsSubscriptionIds
+}
+
 // WithGetUnregisteredClusters adds the getUnregisteredClusters to the list clusters params
 func (o *ListClustersParams) WithGetUnregisteredClusters(getUnregisteredClusters *bool) *ListClustersParams {
 	o.SetGetUnregisteredClusters(getUnregisteredClusters)
@@ -151,6 +167,14 @@ func (o *ListClustersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
+
+	valuesAmsSubscriptionIds := o.AmsSubscriptionIds
+
+	joinedAmsSubscriptionIds := swag.JoinByFormat(valuesAmsSubscriptionIds, "")
+	// query array param ams_subscription_ids
+	if err := r.SetQueryParam("ams_subscription_ids", joinedAmsSubscriptionIds...); err != nil {
+		return err
+	}
 
 	if o.GetUnregisteredClusters != nil {
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2342,6 +2342,10 @@ func (b *bareMetalInventory) ListClusters(ctx context.Context, params installer.
 		whereCondition += fmt.Sprintf(" AND openshift_cluster_id = '%s'", *params.OpenshiftClusterID)
 	}
 
+	if len(params.AmsSubscriptionIds) > 0 {
+		whereCondition += fmt.Sprintf(" AND ams_subscription_id IN %s", common.ToSqlList(params.AmsSubscriptionIds))
+	}
+
 	dbClusters, err := common.GetClustersFromDBWhere(db, common.UseEagerLoading,
 		common.DeleteRecordsState(swag.BoolValue(params.GetUnregisteredClusters)), whereCondition)
 	if err != nil {

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -173,4 +175,10 @@ func (c *Cluster) AfterFind(db *gorm.DB) error {
 	}
 	c.TotalHostCount = int64(len(c.Hosts))
 	return nil
+}
+
+func ToSqlList(strs []string) string {
+	res := strings.Join(strs, `', '`)
+	res = fmt.Sprintf("('%s')", res)
+	return res
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -344,6 +344,15 @@ func init() {
             "description": "A specific cluster to retrieve.",
             "name": "openshift_cluster_id",
             "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If non-empty, returned Clusters are filtered to those with matching subscription IDs.",
+            "name": "ams_subscription_ids",
+            "in": "query"
           }
         ],
         "responses": {
@@ -7958,6 +7967,15 @@ func init() {
             "format": "uuid",
             "description": "A specific cluster to retrieve.",
             "name": "openshift_cluster_id",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If non-empty, returned Clusters are filtered to those with matching subscription IDs.",
+            "name": "ams_subscription_ids",
             "in": "query"
           }
         ],

--- a/restapi/operations/installer/list_clusters_urlbuilder.go
+++ b/restapi/operations/installer/list_clusters_urlbuilder.go
@@ -11,10 +11,12 @@ import (
 	golangswaggerpaths "path"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // ListClustersURL generates an URL for the list clusters operation
 type ListClustersURL struct {
+	AmsSubscriptionIds []string
 	OpenshiftClusterID *strfmt.UUID
 
 	_basePath string
@@ -50,6 +52,23 @@ func (o *ListClustersURL) Build() (*url.URL, error) {
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 
 	qs := make(url.Values)
+
+	var amsSubscriptionIdsIR []string
+	for _, amsSubscriptionIdsI := range o.AmsSubscriptionIds {
+		amsSubscriptionIdsIS := amsSubscriptionIdsI
+		if amsSubscriptionIdsIS != "" {
+			amsSubscriptionIdsIR = append(amsSubscriptionIdsIR, amsSubscriptionIdsIS)
+		}
+	}
+
+	amsSubscriptionIds := swag.JoinByFormat(amsSubscriptionIdsIR, "")
+
+	if len(amsSubscriptionIds) > 0 {
+		qsv := amsSubscriptionIds[0]
+		if qsv != "" {
+			qs.Set("ams_subscription_ids", qsv)
+		}
+	}
 
 	var openshiftClusterIDQ string
 	if o.OpenshiftClusterID != nil {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -113,6 +113,13 @@ paths:
           type: string
           format: uuid
           required: false
+        - in: query
+          name: ams_subscription_ids
+          description: If non-empty, returned Clusters are filtered to those with matching subscription IDs.
+          required: false
+          type: array
+          items:
+            type: string
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
UI needs the option to fetch clusters based on a list of AMS
subscription IDs instead of getting a full list of cluster each time and
filter them one by one.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>