### PR TITLE
Bug 1966485: [operator] Wait for CVO to be ready before marking as done

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -389,7 +389,7 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(log logrus.FieldLogger, ins
 			// from configmap
 			"AUTH_TYPE":                   "local",
 			"BASE_DNS_DOMAINS":            "",
-			"CHECK_CLUSTER_VERSION":       "False",
+			"CHECK_CLUSTER_VERSION":       "True",
 			"CREATE_S3_BUCKET":            "False",
 			"ENABLE_KUBE_API":             "True",
 			"ENABLE_SINGLE_NODE_DNSMASQ":  "True",

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -70,7 +70,7 @@ parameters:
 - name: PUBLIC_CONTAINER_REGISTRIES
   value: ""
 - name: CHECK_CLUSTER_VERSION
-  value: "false"
+  value: "true"
 - name: IPV6_SUPPORT
   value: "true"
   required: false


### PR DESCRIPTION
# Description

This PR changes the default value of `CHECK_CLUSTER_VERSION` to True so
that deployments wait for the CVO to be ready before marking the cluster
as deployed.

This makes the behavior of operator-managed clusters consistent with
cloud deployments.

Closes: [OCPBUGSM-29806](https://issues.redhat.com/browse/OCPBUGSM-29806)

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

Configuration of the assisted-service

```
# oc -n assisted-installer describe cm assisted-service
[...]
Name:         assisted-service
Namespace:    assisted-installer
Labels:       <none>
Annotations:  <none>
    
Data               
====
[...]
CHECK_CLUSTER_VERSION:      
----                       
True       
[...]
```

From the `pod/assisted-installer-controller-cqv69` on the target SNO

```
time="2021-06-02T12:47:18Z" level=info msg="Waiting for cluster version operator: true"
[...]
time="2021-06-02T12:47:18Z" level=info msg="All nodes were successfully installed"
[...]
time="2021-06-02T12:48:18Z" level=info msg="Checking cluster version operator availability status"
time="2021-06-02T12:48:18Z" level=info msg="Cluster version status: progressing message: Working towards 4.8.0-fc.7: 635 of 676 done (93%!c(MISSING)omplete)"
[...]
time="2021-06-02T13:00:18Z" level=info msg="Checking cluster version operator availability status"
time="2021-06-02T13:00:18Z" level=info msg="Service acknowledged CVO is available for cluster 700079a5-8b49-42bd-b00e-6e83dde20580"
[...]
```

At the same time from the hub cluster's `agentclusterinstall`

```
    Last Probe Time:             2021-06-02T13:02:04Z
    Last Transition Time:        2021-06-02T13:02:04Z
    Message:                     The installation has completed: Cluster is installed
    Reason:                      InstallationCompleted
```

From the timestamps we can confirm that cluster has been marked as installed only after the CVO became available. The time between hub and SNO is synchronized.

# Assignees

/assign @flaper87

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
