### PR TITLE
OCPBUGSM-29303: fix crash on undefined pull-secret

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -149,7 +149,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// check for updates from user, compare spec and update if needed
 	err = r.updateIfNeeded(ctx, agent, cluster)
 	if err != nil {
-		return r.updateStatus(ctx, agent, host, err, !IsHTTP4XXError(err))
+		return r.updateStatus(ctx, agent, host, err, !IsUserError(err))
 	}
 
 	err = r.updateInventory(host, agent)

--- a/internal/controller/controllers/error_utils.go
+++ b/internal/controller/controllers/error_utils.go
@@ -2,7 +2,22 @@ package controllers
 
 import (
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/pkg/errors"
 )
+
+type InputError struct {
+	err error
+}
+
+func (i *InputError) Error() string {
+	return i.err.Error()
+}
+
+func newInputError(format string, args ...interface{}) *InputError {
+	return &InputError{
+		err: errors.Errorf(format, args...),
+	}
+}
 
 type KubeAPIError struct {
 	err           error
@@ -44,7 +59,7 @@ func IsHTTPError(err error, httpErrorCode int) bool {
 	}
 }
 
-func IsHTTP4XXError(err error) bool {
+func IsUserError(err error) bool {
 	switch serr := err.(type) {
 	case *common.ApiErrorResponse:
 		if serr.StatusCode() >= 400 && serr.StatusCode() < 500 {
@@ -54,6 +69,8 @@ func IsHTTP4XXError(err error) bool {
 		if serr.StatusCode() >= 400 && serr.StatusCode() < 500 {
 			return true
 		}
+	case *InputError:
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Pull secret is optional in cluster deployment but it is required for assisted service.
Get pull secret will get a reference instaed of the name directly and will check if refence is not nil
if it's nil it will return input error that will cause sync error in the sync condtion.

Added new error type to the controllers inputError type that is changed
as internal error with `IsHTTP4XXError`.