### PR TITLE
MGMT-6500 Add default route host validation

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1476,6 +1476,7 @@ func defaultInventoryWithTimestamp(timestamp int64) string {
 				DriveType: "SSD",
 			},
 		},
+		Routes: common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -26,6 +26,9 @@ const (
 	MirrorRegistriesConfigFile      = "registries.conf"
 	MirrorRegistriesConfigPath      = MirrorRegistriesConfigDir + "/" + MirrorRegistriesConfigFile
 	MaximumAllowedTimeDiffMinutes   = 4
+
+	FamilyIPv4 int32 = 4
+	FamilyIPv6 int32 = 6
 )
 
 // Configuration to be injected by discovery ignition.  It will cause IPv6 DHCP client identifier to be the same

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -91,6 +91,8 @@ var TestImageStatusesFailure = &models.ContainerImageAvailability{
 	Result: models.ContainerImageAvailabilityResultFailure,
 }
 
+var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "192.168.1.1", Destination: "0.0.0.0"}}
+
 func GenerateTestDefaultInventory() string {
 	inventory := &models.Inventory{
 		Interfaces: []*models.Interface{
@@ -107,6 +109,7 @@ func GenerateTestDefaultInventory() string {
 		Disks: []*models.Disk{
 			TestDefaultConfig.Disks,
 		},
+		Routes: TestDefaultRouteConfiguration,
 	}
 
 	b, err := json.Marshal(inventory)
@@ -133,6 +136,7 @@ func GenerateTestDefaultVmwareInventory() string {
 		SystemVendor: &models.SystemVendor{
 			Manufacturer: "vmware",
 		},
+		Routes: TestDefaultRouteConfiguration,
 	}
 
 	b, err := json.Marshal(inventory)
@@ -160,6 +164,7 @@ func GenerateTestInventoryWithNetwork(netAddress NetAddress) string {
 		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(16), UsableBytes: conversions.GibToBytes(16)},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Hostname:     netAddress.Hostname,
+		Routes:       TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(inventory)
 	Expect(err).To(Not(HaveOccurred()))

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -238,6 +238,7 @@ var _ = Describe("hardware_validator", func() {
 				{DriveType: "ODD", Name: "loop0"},
 				{DriveType: "HDD", Name: "sdb"},
 			},
+			Routes: common.TestDefaultRouteConfiguration,
 		}
 		cluster = &common.Cluster{Cluster: models.Cluster{
 			ID:                 &clusterID,

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -885,6 +885,7 @@ func insufficientHWInventory() string {
 		},
 		Memory:       &models.Memory{PhysicalBytes: 130, UsableBytes: 130},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -912,6 +913,7 @@ func inventoryWithUnauthorizedVendor() string {
 		Hostname:     "master-hostname",
 		SystemVendor: &models.SystemVendor{Manufacturer: "RDO", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -937,6 +939,7 @@ func workerInventory() string {
 		},
 		Memory:       &models.Memory{PhysicalBytes: conversions.GibToBytes(8), UsableBytes: conversions.GibToBytes(8)},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -154,6 +154,7 @@ func GenerateMasterInventoryWithHostnameAndCpuFlags(hostname string, cpuflags []
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -181,6 +182,7 @@ func GenerateMasterInventoryWithHostnameAndCpuFlagsV6(hostname string, cpuflags 
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -209,6 +211,7 @@ func GenerateInventoryWithResources(cpu, memory int64, hostname string, gpus ...
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -241,6 +244,7 @@ func GenerateInventoryWithResourcesAndMultipleDisk(cpu, memory int64, hostname s
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -268,6 +272,7 @@ func GenerateInventoryWithResourcesWithBytes(cpu, memory int64, hostname string)
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -224,6 +224,11 @@ func newValidations(v *validator) []validation {
 			condition: v.hasSufficientPacketLossRequirementForRole,
 			formatter: v.printSufficientPacketLossRequirementForRole,
 		},
+		{
+			id:        HasDefaultRoute,
+			condition: v.hasDefaultRoute,
+			formatter: v.printDefaultRoute,
+		},
 	}
 }
 

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -507,7 +507,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr), If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup),
-		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole))
+		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole), If(HasDefaultRoute))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -33,12 +33,13 @@ const (
 	SufficientOrUnknownInstallationDiskSpeed       = validationID(models.HostValidationIDSufficientInstallationDiskSpeed)
 	HasSufficientNetworkLatencyRequirementForRole  = validationID(models.HostValidationIDSufficientNetworkLatencyRequirementForRole)
 	HasSufficientPacketLossRequirementForRole      = validationID(models.HostValidationIDSufficientPacketLossRequirementForRole)
+	HasDefaultRoute                                = validationID(models.HostValidationIDHasDefaultRoute)
 )
 
 func (v validationID) category() (string, error) {
 	switch v {
 	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr,
-		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole:
+		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole, HasDefaultRoute:
 		return "network", nil
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory, SufficientOrUnknownInstallationDiskSpeed,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid:

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -85,6 +85,9 @@ const (
 
 	// HostValidationIDSufficientPacketLossRequirementForRole captures enum value "sufficient-packet-loss-requirement-for-role"
 	HostValidationIDSufficientPacketLossRequirementForRole HostValidationID = "sufficient-packet-loss-requirement-for-role"
+
+	// HostValidationIDHasDefaultRoute captures enum value "has-default-route"
+	HostValidationIDHasDefaultRoute HostValidationID = "has-default-route"
 )
 
 // for schema
@@ -92,7 +95,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6618,7 +6618,8 @@ func init() {
         "sufficient-installation-disk-speed",
         "cnv-requirements-satisfied",
         "sufficient-network-latency-requirement-for-role",
-        "sufficient-packet-loss-requirement-for-role"
+        "sufficient-packet-loss-requirement-for-role",
+        "has-default-route"
       ]
     },
     "host_network": {
@@ -14262,7 +14263,8 @@ func init() {
         "sufficient-installation-disk-speed",
         "cnv-requirements-satisfied",
         "sufficient-network-latency-requirement-for-role",
-        "sufficient-packet-loss-requirement-for-role"
+        "sufficient-packet-loss-requirement-for-role",
+        "has-default-route"
       ]
     },
     "host_network": {

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -106,6 +106,7 @@ var (
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
 		Timestamp:    1601853088,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	validHwInfo = &models.Inventory{
 		CPU:    &models.CPU{Count: 16},
@@ -121,6 +122,7 @@ var (
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
 		Timestamp:    1601853088,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	validFreeAddresses = models.FreeNetworksAddresses{
 		{
@@ -2632,6 +2634,7 @@ spec:
 			},
 			SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
 			Timestamp:    1601853088,
+			Routes:       common.TestDefaultRouteConfiguration,
 		}
 		h1 := &registerHost(clusterID).Host
 		generateEssentialHostStepsWithInventory(ctx, h1, "h1", hwInfo)

--- a/subsystem/ipv6_test.go
+++ b/subsystem/ipv6_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -28,6 +29,7 @@ var (
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
 		Timestamp:    1601853088,
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 )
 

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -303,6 +303,7 @@ func generateValidInventoryWithInterface(networkInterface string) string {
 		Disks:        []*models.Disk{{Name: "sda1", DriveType: "HDD", SizeBytes: validDiskSize}},
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Interfaces:   []*models.Interface{{IPV4Addresses: []string{networkInterface}}},
+		Routes:       common.TestDefaultRouteConfiguration,
 	}
 	b, err := json.Marshal(&inventory)
 	Expect(err).To(Not(HaveOccurred()))
@@ -531,6 +532,7 @@ var _ = Describe("Metrics tests", func() {
 				Disks:        []*models.Disk{&sda1},
 				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
+				Routes:       common.TestDefaultRouteConfiguration,
 			}
 			generateHWPostStepReply(ctx, h, nonValidInventory, "master-0")
 			waitForHostValidationStatus(clusterID, *h.ID, "failure",
@@ -572,6 +574,7 @@ var _ = Describe("Metrics tests", func() {
 				Disks:        []*models.Disk{&sda1},
 				SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "OpenStack Compute", SerialNumber: "3534"},
 				Interfaces:   []*models.Interface{{IPV4Addresses: []string{"1.2.3.4/24"}}},
+				Routes:       common.TestDefaultRouteConfiguration,
 			}
 			generateHWPostStepReply(ctx, h, nonValidInventory, "master-0")
 			waitForHostValidationStatus(clusterID, *h.ID, "failure",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4961,6 +4961,7 @@ definitions:
       - 'cnv-requirements-satisfied'
       - 'sufficient-network-latency-requirement-for-role'
       - 'sufficient-packet-loss-requirement-for-role'
+      - 'has-default-route'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
* Related to https://issues.redhat.com/browse/MGMT-4083
* Adds a new host validation during discovery that checks that the host has at least one default route defined. At this point we're validating that the route exists, but the information captured from the agent could provide further fine tuning (ipv4,ipv6 and GW IP address).

Apparently, the kubeapi-server requires to have a defined route in order to start, even if it's an air gap cluster with no outside access. There is a deferred RFE in place to address this gap, but for the time being we can presume that any deployment will require the node to have at least one default route in order for the cluster to be successfully created. 

@ori-amizur @YuviGold could you please take a look?

~~References #1752. Once that PR is merged I will rebase and remove the dependency on this one.~~ 
~~References [PR](https://github.com/openshift/assisted-installer-agent/pull/199) in assisted-installer-agent to capture route information.~~