### PR TITLE
Bug 1937696: Use hostname for BMH resource name

### DIFF
--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -84,6 +84,19 @@ var _ = Describe("installcfg", func() {
 		Expect(len(result.Platform.Baremetal.Hosts)).Should(Equal(3))
 	})
 
+	It("create_configuration_with_hostnames", func() {
+		var result InstallerConfigBaremetal
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		data, err := installConfig.GetInstallConfig(&cluster, false, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = yaml.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(len(result.Platform.Baremetal.Hosts)).Should(Equal(3))
+		Expect(result.Platform.Baremetal.Hosts[0].Name).Should(Equal("hostname0"))
+		Expect(result.Platform.Baremetal.Hosts[1].Name).Should(Equal("hostname1"))
+		Expect(result.Platform.Baremetal.Hosts[2].Name).Should(Equal("hostname2"))
+	})
+
 	It("create_configuration_with_one_host_disabled", func() {
 		var result InstallerConfigBaremetal
 		host3.Status = swag.String(models.HostStatusDisabled)


### PR DESCRIPTION
# Description

Currently BMH resources in the clusters installed by AI are named in
the form of `openshift-{master|worker}-{0...}`. This PR changes the
convention so that a real hostname of the node will be used, or its UUID
as a fallback option.

For virtual environments this gives us 3 different naming schemas

- Node: libvirt domain name
- BareMetalHost: `openshift-{master|worker}-{0...}`
- Machine: `cluster_name-ID-{master|worker}-{0...}`

This PR unifies naming between Node and BareMetalHost, so that the
output of the 3 following commands is more consistent

- `oc get nodes`
- `oc -n openshift-machine-api get baremetalhosts`
- `oc -n openshift-machine-api get machines`

Closes: [OCPBUGSM-26086](https://issues.redhat.com/browse/OCPBUGSM-26086)

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

Blablabla

# Assignees

/assign @
/assign @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?