### PR TITLE
NO-ISSUE Add examples to the contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,65 @@ Organized history and to create a CHANGE LOG for each version.
 
 ### How does it work?
 
+[This script](https://github.com/openshift/assisted-service/blob/master/tools/check-commit-message.sh#L7) checks for a valid issue (JIRA or GitHub) reference and fails the build otherwise with the message
+
 ```bash
-valid_commit_regex='^([A-Z]+-[0-9]+|#[0-9]+|merge|no-issue)'
-
-error_msg="""Aborting commit.
-Your commit message is missing a prefix of either a JIRA issue ('JIRA-1111'), a GitHub issue ('#39') or 'Merge'.
-You can ignore the ticket by prefixing with 'NO-ISSUE'.
-
-Your message is preserved at '${commit_file}'
-"""
+Your commit message is missing either a JIRA issue ('JIRA-1111'), a GitHub issue ('#39').
+You can also ignore the ticket checking with 'NO-ISSUE'.
 ```
 
-It will search for a commit message starting with a valid JIRA/GitHub issue notation or "NO-ISSUE" in case there's no ticket.
+It will search for a commit message containing a valid JIRA/GitHub issue notation or "NO-ISSUE" in case there's no ticket.
+
+### Bugzilla references
+
+The openshift-ci bot looks for `Bug XXX:` in the title of the pull request in order to reference the GitHub PR in the tracker.
+
+### Examples
+
+1. JIRA reference without a Bugzilla link
+
+```
+MGMT-6075 Implement ResetHostValidation API call
+```
+
+2. No reference
+
+```
+NO-ISSUE allow GitHub-created reverts to be used
+```
+
+3. Bugzilla and JIRA reference
+
+```
+Bug 1957227: Allow overriding defaults via provided ConfigMap
+
+[...]
+
+Closes: OCPBUGSM-28781
+```
+
+**NOTE**
+
+For this commit the following is also correct, but the PR is not automatically linked with the bug tracker. Linking only to Bugzilla without referencing JIRA is not correct.
+
+```
+OCPBUGSM-28781 Allow overriding defaults via provided ConfigMap
+```
+
+4. GitHub reference
+
+```
+#1 Fixing the very first GitHub issue
+```
+
+**NOTE**
+
+The following is also correct
+
+```
+Fixing the very first GitHub issue
+
+[...]
+
+Closes: #1
+```


### PR DESCRIPTION
This PR adds some examples to the contributor guide explaining commit
messages that pass CI checks for the correctness regarding JIRA and
Bugzilla trackers.