### PR TITLE
Fix docs to make use of 'EXTRA_WORKER_<X>' configurations

### DIFF
--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -18,18 +18,12 @@ IP_STACK=v4  # disconnected env is not yet fully supported
 
 # ZTP-related configurations:
 
-# Currently worker and extra-worker specs are using the same specs,
-# so here we're omitting regular workers and provide more memory
-# for the masters so they can offer some workload
-NUM_WORKERS=0
-MASTER_MEMORY=32768
-
 # This will define our single-node host, which is eligible
 # for installation by assisted-service standards
 NUM_EXTRA_WORKERS=1
-WORKER_VCPU=8
-WORKER_MEMORY=32768
-WORKER_DISK=120
+EXTRA_WORKER_VCPU=8
+EXTRA_WORKER_MEMORY=32768
+EXTRA_WORKER_DISK=120
 
 # This will enable us provisioning BMH by BMAC with the
 # redfish-virtualmedia driver, as well as enabling


### PR DESCRIPTION
# Description

Just fixing docs, as we have better configuration options in dev-scripts right now.

# What environments does this code impact?

- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's only docs, but this configuration is already running on CI.

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @lranjbar @YuviGold @eranco74 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?