### PR TITLE
MGMT-6282: Split openshift_cluster_id and status 'Active' update in AMS.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1098,13 +1098,13 @@ func (b *bareMetalInventory) refreshAllHosts(ctx context.Context, cluster *commo
 	return nil
 }
 
-func (b *bareMetalInventory) storeOpenshiftClusterID(ctx context.Context, clusterID string) error {
+func (b *bareMetalInventory) storeOpenshiftClusterID(ctx context.Context, clusterID string) (string, error) {
 	log := logutil.FromContext(ctx, b.log)
 	log.Debug("Downloading bootstrap ignition file")
 	reader, _, err := b.objectHandler.Download(ctx, fmt.Sprintf("%s/%s", clusterID, "bootstrap.ign"))
 	if err != nil {
 		log.WithError(err).Error("Failed downloading bootstrap ignition file")
-		return err
+		return "", err
 	}
 
 	var openshiftClusterID string
@@ -1112,7 +1112,7 @@ func (b *bareMetalInventory) storeOpenshiftClusterID(ctx context.Context, cluste
 	openshiftClusterID, err = ignition.ExtractClusterID(reader)
 	if err != nil {
 		log.WithError(err).Error("Failed extracting Openshift cluster ID from ignition file")
-		return err
+		return "", err
 	}
 	log.Debugf("Got OpenShift cluster ID of %s", openshiftClusterID)
 
@@ -1120,10 +1120,10 @@ func (b *bareMetalInventory) storeOpenshiftClusterID(ctx context.Context, cluste
 	if err = b.db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update(
 		"openshift_cluster_id", openshiftClusterID).Error; err != nil {
 		log.WithError(err).Errorf("Failed storing Openshift cluster ID of cluster %s to DB", clusterID)
-		return err
+		return "", err
 	}
 
-	return nil
+	return openshiftClusterID, nil
 }
 
 func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installer.InstallClusterParams) middleware.Responder {
@@ -1132,6 +1132,16 @@ func (b *bareMetalInventory) InstallCluster(ctx context.Context, params installe
 		return common.GenerateErrorResponder(err)
 	}
 	return installer.NewInstallClusterAccepted().WithPayload(&c.Cluster)
+}
+
+func (b *bareMetalInventory) integrateWithAMSClusterPreInstallation(ctx context.Context, amsSubscriptionID, openshiftClusterID strfmt.UUID) error {
+	log := logutil.FromContext(ctx, b.log)
+	log.Infof("Updating AMS subscription %s with openshift cluster ID %s", amsSubscriptionID, openshiftClusterID)
+	if err := b.ocmClient.AccountsMgmt.UpdateSubscriptionOpenshiftClusterID(ctx, amsSubscriptionID, openshiftClusterID); err != nil {
+		log.WithError(err).Errorf("Failed to update AMS subscription with openshift cluster ID %s", openshiftClusterID)
+		return err
+	}
+	return nil
 }
 
 func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params installer.InstallClusterParams) (*common.Cluster, error) {
@@ -1224,7 +1234,17 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 		log.Infof("generated ignition for cluster %s", cluster.ID.String())
 
 		log.Infof("Storing OpenShift cluster ID of cluster %s to DB", cluster.ID.String())
-		err = b.storeOpenshiftClusterID(ctx, cluster.ID.String())
+		var openshiftClusterID string
+		if openshiftClusterID, err = b.storeOpenshiftClusterID(ctx, cluster.ID.String()); err != nil {
+			return
+		}
+
+		if b.ocmClient != nil && b.ocmClient.Config.WithAMSSubscriptions {
+			if err = b.integrateWithAMSClusterPreInstallation(asyncCtx, cluster.AmsSubscriptionID, strfmt.UUID(openshiftClusterID)); err != nil {
+				log.WithError(err).Errorf("Cluster %s failed to integrate with AMS on cluster pre installation", params.ClusterID)
+				return
+			}
+		}
 	}()
 
 	log.Infof("Successfully prepared cluster <%s> for installation", params.ClusterID.String())

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2279,6 +2279,69 @@ var _ = Describe("cluster", func() {
 			Expect(actual.Payload.MachineNetworkCidr).To(Equal(wrongMachineCidr))
 		})
 
+		It("update cluster day1 with APIVipDNSName failed", func() {
+			mockOperators := operators.NewMockAPI(ctrl)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
+
+			mockClusterRegisterSuccess(bm, true)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String("some-cluster-name"),
+					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+			c, err := bm.getCluster(ctx, actual.Payload.ID.String())
+			Expect(err).ToNot(HaveOccurred())
+
+			newClusterName := "day1-cluster-new-name"
+
+			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: *c.ID,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					Name:          &newClusterName,
+					APIVipDNSName: swag.String("some dns name"),
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.Errorf("error"))))
+		})
+
+		It("cluster update failure on inventory refresh failure", func() {
+			mockOperators := operators.NewMockAPI(ctrl)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
+
+			mockClusterRegisterSuccess(bm, true)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String("some-cluster-name"),
+					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+
+			clusterId := *actual.Payload.ID
+			addHost(strfmt.UUID(uuid.New().String()), models.HostRoleMaster, "known", models.HostKindHost, clusterId, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
+			newClusterName := "new-cluster-name"
+
+			refreshError := errors.New("boom!")
+			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(refreshError)
+
+			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: clusterId,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					Name: &newClusterName,
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+			Expect(reply.(*common.ApiErrorResponse).Error()).To(BeEquivalentTo(refreshError.Error()))
+		})
+
 		Context("Monitored Operators", func() {
 			var (
 				testOLMOperators = []*models.MonitoredOperator{
@@ -5933,37 +5996,6 @@ var _ = Describe("AMS subscriptions", func() {
 			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
 		})
 
-		It("update cluster day1 with APIVipDNSName failed", func() {
-			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
-
-			mockClusterRegisterSuccess(bm, true)
-			mockAMSSubscription(ctx)
-
-			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
-				NewClusterParams: &models.ClusterCreateParams{
-					Name:             swag.String(clusterName),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
-					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
-				},
-			})
-			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
-			actual := reply.(*installer.RegisterClusterCreated)
-			c, err := bm.getCluster(ctx, actual.Payload.ID.String())
-			Expect(err).ToNot(HaveOccurred())
-
-			newClusterName := "day1-cluster-new-name"
-
-			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
-				ClusterID: *c.ID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					Name:          &newClusterName,
-					APIVipDNSName: swag.String("some dns name"),
-				},
-			})
-			Expect(reply).To(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.Errorf("error"))))
-		})
-
 		It("update cluster name with same name", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
@@ -6031,6 +6063,84 @@ var _ = Describe("AMS subscriptions", func() {
 			Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
 		})
 
+		tests := []struct {
+			status string
+		}{
+			{status: "succeed"},
+			{status: "failed"},
+		}
+
+		for i := range tests {
+			test := tests[i]
+
+			ignitionReader := ioutil.NopCloser(strings.NewReader(`{
+					"ignition":{"version":"3.1.0"},
+					"storage":{
+						"files":[
+							{
+								"path":"/opt/openshift/manifests/cvo-overrides.yaml",
+								"contents":{
+									"source":"data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogY29uZmlnLm9wZW5zaGlmdC5pby92MQpraW5kOiBDbHVzdGVyVmVyc2lvbgptZXRhZGF0YToKICBuYW1lc3BhY2U6IG9wZW5zaGlmdC1jbHVzdGVyLXZlcnNpb24KICBuYW1lOiB2ZXJzaW9uCnNwZWM6CiAgdXBzdHJlYW06IGh0dHBzOi8vYXBpLm9wZW5zaGlmdC5jb20vYXBpL3VwZ3JhZGVzX2luZm8vdjEvZ3JhcGgKICBjaGFubmVsOiBzdGFibGUtNC42CiAgY2x1c3RlcklEOiA0MTk0MGVlOC1lYzk5LTQzZGUtODc2Ni0xNzQzODFiNDkyMWQK"
+								}
+							}
+						]
+					},
+					"systemd":{}
+			}`))
+
+			It(fmt.Sprintf("InstallCluster %s to update openshift_cluster_id in AMS", test.status), func() {
+
+				doneChannel := make(chan int)
+				waitForDoneChannel := func() {
+					select {
+					case <-doneChannel:
+						break
+					case <-time.After(1 * time.Second):
+						panic("not all api calls where made")
+					}
+				}
+
+				bm.clusterApi = mockClusterApi
+				clusterID := strfmt.UUID(uuid.New().String())
+
+				By("register cluster", func() {
+					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+						ID:               &clusterID,
+						OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+						Status:           swag.String(models.ClusterStatusReady),
+					}}).Error
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				By("install cluster", func() {
+					mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
+					mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+					mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "")
+					mockClusterApi.EXPECT().PrepareForInstallation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+					masterHostId := strfmt.UUID(uuid.New().String())
+					mockClusterApi.EXPECT().GetMasterNodesIds(ctx, gomock.Any(), gomock.Any()).Return([]*strfmt.UUID{&masterHostId, &masterHostId, &masterHostId}, nil)
+					mockClusterApi.EXPECT().GenerateAdditionalManifests(gomock.Any(), gomock.Any()).Return(nil)
+					mockClusterApi.EXPECT().DeleteClusterLogs(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+					mockGetInstallConfigSuccess(mockInstallConfigBuilder)
+					mockGenerateInstallConfigSuccess(mockGenerator, mockVersions)
+					mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(ignitionReader, int64(0), nil).MinTimes(0)
+					if test.status == "succeed" {
+						mockAccountsMgmt.EXPECT().UpdateSubscriptionOpenshiftClusterID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+						mockClusterApi.EXPECT().HandlePreInstallSuccess(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx, c interface{}) { doneChannel <- 1 })
+					} else {
+						mockAccountsMgmt.EXPECT().UpdateSubscriptionOpenshiftClusterID(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("dummy"))
+						mockClusterApi.EXPECT().HandlePreInstallError(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Do(func(ctx, c, err interface{}) { doneChannel <- 1 })
+					}
+
+					reply := bm.InstallCluster(ctx, installer.InstallClusterParams{
+						ClusterID: clusterID,
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewInstallClusterAccepted()))
+					waitForDoneChannel()
+				})
+			})
+		}
+
 		It("register and deregister cluster happy flow - nil OCM client", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
@@ -6054,40 +6164,6 @@ var _ = Describe("AMS subscriptions", func() {
 
 			reply = bm.DeregisterCluster(ctx, installer.DeregisterClusterParams{ClusterID: clusterID})
 			Expect(reply).Should(BeAssignableToTypeOf(&installer.DeregisterClusterNoContent{}))
-		})
-
-		It("cluster update failure on inventory refresh failure", func() {
-			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil)
-
-			mockClusterRegisterSuccess(bm, true)
-			mockAMSSubscription(ctx)
-
-			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
-				NewClusterParams: &models.ClusterCreateParams{
-					Name:             swag.String(clusterName),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
-					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
-				},
-			})
-			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
-			actual := reply.(*installer.RegisterClusterCreated)
-
-			clusterId := *actual.Payload.ID
-			addHost(strfmt.UUID(uuid.New().String()), models.HostRoleMaster, "known", models.HostKindHost, clusterId, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-			newClusterName := "new-cluster-name"
-
-			refreshError := errors.New("boom!")
-			mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(refreshError)
-
-			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
-				ClusterID: clusterId,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					Name: &newClusterName,
-				},
-			})
-			Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
-			Expect(reply.(*common.ApiErrorResponse).Error()).To(BeEquivalentTo(refreshError.Error()))
 		})
 	})
 })

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1074,8 +1074,8 @@ func (m *Manager) CompleteInstallation(ctx context.Context, db *gorm.DB,
 
 		// Update AMS subscription only if configured and installation succeeded
 		if m.ocmClient != nil && m.ocmClient.Config.WithAMSSubscriptions {
-			if err := m.ocmClient.AccountsMgmt.UpdateSubscriptionPostInstallation(ctx, cluster.AmsSubscriptionID, cluster.OpenshiftClusterID); err != nil {
-				err = errors.Wrapf(err, "Failed to update AMS subscription for cluster %s post installation", *cluster.ID)
+			if err := m.ocmClient.AccountsMgmt.UpdateSubscriptionStatusActive(ctx, cluster.AmsSubscriptionID); err != nil {
+				err = errors.Wrapf(err, "Failed to update AMS subscription for cluster %s with status 'Active'", *cluster.ID)
 				log.Error(err)
 				return nil, err
 			}

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -283,9 +283,9 @@ var _ = Describe("Transition tests", func() {
 
 				if t.updateSuccessfullyFinished {
 					if t.updateAMSSubscription && t.updateAMSSubscriptionSuccess {
-						mockAccountsMgmt.EXPECT().UpdateSubscriptionPostInstallation(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+						mockAccountsMgmt.EXPECT().UpdateSubscriptionStatusActive(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					} else {
-						mockAccountsMgmt.EXPECT().UpdateSubscriptionPostInstallation(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error")).Times(1)
+						mockAccountsMgmt.EXPECT().UpdateSubscriptionStatusActive(gomock.Any(), gomock.Any()).Return(errors.New("error")).Times(1)
 					}
 				}
 

--- a/pkg/ocm/mock_accounts_mgmt.go
+++ b/pkg/ocm/mock_accounts_mgmt.go
@@ -107,16 +107,30 @@ func (mr *MockOCMAccountsMgmtMockRecorder) UpdateSubscriptionDisplayName(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionDisplayName", reflect.TypeOf((*MockOCMAccountsMgmt)(nil).UpdateSubscriptionDisplayName), arg0, arg1, arg2)
 }
 
-// UpdateSubscriptionPostInstallation mocks base method
-func (m *MockOCMAccountsMgmt) UpdateSubscriptionPostInstallation(arg0 context.Context, arg1, arg2 strfmt.UUID) error {
+// UpdateSubscriptionOpenshiftClusterID mocks base method
+func (m *MockOCMAccountsMgmt) UpdateSubscriptionOpenshiftClusterID(arg0 context.Context, arg1, arg2 strfmt.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSubscriptionPostInstallation", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateSubscriptionOpenshiftClusterID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateSubscriptionPostInstallation indicates an expected call of UpdateSubscriptionPostInstallation
-func (mr *MockOCMAccountsMgmtMockRecorder) UpdateSubscriptionPostInstallation(arg0, arg1, arg2 interface{}) *gomock.Call {
+// UpdateSubscriptionOpenshiftClusterID indicates an expected call of UpdateSubscriptionOpenshiftClusterID
+func (mr *MockOCMAccountsMgmtMockRecorder) UpdateSubscriptionOpenshiftClusterID(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionPostInstallation", reflect.TypeOf((*MockOCMAccountsMgmt)(nil).UpdateSubscriptionPostInstallation), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionOpenshiftClusterID", reflect.TypeOf((*MockOCMAccountsMgmt)(nil).UpdateSubscriptionOpenshiftClusterID), arg0, arg1, arg2)
+}
+
+// UpdateSubscriptionStatusActive mocks base method
+func (m *MockOCMAccountsMgmt) UpdateSubscriptionStatusActive(arg0 context.Context, arg1 strfmt.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubscriptionStatusActive", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSubscriptionStatusActive indicates an expected call of UpdateSubscriptionStatusActive
+func (mr *MockOCMAccountsMgmtMockRecorder) UpdateSubscriptionStatusActive(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubscriptionStatusActive", reflect.TypeOf((*MockOCMAccountsMgmt)(nil).UpdateSubscriptionStatusActive), arg0, arg1)
 }

--- a/subsystem/ams_subscriptions_test.go
+++ b/subsystem/ams_subscriptions_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/ocm"
@@ -32,6 +33,255 @@ var _ = Describe("test AMS subscriptions", func() {
 
 	Context("AMS subscription on cluster creation", func() {
 
+		It("happy flow", func() {
+
+			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+			Expect(err).ToNot(HaveOccurred())
+			log.Infof("Register cluster %s", clusterID)
+			cc := getCommonCluster(ctx, clusterID)
+			Expect(cc.AmsSubscriptionID).To(Equal(FakeSubscriptionID))
+		})
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("CreateSubscription failed", func() {
+
+			By("override wiremock stub to fail AMS call on Unauthorized error", func() {
+				err := wiremock.createStubsForCreatingAMSSubscription(http.StatusUnauthorized)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("register cluster", func() {
+				_, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override wiremock stub to fail AMS call on ServiceUnavailable error", func() {
+				err := wiremock.createStubsForCreatingAMSSubscription(http.StatusServiceUnavailable)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("register cluster", func() {
+				_, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err := wiremock.createStubsForCreatingAMSSubscription(http.StatusOK)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("AMS subscription on cluster deletion", func() {
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("happy flow - delete 'reserved' subscription on cluster deletion", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription (in 'reserved' status)", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				// we should delete the subscription, therefore, by making this AMS call fail and
+				// expect inventory failure on deregistering a clsuter we can make sure the service has
+				// try to delete the subscription
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete 'reserved' subscription", func() {
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("happy flow - don't delete 'active' subscription on cluster deletion", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("update subscription with 'active' status", func() {
+				err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusActive)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				// we should not delete the subscription, therefore, by making this AMS call fail and
+				// expect inventory success on deregistering a clsuter we can make sure the service has
+				// not try to delete the subscription
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete subscription", func() {
+				// don't delete 'active' subscription
+				// we can't really check that because it is done in an external dependency (AMS) so we just check there are no errors in the flow
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("GetSubscription failed", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForGettingAMSSubscription(http.StatusUnauthorized, ocm.SubscriptionStatusReserved)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete subscription", func() {
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForGettingAMSSubscription(http.StatusServiceUnavailable, ocm.SubscriptionStatusReserved)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete subscription", func() {
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusReserved)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("DeleteSubscription failed", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete subscription", func() {
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusServiceUnavailable)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("delete subscription", func() {
+				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("AMS subscription on cluster update with new cluster name", func() {
+
+		It("happy flow", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("update subscription's display name", func() {
+				newClusterName := "ams-cluster-new-name"
+				_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
+					ClusterID: clusterID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						Name: &newClusterName,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
+		It("UpdateSubscription failed", func() {
+
+			var clusterID strfmt.UUID
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
+			})
+
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusUnauthorized, subscriptionUpdateDisplayName)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("update subscription's display name", func() {
+				newClusterName := "ams-cluster-new-name"
+				_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
+					ClusterID: clusterID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						Name: &newClusterName,
+					},
+				})
+				Expect(err).To(HaveOccurred())
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateDisplayName)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+	})
+
+	Context("AMS subscription on cluster installation", func() {
+
 		waitForConsoleUrlUpdateInAMS := func(clusterID strfmt.UUID) {
 
 			waitFunc := func() (bool, error) {
@@ -44,192 +294,77 @@ var _ = Describe("test AMS subscriptions", func() {
 
 		It("happy flow", func() {
 
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-			cc := getCommonCluster(ctx, clusterID)
-			Expect(cc.AmsSubscriptionID).To(Equal(FakeSubscriptionID))
+			var clusterID strfmt.UUID
+			var err error
 
-			// update subscription with console url
-			registerHostsAndSetRoles(clusterID, minHosts)
-			setClusterAsFinalizing(ctx, clusterID)
-			completeInstallation(agentBMClient, clusterID)
-			waitForConsoleUrlUpdateInAMS(clusterID)
-
-			// update subscription with openshfit (external) cluster ID
-			waitForClusterState(ctx, clusterID, models.ClusterStatusInstalled, defaultWaitForClusterStateTimeout, clusterInstallingStateInfo)
-		})
-
-		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
-		It("CreateSubscription failed", func() {
-
-			err := wiremock.createStubsForCreatingAMSSubscription(http.StatusUnauthorized)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).To(HaveOccurred())
-
-			err = wiremock.createStubsForCreatingAMSSubscription(http.StatusServiceUnavailable)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).To(HaveOccurred())
-
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForCreatingAMSSubscription(http.StatusOK)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("AMS subscription on cluster deletion", func() {
-
-		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
-		It("happy flow - delete 'reserved' subscription on cluster deletion", func() {
-
-			// create subscription (in 'reserved' status)
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-
-			// we should delete the subscription, therefore, by making this AMS call fail and
-			// expect inventory failure on deregistering a clsuter we can make sure the service has
-			// try to delete the subscription
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
-			Expect(err).ToNot(HaveOccurred())
-
-			// delete 'reserved' subscription
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).To(HaveOccurred())
-
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
-		It("happy flow - don't delete 'active' subscription on cluster deletion", func() {
-
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-
-			// update subscription with 'active' status
-			err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusActive)
-			Expect(err).ToNot(HaveOccurred())
-
-			// we should not delete the subscription, therefore, by making this AMS call fail and
-			// expect inventory success on deregistering a clsuter we can make sure the service has
-			// not try to delete the subscription
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
-			Expect(err).ToNot(HaveOccurred())
-
-			// don't delete 'active' subscription
-			// we can't really check that because it is done in an external dependency (AMS) so we just check there are no errors in the flow
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).ToNot(HaveOccurred())
-
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
-		It("GetSubscription failed", func() {
-
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-
-			err = wiremock.createStubsForGettingAMSSubscription(http.StatusUnauthorized, ocm.SubscriptionStatusReserved)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).To(HaveOccurred())
-
-			err = wiremock.createStubsForGettingAMSSubscription(http.StatusServiceUnavailable, ocm.SubscriptionStatusReserved)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).To(HaveOccurred())
-
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusReserved)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
-		It("DeleteSubscription failed", func() {
-
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusUnauthorized)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).To(HaveOccurred())
-
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusServiceUnavailable)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
-			Expect(err).To(HaveOccurred())
-
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("AMS subscription on cluster update with new cluster name", func() {
-
-		It("happy flow", func() {
-
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
-
-			// update subscription's display name
-			newClusterName := "ams-cluster-new-name"
-			_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
-				ClusterID: clusterID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					Name: &newClusterName,
-				},
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
 			})
-			Expect(err).ToNot(HaveOccurred())
+
+			By("update subscription with openshfit (external) cluster ID", func() {
+				registerHostsAndSetRoles(clusterID, minHosts)
+				setClusterAsInstalling(ctx, clusterID)
+			})
+
+			By("update subscription with console url", func() {
+				c := getCluster(clusterID)
+				for _, host := range c.Hosts {
+					updateProgress(*host.ID, clusterID, models.HostStageDone)
+				}
+				waitForClusterState(ctx, clusterID, models.ClusterStatusFinalizing, defaultWaitForClusterStateTimeout, clusterFinalizingStateInfo)
+				completeInstallation(agentBMClient, clusterID)
+				waitForConsoleUrlUpdateInAMS(clusterID)
+			})
+
+			By("update subscription with status 'Active'", func() {
+				waitForClusterState(ctx, clusterID, models.ClusterStatusInstalled, defaultWaitForClusterStateTimeout, clusterInstallingStateInfo)
+			})
 		})
 
 		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
 		It("UpdateSubscription failed", func() {
 
-			// create subscription
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
-			Expect(err).ToNot(HaveOccurred())
-			log.Infof("Register cluster %s", clusterID)
+			waitForInstallationPreparationCompletionStatus := func(clusterID strfmt.UUID, status string) {
 
-			err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusUnauthorized, subscriptionUpdateDisplayName)
-			Expect(err).ToNot(HaveOccurred())
+				waitFunc := func() (bool, error) {
+					c := getCommonCluster(ctx, clusterID)
+					return c.InstallationPreparationCompletionStatus == status, nil
+				}
+				err := wait.Poll(pollDefaultInterval, pollDefaultTimeout, waitFunc)
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-			// update subscription's display name
-			newClusterName := "ams-cluster-new-name"
-			_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
-				ClusterID: clusterID,
-				ClusterUpdateParams: &models.ClusterUpdateParams{
-					Name: &newClusterName,
-				},
+			var clusterID strfmt.UUID
+			var reply *installer.InstallClusterAccepted
+			var err error
+
+			By("create subscription", func() {
+				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				Expect(err).ToNot(HaveOccurred())
+				log.Infof("Register cluster %s", clusterID)
 			})
-			Expect(err).To(HaveOccurred())
 
-			// override back to keep other tests consistent tests
-			err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdatePostInstallation)
-			Expect(err).ToNot(HaveOccurred())
+			By("override wiremock stub to fail AMS call", func() {
+				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusUnauthorized, subscriptionUpdateOpenshiftClusterID)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("update subscription with openshfit (external) cluster ID", func() {
+				registerHostsAndSetRoles(clusterID, minHosts)
+				reply, err = userBMClient.Installer.InstallCluster(context.Background(), &installer.InstallClusterParams{ClusterID: clusterID})
+				Expect(err).NotTo(HaveOccurred())
+				c := reply.GetPayload()
+				Expect(*c.Status).Should(Equal(models.ClusterStatusPreparingForInstallation))
+				generateEssentialPrepareForInstallationSteps(ctx, c.Hosts...)
+				waitForInstallationPreparationCompletionStatus(clusterID, common.InstallationPreparationFailed)
+			})
+
+			By("override back to keep other tests consistent tests", func() {
+				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateOpenshiftClusterID)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 })

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -531,13 +531,19 @@ func completeInstallationAndVerify(ctx context.Context, client *client.AssistedI
 	waitForClusterState(ctx, clusterID, expectedStatus, defaultWaitForClusterStateTimeout, IgnoreStateInfo)
 }
 
-func setClusterAsFinalizing(ctx context.Context, clusterID strfmt.UUID) {
+func setClusterAsInstalling(ctx context.Context, clusterID strfmt.UUID) {
 	c := installCluster(clusterID)
 	Expect(swag.StringValue(c.Status)).Should(Equal("installing"))
 	Expect(swag.StringValue(c.StatusInfo)).Should(Equal("Installation in progress"))
+
 	for _, host := range c.Hosts {
 		Expect(swag.StringValue(host.Status)).Should(Equal("installing"))
 	}
+}
+
+func setClusterAsFinalizing(ctx context.Context, clusterID strfmt.UUID) {
+	setClusterAsInstalling(ctx, clusterID)
+	c := getCluster(clusterID)
 
 	for _, host := range c.Hosts {
 		updateProgress(*host.ID, clusterID, models.HostStageDone)


### PR DESCRIPTION
openshift_cluster_id is know at an earlier stage, before installation
begin, and this is when we need to update it in AMS subscription.

Currently we are experiencing a race with the subscription created by AMS
when cluster telemetry arrives.

In case the installation fails, we will remain with an obsolete
'external_cluster_id' (aka openshift_cluster_id) in the subscription
until the user restarts the installation (and the openshift_cluster_id is
overwritten) or until the cluster is deregistered from AI DB (and
therefore the subscription deleted in AMS).

Signed-off-by: Yoni Bettan <ybettan@redhat.com>