### PR TITLE
Revert "MGMT-5430 Move assisted service image to stream8"

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -25,10 +25,31 @@ RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-
 FROM quay.io/ocpmetal/oc-image:bug-1823143 as oc-image
 
 # Create final image
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:centos8
 
 # openshift-install requires this
-RUN dnf install -y libvirt-libs nmstate &&\
+RUN dnf install -y libvirt-libs python3 && \
+    dnf install -b -y  dnf-plugins-core && \
+    dnf copr enable -y networkmanager/NetworkManager-master && \
+    dnf copr enable -y nmstate/ovs-el8 && \
+    dnf copr enable -y nmstate/nmstate-1.0&& \
+    dnf copr enable -y nmstate/nispor && \
+    dnf install -y pkg-config && \
+    dnf install -y glib2-devel && \
+    dnf install -y gobject-introspection-devel && \
+    dnf install -y cairo-devel && \
+    dnf install -y cairo-gobject-devel && \
+    dnf install -y python3-devel && \
+    dnf install -y python3-nispor && \
+    dnf install -y NetworkManager && \
+    dnf install -y NetworkManager-ovs && \
+    dnf install -y NetworkManager-team && \
+    dnf install -y NetworkManager-config-server && \
+    dnf install -y openvswitch2.11 && \
+    dnf install -y python3-openvswitch2.11 && \
+    dnf install -y nmstate &&\
+    pip3 install pycairo && \
+    dnf remove -y dnf-plugins-core && \
     dnf clean all
 
 ARG WORK_DIR=/data


### PR DESCRIPTION
Reverts openshift/assisted-service#1763

Image is being replaced by OpenShift CI and causes a variety of issues for subsystem tests.
We will revert for now until it will be solved.

```
Subsystem Suite: [kube-api]cluster installation deploy clusterDeployment and infraEnv and with NMState config

/go/src/github.com/openshift/assisted-service/subsystem/kubeapi_test.go:1102
Timed out after 120.000s.
Expected
    <string>: Failed to create image: 1 error occurred:\n\t* <nmstatectl gc> failed, errorCode 2, stderr usage: nmstatectl [-h] [--version] {commit,edit,rollback,set,show,version} ...\nnmstatectl: error: invalid choice: 'gc' (choose from 'commit', 'edit', 'rollback', 'set', 'show', 'version')\n, input yaml <dns-resolver:\n  config:\n    server:\n    - 192.168.126.1\ninterfaces:\n- ipv4:\n    address:\n    - ip: 192.168.126.30\n      prefix-length: 24\n    dhcp: false\n    enabled: true\n  name: eth0\n  state: up\n  type: ethernet\n- ipv4:\n    address:\n    - ip: 192.168.140.30\n      prefix-length: 24\n    dhcp: false\n    enabled: true\n  name: eth1\n  state: up\n  type: ethernet\nroutes:\n  config:\n  - destination: 0.0.0.0/0\n    next-hop-address: 192.168.126.1\n    next-hop-interface: eth0\n    table-id: 254\n>\n\n
to equal
    <string>: Image has been created
/go/src/github.com/openshift/assisted-service/subsystem/kubeapi_test.go:343
```

```
Subsystem Suite: system-test image tests [minimal-set][full-iso]create_and_get_image

/go/src/github.com/openshift/assisted-service/subsystem/image_test.go:43
Unexpected error:
    <*installer.GenerateClusterISOBadRequest | 0xc000011df8>: {
        Payload: {
            Code: "400",
            Href: "",
            ID: 400,
            Kind: "Error",
            Reason: "1 error occurred:\n\t* <nmstatectl gc> failed, errorCode 2, stderr usage: nmstatectl [-h] [--version] {commit,edit,rollback,set,show,version} ...\nnmstatectl: error: invalid choice: 'gc' (choose from 'commit', 'edit', 'rollback', 'set', 'show', 'version')\n, input yaml <dns-resolver:\n  config:\n    server:\n    - 192.0.2.1\ninterfaces:\n- ipv4:\n    address:\n    - ip: 192.0.2.155\n      prefix-length: 24\n    dhcp: false\n    enabled: true\n  name: nic10\n  state: up\n  type: ethernet\n- ipv4:\n    address:\n    - ip: 192.0.2.156\n      prefix-length: 24\n    dhcp: false\n    enabled: true\n  name: 02000048ba38\n  state: up\n  type: ethernet\nroutes:\n  config:\n  - destination: 0.0.0.0/0\n    next-hop-address: 192.0.2.1\n    next-hop-interface: nic10\n    table-id: 254\n>\n\n",
        },
    }
    [POST /clusters/{cluster_id}/downloads/image][400] generateClusterISOBadRequest  &{Code:0xc000a91500 Href:0xc000a91510 ID:0xc000c2b344 Kind:0xc000a91520 Reason:0xc000a91530}
occurred
/go/src/github.com/openshift/assisted-service/subsystem/image_test.go:79
```
