### PR TITLE
NO-ISSUE: ztp flow download log as insecure

### DIFF
--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -31,7 +31,7 @@ function gather_agentclusterinstall_data() {
 
     logs_url=$(echo ${agentclusterinstall} | jq -r .status.debugInfo.logsURL)
     if [ -n "${logs_url}" ] && [ "${logs_url}" != null ]; then
-      curl "${logs_url}" -o "${cluster_dir}/logs.tar.gz"
+      curl "${logs_url}" -k -o "${cluster_dir}/logs.tar.gz"
     fi
   done
 }


### PR DESCRIPTION
# Description

Downloading the logs from service running with HTTPS require `-k` arg to curl.

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @YuviGold 
/assign @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [] Does this change includes unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

Signed-off-by: Fred Rolland <frolland@redhat.com>