### PR TITLE
OCPBUGSM-30056: host namespace on agent update notification

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -327,7 +327,7 @@ func main() {
 	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, operatorsManager)
 	var crdUtils bminventory.CRDUtils
 	if ctrlMgr != nil {
-		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient())
+		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient(), hostApi)
 	} else {
 		crdUtils = controllers.NewDummyCRDUtils()
 	}

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -65,6 +65,9 @@ func AutoMigrate(db *gorm.DB) error {
 type Host struct {
 	models.Host
 	Approved bool `json:"approved"`
+
+	// Namespace of the KubeAPI resource
+	KubeKeyNamespace string `json:"kube_key_namespace"`
 }
 
 type EagerLoadingState bool

--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -36,10 +36,13 @@ func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt
 	c.log.Debugf("Pushing cluster event %s %s", cluster.KubeKeyName, cluster.KubeKeyNamespace)
 	c.crdEventsHandler.NotifyClusterDeploymentUpdates(cluster.KubeKeyName, cluster.KubeKeyNamespace)
 	if hostID != nil {
-		// TODO once host will have infraEnv params we need to use common.GetHostFromDB()
-		// till then we will use same namespace as cluster deployment
-		c.log.Debugf("Pushing event for host %q %s %s", hostID, cluster.KubeKeyName, cluster.KubeKeyNamespace)
-		c.crdEventsHandler.NotifyAgentUpdates(hostID.String(), cluster.KubeKeyNamespace)
+		host, err := common.GetHostFromDB(c.db, clusterID.String(), hostID.String())
+		if err != nil {
+			return
+		}
+
+		c.log.Debugf("Pushing event for host %q %s", hostID, host.KubeKeyNamespace)
+		c.crdEventsHandler.NotifyAgentUpdates(hostID.String(), host.KubeKeyNamespace)
 	}
 }
 

--- a/internal/controller/controllers/controllers_suite_test.go
+++ b/internal/controller/controllers/controllers_suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/assisted-service/internal/common"
 	hiveext "github.com/openshift/assisted-service/internal/controller/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -32,6 +33,8 @@ const (
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
+	common.InitializeDBTest()
+	defer common.TerminateDBTest()
 	RunSpecs(t, "controllers tests")
 }
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -140,6 +140,7 @@ type API interface {
 	UpdateNTP(ctx context.Context, h *models.Host, ntpSources []*models.NtpSource, db *gorm.DB) error
 	UpdateMachineConfigPoolName(ctx context.Context, db *gorm.DB, h *models.Host, machineConfigPoolName string) error
 	UpdateInstallationDisk(ctx context.Context, db *gorm.DB, h *models.Host, installationDiskId string) error
+	UpdateKubeKeyNS(ctx context.Context, hostID, namespace string) error
 	GetHostValidDisks(role *models.Host) ([]*models.Disk, error)
 	UpdateImageStatus(ctx context.Context, h *models.Host, imageStatus *models.ContainerImageAvailability, db *gorm.DB) error
 	SetDiskSpeed(ctx context.Context, h *models.Host, path string, speedMs int64, exitCode int64, db *gorm.DB) error
@@ -775,6 +776,10 @@ func (m *Manager) UpdateInstallationDisk(ctx context.Context, db *gorm.DB, h *mo
 		"installation_disk_path": h.InstallationDiskPath,
 		"installation_disk_id":   h.InstallationDiskID,
 	}).Error
+}
+
+func (m *Manager) UpdateKubeKeyNS(ctx context.Context, hostID, namespace string) error {
+	return m.db.Model(&common.Host{}).Where("id = ?", hostID).Update("kube_key_namespace", namespace).Error
 }
 
 func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason string, db *gorm.DB) *common.ApiErrorResponse {

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -240,7 +240,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 		}, nil).Times(1)
 	}
 
-	stepsReply, stepsErr := instMng.GetNextSteps(ctx, h)
+	stepsReply, stepsErr := instMng.GetNextSteps(ctx, &h.Host)
 	ExpectWithOffset(1, stepsReply.Instructions).To(HaveLen(len(expectedStepTypes)))
 	if stateValues, ok := instMng.installingClusterStateToSteps[state]; ok {
 		Expect(stepsReply.NextInstructionSeconds).Should(Equal(stateValues.NextStepInSec))

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -15,8 +15,8 @@ import (
 	"github.com/openshift/assisted-service/pkg/conversions"
 )
 
-func GetHostFromDB(hostId, clusterId strfmt.UUID, db *gorm.DB) *models.Host {
-	var host models.Host
+func GetHostFromDB(hostId, clusterId strfmt.UUID, db *gorm.DB) *common.Host {
+	var host common.Host
 	Expect(db.First(&host, "id = ? and cluster_id = ?", hostId, clusterId).Error).ShouldNot(HaveOccurred())
 	return &host
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -487,6 +487,20 @@ func (mr *MockAPIMockRecorder) UpdateInventory(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInventory", reflect.TypeOf((*MockAPI)(nil).UpdateInventory), arg0, arg1, arg2)
 }
 
+// UpdateKubeKeyNS mocks base method
+func (m *MockAPI) UpdateKubeKeyNS(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateKubeKeyNS", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateKubeKeyNS indicates an expected call of UpdateKubeKeyNS
+func (mr *MockAPIMockRecorder) UpdateKubeKeyNS(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubeKeyNS", reflect.TypeOf((*MockAPI)(nil).UpdateKubeKeyNS), arg0, arg1, arg2)
+}
+
 // UpdateLogsProgress mocks base method
 func (m *MockAPI) UpdateLogsProgress(arg0 context.Context, arg1 *models.Host, arg2 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
As Agents are now created using InfraEnv namespace, 'NotifyAgentUpdates'
should be invoked using the namespace of the host instead of the cluster.
Hence, added 'kube_key_namespace' to Host struct (similar to Cluster)
in order to store the proper namespace upon Agent CR creation.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs addess specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

# What environments does this code impact?

- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested using crd_utils unit-tests and kubeapi subsystem-tests.
Verified by creating an InfraEnv with a different namespace than the ClusterDeployment:
no 'Failed to get resource' errors in log.

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @rollandf 
/assign @filanov

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
