### PR TITLE
OCPBUGSM-23667 - add validation for mac/nic uniqueness for static net…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -363,7 +363,7 @@ func main() {
 
 	bm := bminventory.NewBareMetalInventory(db, log.WithField("pkg", "Inventory"), hostApi, clusterApi, Options.BMConfig,
 		generator, eventsHandler, objectHandler, metricsManager, usageManager, operatorsManager, authHandler, ocpClient, ocmClient,
-		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder)
+		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder, staticNetworkConfig)
 
 	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"))
 	expirer := imgexpirer.NewManager(objectHandler, eventsHandler, Options.BMConfig.ImageExpirationTime, lead, Options.EnableKubeAPI)

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -990,16 +990,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	})
 
 	Context("static network config", func() {
-		map1 := models.MacInterfaceMap{
-			&models.MacInterfaceMapItems0{MacAddress: "mac10", LogicalNicName: "nic10"},
-		}
-		map2 := models.MacInterfaceMap{
-			&models.MacInterfaceMapItems0{MacAddress: "mac20", LogicalNicName: "nic20"},
-		}
-		staticNetworkConfig := []*models.HostStaticNetworkConfig{
-			common.FormatStaticConfigHostYAML("nic10", "02000048ba38", "192.168.126.30", "192.168.141.30", "192.168.126.1", map1),
-			common.FormatStaticConfigHostYAML("nic20", "02000048ba48", "192.168.126.31", "192.168.141.31", "192.168.126.1", map2),
-		}
+		formattedInput := "some formated input"
 		staticnetworkConfigOutput := []staticnetworkconfig.StaticNetworkConfigData{
 			{
 				FilePath:     "nic10.nmconnection",
@@ -1016,7 +1007,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		}
 
 		It("produces a valid ignition v3.1 spec with static ips paramters", func() {
-			formattedInput := staticnetworkconfig.FormatStaticNetworkConfigForDB(staticNetworkConfig)
 			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
 			cluster.ImageInfo.StaticNetworkConfig = formattedInput
 			cluster.ImageInfo.Type = models.ImageTypeFullIso
@@ -1035,7 +1025,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			Expect(count).Should(Equal(4))
 		})
 		It("Doesn't include static network config for minimal isos", func() {
-			formattedInput := staticnetworkconfig.FormatStaticNetworkConfigForDB(staticNetworkConfig)
 			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
 			cluster.ImageInfo.StaticNetworkConfig = formattedInput
 			cluster.ImageInfo.Type = models.ImageTypeMinimalIso

--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/pkg/errors"
@@ -28,6 +28,8 @@ type StaticNetworkConfigData struct {
 //go:generate mockgen -source=generator.go -package=staticnetworkconfig -destination=mock_generator.go
 type StaticNetworkConfig interface {
 	GenerateStaticNetworkConfigData(hostsYAMLS string) ([]StaticNetworkConfigData, error)
+	FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetworkConfig) string
+	ValidateStaticConfigParams(staticNetworkConfig []*models.HostStaticNetworkConfig) error
 }
 
 type StaticNetworkConfigGenerator struct {
@@ -62,36 +64,46 @@ func (s *StaticNetworkConfigGenerator) generateHostStaticNetworkConfigData(hostC
 	}
 	hostYAML := hostConfig[0]
 	macInterfaceMapping := hostConfig[1]
-	executer := &executer.CommonExecuter{}
-	f, err := executer.TempFile("", "host-config")
+	result, err := s.executeNMStatectl(hostYAML)
 	if err != nil {
-		s.log.WithError(err).Errorf("Failed to create temp file")
 		return nil, err
 	}
-	_, err = f.WriteString(hostYAML)
-	if err != nil {
-		s.log.WithError(err).Errorf("Failed to write host config to temp file")
-		return nil, err
-	}
-	f.Close()
-	stdout, stderr, retCode := executer.Execute("nmstatectl", "gc", f.Name())
-	if retCode != 0 {
-		msg := fmt.Sprintf("<nmstatectl gc> failed, errorCode %d, stderr %s, input yaml <%s>", retCode, stderr, hostYAML)
-		s.log.Errorf("%s", msg)
-		return nil, fmt.Errorf("%s", msg)
-	}
-	filesList, err := s.createNMConnectionFiles(stdout, hostDir)
+	filesList, err := s.createNMConnectionFiles(result, hostDir)
 	if err != nil {
 		s.log.WithError(err).Errorf("failed to create NM connection files")
 		return nil, err
 	}
-	os.Remove(f.Name())
 	mapConfigData := StaticNetworkConfigData{
 		FilePath:     filepath.Join(hostDir, "mac_interface.ini"),
 		FileContents: macInterfaceMapping,
 	}
 	filesList = append(filesList, mapConfigData)
 	return filesList, nil
+}
+
+func (s *StaticNetworkConfigGenerator) executeNMStatectl(hostYAML string) (string, error) {
+	executer := &executer.CommonExecuter{}
+	f, err := executer.TempFile("", "host-config")
+	if err != nil {
+		s.log.WithError(err).Errorf("Failed to create temp file")
+		return "", err
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+	_, err = f.WriteString(hostYAML)
+	if err != nil {
+		s.log.WithError(err).Errorf("Failed to write host config to temp file")
+		return "", err
+	}
+	stdout, stderr, retCode := executer.Execute("nmstatectl", "gc", f.Name())
+	if retCode != 0 {
+		msg := fmt.Sprintf("<nmstatectl gc> failed, errorCode %d, stderr %s, input yaml <%s>", retCode, stderr, hostYAML)
+		s.log.Errorf("%s", msg)
+		return "", fmt.Errorf("%s", msg)
+	}
+	return stdout, nil
 }
 
 func (s *StaticNetworkConfigGenerator) createNMConnectionFiles(nmstateOutput, hostDir string) ([]StaticNetworkConfigData, error) {
@@ -151,32 +163,37 @@ func (s *StaticNetworkConfigGenerator) formatNMConnection(nmConnection string) (
 	return buf.String(), nil
 }
 
-func (s *StaticNetworkConfigGenerator) validateAndCalculateMAC(ifaceName string) (string, error) {
-	// check the format of the interface name
-	ifaceNameRegexp := "^[0-9A-Fa-f]{12}$"
-	match, err := regexp.MatchString(ifaceNameRegexp, ifaceName)
-	if err != nil {
-		s.log.WithError(err).Errorf("Invalid regexp expression %s", ifaceNameRegexp)
-		return "", err
+func (s *StaticNetworkConfigGenerator) ValidateStaticConfigParams(staticNetworkConfig []*models.HostStaticNetworkConfig) error {
+	var err *multierror.Error
+	for i, hostConfig := range staticNetworkConfig {
+		err = multierror.Append(err, s.validateMacInterfaceName(i, hostConfig.MacInterfaceMap))
+		err = multierror.Append(err, s.validateNMStateYaml(hostConfig.NetworkYaml))
 	}
-	if !match {
-		msg := "Interface name %s is in invalid format: must be mac address without\":\""
-		s.log.Errorf("%s", msg)
-		return "", fmt.Errorf("%s", msg)
-	}
-	splitMac := []string{}
-	i := 0
-	for i < len(ifaceName) {
-		splitMac = append(splitMac, ifaceName[i:i+2])
-		i += 2
-	}
-	return strings.Join(splitMac, ":"), nil
+	return err.ErrorOrNil()
 }
 
-func FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetworkConfig) string {
+func (s *StaticNetworkConfigGenerator) validateMacInterfaceName(hostIdx int, macInterfaceMap models.MacInterfaceMap) error {
+	interfaceCheck := make(map[string]struct{}, len(macInterfaceMap))
+	macCheck := make(map[string]struct{}, len(macInterfaceMap))
+	for _, macInterface := range macInterfaceMap {
+		interfaceCheck[macInterface.LogicalNicName] = struct{}{}
+		macCheck[macInterface.MacAddress] = struct{}{}
+	}
+	if len(interfaceCheck) < len(macInterfaceMap) || len(macCheck) < len(macInterfaceMap) {
+		return fmt.Errorf("MACs and Interfaces for host %d must be unique", hostIdx)
+	}
+	return nil
+}
+
+func (s *StaticNetworkConfigGenerator) validateNMStateYaml(networkYaml string) error {
+	_, err := s.executeNMStatectl(networkYaml)
+	return err
+}
+
+func (s *StaticNetworkConfigGenerator) FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetworkConfig) string {
 	lines := make([]string, len(staticNetworkConfig))
 	for i, hostConfig := range staticNetworkConfig {
-		hostLine := hostConfig.NetworkYaml + hostStaticNetworkDelimeter + formatMacInterfaceMap(hostConfig.MacInterfaceMap)
+		hostLine := hostConfig.NetworkYaml + hostStaticNetworkDelimeter + s.formatMacInterfaceMap(hostConfig.MacInterfaceMap)
 		lines[i] = hostLine
 	}
 	sort.Strings(lines)
@@ -184,7 +201,7 @@ func FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetw
 	return strings.Join(lines, staticNetworkConfigHostsDelimeter)
 }
 
-func formatMacInterfaceMap(macInterfaceMap models.MacInterfaceMap) string {
+func (s *StaticNetworkConfigGenerator) formatMacInterfaceMap(macInterfaceMap models.MacInterfaceMap) string {
 	lines := make([]string, len(macInterfaceMap))
 	for i, entry := range macInterfaceMap {
 		lines[i] = fmt.Sprintf("%s=%s", entry.MacAddress, entry.LogicalNicName)

--- a/pkg/staticnetworkconfig/mock_generator.go
+++ b/pkg/staticnetworkconfig/mock_generator.go
@@ -6,6 +6,7 @@ package staticnetworkconfig
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	models "github.com/openshift/assisted-service/models"
 	reflect "reflect"
 )
 
@@ -45,4 +46,32 @@ func (m *MockStaticNetworkConfig) GenerateStaticNetworkConfigData(hostsYAMLS str
 func (mr *MockStaticNetworkConfigMockRecorder) GenerateStaticNetworkConfigData(hostsYAMLS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateStaticNetworkConfigData", reflect.TypeOf((*MockStaticNetworkConfig)(nil).GenerateStaticNetworkConfigData), hostsYAMLS)
+}
+
+// FormatStaticNetworkConfigForDB mocks base method
+func (m *MockStaticNetworkConfig) FormatStaticNetworkConfigForDB(staticNetworkConfig []*models.HostStaticNetworkConfig) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FormatStaticNetworkConfigForDB", staticNetworkConfig)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// FormatStaticNetworkConfigForDB indicates an expected call of FormatStaticNetworkConfigForDB
+func (mr *MockStaticNetworkConfigMockRecorder) FormatStaticNetworkConfigForDB(staticNetworkConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatStaticNetworkConfigForDB", reflect.TypeOf((*MockStaticNetworkConfig)(nil).FormatStaticNetworkConfigForDB), staticNetworkConfig)
+}
+
+// ValidateStaticConfigParams mocks base method
+func (m *MockStaticNetworkConfig) ValidateStaticConfigParams(staticNetworkConfig []*models.HostStaticNetworkConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateStaticConfigParams", staticNetworkConfig)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateStaticConfigParams indicates an expected call of ValidateStaticConfigParams
+func (mr *MockStaticNetworkConfigMockRecorder) ValidateStaticConfigParams(staticNetworkConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStaticConfigParams", reflect.TypeOf((*MockStaticNetworkConfig)(nil).ValidateStaticConfigParams), staticNetworkConfig)
 }

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -59,10 +59,10 @@ var _ = Describe("system-test image tests", func() {
 				macInterfaceMap := models.MacInterfaceMap{
 					&models.MacInterfaceMapItems0{
 						LogicalNicName: "eth0",
-						MacAddress:     "00:00:5E:00:53:EF",
+						MacAddress:     "00:00:5E:00:53:EE",
 					},
 					&models.MacInterfaceMapItems0{
-						LogicalNicName: "eth0",
+						LogicalNicName: "eth1",
 						MacAddress:     "00:00:5E:00:53:EF",
 					},
 				}


### PR DESCRIPTION
…work

[MGMT-4696](https://issues.redhat.com/browse/MGMT-4696) - GenerateClusterISO should return BadRequest in case of invalid nmstate yaml

Adding validations to the static network configuration input parameters:
1) verify per host that mac and nics are unique
2) verify per host that nmstate yaml can actually produce valid output

In case any of the conditions is not valid, a BadRequest error code will be returned