### PR TITLE
OCPBUGSM-27828 - do not output Status field to the BMH on bootstrap

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -767,7 +767,9 @@ func (g *installerGenerator) modifyBMHFile(file *config_latest_types.File, bmh *
 		return err
 	}
 
-	encodedBMH := base64.StdEncoding.EncodeToString(buf.Bytes())
+	// remove status if exists
+	res := bytes.Split(buf.Bytes(), []byte("status:\n"))
+	encodedBMH := base64.StdEncoding.EncodeToString(res[0])
 	source := "data:text/plain;charset=utf-8;base64," + encodedBMH
 	file.Contents.Source = &source
 


### PR DESCRIPTION
when modifying BMH on bootsrap, we need to not output Status field,
so that cluster bootsrap won't try to update it. since BMHStatus is
a struct in BMH, we need to splice a output string itself