### PR TITLE
MGMT-6495 Parameterize OPENSHIFT_INSTALL_INVOKER

### DIFF
--- a/deploy/olm-catalog/metadata/annotations.yaml
+++ b/deploy/olm-catalog/metadata/annotations.yaml
@@ -6,9 +6,9 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: assisted-service-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,ocm-2.3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -313,6 +313,7 @@ type installerGenerator struct {
 	s3Client                 s3wrapper.API
 	enableMetal3Provisioning bool
 	operatorsApi             operators.API
+	installInvoker           string
 }
 
 // IgnitionConfig contains the attributes required to build the discovery ignition file
@@ -343,7 +344,7 @@ func NewBuilder(log logrus.FieldLogger, staticNetworkConfig staticnetworkconfig.
 
 // NewGenerator returns a generator that can generate ignition files
 func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, releaseImage string, releaseImageMirror string,
-	serviceCACert string, s3Client s3wrapper.API, log logrus.FieldLogger, operatorsApi operators.API) Generator {
+	serviceCACert, installInvoker string, s3Client s3wrapper.API, log logrus.FieldLogger, operatorsApi operators.API) Generator {
 	return &installerGenerator{
 		cluster:                  cluster,
 		log:                      log,
@@ -355,6 +356,7 @@ func NewGenerator(workDir string, installerDir string, cluster *common.Cluster, 
 		s3Client:                 s3Client,
 		enableMetal3Provisioning: true,
 		operatorsApi:             operatorsApi,
+		installInvoker:           installInvoker,
 	}
 }
 
@@ -385,7 +387,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte)
 	}
 	envVars := append(os.Environ(),
 		"OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="+g.releaseImage,
-		"OPENSHIFT_INSTALL_INVOKER=assisted-installer",
+		"OPENSHIFT_INSTALL_INVOKER="+g.installInvoker,
 	)
 
 	// write installConfig to install-config.yaml so openshift-install can read it

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 				Role:              models.HostRoleMaster,
 			},
 		}
-		g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+		g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 		err = g.updateBootstrap(examplePath)
 
 		bootstrapBytes, _ := ioutil.ReadFile(examplePath)
@@ -209,7 +209,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 
 	Describe("update ignitions", func() {
 		It("with ca cert file", func() {
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", caCertPath, nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", caCertPath, "", nil, log, mockOperatorManager).(*installerGenerator)
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -230,7 +230,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			Expect(file.Path).To(Equal(common.HostCACertPath))
 		})
 		It("with no ca cert file", func() {
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -247,7 +247,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			Expect(workerConfig.Storage.Files).To(HaveLen(0))
 		})
 		It("with service ips", func() {
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 			err := g.UpdateEtcHosts("10.10.10.1,10.10.10.2")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -268,7 +268,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			Expect(file.Path).To(Equal("/etc/hosts"))
 		})
 		It("with no service ips", func() {
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 			err := g.UpdateEtcHosts("")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -296,7 +296,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		Context("DHCP generation", func() {
 			It("Definitions only", func() {
-				g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+				g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 				g.encodedDhcpFileContents = "data:,abc"
 				err := g.updateIgnitions()
 				Expect(err).NotTo(HaveOccurred())
@@ -313,7 +313,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 			})
 		})
 		It("Definitions+leases", func() {
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 			g.encodedDhcpFileContents = "data:,abc"
 			cluster.ApiVipLease = "api"
 			cluster.IngressVipLease = "ingress"
@@ -434,7 +434,7 @@ var _ = Describe("createHostIgnitions", func() {
 				host.ID = &id
 			}
 
-			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+			g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 			err := g.createHostIgnitions()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -477,7 +477,7 @@ var _ = Describe("createHostIgnitions", func() {
 			IgnitionConfigOverrides: `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`,
 		}}
 
-		g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
+		g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", nil, log, mockOperatorManager).(*installerGenerator)
 		err := g.createHostIgnitions()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -26,7 +26,8 @@ type Config struct {
 	ServiceCACertPath  string `envconfig:"SERVICE_CA_CERT_PATH" default:""`
 	ServiceIPs         string `envconfig:"SERVICE_IPS" default:""`
 	ReleaseImageMirror string
-	DummyIgnition      bool `envconfig:"DUMMY_IGNITION"`
+	DummyIgnition      bool   `envconfig:"DUMMY_IGNITION"`
+	InstallInvoker     string `envconfig:"INSTALL_INVOKER" default:"assisted-installer"`
 }
 
 type installGenerator struct {
@@ -84,7 +85,7 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 	if k.Config.DummyIgnition {
 		generator = ignition.NewDummyGenerator(clusterWorkDir, &cluster, k.s3Client, log)
 	} else {
-		generator = ignition.NewGenerator(clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror, k.Config.ServiceCACertPath, k.s3Client, log, k.operatorsApi)
+		generator = ignition.NewGenerator(clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror, k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi)
 	}
 	err = generator.Generate(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
Make OPENSHIFT_INSTALL_INVOKER configurable to distinguish between
types of deployments (cloud, operator). The value of
OPENSHIFT_INSTALL_INVOKER goes into the `invoker` attribute of an
installed cluster via a manifest. Using different values for different
deployment types can be used for telemetry and analytics to tell the
number of clusters installed from the cloud (`invoker: assisted-installer`)
vs. clusters installed by operator deployments
(`invoker: assisted-installer-operator`).