### PR TITLE
MGMT-6633  set db connection pool

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,6 +132,9 @@ var Options struct {
 	ServeHTTPS                  bool          `envconfig:"SERVE_HTTPS" default:"false"`
 	HTTPSKeyFile                string        `envconfig:"HTTPS_KEY_FILE" default:""`
 	HTTPSCertFile               string        `envconfig:"HTTPS_CERT_FILE" default:""`
+	MaxIdleConns                int           `envconfig:"DB_MAX_IDLE_CONNECTIONS" default:"50"`
+	MaxOpenConns                int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"100"`
+	ConnMaxLifetime             time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
 	FileSystemUsageThreshold    int           `envconfig:"FILESYSTEM_USAGE_THRESHOLD" default:"80"`
 	EnableElasticAPM            bool          `envconfig:"ENABLE_ELASTIC_APM" default:"false"`
 	WorkDir                     string        `envconfig:"WORK_DIR" default:"/data/"`
@@ -544,9 +547,9 @@ func setupDB(log logrus.FieldLogger) *gorm.DB {
 			log.WithError(err).Info("Failed to connect to DB, retrying")
 			return
 		}
-		db.DB().SetMaxIdleConns(0)
-		db.DB().SetMaxOpenConns(0)
-		db.DB().SetConnMaxLifetime(0)
+		db.DB().SetMaxIdleConns(Options.MaxIdleConns)
+		db.DB().SetMaxOpenConns(Options.MaxOpenConns)
+		db.DB().SetConnMaxLifetime(Options.ConnMaxLifetime)
 		cancel()
 	}, retryInterval)
 	if ctx.Err().Error() == context.DeadlineExceeded.Error() {

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -87,6 +87,12 @@ parameters:
   value: "false"
 - name: ENABLE_DELETE_UNREGISTER_GC
   value: "true"
+- name: DB_MAX_IDLE_CONNECTIONS
+  value: "50"
+  required: false
+- name: DB_MAX_OPEN_CONNECTIONS
+  value: "600"
+  required: false
 apiVersion: v1
 kind: Template
 metadata:
@@ -280,6 +286,10 @@ objects:
                 value: ${IPV6_SUPPORT}
               - name: ENABLE_SINGLE_NODE_DNSMASQ
                 value: ${ENABLE_SINGLE_NODE_DNSMASQ}
+              - name: DB_MAX_IDLE_CONNECTIONS
+                  value: ${DB_MAX_IDLE_CONNECTIONS}
+              - name: DB_MAX_OPEN_CONNECTIONS
+                  value: ${DB_MAX_OPEN_CONNECTIONS}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
Right now we are using unlimited connections with default number of idle. This default value is 2. When we have burst or more than 2 routines that reaches DB in parallel assisted-service will create new db connection and then close it after finishing db call. Creating this DB connection when we have some burst of apis is relatively expensive and can increase api call for a second.  
Max open connections number will be set to 100 by default (it is default value in postgress) but in cloud default will be 600 as we have db.r5.large instance with 16G ram and by https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.MaxConnections maximum number of open connections should be less than 1800 and we have 3 instances so it should be 1800/3