### PR TITLE
OCPBUGSM-30203: remove cluster_id from prometheus metrics + update tests

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3043,7 +3043,7 @@ func (b *bareMetalInventory) processDiskSpeedCheckResponse(ctx context.Context, 
 	}
 
 	if exitCode == 0 {
-		b.metricApi.DiskSyncDuration(h.ClusterID, *h.ID, diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
+		b.metricApi.DiskSyncDuration(*h.ID, diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
 
 		thresholdMs, err := b.getInstallationDiskSpeedThresholdMs(ctx, h)
 		if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1637,7 +1637,7 @@ var _ = Describe("PostStepReply", func() {
 
 		It("Disk speed success", func() {
 			mockHostApi.EXPECT().SetDiskSpeed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(10), nil).Times(1)
 			params := makeStepReply(*clusterId, *hostId, "/dev/sda", 5, 0)
 			reply := bm.PostStepReply(ctx, params)

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -514,7 +514,7 @@ func (th *transitionHandler) InstallCluster(sw stateswitch.StateSwitch, args sta
 	}
 	// send metric and event that installation process has been started
 	params.metricApi.InstallationStarted(cluster.OpenshiftVersion, *cluster.ID, cluster.EmailDomain, strconv.FormatBool(swag.BoolValue(cluster.UserManagedNetworking)))
-	params.metricApi.ClusterHostInstallationCount(*cluster.ID, cluster.EmailDomain, len(cluster.Hosts), cluster.OpenshiftVersion)
+	params.metricApi.ClusterHostInstallationCount(cluster.EmailDomain, len(cluster.Hosts), cluster.OpenshiftVersion)
 	return nil
 }
 

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -1459,7 +1459,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					}
 				}
 				mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any()).Times(1)
-				mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), nonDisabled, gomock.Any()).Times(1)
+				mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), nonDisabled, gomock.Any()).Times(1)
 			}
 			Expect(cluster.ValidationsInfo).To(BeEmpty())
 			clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
@@ -4374,7 +4374,7 @@ var _ = Describe("Single node", func() {
 					cluster.InstallationPreparationCompletionStatus = common.InstallationPreparationSucceeded
 
 					mockMetric.EXPECT().InstallationStarted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-					mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+					mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 				}
 				Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -710,7 +710,7 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 	} else {
 		common.SetImageStatus(hostImageStatuses, newImageStatus)
 		m.log.Infof("Adding new image status for %s with status %s to host %s", newImageStatus.Name, newImageStatus.Result, h.ID.String())
-		m.metricApi.ImagePullStatus(h.ClusterID, *h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
+		m.metricApi.ImagePullStatus(*h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
 
 		eventInfo := fmt.Sprintf("Host %s: New image status %s. result: %s.",
 			hostutil.GetHostnameForMsg(h), newImageStatus.Name, newImageStatus.Result)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1966,7 +1966,7 @@ var _ = Describe("UpdateImageStatus", func() {
 				}
 
 				mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo, eventMsg, gomock.Any()).Times(1)
-				mockMetric.EXPECT().ImagePullStatus(clusterId, hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
+				mockMetric.EXPECT().ImagePullStatus(hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
 			} else {
 				expectedImage.DownloadRate = t.originalImageStatuses[common.TestDefaultConfig.ImageName].DownloadRate
 				expectedImage.SizeBytes = t.originalImageStatuses[common.TestDefaultConfig.ImageName].SizeBytes
@@ -2553,7 +2553,7 @@ var _ = Describe("ResetHostValidation", func() {
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil)
 		h = registerTestHost(strfmt.UUID(uuid.New().String()))
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
-		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -109,15 +109,15 @@ func (mr *MockAPIMockRecorder) InstallationStarted(clusterVersion, clusterID, em
 }
 
 // ClusterHostInstallationCount mocks base method
-func (m *MockAPI) ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string) {
+func (m *MockAPI) ClusterHostInstallationCount(emailDomain string, hostCount int, clusterVersion string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterHostInstallationCount", clusterID, emailDomain, hostCount, clusterVersion)
+	m.ctrl.Call(m, "ClusterHostInstallationCount", emailDomain, hostCount, clusterVersion)
 }
 
 // ClusterHostInstallationCount indicates an expected call of ClusterHostInstallationCount
-func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(clusterID, emailDomain, hostCount, clusterVersion interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(emailDomain, hostCount, clusterVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), clusterID, emailDomain, hostCount, clusterVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), emailDomain, hostCount, clusterVersion)
 }
 
 // Duration mocks base method
@@ -157,27 +157,27 @@ func (mr *MockAPIMockRecorder) ReportHostInstallationMetrics(ctx, clusterVersion
 }
 
 // DiskSyncDuration mocks base method
-func (m *MockAPI) DiskSyncDuration(clusterID, hostID strfmt.UUID, diskPath string, syncDuration int64) {
+func (m *MockAPI) DiskSyncDuration(hostID strfmt.UUID, diskPath string, syncDuration int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DiskSyncDuration", clusterID, hostID, diskPath, syncDuration)
+	m.ctrl.Call(m, "DiskSyncDuration", hostID, diskPath, syncDuration)
 }
 
 // DiskSyncDuration indicates an expected call of DiskSyncDuration
-func (mr *MockAPIMockRecorder) DiskSyncDuration(clusterID, hostID, diskPath, syncDuration interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) DiskSyncDuration(hostID, diskPath, syncDuration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), clusterID, hostID, diskPath, syncDuration)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), hostID, diskPath, syncDuration)
 }
 
 // ImagePullStatus mocks base method
-func (m *MockAPI) ImagePullStatus(clusterID, hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
+func (m *MockAPI) ImagePullStatus(hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ImagePullStatus", clusterID, hostID, imageName, resultStatus, downloadRate)
+	m.ctrl.Call(m, "ImagePullStatus", hostID, imageName, resultStatus, downloadRate)
 }
 
 // ImagePullStatus indicates an expected call of ImagePullStatus
-func (mr *MockAPIMockRecorder) ImagePullStatus(clusterID, hostID, imageName, resultStatus, downloadRate interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ImagePullStatus(hostID, imageName, resultStatus, downloadRate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), clusterID, hostID, imageName, resultStatus, downloadRate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), hostID, imageName, resultStatus, downloadRate)
 }
 
 // FileSystemUsage mocks base method


### PR DESCRIPTION
# Description
We need to remove cluster_id from the metrics we are sending to Prometheus because it causes overloading by assisted-installer pods and scraped by Prometheus.


# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed
* testing on deployment Prometheus DB 


# Assignees
/cc @nmagnezi 
/cc @slaviered 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
