### PR TITLE
MGMT-6438 Remove references to unused env variables for hardware requiremets

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -36,25 +36,10 @@ parameters:
 - name: IMAGE_BUILDER
   value: ''
   required: true
-- name: HW_VALIDATOR_MIN_RAM_GIB_MASTER
-  value: ''
-  required: true
-- name: HW_VALIDATOR_MIN_CPU_CORES_MASTER
-  value: ''
-  required: true
-- name: HW_VALIDATOR_MIN_CPU_CORES_WORKER
-  value: ''
-  required: true
-- name: HW_VALIDATOR_MIN_RAM_GIB_WORKER
-  value: ''
-  required: true
 - name: HW_VALIDATOR_MIN_CPU_CORES
   value: ''
   required: true
 - name: HW_VALIDATOR_MIN_RAM_GIB
-  value: ''
-  required: true
-- name: HW_VALIDATOR_MIN_DISK_SIZE_GIB
   value: ''
   required: true
 - name: HW_VALIDATOR_REQUIREMENTS
@@ -257,20 +242,10 @@ objects:
                 value: ${OCM_LOG_LEVEL}
               - name: IMAGE_BUILDER
                 value: ${IMAGE_BUILDER}:${IMAGE_TAG}
-              - name: HW_VALIDATOR_MIN_RAM_GIB_MASTER
-                value: ${HW_VALIDATOR_MIN_RAM_GIB_MASTER}
-              - name: HW_VALIDATOR_MIN_CPU_CORES_MASTER
-                value: ${HW_VALIDATOR_MIN_CPU_CORES_MASTER}
-              - name: HW_VALIDATOR_MIN_CPU_CORES_WORKER
-                value: ${HW_VALIDATOR_MIN_CPU_CORES_WORKER}
-              - name: HW_VALIDATOR_MIN_RAM_GIB_WORKER
-                value: ${HW_VALIDATOR_MIN_RAM_GIB_WORKER}
               - name: HW_VALIDATOR_MIN_CPU_CORES
                 value: ${HW_VALIDATOR_MIN_CPU_CORES}
               - name: HW_VALIDATOR_MIN_RAM_GIB
                 value: ${HW_VALIDATOR_MIN_RAM_GIB}
-              - name: HW_VALIDATOR_MIN_DISK_SIZE_GIB
-                value: ${HW_VALIDATOR_MIN_DISK_SIZE_GIB}
               - name: HW_VALIDATOR_REQUIREMENTS
                 value: ${HW_VALIDATOR_REQUIREMENTS}
               - name: INSTALLER_IMAGE


### PR DESCRIPTION
This PR removes last traces of env variables removed in #1715:
- HW_VALIDATOR_MIN_CPU_CORES_WORKER
- HW_VALIDATOR_MIN_CPU_CORES_MASTER
- HW_VALIDATOR_MIN_RAM_GIB_WORKER
- HW_VALIDATOR_MIN_RAM_GIB_MASTER
- HW_VALIDATOR_MIN_DISK_SIZE_GIB

Signed-off-by: Jakub Dzon <jdzon@redhat.com>