### PR TITLE
Bug 1972262: Change default value for BMH_DETACHED_ANNOTATION

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -316,7 +316,7 @@ func (r *BMACReconciler) addBMHDetachedAnnotationIfAgentHasStartedInstallation(c
 		bmh.ObjectMeta.Annotations = make(map[string]string)
 	}
 
-	bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "true"
+	bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
 
 	return reconcileComplete{dirty: true}
 }
@@ -664,7 +664,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 		if bmh.ObjectMeta.Annotations == nil {
 			bmh.ObjectMeta.Annotations = make(map[string]string)
 		}
-		bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "true"
+		bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
 		return reconcileComplete{dirty: true}
 	}
 

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -632,7 +632,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_HARDWARE_DETAILS_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
-				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("true"))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 
 				spokeBMH := &bmh_v1alpha1.BareMetalHost{}
 				spokeClient := bmhr.spokeClient
@@ -717,6 +717,7 @@ var _ = Describe("bmac reconcile", func() {
 				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 			})
 
 			It("should set the detached annotation if agent is installation is progressing", func() {
@@ -737,6 +738,7 @@ var _ = Describe("bmac reconcile", func() {
 				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 			})
 
 			It("should set the detached annotation if agent is installation has failed", func() {
@@ -757,6 +759,7 @@ var _ = Describe("bmac reconcile", func() {
 				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 			})
 		})
 


### PR DESCRIPTION
Currently for the `baremetalhost.metal3.io/detached` annotation we are
using `"true"` as a value whenever we decide to create it. Given that,
based on the behaviour of the baremetal-operator, this annotation
accepts string and not a boolean, it may create a confusion if an
administrator decides to set the value to e.g. `"false"` or
`"disabled"`.

It is a design decision in the upstream that the annotation could
provide a context from whatever external system the annotation is coming
from and that the value itself is completely ignored.

Conflicts:
  - internal/controller/controllers/bmh_agent_controller_test.go

Cherry-picks: openshift#1974
Closes: [OCPBUGSM-30953](https://issues.redhat.com/browse/OCPBUGSM-30953)