### PR TITLE
MGMT-5430 Move assisted service image to stream8

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -25,31 +25,10 @@ RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-
 FROM quay.io/ocpmetal/oc-image:bug-1823143 as oc-image
 
 # Create final image
-FROM quay.io/centos/centos:centos8
+FROM quay.io/centos/centos:stream8
 
 # openshift-install requires this
-RUN dnf install -y libvirt-libs python3 && \
-    dnf install -b -y  dnf-plugins-core && \
-    dnf copr enable -y networkmanager/NetworkManager-master && \
-    dnf copr enable -y nmstate/ovs-el8 && \
-    dnf copr enable -y nmstate/nmstate-1.0&& \
-    dnf copr enable -y nmstate/nispor && \
-    dnf install -y pkg-config && \
-    dnf install -y glib2-devel && \
-    dnf install -y gobject-introspection-devel && \
-    dnf install -y cairo-devel && \
-    dnf install -y cairo-gobject-devel && \
-    dnf install -y python3-devel && \
-    dnf install -y python3-nispor && \
-    dnf install -y NetworkManager && \
-    dnf install -y NetworkManager-ovs && \
-    dnf install -y NetworkManager-team && \
-    dnf install -y NetworkManager-config-server && \
-    dnf install -y openvswitch2.11 && \
-    dnf install -y python3-openvswitch2.11 && \
-    dnf install -y nmstate &&\
-    pip3 install pycairo && \
-    dnf remove -y dnf-plugins-core && \
+RUN dnf install -y libvirt-libs nmstate &&\
     dnf clean all
 
 ARG WORK_DIR=/data


### PR DESCRIPTION
Packages removed in this PR were added here b41e2b6af in order to be able to build `nmstate`. Now that we are installing the RPM, we don't need these packages anymore.

```
[root@eabcc7206785 /]# nmstatectl --help
usage: nmstatectl [-h] [--version]
                  {commit,edit,rollback,set,apply,show,version,varlink,gc} ...

positional arguments:
  {commit,edit,rollback,set,apply,show,version,varlink,gc}
    commit              Commit a change
    edit                Edit network state in EDITOR
    rollback            Rollback a change
    set                 Set network state, deprecated please consider
                        using'apply' instead.
    apply               Apply network state
    show                Show network state
    version             Display nmstate version
    varlink             Varlink support for libnmstate
    gc                  Generate configurations

optional arguments:
  -h, --help            show this help message and exit
  --version             Display nmstate version
[root@eabcc7206785 /]# nmstatectl --version
1.0.2
[root@eabcc7206785 /]#
```

Signed-off-by: Flavio Percoco <flavio@redhat.com>