### PR TITLE
MGMT-5274 Allow override SERVICE_BASE_URL for test-infra port-forwarding

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -352,7 +352,7 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(instance *aiv1beta1.AgentSe
 		}
 
 		cm.Data = map[string]string{
-			"SERVICE_BASE_URL": serviceURL.String(),
+			"SERVICE_BASE_URL": getEnvVar("SERVICE_BASE_URL", serviceURL.String()),
 
 			// image overrides
 			"AGENT_DOCKER_IMAGE": AgentImage(),


### PR DESCRIPTION
Matches https://github.com/openshift/assisted-test-infra/pull/725 to
allow port-forwarding from test-infra host.
It was already merged on
https://github.com/openshift/assisted-service/pull/1572 but got
accidentally deleted as part of
https://github.com/openshift/assisted-service/pull/1699

/cc @filanov @mkowalski 