### PR TITLE
MGMT-6650 Example CRDs update with clusterImageSet tag and SNO cluster name

### DIFF
--- a/docs/crds/agentClusterInstall-SNO.yaml
+++ b/docs/crds/agentClusterInstall-SNO.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: assisted-installer
 spec:
   clusterDeploymentRef:
-    name: test-cluster
+    name: single-node
   imageSetRef:
     name: openshift-v4.8.0
   networking:
@@ -18,4 +18,4 @@ spec:
     - 172.30.0.0/16
   provisionRequirements:
     controlPlaneAgents: 1
-  sshPublicKey: ssh-rsa your-public-key-here
+ #sshPublicKey: ssh-rsa your-public-key-here (optional)

--- a/docs/crds/agentClusterInstall.yaml
+++ b/docs/crds/agentClusterInstall.yaml
@@ -18,5 +18,4 @@ spec:
     - 172.30.0.0/16
   provisionRequirements:
     controlPlaneAgents: 3
-  sshPublicKey: ssh-rsa your-public-key-here
-
+ #sshPublicKey: ssh-rsa your-public-key-here (optional)

--- a/docs/crds/clusterDeployment.yaml
+++ b/docs/crds/clusterDeployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment
 metadata:
-  name: test-cluster
+  name: single-node
   namespace: assisted-installer
 spec:
   baseDomain: hive.example.com

--- a/docs/crds/clusterImageSet.yaml
+++ b/docs/crds/clusterImageSet.yaml
@@ -1,6 +1,6 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-v4.7.0
+  name: openshift-v4.8.0
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.7.0-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64

--- a/docs/crds/infraEnv.yaml
+++ b/docs/crds/infraEnv.yaml
@@ -14,7 +14,7 @@ spec:
   proxy:
     httpProxy: http://11.11.11.33
     httpsProxy: http://22.22.22.55
-  sshAuthorizedKey: 'your_pub_key_here'
+ #sshAuthorizedKey: 'your_pub_key_here' (optional)
   ignitionConfigOverride: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/etc/someconfig", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
   nmStateConfigLabelSelector:
     matchLabels:


### PR DESCRIPTION
The purpose of those CRD examples is for everyone to
have out-of-the-box working examples.

Updates:
1. Image tag set to a valid tag, currently 4.8.0-fc.3-x86_64
2. Some CRDs refer to single-node and some to the multi node cluster. This change fixes that.
3. Commented out the 'you-ssh-key-here' (which are optional) as it fails for backend validations.