### PR TITLE
MGMT-6549 Removing support for min CPU and RAM env variables

### DIFF
--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -53,9 +53,7 @@ func NewValidator(log logrus.FieldLogger, cfg ValidatorCfg, operatorsAPI operato
 }
 
 type ValidatorCfg struct {
-	MinCPUCores                   int64                        `envconfig:"HW_VALIDATOR_MIN_CPU_CORES" default:"2"`
 	MinCPUCoresSno                int64                        `envconfig:"HW_VALIDATOR_MIN_CPU_CORES_SNO" default:"8"`
-	MinRamGib                     int64                        `envconfig:"HW_VALIDATOR_MIN_RAM_GIB" default:"8"`
 	MinRamGibSno                  int64                        `envconfig:"HW_VALIDATOR_MIN_RAM_GIB_SNO" default:"32"`
 	MaximumAllowedTimeDiffMinutes int64                        `envconfig:"HW_VALIDATOR_MAX_TIME_DIFF_MINUTES" default:"4"`
 	VersionedRequirements         VersionedRequirementsDecoder `envconfig:"HW_VALIDATOR_REQUIREMENTS" default:"[]"`

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -48,6 +48,16 @@ var _ = Describe("monitor_disconnection", func() {
 		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
 			Total: &models.ClusterHostRequirementsDetails{},
 		}, nil)
+		mockHwValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+			Ocp: &models.HostTypeHardwareRequirementsWrapper{
+				Worker: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+				Master: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+			},
+		}, nil)
 		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
@@ -156,6 +166,16 @@ var _ = Describe("TestHostMonitoring", func() {
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).AnyTimes()
 		mockHwValidator.EXPECT().GetClusterHostRequirements(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&models.ClusterHostRequirements{
 			Total: &models.ClusterHostRequirementsDetails{},
+		}, nil)
+		mockHwValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+			Ocp: &models.HostTypeHardwareRequirementsWrapper{
+				Worker: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+				Master: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+			},
 		}, nil)
 		mockHwValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return(nil, nil).AnyTimes()
 		mockOperators := operators.NewMockAPI(ctrl)

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"sort"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
-	"github.com/openshift/assisted-service/pkg/mathutils"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
@@ -135,8 +135,8 @@ func (c *validationContext) loadGeneralMinRequirements(hwValidator hardware.Vali
 		return err
 	}
 
-	c.minCPUCoresRequirement = mathutils.Min(requirements.Ocp.Master.Quantitative.CPUCores, requirements.Ocp.Worker.Quantitative.CPUCores)
-	c.minRAMMibRequirement = mathutils.Min(requirements.Ocp.Master.Quantitative.RAMMib, requirements.Ocp.Worker.Quantitative.RAMMib)
+	c.minCPUCoresRequirement = int64(math.Min(float64(requirements.Ocp.Master.Quantitative.CPUCores), float64(requirements.Ocp.Worker.Quantitative.CPUCores)))
+	c.minRAMMibRequirement = int64(math.Min(float64(requirements.Ocp.Master.Quantitative.RAMMib), float64(requirements.Ocp.Worker.Quantitative.RAMMib)))
 
 	return err
 }

--- a/pkg/mathutils/mathutils.go
+++ b/pkg/mathutils/mathutils.go
@@ -1,0 +1,9 @@
+package mathutils
+
+// Min returns the smaller of x or y.
+func Min(x, y int64) int64 {
+	if x > y {
+		return y
+	}
+	return x
+}

--- a/pkg/mathutils/mathutils.go
+++ b/pkg/mathutils/mathutils.go
@@ -1,9 +1,0 @@
-package mathutils
-
-// Min returns the smaller of x or y.
-func Min(x, y int64) int64 {
-	if x > y {
-		return y
-	}
-	return x
-}


### PR DESCRIPTION
`HW_VALIDATOR_MIN_CPU_CORES` and `HW_VALIDATOR_MIN_RAM_GIB` will no longer be supported and related runtime values will be calculated based on pre-flight OCP requirements; the smaller values of the requirements for master and worker will be used.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>