### PR TITLE
enable defining public registries that should not be validated against PS

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -58,6 +58,12 @@ cat <<EOF
   SERVICE_BASE_URL: '${SERVICE_BASE_URL}'
 EOF
     fi
+
+    if [ -n "${PUBLIC_CONTAINER_REGISTRIES:-}" ]; then
+cat <<EOF
+  PUBLIC_CONTAINER_REGISTRIES: 'quay.io,${PUBLIC_CONTAINER_REGISTRIES}'
+EOF
+    fi
 }
 
 tee << EOCR >(oc apply -f -)


### PR DESCRIPTION
We'll go over used images for assisted-installer, controller, agent and postgres, get their registries and add them to the ``PUBLIC_CONTAINER_REGISTRIES`` config.
That will enable us to use images from prow's registries based on the cluster we're running on (build01, build02 or any other cluster).

No patch to ocm-2.3 is needed, as we use upstream code on CI.