### PR TITLE
MGMT-6549 Remove HW_VALIDATOR_MIN_* references in template.yaml

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -36,12 +36,6 @@ parameters:
 - name: IMAGE_BUILDER
   value: ''
   required: true
-- name: HW_VALIDATOR_MIN_CPU_CORES
-  value: ''
-  required: true
-- name: HW_VALIDATOR_MIN_RAM_GIB
-  value: ''
-  required: true
 - name: HW_VALIDATOR_REQUIREMENTS
   value: ''
   required: true
@@ -248,10 +242,6 @@ objects:
                 value: ${OCM_LOG_LEVEL}
               - name: IMAGE_BUILDER
                 value: ${IMAGE_BUILDER}:${IMAGE_TAG}
-              - name: HW_VALIDATOR_MIN_CPU_CORES
-                value: ${HW_VALIDATOR_MIN_CPU_CORES}
-              - name: HW_VALIDATOR_MIN_RAM_GIB
-                value: ${HW_VALIDATOR_MIN_RAM_GIB}
               - name: HW_VALIDATOR_REQUIREMENTS
                 value: ${HW_VALIDATOR_REQUIREMENTS}
               - name: INSTALLER_IMAGE


### PR DESCRIPTION
Support for HW_VALIDATOR_MIN_CPU_CORES and HW_VALIDATOR_MIN_RAM_GIB has been removed from code and they can be safely removed from template.yaml

Signed-off-by: Jakub Dzon <jdzon@redhat.com>