### PR TITLE
MGMT-6438 Removed deprecated requirements env variables.

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -76,10 +76,6 @@ function generate_configuration() {
     docker run --rm -v ${__root}/config/onprem-iso-fcc.yaml:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict /config.fcc > ${__root}/config/onprem-iso-config.ign
 }
 
-function generate_ocp_version() {
-  generate_configuration
-}
-
 # Generate manifests e.g. CRD, RBAC etc.
 function generate_manifests() {
     if [ "${ENABLE_KUBE_API:-}" != "true" ]; then exit 0; fi

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1492,13 +1492,21 @@ var _ = Describe("PostStepReply", func() {
 				ClusterID: *clusterId,
 				Status:    swag.String("discovering"),
 			}
+
+			cluster := common.Cluster{Cluster: models.Cluster{
+				ID:               clusterId,
+				PullSecretSet:    true,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+			}, PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"}
+
+			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		})
 
 		It("Disk speed success", func() {
 			mockHostApi.EXPECT().SetDiskSpeed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs().Return(int64(10)).Times(1)
+			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(10), nil).Times(1)
 			params := makeStepReply(*clusterId, *hostId, "/dev/sda", 5, 0)
 			reply := bm.PostStepReply(ctx, params)
 			Expect(reply).Should(BeAssignableToTypeOf(installer.NewPostStepReplyNoContent()))

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -50,20 +50,6 @@ func (mr *MockValidatorMockRecorder) GetHostValidDisks(host interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostValidDisks", reflect.TypeOf((*MockValidator)(nil).GetHostValidDisks), host)
 }
 
-// GetHostRequirements mocks base method
-func (m *MockValidator) GetHostRequirements(singleNodeCluster bool) *models.VersionedHostRequirements {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostRequirements", singleNodeCluster)
-	ret0, _ := ret[0].(*models.VersionedHostRequirements)
-	return ret0
-}
-
-// GetHostRequirements indicates an expected call of GetHostRequirements
-func (mr *MockValidatorMockRecorder) GetHostRequirements(singleNodeCluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostRequirements", reflect.TypeOf((*MockValidator)(nil).GetHostRequirements), singleNodeCluster)
-}
-
 // GetHostInstallationPath mocks base method
 func (m *MockValidator) GetHostInstallationPath(host *models.Host) string {
 	m.ctrl.T.Helper()
@@ -123,17 +109,18 @@ func (mr *MockValidatorMockRecorder) ListEligibleDisks(inventory interface{}) *g
 }
 
 // GetInstallationDiskSpeedThresholdMs mocks base method
-func (m *MockValidator) GetInstallationDiskSpeedThresholdMs() int64 {
+func (m *MockValidator) GetInstallationDiskSpeedThresholdMs(ctx context.Context, cluster *common.Cluster, host *models.Host) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstallationDiskSpeedThresholdMs")
+	ret := m.ctrl.Call(m, "GetInstallationDiskSpeedThresholdMs", ctx, cluster, host)
 	ret0, _ := ret[0].(int64)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetInstallationDiskSpeedThresholdMs indicates an expected call of GetInstallationDiskSpeedThresholdMs
-func (mr *MockValidatorMockRecorder) GetInstallationDiskSpeedThresholdMs() *gomock.Call {
+func (mr *MockValidatorMockRecorder) GetInstallationDiskSpeedThresholdMs(ctx, cluster, host interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallationDiskSpeedThresholdMs", reflect.TypeOf((*MockValidator)(nil).GetInstallationDiskSpeedThresholdMs))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallationDiskSpeedThresholdMs", reflect.TypeOf((*MockValidator)(nil).GetInstallationDiskSpeedThresholdMs), ctx, cluster, host)
 }
 
 // GetPreflightHardwareRequirements mocks base method

--- a/internal/hardware/versioned-requirements.go
+++ b/internal/hardware/versioned-requirements.go
@@ -13,11 +13,11 @@ type VersionedRequirementsDecoder map[string]models.VersionedHostRequirements
 
 func (d *VersionedRequirementsDecoder) GetVersionedHostRequirements(version string) (*models.VersionedHostRequirements, error) {
 	if requirements, ok := (*d)[version]; ok {
-		return &requirements, nil
+		return copyVersionedHostRequirements(&requirements), nil
 	}
 
 	if requirements, ok := (*d)[DefaultVersion]; ok {
-		return &requirements, nil
+		return copyVersionedHostRequirements(&requirements), nil
 	}
 	return nil, fmt.Errorf("requirements for version %v not found", version)
 }
@@ -68,4 +68,21 @@ func validateDetails(details *models.ClusterHostRequirementsDetails, version str
 		return fmt.Errorf("CPU cores requirement must not be negative for version %v and %v role", version, role)
 	}
 	return nil
+}
+
+func copyVersionedHostRequirements(requirements *models.VersionedHostRequirements) *models.VersionedHostRequirements {
+	return &models.VersionedHostRequirements{
+		Version:            requirements.Version,
+		MasterRequirements: copyClusterHostRequirementsDetails(requirements.MasterRequirements),
+		WorkerRequirements: copyClusterHostRequirementsDetails(requirements.WorkerRequirements),
+	}
+}
+
+func copyClusterHostRequirementsDetails(details *models.ClusterHostRequirementsDetails) *models.ClusterHostRequirementsDetails {
+	return &models.ClusterHostRequirementsDetails{
+		CPUCores:                         details.CPUCores,
+		DiskSizeGb:                       details.DiskSizeGb,
+		InstallationDiskSpeedThresholdMs: details.InstallationDiskSpeedThresholdMs,
+		RAMMib:                           details.RAMMib,
+	}
 }

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -32,13 +32,25 @@ import (
 
 func createValidatorCfg() *hardware.ValidatorCfg {
 	return &hardware.ValidatorCfg{
+		VersionedRequirements: hardware.VersionedRequirementsDecoder{
+			"default": {
+				Version: "default",
+				MasterRequirements: &models.ClusterHostRequirementsDetails{
+					CPUCores:                         4,
+					RAMMib:                           16384,
+					DiskSizeGb:                       120,
+					InstallationDiskSpeedThresholdMs: 10,
+				},
+				WorkerRequirements: &models.ClusterHostRequirementsDetails{
+					CPUCores:                         2,
+					RAMMib:                           8192,
+					DiskSizeGb:                       120,
+					InstallationDiskSpeedThresholdMs: 10,
+				},
+			},
+		},
 		MinCPUCores:                   2,
-		MinCPUCoresWorker:             2,
-		MinCPUCoresMaster:             4,
-		MinDiskSizeGb:                 120,
 		MinRamGib:                     8,
-		MinRamGibWorker:               8,
-		MinRamGibMaster:               16,
 		MaximumAllowedTimeDiffMinutes: 4,
 	}
 }


### PR DESCRIPTION
Following environments variables support have been removed:
 - HW_VALIDATOR_MIN_CPU_CORES_WORKER
 - HW_VALIDATOR_MIN_CPU_CORES_MASTER
 - HW_VALIDATOR_MIN_RAM_GIB_WORKER
 - HW_VALIDATOR_MIN_RAM_GIB_MASTER
 - HW_VALIDATOR_MIN_DISK_SIZE_GIB
 - HW_INSTALLATION_DISK_SPEED_THRESHOLD_MS

The requirements customization can be made through `HW_VALIDATOR_REQUIREMENTS`.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>