### PR TITLE
MGMT-5422: AgentClusterInstall - ControllerLogs conditions

### DIFF
--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -300,6 +300,10 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains events
                       which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs
+                      tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -232,6 +232,9 @@ spec:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -232,6 +232,9 @@ spec:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.

--- a/docs/kube-api-conditions.md
+++ b/docs/kube-api-conditions.md
@@ -35,6 +35,19 @@ AgentClusterInstall supported condition types are: `SpecSynced`, `RequirementsMe
 |Stopped|True|InstallationCancelled|The installation has stopped because it was cancelled|if the cluster status is "cancelled"|
 |Stopped|True|InstallationCompleted|The installation has stopped because it completed successfully|if the cluster status is "installed"|
 |Stopped|False|InstallationNotStopped|The installation is waiting to start or in progress|If the cluster status is not "error", "cancelled" or "installed|
+||||||
+|LogCollectionCompleted|True|Completed|Logs are available|after installation completed or failed and logs are collected|
+|LogCollectionCompleted|False|Requested|Logs have been requested but not yet collected|a request for logs has been made before gathering|
+|LogCollectionCompleted|False|Collecting|Logs are currently being collected|after installation completed or failed|
+|LogCollectionCompleted|False|Timeout|Log collection has failed due to timeout|after installation has completed or failed|
+|LogCollectionCompleted|False|Unavailable|Log collection not yet started|before and during installation|
+||||||
+|LogCollectionStopped|True|Completed|Logs are available|after installation completed or failed and logs are collected|
+|LogCollectionStopped|False|Requested|Logs have been requested but not yet collected|a request for logs has been made before it was uploaded|
+|LogCollectionStopped|False|Collecting|Logs are currently being collected|after installation completed or failed|
+|LogCollectionStopped|False|Timeout|Log collection has failed due to timeout|after installation has completed or failed|
+|LogCollectionStopped|False|Unavailable|Log collection not yet started|before and during installation|
+
 
 Here an example of AgentClusterInstall conditions:
 
@@ -77,6 +90,18 @@ Status:
     Reason:                      InstallationNotStopped
     Status:                      False
     Type:                        Stopped
+    Last Probe Time:             2021-05-21T21:11:47Z
+    Last Transition Time:        2021-05-21T21:11:47Z
+    Message:                     Log collection not yet started
+    Reason:                      Unavailable
+    Status:                      False
+    Type:                        LogCollectionCompleted
+    Last Probe Time:             2021-05-21T21:11:47Z
+    Last Transition Time:        2021-05-21T21:11:47Z
+    Message:                     Log collection not yet started
+    Reason:                      Unavailable
+    Status:                      False
+    Type:                        LogCollectionStopped
 ```
 
 ## Agent Conditions

--- a/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -99,6 +99,9 @@ type DebugInfo struct {
 	// EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
 	// +optional
 	EventsURL string `json:"eventsURL,omitempty"`
+
+	// LogsURL specifies a url for download controller logs tar file.
+	LogsURL string `json:"logsURL,omitempty"`
 }
 
 // Networking defines the pod network provider in the cluster.

--- a/internal/controller/controllers/conditions.go
+++ b/internal/controller/controllers/conditions.go
@@ -116,4 +116,18 @@ const (
 	AgentValidationsPassingMsg string                     = "The agent's validations are passing"
 	AgentValidationsUnknownMsg string                     = "The agent's validations have not yet been calculated"
 	AgentValidationsFailingMsg string                     = "The agent's validations are failing:"
+
+	LogCollectionCompletedCondition string = "LogCollectionCompleted"
+	LogCollectionStoppedCondition   string = "LogCollectionStopped"
+
+	LogCollectionCompletedReason   string = "Completed"
+	LogCollectionCompletedMsg      string = "Logs are available"
+	LogCollectionRequestedReason   string = "Requested"
+	LogCollectionRequestedMsg      string = "Logs have been requested but not yet collected"
+	LogCollectionCollectingReason  string = "Collecting"
+	LogCollectionCollectingMsg     string = "Logs are currently being collected"
+	LogCollectionTimeoutReason     string = "Timeout"
+	LogCollectionTimeoutMsg        string = "Log collection has failed due to timeout"
+	LogCollectionUnavailableReason string = "Unavailable"
+	LogCollectionUnavailableMsg    string = "Log collection not yet started"
 )

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -3,6 +3,7 @@ package subsystem
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -139,6 +140,22 @@ func updateClusterLogProgress(clusterID strfmt.UUID, progress models.LogsState) 
 	})
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(updateReply).Should(BeAssignableToTypeOf(installer.NewUpdateClusterLogsProgressNoContent()))
+}
+
+func uploadClusterLogs(clusterID strfmt.UUID) {
+	ctx := context.Background()
+
+	kubeconfigFile, err := os.Open("test_kubeconfig")
+	Expect(err).NotTo(HaveOccurred())
+
+	updateReply, err := agentBMClient.Installer.UploadLogs(ctx, &installer.UploadLogsParams{
+		ClusterID: clusterID,
+		LogsType:  string(models.LogsTypeController),
+		Upfile:    kubeconfigFile,
+	})
+	Expect(kubeconfigFile.Close()).ShouldNot(HaveOccurred())
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(updateReply).Should(BeAssignableToTypeOf(installer.NewUploadLogsNoContent()))
 }
 
 func updateProgress(hostID strfmt.UUID, clusterID strfmt.UUID, current_step models.HostStage) {


### PR DESCRIPTION
Two conditions were added - "LogCollectionCompleted" and
"LogCollectionStopped", contain the same data bug exists
for user convenience.
When collection is completed, it will expose the download
url in the debugInfo under logsURL field.