### PR TITLE
Bug 1977449: Fix flaky test: invalid NMState config YAML 

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1564,7 +1564,6 @@ var _ = Describe("[kube-api]cluster installation", func() {
 	})
 
 	It("deploy clusterDeployment and infraEnv and with an invalid NMState config YAML", func() {
-		Skip("MGMT-5324 flaky test")
 		var (
 			NMStateLabelName  = "someName"
 			NMStateLabelValue = "someValue"


### PR DESCRIPTION
The root cause is how InfraEnv used to requeue for errors,
which changed with other fixes. We will now requeue after 20s
(as the backend limits image generation requests windows
to be above 10s), and avoid requeue for non-recoverable
issues such as BadRequest (invalid config).