### PR TITLE
OCPBUGSM-30076: Add role, bootstrap and ntp sources to Agent CR

### DIFF
--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -310,6 +310,9 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -558,6 +558,9 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
             type: object
         type: object
     served: true

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -293,6 +293,9 @@ spec:
                     description: 'Name in REST API: stage_updated_at'
                     type: string
                 type: object
+              role:
+                description: "HostRole host role \n swagger:model host-role"
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -137,8 +137,10 @@ type HostNTPSources struct {
 
 // AgentStatus defines the observed state of Agent
 type AgentStatus struct {
-	Hostname   string                   `json:"hostname,omitempty"`
-	Bootstrap  bool                     `json:"bootstrap,omitempty"`
+	Hostname  string `json:"hostname,omitempty"`
+	Bootstrap bool   `json:"bootstrap,omitempty"`
+	// +optional
+	Role       models.HostRole          `json:"role" protobuf:"bytes,1,opt,name=role,casttype=HostRole,omitempty"`
 	Inventory  HostInventory            `json:"inventory,omitempty"`
 	Progress   HostProgressInfo         `json:"progress,omitempty"`
 	NtpSources []HostNTPSources         `json:"ntpSources,omitempty"`

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1524,6 +1524,18 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return aci.Status.DebugInfo.LogsURL
 		}, "30s", "10s").ShouldNot(Equal(""))
 
+		By("Check NTP Source")
+		generateNTPPostStepReply(ctx, host, []*models.NtpSource{
+			{SourceName: common.TestNTPSourceSynced.SourceName, SourceState: models.SourceStateUnreachable},
+		})
+		Eventually(func() bool {
+			agent := getAgentCRD(ctx, kubeClient, key)
+			return agent.Status.NtpSources != nil &&
+				agent.Status.NtpSources[0].SourceName == common.TestNTPSourceSynced.SourceName &&
+				agent.Status.NtpSources[0].SourceState == models.SourceStateUnreachable
+
+		}, "30s", "10s").Should(BeTrue())
+
 		By("Approve Agent")
 		Eventually(func() error {
 			agent := getAgentCRD(ctx, kubeClient, key)
@@ -1551,6 +1563,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}, "1m", "2s").Should(BeTrue())
 
 		updateProgress(*host.ID, *cluster.ID, models.HostStageDone)
+
+		By("Check Agent Role and Bootstrap")
+		Eventually(func() bool {
+			agent := getAgentCRD(ctx, kubeClient, key)
+			return agent.Status.Bootstrap && agent.Status.Role == models.HostRoleMaster
+		}, "30s", "10s").Should(BeTrue())
 
 		By("Complete Installation")
 		completeInstallation(agentBMClient, *cluster.ID)


### PR DESCRIPTION
# Description

Agent CRD Status:
- Populate NTP Sources and Bootstrap fields.
- Add and populate Role field.

Signed-off-by: Fred Rolland <frolland@redhat.com>

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Output from subsystem Agent CR:
```
  ntpSources:
  - sourceName: clock.dummy.com
    sourceState: synced
  progress: {}
  role: auto-assign
```


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @filanov 
/assign @nmagnezi 
/assign @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
