### PR TITLE
move provisioning configuration for watching all namespaces to hub deployment

### DIFF
--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -34,6 +34,14 @@ REDFISH_EMULATOR_IGNORE_BOOT_DEVICE=True
 
 ## Operator Installation
 
+A complete installation of hub-cluster consists on the following:
+
+* Setting up several (virtual) disks for persistent storage.
+* Installing Local Storage Operator and creating a storage class.
+* Installing Hive Operator.
+* Installing Assisted Service Operator.
+* Configuring BMO to watch all namespaces searching for BMH objects.
+
 Installation of the operator is pretty simple:
 
 ```
@@ -75,7 +83,6 @@ cd deploy/operator/ztp/
 ```
 
 The following actions are happening in this script:
-* It will instruct BMO to watch all namespaces searching for BMH objects.
 * Secrets for pull-secret and for private SSH key will be created.
 * A BMH object will be created for the extra host specified on the provided json file.
 * The following objects will be created as well: cluster-deployment, infra-env,

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -165,6 +165,9 @@ EOCR
   wait_for_operator "assisted-service-operator" "${ASSISTED_NAMESPACE}"
   wait_for_pod "assisted-service" "${ASSISTED_NAMESPACE}" "app=assisted-service"
 
+  echo "Enabling configuration of BMH resources outside of openshift-machine-api namespace"
+  oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true}}'
+
   echo "Installation of Assisted Installer operator passed successfully!"
 }
 

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -17,9 +17,6 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-echo "Enabling configuration of BMH resources outside of openshift-machine-api namespace"
-oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true}}'
-
 echo "Extract information about extra worker nodes..."
 config=$(jq --raw-output '.[] | .name + " " + .ports[0].address + " " + .driver_info.username + " " + .driver_info.password + " " + .driver_info.address' "${EXTRA_BAREMETALHOSTS_FILE}")
 IFS=" " read BMH_NAME MAC_ADDRESS username password ADDRESS <<< "${config}"


### PR DESCRIPTION
# Description

Configuring BMO to watch all namespaces is more relevant as a hub-cluster configuration than spoke cluster configuration.

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @YuviGold 
/assign @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
