### PR TITLE
MGMT-4658 Remove contents of Hosts field from payload

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2360,11 +2360,9 @@ func (b *bareMetalInventory) ListClusters(ctx context.Context, params installer.
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 
+	// we need to fetch Hosts association to allow AfterFind hook to run
 	for _, c := range dbClusters {
-		for _, h := range c.Hosts {
-			// Clear this field as it is not needed to be sent via API
-			h.FreeAddresses = ""
-		}
+		c.Hosts = []*models.Host{}
 		clusters = append(clusters, &c.Cluster)
 	}
 	return installer.NewListClustersOK().WithPayload(clusters)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4331,7 +4331,7 @@ var _ = Describe("List clusters", func() {
 		Expect(payload[0].TotalHostCount).Should(Equal(int64(1)))
 		Expect(payload[0].EnabledHostCount).Should(Equal(int64(1)))
 		Expect(payload[0].ReadyHostCount).Should(Equal(int64(1)))
-		Expect(payload[0].Hosts[0].ID.String()).Should(Equal(hostID.String()))
+		Expect(len(payload[0].Hosts)).Should(Equal(0))
 	})
 
 	It("List unregistered clusters failure - cluster was permanently deleted", func() {

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -242,7 +242,6 @@ var _ = Describe("Cluster", func() {
 		}
 		Expect(clusterFound.ID.String()).Should(Equal(clusterID.String()))
 		Expect(clusterFound.DeletedAt).ShouldNot(Equal(strfmt.DateTime{}))
-		Expect(len(clusterFound.Hosts)).ShouldNot(Equal(0))
 	})
 
 	It("cluster CRUD", func() {


### PR DESCRIPTION
When returning payload for `listClusters` we should not serve `Hosts` field because it may be a lot of data. This PRs clears the field but still keeps querying for it from the db to run `AfterFind` hook which populates other info we need.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>