### PR TITLE
OCPBUGSM-29066 Remove cluster resources after clusterdeployment deletion

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -338,10 +338,12 @@ func main() {
 	} else {
 		crdUtils = controllers.NewDummyCRDUtils()
 	}
-	if !Options.EnableKubeAPI && (Options.EnableDeregisterInactiveGC || Options.EnableDeletedUnregisteredGC) {
+
+	if Options.EnableDeregisterInactiveGC || Options.EnableDeletedUnregisteredGC {
 		gc := garbagecollector.NewGarbageCollectors(Options.GCConfig, db, log.WithField("pkg", "garbage_collector"), hostApi, clusterApi, objectHandler, lead)
 
-		if Options.EnableDeregisterInactiveGC {
+		// In operator-deployment, ClusterDeployment is responsible for managing the lifetime of the cluster resource.
+		if !Options.EnableKubeAPI && Options.EnableDeregisterInactiveGC {
 			deregisterWorker := thread.New(
 				log.WithField("garbagecollector", "Deregister Worker"),
 				"Deregister Worker",

--- a/tools/deploy_assisted_installer.py
+++ b/tools/deploy_assisted_installer.py
@@ -17,6 +17,10 @@ KEY_FILE = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'auth-te
 TEST_CLUSTER_MONITOR_INTERVAL = "1s"
 TEST_HOST_MONITOR_INTERVAL = "1s"
 
+# Garbage collector configuration
+TEST_DEREGISTER_WORKER_INTERVAL = "5s"
+TEST_DELETION_WORKER_INTERVAL = "5s"
+
 WIREMOCK_SERVICE = "http://wiremock:8080"
 
 def load_key():
@@ -45,6 +49,8 @@ def main():
                 data["spec"]["template"]["spec"]["containers"][0]["env"] = []
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'CLUSTER_MONITOR_INTERVAL', 'value': TEST_CLUSTER_MONITOR_INTERVAL})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'HOST_MONITOR_INTERVAL', 'value': TEST_HOST_MONITOR_INTERVAL})
+            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DEREGISTER_WORKER_INTERVAL', 'value': TEST_DEREGISTER_WORKER_INTERVAL})
+            data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DELETION_WORKER_INTERVAL', 'value': TEST_DELETION_WORKER_INTERVAL})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name': 'JWKS_CERT', 'value': load_key()})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'SUBSYSTEM_RUN', 'value': 'True'})
             data["spec"]["template"]["spec"]["containers"][0]["env"].append({'name':'DUMMY_IGNITION', 'value': 'True'})


### PR DESCRIPTION
When cluster is deregistered, either by clusterdeployment or by the API,
the cluster record is softly deleted, meaning the  attribute `deleted_at`
in the DB is being set.
It is the responsiblity of the garbage collector to run periodically and
remove all of the cluster's resources.
For that purpose, the garbage collection should be enabled for clearing
cluster resources in operator deployment as well.

Signed-off-by: Moti Asayag <masayag@redhat.com>