### PR TITLE
OCPBUGSM-29621 Unify client Scheme registration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,15 +16,12 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/kelseyhightower/envconfig"
-	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift/assisted-service/internal/assistedserviceiso"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/connectivity"
-	hiveext "github.com/openshift/assisted-service/internal/controller/api/hiveextension/v1beta1"
-	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/controller/controllers"
 	"github.com/openshift/assisted-service/internal/dns"
 	"github.com/openshift/assisted-service/internal/domains"
@@ -64,18 +61,14 @@ import (
 	"github.com/openshift/assisted-service/pkg/staticnetworkconfig"
 	"github.com/openshift/assisted-service/pkg/thread"
 	"github.com/openshift/assisted-service/restapi"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"go.elastic.co/apm/module/apmhttp"
 	"go.elastic.co/apm/module/apmlogrus"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -692,12 +685,7 @@ func createCRDEventsHandler() controllers.CRDEventsHandler {
 
 func createControllerManager() (manager.Manager, error) {
 	if Options.EnableKubeAPI {
-		var schemes = runtime.NewScheme()
-		utilruntime.Must(scheme.AddToScheme(schemes))
-		utilruntime.Must(aiv1beta1.AddToScheme(schemes))
-		utilruntime.Must(hivev1.AddToScheme(schemes))
-		utilruntime.Must(hiveext.AddToScheme(schemes))
-		utilruntime.Must(bmh_v1alpha1.AddToScheme(schemes))
+		schemes := controllers.GetKubeClientSchemes()
 
 		return ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 			Scheme:           schemes,

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -36,15 +36,14 @@ var _ = Describe("bmac reconcile", func() {
 	)
 
 	BeforeEach(func() {
-		err := machinev1beta1.AddToScheme(scheme.Scheme)
-		Expect(err).To(BeNil())
-		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		schemes := GetKubeClientSchemes()
+		c = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
 		bmhr = &BMACReconciler{
 			Client:      c,
 			Scheme:      scheme.Scheme,
 			Log:         common.GetTestLog(),
-			spokeClient: fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build(),
+			spokeClient: fakeclient.NewClientBuilder().WithScheme(schemes).Build(),
 		}
 	})
 

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -6,14 +6,20 @@ import (
 	"math/big"
 	"strings"
 
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	hiveext "github.com/openshift/assisted-service/internal/controller/api/hiveextension/v1beta1"
 	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	"github.com/openshift/assisted-service/pkg/requestid"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/scale/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -133,4 +139,16 @@ func addRequestIdIfNeeded(ctx context.Context) context.Context {
 		ctxWithReqID = requestid.ToContext(ctx, requestid.NewID())
 	}
 	return ctxWithReqID
+}
+
+func GetKubeClientSchemes() *runtime.Scheme {
+	var schemes = runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(schemes))
+	utilruntime.Must(corev1.AddToScheme(schemes))
+	utilruntime.Must(aiv1beta1.AddToScheme(schemes))
+	utilruntime.Must(hivev1.AddToScheme(schemes))
+	utilruntime.Must(hiveext.AddToScheme(schemes))
+	utilruntime.Must(bmh_v1alpha1.AddToScheme(schemes))
+	utilruntime.Must(machinev1beta1.AddToScheme(schemes))
+	return schemes
 }

--- a/internal/controller/controllers/spoke_cluster.go
+++ b/internal/controller/controllers/spoke_cluster.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,7 +23,9 @@ func getSpokeClient(secret *corev1.Secret) (client.Client, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get restconfig for spoke kube client")
 	}
-	targetClient, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
+
+	schemes := GetKubeClientSchemes()
+	targetClient, err := client.New(restConfig, client.Options{Scheme: schemes})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get spoke kube client")
 	}


### PR DESCRIPTION
The controller client, spokeClient, and tests client all register the
runtime.Scheme differently. This has led to bugs like the one linked to
this commit where the controller tries to interact with a custom
resource but doesn't have the right Scheme registered.

This commit uifies the process used to register these Schemes so that
the same one used everywhere. This prevents having schemes registered
for tests that are not registered in the real client and the other way
around.


Signed-off-by: Flavio Percoco <flavio@redhat.com>