### PR TITLE
NO-ISSUE: Fix bug in the date for ocm tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
         PATH = "${PATH}:/usr/local/go/bin"
         BUILD_TYPE = "CI"
 
-        CURRENT_DATE = now.format("Ymd")
+        CURRENT_DATE = now.format("YMMdd")
         CURRENT_HOUR = now.format("H")
         PUBLISH_TAG = releaseBranchPublishTag(env.BRANCH_NAME)
 


### PR DESCRIPTION
Signed-off-by: Lisa Rashidi-Ranjbar <lranjbar@redhat.com>

# Description

Fixes a small bug where the wrong format date string was used. 😅 

# What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I've been using the Jenkins replay functionality to test Jenkins changes:
Here is the manual replay log:
http://assisted-jenkins.usersys.redhat.com/job/assisted-service/job/ocm-2.3/36/console
![image](https://user-images.githubusercontent.com/7851712/121231598-6ce24980-c845-11eb-9000-6c641434a40d.png)

First one is YMMdd (new), second is Ymd (current) third is H for the current hour.

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @djzager 
/assign @YuviGold 

## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
