### PR TITLE
MGMT-6663: Make an event for any operator status change

### DIFF
--- a/internal/operators/handler/handler.go
+++ b/internal/operators/handler/handler.go
@@ -145,10 +145,8 @@ func (h *Handler) UpdateMonitoredOperatorStatus(ctx context.Context, clusterID s
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	if operator.Name == operators.OperatorCVO.Name {
-		eventInfo := fmt.Sprintf("Cluster version status: %s message: %s", status, statusInfo)
-		h.eventsHandler.AddEvent(ctx, clusterID, nil, models.EventSeverityInfo, eventInfo, time.Now())
-	}
+	eventMsg := fmt.Sprintf("Operator %s status: %s message: %s", operator.Name, status, statusInfo)
+	h.eventsHandler.AddEvent(ctx, clusterID, nil, models.EventSeverityInfo, eventMsg, time.Now())
 
 	txSuccess = true
 	return nil

--- a/internal/operators/handler/handler_test.go
+++ b/internal/operators/handler/handler_test.go
@@ -140,6 +140,8 @@ var _ = Describe("Operators manager", func() {
 			operatorName := common.TestDefaultConfig.MonitoredOperator.Name
 			newStatus := models.OperatorStatusFailed
 
+			mockEvents.EXPECT().AddEvent(gomock.Any(), *cluster.ID, nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
+
 			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operatorName, newStatus, statusInfo)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -185,16 +187,6 @@ var _ = Describe("Operators manager", func() {
 			for _, operator := range operators {
 				Expect(operator.StatusUpdatedAt.String()).Should(Equal(lastUpdatedTime.String()))
 			}
-		})
-
-		It("Should create an event when CVO is reported", func() {
-			newStatus := models.OperatorStatusAvailable
-			statusInfo := common.TestDefaultConfig.StatusInfo
-
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *cluster.ID, nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
-
-			err := handler.UpdateMonitoredOperatorStatus(context.TODO(), *cluster.ID, operators.OperatorCVO.Name, newStatus, statusInfo)
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION


# Assisted Pull Request

## Description

Till now only CVO status update was creating an event.
We would like to expose more what happens in finalizing phase so 
we make an event for any operator status change.

Depends on https://github.com/openshift/assisted-installer/pull/298 to avoid OLM spamming

## List all the issues related to this PR

- [x] New Feature

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] Manual (Elaborate on how it was tested)

## Assignees

/cc @filanov 
/cc @machacekondra 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
