### PR TITLE
Bug 1967423: CD ctrl reqeueue after 1m when failing with AddOpenshiftVersion

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -71,6 +71,7 @@ const (
 
 const HighAvailabilityModeNone = "None"
 const defaultRequeueAfterOnError = 10 * time.Second
+const longerRequeueAfterOnError = 1 * time.Minute
 
 // ClusterDeploymentsReconciler reconciles a Cluster object
 type ClusterDeploymentsReconciler struct {
@@ -348,7 +349,7 @@ func (r *ClusterDeploymentsReconciler) installDay1(ctx context.Context, log logr
 			// We decided to requeue with one minute timeout in order to give user a chance to fix manifest
 			// this timeout allows us not to run reconcile too much time and
 			// still have a nice feedback when user will fix the error
-			return ctrl.Result{Requeue: true, RequeueAfter: 1 * time.Minute}, nil
+			return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
 		}
 
 		log.Infof("Installing clusterDeployment %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
@@ -787,7 +788,9 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	openshiftVersion, err := r.addOpenshiftVersion(ctx, clusterInstall.Spec, pullSecret)
 	if err != nil {
 		log.WithError(err).Error("failed to add OCP version")
-		return r.updateStatus(ctx, log, clusterInstall, nil, err)
+		_, _ = r.updateStatus(ctx, log, clusterInstall, nil, err)
+		// The controller will requeue after one minute, giving the user a chance to fix releaseImage
+		return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
 	}
 
 	clusterParams := &models.ClusterCreateParams{
@@ -848,7 +851,9 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 	openshiftVersion, err := r.addOpenshiftVersion(ctx, clusterInstall.Spec, pullSecret)
 	if err != nil {
 		log.WithError(err).Error("failed to add OCP version")
-		return r.updateStatus(ctx, log, clusterInstall, nil, err)
+		_, _ = r.updateStatus(ctx, log, clusterInstall, nil, err)
+		// The controller will requeue after one minute, giving the user a chance to fix releaseImage
+		return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
 	}
 
 	clusterParams := &models.AddHostsClusterCreateParams{


### PR DESCRIPTION
# Description

The clusterDeployments invokes AddOpenshiftVersion() with parameters
coming from clusterImageSet[1]. If it fails, (e.g. bad URL or it is
just unreachable at the moment), the controller currently requeues every 10s.

The controller should keep trying since we cannot currently determine the
reason for the failure. However, in this case, it should wait for
1 minute and not 10 seconds.

[1] https://github.com/openshift/assisted-service/blob/master/docs/crds/clusterImageSet.yaml

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Testing by unit tests and manually by misconfiguring clusterImageSet and inspecting the svc log.

# Assignees

/assign @danielerez 
/assign @rollandf 
/assign @filanov  
## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
