### PR TITLE
MGMT-6483 Selective monitoring for cluster and hosts

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2770,7 +2770,7 @@ func (b *bareMetalInventory) GetNextSteps(ctx context.Context, params installer.
 	}
 
 	host.CheckedInAt = strfmt.DateTime(time.Now())
-	if err = tx.Model(&host).Update("checked_in_at", host.CheckedInAt).Error; err != nil {
+	if err = tx.Model(&host).UpdateColumn("checked_in_at", host.CheckedInAt).Error; err != nil {
 		log.WithError(err).Errorf("failed to update host: %s", params.ClusterID)
 		return installer.NewGetNextStepsInternalServerError()
 	}
@@ -2886,7 +2886,7 @@ func (b *bareMetalInventory) updateFreeAddressesReport(ctx context.Context, host
 		return err
 	}
 	if err = b.db.Model(&common.Host{}).Where("id = ? and cluster_id = ?", host.ID.String(),
-		host.ClusterID.String()).Updates(map[string]interface{}{"free_addresses": freeAddressesReport}).Error; err != nil {
+		host.ClusterID.String()).UpdateColumn("free_addresses", freeAddressesReport).Error; err != nil {
 		log.WithError(err).Warnf("Update free addresses of host %s", host.ID.String())
 		return err
 	}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -905,8 +905,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			srcState: models.ClusterStatusPendingForInput,
 			hosts: []*models.Host{
 				{
-					Status:    swag.String(models.HostStatusDiscovering),
-					Inventory: common.GenerateTestDefaultInventory(),
+					Status: swag.String(models.HostStatusDiscovering),
 				},
 			},
 			dhcpEnabled: false,

--- a/internal/common/monitor_query_generator.go
+++ b/internal/common/monitor_query_generator.go
@@ -1,0 +1,177 @@
+package common
+
+import (
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/jinzhu/gorm"
+)
+
+/*
+   Support querying for cluster or host monitoring. Implementation for both full query, and timed query according to
+   updated_at field.
+   Querying is done at cluster level.  Checking the update_at field is done both for hosts and clusters
+*/
+const (
+	DefaultBatchSize = 100
+	IdsQuerySize     = 10000
+)
+
+type MonitorQuery interface {
+	Next() ([]*Cluster, error)
+}
+
+type fullQuery struct {
+	lastId          string
+	dbWithCondition *gorm.DB
+	eof             bool
+	batchSize       int
+}
+
+/*
+  Full scan (backward compatible) query.  Instead of using offset, the query uses the lastId to indicate where to start the next batch
+*/
+func (f *fullQuery) Next() ([]*Cluster, error) {
+	var clusters []*Cluster
+	if f.eof {
+		return clusters, nil
+	}
+	if err := f.dbWithCondition.Where("id > ?", f.lastId).Order("id").Limit(f.batchSize).Find(&clusters).Error; err != nil {
+		return clusters, err
+	}
+	if len(clusters) < f.batchSize {
+		f.eof = true
+	}
+	if len(clusters) > 0 {
+		f.lastId = clusters[len(clusters)-1].ID.String()
+	}
+	return clusters, nil
+}
+
+/*
+  Timed query which queries according to the updated_at field
+*/
+type timedQuery struct {
+	// Where to start the next query for ids
+	lastId string
+
+	// db connection to query ids
+	db *gorm.DB
+
+	// db connection to query the clusters
+	dbWithCondition *gorm.DB
+
+	// The time to compare to the updated_at fieldd
+	timeToCompare strfmt.DateTime
+
+	// The relevant cluster ids
+	ids []string
+
+	// True if last id was already received
+	eof bool
+
+	// Offset in the id list
+	offset int
+
+	// Max batch size (limit)
+	batchSize int
+}
+
+func min(i, j int) int {
+	if i < j {
+		return i
+	}
+	return j
+}
+
+func (t *timedQuery) Next() ([]*Cluster, error) {
+	var (
+		clusters []*Cluster
+		err      error
+	)
+	if t.eof && t.offset == len(t.ids) {
+		return clusters, nil
+	}
+	for (!t.eof || t.offset < len(t.ids)) && len(clusters) == 0 {
+		if t.offset == len(t.ids) {
+			t.ids = nil
+			// Retrieve cluster ids that the related cluster or hosts have been updated after the timeToCompare
+			err = t.db.Raw("select distinct(cid) as id from (select id as cid from clusters where updated_at > ?  and clusters.id > ? union select cluster_id as cid from hosts where updated_at > ? and hosts.cluster_id > ?) as t order by id limit ?",
+				t.timeToCompare, t.lastId, t.timeToCompare, t.lastId, IdsQuerySize).Pluck("id", &t.ids).Error
+			if err != nil {
+				return clusters, err
+			}
+			if len(t.ids) < IdsQuerySize {
+				t.eof = true
+			}
+			if len(t.ids) > 0 {
+				t.lastId = t.ids[len(t.ids)-1]
+			}
+			t.offset = 0
+		}
+		for len(clusters) == 0 && t.offset < len(t.ids) {
+			nextOffset := min(t.offset+t.batchSize, len(t.ids))
+
+			// Query according to moving range on the id slice
+			err = t.dbWithCondition.Where("id in (?)", t.ids[t.offset:nextOffset]).Find(&clusters).Error
+			if err != nil {
+				return clusters, err
+			}
+			t.offset = nextOffset
+		}
+	}
+	return clusters, nil
+}
+
+type MonitorQueryGenerator struct {
+	lastInvokeTime  time.Time
+	calls           int64
+	db              *gorm.DB
+	dbWithCondition *gorm.DB
+	batchSize       int
+}
+
+func NewMonitorQueryGenerator(db, dbWithCondition *gorm.DB, batchSize int) *MonitorQueryGenerator {
+	if batchSize < 1 {
+		batchSize = DefaultBatchSize
+	}
+	return &MonitorQueryGenerator{
+		db:              db,
+		dbWithCondition: dbWithCondition,
+		batchSize:       batchSize,
+	}
+}
+
+func timeForDuration(d time.Duration) strfmt.DateTime {
+	return strfmt.DateTime(time.Now().Add(-d))
+}
+
+func (m *MonitorQueryGenerator) NewQuery() MonitorQuery {
+	newInvokeTime := time.Now()
+	defer func() {
+		m.lastInvokeTime = newInvokeTime
+		m.calls++
+	}()
+	if m.calls == 0 ||
+		m.lastInvokeTime.Minute()/5 != newInvokeTime.Minute()/5 {
+		return &fullQuery{
+			dbWithCondition: m.dbWithCondition,
+			batchSize:       m.batchSize,
+		}
+	}
+
+	if m.lastInvokeTime.Minute() != newInvokeTime.Minute() {
+		return &timedQuery{
+			db:              m.db,
+			dbWithCondition: m.dbWithCondition,
+			timeToCompare:   timeForDuration(15 * time.Minute),
+			batchSize:       m.batchSize,
+		}
+	}
+	return &timedQuery{
+		db:              m.db,
+		dbWithCondition: m.dbWithCondition,
+		timeToCompare:   timeForDuration(30 * time.Second),
+		batchSize:       m.batchSize,
+	}
+}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	reflect "reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -145,16 +146,17 @@ type API interface {
 }
 
 type Manager struct {
-	log            logrus.FieldLogger
-	db             *gorm.DB
-	instructionApi hostcommands.InstructionApi
-	hwValidator    hardware.Validator
-	eventsHandler  events.Handler
-	sm             stateswitch.StateMachine
-	rp             *refreshPreprocessor
-	metricApi      metrics.API
-	Config         Config
-	leaderElector  leader.Leader
+	log                   logrus.FieldLogger
+	db                    *gorm.DB
+	instructionApi        hostcommands.InstructionApi
+	hwValidator           hardware.Validator
+	eventsHandler         events.Handler
+	sm                    stateswitch.StateMachine
+	rp                    *refreshPreprocessor
+	metricApi             metrics.API
+	Config                Config
+	leaderElector         leader.Leader
+	monitorQueryGenerator *common.MonitorQueryGenerator
 }
 
 func NewManager(log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, hwValidator hardware.Validator, instructionApi hostcommands.InstructionApi,
@@ -293,6 +295,53 @@ func (m *Manager) UpdateInventory(ctx context.Context, h *models.Host, inventory
 	return m.updateInventory(ctx, cluster, h, inventoryStr, m.db)
 }
 
+// Check if the value of the
+func (m *Manager) ntpSyncedChanged(c *common.Cluster, host *models.Host, inventoryStr string) bool {
+	prev, err := common.IsNtpSynced(c)
+	if err != nil {
+		m.log.WithError(err).Error("Checking ntp synced")
+
+		// Sine the was an error we would like to indicate that the synced has changed for safe side
+		return true
+	}
+	for _, h := range c.Hosts {
+		if h.ID.String() == host.ID.String() {
+			h.Inventory = inventoryStr
+			break
+		}
+	}
+	current, err := common.IsNtpSynced(c)
+	if err != nil {
+		m.log.WithError(err).Error("Checking ntp synced")
+
+		// Sine the was an error we would like to indicate that the synced has changed for safe side
+		return true
+	}
+	return prev != current
+}
+
+// Create a JSON encoded inventory that can be compared to other such string for invariance.  Mainly it removes timestamps
+// that are constantly changing
+func canonizeInventory(inventoryStr string) string {
+	var inventory models.Inventory
+	err := json.Unmarshal([]byte(inventoryStr), &inventory)
+	if err != nil {
+		return inventoryStr
+	}
+	inventory.Timestamp = 0
+	if inventory.Memory != nil {
+		inventory.Memory.UsableBytes = 0
+	}
+	for _, d := range inventory.Disks {
+		d.Smart = ""
+	}
+	b, err := json.Marshal(&inventory)
+	if err != nil {
+		return inventoryStr
+	}
+	return string(b)
+}
+
 func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, h *models.Host, inventoryStr string, db *gorm.DB) error {
 	log := logutil.FromContext(ctx, m.log)
 
@@ -317,7 +366,7 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	}
 	m.populateDisksId(inventory)
 
-	h.Inventory, err = hostutil.MarshalInventory(inventory)
+	marshalledInventory, err := hostutil.MarshalInventory(inventory)
 	if err != nil {
 		return err
 	}
@@ -325,19 +374,37 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	validDisks := m.hwValidator.ListEligibleDisks(inventory)
 	installationDisk := hostutil.DetermineInstallationDisk(validDisks, hostutil.GetHostInstallationPath(h))
 
+	var (
+		installationDiskPath string
+		installationDiskID   string
+	)
 	if installationDisk == nil {
-		h.InstallationDiskPath = ""
-		h.InstallationDiskID = ""
+		installationDiskPath = ""
+		installationDiskID = ""
 	} else {
-		h.InstallationDiskPath = hostutil.GetDeviceFullName(installationDisk)
-		h.InstallationDiskID = hostutil.GetDeviceIdentifier(installationDisk)
+		installationDiskPath = hostutil.GetDeviceFullName(installationDisk)
+		installationDiskID = hostutil.GetDeviceIdentifier(installationDisk)
 	}
 
-	return db.Model(h).Update(map[string]interface{}{
-		"inventory":              h.Inventory,
-		"installation_disk_path": h.InstallationDiskPath,
-		"installation_disk_id":   h.InstallationDiskID,
-	}).Error
+	// If there is substantial change in the inventory that might cause the state machine to move to a new status
+	// or one of the validations to change, then the updated_at field has to be modified.  Otherwise, we just
+	// perform update with touching the updated_at field
+	if canonizeInventory(marshalledInventory) != canonizeInventory(h.Inventory) ||
+		installationDiskPath != h.InstallationDiskPath ||
+		installationDiskID != h.InstallationDiskID ||
+		m.ntpSyncedChanged(cluster, h, marshalledInventory) {
+		return db.Model(h).Update(map[string]interface{}{
+			"inventory":              marshalledInventory,
+			"installation_disk_path": installationDiskPath,
+			"installation_disk_id":   installationDiskID,
+		}).Error
+	} else {
+		return db.Model(h).UpdateColumns(map[string]interface{}{
+			"inventory":              marshalledInventory,
+			"installation_disk_path": installationDiskPath,
+			"installation_disk_id":   installationDiskID,
+		}).Error
+	}
 }
 
 func (m *Manager) refreshStatusInternal(ctx context.Context, h *models.Host, c *common.Cluster, db *gorm.DB) error {
@@ -427,9 +494,15 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 	previousProgress := h.Progress
 
 	if previousProgress != nil &&
-		previousProgress.CurrentStage == progress.CurrentStage &&
-		previousProgress.ProgressInfo == progress.ProgressInfo {
-		return nil
+		previousProgress.CurrentStage == progress.CurrentStage {
+		if previousProgress.ProgressInfo == progress.ProgressInfo {
+			return nil
+		}
+		updates := map[string]interface{}{
+			"progress_progress_info":    progress.ProgressInfo,
+			"progress_stage_updated_at": strfmt.DateTime(time.Now()),
+		}
+		return m.db.Model(h).UpdateColumns(updates).Error
 	}
 
 	validStatuses := []string{
@@ -513,9 +586,53 @@ func (m *Manager) SetUploadLogsAt(ctx context.Context, h *models.Host, db *gorm.
 	return nil
 }
 
+// Create JSON encoded connectivity report that can be checked against similar string if the
+// connectivity between the current host and other hosts has changed
+func canonizeConnectivity(connectivityReportStr string) string {
+	var connectivityReport models.ConnectivityReport
+	err := json.Unmarshal([]byte(connectivityReportStr), &connectivityReport)
+	if err != nil {
+		return connectivityReportStr
+	}
+	for _, h := range connectivityReport.RemoteHosts {
+		for _, l3 := range h.L3Connectivity {
+			l3.AverageRTTMs = 0
+			l3.PacketLossPercentage = 0
+		}
+		l3 := h.L3Connectivity
+		sort.Slice(l3, func(i, j int) bool {
+			if l3[i].RemoteIPAddress != l3[j].RemoteIPAddress {
+				return l3[i].RemoteIPAddress < l3[j].RemoteIPAddress
+			}
+			return l3[i].OutgoingNic < l3[j].OutgoingNic
+		})
+		l2 := h.L2Connectivity
+		sort.Slice(l2, func(i, j int) bool {
+			if l2[i].RemoteIPAddress != l2[j].RemoteIPAddress {
+				return l2[i].RemoteIPAddress < l2[j].RemoteIPAddress
+			}
+			return l2[i].OutgoingNic < l2[j].OutgoingNic
+		})
+	}
+	sort.Slice(connectivityReport.RemoteHosts, func(i, j int) bool {
+		return connectivityReport.RemoteHosts[i].HostID.String() < connectivityReport.RemoteHosts[j].HostID.String()
+	})
+	b, err := json.Marshal(&connectivityReport)
+	if err != nil {
+		return connectivityReportStr
+	}
+	return string(b)
+}
+
 func (m *Manager) UpdateConnectivityReport(ctx context.Context, h *models.Host, connectivityReport string) error {
 	if h.Connectivity != connectivityReport {
-		err := m.db.Model(h).Update("connectivity", connectivityReport).Error
+		var err error
+		// Only if the connectivity between the hosts changed change the updated_at field
+		if canonizeConnectivity(h.Connectivity) != canonizeConnectivity(connectivityReport) {
+			err = m.db.Model(h).Update("connectivity", connectivityReport).Error
+		} else {
+			err = m.db.Model(h).UpdateColumn("connectivity", connectivityReport).Error
+		}
 		if err != nil {
 			return errors.Wrapf(err, "failed to set connectivity to host %s", h.ID.String())
 		}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1042,6 +1042,58 @@ var _ = Describe("UpdateInventory", func() {
 		})
 	})
 
+	Context("Inventory changes", func() {
+		BeforeEach(func() {
+			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
+			host.Inventory = common.GenerateTestDefaultInventory()
+			host.InstallationDiskPath = ""
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		})
+		It("Invariant changes to inventory", func() {
+			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
+				[]*models.Disk{},
+			).AnyTimes()
+			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
+			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			updatedAt := h.UpdatedAt
+			var inventory models.Inventory
+			Expect(json.Unmarshal([]byte(h.Inventory), &inventory)).ToNot(HaveOccurred())
+			inventory.Timestamp = 555
+			inventory.Disks[0].Smart = "kuku"
+			b, err := json.Marshal(&inventory)
+			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(time.Second)
+			Expect(hapi.UpdateInventory(ctx, &host, string(b))).ToNot(HaveOccurred())
+			h = hostutil.GetHostFromDB(hostId, clusterId, db)
+			Expect(updatedAt).To(Equal(h.UpdatedAt))
+			Expect(h.Inventory).To(Equal(string(b)))
+		})
+
+		It("Variant changes to inventory", func() {
+			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
+				[]*models.Disk{},
+			).AnyTimes()
+			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
+			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			updatedAt := h.UpdatedAt
+			var inventory models.Inventory
+			Expect(json.Unmarshal([]byte(h.Inventory), &inventory)).ToNot(HaveOccurred())
+			inventory.Interfaces = append(inventory.Interfaces, &models.Interface{
+				HasCarrier: false,
+				Mtu:        1500,
+				Name:       "abcd",
+			})
+			b, err := json.Marshal(&inventory)
+			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(time.Second)
+			Expect(hapi.UpdateInventory(ctx, &host, string(b))).ToNot(HaveOccurred())
+			h = hostutil.GetHostFromDB(hostId, clusterId, db)
+			Expect(updatedAt).ToNot(Equal(h.UpdatedAt))
+			Expect(h.Inventory).To(Equal(string(b)))
+		})
+	})
+
 	Context("enable host", func() {
 		var newInventoryBytes []byte
 

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -18,7 +18,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/events"
 	"github.com/openshift/assisted-service/client/installer"
-	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/models"
@@ -996,7 +995,7 @@ var _ = Describe("Metrics tests", func() {
 
 			// create a validation failure
 			nonSyncedInventory := &models.Inventory{
-				Timestamp: validHwInfo.Timestamp + (cluster.MaximumAllowedTimeDiffMinutes+1)*60,
+				Timestamp: validHwInfo.Timestamp + (common.MaximumAllowedTimeDiffMinutes+1)*60,
 			}
 			generateHWPostStepReply(ctx, h1, nonSyncedInventory, "h1")
 			Expect(db.Model(h1).Update("status", "known").Error).NotTo(HaveOccurred())
@@ -1017,7 +1016,7 @@ var _ = Describe("Metrics tests", func() {
 			h1 := registerNode(ctx, clusterID, "h1")
 			registerNode(ctx, clusterID, "h2")
 			nonSyncedInventory := &models.Inventory{
-				Timestamp: validHwInfo.Timestamp + (cluster.MaximumAllowedTimeDiffMinutes+1)*60,
+				Timestamp: validHwInfo.Timestamp + (common.MaximumAllowedTimeDiffMinutes+1)*60,
 			}
 			generateHWPostStepReply(ctx, h1, nonSyncedInventory, "h1")
 			Expect(db.Model(h1).Update("status", "known").Error).NotTo(HaveOccurred())


### PR DESCRIPTION
- Add selective monitoring for cluster and hosts.  The aim is to minimize the number of entities to perform the monitoring operation on
- It is done using the update_at field, so we try to monitor only the changed clusters/hosts

/cc @tsorya 

/hold