### PR TITLE
Bug 1972096: Use .invalid domain instead of dummy.com

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6291,7 +6291,7 @@ var _ = Describe("AMS subscriptions", func() {
 				subStrings: []string{"Updated status of cluster", clusterName},
 			}, gomock.Any())
 
-			dummyDNSDomain := "dummy.com"
+			dummyDNSDomain := "dummy.test"
 			reply = bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 				ClusterID: *c.ID,
 				ClusterUpdateParams: &models.ClusterUpdateParams{

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2661,7 +2661,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	const (
 		openshiftVersion = "dummyVersion"
-		emailDomain      = "dummy.com"
+		emailDomain      = "dummy.test"
 	)
 
 	var (

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -77,7 +77,7 @@ var TestDefaultConfig = &TestConfiguration{
 	},
 }
 
-var TestNTPSourceSynced = &models.NtpSource{SourceName: "clock.dummy.com", SourceState: models.SourceStateSynced}
+var TestNTPSourceSynced = &models.NtpSource{SourceName: "clock.dummy.test", SourceState: models.SourceStateSynced}
 var TestNTPSourceUnsynced = &models.NtpSource{SourceName: "2.2.2.2", SourceState: models.SourceStateUnreachable}
 var TestImageStatusesSuccess = &models.ContainerImageAvailability{
 	Name:         TestDefaultConfig.ImageName,

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2325,7 +2325,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	const (
 		openshiftVersion = "dummyVersion"
-		emailDomain      = "dummy.com"
+		emailDomain      = "dummy.test"
 	)
 
 	var (

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -315,7 +315,7 @@ data:
 	stageServiceBaseURL       = "https://api.stage.openshift.com"
 	integrationServiceBaseURL = "https://api.integration.openshift.com"
 	stageTelemeterURL         = "https://infogw.api.stage.openshift.com"
-	dummyURL                  = "https://dummy.com"
+	dummyURL                  = "https://dummy.invalid"
 )
 
 // Default Telemeter server is prod.


### PR DESCRIPTION
# Description

As a convention, one of the following should be used when a dummy domain
name is required for testing or documentation purposes - `example.com`,
`.invalid`, `.example`, `.localhost` or `.test` as those are reserved by
IANA/IETF.

Using a domain from `.com` as a default value in our configuration may
cause undesired affects in the future if such a domain is not changed by
the operator and we use it for sending data out of the cluster.

Closes: [OCPBUGSM-30935](https://issues.redhat.com/browse/OCPBUGSM-30935)

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

# Assignees

/assign @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?