### PR TITLE
MGMT-4669: Add monitored operator version

### DIFF
--- a/internal/operators/handler/handler.go
+++ b/internal/operators/handler/handler.go
@@ -63,7 +63,7 @@ func (h *Handler) ListOfClusterOperators(ctx context.Context, params restoperato
 
 // ReportMonitoredOperatorStatus Controller API to report of monitored operators.
 func (h *Handler) ReportMonitoredOperatorStatus(ctx context.Context, params restoperators.ReportMonitoredOperatorStatusParams) middleware.Responder {
-	err := h.UpdateMonitoredOperatorStatus(ctx, params.ClusterID, params.ReportParams.Name, params.ReportParams.Status, params.ReportParams.StatusInfo)
+	err := h.UpdateMonitoredOperatorStatus(ctx, params.ClusterID, params.ReportParams.Name, params.ReportParams.Status, params.ReportParams.StatusInfo, params.ReportParams.Version)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}
@@ -109,7 +109,7 @@ func (h *Handler) FindMonitoredOperator(ctx context.Context, clusterID strfmt.UU
 }
 
 // UpdateMonitoredOperatorStatus updates status and status info of a monitored operator for a cluster
-func (h *Handler) UpdateMonitoredOperatorStatus(ctx context.Context, clusterID strfmt.UUID, monitoredOperatorName string, status models.OperatorStatus, statusInfo string) error {
+func (h *Handler) UpdateMonitoredOperatorStatus(ctx context.Context, clusterID strfmt.UUID, monitoredOperatorName string, status models.OperatorStatus, statusInfo string, operatorVersion string) error {
 	log := logutil.FromContext(ctx, h.log)
 
 	txSuccess := false
@@ -132,6 +132,7 @@ func (h *Handler) UpdateMonitoredOperatorStatus(ctx context.Context, clusterID s
 
 	operator.Status = status
 	operator.StatusInfo = statusInfo
+	operator.Version = operatorVersion
 	operator.StatusUpdatedAt = strfmt.DateTime(time.Now())
 
 	if err = tx.Save(operator).Error; err != nil {

--- a/internal/operators/handler/handler_test.go
+++ b/internal/operators/handler/handler_test.go
@@ -136,11 +136,12 @@ var _ = Describe("Operators manager", func() {
 
 	Context("UpdateMonitoredOperatorStatus", func() {
 		It("should update operator status", func() {
+			operatorVersion := "1.0.0"
 			statusInfo := "sorry, failed"
 			operatorName := common.TestDefaultConfig.MonitoredOperator.Name
 			newStatus := models.OperatorStatusFailed
 
-			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo)
+			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo, operatorVersion)
 
 			Expect(err).ToNot(HaveOccurred())
 
@@ -154,11 +155,12 @@ var _ = Describe("Operators manager", func() {
 		})
 
 		It("should report error when operator not found", func() {
+			operatorVersion := "1.0.0"
 			statusInfo := "the very new progressing info"
 			newStatus := models.OperatorStatusProgressing
 			operatorName := "unknown"
 
-			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo)
+			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo, operatorVersion)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.(*common.ApiErrorResponse).StatusCode()).To(BeEquivalentTo(http.StatusNotFound))
@@ -171,11 +173,12 @@ var _ = Describe("Operators manager", func() {
 		})
 
 		It("should report error for empty operator name", func() {
+			operatorVersion := "1.0.0"
 			statusInfo := "the very new progressing info"
 			newStatus := models.OperatorStatusProgressing
 			operatorName := ""
 
-			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo)
+			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo, operatorVersion)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.(*common.ApiErrorResponse).StatusCode()).To(BeEquivalentTo(http.StatusBadRequest))
@@ -188,12 +191,13 @@ var _ = Describe("Operators manager", func() {
 		})
 
 		It("Should create an event when CVO is reported", func() {
+			operatorVersion := "1.0.0"
 			newStatus := models.OperatorStatusAvailable
 			statusInfo := common.TestDefaultConfig.StatusInfo
 
 			mockEvents.EXPECT().AddEvent(gomock.Any(), *cluster.ID, nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
 
-			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operators.OperatorCVO.Name, newStatus, statusInfo)
+			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operators.OperatorCVO.Name, newStatus, statusInfo, operatorVersion)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/models/monitored_operator.go
+++ b/models/monitored_operator.go
@@ -48,6 +48,9 @@ type MonitoredOperator struct {
 
 	// Positive number represents a timeout in seconds for the operator to be available.
 	TimeoutSeconds int64 `json:"timeout_seconds,omitempty"`
+
+	// Version of the operator.
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this monitored operator

--- a/models/operator_monitor_report.go
+++ b/models/operator_monitor_report.go
@@ -24,6 +24,9 @@ type OperatorMonitorReport struct {
 
 	// Detailed information about the operator state.
 	StatusInfo string `json:"status_info,omitempty"`
+
+	// Version of the operator.
+	Version string `json:"version,omitempty"`
 }
 
 // Validate validates this operator monitor report

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7174,6 +7174,10 @@ func init() {
         "timeout_seconds": {
           "description": "Positive number represents a timeout in seconds for the operator to be available.",
           "type": "integer"
+        },
+        "version": {
+          "description": "Version of the operator.",
+          "type": "string"
         }
       }
     },
@@ -7332,6 +7336,10 @@ func init() {
         },
         "status_info": {
           "description": "Detailed information about the operator state.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the operator.",
           "type": "string"
         }
       }
@@ -14861,6 +14869,10 @@ func init() {
         "timeout_seconds": {
           "description": "Positive number represents a timeout in seconds for the operator to be available.",
           "type": "integer"
+        },
+        "version": {
+          "description": "Version of the operator.",
+          "type": "string"
         }
       }
     },
@@ -15019,6 +15031,10 @@ func init() {
         },
         "status_info": {
           "description": "Detailed information about the operator state.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version of the operator.",
           "type": "string"
         }
       }

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -502,7 +502,7 @@ func completeInstallation(client *client.AssistedInstall, clusterID strfmt.UUID)
 			continue
 		}
 
-		reportMonitoredOperatorStatus(ctx, client, clusterID, operator.Name, status)
+		reportMonitoredOperatorStatus(ctx, client, clusterID, operator.Name, status, "1.0")
 	}
 }
 

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Operators endpoint tests", func() {
 		})
 
 		It("should be updated", func() {
-			reportMonitoredOperatorStatus(ctx, agentBMClient, *cluster.Payload.ID, ocs.Operator.Name, models.OperatorStatusFailed)
+			reportMonitoredOperatorStatus(ctx, agentBMClient, *cluster.Payload.ID, ocs.Operator.Name, models.OperatorStatusFailed, "1.0")
 
 			ops, err := agentBMClient.Operators.ListOfClusterOperators(ctx, opclient.NewListOfClusterOperatorsParams().
 				WithClusterID(*cluster.Payload.ID).
@@ -245,7 +245,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			})
 
 			By("Report operator available", func() {
-				reportMonitoredOperatorStatus(context.TODO(), agentBMClient, clusterID, lso.Operator.Name, models.OperatorStatusAvailable)
+				reportMonitoredOperatorStatus(context.TODO(), agentBMClient, clusterID, lso.Operator.Name, models.OperatorStatusAvailable, "1.0")
 			})
 
 			By("Wait for cluster to be installed", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			})
 
 			By("Report operator failed", func() {
-				reportMonitoredOperatorStatus(context.TODO(), agentBMClient, clusterID, lso.Operator.Name, models.OperatorStatusFailed)
+				reportMonitoredOperatorStatus(context.TODO(), agentBMClient, clusterID, lso.Operator.Name, models.OperatorStatusFailed, "1.0")
 			})
 
 			By("Wait for cluster to be degraded", func() {

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -337,13 +337,14 @@ func register3nodes(ctx context.Context, clusterID strfmt.UUID) []*models.Host {
 	return []*models.Host{h1, h2, h3}
 }
 
-func reportMonitoredOperatorStatus(ctx context.Context, client *client.AssistedInstall, clusterID strfmt.UUID, opName string, opStatus models.OperatorStatus) {
+func reportMonitoredOperatorStatus(ctx context.Context, client *client.AssistedInstall, clusterID strfmt.UUID, opName string, opStatus models.OperatorStatus, opVersion string) {
 	_, err := client.Operators.ReportMonitoredOperatorStatus(ctx, &operatorsClient.ReportMonitoredOperatorStatusParams{
 		ClusterID: clusterID,
 		ReportParams: &models.OperatorMonitorReport{
 			Name:       opName,
 			Status:     opStatus,
 			StatusInfo: string(opStatus),
+			Version:    opVersion,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3235,6 +3235,9 @@ definitions:
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"
         description: Time at which the operator was last updated.
+      version:
+        type: string
+        description: Version of the operator.
 
   operator-monitor-report:
     type: object
@@ -3242,6 +3245,9 @@ definitions:
       name:
         type: string
         description: Unique name of the operator.
+      version:
+        type: string
+        description: Version of the operator.
       status:
         $ref: '#/definitions/operator-status'
       status_info:


### PR DESCRIPTION
This PR adds a `version` parameter to monitored operators model, which will reflect:

  - for OLM operator - the CSV version
  - for cluster version - Desired version
  - for console operator - take "operator" version from list of versions 

Those parameter are reported by the [assisted-installer-controller](https://github.com/openshift/assisted-installer/pull/284).

By this PR, the `assisted-service` will know the exact version of the operator. And so the specific features of the version.

Signed-off-by: Ondra Machacek <omachace@redhat.com>