### PR TITLE
MGMT-6458 - Don't override hw master requirements with sno one

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -268,12 +268,8 @@ func (v *validator) updateSingleNodeHwRequirements(requirements *models.Versione
 
 func (v *validator) getOCPRequirementsForVersion(cluster *common.Cluster) *models.VersionedHostRequirements {
 	requirements, err := v.VersionedRequirements.GetVersionedHostRequirements(cluster.OpenshiftVersion)
-	if err != nil {
+	if err != nil || common.IsSingleNodeCluster(cluster) {
 		return v.GetHostRequirements(common.IsSingleNodeCluster(cluster))
-	}
-
-	if common.IsSingleNodeCluster(cluster) {
-		v.updateSingleNodeHwRequirements(requirements)
 	}
 
 	return requirements


### PR DESCRIPTION
Object inside v.VersionedRequirements.GetVersionedHostRequirements is created once and if we had sno cluster we got those values changed to sno ones.
Removing overriding code. In case of sno we will always create values from scratch