### PR TITLE
OCPBUGSM-30346: Populate State and StateInfo and move to DebugInfo in CRDs

### DIFF
--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -171,6 +171,13 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains events
                       which occured during the cluster installation process
                     type: string
+                  state:
+                    description: Current state of the Agent
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of
+                      the Agent
+                    type: string
                 type: object
               discoveryAgentVersion:
                 type: string
@@ -398,10 +405,6 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
-              state:
-                type: string
-              stateInfo:
-                type: string
               stateUpdatedTime:
                 description: 'Name in REST API: status_updated_at'
                 format: date-time

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -304,6 +304,13 @@ spec:
                     description: LogsURL specifies a url for download controller logs
                       tar file.
                     type: string
+                  state:
+                    description: Current state of the AgentClusterInstall
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of
+                      the AgentClusterInstall
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -235,6 +235,12 @@ spec:
                   logsURL:
                     description: LogsURL specifies a url for download controller logs tar file.
                     type: string
+                  state:
+                    description: Current state of the AgentClusterInstall
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of the AgentClusterInstall
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.
@@ -410,6 +416,12 @@ spec:
                 properties:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
+                    type: string
+                  state:
+                    description: Current state of the Agent
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of the Agent
                     type: string
                 type: object
               discoveryAgentVersion:
@@ -638,10 +650,6 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
-              state:
-                type: string
-              stateInfo:
-                type: string
               stateUpdatedTime:
                 description: 'Name in REST API: status_updated_at'
                 format: date-time

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -152,6 +152,12 @@ spec:
                   eventsURL:
                     description: EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
                     type: string
+                  state:
+                    description: Current state of the Agent
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of the Agent
+                    type: string
                 type: object
               discoveryAgentVersion:
                 type: string
@@ -379,10 +385,6 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
-              state:
-                type: string
-              stateInfo:
-                type: string
               stateUpdatedTime:
                 description: 'Name in REST API: status_updated_at'
                 format: date-time

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -235,6 +235,12 @@ spec:
                   logsURL:
                     description: LogsURL specifies a url for download controller logs tar file.
                     type: string
+                  state:
+                    description: Current state of the AgentClusterInstall
+                    type: string
+                  stateInfo:
+                    description: Additional information pertaining to the status of the AgentClusterInstall
+                    type: string
                 type: object
               workerAgentsDiscovered:
                 description: WorkerAgentsDiscovered is the number of worker Agents currently linked to this ClusterDeployment.

--- a/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -103,6 +103,11 @@ type DebugInfo struct {
 	// LogsURL specifies a url for download controller logs tar file.
 	// +optional
 	LogsURL string `json:"logsURL"`
+	// Current state of the AgentClusterInstall
+	State string `json:"state,omitempty"`
+	//Additional information pertaining to the status of the AgentClusterInstall
+	// +optional
+	StateInfo string `json:"stateInfo,omitempty"`
 }
 
 // Networking defines the pod network provider in the cluster.

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -195,8 +195,6 @@ type HostNTPSources struct {
 
 // AgentStatus defines the observed state of Agent
 type AgentStatus struct {
-	State     string `json:"state,omitempty"`
-	StateInfo string `json:"stateInfo,omitempty"`
 	// Name in REST API: status_updated_at
 	StateUpdatedTime *metav1.Time `json:"stateUpdatedTime,omitempty"`
 	// Name in REST API: logs_collected_at
@@ -225,6 +223,12 @@ type DebugInfo struct {
 	// EventsURL specifies an HTTP/S URL that contains events which occured during the cluster installation process
 	// +optional
 	EventsURL string `json:"eventsURL,omitempty"`
+	// +optional
+	// Current state of the Agent
+	State string `json:"state,omitempty"`
+	//Additional information pertaining to the status of the Agent
+	// +optional
+	StateInfo string `json:"stateInfo,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -250,6 +250,8 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 	specSynced(agent, syncErr, internal)
 
 	if h != nil && h.Status != nil {
+		agent.Status.DebugInfo.State = swag.StringValue(h.Status)
+		agent.Status.DebugInfo.StateInfo = swag.StringValue(h.StatusInfo)
 		status := *h.Status
 		if clusterId != nil {
 			err := r.populateEventsURL(log, agent, *clusterId)
@@ -300,6 +302,8 @@ func (r *AgentReconciler) eventsURL(log logrus.FieldLogger, clusterId, agentId s
 }
 
 func setConditionsUnknown(agent *aiv1beta1.Agent) {
+	agent.Status.DebugInfo.State = ""
+	agent.Status.DebugInfo.StateInfo = ""
 	conditionsv1.SetStatusConditionNoHeartbeat(&agent.Status.Conditions, conditionsv1.Condition{
 		Type:    InstalledCondition,
 		Status:  corev1.ConditionUnknown,

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1002,7 +1002,8 @@ var _ = Describe("TestConditions", func() {
 				Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, cond.Type).Reason).To(Equal(cond.Reason))
 				Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, cond.Type).Status).To(Equal(cond.Status))
 			}
-
+			Expect(agent.Status.DebugInfo.State).To(Equal(t.hostStatus))
+			Expect(agent.Status.DebugInfo.StateInfo).To(Equal(t.statusInfo))
 		})
 	}
 })

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1052,6 +1052,8 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 		clusterInstall.Status.ConnectivityMajorityGroups = c.ConnectivityMajorityGroups
 
 		if c.Status != nil {
+			clusterInstall.Status.DebugInfo.State = swag.StringValue(c.Status)
+			clusterInstall.Status.DebugInfo.StateInfo = swag.StringValue(c.StatusInfo)
 			status := *c.Status
 			var err error
 			err = r.populateEventsURL(log, clusterInstall, c)
@@ -1361,6 +1363,8 @@ func clusterValidated(clusterInstall *hiveext.AgentClusterInstall, status string
 }
 
 func setClusterConditionsUnknown(clusterInstall *hiveext.AgentClusterInstall) {
+	clusterInstall.Status.DebugInfo.State = ""
+	clusterInstall.Status.DebugInfo.StateInfo = ""
 	setClusterCondition(&clusterInstall.Status.Conditions, hivev1.ClusterInstallCondition{
 		Type:    ClusterValidatedCondition,
 		Status:  corev1.ConditionUnknown,

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -2140,7 +2140,8 @@ var _ = Describe("TestConditions", func() {
 				Expect(FindStatusCondition(clusterInstall.Status.Conditions, cond.Type).Reason).To(Equal(cond.Reason))
 				Expect(FindStatusCondition(clusterInstall.Status.Conditions, cond.Type).Status).To(Equal(cond.Status))
 			}
-
+			Expect(clusterInstall.Status.DebugInfo.State).To(Equal(t.clusterStatus))
+			Expect(clusterInstall.Status.DebugInfo.StateInfo).To(Equal(t.statusInfo))
 		})
 	}
 })


### PR DESCRIPTION
# Description

For better visibility of the install process, populate State and StateInfo in Agent and AgentClusterInstall CRDs.
Also, move to "DebugInfo" struct.

Signed-off-by: Fred Rolland <frolland@redhat.com>
# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Output for Agent CR:
```
  debugInfo:
    eventsURL: http://10.1.37.42:6000/api/assisted-install/v1/clusters/6146e211-c6b0-49a6-b3a2-af3e85bbcfc6/events?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNjE0NmUyMTEtYzZiMC00OWE2LWIzYTItYWYzZTg1YmJjZmM2In0.dqA9LnGgkFpB-Mc0w8LN9Or8W-OECPbZO_zrJj2-lROgujZS-29ydOh0ro99pRsiYhDza47bViF_mTkbWR43ng&host_id=764254a7-36a6-4d79-aac9-29d50fa36305
    state: installed
    stateInfo: Done
```
Output for AgentClusterInstall CR:
```
  debugInfo:
    eventsURL: http://10.1.37.42:6000/api/assisted-install/v1/clusters/6146e211-c6b0-49a6-b3a2-af3e85bbcfc6/events?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNjE0NmUyMTEtYzZiMC00OWE2LWIzYTItYWYzZTg1YmJjZmM2In0.DoGdKJdqyWa14IvQIYAxiNirUaJmy2_WRU0vTMu1mAWX8ckvWQUTbJhS0h9WETVuEumdsImddeM-Kfsns6Ldig
    logsURL: http://10.1.37.42:6000/api/assisted-install/v1/clusters/6146e211-c6b0-49a6-b3a2-af3e85bbcfc6/logs?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNjE0NmUyMTEtYzZiMC00OWE2LWIzYTItYWYzZTg1YmJjZmM2In0.coIohCHCrusV5RMm-XONyYOERKI3EzGdyGBEukyCyNVYKVOeLLtZQh_I3qpMj7SyHIAPm8MyDcPxHadJBmLkUw
    state: installed
    stateInfo: Cluster is installed
```

# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @filanov 
/assign @nmagnezi 
/assign @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
