### PR TITLE
Bug 1966268 - remove default.nmconnection as a WA for NM priority issue

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -56,6 +56,10 @@ else
   ETC_NETWORK_MANAGER="/etc/NetworkManager/system-connections"
 fi
 
+# remove default connection file create by NM(nm-initrd-generator). This is a WA until
+# NM is back to supporting priority between nmconnections
+rm -f ${ETC_NETWORK_MANAGER}/*
+
 # Create a map of host mac addresses to their network interfaces
 function map_host_macs_to_interfaces() {
   SYS_CLASS_NET_DIR='/sys/class/net'

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -165,7 +165,7 @@ const discoveryIgnitionConfigFormat = `{
     {
         "name": "pre-network-manager-config.service",
         "enabled": true,
-        "contents": "[Unit]\nDescription=Prepare network manager config content\nBefore=NetworkManager.service\nDefaultDependencies=no\n[Service]\nUser=root\nType=oneshot\nTimeoutSec=10\nExecStart=/bin/bash /usr/local/bin/pre-network-manager-config.sh\nPrivateTmp=true\nRemainAfterExit=no\n[Install]\nWantedBy=multi-user.target"
+        "contents": "[Unit]\nDescription=Prepare network manager config content\nBefore=dracut-initqueue.service\nAfter=dracut-cmdline.service\nDefaultDependencies=no\n[Service]\nUser=root\nType=oneshot\nTimeoutSec=10\nExecStart=/bin/bash /usr/local/bin/pre-network-manager-config.sh\nPrivateTmp=true\nRemainAfterExit=no\n[Install]\nWantedBy=multi-user.target"
     }{{end}}
     ]
   },


### PR DESCRIPTION
The current version of the NM in the 4.8 does not support priority between nmconnections
Until this is fixed, we need to remove default.nmconnection file (so that it won't interfere
with ours static network nmconnections) both in minimal and full ISO