### PR TITLE
Fix hive installation to create namespace and OperatorGroup

### DIFF
--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -38,6 +38,22 @@ function with_olm() {
   fi
 
   cat <<EOCR | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${HIVE_NAMESPACE}
+  labels:
+    name: ${HIVE_NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: hive-group
+  namespace: ${HIVE_NAMESPACE}
+spec:
+  targetNamespaces:
+    - ${HIVE_NAMESPACE}
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
# Description

In #2006 , I've changed installation of hive to occur on top of hive namespace instead of installing it on all namespaces.
What I forgot to do is to actually create the namespace.
This will take care of the failing job.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [] None

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [] Manual (Elaborate on how it was tested)
- [] No tests needed

Just ran it on my local environment.

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?