### PR TITLE
Bug 1967121: Docs should clarify that the pullSecretRef is currently ignored

### DIFF
--- a/docs/Kube-API.md
+++ b/docs/Kube-API.md
@@ -43,6 +43,8 @@ The `DebugInfo` field under `Status` provides additional information for debuggi
 The InfraEnv CRD represents the configuration needed to create the discovery ISO.
 The user can specify proxy settings, ignition overrides and specify NMState labels.
 
+Note that the pull-secret that gets baked into the discovery ISO is taken from `clusterDeployment.Spec.pullSecretRef`. The pull-secret found in `infraEnv.Spec.pullSecretRef` is currently being ignored.
+
 When the ISO is ready, an URL will be available in the CR.
 
 The InfraEnv reflects the image creation status through Conditions.

--- a/docs/crds/infraEnv.yaml
+++ b/docs/crds/infraEnv.yaml
@@ -9,8 +9,9 @@ spec:
   agentLabelSelector:
     matchLabels:
       bla: aaa
-  pullSecretRef:
-    name: pull-secret
+  # pullSecretRef is currently ignored in infraenv_controller. Use clusterDeployment.Spec.pullSecretRef instead
+  #pullSecretRef:
+  #  name: pull-secret
   proxy:
     httpProxy: http://11.11.11.33
     httpsProxy: http://22.22.22.55


### PR DESCRIPTION
# Description

A documentation update to kubeAPI docs and examples to clarify that the `infraEnv.Spec.pullSecretRef` is currently ignored by infraEnv controller.

# What environments does this code impact?

- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @filanov 
/assign @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
