### PR TITLE
Bug 1964623: Tune FS disk usage log messages

### DIFF
--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -418,7 +418,7 @@ func (d *FSClientDecorator) shouldLog() bool {
 }
 
 func (d *FSClientDecorator) conditionalLog(msg string, logLevel logrus.Level, fixedPercentage float64) {
-	if d.lastFSUsage != fixedPercentage && d.shouldLog() {
+	if d.shouldLog() {
 		switch logLevel {
 		case logrus.WarnLevel:
 			d.log.Warn(msg)


### PR DESCRIPTION
We'd like to log the disk usage no more than once every 5 minutes if it
exceeds a predefined threshold. However, if disk usage wasn't changed
and exceeds it limit, we'd like a message to log it, regardless of the
previous disk usage.

Signed-off-by: Moti Asayag <masayag@redhat.com>