### PR TITLE
MGMT-6533: Skip "Token used before issued" validation in jwt-go.

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Pull secret validation", func() {
 
 	log := logrus.New()
 	authHandlerDisabled := auth.NewNoneAuthenticator(log.WithField("pkg", "auth"))
-	_, JwkCert := auth.GetTokenAndCert()
+	_, JwkCert := auth.GetTokenAndCert(false)
 	fakeConfig := &auth.Config{
 		JwkCertURL: "",
 		JwkCert:    string(JwkCert),

--- a/pkg/auth/authenticator_test.go
+++ b/pkg/auth/authenticator_test.go
@@ -24,7 +24,7 @@ var _ = Describe("NewAuthenticator", func() {
 		Expect(ok).To(BeTrue())
 
 		// RHSSOAuthenticator
-		_, cert := GetTokenAndCert()
+		_, cert := GetTokenAndCert(false)
 		config = &Config{
 			AuthType:   TypeRHSSO,
 			JwkCertURL: "",

--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -201,7 +201,7 @@ var _ = Describe("authz", func() {
 		})
 	}
 
-	userToken, JwkCert := GetTokenAndCert()
+	userToken, JwkCert := GetTokenAndCert(false)
 	h, err := restapi.Handler(
 		restapi.Config{
 			AuthAgentAuth:       mockAgentAuth,

--- a/pkg/auth/local_authenticator_test.go
+++ b/pkg/auth/local_authenticator_test.go
@@ -110,7 +110,7 @@ var _ = Describe("AuthAgentAuth", func() {
 	})
 
 	It("Fails with an RSA token", func() {
-		rsaToken, _ := GetTokenAndCert()
+		rsaToken, _ := GetTokenAndCert(false)
 		_, err := a.AuthAgentAuth(rsaToken)
 		Expect(err).To(HaveOccurred())
 		validateErrorResponse(err)


### PR DESCRIPTION
When running inside a VM (like minikube) the service clock may be slightly
late, therefore this validation can failed.

The validation will be removed in jwt-go v4 anyway and this is just a
work around in the meantime.

Without this fix, running e2e flow locally using auth will most probably
fail on that error.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>