### PR TITLE
OCPBUGSM-30082: Don't reconcile BMH in a detached state

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -462,6 +462,18 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	log.Debugf("Started BMH reconcile for %s/%s", bmh.Namespace, bmh.Name)
 	log.Debugf("BMH value %v", bmh)
 
+	// A detached BMH is considered to be unmanaged by the hub
+	// cluster and, therefore, BMAC reconciles on this BMH should
+	// not happen.
+	//
+	// User is expected to remove the `detached` annotation manually
+	// to bring this BMH back into the pool of reconciled BMH resources.
+	bmhAnnotations := bmh.ObjectMeta.GetAnnotations()
+	if _, ok := bmhAnnotations[BMH_DETACHED_ANNOTATION]; ok {
+		log.Debugf("Stopped BMH reconcile for %s/%s because it has been detached", bmh.Namespace, bmh.Name)
+		return reconcileComplete{stop: true}
+	}
+
 	infraEnv, err := r.findInfraEnvForBMH(ctx, log, bmh)
 
 	if err != nil {
@@ -508,14 +520,6 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	if bmh.Spec.Image != nil && bmh.Spec.Image.URL == infraEnv.Status.ISODownloadURL {
 		return reconcileComplete{}
 	}
-
-	// BMH is set to `detached` after a cluster deployment. The
-	// following call makes sure the node is attached an image
-	// update happens. In the case of a `non-ready` node, Ironic
-	// will first deprovision the node (meaning the cache will be
-	// invalidated) and then it will provision the new image once
-	// the BMH.Spec.Image field is set.
-	delete(bmh.ObjectMeta.Annotations, BMH_DETACHED_ANNOTATION)
 
 	// Set the bmh.Spec.Image field to nil if the BMH is in a non-ready state.
 	// This will make sure that any existing image will be de-provisioned first


### PR DESCRIPTION
# Description

Detached BMH resources are not considered to be part of the hub cluster as they belong
to a spoke cluster that has been installed already. Therefore, BMAC should not reconcile
these resources. This change will prevent re-deploying installed clusters when an ISO is
re-generated, which is the desired behavior.

Users that want to redeploy a node that has been installed will have to remove the
label from the BMH manually.

Signed-off-by: Flavio Percoco <flavio@redhat.com>Detached BMH resources are not considered to be part of the hub cluster as they belong
to a spoke cluster that has been installed already. Therefore, BMAC should not reconcile
these resources. This change will prevent re-deploying installed clusters when an ISO is
re-generated, which is the desired behavior.

Users that want to redeploy a node that has been installed will have to remove the
label from the BMH manually.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

# What environments does this code impact?

- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] subsystem (unit-tests)
- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @avishayt 
/assign @nmagnezi 
/assign @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
