### PR TITLE
MGMT-5255 KubeAPI clear events URL when "installed"

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -417,7 +417,8 @@ var _ = Describe("cluster reconcile", func() {
 		sId := strfmt.UUID(uuid.New().String())
 		backEndCluster := &common.Cluster{
 			Cluster: models.Cluster{
-				ID: &sId,
+				ID:     &sId,
+				Status: swag.String(models.ClusterStatusInsufficient),
 			},
 		}
 		expectedEventUrlPrefix := fmt.Sprintf("%s/api/assisted-install/v1/clusters/%s/events", serviceBaseURL, sId)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1415,11 +1415,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 		configSecret := getSecret(ctx, kubeClient, configkey)
 		Expect(configSecret.Data["kubeconfig"]).NotTo(BeNil())
-		// By("Check Event URL does not exist")
-		// Eventually(func() string {
-		// 	aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
-		// 	return aci.Status.DebugInfo.EventsURL
-		// }, "1m", "10s").Should(Equal(""))
+		By("Check Event URL does not exist")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.DebugInfo.EventsURL
+		}, "1m", "10s").Should(Equal(""))
 	})
 
 	It("None SNO deploy clusterDeployment full install and validate MetaData", func() {


### PR DESCRIPTION
Clear events URL when cluster is in "installed" state.

Signed-off-by: Fred Rolland <frolland@redhat.com>