### PR TITLE
NO-ISSUE: Extend waiting for pod to 20 minutes

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -46,7 +46,7 @@ function wait_for_pod() {
     done
 
     echo "Waiting for pod (${pod}) on namespace (${namespace}) with labels (${selector}) to become ready..."
-    oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=10m
+    oc wait -n "$namespace" --for=condition=Ready pod --selector "$selector" --timeout=20m
 }
 
 function hash() {


### PR DESCRIPTION
# Description

Seems that sometimes the ZTP workflow is failing to wait for the pod.
This PR extends the waiting time from 10 minutes to 20 minutes.

# What environments does this code impact?

- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @osherdp 
/assign @RazRegev 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
