### PR TITLE
MGMT-6001 Misleading status after prepare-for-install error

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -712,7 +712,7 @@ func (m *Manager) HandlePreInstallError(ctx context.Context, c *common.Cluster, 
 		log.WithError(err).Errorf("Failed to handle pre installation error for cluster %s", c.ID.String())
 	} else {
 		log.Infof("Successfully handled pre-installation error, cluster %s", c.ID.String())
-		m.eventsHandler.AddEvent(ctx, *c.ID, nil, models.EventSeverityWarning, "Failed to prepare cluster for installation. Please retry later", time.Now())
+		m.eventsHandler.AddEvent(ctx, *c.ID, nil, models.EventSeverityWarning, "Failed to prepare the installation due to an unexpected error. Please retry later", time.Now())
 	}
 }
 

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -27,7 +27,6 @@ const (
 	statusInfoResettingPendingUserAction                       = "Host requires booting into the discovery image to complete resetting the installation"
 	statusInfoPreparingForInstallation                         = "Host is preparing for installation"
 	statusInfoHostPreparationSuccessful                        = "Host finished successfully to prepare for installation"
-	statusInfoClusterIsNotPreparing                            = "Host failed to prepare for installation because cluster failed to prepare for installation"
 	statusInfoAbortingDueClusterErrors                         = "Host is part of a cluster that failed to install"
 	statusInfoInstallationTimedOut                             = "Host failed to install due to timeout while starting installation"
 	statusInfoConnectionTimedOut                               = "Host failed to install due to timeout while connecting to host"

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1031,7 +1031,7 @@ func (m *Manager) ResetHostValidation(ctx context.Context, hostID, clusterID str
 	log := logutil.FromContext(ctx, m.log)
 	host := &h.Host
 	switch validationID {
-	case string(models.HostValidationIDSufficientOrUnknownInstallationDiskSpeed):
+	case string(models.HostValidationIDSufficientInstallationDiskSpeed):
 		return m.resetDiskSpeedValidation(host, log, db)
 	case string(models.HostValidationIDContainerImagesAvailable):
 		return m.resetContainerImagesValidation(host, db)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2355,7 +2355,7 @@ var _ = Describe("ResetHostValidation", func() {
 		var newHost models.Host
 		Expect(db.Take(&newHost, "id = ? and cluster_id = ?", h.ID.String(), h.ClusterID.String()).Error).ToNot(HaveOccurred())
 		verifyExistingDiskResult(&newHost, "/dev/sda", 5, 2)
-		Expect(m.ResetHostValidation(ctx, *h.ID, h.ClusterID, string(models.HostValidationIDSufficientOrUnknownInstallationDiskSpeed), nil)).ToNot(HaveOccurred())
+		Expect(m.ResetHostValidation(ctx, *h.ID, h.ClusterID, string(models.HostValidationIDSufficientInstallationDiskSpeed), nil)).ToNot(HaveOccurred())
 		Expect(db.Take(&newHost, "id = ? and cluster_id = ?", h.ID.String(), h.ClusterID.String()).Error).ToNot(HaveOccurred())
 		verifyNonExistentDiskResult(&newHost, "/dev/sda")
 	})

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -358,7 +358,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		},
 		Condition:        stateswitch.And(If(IsConnected), allConditionsSuccessfulOrUnknown, stateswitch.Not(If(ClusterPreparingForInstallation))),
 		DestinationState: stateswitch.State(models.HostStatusKnown),
-		PostTransition:   th.PostRefreshHost(statusInfoClusterIsNotPreparing),
+		PostTransition:   th.PostRefreshHost(statusInfoKnown),
 	})
 
 	sm.AddTransition(stateswitch.TransitionRule{
@@ -377,7 +377,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 		},
 		Condition:        stateswitch.And(If(IsConnected), stateswitch.Not(stateswitch.Or(If(ClusterPreparingForInstallation), If(ClusterInstalling)))),
 		DestinationState: stateswitch.State(models.HostStatusKnown),
-		PostTransition:   th.PostRefreshHost(statusInfoClusterIsNotPreparing),
+		PostTransition:   th.PostRefreshHost(statusInfoKnown),
 	})
 
 	sm.AddTransition(stateswitch.TransitionRule{

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1947,7 +1947,7 @@ var _ = Describe("Refresh Host", func() {
 				validCheckInTime:  true,
 				dstState:          models.HostStatusKnown,
 				clusterState:      models.ClusterStatusInsufficient,
-				statusInfoChecker: makeValueChecker(statusInfoClusterIsNotPreparing),
+				statusInfoChecker: makeValueChecker(statusInfoKnown),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
 					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationSuccess, messagePattern: "Speed of installation disk has not yet been measured"},
 					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
@@ -1958,7 +1958,7 @@ var _ = Describe("Refresh Host", func() {
 				validCheckInTime:  true,
 				dstState:          models.HostStatusKnown,
 				clusterState:      models.ClusterStatusInsufficient,
-				statusInfoChecker: makeValueChecker(statusInfoClusterIsNotPreparing),
+				statusInfoChecker: makeValueChecker(statusInfoKnown),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
 					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationSuccess, messagePattern: "Speed of installation disk is sufficient"},
 					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
@@ -1970,9 +1970,9 @@ var _ = Describe("Refresh Host", func() {
 				validCheckInTime:  true,
 				dstState:          models.HostStatusInsufficient,
 				clusterState:      models.ClusterStatusPreparingForInstallation,
-				statusInfoChecker: makeRegexChecker("Host cannot be installed due to following failing validation.*Insufficient disk speed or error occurred during disk speed measurement"),
+				statusInfoChecker: makeRegexChecker("Host cannot be installed due to following failing validation.*While preparing the previous installation the installation disk speed measurement failed or was found to be insufficient"),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
-					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationFailure, messagePattern: "Insufficient disk speed or error occurred during disk speed measurement"},
+					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationFailure, messagePattern: "While preparing the previous installation the installation disk speed measurement failed or was found to be insufficient"},
 					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
 				}),
 				disksInfo: createDiskInfo("/dev/sda", 0, -1),
@@ -2092,7 +2092,7 @@ var _ = Describe("Refresh Host", func() {
 				validCheckInTime:  true,
 				dstState:          models.HostStatusKnown,
 				clusterState:      models.ClusterStatusInsufficient,
-				statusInfoChecker: makeValueChecker(statusInfoClusterIsNotPreparing),
+				statusInfoChecker: makeValueChecker(statusInfoKnown),
 			},
 		}
 		for i := range tests {
@@ -2861,7 +2861,7 @@ var _ = Describe("Refresh Host", func() {
 					IsHostnameValid:      {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
 					IsNTPSynced:          {status: ValidationSuccess, messagePattern: "Host NTP is synced"},
 					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
-					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationFailure, messagePattern: "Insufficient disk speed or error occurred during disk speed measurement"},
+					SufficientOrUnknownInstallationDiskSpeed:       {status: ValidationFailure, messagePattern: "While preparing the previous installation the installation disk speed measurement failed or was found to be insufficient"},
 				}),
 				inventory:     hostutil.GenerateMasterInventory(),
 				disksInfo:     createDiskInfo("/dev/sda", 0, -1),
@@ -3320,7 +3320,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "Timeout",
 				dstState:      models.HostStatusKnown,
-				statusInfo:    statusInfoClusterIsNotPreparing,
+				statusInfo:    statusInfoKnown,
 				clusterStatus: models.ClusterStatusInstalled,
 			},
 		}

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -30,7 +30,7 @@ const (
 	AreLsoRequirementsSatisfied                    = validationID(models.HostValidationIDLsoRequirementsSatisfied)
 	AreOcsRequirementsSatisfied                    = validationID(models.HostValidationIDOcsRequirementsSatisfied)
 	AreCnvRequirementsSatisfied                    = validationID(models.HostValidationIDCnvRequirementsSatisfied)
-	SufficientOrUnknownInstallationDiskSpeed       = validationID(models.HostValidationIDSufficientOrUnknownInstallationDiskSpeed)
+	SufficientOrUnknownInstallationDiskSpeed       = validationID(models.HostValidationIDSufficientInstallationDiskSpeed)
 )
 
 func (v validationID) category() (string, error) {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -639,7 +639,7 @@ func (v *validator) printSufficientOrUnknownInstallationDiskSpeed(c *validationC
 		}
 		return "Speed of installation disk is sufficient"
 	case ValidationFailure:
-		return "Insufficient disk speed or error occurred during disk speed measurement"
+		return "While preparing the previous installation the installation disk speed measurement failed or was found to be insufficient"
 	case ValidationError:
 		return "Error occured while getting boot device"
 	default:

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -74,8 +74,8 @@ const (
 	// HostValidationIDOcsRequirementsSatisfied captures enum value "ocs-requirements-satisfied"
 	HostValidationIDOcsRequirementsSatisfied HostValidationID = "ocs-requirements-satisfied"
 
-	// HostValidationIDSufficientOrUnknownInstallationDiskSpeed captures enum value "sufficient-or-unknown-installation-disk-speed"
-	HostValidationIDSufficientOrUnknownInstallationDiskSpeed HostValidationID = "sufficient-or-unknown-installation-disk-speed"
+	// HostValidationIDSufficientInstallationDiskSpeed captures enum value "sufficient-installation-disk-speed"
+	HostValidationIDSufficientInstallationDiskSpeed HostValidationID = "sufficient-installation-disk-speed"
 
 	// HostValidationIDCnvRequirementsSatisfied captures enum value "cnv-requirements-satisfied"
 	HostValidationIDCnvRequirementsSatisfied HostValidationID = "cnv-requirements-satisfied"
@@ -86,7 +86,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-or-unknown-installation-disk-speed","cnv-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6689,7 +6689,7 @@ func init() {
         "container-images-available",
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
-        "sufficient-or-unknown-installation-disk-speed",
+        "sufficient-installation-disk-speed",
         "cnv-requirements-satisfied"
       ]
     },
@@ -14372,7 +14372,7 @@ func init() {
         "container-images-available",
         "lso-requirements-satisfied",
         "ocs-requirements-satisfied",
-        "sufficient-or-unknown-installation-disk-speed",
+        "sufficient-installation-disk-speed",
         "cnv-requirements-satisfied"
       ]
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4985,7 +4985,7 @@ definitions:
       - 'container-images-available'
       - 'lso-requirements-satisfied'
       - 'ocs-requirements-satisfied'
-      - 'sufficient-or-unknown-installation-disk-speed'
+      - 'sufficient-installation-disk-speed'
       - 'cnv-requirements-satisfied'
 
   dhcp_allocation_request:


### PR DESCRIPTION
- Remove status info "Host failed to prepare for installation because cluster failed to prepare for installation".  Instead use status-info-known.
- Change event when cluster preparation failed "Failed to prepare cluster for installation. Please retry later" to "Failed to prepare cluster for installation. Something went wrong on our side, please retry later"
- Change validation-id "sufficient-or-unknown-installation-disk-speed" to "sufficient-installation-disk-speed"  (remove unknown).

/cc @avishayt 