### PR TITLE
OCPBUGSM-28872 Requirement Conditions for stopped state

### DIFF
--- a/docs/kube-api-conditions.md
+++ b/docs/kube-api-conditions.md
@@ -18,7 +18,8 @@ AgentClusterInstall supported condition types are: `SpecSynced`, `RequirementsMe
 ||||||
 |RequirementsMet|True|ClusterIsReady|The cluster is ready to begin the installation|if the cluster status is "ready"|
 |RequirementsMet|False|ClusterNotReady|The cluster is not ready to begin the installation|If the cluster is before installation ("insufficient"/"pending-for-input")|
-|RequirementsMet|True|ClusterAlreadyInstalling|The cluster requirements are met|If the cluster has begun installing ("preparing-for-installation", "installing", "finalizing", "installing-pending-user-action", "adding-hosts", "installed", "error") |
+|RequirementsMet|True|ClusterAlreadyInstalling|The cluster requirements are met|If the cluster has begun installing ("preparing-for-installation", "installing", "finalizing", "installing-pending-user-action", "adding-hosts") |
+|RequirementsMet|True|ClusterInstallationStopped|The cluster installation stopped|If the cluster has stopped installing ("installed", "error") |
 ||||||
 |Completed|True|InstallationCompleted|The installation has completed: "status_info"|If the cluster status is "installed"|
 |Completed|False|InstallationFailed|The installation has failed: "status_info"|If the cluster status is "error"|
@@ -92,8 +93,10 @@ The Agent condition types supported are: `SpecSynced`, `Connected`, `ReadyForIns
 ||||||
 |ReadyForInstallation|True|AgentIsReady|The agent is ready to begin the installation|If the host is approved and in status "known"|
 |ReadyForInstallation|False|AgentNotReady|The agent is not ready to begin the installation|If the host is before installation ("discovering"/"insufficient"/"disconnected"/"pending-input")|
-|ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing", "installed", "error") |
+|ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing") |
 |ReadyForInstallation|False|AgentIsNotApproved|The agent is not approved|If the host is not approved and in status "known"|
+|ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing") |
+|ReadyForInstallation|False|AgentInstallationStopped|The agent installation stopped|If the agent has stopped installing ("installed", "error") |
 ||||||
 |Installed|True|InstallationCompleted|The installation has completed: "status_info"|If the host status is "installed"|
 |Installed|False|InstallationFailed|The installation has failed: "status_info"|If the host status is "error"|

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -457,12 +457,15 @@ func readyForInstallation(agent *aiv1beta1.Agent, status string) {
 		condStatus = corev1.ConditionFalse
 		reason = AgentNotReadyReason
 		msg = AgentNotReadyMsg
-	case models.HostStatusPreparingForInstallation, models.HostStatusPreparingSuccessful, models.HostStatusInstalled,
-		models.HostStatusInstalling, models.HostStatusInstallingInProgress, models.HostStatusInstallingPendingUserAction,
-		models.HostStatusError:
+	case models.HostStatusPreparingForInstallation, models.HostStatusPreparingSuccessful, models.HostStatusInstalling,
+		models.HostStatusInstallingInProgress, models.HostStatusInstallingPendingUserAction:
 		condStatus = corev1.ConditionFalse
 		reason = AgentAlreadyInstallingReason
 		msg = AgentAlreadyInstallingMsg
+	case models.HostStatusInstalled, models.HostStatusError:
+		condStatus = corev1.ConditionFalse
+		reason = AgentInstallationStoppedReason
+		msg = AgentInstallationStoppedMsg
 	default:
 		condStatus = corev1.ConditionUnknown
 		reason = UnknownStatusReason

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -811,8 +811,8 @@ var _ = Describe("TestConditions", func() {
 			conditions: []conditionsv1.Condition{
 				{
 					Type:    ReadyForInstallationCondition,
-					Message: AgentAlreadyInstallingMsg,
-					Reason:  AgentAlreadyInstallingReason,
+					Message: AgentInstallationStoppedMsg,
+					Reason:  AgentInstallationStoppedReason,
 					Status:  corev1.ConditionFalse,
 				},
 				{
@@ -875,8 +875,8 @@ var _ = Describe("TestConditions", func() {
 			conditions: []conditionsv1.Condition{
 				{
 					Type:    ReadyForInstallationCondition,
-					Message: AgentAlreadyInstallingMsg,
-					Reason:  AgentAlreadyInstallingReason,
+					Message: AgentInstallationStoppedMsg,
+					Reason:  AgentInstallationStoppedReason,
 					Status:  corev1.ConditionFalse,
 				},
 				{

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1073,12 +1073,16 @@ func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status 
 		condStatus = corev1.ConditionFalse
 		reason = ClusterNotReadyReason
 		msg = ClusterNotReadyMsg
-	case models.ClusterStatusPreparingForInstallation, models.ClusterStatusInstalled,
+	case models.ClusterStatusPreparingForInstallation,
 		models.ClusterStatusInstalling, models.ClusterStatusInstallingPendingUserAction,
-		models.ClusterStatusError, models.ClusterStatusAddingHosts, models.ClusterStatusFinalizing:
+		models.ClusterStatusAddingHosts, models.ClusterStatusFinalizing:
 		condStatus = corev1.ConditionTrue
 		reason = ClusterAlreadyInstallingReason
 		msg = ClusterAlreadyInstallingMsg
+	case models.ClusterStatusInstalled, models.ClusterStatusError:
+		condStatus = corev1.ConditionTrue
+		reason = ClusterInstallationStoppedReason
+		msg = ClusterInstallationStoppedMsg
 	default:
 		condStatus = corev1.ConditionUnknown
 		reason = UnknownStatusReason

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1731,8 +1731,8 @@ var _ = Describe("TestConditions", func() {
 			conditions: []hivev1.ClusterInstallCondition{
 				{
 					Type:    ClusterRequirementsMetCondition,
-					Message: ClusterAlreadyInstallingMsg,
-					Reason:  ClusterAlreadyInstallingReason,
+					Message: ClusterInstallationStoppedMsg,
+					Reason:  ClusterInstallationStoppedReason,
 					Status:  corev1.ConditionTrue,
 				},
 				{
@@ -1845,8 +1845,8 @@ var _ = Describe("TestConditions", func() {
 			conditions: []hivev1.ClusterInstallCondition{
 				{
 					Type:    ClusterRequirementsMetCondition,
-					Message: ClusterAlreadyInstallingMsg,
-					Reason:  ClusterAlreadyInstallingReason,
+					Message: ClusterInstallationStoppedMsg,
+					Reason:  ClusterInstallationStoppedReason,
 					Status:  corev1.ConditionTrue,
 				},
 				{

--- a/internal/controller/controllers/conditions.go
+++ b/internal/controller/controllers/conditions.go
@@ -54,13 +54,15 @@ const (
 
 	ClusterCompletedCondition string = hivev1.ClusterInstallCompleted
 
-	ClusterRequirementsMetCondition string = hivev1.ClusterInstallRequirementsMet
-	ClusterReadyReason              string = "ClusterIsReady"
-	ClusterReadyMsg                 string = "The cluster is ready to begin the installation"
-	ClusterNotReadyReason           string = "ClusterNotReady"
-	ClusterNotReadyMsg              string = "The cluster is not ready to begin the installation"
-	ClusterAlreadyInstallingReason  string = "ClusterAlreadyInstalling"
-	ClusterAlreadyInstallingMsg     string = "The cluster requirements are met"
+	ClusterRequirementsMetCondition  string = hivev1.ClusterInstallRequirementsMet
+	ClusterReadyReason               string = "ClusterIsReady"
+	ClusterReadyMsg                  string = "The cluster is ready to begin the installation"
+	ClusterNotReadyReason            string = "ClusterNotReady"
+	ClusterNotReadyMsg               string = "The cluster is not ready to begin the installation"
+	ClusterAlreadyInstallingReason   string = "ClusterAlreadyInstalling"
+	ClusterAlreadyInstallingMsg      string = "The cluster requirements are met"
+	ClusterInstallationStoppedReason string = "ClusterInstallationStopped"
+	ClusterInstallationStoppedMsg    string = "The cluster installation stopped"
 
 	ClusterValidatedCondition    string = "Validated"
 	ClusterValidationsOKMsg      string = "The cluster's validations are passing"
@@ -94,15 +96,17 @@ const (
 
 	InstalledCondition conditionsv1.ConditionType = "Installed"
 
-	ReadyForInstallationCondition conditionsv1.ConditionType = "ReadyForInstallation"
-	AgentReadyReason              string                     = "AgentIsReady"
-	AgentReadyMsg                 string                     = "The agent is ready to begin the installation"
-	AgentNotReadyReason           string                     = "AgentNotReady"
-	AgentNotReadyMsg              string                     = "The agent is not ready to begin the installation"
-	AgentAlreadyInstallingReason  string                     = "AgentAlreadyInstalling"
-	AgentAlreadyInstallingMsg     string                     = "The agent cannot begin the installation because it has already started"
-	AgentIsNotApprovedReason      string                     = "AgentIsNotApproved"
-	AgentIsNotApprovedMsg         string                     = "The agent is not approved"
+	ReadyForInstallationCondition  conditionsv1.ConditionType = "ReadyForInstallation"
+	AgentReadyReason               string                     = "AgentIsReady"
+	AgentReadyMsg                  string                     = "The agent is ready to begin the installation"
+	AgentNotReadyReason            string                     = "AgentNotReady"
+	AgentNotReadyMsg               string                     = "The agent is not ready to begin the installation"
+	AgentAlreadyInstallingReason   string                     = "AgentAlreadyInstalling"
+	AgentAlreadyInstallingMsg      string                     = "The agent cannot begin the installation because it has already started"
+	AgentIsNotApprovedReason       string                     = "AgentIsNotApproved"
+	AgentIsNotApprovedMsg          string                     = "The agent is not approved"
+	AgentInstallationStoppedReason string                     = "AgentInstallationStopped"
+	AgentInstallationStoppedMsg    string                     = "The agent installation stopped"
 
 	ValidatedCondition         conditionsv1.ConditionType = "Validated"
 	AgentValidationsPassingMsg string                     = "The agent's validations are passing"


### PR DESCRIPTION
In case that the installation stopped (error or installed):

Agent:
|ReadyForInstallation|False|AgentInstallationStopped|The agent installation stopped|If the agent has stopped installing ("installed", "error")

AgentCLusterInstall:
|RequirementsMet|True|ClusterInstallationStopped|The cluster installation stopped|If the cluster has stopped installing ("installed", "error")

Signed-off-by: Fred Rolland <frolland@redhat.com>