### PR TITLE
NO-ISSUE: don't overwrite bundle metadata

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -101,7 +101,7 @@ function generate_manifests() {
 function generate_bundle() {
     ENABLE_KUBE_API=true generate_manifests
     operator-sdk generate kustomize manifests --apis-dir internal/controller/api -q
-    kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --output-dir ${BUNDLE_OUTPUT_DIR} ${BUNDLE_METADATA_OPTS}
+    kustomize build config/manifests | operator-sdk generate bundle -q --overwrite=false --output-dir ${BUNDLE_OUTPUT_DIR} ${BUNDLE_METADATA_OPTS}
     # TODO(djzager) structure config/rbac in such a way to avoid need for this
     rm ${BUNDLE_OUTPUT_DIR}/manifests/assisted-service_v1_serviceaccount.yaml
 


### PR DESCRIPTION
This commit: https://github.com/openshift/assisted-service/pull/1743/commits/1a6191fcff8c6fdba552371d0cdf1da6bc8e5441
of #1743 made it so the operator manifests were generated on calls to `generate_all` (ie. via `make generate-all`). The problem is that the ordering of the metadata can change at random, for example:

```
13:30:43  --- a/deploy/olm-catalog/metadata/annotations.yaml
13:30:43  +++ b/deploy/olm-catalog/metadata/annotations.yaml
13:30:43  @@ -6,9 +6,9 @@ annotations:
13:30:43     operators.operatorframework.io.bundle.package.v1: ****-service-operator
13:30:43     operators.operatorframework.io.bundle.channels.v1: alpha,ocm-2.3
13:30:43     operators.operatorframework.io.bundle.channel.default.v1: alpha
13:30:43  +  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
13:30:43     operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
13:30:43     operators.operatorframework.io.metrics.builder: operator-sdk-v1.6.1+git
13:30:43  -  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
```

This PR addresses that problem by setting `--overwrite=false` on the `operator-sdk generate bundle` command to prevent the metadata from being overwritten.