### PR TITLE
MGMT-6749: Automate ocm-2.3 tag for quay.io/ocpmetal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,45 @@
-String cron_string = BRANCH_NAME == "master" ? "@hourly" : BRANCH_NAME.startsWith("PR") ? "@midnight" : ""
+def now = new Date()
+String current_date = now.format("Ymd")
+String current_hour = now.format("H")
+
+def cronScheduleString(branchName = BRANCH_NAME) {
+    String cronScheduleString
+    if (isCandidateBranch(branchName)) {
+        cronScheduleString = '@hourly'
+    } else if (branchName ==~ /^PR.*/) {
+        cronScheduleString = '@midnight'
+    } else {
+        cronScheduleString = ''
+    }
+    return cronScheduleString
+}
+
+def isCandidateBranch(branchName = BRANCH_NAME) {
+    // List of regex to match branches for release candidate publishing
+    def candidateBranches = [/^master$/, /^ocm-\d[.]{1}\d$/]
+    return branchName && (candidateBranches.collect { branchName =~ it ? true : false }).contains(true)
+}
+
+def releaseBranchPublishTag(branchName = BRANCH_NAME) {
+    String publish_tag
+    if (branchName == 'master') {
+        publish_tag = 'latest'
+    } else {
+        publish_tag = branchName
+    }
+    return publish_tag
+}
 
 pipeline {
     agent { label 'centos_worker' }
-    triggers { cron(cron_string) }
+    triggers { cron(cronScheduleString(env.BRANCH_NAME)) }
     environment {
         PATH = "${PATH}:/usr/local/go/bin"
         BUILD_TYPE = "CI"
+
+        CURRENT_DATE = current_date
+        CURRENT_HOUR = current_hour
+        PUBLISH_TAG = releaseBranchPublishTag(env.BRANCH_NAME)
 
         // Images
         ASSISTED_ORG = "quay.io/ocpmetal"
@@ -61,14 +95,24 @@ pipeline {
             }
         }
 
-        stage('Publish master') {
-            when { branch 'master'}
+        stage("Publish ${BRANCH_NAME}") {
+            when { 
+                expression { isCandidateBranch(env.BRANCH_NAME) }
+            }
             steps {
-                sh "make publish PUBLISH_TAG=latest"
+                sh "make publish PUBLISH_TAG=${PUBLISH_TAG}"
                 // When the index index is being built, the opm tooling pulls the bundle
                 // image from quay, so the index is built after the bundle image has been
                 // published.
-                sh "make build-publish-index PUBLISH_TAG=latest"
+                sh "make build-publish-index PUBLISH_TAG=${PUBLISH_TAG}"
+
+                // Release a nightly build at midnight for ocm branches
+                script {
+                    if (env.BRANCH_NAME ==~ /^ocm-\d[.]{1}\d$/ && env.CURRENT_HOUR == '0') {
+                        sh "make publish PUBLISH_TAG=${PUBLISH_TAG}-${CURRENT_DATE}"
+                        sh "make build-publish-index PUBLISH_TAG=${PUBLISH_TAG}-${CURRENT_DATE}"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
# Description

This PR adds published images in quay.io/ocpmetal for the ocm-2.3 branch. It creates a dated image during the midnight run.

# What environments does this code impact?

- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None
- [x] CI

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I test groovy code outside of Jenkins using the groovy playground.

How to test:

It is hard to fully test Jenkinsfile changes inside of Jenkins without some fancy work. But you can copy the switch statement and date creation into the groovy playground and print out the values as a test. :)

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @djzager 
/assign @osherdp 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
