### PR TITLE
MGMT-4189 - block in update cluster setting API VIP DHCP allocation when user_managed_network is set

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1966,11 +1966,11 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 		userManagedNetworking = swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking)
 		updates["user_managed_networking"] = userManagedNetworking
 		machineCidr = ""
-		if userManagedNetworking {
-			err, vipDhcpAllocation = setCommonUserNetworkManagedParams(params.ClusterUpdateParams, common.IsSingleNodeCluster(cluster), machineCidr, updates, log)
-			if err != nil {
-				return err
-			}
+	}
+	if userManagedNetworking && !common.IsSingleNodeCluster(cluster) {
+		err, vipDhcpAllocation = setCommonUserNetworkManagedParams(params.ClusterUpdateParams, common.IsSingleNodeCluster(cluster), machineCidr, updates, log)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2948,6 +2948,26 @@ var _ = Describe("cluster", func() {
 					VipDhcpAllocation:     swag.Bool(true),
 				},
 			})
+
+			verifyApiError(reply, http.StatusBadRequest)
+		})
+
+		It("Fail Update VIP DHCP while UserManagedNetworking was set", func() {
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				ID:                    &clusterID,
+				UserManagedNetworking: swag.Bool(true),
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+			reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+				ClusterID: clusterID,
+				ClusterUpdateParams: &models.ClusterUpdateParams{
+					VipDhcpAllocation: swag.Bool(true),
+				},
+			})
+
 			verifyApiError(reply, http.StatusBadRequest)
 		})
 


### PR DESCRIPTION
We should block api_vip_allocation in none platform as it is blocked in
sno already. Right now we block it in register cluster but allow in
update. This code should block it on update