### PR TITLE
OCPBUGSM-29525 Assisted installer chrony manifests missing index numbering

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -55,7 +55,7 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: {{.ROLE}}
-  name: {{.ROLE}}s-chrony-configuration
+  name: 50-{{.ROLE}}s-chrony-configuration
 spec:
   config:
     ignition:
@@ -188,7 +188,7 @@ func (m *ManifestsGenerator) AddChronyManifest(ctx context.Context, log logrus.F
 			return errors.Wrapf(err, "Failed to create chrony manifest content for role %s cluster id %s", role, *cluster.ID)
 		}
 
-		chronyManifestFileName := fmt.Sprintf("%ss-chrony-configuration.yaml", string(role))
+		chronyManifestFileName := fmt.Sprintf("50-%ss-chrony-configuration.yaml", string(role))
 		err = m.createManifests(ctx, cluster, chronyManifestFileName, content)
 		if err != nil {
 			return err
@@ -289,7 +289,7 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: %s
-  name: %ss-disable-tunnel-offload
+  name: 50-%ss-disable-tunnel-offload
 spec:
   config:
     ignition:
@@ -339,7 +339,7 @@ func createDisableTunnelOffloadingContext(role string) string {
 
 func (m *ManifestsGenerator) AddDisableVmwareTunnelOffloading(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
 	for _, role := range []string{"master", "worker"} {
-		fname := fmt.Sprintf("%ss-disable-tunnel-offload.yaml", role)
+		fname := fmt.Sprintf("50-%ss-disable-tunnel-offload.yaml", role)
 		if err := m.createManifests(ctx, c, fname, []byte(createDisableTunnelOffloadingContext(role))); err != nil {
 			log.WithError(err).Errorf("Failed to create disable tunnel offloading manifest for role %s", role)
 			return err


### PR DESCRIPTION


Bug: 1963949

To allow documented customization, index at the beginning of the name and the file name is mandatory for every manifest

# What environments does this code impact?

All

# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @YuviGold 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [] Should this PR be backported?


