### PR TITLE
Bug 1969796: Fix logline containing ConfigMap for AgentServiceConfig

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -711,7 +711,7 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(log logrus.F
 	annotations := instance.ObjectMeta.GetAnnotations()
 	configmapName, ok := annotations[configmapAnnotation]
 	if ok {
-		log.Infof("ConfigMap %v being used to configure assisted-service deployment", configmapName)
+		log.Infof("ConfigMap %s from namespace %s being used to configure assisted-service deployment", configmapName, r.Namespace)
 		envFrom = append(envFrom, []corev1.EnvFromSource{
 			{
 				ConfigMapRef: &corev1.ConfigMapEnvSource{


### PR DESCRIPTION
# Description

This PR fixes the INFO logline printed when an operator requests the
assisted-service deployment to be configured using a manually created
ConfigMap.

In the current version the log line does not render the name of the
ConfigMap correctly, so that the message appearing in the logs looks as
follows

```
level=info msg="ConfigMap %v being used to configure [...]
```

Closes: [OCPBUGSM-30263](https://issues.redhat.com/browse/OCPBUGSM-30263)

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

Using the `quay.io/mkowalski/assisted-service:bz1969796-2` image I got the following log entry

```
time="2021-06-15T08:20:10Z" level=info msg="ConfigMap my-assisted-service-config from namespace assisted-installer-bz1969796-2 being used to configure assisted-service deployment" agent_service_config=agent agent_service_config_namespace= go-id=490 request_id=df28e33e-2fdd-4c09-85b1-60dbb434ab81
```

# Assignees

/assign @flaper87 
/assign @masayag 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?