### PR TITLE
UpdateCluster changes for REST API

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3441,9 +3441,7 @@ var _ = Describe("cluster", func() {
 			}
 
 			Context("Non DHCP", func() {
-				It("No machine network (no error)", func() {
-					mockSuccess(1)
-
+				It("No machine network", func() {
 					apiVip := "8.8.8.8"
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
@@ -3451,12 +3449,10 @@ var _ = Describe("cluster", func() {
 							APIVip: &apiVip,
 						},
 					})
-					Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
-					actual := reply.(*installer.UpdateClusterCreated)
-					Expect(actual.Payload.APIVip).To(Equal(apiVip))
+					Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+					Expect(reply.(*common.ApiErrorResponse).StatusCode()).To(Equal(int32(http.StatusBadRequest)))
 				})
-				It("Api and ingress mismatch (no error)", func() {
-					mockSuccess(1)
+				It("Api and ingress mismatch", func() {
 					apiVip := "10.11.12.15"
 					ingressVip := "1.2.3.20"
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
@@ -3466,10 +3462,8 @@ var _ = Describe("cluster", func() {
 							IngressVip: &ingressVip,
 						},
 					})
-					Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
-					actual := reply.(*installer.UpdateClusterCreated)
-					Expect(actual.Payload.APIVip).To(Equal(apiVip))
-					Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
+					Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+					Expect(reply.(*common.ApiErrorResponse).StatusCode()).To(Equal(int32(http.StatusBadRequest)))
 				})
 				It("Same api and ingress", func() {
 					apiVip := "10.11.12.15"
@@ -3522,7 +3516,7 @@ var _ = Describe("cluster", func() {
 					actual := reply.(*installer.UpdateClusterCreated)
 					Expect(actual.Payload.APIVip).To(Equal(apiVip))
 					Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
-					Expect(actual.Payload.MachineNetworkCidr).To(Equal(""))
+					Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
 					expectedNetworks := sortedNetworks([]*models.HostNetwork{
 						{
 							Cidr: "1.2.3.0/24",
@@ -3589,7 +3583,7 @@ var _ = Describe("cluster", func() {
 					actual := reply.(*installer.UpdateClusterCreated)
 					Expect(actual.Payload.APIVip).To(Equal(apiVip))
 					Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
-					Expect(actual.Payload.MachineNetworkCidr).To(Equal(""))
+					Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
 					Expect(actual.Payload.ClusterNetworkCidr).To(Equal("192.168.0.0/21"))
 					Expect(actual.Payload.ServiceNetworkCidr).To(Equal("193.168.5.0/24"))
 					expectedNetworks := sortedNetworks([]*models.HostNetwork{
@@ -3755,7 +3749,7 @@ var _ = Describe("cluster", func() {
 					actual := reply.(*installer.UpdateClusterCreated)
 					Expect(actual.Payload.APIVip).To(Equal(apiVip))
 					Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
-					Expect(actual.Payload.MachineNetworkCidr).To(Equal(""))
+					Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
 					reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.ClusterUpdateParams{
@@ -3809,7 +3803,7 @@ var _ = Describe("cluster", func() {
 					actual = reply.(*installer.UpdateClusterCreated)
 					Expect(actual.Payload.APIVip).To(Equal(apiVip))
 					Expect(actual.Payload.IngressVip).To(Equal(ingressVip))
-					Expect(actual.Payload.MachineNetworkCidr).To(Equal(""))
+					Expect(actual.Payload.MachineNetworkCidr).To(Equal("10.11.0.0/16"))
 				})
 				It("DHCP non existent network (no error)", func() {
 					mockSuccess(1)

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -277,19 +277,19 @@ func (mr *MockInstallerInternalsMockRecorder) UpdateClusterInstallConfigInternal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterInstallConfigInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateClusterInstallConfigInternal), arg0, arg1)
 }
 
-// UpdateClusterInternal mocks base method
-func (m *MockInstallerInternals) UpdateClusterInternal(arg0 context.Context, arg1 installer.UpdateClusterParams) (*common.Cluster, error) {
+// UpdateClusterNonInteractive mocks base method
+func (m *MockInstallerInternals) UpdateClusterNonInteractive(arg0 context.Context, arg1 installer.UpdateClusterParams) (*common.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateClusterNonInteractive", arg0, arg1)
 	ret0, _ := ret[0].(*common.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateClusterInternal indicates an expected call of UpdateClusterInternal
-func (mr *MockInstallerInternalsMockRecorder) UpdateClusterInternal(arg0, arg1 interface{}) *gomock.Call {
+// UpdateClusterNonInteractive indicates an expected call of UpdateClusterNonInteractive
+func (mr *MockInstallerInternalsMockRecorder) UpdateClusterNonInteractive(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateClusterInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterNonInteractive", reflect.TypeOf((*MockInstallerInternals)(nil).UpdateClusterNonInteractive), arg0, arg1)
 }
 
 // UpdateDiscoveryIgnitionInternal mocks base method

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -791,7 +791,7 @@ func (r *AgentReconciler) updateIfNeeded(ctx context.Context, log logrus.FieldLo
 		return nil
 	}
 
-	_, err = r.Installer.UpdateClusterInternal(ctx, installer.UpdateClusterParams{
+	_, err = r.Installer.UpdateClusterNonInteractive(ctx, installer.UpdateClusterParams{
 		ClusterUpdateParams: params,
 		ClusterID:           *c.ID,
 	})

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -212,7 +212,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Host{}, nil)
-		mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, param installer.UpdateClusterParams) {
 				Expect(param.ClusterUpdateParams.DisksSelectedConfig[0].DisksConfig[0].ID).To(Equal(&newInstallDiskPath))
 				Expect(param.ClusterUpdateParams.DisksSelectedConfig[0].DisksConfig[0].Role).To(Equal(models.DiskRoleInstall))
@@ -258,7 +258,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Host{}, nil)
-		mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())
@@ -294,7 +294,7 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 		mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Host{}, nil)
 		errString := "update internal error"
-		mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).Return(nil, common.NewApiError(http.StatusInternalServerError,
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).Return(nil, common.NewApiError(http.StatusInternalServerError,
 			errors.New(errString)))
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -640,7 +640,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	if !update {
 		return nil
 	}
-	_, err = r.Installer.UpdateClusterInternal(ctx, installer.UpdateClusterParams{
+	_, err = r.Installer.UpdateClusterNonInteractive(ctx, installer.UpdateClusterParams{
 		ClusterUpdateParams: params,
 		ClusterID:           *cluster.ID,
 	})

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1452,7 +1452,7 @@ var _ = Describe("cluster reconcile", func() {
 				},
 				PullSecret: testPullSecretVal,
 			}
-			mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, param installer.UpdateClusterParams) {
 					Expect(swag.StringValue(param.ClusterUpdateParams.PullSecret)).To(Equal(testPullSecretVal))
 					Expect(swag.StringValue(param.ClusterUpdateParams.Name)).To(Equal(defaultClusterSpec.ClusterName))
@@ -1536,7 +1536,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			errString := "update internal error"
-			mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -124,7 +124,7 @@ func (r *InfraEnvReconciler) updateClusterIfNeeded(ctx context.Context, log logr
 		}
 		log.Infof("updating cluster %s %s with %s",
 			infraEnv.Spec.ClusterRef.Name, infraEnv.Spec.ClusterRef.Namespace, string(updateString))
-		_, err = r.Installer.UpdateClusterInternal(ctx, installer.UpdateClusterParams{
+		_, err = r.Installer.UpdateClusterNonInteractive(ctx, installer.UpdateClusterParams{
 			ClusterUpdateParams: params,
 			ClusterID:           *cluster.ID,
 		})

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -359,7 +359,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
 			Do(func(ctx context.Context, param installer.UpdateClusterParams) {
 				Expect(swag.StringValue(param.ClusterUpdateParams.HTTPProxy)).To(Equal("http://192.168.1.2"))
 				Expect(swag.StringValue(param.ClusterUpdateParams.AdditionalNtpSource)).To(Equal("foo.com,bar.com"))
@@ -429,7 +429,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
 
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-		mockInstallerInternal.EXPECT().UpdateClusterInternal(gomock.Any(), gomock.Any()).
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
 			Return(nil, errors.Errorf("failure")).Times(1)
 
 		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -89,6 +89,9 @@ func VerifyVip(hosts []*models.Host, machineNetworkCidr string, vip string, vipN
 	if !mustExist && vip == "" {
 		return nil
 	}
+	if machineNetworkCidr == "" {
+		return errors.Errorf("%s <%s> cannot be set if Machine Network CIDR is empty", vipName, vip)
+	}
 	if !ipInCidr(vip, machineNetworkCidr) {
 		return errors.Errorf("%s <%s> does not belong to machine-network-cidr <%s>", vipName, vip, machineNetworkCidr)
 	}


### PR DESCRIPTION
[OCPBUGSM-26021](https://issues.redhat.com/browse/OCPBUGSM-26021):  Can't proceed beyond the first wizard screen, if a cluster already has VIPs but no hosts
- Do not force that machine network can be calculated during update

[OCPBUGSM-28971](https://issues.redhat.com/browse/OCPBUGSM-28971): The VIP fields remain disabled when de-selecting DHCP
- Return machine CIDR after setting VIPs when in interactive mode (REST)

[OCPBUGSM-27652](https://issues.redhat.com/browse/OCPBUGSM-27652): Assisted service not returning an error when setting API/Ingress vip outside of CIDR
- Perform VIPs verification when updating them throgh REST API
# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? No
- Is this PR relying on CI for an e2e test run? No
- Should this PR be tested in a specific environment? No
- Any logs, screenshots, etc that can help with the review process? No


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @empovit 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
