### PR TITLE
MGMT-6628: Exposing the deregistration time on cluster API.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -361,7 +361,8 @@ func main() {
 
 	bm := bminventory.NewBareMetalInventory(db, log.WithField("pkg", "Inventory"), hostApi, clusterApi, Options.BMConfig,
 		generator, eventsHandler, objectHandler, metricsManager, usageManager, operatorsManager, authHandler, ocpClient, ocmClient,
-		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder, staticNetworkConfig)
+		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder, staticNetworkConfig,
+		Options.GCConfig)
 
 	events := events.NewApi(eventsHandler, logrus.WithField("pkg", "eventsApi"))
 	expirer := imgexpirer.NewManager(objectHandler, eventsHandler, Options.BMConfig.ImageExpirationTime, lead, Options.EnableKubeAPI)

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/dns"
 	"github.com/openshift/assisted-service/internal/events"
+	"github.com/openshift/assisted-service/internal/garbagecollector"
 	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/host"
@@ -163,6 +164,7 @@ type bareMetalInventory struct {
 	hwValidator          hardware.Validator
 	installConfigBuilder installcfg.InstallConfigBuilder
 	staticNetworkConfig  staticnetworkconfig.StaticNetworkConfig
+	gcConfig             garbagecollector.Config
 }
 
 func NewBareMetalInventory(
@@ -190,6 +192,7 @@ func NewBareMetalInventory(
 	dnsApi dns.DNSApi,
 	installConfigBuilder installcfg.InstallConfigBuilder,
 	staticNetworkConfig staticnetworkconfig.StaticNetworkConfig,
+	gcConfig garbagecollector.Config,
 ) *bareMetalInventory {
 	return &bareMetalInventory{
 		db:                   db,
@@ -216,6 +219,7 @@ func NewBareMetalInventory(
 		hwValidator:          hwValidator,
 		installConfigBuilder: installConfigBuilder,
 		staticNetworkConfig:  staticNetworkConfig,
+		gcConfig:             gcConfig,
 	}
 }
 
@@ -1491,6 +1495,7 @@ func (b *bareMetalInventory) GetClusterDefaultConfig(_ context.Context, _ instal
 	body.ClusterNetworkCidr = b.Config.DefaultClusterNetworkCidr
 	body.ServiceNetworkCidr = b.Config.DefaultServiceNetworkCidr
 	body.ClusterNetworkHostPrefix = b.Config.DefaultClusterNetworkHostPrefix
+	body.InactiveDeletionHours = int64(b.gcConfig.DeregisterInactiveAfter.Hours())
 
 	return installer.NewGetClusterDefaultConfigOK().WithPayload(&body)
 }

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/dns"
 	"github.com/openshift/assisted-service/internal/events"
+	"github.com/openshift/assisted-service/internal/garbagecollector"
 	"github.com/openshift/assisted-service/internal/gencrypto"
 	"github.com/openshift/assisted-service/internal/hardware"
 	"github.com/openshift/assisted-service/internal/host"
@@ -6930,10 +6931,12 @@ func createInventory(db *gorm.DB, cfg Config) *bareMetalInventory {
 	mockHwValidator = hardware.NewMockValidator(ctrl)
 	mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
 	dnsApi := dns.NewDNSHandler(cfg.BaseDNSDomains, common.GetTestLog())
+	gcConfig := garbagecollector.Config{DeregisterInactiveAfter: 20 * 24 * time.Hour}
 	return NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterApi, cfg,
 		mockGenerator, mockEvents, mockS3Client, mockMetric, mockUsage, mockOperatorManager,
 		getTestAuthHandler(), mockK8sClient, ocmClient, nil, mockSecretValidator, mockVersions,
-		mockIsoEditorFactory, mockCRDUtils, mockIgnitionBuilder, mockHwValidator, dnsApi, mockInstallConfigBuilder, mockStaticNetworkConfig)
+		mockIsoEditorFactory, mockCRDUtils, mockIgnitionBuilder, mockHwValidator, dnsApi, mockInstallConfigBuilder, mockStaticNetworkConfig,
+		gcConfig)
 }
 
 var _ = Describe("IPv6 support disabled", func() {

--- a/models/cluster_default_config.go
+++ b/models/cluster_default_config.go
@@ -26,6 +26,9 @@ type ClusterDefaultConfig struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// inactive deletion hours
+	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
+
 	// ntp source
 	NtpSource string `json:"ntp_source"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5556,6 +5556,9 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "inactive_deletion_hours": {
+          "type": "integer"
+        },
         "ntp_source": {
           "type": "string",
           "x-omitempty": false
@@ -13232,6 +13235,9 @@ func init() {
           "type": "integer",
           "maximum": 32,
           "minimum": 1
+        },
+        "inactive_deletion_hours": {
+          "type": "integer"
         },
         "ntp_source": {
           "type": "string",

--- a/subsystem/cluster_default_config_test.go
+++ b/subsystem/cluster_default_config_test.go
@@ -1,0 +1,18 @@
+package subsystem
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/client/installer"
+)
+
+var _ = Describe("GetClusterDefaultConfig", func() {
+
+	It("InactiveDeletionHours", func() {
+		res, err := userBMClient.Installer.GetClusterDefaultConfig(context.Background(), &installer.GetClusterDefaultConfigParams{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.GetPayload().InactiveDeletionHours).To(Equal(int64(Options.DeregisterInactiveAfter.Hours())))
+	})
+})

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -40,19 +40,20 @@ const (
 )
 
 var Options struct {
-	DBHost               string        `envconfig:"DB_HOST"`
-	DBPort               string        `envconfig:"DB_PORT"`
-	AuthType             auth.AuthType `envconfig:"AUTH_TYPE"`
-	InventoryHost        string        `envconfig:"INVENTORY"`
-	TestToken            string        `envconfig:"TEST_TOKEN"`
-	TestTokenAdmin       string        `envconfig:"TEST_TOKEN_ADMIN"`
-	TestTokenUnallowed   string        `envconfig:"TEST_TOKEN_UNALLOWED"`
-	OCMHost              string        `envconfig:"OCM_HOST"`
-	DeployTarget         string        `envconfig:"DEPLOY_TARGET" default:"k8s"`
-	Storage              string        `envconfig:"STORAGE" default:""`
-	Namespace            string        `envconfig:"NAMESPACE" default:"assisted-installer"`
-	EnableKubeAPI        bool          `envconfig:"ENABLE_KUBE_API" default:"false"`
-	WithAMSSubscriptions bool          `envconfig:"WITH_AMS_SUBSCRIPTIONS" default:"false"`
+	DBHost                  string        `envconfig:"DB_HOST"`
+	DBPort                  string        `envconfig:"DB_PORT"`
+	AuthType                auth.AuthType `envconfig:"AUTH_TYPE"`
+	InventoryHost           string        `envconfig:"INVENTORY"`
+	TestToken               string        `envconfig:"TEST_TOKEN"`
+	TestTokenAdmin          string        `envconfig:"TEST_TOKEN_ADMIN"`
+	TestTokenUnallowed      string        `envconfig:"TEST_TOKEN_UNALLOWED"`
+	OCMHost                 string        `envconfig:"OCM_HOST"`
+	DeployTarget            string        `envconfig:"DEPLOY_TARGET" default:"k8s"`
+	Storage                 string        `envconfig:"STORAGE" default:""`
+	Namespace               string        `envconfig:"NAMESPACE" default:"assisted-installer"`
+	EnableKubeAPI           bool          `envconfig:"ENABLE_KUBE_API" default:"false"`
+	WithAMSSubscriptions    bool          `envconfig:"WITH_AMS_SUBSCRIPTIONS" default:"false"`
+	DeregisterInactiveAfter time.Duration `envconfig:"DELETED_INACTIVE_AFTER" default:"480h"` // 20d
 }
 
 func clientcfg(authInfo runtime.ClientAuthInfoWriter) client.Config {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4532,6 +4532,8 @@ definitions:
         type: integer
         minimum: 1
         maximum: 32
+      inactive_deletion_hours:
+        type: integer
       service_network_cidr:
         type: string
         pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\/]([1-9]|[1-2][0-9]|3[0-2]?)$'


### PR DESCRIPTION
# Description

The UI want to warn the user that the kubeconfig/logs files won't be kept
in the service forever and he needs to download them.
In order to do that it needs the GC configuration.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

```
$ curl -s $(minikube service assisted-service -n assisted-installer --url)/api/assisted-install/v1/clusters/default-config | jq '.'
{
  "cluster_network_cidr": "10.128.0.0/14",
  "cluster_network_host_prefix": 23,
  "inactive_deletion_hours": 480,         <---------
  "ntp_source": "",
  "service_network_cidr": "172.30.0.0/16"
}
```

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @
/assign @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
