### PR TITLE
OCPBUGSM-30014: Cluster folder should be cleared from FS

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1000,6 +1000,10 @@ func (m Manager) PermanentClustersDeletion(ctx context.Context, olderThan strfmt
 			deleteFromDB = false
 			m.log.WithError(err).Warnf("Failed deleting s3 manifests of cluster %s", c.ID.String())
 		}
+		if _, err := objectHandler.DeleteObject(ctx, c.ID.String()); err != nil {
+			deleteFromDB = false
+			m.log.WithError(err).Warnf("Failed deleting cluster directory %s", c.ID.String())
+		}
 		if !deleteFromDB {
 			continue
 		}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2508,7 +2508,8 @@ var _ = Describe("Permanently delete clusters", func() {
 		Expect(db.First(&common.Cluster{}, "id = ?", c2.ID).RowsAffected).Should(Equal(int64(0)))
 		Expect(db.Unscoped().First(&common.Cluster{}, "id = ?", c2.ID).RowsAffected).Should(Equal(int64(1)))
 
-		mockS3Api.EXPECT().DeleteObject(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+		mockS3Api.EXPECT().DeleteObject(gomock.Any(), c1.ID.String()).Return(false, nil).Times(1)
+		mockS3Api.EXPECT().DeleteObject(gomock.Any(), c2.ID.String()).Return(false, nil).Times(1)
 		mockS3Api.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
 
 		Expect(state.PermanentClustersDeletion(ctx, strfmt.DateTime(time.Now()), mockS3Api)).ShouldNot(HaveOccurred())


### PR DESCRIPTION
When cluster is being removed, the folder cluster remains on the FS.
The GC needs to make sure that no leftovers remains after the cluster was removed.

Signed-off-by: Moti Asayag <masayag@redhat.com>
