### PR TITLE
OCPBUGSM-29957: InfraEnv should log the amount of NMstate Configs baked into the image

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -283,6 +283,7 @@ func (r *InfraEnvReconciler) ensureISO(ctx context.Context, log logrus.FieldLogg
 		return r.handleEnsureISOErrors(ctx, log, infraEnv, err)
 	}
 	if len(staticNetworkConfig) > 0 {
+		log.Infof("the amount of nmStateConfigs included in the image is: %d", len(staticNetworkConfig))
 		isoParams.ImageCreateParams.StaticNetworkConfig = staticNetworkConfig
 	}
 


### PR DESCRIPTION
# Description

The infraEnv controller doesn't have a way to know how many NMStateConfigs to anticipate.

Since the controller watches for NMStateConfig changes and invokes image regeneration per each NMStateConfig addition/removal/update, it would help to log the amount of NMStateConfigs in each image generation.

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @filanov 
/assign @rollandf 
/assign @danielerez 
/assign @RazRegev  
/assign @eliorerz   

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
