### PR TITLE
OCPBUGSM-28625 Moving host to Insufficient state even when IsMachineCidrDefined fails

### DIFF
--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2436,14 +2436,20 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected: false,
 			},
 			{
-				name:              "pending to insufficient (1)",
-				role:              models.HostRoleAutoAssign,
-				validCheckInTime:  true,
-				srcState:          models.HostStatusPendingForInput,
-				dstState:          models.HostStatusPendingForInput,
-				statusInfoChecker: makeValueChecker(""),
-				inventory:         insufficientHWInventory(),
-				errorExpected:     true,
+				name:             "pending to insufficient (1)",
+				role:             models.HostRoleAutoAssign,
+				validCheckInTime: true,
+				srcState:         models.HostStatusPendingForInput,
+				dstState:         models.HostStatusInsufficient,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoNotReadyForInstall,
+					"Host couldn't synchronize with any NTP server ; Machine Network CIDR is undefined; "+
+						"the Machine Network CIDR can be defined by setting either the API or Ingress virtual IPs ; "+
+						"Require a disk of at least 120 GB ; "+
+						"Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes ; "+
+						"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for "+
+						"any role is 8.00 GiB, found only 130 bytes")),
+				inventory:     insufficientHWInventory(),
+				errorExpected: false,
 			},
 			{
 				name:             "known to insufficient (1)",


### PR DESCRIPTION
Host was marked as `Pending For Input` when hardware validations failed and machine CIDR was not defined. The desired behavior is to mark host as `Insufficient` in that situation.

This PR aims at fixing that problem.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>