### PR TITLE
MGMT-6286 install AI operator on disconnected env

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -14,4 +14,4 @@ fi
 
 ${__dir}/setup_lso.sh create_local_volume
 ${__dir}/setup_hive.sh with_olm
-${__dir}/setup_assisted_operator.sh
+${__dir}/setup_assisted_operator.sh from_index_image

--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -66,6 +66,9 @@ function destroy() {
     echo "Done destroying libvirt disks!"
 }
 
-declare -F "$@" || (print_help && exit 1)
+if [ -z "$@" ] || ! declare -F "$@"; then
+  print_help
+  exit 1
+fi
 
 "$@"

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -84,6 +84,9 @@ function from_upstream() {
   popd
 }
 
-declare -F $@ || (print_help && exit 1)
+if [ -z "$@" ] || ! declare -F "$@"; then
+  print_help
+  exit 1
+fi
 
 "$@"


### PR DESCRIPTION
This will enable full environment installation of the Assisted Service operator.
On disconnected mode, it will mirror the assisted-service-operator package from given ``INDEX_IMAGE``, create a ``CatalogSource`` for mirrored index, and use it for the installation.
/cc @YuviGold @lranjbar 