### PR TITLE
MGMT-6005 conditions for ready and approved agents

### DIFF
--- a/docs/kube-api-conditions.md
+++ b/docs/kube-api-conditions.md
@@ -20,6 +20,8 @@ AgentClusterInstall supported condition types are: `SpecSynced`, `RequirementsMe
 |RequirementsMet|False|ClusterNotReady|The cluster is not ready to begin the installation|If the cluster is before installation ("insufficient"/"pending-for-input")|
 |RequirementsMet|True|ClusterAlreadyInstalling|The cluster requirements are met|If the cluster has begun installing ("preparing-for-installation", "installing", "finalizing", "installing-pending-user-action", "adding-hosts") |
 |RequirementsMet|True|ClusterInstallationStopped|The cluster installation stopped|If the cluster has stopped installing ("installed", "error") |
+|RequirementsMet|False|InsufficientAgents|The cluster currently requires `X` agents but only `Y` are ready|If the cluster is ready but we don't have the expected number of ready agents |
+|RequirementsMet|False|UnapprovedAgents|The installation is pending on the approval of `X` agents|If the cluster is ready with the expected number of ready agents, but not all have been approved |
 ||||||
 |Completed|True|InstallationCompleted|The installation has completed: "status_info"|If the cluster status is "installed"|
 |Completed|False|InstallationFailed|The installation has failed: "status_info"|If the cluster status is "error"|

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -312,12 +312,11 @@ func isInstalled(clusterDeployment *hivev1.ClusterDeployment, clusterInstall *hi
 
 func (r *ClusterDeploymentsReconciler) installDay1(ctx context.Context, log logrus.FieldLogger, clusterDeployment *hivev1.ClusterDeployment,
 	clusterInstall *hiveext.AgentClusterInstall, cluster *common.Cluster) (ctrl.Result, error) {
-	ready, err := r.isReadyForInstallation(ctx, clusterDeployment, clusterInstall, cluster)
+	ready, err := r.isReadyForInstallation(ctx, log, clusterInstall, cluster)
 	if err != nil {
 		return r.updateStatus(ctx, log, clusterInstall, cluster, err)
 	}
 	if ready {
-
 		// create custom manifests if needed before installation
 		err = r.addCustomManifests(ctx, log, clusterInstall, cluster)
 		if err != nil {
@@ -454,25 +453,20 @@ func (r *ClusterDeploymentsReconciler) createClusterCredentialSecret(ctx context
 	return s, r.Create(ctx, s)
 }
 
-func (r *ClusterDeploymentsReconciler) isReadyForInstallation(ctx context.Context, cluster *hivev1.ClusterDeployment, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster) (bool, error) {
+func (r *ClusterDeploymentsReconciler) isReadyForInstallation(ctx context.Context, log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster) (bool, error) {
 	if ready, _ := r.ClusterApi.IsReadyForInstallation(c); !ready {
 		return false, nil
 	}
 
-	readyHosts := 0
-	for _, h := range c.Hosts {
-		commonh, err := r.Installer.GetCommonHostInternal(ctx, c.ID.String(), h.ID.String())
-		if err != nil {
-			return false, err
-		}
-		if r.HostApi.IsInstallable(h) && commonh.Approved {
-			readyHosts += 1
-		}
+	_, approvedHosts, err := r.getNumOfClusterAgents(ctx, clusterInstall, c)
+	if err != nil {
+		log.WithError(err).Error("failed to fetch agents")
+		return false, err
 	}
 
 	expectedHosts := clusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents +
 		clusterInstall.Spec.ProvisionRequirements.WorkerAgents
-	return readyHosts == expectedHosts, nil
+	return approvedHosts == expectedHosts, nil
 }
 
 func isSupportedPlatform(cluster *hivev1.ClusterDeployment) bool {
@@ -1004,7 +998,7 @@ func (r *ClusterDeploymentsReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 // updateStatus is updating all the AgentClusterInstall Conditions.
-// In case that an error has occured when trying to sync the Spec, the error (syncErr) is presented in SpecSyncedCondition.
+// In case that an error has occurred when trying to sync the Spec, the error (syncErr) is presented in SpecSyncedCondition.
 // Internal bool differentiate between backend server error (internal HTTP 5XX) and user input error (HTTP 4XXX)
 func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster, syncErr error) (ctrl.Result, error) {
 	clusterSpecSynced(clusterInstall, syncErr)
@@ -1013,11 +1007,20 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 
 		if c.Status != nil {
 			status := *c.Status
-			err := r.populateEventsURL(log, clusterInstall, c)
+			var err error
+			err = r.populateEventsURL(log, clusterInstall, c)
 			if err != nil {
 				return ctrl.Result{Requeue: true}, nil
 			}
-			clusterRequirementsMet(clusterInstall, status)
+			var registeredHosts, approvedHosts int
+			if status == models.ClusterStatusReady {
+				registeredHosts, approvedHosts, err = r.getNumOfClusterAgents(ctx, clusterInstall, c)
+				if err != nil {
+					log.WithError(err).Error("failed to fetch cluster's agents")
+					return ctrl.Result{Requeue: true}, nil
+				}
+			}
+			clusterRequirementsMet(clusterInstall, status, c, registeredHosts, approvedHosts)
 			clusterValidated(clusterInstall, status, c)
 			clusterCompleted(clusterInstall, status, swag.StringValue(c.StatusInfo))
 			clusterFailed(clusterInstall, status, swag.StringValue(c.StatusInfo))
@@ -1066,6 +1069,25 @@ func (r *ClusterDeploymentsReconciler) eventsURL(log logrus.FieldLogger, cluster
 	return eventsURL, nil
 }
 
+func (r *ClusterDeploymentsReconciler) getNumOfClusterAgents(ctx context.Context, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster) (int, int, error) {
+	registeredHosts := 0
+	approvedHosts := 0
+	for _, h := range c.Hosts {
+		if r.HostApi.IsInstallable(h) {
+			registeredHosts += 1
+			commonh, err := r.Installer.GetCommonHostInternal(ctx, c.ID.String(), h.ID.String())
+			if err != nil {
+				return 0, 0, err
+			}
+			if commonh.Approved {
+				approvedHosts += 1
+			}
+		}
+	}
+
+	return registeredHosts, approvedHosts, nil
+}
+
 // clusterSpecSynced is updating the Cluster SpecSynced Condition.
 func clusterSpecSynced(cluster *hiveext.AgentClusterInstall, syncErr error) {
 	var condStatus corev1.ConditionStatus
@@ -1093,15 +1115,28 @@ func clusterSpecSynced(cluster *hiveext.AgentClusterInstall, syncErr error) {
 	})
 }
 
-func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status string) {
+func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status string, c *common.Cluster, registeredHosts, approvedHosts int) {
 	var condStatus corev1.ConditionStatus
 	var reason string
 	var msg string
+
 	switch status {
 	case models.ClusterStatusReady:
-		condStatus = corev1.ConditionTrue
-		reason = ClusterReadyReason
-		msg = ClusterReadyMsg
+		expectedHosts := clusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents +
+			clusterInstall.Spec.ProvisionRequirements.WorkerAgents
+		if registeredHosts < expectedHosts {
+			condStatus = corev1.ConditionFalse
+			reason = ClusterInsufficientAgentsReason
+			msg = fmt.Sprintf(ClusterInsufficientAgentsMsg, expectedHosts, approvedHosts)
+		} else if approvedHosts < expectedHosts {
+			condStatus = corev1.ConditionFalse
+			reason = ClusterUnapprovedAgentsReason
+			msg = fmt.Sprintf(ClusterUnapprovedAgentsMsg, expectedHosts-approvedHosts)
+		} else {
+			condStatus = corev1.ConditionTrue
+			reason = ClusterReadyReason
+			msg = ClusterReadyMsg
+		}
 	case models.ClusterStatusInsufficient, models.ClusterStatusPendingForInput:
 		condStatus = corev1.ConditionFalse
 		reason = ClusterNotReadyReason

--- a/internal/controller/controllers/conditions.go
+++ b/internal/controller/controllers/conditions.go
@@ -63,6 +63,10 @@ const (
 	ClusterAlreadyInstallingMsg      string = "The cluster requirements are met"
 	ClusterInstallationStoppedReason string = "ClusterInstallationStopped"
 	ClusterInstallationStoppedMsg    string = "The cluster installation stopped"
+	ClusterInsufficientAgentsReason  string = "InsufficientAgents"
+	ClusterInsufficientAgentsMsg     string = "The cluster currently requires %d agents but only %d have registered"
+	ClusterUnapprovedAgentsReason    string = "UnapprovedAgents"
+	ClusterUnapprovedAgentsMsg       string = "The installation is pending on the approval of %d agents"
 
 	ClusterValidatedCondition    string = "Validated"
 	ClusterValidationsOKMsg      string = "The cluster's validations are passing"


### PR DESCRIPTION
Added the following RequirementsMet conditions for AgentClusterInstall:
* type: RequirementsMet,
  status: False,
  reason: InsufficientAgents,
  message: The cluster currently requires `X` agents but only `Y` are ready,
  desc: If the cluster is ready but we don't have the expected number of ready agents
* type: RequirementsMet,
  status: False,
  reeason: UnapprovedAgents,
  message: The installation is pending on the approval of `X` agents,
  desc: If the cluster is ready with the expected number of ready agents, but not all have been approved