### PR TITLE
[ocm-2.3]  Bug 1967633: SNO node cannot transition into "Writing image to disk" …

### DIFF
--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -33,21 +33,21 @@ func GenerateTestCluster(clusterID strfmt.UUID, machineNetworkCidr string) commo
 /* Host */
 
 func GenerateTestHost(hostID, clusterID strfmt.UUID, state string) models.Host {
-	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindHost)
+	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindHost, models.HostRoleWorker)
 }
 
 func GenerateTestHostAddedToCluster(hostID, clusterID strfmt.UUID, state string) models.Host {
-	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindAddToExistingClusterHost)
+	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindAddToExistingClusterHost, models.HostRoleWorker)
 }
 
-func GenerateTestHostByKind(hostID, clusterID strfmt.UUID, state, kind string) models.Host {
+func GenerateTestHostByKind(hostID, clusterID strfmt.UUID, state, kind string, role models.HostRole) models.Host {
 	now := strfmt.DateTime(time.Now())
 	return models.Host{
 		ID:              &hostID,
 		ClusterID:       clusterID,
 		Status:          swag.String(state),
 		Inventory:       common.GenerateTestDefaultInventory(),
-		Role:            models.HostRoleWorker,
+		Role:            role,
 		Kind:            swag.String(kind),
 		CheckedInAt:     now,
 		StatusUpdatedAt: now,


### PR DESCRIPTION
…from "Waiting for bootkube"

Fix update stage failure in case of installing single node OpenShift (SNO).
The installation stages order is different in case of SNO.
Specificly, SNO installation first wait for bootkube and only later write the image to disk.
This PR adds code that make an exception in case of SNO and allow the stage update


This is a cherry-pick of #1901
