### PR TITLE
Bug 1966546: KubeAPI keep day1 cluster after install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ _run_subsystem_test:
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=120m TEST="$(or $(TEST),./subsystem/...)"
 
 enable-kube-api-for-subsystem: $(BUILD_FOLDER)
-	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true ENABLE_KUBE_API_DAY2=true
+	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true ENABLE_KUBE_API_DAY2=false
 	$(call restart_service_pods)
 	$(MAKE) wait-for-service
 

--- a/docs/Kube-API.md
+++ b/docs/Kube-API.md
@@ -116,14 +116,7 @@ Validated	The agent's validations are passing
 Installed	The installation is in progress: Waiting for control plane
 ```
 
-## Day 2 worker
 Once the cluster is installed, the ClusterDeployment is set to Installed and secrets for kubeconfig and credentials are created and referenced in the AgentClusterInstall.
-
-In the Assisted Service, the original cluster is deleted and a Day 2 cluster is created instead.
-
-Additional nodes can be added by booting from the new generated ISO. Each additional host will start installation once the Agent is Approved and the Host is in known state.
-
-Note that the user needs to approved the additional nodes in the installed cluster.
 
 ## Bare Metal Operator Integration
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -211,7 +211,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 				log.WithError(err).Error("failed to update cluster metadata")
 			}
 			return r.updateStatus(ctx, log, clusterInstall, cluster, err)
-		} else {
+		} else if r.EnableDay2Cluster {
 			// Delete Day1 Cluster
 			_, err = r.deregisterClusterIfNeeded(ctx, log, req.NamespacedName)
 			if err != nil {
@@ -222,8 +222,8 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 				//Create Day2 cluster
 				return r.createNewDay2Cluster(ctx, log, req.NamespacedName, clusterDeployment, clusterInstall)
 			}
-			return r.updateStatus(ctx, log, clusterInstall, cluster, err)
 		}
+		return r.updateStatus(ctx, log, clusterInstall, cluster, err)
 	}
 
 	if swag.StringValue(cluster.Kind) == models.ClusterKindCluster {
@@ -1095,7 +1095,7 @@ func (r *ClusterDeploymentsReconciler) populateEventsURL(log logrus.FieldLogger,
 			}
 			clusterInstall.Status.DebugInfo.EventsURL = eventUrl
 		}
-	} else {
+	} else if r.EnableDay2Cluster {
 		clusterInstall.Status.DebugInfo.EventsURL = ""
 	}
 	return nil
@@ -1107,7 +1107,7 @@ func (r *ClusterDeploymentsReconciler) populateLogsURL(log logrus.FieldLogger, c
 			log.WithError(err).Error("failed to generate controller logs URL")
 			return err
 		}
-	} else {
+	} else if r.EnableDay2Cluster {
 		clusterInstall.Status.DebugInfo.LogsURL = ""
 	}
 	return nil

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -116,7 +116,7 @@ def main():
                 y['data']['ENABLE_KUBE_API'] = 'true'
 
             if deploy_options.kubeapi_day2:
-                y['data']['ENABLE_KUBE_API_DAY2'] = 'true'
+                y['data']['ENABLE_KUBE_API_DAY2'] = deploy_options.kubeapi_day2
 
             data = yaml.dump(y)
             dst.write(data)


### PR DESCRIPTION
# Description

Currently, once the cluster is installed, the day1 backend cluster is deleted.
Therefore the events and logs are not available anymore.

In this patch, the day1 is not deleted.
Note that day2 functionality will not work anymore and will need to be
revisited when the support for it will be required.

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Test-infra run: debug URLs still available after install finished
```
  - lastProbeTime: "2021-06-02T14:31:05Z"
    lastTransitionTime: "2021-06-02T14:31:05Z"
    message: The installation has stopped because it completed successfully
    reason: InstallationCompleted
    status: "True"
    type: Stopped
  connectivityMajorityGroups: '{"192.168.126.0/24":[],"192.168.141.0/24":[]}'
  debugInfo:
    eventsURL: http://10.1.37.42:6000/api/assisted-install/v1/clusters/76fb3d0f-f06f-4501-be6d-fddbb55ea324/events?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNzZmYjNkMGYtZjA2Zi00NTAxLWJlNmQtZmRkYmI1NWVhMzI0In0.JdSnNXFh6ajISm8xaJFZiOSLnf13p-DxsIfiVzOOkCvyOKxKgnhctUcru0RMBkVycxsAjkDqiowVr1zWRpwQeg
    logsURL: http://10.1.37.42:6000/api/assisted-install/v1/clusters/76fb3d0f-f06f-4501-be6d-fddbb55ea324/logs?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNzZmYjNkMGYtZjA2Zi00NTAxLWJlNmQtZmRkYmI1NWVhMzI0In0.x4_EZpZYQ2DtxuI_xkMzcPaljJVYhbt8A3SnOCu4nuQstaRYxPTHCDsfDyESSe32mP2yVFWv6IkuBAPVt-TuLg
```

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @danielerez 
/assign @filanov 
/assign @RazRegev 
/assign @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

Signed-off-by: Fred Rolland <frolland@redhat.com>