### PR TITLE
MGMT-6514 Set invoker for assisted operator

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -399,7 +399,8 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(log logrus.FieldLogger, ins
 			"WITH_AMS_SUBSCRIPTIONS":      "False",
 			"HW_VALIDATOR_REQUIREMENTS":   `[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]`,
 
-			"NAMESPACE": r.Namespace,
+			"NAMESPACE":       r.Namespace,
+			"INSTALL_INVOKER": "assisted-installer-operator",
 
 			// enable https
 			"SERVE_HTTPS":            "True",

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -382,6 +383,26 @@ var _ = Describe("getOpenshiftVersions", func() {
 			ascr = newTestReconciler(asc)
 			Expect(ascr.getOpenshiftVersions(log, asc)).To(MatchJSON(expectedEnv))
 		})
+	})
+})
+
+var _ = Describe("Default ConfigMap values", func() {
+
+	var (
+		configMap *corev1.ConfigMap
+		log       = logrus.New()
+	)
+
+	BeforeEach(func() {
+		asc := newASCDefault()
+		r := newTestReconciler(asc)
+		cm, mutateFn := r.newAssistedCM(log, asc, &url.URL{Scheme: "https", Host: "localhost"})
+		Expect(mutateFn()).ShouldNot(HaveOccurred())
+		configMap = cm
+	})
+
+	It("INSTALL_INVOKER", func() {
+		Expect(configMap.Data["INSTALL_INVOKER"]).To(Equal("assisted-installer-operator"))
 	})
 })
 


### PR DESCRIPTION
See PR #1756

By setting `INSTALL_INVOKER` to `assisted-installer-operator`, we
can distinguish clusters installed by the operator from clusters
installed by other assisted service deployments, e.g. the cloud.

The value of `INSTALL_INVOKER` is written to a cluster manifest like
```
[core@master-0 ~]$ cat /var/opt/openshift/manifests/openshift-install-manifests.yaml
...
data:
 invoker: assisted-installer-operator
```
This field will be used by telemetry. Cloud installations will continue
to have `invoker: assisted-installer` as today.