### PR TITLE
OCPBUGSM-29737 - disable /etc/resolve.conf handling by NM during boot…

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -45,12 +45,12 @@ ipv6.dhcp-duid=ll
 path=/etc/NetworkManager/system-connections-merged
 `
 
-// Configuration of the NM hostname mode in case of static network configuration
-// needed in order to prevent hostname update in bootstrap node, which may cause dns resolution
-// failure due to OCPBUGSM-26430
-const StaticNetworkHostnameConf = `
+// configuration of NM to disable handling of /etc/resolv.conf
+// used for configuration of bootstrap node during bootkube (before reboot)
+// and of masters after reboot
+const UnmanagedResolvConf = `
 [main]
-hostname-mode=none
+rc-manager=unmanaged
 `
 
 // NM configuration to be activated (set into discovery ignition) in case we want more logging for NM debugging purposes.

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -125,12 +125,17 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		Expect(err1).NotTo(HaveOccurred())
 
 		var file *config_32_types.File
+		foundNMConfig := false
 		for i := range config.Storage.Files {
 			if isBMHFile(&config.Storage.Files[i]) {
 				file = &config.Storage.Files[i]
 			}
+			if config.Storage.Files[i].Node.Path == "/etc/NetworkManager/conf.d/99-kni.conf" {
+				foundNMConfig = true
+			}
 		}
 		bmh, _ = fileToBMH(file)
+		Expect(foundNMConfig).To(BeTrue(), "file /etc/NetworkManager/conf.d/99-kni.conf not present in bootstrap.ign")
 	})
 
 	Describe("update bootstrap.ign", func() {
@@ -1020,11 +1025,11 @@ var _ = Describe("IgnitionBuilder", func() {
 			Expect(report.IsFatal()).To(BeFalse())
 			count := 0
 			for _, f := range config.Storage.Files {
-				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") || strings.HasSuffix(f.Path, "02-hostname-mode.conf") {
+				if strings.HasSuffix(f.Path, "nmconnection") || strings.HasSuffix(f.Path, "mac_interface.ini") {
 					count += 1
 				}
 			}
-			Expect(count).Should(Equal(4))
+			Expect(count).Should(Equal(3))
 		})
 		It("Doesn't include static network config for minimal isos", func() {
 			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)


### PR DESCRIPTION
…strap

After installing bootstrap.ign we need to disable NM updating of the /etc/resolve.conf
in order to avoid race condition when NM updates /etc/resolve.conf again in case of
slow upcoming interfaces (like bonding)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs addess specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @
/assign @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
