### PR TITLE
Gather hive logs on CI

### DIFF
--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -8,6 +8,7 @@ set -o xtrace
 
 DISCONNECTED="${DISCONNECTED:-false}"
 HIVE_IMAGE="${HIVE_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"
+HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
 
 function print_help() {
   ALL_FUNCS="with_olm|from_upstream|enable_agent_install_strategy|print_help"
@@ -41,7 +42,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: hive-operator
-  namespace: openshift-operators
+  namespace: ${HIVE_NAMESPACE}
 spec:
   installPlanApproval: Automatic
   name: hive-operator
@@ -49,7 +50,7 @@ spec:
   sourceNamespace: openshift-marketplace
 EOCR
 
-  wait_for_operator "hive-operator" "openshift-operators"
+  wait_for_operator "hive-operator" "${HIVE_NAMESPACE}"
   wait_for_crd "clusterdeployments.hive.openshift.io"
 
   echo "Hive installed successfully!"
@@ -79,9 +80,9 @@ function from_upstream() {
     export IMG="${HIVE_IMAGE}"
   fi
 
-  make deploy
-  wait_for_pod "hive-operator" "hive" "control-plane=hive-operator"
-  wait_for_pod "hive-controllers" "hive" "control-plane=controller-manager"
+  make deploy HIVE_OPERATOR_NS="${HIVE_NAMESPACE}" HIVE_NS="${HIVE_NAMESPACE}"
+  wait_for_pod "hive-operator" "${HIVE_NAMESPACE}" "control-plane=hive-operator"
+  wait_for_pod "hive-controllers" "${HIVE_NAMESPACE}" "control-plane=controller-manager"
 
   echo "Hive installed successfully!"
   popd
@@ -97,7 +98,7 @@ metadata:
   name: hive
 spec:
   logLevel: debug
-  targetNamespace: hive
+  targetNamespace: ${HIVE_NAMESPACE}
   featureGates:
     custom:
       enabled:


### PR DESCRIPTION
# Description

Doing a couple of changes:
* Gathering data relevant to hive
* Enable configuring hive namespace
* Installing only on given namespace, instead on ``openshift-operators`` (which actually means on all namespaces)

# What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR.

/cc @lranjbar @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
