### PR TITLE
NO-ISSUE: Use /cc instead of /assign to link PRs to users

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -37,10 +37,11 @@ how this code was tested. Here are some questions that may be worth answering:
 
 # Assignees
 
-Please, add one or two reviewers that could help review this PR.
+Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
+this PR directly to someone.
 
-/assign @
-/assign @
+/cc @
+/cc @
 
 ## Checklist
 


### PR DESCRIPTION
# Description

The pull request template currently suggests usin /assign to add reviewers to the PR. This
duplicates the number of people associated to a PR since the bot will add 2 people to the
reviewers section, in addition to the 2 assignees added with /assign.

Switch from using /assign to using /cc to only have 2 (and relevant) people added to the PR.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR.

/cc @osherdp 
/cc @ronniel1 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
