### PR TITLE
Bug 1962957 - Check the response status code when downloading files

### DIFF
--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -83,6 +84,9 @@ func DownloadURLToTemporaryFile(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed fetching from URL %s", url)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("Failed fetching from URL %s: Received %s", url, resp.Status)
 	}
 
 	_, err = io.Copy(tmpfile, resp.Body)

--- a/pkg/s3wrapper/util_test.go
+++ b/pkg/s3wrapper/util_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -165,6 +167,43 @@ var _ = Describe("HaveLatestMinimalTemplate", func() {
 
 		latestExists := HaveLatestMinimalTemplate(ctx, log, client)
 		Expect(latestExists).To(Equal(false))
+	})
+})
+
+var _ = Describe("DownloadURLToTemporaryFile", func() {
+	var ts *httptest.Server
+
+	BeforeEach(func() {
+		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch p := r.URL.Path; p {
+			case "/ok":
+				_, err := w.Write([]byte("ok"))
+				Expect(err).NotTo(HaveOccurred())
+			case "/notfound":
+				w.WriteHeader(http.StatusNotFound)
+			case "/servererror":
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+	})
+
+	AfterEach(func() {
+		ts.Close()
+	})
+
+	It("Succeeds when the download succeeds", func() {
+		f, err := DownloadURLToTemporaryFile(ts.URL + "/ok")
+		defer os.Remove(f)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ioutil.ReadFile(f)).To(Equal([]byte("ok")))
+	})
+
+	It("Fails when the download fails", func() {
+		_, err := DownloadURLToTemporaryFile(ts.URL + "/notfound")
+		Expect(err).To(HaveOccurred())
+
+		_, err = DownloadURLToTemporaryFile(ts.URL + "/servererror")
+		Expect(err).To(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
Before this change if the GET request here failed in a way that didn't
produce an error we would continue on to try to extract the boot files
from the error response body.

According to https://golang.org/pkg/net/http/#Get non-200 responses do
not generate an error so we need to check this ourselves.

https://bugzilla.redhat.com/show_bug.cgi?id=1962957