### PR TITLE
OCPBUGSM-29119 Can't change Installation disk

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1563,7 +1563,7 @@ func (b *bareMetalInventory) refreshClusterHosts(ctx context.Context, cluster *c
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	for _, dbHost := range cluster.Hosts {
+	for _, dbHost := range dbCluster.Hosts {
 		var err error
 
 		// Refresh inventory - especially disk eligibility. The host requirements might have changed.

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -289,8 +289,8 @@ func (v *validator) getOCPRequirementsForVersion(cluster *common.Cluster) (*mode
 	return requirements, nil
 }
 
-func compileDiskReasonTemplate(template string, wildcards ...string) *regexp.Regexp {
-	tmp, err := regexp.Compile(fmt.Sprintf(regexp.QuoteMeta(template), wildcards))
+func compileDiskReasonTemplate(template string, wildcards ...interface{}) *regexp.Regexp {
+	tmp, err := regexp.Compile(fmt.Sprintf(regexp.QuoteMeta(template), wildcards...))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -173,6 +173,25 @@ var _ = Describe("Disk eligibility", func() {
 		Expect(eligible).To(ContainElements(existingReasons))
 		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
 	})
+
+	It("Check that a old service reasons have been purged", func() {
+		operatorsMock.EXPECT().GetRequirementsBreakdownForHostInCluster(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*models.OperatorHostRequirements{}, nil)
+		existingReasons := []string{"Reason 1", "Reason 2"}
+		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
+
+		testDisk.SizeBytes = tooSmallSize
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, &cluster, &host)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(ContainElements(existingReasons))
+		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
+
+		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, &cluster, &host)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(ContainElements(existingReasons))
+		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
+	})
 })
 
 var _ = Describe("hardware_validator", func() {


### PR DESCRIPTION
When patching a cluster first we update the hosts according to the parameters (For instance updating the installation path which succeed and updates the DB)
Then calling to the inventory.updateHostsAndClusterStatus which reads a new cluster object from the DB but calling the actual update with the old host objects (contain the old installation path in our example)
The updateInventory just reverts the user selection and reselect the old installationDiskId/Path
We have another issue that changing the selected disk add more and more identical messages.