### PR TITLE
MGMT-4966 Mapping /run/media directory to the next_step agent

### DIFF
--- a/internal/host/hostcommands/next_step_runner_cmd.go
+++ b/internal/host/hostcommands/next_step_runner_cmd.go
@@ -22,7 +22,8 @@ func GetNextStepRunnerCommand(config *NextStepRunnerConfig) (string, *[]string) 
 	arguments := []string{"run", "--rm", "-ti", "--privileged", "--pid=host", "--net=host",
 		"-v", "/dev:/dev:rw", "-v", "/opt:/opt:rw",
 		"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
-		"-v", "/var/log:/var/log:rw"}
+		"-v", "/var/log:/var/log:rw",
+		"-v", "/run/media:/run/media:rw"}
 
 	if config.UseCustomCACert {
 		arguments = append(arguments, "-v", fmt.Sprintf("%s:%s", common.HostCACertPath, common.HostCACertPath))


### PR DESCRIPTION
This PR is related to an agent PR: https://github.com/openshift/assisted-installer-agent/pull/197
This PR aready merged https://github.com/openshift/assisted-service/pull/1685 and reverted https://github.com/openshift/assisted-service/pull/1691 after discovering that /run/media/iso directory does not exist for a minimal ISO
so here we mounted the /run/media directory which exist in them both

When a media disconnection error occurred the system became unstable and the step execution might be stuck on IO errors or failed with an unfriendly message.
Media disconnection occurred when a network drive (mostly PXE) has any errors (Network issue) and the controller disconnects it automatically.
Since this error is common to all the steps, we add this verification to the agent.
/run/media/iso is the ISO directory which mounted to the ISO device for a full-iso
The disconnection event not reproduced for the minimal-iso