### PR TITLE
MGMT-6747 Media disconnection: Mark host as failed and show an Indicative error

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -70,9 +70,13 @@ import (
 
 const DefaultUser = "kubeadmin"
 
-// 125 is the generic exit code for cases the error is in podman / docker and not the container we tried to run
-const ContainerAlreadyRunningExitCode = 125
 const WindowBetweenRequestsInSeconds = 10 * time.Second
+
+const (
+	MediaDisconnected int64 = 256
+	// 125 is the generic exit code for cases the error is in podman / docker and not the container we tried to run
+	ContainerAlreadyRunningExitCode = 125
+)
 
 type Config struct {
 	ignition.IgnitionConfig
@@ -2843,6 +2847,12 @@ func (b *bareMetalInventory) PostStepReply(ctx context.Context, params installer
 }
 
 func (b *bareMetalInventory) handleReplyError(params installer.PostStepReplyParams, ctx context.Context, log logrus.FieldLogger, h *models.Host, exitCode int64) error {
+	if exitCode == MediaDisconnected {
+		if err := b.handleMediaDisconnection(params, ctx, log, h); err != nil {
+			return err
+		}
+	}
+
 	switch params.Reply.StepType {
 	case models.StepTypeInstall:
 		// Handle case of installation error due to an already running assisted-installer.
@@ -2860,6 +2870,29 @@ func (b *bareMetalInventory) handleReplyError(params installer.PostStepReplyPara
 		return b.processDiskSpeedCheckResponse(ctx, h, stepReply, exitCode)
 	}
 	return nil
+}
+
+func (b *bareMetalInventory) handleMediaDisconnection(params installer.PostStepReplyParams, ctx context.Context, log logrus.FieldLogger, h *models.Host) error {
+	statusInfo := fmt.Sprintf("%s - %s", string(models.HostStageFailed),
+		"Cannot read from the media (ISO) - media was likely disconnected")
+
+	// Install command reports its status with a different API, directly from the assisted-installer.
+	// Just adding our diagnose to the existing error message.
+	if swag.StringValue(h.Status) == models.HostStatusError && h.StatusInfo != nil {
+		// Add the message only once
+		if strings.Contains(*h.StatusInfo, statusInfo) {
+			return nil
+		}
+
+		statusInfo = fmt.Sprintf("%s. %s", statusInfo, *h.StatusInfo)
+	} else if params.Reply.Error != "" {
+		statusInfo = fmt.Sprintf("%s. %s", statusInfo, params.Reply.Error)
+	}
+
+	_, err := hostutil.UpdateHostStatus(ctx, log, b.db, b.eventsHandler, h.ClusterID, *h.ID,
+		swag.StringValue(h.Status), models.HostStatusError, statusInfo)
+
+	return err
 }
 
 func (b *bareMetalInventory) updateFreeAddressesReport(ctx context.Context, host *models.Host, freeAddressesReport string) error {


### PR DESCRIPTION
The purpose of this PR is to mark the host as failed and show an indicative error to the user via the AI UI.
The assisted-installer-agent returns a special exit code (256) which indicates to the assisted-service PostReply that media disconnection  event has occurred.

This PR is the completion of the media disconnection EPIC.
https://github.com/openshift/assisted-service/pull/1780
https://github.com/openshift/assisted-installer-agent/pull/197