### PR TITLE
NO-ISSUE: Bump operator to 0.0.4

### DIFF
--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -4,14 +4,15 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    categories: OpenShift Optional
     description: Assisted Service is used to orchestrate baremetal OpenShift installations.
-    olm.skipRange: <0.0.3
+    olm.skipRange: <0.0.4
     operatorframework.io/suggested-namespace: assisted-installer
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/assisted-service
     support: https://github.com/openshift/assisted-service/issues/new
-  name: assisted-service-operator.v0.0.3
+  name: assisted-service-operator.v0.0.4
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -82,4 +83,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.0.3
+  version: 0.0.4

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -55,14 +55,15 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    categories: OpenShift Optional
     description: Assisted Service is used to orchestrate baremetal OpenShift installations.
-    olm.skipRange: <0.0.3
+    olm.skipRange: <0.0.4
     operatorframework.io/suggested-namespace: assisted-installer
     operators.operatorframework.io/builder: operator-sdk-v1.6.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/assisted-service
     support: https://github.com/openshift/assisted-service/issues/new
-  name: assisted-service-operator.v0.0.3
+  name: assisted-service-operator.v0.0.4
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -564,4 +565,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 0.0.3
+  version: 0.0.4

--- a/deploy/olm-catalog/metadata/annotations.yaml
+++ b/deploy/olm-catalog/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: assisted-service-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,ocm-2.3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -98,6 +98,17 @@ function generate_manifests() {
     cp ${controller_crd_path}/resources.yaml ${BUILD_FOLDER}/resources.yaml
 }
 
+function generate_bundle() {
+    ENABLE_KUBE_API=true generate_manifests
+    operator-sdk generate kustomize manifests --apis-dir internal/controller/api -q
+    # TODO(djzager) use this line to pin images in the future
+    # cd config/manager && kustomize edit set image controller=${SERVICE}
+    kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --output-dir ${BUNDLE_OUTPUT_DIR} ${BUNDLE_METADATA_OPTS}
+    # TODO(djzager) structure config/rbac in such a way to avoid need for this
+    rm ${BUNDLE_OUTPUT_DIR}/manifests/assisted-service_v1_serviceaccount.yaml
+    operator-sdk bundle validate ${BUNDLE_OUTPUT_DIR}
+}
+
 function generate_all() {
     generate_from_swagger
     generate_mocks


### PR DESCRIPTION
Now that 0.0.3 is released in community-operators, this PR:
* bumps the operator version to 0.0.4
* moves the operator-bundle make target into `hack/generate.sh` scripts
  and now `make generate-bundle` will build the bundle (and the rbac +
  crd manifests needed to get a correct bundle)