### PR TITLE
OCPBUGSM-30087: Fix doc for installconfig on ACI

### DIFF
--- a/docs/Kube-API.md
+++ b/docs/Kube-API.md
@@ -156,7 +156,7 @@ You will likely need to adapt those for your own needs.
 
 In order to alter the default install config yaml used when running `openshift-install create` commands.
 More information about install-config overrides is available [here](user-guide/install-customization.md#Install-Config)
-In case of failure to apply the overrides the clusterdeployment conditions will reflect the error and show the relevant error message. 
+In case of failure to apply the overrides the agentclusterinstall conditions will reflect the error and show the relevant error message.
 
 Add an annotation with the desired options, the clusterdeployment controller will update the install config yaml with the annotation value.
 Note that this configuration must be applied prior to starting the installation
@@ -166,11 +166,11 @@ agentclusterinstalls.extensions.hive.openshift.io/test-cluster annotated
 ```
 
 ```sh
-$ kubectl get clusterdeployments.hive.openshift.io test-cluster -n assisted-installer -o yaml
+$ kubectl get agentclusterinstalls.extensions.hive.openshift.io test-cluster -n assisted-installer -o yaml
 ```
 ```yaml
-apiVersion: hive.openshift.io/v1
-kind: ClusterDeployment
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
 metadata:
   annotations:
     agent-install.openshift.io/install-config-overrides: '{"networking":{"networkType": "OVNKubernetes"},"fips":true}'
@@ -179,9 +179,7 @@ metadata:
   name: test-cluster
   namespace: assisted-installer
   resourceVersion: "183201"
-  selfLink: /apis/hive.openshift.io/v1/namespaces/assisted-installer/clusterdeployments/test-cluster
-  uid: 25769614-52db-448d-8366-05cb38c776fa
-spec:
+...
 ```
 
 ### Creating host installer args overrides


### PR DESCRIPTION
# Description

Some of the documentation for setting install config override in KubeAPI was still referencing ClusterDeployment instead of AgentClusterInstall.

Signed-off-by: Fred Rolland <frolland@redhat.com>

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @nmagnezi 
/assign @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
