### PR TITLE
[WIP] MGMT-4321 Prevent mixing IP families

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -649,10 +649,15 @@ var _ = Describe("IPv6 support", func() {
 			element:       []*string{swag.String("10.56.20.70"), swag.String("10.56.20.0/24")},
 			valid:         true,
 		},
+		{
+			ipV6Supported: true,
+			element:       []*string{swag.String("10.56.20.70"), swag.String("1001:db8::1")},
+			valid:         false,
+		},
 	}
 	for _, t := range tests {
 		t := t
-		It(fmt.Sprintf("IPv6 support validation. Supported: %t, IP addresses/CIDRs: %v", t.ipV6Supported, t.element), func() {
+		It(fmt.Sprintf("IP address family validation. IPv6 supported: %t, IP addresses/CIDRs: %v", t.ipV6Supported, t.element), func() {
 			if t.valid {
 				Expect(ValidateIPAddressFamily(t.ipV6Supported, t.element...)).ToNot(HaveOccurred())
 			} else {

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -281,7 +281,7 @@ func appendDHCPArgs(cluster *common.Cluster, host *models.Host, installerArgs []
 		return installerArgs, nil
 	}
 
-	machineNetworkCIDR := network.GetMachineCidrForUserManagedNetwork(cluster, log)
+	machineNetworkCIDR := network.GetMachineCidrForUserManagedNetwork(cluster, log, network.Any)
 	if machineNetworkCIDR != "" {
 		ipv6 := network.IsIPv6CIDR(machineNetworkCIDR)
 		log.Debugf("Machine network CIDR: %s. IPv6: %t", machineNetworkCIDR, ipv6)

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -355,7 +355,7 @@ func (i *installConfigBuilder) getInstallConfig(cluster *common.Cluster, addRhCa
 			None:      &platformNone{},
 		}
 
-		bootstrapCidr := network.GetMachineCidrForUserManagedNetwork(cluster, i.log)
+		bootstrapCidr := network.GetMachineCidrForUserManagedNetwork(cluster, i.log, network.Any)
 		if bootstrapCidr != "" {
 			i.log.Infof("None-Platform: Selected bootstrap machine network CIDR %s for cluster %s", bootstrapCidr, cluster.ID.String())
 			cfg.Networking.MachineNetwork = []struct {

--- a/internal/network/family_utils.go
+++ b/internal/network/family_utils.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+type AddressFamily int
+
+const (
+	IPv4 AddressFamily = iota
+	IPv6
+	Any
+)
+
 func IsIPv4Addr(ip string) bool {
 	return strings.Contains(ip, ".") && net.ParseIP(ip) != nil
 }

--- a/internal/network/machine_network_cidr_test.go
+++ b/internal/network/machine_network_cidr_test.go
@@ -339,7 +339,7 @@ var _ = Describe("inventory", func() {
 			cluster := createCluster("", "",
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
-			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log)
+			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log, Any)
 			Expect(machineCidr).To(BeEmpty())
 		})
 
@@ -349,7 +349,7 @@ var _ = Describe("inventory", func() {
 				createInventory(addIPv6Addresses(createInterface("10.2.3.20/24"), "fe80:5054::4/120")))
 			cluster.Hosts[0].Bootstrap = true
 
-			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log)
+			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log, Any)
 			Expect(true).To(Equal(machineCidr == "1.2.3.0/28" || machineCidr == "2001:db8::/120"))
 		})
 
@@ -358,7 +358,7 @@ var _ = Describe("inventory", func() {
 				createInventory(createInterface("3.3.3.3/16"), createInterface("8.8.8.8/8", "1.2.5.7/23")),
 				createInventory(createInterface("127.0.0.1/17")))
 			cluster.MachineNetworkCidr = "1.2.5.0/23"
-			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log)
+			machineCidr := GetMachineCidrForUserManagedNetwork(cluster, log, Any)
 			Expect(machineCidr).To(Equal(cluster.MachineNetworkCidr))
 		})
 


### PR DESCRIPTION
Although OCP supports dual stack, more work is needed to properly
support it in Assisted Installer. For now we will block combinations
of IPv4 with IPv6 addresses in the API, and make sure we do not
automatically pick up an IP address or CIDR that do not match the
selected address family.