### PR TITLE
NO-ISSUE Use `annotate` instead of `apply` for AgentServiceConfig annotation

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -195,14 +195,7 @@ EOF
 Add the annotation to the AgentServiceConfig:
 
 ```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: agent-install.openshift.io/v1beta1
-kind: AgentServiceConfig
-metadata:
-  name: agent
-  annotations:
-    unsupported.agent-install.openshift.io/assisted-service-configmap: "my-assisted-service-config"
-EOF
+oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.openshift.io/assisted-service-configmap=my-assisted-service-config
 ```
 
 **NOTE**


### PR DESCRIPTION
# Description

This PR changes the documentation of the operator in the part describing
how to override environment variables of the assisted-service container.

Instead of `kubectl apply` we are using `oc annotate` so that we do not
recreate AgentServiceConfig resource but only patch the required
annotation (in this case `assisted-service-configmap`). This is caused
by the fact that using `kubectl apply` in case AgentServiceConfig
already exists and has its PersistentVolumeClaim created results in the
following error

```
"Failed to ensure filesystem storage: PersistentVolumeClaim \"assisted-service\"
is invalid: [spec.resources[storage]: Required value, spec: Forbidden: spec
is immutable after creation except resources.requests for bound claims\n  core.PersistentVolumeClaimSpec{\n  \tAccessModes:
{\"ReadWriteOnce\"},\n  \tSelector:    nil,\n  \tResources: core.ResourceRequirements{\n  \t\tLimits:
\  nil,\n- \t\tRequests: nil,\n+ \t\tRequests: core.ResourceList{s\"storage\":
{i: resource.int64Amount{value: 8589934592}, Format: \"BinarySI\"}},\n  \t},\n  \tVolumeName:
\      \"local-pv-94c2e997\",\n  \tStorageClassName: &\"assisted-service\",\n  \t...
// 2 identical fields\n  }\n, spec.resources.requests.storage: Forbidden: field
can not be less than previous value]"
```
# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

```
[root@edge-14 ~]# cat <<EOF | kubectl create -f -
> apiVersion: v1
> kind: ConfigMap
> metadata:
>   name: my-assisted-service-config
>   namespace: assisted-installer-bz1969753-4
> data:
>   ASSISTED_AGENT_IMAGE: "quay.io/mkowalski/assisted-installer-agent:bz1969753"
> EOF
configmap/my-assisted-service-config created

[root@edge-14 ~]# oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.openshift.io/assisted-service-configmap=my-assisted-service-config
agentserviceconfig.agent-install.openshift.io/agent annotated

[root@edge-14 ~]# oc get agentserviceconfig.agent-install.openshift.io/agent -o yaml
apiVersion: agent-install.openshift.io/v1beta1
kind: AgentServiceConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"agent-install.openshift.io/v1beta1","kind":"AgentServiceConfig","metadata":{"annotations":{},"name":"agent"},"spec":{"databaseStorage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"8Gi"}},"storageClassName":"assisted-service"},"filesystemStorage":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"8Gi"}},"storageClassName":"assisted-service"}}}
    unsupported.agent-install.openshift.io/assisted-service-configmap: my-assisted-service-config
  creationTimestamp: "2021-06-09T13:19:04Z"
[...]
```


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @djzager 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
