### PR TITLE
Bug 1971589: Change default telemeter server of installed clusters to prod. (#1988)

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -361,10 +361,10 @@ data:
       telemeterServerURL: {{.TELEMETER_SERVER_URL}}
 `
 
-	prodServiceBaseURL  = "https://api.openshift.com"
-	stageServiceBaseURL = "https://api.stage.openshift.com"
-	stageTelemeterURL   = "https://infogw.stage.api.openshift.com"
-	dummyURL            = "https://dummy.com"
+	stageServiceBaseURL       = "https://api.stage.openshift.com"
+	integrationServiceBaseURL = "https://api.integration.openshift.com"
+	stageTelemeterURL         = "https://infogw.api.stage.openshift.com"
+	dummyURL                  = "https://dummy.com"
 )
 
 // Default Telemeter server is prod.
@@ -374,19 +374,20 @@ func (m *ManifestsGenerator) AddTelemeterManifest(ctx context.Context, log logru
 
 	manifestParams := map[string]string{}
 
-	if m.Config.ServiceBaseURL == prodServiceBaseURL {
-		return nil
-	}
+	switch m.Config.ServiceBaseURL {
 
-	if m.Config.ServiceBaseURL == stageServiceBaseURL {
+	case stageServiceBaseURL:
 
 		log.Infof("Creating manifest to redirect metrics from installed cluster to telemeter-stage")
 		manifestParams["TELEMETER_SERVER_URL"] = stageTelemeterURL
 
-	} else {
+	case integrationServiceBaseURL:
 
-		log.Infof("Creating manifest to redirect metrics from installed cluster to a dummy URL")
+		log.Infof("Creating manifest to redirect metrics from installed cluster to dummy URL")
 		manifestParams["TELEMETER_SERVER_URL"] = dummyURL
+
+	default:
+		return nil
 
 	}
 

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -346,16 +346,15 @@ var _ = Describe("telemeter manifest", func() {
 		serviceBaseURL string
 	}{
 		{
-			envName:        "Prod env",
-			serviceBaseURL: prodServiceBaseURL,
-		},
-		{
 			envName:        "Stage env",
 			serviceBaseURL: stageServiceBaseURL,
 		},
 		{
-			envName:        "Other envs",
-			serviceBaseURL: dummyURL,
+			envName:        "Integration env",
+			serviceBaseURL: integrationServiceBaseURL,
+		},
+		{
+			envName: "Other envs",
 		},
 	} {
 		test := test
@@ -366,7 +365,7 @@ var _ = Describe("telemeter manifest", func() {
 			})
 
 			It("happy flow", func() {
-				if test.envName != "Prod env" {
+				if test.envName == "Stage env" || test.envName == "Integration env" {
 					mockManifestsApi.EXPECT().CreateClusterManifest(ctx, gomock.Any()).Return(operations.NewCreateClusterManifestCreated())
 				}
 				err := manifestsGeneratorApi.AddTelemeterManifest(ctx, log, &cluster)
@@ -374,7 +373,7 @@ var _ = Describe("telemeter manifest", func() {
 			})
 
 			It("AddTelemeterManifest failure", func() {
-				if test.envName == "Prod env" {
+				if test.envName != "Stage env" && test.envName != "Integration env" {
 					Skip("We don't create any additional manifest in prod")
 				}
 				mockManifestsApi.EXPECT().CreateClusterManifest(ctx, gomock.Any()).Return(common.GenerateErrorResponder(errors.Errorf("failed to upload to s3")))

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -139,7 +139,7 @@ spec:
 	It("check installation telemeter manifests", func() {
 
 		isProdDeployment := func() bool {
-			return Options.InventoryHost == "api.openshift.com"
+			return Options.InventoryHost != "api.stage.openshift.com" && Options.InventoryHost != "api.integration.openshift.com"
 		}
 
 		if isProdDeployment() {


### PR DESCRIPTION
# Description

Until now, in the service, we changed the default behavior of openshift,
which is to always send cluster metrics to prod-telemeter-server unless
changed by the user, and we:
    * left untouched clusters created by cloud prod env
    * redirected to telemeter-stage stage clusters
    * redirected to dummy-url all other clusters

The issue with this approach is that all prod clusters that aren't
created in the cloud, operator clusters for example,  will fail to
deliver telemetry.

Instead, we will now default to prod-telemeter instead of dummy-url
unless we know better:
    * left untouched clusters created by ALL prod envs (not just cloud)
    * redirect to telemeter-stage stage clusters
    * redirect to dummy-url integration clusters

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

This PR clones https://github.com/openshift/assisted-service/pull/1988 and was cherry-picked from it to this specific branch.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

**Manual system tests:**

I have run test-infra locally and we can see that no manifest was created to redirect the metrics (we defaulted to prod):
```
$ curl -s $(minikube service assisted-service -n assisted-installer --url)/api/assisted-install/v1/clusters/baa05cab-8b82-41e0-aef2-6771e350c2d2/manifests | jq '.'
[
  {
    "file_name": "50-masters-chrony-configuration.yaml",
    "folder": "openshift"
  },
  {
    "file_name": "50-workers-chrony-configuration.yaml",
    "folder": "openshift"
  }
]
```

Also, in the created cluster, we can see that the ConfigMap for redirection wasn't created:
```
$ oc --kubeconfig kubeconfig describe cm/cluster-monitoring-config -n openshift-monitoring
Error from server (NotFound): configmaps "cluster-monitoring-config" not found
```

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/assign @
/assign @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
