### PR TITLE
MGMT-6647: Allow wildcard NoProxy with OCP 4.8+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/thedevsaddam/retry v0.0.0-20200324223450-9769a859cc6d
 	github.com/thoas/go-funk v0.8.0
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
+	go.elastic.co/apm v1.11.0
 	go.elastic.co/apm/module/apmhttp v1.11.0
 	go.elastic.co/apm/module/apmlogrus v1.11.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -290,41 +290,48 @@ var _ = Describe("Proxy validations", func() {
 
 	Context("test no-proxy", func() {
 		It("domain name", func() {
-			err := ValidateNoProxyFormat("domain.com")
+			err := ValidateNoProxyFormat("domain.com", "4.7.0")
 			Expect(err).Should(BeNil())
 		})
 		It("domain starts with . for all sub-domains", func() {
-			err := ValidateNoProxyFormat(".domain.com")
+			err := ValidateNoProxyFormat(".domain.com", "4.7.0")
 			Expect(err).Should(BeNil())
 		})
 		It("CIDR", func() {
-			err := ValidateNoProxyFormat("10.9.0.0/16")
+			err := ValidateNoProxyFormat("10.9.0.0/16", "4.7.0")
 			Expect(err).Should(BeNil())
 		})
 		It("IP Address", func() {
-			err := ValidateNoProxyFormat("10.9.8.7")
+			err := ValidateNoProxyFormat("10.9.8.7", "4.7.0")
 			Expect(err).Should(BeNil())
 		})
 		It("multiple entries", func() {
-			err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7")
+			err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7", "4.7.0")
 			Expect(err).Should(BeNil())
 		})
-		It("'*' bypass proxy for all destinations", func() {
-			err := ValidateNoProxyFormat("*")
-			// TODO: Start accepting '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed
+		It("'*' bypass proxy for all destinations FC version", func() {
+			err := ValidateNoProxyFormat("*", "4.8.0-fc.7")
+			Expect(err).Should(BeNil())
+		})
+		It("'*' bypass proxy for all destinations release version", func() {
+			err := ValidateNoProxyFormat("*", "4.8.0")
+			Expect(err).Should(BeNil())
+		})
+		It("'*' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
+			err := ValidateNoProxyFormat("*", "4.7.0")
 			Expect(err).ShouldNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in this release"))
 		})
 		It("invalid format", func() {
-			err := ValidateNoProxyFormat("...")
+			err := ValidateNoProxyFormat("...", "4.8.0-fc.7")
 			Expect(err).ShouldNot(BeNil())
 		})
 		It("invalid format of a single value", func() {
-			err := ValidateNoProxyFormat("domain.com,...")
+			err := ValidateNoProxyFormat("domain.com,...", "4.8.0-fc.7")
 			Expect(err).ShouldNot(BeNil())
 		})
 		It("invalid use of asterisk", func() {
-			err := ValidateNoProxyFormat("*,domain.com")
+			err := ValidateNoProxyFormat("*,domain.com", "4.8.0-fc.7")
 			Expect(err).ShouldNot(BeNil())
 		})
 	})

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -268,10 +268,14 @@ func ValidateHTTPProxyFormat(proxyURL string) error {
 // ValidateNoProxyFormat validates the no-proxy format which should be a comma-separated list
 // of destination domain names, domains, IP addresses or other network CIDRs. A domain can be
 // prefaced with '.' to include all subdomains of that domain.
-// Use '*' to bypass proxy for all destinations.
-func ValidateNoProxyFormat(noProxy string) error {
+// Use '*' to bypass proxy for all destinations in OCP 4.8 or later.
+func ValidateNoProxyFormat(noProxy string, ocpVersion string) error {
 	if noProxy == "*" {
-		// TODO: Start accepting '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed, return an error until then
+		if wildcardSupported, err := common.VersionGreaterOrEqual(ocpVersion, "4.8.0-fc.4"); err != nil {
+			return err
+		} else if wildcardSupported {
+			return nil
+		}
 		return errors.Errorf("Sorry, no-proxy value '*' is not supported in this release")
 	}
 	domains := strings.Split(noProxy, ",")
@@ -290,9 +294,7 @@ func ValidateNoProxyFormat(noProxy string) error {
 		}
 		return errors.Errorf("NO Proxy format is not valid: '%s'. "+
 			"NO Proxy is a comma-separated list of destination domain names, domains, IP addresses or other network CIDRs. "+
-			// TODO: Change this to allow '*' when https://bugzilla.redhat.com/show_bug.cgi?id=1947066 is fixed
-			// "A domain can be prefaced with '.' to include all subdomains of that domain. Use '*' to bypass proxy for all destinations.", noProxy)
-			"A domain can be prefaced with '.' to include all subdomains of that domain.", noProxy)
+			"A domain can be prefaced with '.' to include all subdomains of that domain. Use '*' to bypass proxy for all destinations with OpenShift 4.8 or later.", noProxy)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Before OCP 4.8.0-fc4, it wasn't possible to use the wildcard (`*`) as a NoProxy value, meaning "bypass proxy for all destination". As https://bugzilla.redhat.com/show_bug.cgi?id=1947066 has been fixed, we want to re-enable `*` as a valid NoProxy value, but only for OCP versions 4.8 and later.

This removes (for OCP 4.8 and up) the restriction put by #1409.

It also cancels a need for UI changes as part of [MGMT-5267](https://issues.redhat.com/browse/MGMT-5267): Hide the possibility to use * as a valid no-proxy value until it becomes possible.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual - define a non-existent proxy address and use NoProxy=*, cluster installation should succeed.
- [ ] No tests needed

IMPORTANT: Successful installation is not sufficient - the cluster must be finalized and functional.

Testing:
1. Build a custom assisted service with this fix.
2. Choose a random IP that is not routeable in your test infra environment, e.g. 10.56.20.50.
3. Using test infra, run `make run_full_flow_with_install SERVICE=<service-image> OPENSHIFT_VERSION=4.8 HTTP_PROXY_URL='http://10.56.20.50:8088' NO_PROXY_VALUES=\\*`
4. Wait for the cluster to be installed.
5. Download the `kubeconfig`.
6. Verify the proxy configuration: `oc get proxy cluster --kubeconfig=./kubeconfig -oyaml | grep -i proxy`.
7. Verify cluster health: `oc get co --kubeconfig=./build/kubeconfig`.

A wildcard must be accepted during both cluster creation and cluster update, when the cluster's OpenShift version allows it (test also with `OPENSHIFT_VERSION=4.7`).

As it's a corner non-critical case, there is no automated test for it.

# Assignees

/assign @masayag 
/assign @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
