### PR TITLE
ZTP CI gather more CRDs

### DIFF
--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -69,12 +69,36 @@ function gather_agent_data() {
   done
 }
 
+function gather_clusterdeployment_data() {
+  cd_dir="${LOGS_DEST}/clusterdeployment"
+  mkdir -p "${cd_dir}"
+
+  readarray -t cd_objects < <(oc get clusterdeployments.hive.openshift.io -n assisted-installer -o json | jq -c '.items[]')
+  for cd in "${cd_objects[@]}"; do
+    cd_name=$(echo ${cd} | jq -r .metadata.name)
+    oc get clusterdeployments.hive.openshift.io -n assisted-installer "${cd_name}" -o yaml > "${cd_dir}/${cd_name}.yaml"
+  done
+}
+
+function gather_imageset_data() {
+  imageset_dir="${LOGS_DEST}/imageset"
+  mkdir -p "${imageset_dir}"
+
+  readarray -t imageset_objects < <(oc get clusterimagesets.hive.openshift.io -o json | jq -c '.items[]')
+  for is in "${imageset_objects[@]}"; do
+    is_name=$(echo ${is} | jq -r .metadata.name)
+    oc get clusterimagesets.hive.openshift.io "${is_name}" -o yaml > "${imageset_dir}/${is_name}.yaml"
+  done
+}
+
 function gather_all() {
   gather_operator_data
   gather_agentclusterinstall_data
   gather_bmh_data
   gather_infraenv_data
   gather_agent_data
+  gather_clusterdeployment_data
+  gather_imageset_data
 }
 
 gather_all


### PR DESCRIPTION
# Description

Add ClusterDeployment and ClusterImageSet to ZTP CI gather.
Signed-off-by: Fred Rolland <frolland@redhat.com>

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @YuviGold 
/assign @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
