### PR TITLE
Bug 1966156: run update-ca-trust before running service

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -63,4 +63,16 @@ COPY --from=builder /build/assisted-service /assisted-service
 COPY --from=builder /build/assisted-service-operator /assisted-service-operator
 COPY --from=pybuilder /assisted-service-client/assisted-service-client-*.tar.gz /clients/
 COPY /config/onprem-iso-config.ign /data/onprem-iso-config.ign
-CMD ["/assisted-service"]
+# This is so that we can write source certificate anchors during container start up.
+RUN mkdir -p /etc/pki/ca-trust/source/anchors && \
+    chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
+    chmod -R g=u /etc/pki/ca-trust/source/anchors
+
+# This is so that we can run update-ca-trust during container start up.
+RUN mkdir -p /etc/pki/ca-trust/extracted/openssl && \
+    mkdir -p /etc/pki/ca-trust/extracted/pem && \
+    mkdir -p /etc/pki/ca-trust/extracted/java && \
+    chgrp -R 0 /etc/pki/ca-trust/extracted && \
+    chmod -R g=u /etc/pki/ca-trust/extracted
+
+ENTRYPOINT ["/bin/sh", "-c", "update-ca-trust && /assisted-service"]

--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -155,7 +155,7 @@ spec:
               mountPath: "/etc/.aws"
               readOnly: true
             - name: mirror-registry-ca
-              mountPath: "/etc/pki/ca-trust/extracted/pem/mirror_ca.pem"
+              mountPath: "/etc/pki/ca-trust/source/anchors/mirror_ca.pem"
               readOnly: true
               subPath: mirror_ca.pem
             - name: mirror-registry-conf

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -21,7 +21,7 @@ const (
 	consoleUrlPrefix = "https://console-openshift-console.apps"
 
 	MirrorRegistriesCertificateFile = "tls-ca-bundle.pem"
-	MirrorRegistriesCertificatePath = "/etc/pki/ca-trust/extracted/pem/" + MirrorRegistriesCertificateFile
+	MirrorRegistriesCertificatePath = "/etc/pki/ca-trust/source/anchors/" + MirrorRegistriesCertificateFile
 	MirrorRegistriesConfigDir       = "/etc/containers"
 	MirrorRegistriesConfigFile      = "registries.conf"
 	MirrorRegistriesConfigPath      = MirrorRegistriesConfigDir + "/" + MirrorRegistriesConfigFile


### PR DESCRIPTION
In order to install additional certificated, running update-ca-trust is
needed before running the assisted service

Signed-off-by: Fred Rolland <frolland@redhat.com>