### PR TITLE
OCPBUGSM-30211: cache image fetched from release

### DIFF
--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -76,6 +76,22 @@ var _ = Describe("oc", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
+		It("mco image exists in cache", func() {
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mcoImageName, true, releaseImageMirror, tempFilePath)
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mcoImage, "", 0).Times(1)
+
+			mco, err := oc.GetMCOImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch image again
+			mco, err = oc.GetMCOImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mco).Should(Equal(mcoImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
 		It("mco image with no release image or mirror", func() {
 			mco, err := oc.GetMCOImage(log, "", "", pullSecret)
 			Expect(mco).Should(BeEmpty())
@@ -115,6 +131,22 @@ var _ = Describe("oc", func() {
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mustGatherImage, "", 0).Times(1)
 
 			mustGather, err := oc.GetMustGatherImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mustGather).Should(Equal(mustGatherImage))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("must-gather image exists in cache", func() {
+			command := fmt.Sprintf(templateGetImage+" --registry-config=%s",
+				mustGatherImageName, true, releaseImageMirror, tempFilePath)
+			args := splitStringToInterfacesArray(command)
+			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return(mustGatherImage, "", 0).Times(1)
+
+			mustGather, err := oc.GetMustGatherImage(log, releaseImage, releaseImageMirror, pullSecret)
+			Expect(mustGather).Should(Equal(mustGatherImage))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Fetch image again
+			mustGather, err = oc.GetMustGatherImage(log, releaseImage, releaseImageMirror, pullSecret)
 			Expect(mustGather).Should(Equal(mustGatherImage))
 			Expect(err).ShouldNot(HaveOccurred())
 		})


### PR DESCRIPTION
# Description

In order to avoid redundant calls to 'oc adm release info',
caching image when fetched from OCP release.
For simplicity, images map is maintained under release struct
in the following format: image name > release image URL > image URL.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)

The cache functionality could be tested by verifying that each image (machine-config-operator/must-gather) is fetched only once. The following info message should be available in the assisted-service log for each image: "Fetching image from OCP release...".

# Assignees

/assign @tsorya 
/assign @omertuc 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
