### PR TITLE
NO-ISSUE: Adding subsystem-tests for telemeter manifest generation.

### DIFF
--- a/subsystem/ams_subscriptions_test.go
+++ b/subsystem/ams_subscriptions_test.go
@@ -326,16 +326,6 @@ var _ = Describe("test AMS subscriptions", func() {
 		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
 		It("UpdateSubscription failed", func() {
 
-			waitForInstallationPreparationCompletionStatus := func(clusterID strfmt.UUID, status string) {
-
-				waitFunc := func() (bool, error) {
-					c := getCommonCluster(ctx, clusterID)
-					return c.InstallationPreparationCompletionStatus == status, nil
-				}
-				err := wait.Poll(pollDefaultInterval, pollDefaultTimeout, waitFunc)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
 			var clusterID strfmt.UUID
 			var reply *installer.InstallClusterAccepted
 			var err error

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -14,6 +14,7 @@ import (
 	operatorsClient "github.com/openshift/assisted-service/client/operators"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -365,4 +366,14 @@ func verifyUsageNotSet(featureUsage string, features ...string) {
 	for _, name := range features {
 		Expect(usages[name]).To(BeNil())
 	}
+}
+
+func waitForInstallationPreparationCompletionStatus(clusterID strfmt.UUID, status string) {
+
+	waitFunc := func() (bool, error) {
+		c := getCommonCluster(context.Background(), clusterID)
+		return c.InstallationPreparationCompletionStatus == status, nil
+	}
+	err := wait.Poll(pollDefaultInterval, pollDefaultTimeout, waitFunc)
+	Expect(err).NotTo(HaveOccurred())
 }


### PR DESCRIPTION
In case this is not a production env, the telemeter manifest should be
visible through the manifests API.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>