### PR TITLE
OCPBUGSM-29458: Check the response status code from http.Get

### DIFF
--- a/pkg/s3wrapper/util.go
+++ b/pkg/s3wrapper/util.go
@@ -75,6 +75,9 @@ func UploadFromURLToPublicBucket(ctx context.Context, objectName, url string, ap
 	if err != nil {
 		return errors.Wrapf(err, "Failed fetching from URL %s", url)
 	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("Failed fetching from URL %s: Received %s", url, resp.Status)
+	}
 
 	err = api.UploadStreamToPublicBucket(ctx, resp.Body, objectName)
 	if err != nil {


### PR DESCRIPTION


# Description

Before this change if the GET request here failed in a way that didn't
produce an error we would continue on to try to extract the boot files
from the error response body.

According to https://golang.org/pkg/net/http/#Get non-200 responses do
not generate an error so we need to check this ourselves.

This was previously addressed for s3 in b8d2b084 which uses a separate
function for downloading the iso.

https://bugzilla.redhat.com/show_bug.cgi?id=1962957
https://issues.redhat.com/browse/OCPBUGSM-29458

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

For a manual test I deployed the operator to my CRC instance on my laptop configured to deploy a service image built from my branch. I then created a service to host the iso images and deployed it to the `assisted-installer` namespace. I created an agentserviceconfig with an iso url that would return a 404 from the service I deployed and observed the behavior of assisted-service.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
No
- Is this PR relying on CI for an e2e test run?
Yes
- Should this PR be tested in a specific environment?
Yes - specifically with filesystem storage. That is the only scenario that uses the `UploadFromURLToPublicBucket` function
- Any logs, screenshots, etc that can help with the review process?
Logs before the fix:
`time="2021-06-08T20:53:11Z" level=fatal msg="Failed to upload boot files" func=main.main.func1 file="/go/src/github.com/openshift/origin/cmd/main.go:176" error="Failed uploading boot files for OCP version 4.8: Unknown filesystem on partition 0"`
Logs after the fix:
`time="2021-06-08T20:58:04Z" level=fatal msg="Failed to upload boot files" func=main.main.func1 file="/go/src/github.com/openshift/origin/cmd/main.go:176" error="Failed uploading boot files for OCP version 4.8: Failed fetching from URL http://iso-mirror/rhcos-4.8.0-fc.8-x86_64-lives.x86_64.iso: Received 404 Not Found"`

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @djzager 
/assign @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
