### PR TITLE
OCPBUGSM-30145: Missing request ID field on image uploading logs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -516,13 +516,16 @@ func uploadISOs(objectHandler s3wrapper.API, openshiftVersionsMap models.Openshi
 	//cancel the context in case this method ends
 	defer cancel()
 
+	//starts a functional context to pass to loggers and derived flows
+	uploadctx := requestid.ToContext(context.Background(), "main-uploadISOs")
+
 	// Checks whether latest version of minimal ISO templates already exists
 	// Must be done while holding the leader lock but outside of the version loop
-	haveLatestMinimalTemplate := s3wrapper.HaveLatestMinimalTemplate(context.Background(), log, objectHandler)
+	haveLatestMinimalTemplate := s3wrapper.HaveLatestMinimalTemplate(uploadctx, log, objectHandler)
 	for version := range openshiftVersionsMap {
 		currVersion := version
 		errs.Go(func() error {
-			err := objectHandler.UploadISOs(context.Background(), currVersion, haveLatestMinimalTemplate)
+			err := objectHandler.UploadISOs(uploadctx, currVersion, haveLatestMinimalTemplate)
 			return errors.Wrapf(err, "Failed uploading boot files for OCP version %s", currVersion)
 		})
 	}


### PR DESCRIPTION
# Description

uploadISO flow from the main thread created contexts with no requestID. This commit adds the missing ID

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @
/assign @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [x] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
