### PR TITLE
MGMT-6425 Add validation for API DNS name resolution

### DIFF
--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -2,3 +2,8 @@ package constants
 
 const Kubeconfig = "kubeconfig"
 const KubeconfigNoIngress = "kubeconfig-noingress"
+
+//A Sub domain of apps.clusterName.baseDomain used by DNS validations to verify that *.apps wildcard configured properly.
+const AppsSubDomainNameHostDNSValidation = "console-openshift-console"
+const APIName = "api"
+const APIInternalName = "api-int"

--- a/internal/host/hostcommands/domain_name_resolution_cmd.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd.go
@@ -1,0 +1,98 @@
+package hostcommands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type domainNameResolutionCmd struct {
+	baseCmd
+	domainNameResolutionImage string
+	db                        *gorm.DB
+}
+
+func NewDomainNameResolutionCmd(log logrus.FieldLogger, domainNameResolutionImage string, db *gorm.DB) *domainNameResolutionCmd {
+	return &domainNameResolutionCmd{
+		baseCmd:                   baseCmd{log: log},
+		domainNameResolutionImage: domainNameResolutionImage,
+		db:                        db,
+	}
+}
+
+func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *common.Cluster) (string, error) {
+	clusterName := cluster.Cluster.Name
+	if len(clusterName) == 0 {
+		err := errors.Errorf("Cluster name is empty for cluster %s", host.ClusterID)
+		f.log.WithError(err).Warn("Cluster name is empty")
+		return "", err
+	}
+
+	baseDNSDomain := cluster.Cluster.BaseDNSDomain
+	if len(baseDNSDomain) == 0 {
+		err := errors.Errorf("Cluster base domain is empty for cluster %s", host.ClusterID)
+		f.log.WithError(err).Warn("Cluster base domain is empty")
+		return "", err
+	}
+	apiDomainName := fmt.Sprintf("api.%s.%s", clusterName, baseDNSDomain)
+	apiInternalDomainName := fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain)
+	appsDomainName := fmt.Sprintf("%s.apps.%s.%s", constants.AppsSubDomainNameHostDNSValidation, clusterName, baseDNSDomain)
+
+	apiDomain := models.DomainResolutionRequestDomain{
+		DomainName: &apiDomainName,
+	}
+	apiInternalDomain := models.DomainResolutionRequestDomain{
+		DomainName: &apiInternalDomainName,
+	}
+	appsDomain := models.DomainResolutionRequestDomain{
+		DomainName: &appsDomainName,
+	}
+
+	var domains []*models.DomainResolutionRequestDomain
+	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain)
+
+	request := models.DomainResolutionRequest{
+		Domains: domains,
+	}
+
+	b, err := json.Marshal(&request)
+	if err != nil {
+		f.log.WithError(err).Warn("Json marshal")
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (f *domainNameResolutionCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
+	var cluster common.Cluster
+	if err := f.db.First(&cluster, "id = ?", host.ClusterID).Error; err != nil {
+		f.log.WithError(err).Errorf("failed to fetch cluster %s", host.ClusterID)
+		return nil, err
+	}
+	param, err := f.prepareParam(host, &cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	step := &models.Step{
+		StepType: models.StepTypeDomainResolution,
+		Command:  "podman",
+		Args: []string{
+			"run", "--privileged", "--net=host", "--rm", "--quiet",
+			"-v", "/var/log:/var/log",
+			"-v", "/run/systemd/journal/socket:/run/systemd/journal/socket",
+			f.domainNameResolutionImage,
+			"domain_resolution",
+			"-request",
+			param,
+		},
+	}
+	return []*models.Step{step}, nil
+}

--- a/internal/host/hostcommands/domain_name_resolution_cmd_test.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd_test.go
@@ -1,0 +1,71 @@
+package hostcommands
+
+import (
+	"context"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("domainNameResolution", func() {
+	ctx := context.Background()
+	var host models.Host
+	var cluster common.Cluster
+	var db *gorm.DB
+	var dCmd *domainNameResolutionCmd
+	var id, clusterID strfmt.UUID
+	var stepReply []*models.Step
+	var stepErr error
+	var dbName string
+	var name string
+	var baseDNSDomain string
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		dCmd = NewDomainNameResolutionCmd(common.GetTestLog(), "quay.io/ocpmetal/assisted-installer-agent:latest", db)
+		id = strfmt.UUID(uuid.New().String())
+		clusterID = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, clusterID, models.HostStatusPreparingForInstallation)
+		host.Inventory = hostutil.GenerateMasterInventory()
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+		name = "example"
+		baseDNSDomain = "test.com"
+	})
+
+	It("happy flow", func() {
+		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, Name: name, BaseDNSDomain: baseDNSDomain}}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
+		Expect(stepReply).ToNot(BeNil())
+		Expect(stepReply[0].StepType).To(Equal(models.StepTypeDomainResolution))
+		Expect(stepErr).ShouldNot(HaveOccurred())
+	})
+
+	It("Missing cluster name", func() {
+		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, BaseDNSDomain: baseDNSDomain}}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
+		Expect(stepReply).To(BeNil())
+		Expect(stepErr).To(HaveOccurred())
+	})
+
+	It("Missing domain base name", func() {
+		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, Name: name}}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+		stepReply, stepErr = dCmd.GetSteps(ctx, &host)
+		Expect(stepReply).To(BeNil())
+		Expect(stepErr).To(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+		stepReply = nil
+		stepErr = nil
+	})
+})

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -67,7 +67,7 @@ var _ = Describe("instruction_manager", func() {
 
 	Context("No DHCP", func() {
 		BeforeEach(func() {
-			cluster := common.Cluster{Cluster: models.Cluster{ID: &clusterId, VipDhcpAllocation: swag.Bool(false), MachineNetworkCidr: "1.2.3.0/24"}}
+			cluster := common.Cluster{Cluster: models.Cluster{ID: &clusterId, VipDhcpAllocation: swag.Bool(false), MachineNetworkCidr: "1.2.3.0/24", Name: "example", BaseDNSDomain: "test.com"}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
@@ -85,6 +85,7 @@ var _ = Describe("instruction_manager", func() {
 				checkStep(models.HostStatusKnown, []models.StepType{
 					models.StepTypeConnectivityCheck, models.StepTypeFreeNetworkAddresses,
 					models.StepTypeInventory, models.StepTypeNtpSynchronizer,
+					models.StepTypeDomainResolution,
 				})
 			})
 			It("disconnected", func() {
@@ -96,12 +97,14 @@ var _ = Describe("instruction_manager", func() {
 				checkStep(models.HostStatusInsufficient, []models.StepType{
 					models.StepTypeInventory, models.StepTypeConnectivityCheck,
 					models.StepTypeFreeNetworkAddresses, models.StepTypeNtpSynchronizer,
+					models.StepTypeDomainResolution,
 				})
 			})
 			It("pending-for-input", func() {
 				checkStep(models.HostStatusPendingForInput, []models.StepType{
 					models.StepTypeInventory, models.StepTypeConnectivityCheck,
 					models.StepTypeFreeNetworkAddresses, models.StepTypeNtpSynchronizer,
+					models.StepTypeDomainResolution,
 				})
 			})
 			It("error", func() {
@@ -136,7 +139,7 @@ var _ = Describe("instruction_manager", func() {
 
 	Context("With DHCP", func() {
 		BeforeEach(func() {
-			cluster := common.Cluster{Cluster: models.Cluster{ID: &clusterId, VipDhcpAllocation: swag.Bool(true), MachineNetworkCidr: "1.2.3.0/24"}}
+			cluster := common.Cluster{Cluster: models.Cluster{ID: &clusterId, VipDhcpAllocation: swag.Bool(true), MachineNetworkCidr: "1.2.3.0/24", Name: "example", BaseDNSDomain: "test.com"}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
@@ -154,7 +157,7 @@ var _ = Describe("instruction_manager", func() {
 				checkStep(models.HostStatusKnown, []models.StepType{
 					models.StepTypeConnectivityCheck, models.StepTypeFreeNetworkAddresses,
 					models.StepTypeDhcpLeaseAllocate, models.StepTypeInventory,
-					models.StepTypeNtpSynchronizer,
+					models.StepTypeNtpSynchronizer, models.StepTypeDomainResolution,
 				})
 			})
 			It("disconnected", func() {
@@ -166,14 +169,14 @@ var _ = Describe("instruction_manager", func() {
 				checkStep(models.HostStatusInsufficient, []models.StepType{
 					models.StepTypeInventory, models.StepTypeConnectivityCheck,
 					models.StepTypeFreeNetworkAddresses, models.StepTypeDhcpLeaseAllocate,
-					models.StepTypeNtpSynchronizer,
+					models.StepTypeNtpSynchronizer, models.StepTypeDomainResolution,
 				})
 			})
 			It("pending-for-input", func() {
 				checkStep(models.HostStatusPendingForInput, []models.StepType{
 					models.StepTypeInventory, models.StepTypeConnectivityCheck,
 					models.StepTypeFreeNetworkAddresses, models.StepTypeDhcpLeaseAllocate,
-					models.StepTypeNtpSynchronizer,
+					models.StepTypeNtpSynchronizer, models.StepTypeDomainResolution,
 				})
 			})
 			It("error", func() {

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -461,6 +461,20 @@ func (mr *MockAPIMockRecorder) UpdateConnectivityReport(arg0, arg1, arg2 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateConnectivityReport", reflect.TypeOf((*MockAPI)(nil).UpdateConnectivityReport), arg0, arg1, arg2)
 }
 
+// UpdateDomainNameResolution mocks base method
+func (m *MockAPI) UpdateDomainNameResolution(arg0 context.Context, arg1 *models.Host, arg2 models.DomainResolutionResponse, arg3 *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomainNameResolution", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDomainNameResolution indicates an expected call of UpdateDomainNameResolution
+func (mr *MockAPIMockRecorder) UpdateDomainNameResolution(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainNameResolution", reflect.TypeOf((*MockAPI)(nil).UpdateDomainNameResolution), arg0, arg1, arg2, arg3)
+}
+
 // UpdateHostname mocks base method
 func (m *MockAPI) UpdateHostname(arg0 context.Context, arg1 *models.Host, arg2 string, arg3 *gorm.DB) error {
 	m.ctrl.T.Helper()

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -235,6 +235,21 @@ func newValidations(v *validator) []validation {
 			condition: v.hasDefaultRoute,
 			formatter: v.printDefaultRoute,
 		},
+		{
+			id:        IsAPIDomainNameResolvedCorrectly,
+			condition: v.isAPIDomainNameResolvedCorrectly,
+			formatter: v.printIsAPIDomainNameResolvedCorrectly,
+		},
+		{
+			id:        IsAPIInternalDomainNameResolvedCorrectly,
+			condition: v.isAPIInternalDomainNameResolvedCorrectly,
+			formatter: v.printIsAPIInternalDomainNameResolvedCorrectly,
+		},
+		{
+			id:        IsAppsDomainNameResolvedCorrectly,
+			condition: v.isAppsDomainNameResolvedCorrectly,
+			formatter: v.printIsAppsDomainNameResolvedCorrectly,
+		},
 	}
 }
 

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -507,7 +507,7 @@ func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr), If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup),
-		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole), If(HasDefaultRoute))
+		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole), If(HasDefaultRoute), If(IsAPIDomainNameResolvedCorrectly), If(IsAPIInternalDomainNameResolvedCorrectly), If(IsAppsDomainNameResolvedCorrectly))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -34,12 +34,15 @@ const (
 	HasSufficientNetworkLatencyRequirementForRole  = validationID(models.HostValidationIDSufficientNetworkLatencyRequirementForRole)
 	HasSufficientPacketLossRequirementForRole      = validationID(models.HostValidationIDSufficientPacketLossRequirementForRole)
 	HasDefaultRoute                                = validationID(models.HostValidationIDHasDefaultRoute)
+	IsAPIDomainNameResolvedCorrectly               = validationID(models.HostValidationIDAPIDomainNameResolvedCorrectly)
+	IsAPIInternalDomainNameResolvedCorrectly       = validationID(models.HostValidationIDAPIIntDomainNameResolvedCorrectly)
+	IsAppsDomainNameResolvedCorrectly              = validationID(models.HostValidationIDAppsDomainNameResolvedCorrectly)
 )
 
 func (v validationID) category() (string, error) {
 	switch v {
 	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr,
-		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole, HasDefaultRoute:
+		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole, HasDefaultRoute, IsAPIDomainNameResolvedCorrectly, IsAPIInternalDomainNameResolvedCorrectly, IsAppsDomainNameResolvedCorrectly:
 		return "network", nil
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory, SufficientOrUnknownInstallationDiskSpeed,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid:

--- a/models/host.go
+++ b/models/host.go
@@ -51,6 +51,9 @@ type Host struct {
 	// Additional information about disks, formatted as JSON.
 	DisksInfo string `json:"disks_info,omitempty" gorm:"type:text"`
 
+	// The domain name resolution result.
+	DomainNameResolutions string `json:"domain_name_resolutions,omitempty" gorm:"type:text"`
+
 	// free addresses
 	FreeAddresses string `json:"free_addresses,omitempty" gorm:"type:text"`
 

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -88,6 +88,15 @@ const (
 
 	// HostValidationIDHasDefaultRoute captures enum value "has-default-route"
 	HostValidationIDHasDefaultRoute HostValidationID = "has-default-route"
+
+	// HostValidationIDAPIDomainNameResolvedCorrectly captures enum value "api-domain-name-resolved-correctly"
+	HostValidationIDAPIDomainNameResolvedCorrectly HostValidationID = "api-domain-name-resolved-correctly"
+
+	// HostValidationIDAPIIntDomainNameResolvedCorrectly captures enum value "api-int-domain-name-resolved-correctly"
+	HostValidationIDAPIIntDomainNameResolvedCorrectly HostValidationID = "api-int-domain-name-resolved-correctly"
+
+	// HostValidationIDAppsDomainNameResolvedCorrectly captures enum value "apps-domain-name-resolved-correctly"
+	HostValidationIDAppsDomainNameResolvedCorrectly HostValidationID = "apps-domain-name-resolved-correctly"
 )
 
 // for schema
@@ -95,7 +104,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6774,6 +6774,11 @@ func init() {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\""
         },
+        "domain_name_resolutions": {
+          "description": "The domain name resolution result.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "free_addresses": {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\""
@@ -7095,7 +7100,10 @@ func init() {
         "cnv-requirements-satisfied",
         "sufficient-network-latency-requirement-for-role",
         "sufficient-packet-loss-requirement-for-role",
-        "has-default-route"
+        "has-default-route",
+        "api-domain-name-resolved-correctly",
+        "api-int-domain-name-resolved-correctly",
+        "apps-domain-name-resolved-correctly"
       ]
     },
     "host_network": {
@@ -15164,6 +15172,11 @@ func init() {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\""
         },
+        "domain_name_resolutions": {
+          "description": "The domain name resolution result.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "free_addresses": {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\""
@@ -15485,7 +15498,10 @@ func init() {
         "cnv-requirements-satisfied",
         "sufficient-network-latency-requirement-for-role",
         "sufficient-packet-loss-requirement-for-role",
-        "has-default-route"
+        "has-default-route",
+        "api-domain-name-resolved-correctly",
+        "api-int-domain-name-resolved-correctly",
+        "apps-domain-name-resolved-correctly"
       ]
     },
     "host_network": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3962,6 +3962,10 @@ definitions:
         x-go-custom-tag: gorm:"type:text"
         type: string
         description: Array of image statuses.
+      domain_name_resolutions:
+        x-go-custom-tag: gorm:"type:text"
+        type: string
+        description: The domain name resolution result.
 
 
   installer-args-params:
@@ -5334,6 +5338,9 @@ definitions:
       - 'sufficient-network-latency-requirement-for-role'
       - 'sufficient-packet-loss-requirement-for-role'
       - 'has-default-route'
+      - 'api-domain-name-resolved-correctly'
+      - 'api-int-domain-name-resolved-correctly'
+      - 'apps-domain-name-resolved-correctly'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
Add new host validation that checks if the following domains name were resolved correctly:

  - api.`cluster_name`.`base_dns_domain_name`
  - api-int.`cluster_name`.`base_dns_domain_name`
  - *.apps.`cluster_name`.`base_dns_domain_name`
  
For `user_managed_networking`, if the hosts cant resolve the above domains name to any IP address the installation 
won't start until the right DNS records will be created.
  
  ## List all the issues related to this PR
 
  - [x] New Feature
  - [ ] Bug fix
  - [ ] Tests
  - [ ] Documentation
  - [ ] CI/CD
  
  ## What environments does this code impact?
  
  - [x] Automation (CI, tools, etc)
  - [x] Cloud
  - [ ] Operator Managed Deployments
  - [ ] None
  
  ## How was this code tested?
  
  <!-- Please, select one or more if needed: -->
  
  - [ ] assisted-test-infra environment
  - [ ] dev-scripts environment
  - [ ] Reviewer's test appreciated
  - [x] Waiting for CI to do a full test run
  - [x] Manual (Elaborate on how it was tested)
  - [ ] No tests needed
  
  ## Assignees
  /cc @omertuc
  /cc @eranco74 
  /cc @ori-amizur 
  
  ## Checklist
  
  - [x] Title and description added to both, commit and PR.
  - [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
  - [x] Reviewers have been listed
  - [x] This change does not require a documentation update (docstring, `docs`, README, etc)
  - [x] Does this change include unit-tests (note that code changes require unit-tests)
  
  ## Reviewers Checklist
  
  - [ ] Are the title and description (in both PR and commit) meaningful and clear?
  - [ ] Is there a bug required (and linked) for this change?
  - [ ] Should this PR be backported?