### PR TITLE
Bug 1970494: asc controller log line (#1946)

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -711,7 +711,7 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(log logrus.F
 	annotations := instance.ObjectMeta.GetAnnotations()
 	configmapName, ok := annotations[configmapAnnotation]
 	if ok {
-		log.Info("ConfigMap %v being used to configure assisted-service deployment", configmapName)
+		log.Infof("ConfigMap %v being used to configure assisted-service deployment", configmapName)
 		envFrom = append(envFrom, []corev1.EnvFromSource{
 			{
 				ConfigMapRef: &corev1.ConfigMapEnvSource{


### PR DESCRIPTION
This updates the agent service config controller to use `log.Infof` so
that the name of the configmap is properly included in the formatted log
message.

Cherry pick of https://github.com/openshift/assisted-service/pull/1946 to try and address my failure to follow the correct procedure.