### PR TITLE
Bug 1969304: Don't queue BMH reconcile if the InfraEnv URL hasn't changed

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -445,9 +445,7 @@ func (r *BMACReconciler) reconcileAgentInventory(bmh *bmh_v1alpha1.BareMetalHost
 // 1. Should we proceed with the BMH's reconcile
 // 2. Should the full `Reconcile` stop as well
 func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.InfraEnv) (bool, bool) {
-	// The global `Reconcile` flow is not stopped in this case
-	// as we may be reconciling a BMH in the spokeCluster that
-	// doesn't have an InfraEnv.
+	// Stop `Reconcile` if BMH does not have an InfraEnv.
 	if infraEnv == nil {
 		return false, false
 	}

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -426,6 +426,49 @@ func (r *BMACReconciler) reconcileAgentInventory(bmh *bmh_v1alpha1.BareMetalHost
 
 }
 
+// Utility to verify whether a BMH should be reconciled based on the InfraEnv
+//
+// This function verifies three things:
+//
+// 1. InfraEnv existsD
+// 2. InfraEnv's ISODownloadURL exists
+// 3. The BMH.Spec.URL is the same to the InfraEnv's ISODownload URL
+//
+// If the three checks above are true, then the reconcile won't happen
+// and the reconcileBMH function will return.
+//
+// Note that this function is also used to decide whether a BMH reconcile should be queued
+// or not. This will help queuing fewer reconciles when we know the BMH is not ready.
+//
+// The function returns 2 booleans:
+//
+// 1. Should we proceed with the BMH's reconcile
+// 2. Should the full `Reconcile` stop as well
+func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.InfraEnv) (bool, bool) {
+	// The global `Reconcile` flow is not stopped in this case
+	// as we may be reconciling a BMH in the spokeCluster that
+	// doesn't have an InfraEnv.
+	if infraEnv == nil {
+		return false, false
+	}
+
+	// This is a separate check because an existing
+	// InfraEnv with an empty ISODownloadURL means the
+	// global `Reconcile` function should also return
+	// as there is nothing left to do for it.
+	if infraEnv.Status.ISODownloadURL == "" {
+		return false, true
+	}
+
+	// The Image URL exists and InfraEnv's URL has not changed
+	// nothing else to do.
+	if bmh.Spec.Image != nil && bmh.Spec.Image.URL == infraEnv.Status.ISODownloadURL {
+		return false, false
+	}
+
+	return true, false
+}
+
 func (r *BMACReconciler) findInfraEnvForBMH(ctx context.Context, log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost) (*aiv1beta1.InfraEnv, error) {
 	for ann, value := range bmh.Labels {
 		log.Debugf("BMH label %s value %s", ann, value)
@@ -468,10 +511,6 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 		return reconcileError{err}
 	}
 
-	if infraEnv == nil {
-		return reconcileComplete{}
-	}
-
 	dirty := false
 	annotations := bmh.ObjectMeta.GetAnnotations()
 
@@ -503,10 +542,10 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 		return reconcileComplete{stop: true, dirty: dirty}
 	}
 
-	// The Image URL exists and InfraEnv's URL has not changed
-	// nothing else to do.
-	if bmh.Spec.Image != nil && bmh.Spec.Image.URL == infraEnv.Status.ISODownloadURL {
-		return reconcileComplete{}
+	proceed, stop := shouldReconcileBMH(bmh, infraEnv)
+
+	if !proceed {
+		return reconcileComplete{stop: stop}
 	}
 
 	// BMH is set to `detached` after a cluster deployment. The
@@ -1034,6 +1073,12 @@ func (r *BMACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		requests := make([]reconcile.Request, len(bmhs))
 
 		for i, bmh := range bmhs {
+
+			queue, _ := shouldReconcileBMH(bmh, infraEnv)
+			if !queue {
+				continue
+			}
+
 			requests[i] = reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: bmh.Namespace,


### PR DESCRIPTION
The reconcileBMH function already verifies whether the InfraEnv URL has changed or not. The InfraEnv watcher doesn't, tho.

This commit checks whether the BMH should be reconciled based on the InfraEnv info, before queuing the request. The check is
now used by both, the watcher and the reconcileBMH function

Signed-off-by: Flavio Percoco <flavio@redhat.com>