### PR TITLE
OCPBUGSM-28708, OCPBUGSM-28573 Disable OCS installation on OCP 4.8

### DIFF
--- a/internal/operators/ocs/validation_test.go
+++ b/internal/operators/ocs/validation_test.go
@@ -134,6 +134,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		validationsChecker      *validationsChecker
 		setMachineCidrUpdatedAt bool
 		errorExpected           bool
+		OpenShiftVersion        string
 	}{
 		{
 			name:               "ocs enabled, 3 sufficient nodes",
@@ -313,6 +314,49 @@ var _ = Describe("Ocs Operator use-cases", func() {
 				clust.IsPullSecretSet:                     {status: clust.ValidationSuccess, messagePattern: "The pull secret is set"},
 				clust.SufficientMastersCount:              {status: clust.ValidationSuccess, messagePattern: "The cluster has a sufficient number of master candidates."},
 				clust.IsOcsRequirementsSatisfied:          {status: clust.ValidationFailure, messagePattern: "The number of disks in the cluster for OCS must be a multiple of 3 with a minimum size of 5 GB"},
+			}),
+			errorExpected: false,
+		},
+		{
+			name:               "ocs enabled, OpenShiftVersion 4.8",
+			srcState:           models.ClusterStatusReady,
+			dstState:           models.ClusterStatusInsufficient,
+			machineNetworkCidr: "1.2.3.0/24",
+			apiVip:             "1.2.3.5",
+			ingressVip:         "1.2.3.6",
+			dnsDomain:          "test.com",
+			pullSecretSet:      true,
+			OpenShiftVersion:   "4.8.1",
+			hosts: []models.Host{
+				{ID: &hid1, Status: swag.String(models.HostStatusKnown),
+					Inventory: ocs.Inventory(&ocs.InventoryResources{Cpus: 16, Ram: 64 * conversions.GiB, Disks: []*models.Disk{
+						{SizeBytes: 20 * conversions.GB, DriveType: "HDD"},
+						{SizeBytes: 40 * conversions.GB, DriveType: "SSD"}}}),
+					Role: models.HostRoleMaster},
+				{ID: &hid2, Status: swag.String(models.HostStatusKnown),
+					Inventory: ocs.Inventory(&ocs.InventoryResources{Cpus: 16, Ram: 64 * conversions.GiB, Disks: []*models.Disk{
+						{SizeBytes: 20 * conversions.GB, DriveType: "HDD"},
+						{SizeBytes: 40 * conversions.GB, DriveType: "SSD"}}}),
+					Role: models.HostRoleMaster},
+				{ID: &hid3, Status: swag.String(models.HostStatusKnown),
+					Inventory: ocs.Inventory(&ocs.InventoryResources{Cpus: 16, Ram: 64 * conversions.GiB, Disks: []*models.Disk{
+						{SizeBytes: 20 * conversions.GB, DriveType: "HDD"},
+						{SizeBytes: 40 * conversions.GB, DriveType: "SSD"}}}),
+					Role: models.HostRoleMaster},
+			},
+			statusInfoChecker: makeValueChecker(clust.StatusInfoInsufficient),
+			validationsChecker: makeJsonChecker(map[clust.ValidationID]validationCheckResult{
+				clust.IsMachineCidrDefined:                {status: clust.ValidationSuccess, messagePattern: "The Machine Network CIDR is defined"},
+				clust.IsMachineCidrEqualsToCalculatedCidr: {status: clust.ValidationSuccess, messagePattern: "The Cluster Machine CIDR is equivalent to the calculated CIDR"},
+				clust.IsApiVipDefined:                     {status: clust.ValidationSuccess, messagePattern: "The API virtual IP is defined"},
+				clust.IsApiVipValid:                       {status: clust.ValidationSuccess, messagePattern: "belongs to the Machine CIDR and is not in use."},
+				clust.IsIngressVipDefined:                 {status: clust.ValidationSuccess, messagePattern: "The Ingress virtual IP is defined"},
+				clust.IsIngressVipValid:                   {status: clust.ValidationSuccess, messagePattern: "belongs to the Machine CIDR and is not in use."},
+				clust.AllHostsAreReadyToInstall:           {status: clust.ValidationSuccess, messagePattern: "All hosts in the cluster are ready to install"},
+				clust.IsDNSDomainDefined:                  {status: clust.ValidationSuccess, messagePattern: "The base domain is defined"},
+				clust.IsPullSecretSet:                     {status: clust.ValidationSuccess, messagePattern: "The pull secret is set"},
+				clust.SufficientMastersCount:              {status: clust.ValidationSuccess, messagePattern: "The cluster has a sufficient number of master candidates."},
+				clust.IsOcsRequirementsSatisfied:          {status: clust.ValidationFailure, messagePattern: "OCS is not supported on OCP 4.8."},
 			}),
 			errorExpected: false,
 		},
@@ -1241,6 +1285,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 					ServiceNetworkCidr:       "1.4.0.0/16",
 					ClusterNetworkHostPrefix: 24,
 					MonitoredOperators:       operators,
+					OpenshiftVersion:         t.OpenShiftVersion,
 				},
 			}
 

--- a/internal/operators/ocs/validations.go
+++ b/internal/operators/ocs/validations.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
@@ -37,6 +38,13 @@ func (o *operator) validateRequirements(cluster *models.Cluster) (api.Validation
 	var status string
 	hosts := cluster.Hosts
 	numAvailableHosts := int64(len(hosts))
+
+	// TODO: Remove this validation once OCS 4.7 is GA
+	if strings.HasPrefix(cluster.OpenshiftVersion, "4.8") {
+		status = "OCS is not supported on OCP 4.8."
+		o.log.Info("OCS requirements validation status ", status)
+		return api.Failure, status
+	}
 
 	if numAvailableHosts < o.config.OCSRequiredHosts {
 		status = "Insufficient hosts to deploy OCS. A minimum of 3 hosts is required to deploy OCS."


### PR DESCRIPTION
OCS installation fails on OCP 4.8.
OCS 4.6 is not supported on OCS 4.8 but OCS 4.7 has not yet been released.
Temporarily failing OCS validation on OCP 4.8 until OCS 4.7 is available.

Signed off by: Priyanka Jiandani <pjiandan@redhat.com>