### PR TITLE
MGMT-5422 AgentClusterInstall - Added LogsURL field

### DIFF
--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -300,6 +300,10 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains events
                       which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs
+                      tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -232,6 +232,9 @@ spec:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -232,6 +232,9 @@ spec:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
                     type: string
+                  logsURL:
+                    description: LogsURL specifies a url for download controller logs tar file.
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.

--- a/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -98,7 +98,11 @@ type AgentClusterInstallStatus struct {
 type DebugInfo struct {
 	// EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
 	// +optional
-	EventsURL string `json:"eventsURL,omitempty"`
+	EventsURL string `json:"eventsURL"`
+
+	// LogsURL specifies a url for download controller logs tar file.
+	// +optional
+	LogsURL string `json:"logsURL"`
 }
 
 // Networking defines the pod network provider in the cluster.

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1403,6 +1403,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return aci.Status.DebugInfo.EventsURL
 		}, "30s", "10s").ShouldNot(Equal(""))
 
+		By("Check ACI Logs URL exists")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.DebugInfo.LogsURL
+		}, "30s", "10s").ShouldNot(Equal(""))
+
 		By("Approve Agent")
 		Eventually(func() error {
 			agent := getAgentCRD(ctx, kubeClient, key)
@@ -1464,10 +1470,17 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 		configSecret := getSecret(ctx, kubeClient, configkey)
 		Expect(configSecret.Data["kubeconfig"]).NotTo(BeNil())
+
 		By("Check Event URL does not exist")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.EventsURL
+		}, "1m", "10s").Should(Equal(""))
+
+		By("Check Logs URL does not exist")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.DebugInfo.LogsURL
 		}, "1m", "10s").Should(Equal(""))
 	})
 


### PR DESCRIPTION
A new LogsURL field was added to AgentClusterInstall DebugInfo
field. It contains a link for download the controller (cluster)
logs which is available until the installation is completed.

```
Name:         test-infra-cluster-assisted-installer-agent-cluster-install
Namespace:    assisted-installer
Labels:       <none>
Annotations:  <none>
API Version:  extensions.hive.openshift.io/v1beta1
Kind:         AgentClusterInstall
Metadata:
  Creation Timestamp:  2021-05-27T15:05:44Z
  Finalizers:
    agentclusterinstall.agent-install.openshift.io/ai-deprovision
  Generation:  2
  Managed Fields:
    API Version:  extensions.hive.openshift.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:apiVIP:
        f:clusterDeploymentRef:
          .:
          f:name:
        f:imageSetRef:
          .:
          f:name:
        f:ingressVIP:
        f:networking:
          .:
          f:clusterNetwork:
          f:machineNetwork:
          f:serviceNetwork:
        f:provisionRequirements:
          .:
          f:controlPlaneAgents:
        f:sshPublicKey:
    Manager:      OpenAPI-Generator
    Operation:    Update
    Time:         2021-05-27T15:05:44Z
    API Version:  extensions.hive.openshift.io/v1beta1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"agentclusterinstall.agent-install.openshift.io/ai-deprovision":
        f:ownerReferences:
          .:
          k:{"uid":"09b6d111-28e1-4a19-9adb-c97f7c8b4c28"}:
            .:
            f:apiVersion:
            f:kind:
            f:name:
            f:uid:
      f:status:
        .:
        f:conditions:
        f:connectivityMajorityGroups:
        f:debugInfo:
          .:
          f:eventsURL:
          f:logsURL:
    Manager:    assisted-service
    Operation:  Update
    Time:       2021-05-27T15:05:50Z
  Owner References:
    API Version:     hive.openshift.io/v1
    Kind:            ClusterDeployment
    Name:            test-infra-cluster-assisted-installer
    UID:             09b6d111-28e1-4a19-9adb-c97f7c8b4c28
  Resource Version:  1222
  UID:               04dbc3cc-0bff-4289-809f-c38270811ffc
Spec:
  API VIP:  192.168.126.100
  Cluster Deployment Ref:
    Name:  test-infra-cluster-assisted-installer
  Image Set Ref:
    Name:       test-infra-cluster-assisted-installer-image-set
  Ingress VIP:  192.168.126.101
  Networking:
    Cluster Network:
      Cidr:         10.128.0.0/14
      Host Prefix:  23
    Machine Network:
      Cidr:  192.168.126.0/24
    Service Network:
      172.30.0.0/16
  Provision Requirements:
    Control Plane Agents:  3
  Ssh Public Key:          ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V5DVvyr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUAAbfmn/HalJTHB73LyjilKiPvJ+x2bG7AeiqyVHwtQSpt02FCdQGptmsSqqWF/b9botOO38eUsqPNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= oscohen@localhost.localdomain
Status:
  Conditions:
    Last Probe Time:             2021-05-27T15:07:10Z
    Last Transition Time:        2021-05-27T15:07:10Z
    Message:                     The Spec has been successfully applied
    Reason:                      SyncOK
    Status:                      True
    Type:                        SpecSynced
    Last Probe Time:             2021-05-27T15:05:44Z
    Last Transition Time:        2021-05-27T15:05:44Z
    Message:                     The cluster is not ready to begin the installation
    Reason:                      ClusterNotReady
    Status:                      False
    Type:                        RequirementsMet
    Last Probe Time:             2021-05-27T15:07:10Z
    Last Transition Time:        2021-05-27T15:07:10Z
    Message:                     The cluster's validations are failing: The cluster has hosts that are not ready to install.
    Reason:                      ValidationsFailing
    Status:                      False
    Type:                        Validated
    Last Probe Time:             2021-05-27T15:05:44Z
    Last Transition Time:        2021-05-27T15:05:44Z
    Message:                     The installation has not yet started
    Reason:                      InstallationNotStarted
    Status:                      False
    Type:                        Completed
    Last Probe Time:             2021-05-27T15:05:44Z
    Last Transition Time:        2021-05-27T15:05:44Z
    Message:                     The installation has not failed
    Reason:                      InstallationNotFailed
    Status:                      False
    Type:                        Failed
    Last Probe Time:             2021-05-27T15:05:44Z
    Last Transition Time:        2021-05-27T15:05:44Z
    Message:                     The installation is waiting to start or in progress
    Reason:                      InstallationNotStopped
    Status:                      False
    Type:                        Stopped
  Connectivity Majority Groups:  {"192.168.126.0/24":[],"192.168.141.0/24":[]}
  Debug Info:
    Events URL:  http://10.1.37.74:6000/api/assisted-install/v1/clusters/23617e69-296d-46e0-98ad-213f02295fdb/events?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiMjM2MTdlNjktMjk2ZC00NmUwLTk4YWQtMjEzZjAyMjk1ZmRiIn0.fNnNGRjtDHNdnwR8XKjU4BHfBPD79MvM7JVXNg779gNCxoAcQ2YslwkhK4mOlVDKqw2uDdb-hxBv2DsheLg_hA
    Logs URL:    http://10.1.37.74:6000/api/assisted-install/v1/clusters/23617e69-296d-46e0-98ad-213f02295fdb/logs?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiMjM2MTdlNjktMjk2ZC00NmUwLTk4YWQtMjEzZjAyMjk1ZmRiIn0.kJEqKYJ3zssDXttrnm6DiazIdx7LrfBIWm91mUkiGBOZdGbxCxgrEyAPzLipF5VrffSz4axeE8Oi_J0bI13SPQ
Events:          <none>
```
