### PR TITLE
MGMT-5999 Add a flag to enable day2 in kubeapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ deploy-service-requirements: | deploy-namespace deploy-inventory-service-file
 		--ocp-versions '$(subst ",\",$(OPENSHIFT_VERSIONS))' --public-registries "$(PUBLIC_CONTAINER_REGISTRIES)" \
 		--check-cvo $(CHECK_CLUSTER_VERSION) --apply-manifest $(APPLY_MANIFEST) $(ENABLE_KUBE_API_CMD) $(E2E_TESTS_CONFIG) \
 		--storage $(STORAGE) --ipv6-support $(IPV6_SUPPORT) --enable-sno-dnsmasq $(ENABLE_SINGLE_NODE_DNSMASQ) \
-		--hw-requirements '$(subst ",\",$(HW_REQUIREMENTS))'
+		--hw-requirements '$(subst ",\",$(HW_REQUIREMENTS))' --kubeapi-day2 "$(ENABLE_KUBE_API_DAY2)"
 ifeq ($(MIRROR_REGISTRY_SUPPORT), True)
 	python3 ./tools/deploy_assisted_installer_configmap_registry_ca.py  --target "$(TARGET)" \
 		--namespace "$(NAMESPACE)"  --apply-manifest $(APPLY_MANIFEST) --ca-file-path $(MIRROR_REG_CA_FILE) --registries-file-path $(REGISTRIES_FILE_PATH)
@@ -376,7 +376,7 @@ _run_subsystem_test:
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=120m TEST="$(or $(TEST),./subsystem/...)"
 
 enable-kube-api-for-subsystem: $(BUILD_FOLDER)
-	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true
+	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true ENABLE_KUBE_API_DAY2=true
 	$(call restart_service_pods)
 	$(MAKE) wait-for-service
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,6 +122,7 @@ var Options struct {
 	AssistedServiceISOConfig    assistedserviceiso.Config
 	manifestsGeneratorConfig    network.Config
 	EnableKubeAPI               bool `envconfig:"ENABLE_KUBE_API" default:"false"`
+	EnableKubeAPIDay2Cluster    bool `envconfig:"ENABLE_KUBE_API_DAY2" default:"false"`
 	InfraEnvConfig              controllers.InfraEnvConfig
 	ISOEditorConfig             isoeditor.Config
 	CheckClusterVersion         bool          `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
@@ -454,16 +455,17 @@ func main() {
 			}).SetupWithManager(ctrlMgr), "unable to create controller InfraEnv")
 
 			failOnError((&controllers.ClusterDeploymentsReconciler{
-				Client:           ctrlMgr.GetClient(),
-				Log:              log,
-				Scheme:           ctrlMgr.GetScheme(),
-				Installer:        bm,
-				ClusterApi:       clusterApi,
-				HostApi:          hostApi,
-				CRDEventsHandler: crdEventsHandler,
-				Manifests:        manifestsApi,
-				ServiceBaseURL:   Options.BMConfig.ServiceBaseURL,
-				AuthType:         Options.Auth.AuthType,
+				Client:            ctrlMgr.GetClient(),
+				Log:               log,
+				Scheme:            ctrlMgr.GetScheme(),
+				Installer:         bm,
+				ClusterApi:        clusterApi,
+				HostApi:           hostApi,
+				CRDEventsHandler:  crdEventsHandler,
+				Manifests:         manifestsApi,
+				ServiceBaseURL:    Options.BMConfig.ServiceBaseURL,
+				AuthType:          Options.Auth.AuthType,
+				EnableDay2Cluster: Options.EnableKubeAPIDay2Cluster,
 			}).SetupWithManager(ctrlMgr), "unable to create controller ClusterDeployment")
 
 			failOnError((&controllers.AgentReconciler{

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -75,15 +75,16 @@ const defaultRequeueAfterOnError = 10 * time.Second
 // ClusterDeploymentsReconciler reconciles a Cluster object
 type ClusterDeploymentsReconciler struct {
 	client.Client
-	Log              logrus.FieldLogger
-	Scheme           *runtime.Scheme
-	Installer        bminventory.InstallerInternals
-	ClusterApi       cluster.API
-	HostApi          host.API
-	CRDEventsHandler CRDEventsHandler
-	Manifests        manifests.ClusterManifestsInternals
-	ServiceBaseURL   string
-	AuthType         auth.AuthType
+	Log               logrus.FieldLogger
+	Scheme            *runtime.Scheme
+	Installer         bminventory.InstallerInternals
+	ClusterApi        cluster.API
+	HostApi           host.API
+	CRDEventsHandler  CRDEventsHandler
+	Manifests         manifests.ClusterManifestsInternals
+	ServiceBaseURL    string
+	AuthType          auth.AuthType
+	EnableDay2Cluster bool
 }
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update;create
@@ -176,7 +177,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 		if !isInstalled(clusterDeployment, clusterInstall) {
 			return r.createNewCluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
 		}
-		if !r.isSNO(clusterInstall) {
+		if !r.isSNO(clusterInstall) && r.EnableDay2Cluster {
 			return r.createNewDay2Cluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
 		}
 		// cluster is installed and SNO. Clear EventsURL

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -711,6 +711,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("installed SNO no day2", func() {
+			cr.EnableDay2Cluster = true
 			openshiftID := strfmt.UUID(uuid.New().String())
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
 			backEndCluster.StatusInfo = swag.String("Done")
@@ -788,6 +789,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("Fail to create day2", func() {
+			cr.EnableDay2Cluster = true
 			openshiftID := strfmt.UUID(uuid.New().String())
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
 			backEndCluster.OpenshiftClusterID = openshiftID
@@ -819,6 +821,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("Create day2 if day1 is already deleted none SNO", func() {
+			cr.EnableDay2Cluster = true
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
 			id := strfmt.UUID(uuid.New().String())
 			clusterReply := &common.Cluster{
@@ -962,6 +965,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("install day2 host", func() {
+			cr.EnableDay2Cluster = true
 			openshiftID := strfmt.UUID(uuid.New().String())
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
 			backEndCluster.OpenshiftClusterID = openshiftID
@@ -991,6 +995,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("install failure day2 host", func() {
+			cr.EnableDay2Cluster = true
 			openshiftID := strfmt.UUID(uuid.New().String())
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
 			backEndCluster.OpenshiftClusterID = openshiftID

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -26,6 +26,7 @@ def handle_arguments():
     parser.add_argument("--ipv6-support", default="True")
     parser.add_argument("--enable-sno-dnsmasq", default="True")
     parser.add_argument("--hw-requirements")
+    parser.add_argument("--kubeapi-day2", default="False")
 
     return deployment_options.load_deployment_options(parser)
 
@@ -113,6 +114,9 @@ def main():
 
             if deploy_options.enable_kube_api:
                 y['data']['ENABLE_KUBE_API'] = 'true'
+
+            if deploy_options.kubeapi_day2:
+                y['data']['ENABLE_KUBE_API_DAY2'] = 'true'
 
             data = yaml.dump(y)
             dst.write(data)


### PR DESCRIPTION
Add a flag to disable by default the automatic creation of Day2 cluster in KubeApi.

Signed-off-by: Fred Rolland <frolland@redhat.com>