### PR TITLE
MGMT-6286: add image mirroring in service installation automation for CI

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -14,4 +14,15 @@ fi
 
 ${__dir}/setup_lso.sh create_local_volume
 ${__dir}/setup_hive.sh with_olm
+
+export OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-$(cat ${__dir}/../../data/default_ocp_versions.json)}"
+OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
+    jq -rc 'with_entries(.key = "4.8") | with_entries(
+    {
+        key: .key,
+        value: {rhcos_image:   .value.rhcos_image,
+                rhcos_version: .value.rhcos_version,
+                rhcos_rootfs:  .value.rhcos_rootfs}
+    }
+    )')
 ${__dir}/setup_assisted_operator.sh from_index_image

--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -93,6 +93,17 @@ function mirror_package_from_official_index() {
   mirror_package "${package}" "${remote_index}" "${local_registry}" "${authfile}" "${catalog_source_name}"
 }
 
+function mirror_file() {
+  remote_url="${1}"
+  httpd_path="${2}"
+  base_mirror_url="${3}"
+
+  local file_name="$(basename ${remote_url})"
+  curl --retry 5 "${remote_url}" -o "${httpd_path}/${file_name}"
+
+  echo "${base_mirror_url}/${file_name}"
+}
+
 function disable_default_indexes() {
   oc patch OperatorHub cluster --type json \
         -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'


### PR DESCRIPTION
# Description

Mirroring RHCOS and Rootfs images to a HTTP local mirror, for handling the disconnected environment flow on CI.
This will require two more options: one for the directory serving all files, and one for the matching URL of the files.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR.

/cc @YuviGold @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)