### PR TITLE
MGMT-6451 fixing flaky subsystem tests with bmh deployments

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -424,14 +424,20 @@ func getDefaultNMStateConfigSpec(nicPrimary, nicSecondary, macPrimary, macSecond
 	}
 }
 
-func getAgentMac(agent *v1beta1.Agent) string {
-
-	for _, agentInterface := range agent.Status.Inventory.Interfaces {
-		if agentInterface.MacAddress != "" {
-			return agentInterface.MacAddress
+func getAgentMac(ctx context.Context, client k8sclient.Client, key types.NamespacedName) string {
+	mac := ""
+	Eventually(func() bool {
+		agent := getAgentCRD(ctx, client, key)
+		for _, agentInterface := range agent.Status.Inventory.Interfaces {
+			if agentInterface.MacAddress != "" {
+				mac = agentInterface.MacAddress
+				return true
+			}
 		}
-	}
-	return ""
+		return false
+	}, "60s", "10s").Should(BeTrue())
+
+	return mac
 }
 
 func cleanUP(ctx context.Context, client k8sclient.Client) {
@@ -580,8 +586,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      host.ID.String(),
 		}
 
-		agent := getAgentCRD(ctx, kubeClient, key)
-		bmhSpec := bmhv1alpha1.BareMetalHostSpec{BootMACAddress: getAgentMac(agent)}
+		bmhSpec := bmhv1alpha1.BareMetalHostSpec{BootMACAddress: getAgentMac(ctx, kubeClient, key)}
 		deployBMHCRD(ctx, kubeClient, host.ID.String(), &bmhSpec)
 
 		Eventually(func() error {
@@ -817,8 +822,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      host.ID.String(),
 		}
 
-		agent := getAgentCRD(ctx, kubeClient, key)
-		bmhSpec := bmhv1alpha1.BareMetalHostSpec{BootMACAddress: getAgentMac(agent)}
+		bmhSpec := bmhv1alpha1.BareMetalHostSpec{BootMACAddress: getAgentMac(ctx, kubeClient, key)}
 		deployBMHCRD(ctx, kubeClient, host.ID.String(), &bmhSpec)
 
 		installerArgs := `["--append-karg", "ip=192.0.2.2::192.0.2.254:255.255.255.0:core0.example.com:enp1s0:none", "--save-partindex", "1", "-n"]`
@@ -1708,8 +1712,7 @@ var _ = Describe("bmac reconcile flow", func() {
 
 		It("reconciles the agent", func() {
 			bmh = getBmhCRD(ctx, kubeClient, bmhNsName)
-			agent := getAgentCRD(ctx, kubeClient, agentNsName)
-			bmh.Spec.BootMACAddress = getAgentMac(agent)
+			bmh.Spec.BootMACAddress = getAgentMac(ctx, kubeClient, agentNsName)
 			bmh.SetLabels(map[string]string{controllers.BMH_INFRA_ENV_LABEL: infraNsName.Name})
 			Expect(kubeClient.Update(ctx, bmh)).ToNot(HaveOccurred())
 


### PR DESCRIPTION
We had a race were some times agent cr didn't had mac yet that cause us to create bmh with "" as mac