### PR TITLE
MGMT-5255 KubeAPI Update event URL only once

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -842,12 +842,12 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, cluster
 	clusterSpecSynced(clusterInstall, syncErr)
 	if c != nil {
 		clusterInstall.Status.ConnectivityMajorityGroups = c.ConnectivityMajorityGroups
-		eventUrl, err := r.eventsURL(string(*c.ID))
-		if err != nil {
-			return ctrl.Result{Requeue: true}, nil
-		}
-		clusterInstall.Status.DebugInfo = hiveext.DebugInfo{
-			EventsURL: eventUrl,
+		if clusterInstall.Status.DebugInfo.EventsURL == "" {
+			eventUrl, err := r.eventsURL(string(*c.ID))
+			if err != nil {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			clusterInstall.Status.DebugInfo.EventsURL = eventUrl
 		}
 		if c.Status != nil {
 			status := *c.Status

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1337,7 +1337,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.EventsURL
-		}, "30s", "10s").Should(Equal(""))
+		}, "1m", "10s").Should(Equal(""))
 	})
 
 	It("None SNO deploy clusterDeployment full install and validate MetaData", func() {


### PR DESCRIPTION
The API Key for auth in the event URL is regenerated every call, causing
a change in the CRD every reconcile loop.

Signed-off-by: Fred Rolland <frolland@redhat.com>