### PR TITLE
MGMT-6531 agent conditions: check if approved

### DIFF
--- a/docs/kube-api-conditions.md
+++ b/docs/kube-api-conditions.md
@@ -90,9 +90,10 @@ The Agent condition types supported are: `SpecSynced`, `Connected`, `ReadyForIns
 |Validated|False|ValidationsFailing|The agent's validations are failing: "summary of failed validations"|If the host status is "insufficient"|
 |Validated|Unknown|ValidationsUnknown|The agent's validations have not yet been calculated|If the validations have not yet been calculated|
 ||||||
-|ReadyForInstallation|True|AgentIsReady|The agent is ready to begin the installation|if the host status is "known"|
+|ReadyForInstallation|True|AgentIsReady|The agent is ready to begin the installation|If the host is approved and in status "known"|
 |ReadyForInstallation|False|AgentNotReady|The agent is not ready to begin the installation|If the host is before installation ("discovering"/"insufficient"/"disconnected"/"pending-input")|
 |ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing", "installed", "error") |
+|ReadyForInstallation|False|AgentIsNotApproved|The agent is not approved|If the host is not approved and in status "known"|
 ||||||
 |Installed|True|InstallationCompleted|The installation has completed: "status_info"|If the host status is "installed"|
 |Installed|False|InstallationFailed|The installation has failed: "status_info"|If the host status is "error"|

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -443,9 +443,15 @@ func readyForInstallation(agent *aiv1beta1.Agent, status string) {
 	var msg string
 	switch status {
 	case models.HostStatusKnown:
-		condStatus = corev1.ConditionTrue
-		reason = AgentReadyReason
-		msg = AgentReadyMsg
+		if agent.Spec.Approved {
+			condStatus = corev1.ConditionTrue
+			reason = AgentReadyReason
+			msg = AgentReadyMsg
+		} else {
+			condStatus = corev1.ConditionFalse
+			reason = AgentIsNotApprovedReason
+			msg = AgentIsNotApprovedMsg
+		}
 	case models.HostStatusInsufficient, models.HostStatusDisconnected,
 		models.HostStatusDiscovering, models.HostStatusPendingForInput:
 		condStatus = corev1.ConditionFalse

--- a/internal/controller/controllers/conditions.go
+++ b/internal/controller/controllers/conditions.go
@@ -101,6 +101,8 @@ const (
 	AgentNotReadyMsg              string                     = "The agent is not ready to begin the installation"
 	AgentAlreadyInstallingReason  string                     = "AgentAlreadyInstalling"
 	AgentAlreadyInstallingMsg     string                     = "The agent cannot begin the installation because it has already started"
+	AgentIsNotApprovedReason      string                     = "AgentIsNotApproved"
+	AgentIsNotApprovedMsg         string                     = "The agent is not approved"
 
 	ValidatedCondition         conditionsv1.ConditionType = "Validated"
 	AgentValidationsPassingMsg string                     = "The agent's validations are passing"


### PR DESCRIPTION
Added the following ReadyForInstallation conditions for Agent Conditions::

* type: ReadyForInstallation,
  status: True,
  reason: AgentIsReady,
  message: The agent is ready to begin the installation,
  desc: If the host is approved and in status "known"
* type: ReadyForInstallation,
  status: False,
  reeason: AgentIsNotApproved,
  message: The agent is not approved,
  desc: If the host is not approved and in status "known"