### PR TITLE
OCPBUGSM-29588: ACM/ZTP with Wan emulation, several clusters fail to step past discovery

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -242,6 +242,7 @@ func main() {
 	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler)
 	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
+	Options.InstructionConfig.SupportFreeAddresses = Options.InstructionConfig.SupportFreeAddresses && !Options.EnableKubeAPI
 	instructionApi := hostcommands.NewInstructionManager(log.WithField("pkg", "instructions"), db, hwValidator,
 		releaseHandler, Options.InstructionConfig, connectivityValidator, eventsHandler, versionHandler)
 

--- a/internal/host/hostcommands/free_addresses_cmd.go
+++ b/internal/host/hostcommands/free_addresses_cmd.go
@@ -17,7 +17,10 @@ type freeAddressesCmd struct {
 	freeAddressesImage string
 }
 
-func NewFreeAddressesCmd(log logrus.FieldLogger, freeAddressesImage string) *freeAddressesCmd {
+func newFreeAddressesCmd(log logrus.FieldLogger, freeAddressesImage string, enabled bool) CommandGetter {
+	if !enabled {
+		return NewNoopCmd()
+	}
 	return &freeAddressesCmd{
 		baseCmd:            baseCmd{log: log},
 		freeAddressesImage: freeAddressesImage,

--- a/internal/host/hostcommands/free_addresses_cmd_test.go
+++ b/internal/host/hostcommands/free_addresses_cmd_test.go
@@ -17,48 +17,89 @@ var _ = Describe("free_addresses", func() {
 	ctx := context.Background()
 	var host models.Host
 	var db *gorm.DB
-	var fCmd *freeAddressesCmd
+	var fCmd CommandGetter
 	var id, clusterId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
 
-	BeforeEach(func() {
-		db, dbName = common.PrepareTestDB()
-		fCmd = NewFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest")
+	Context("Enabled", func() {
+		BeforeEach(func() {
+			db, dbName = common.PrepareTestDB()
+			fCmd = newFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest", true)
 
-		id = strfmt.UUID(uuid.New().String())
-		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
-		host.Inventory = common.GenerateTestDefaultInventory()
-		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+			id = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
+			host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+			host.Inventory = common.GenerateTestDefaultInventory()
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+		})
+
+		It("happy flow", func() {
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).ToNot(BeNil())
+			Expect(stepReply[0].StepType).To(Equal(models.StepTypeFreeNetworkAddresses))
+			Expect(stepErr).ShouldNot(HaveOccurred())
+		})
+
+		It("Illegal inventory", func() {
+			host.Inventory = "blah"
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).To(BeNil())
+			Expect(stepErr).To(HaveOccurred())
+		})
+
+		It("Missing networks", func() {
+			host.Inventory = "{}"
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).To(BeNil())
+			Expect(stepErr).To(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// cleanup
+			common.DeleteTestDB(db, dbName)
+			stepReply = nil
+			stepErr = nil
+		})
 	})
+	Context("Disabled", func() {
+		BeforeEach(func() {
+			db, dbName = common.PrepareTestDB()
+			fCmd = newFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest", false)
 
-	It("happy flow", func() {
-		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-		Expect(stepReply).ToNot(BeNil())
-		Expect(stepReply[0].StepType).To(Equal(models.StepTypeFreeNetworkAddresses))
-		Expect(stepErr).ShouldNot(HaveOccurred())
-	})
+			id = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
+			host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+			host.Inventory = common.GenerateTestDefaultInventory()
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+		})
 
-	It("Illegal inventory", func() {
-		host.Inventory = "blah"
-		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-		Expect(stepReply).To(BeNil())
-		Expect(stepErr).To(HaveOccurred())
-	})
+		It("happy flow", func() {
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).To(BeNil())
+			Expect(stepErr).ShouldNot(HaveOccurred())
+		})
 
-	It("Missing networks", func() {
-		host.Inventory = "{}"
-		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-		Expect(stepReply).To(BeNil())
-		Expect(stepErr).To(HaveOccurred())
-	})
+		It("Illegal inventory", func() {
+			host.Inventory = "blah"
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).To(BeNil())
+			Expect(stepErr).ShouldNot(HaveOccurred())
+		})
 
-	AfterEach(func() {
-		// cleanup
-		common.DeleteTestDB(db, dbName)
-		stepReply = nil
-		stepErr = nil
+		It("Missing networks", func() {
+			host.Inventory = "{}"
+			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+			Expect(stepReply).To(BeNil())
+			Expect(stepErr).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			// cleanup
+			common.DeleteTestDB(db, dbName)
+			stepReply = nil
+			stepErr = nil
+		})
 	})
 })

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -55,6 +55,7 @@ type InstructionConfig struct {
 	SupportL2            bool          `envconfig:"SUPPORT_L2" default:"true"`
 	InstallationTimeout  uint          `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
 	DiskCheckTimeout     time.Duration `envconfig:"DISK_CHECK_TIMEOUT" default:"8m"`
+	SupportFreeAddresses bool          `envconfig:"SUPPORT_FREE_ADDRESSES" default:"true"`
 	ReleaseImageMirror   string
 	CheckClusterVersion  bool
 }
@@ -64,7 +65,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.AgentImage)
 	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler)
 	inventoryCmd := NewInventoryCmd(log, instructionConfig.AgentImage)
-	freeAddressesCmd := NewFreeAddressesCmd(log, instructionConfig.AgentImage)
+	freeAddressesCmd := newFreeAddressesCmd(log, instructionConfig.AgentImage, instructionConfig.SupportFreeAddresses)
 	resetCmd := NewResetInstallationCmd(log)
 	stopCmd := NewStopInstallationCmd(log)
 	logsCmd := NewLogsCmd(log, db, instructionConfig)

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -50,6 +50,7 @@ var _ = Describe("instruction_manager", func() {
 		hwValidator = hardware.NewMockValidator(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		cnValidator = connectivity.NewMockValidator(ctrl)
+		instructionConfig.SupportFreeAddresses = true
 		instMng = NewInstructionManager(common.GetTestLog(), db, hwValidator, mockRelease, instructionConfig, cnValidator, mockEvents, mockVersions)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())

--- a/internal/host/hostcommands/noop_cmd.go
+++ b/internal/host/hostcommands/noop_cmd.go
@@ -1,0 +1,17 @@
+package hostcommands
+
+import (
+	"context"
+
+	"github.com/openshift/assisted-service/models"
+)
+
+func NewNoopCmd() CommandGetter {
+	return &noopCmd{}
+}
+
+type noopCmd struct{}
+
+func (n *noopCmd) GetSteps(_ context.Context, _ *models.Host) ([]*models.Step, error) {
+	return nil, nil
+}


### PR DESCRIPTION
# Description

- Add a configurable flag to indicate if free addresses is supported
- Avoid sending free addresses request in get-next-steps if the above flag is false or kube api is enabled

# What environments does this code impact?
- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x]  Unit tests
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? No
- Is this PR relying on CI for an e2e test run? No
- Should this PR be tested in a specific environment? No
- Any logs, screenshots, etc that can help with the review process? No


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @ronniel1 
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
