### PR TITLE
OCPBUGSM-30089 parsing error indication for config override

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"time"
 
@@ -677,6 +678,10 @@ func (r *ClusterDeploymentsReconciler) updateInstallConfigOverrides(ctx context.
 			InstallConfigParams: cluster.InstallConfigOverrides,
 		})
 		if err != nil {
+			if IsUserError(err) {
+				apiErr := errors.Wrapf(err, "Failed to parse '%s' annotation", InstallConfigOverrides)
+				return common.NewApiError(http.StatusBadRequest, apiErr)
+			}
 			return err
 		}
 		log.Infof("Updated InstallConfig overrides on clusterInstall %s/%s", clusterInstall.Namespace, clusterInstall.Name)


### PR DESCRIPTION
# Description

When specifying an invalid json in 'install-config-overrides'
anntation, a proper message should be specified in AgentClusterInstall
conditions.

E.g.
AgentClusterInstall CRD -> metadata.annotations:
agent-install.openshift.io/install-config-overrides: '{{{'

Message in conditions:
The Spec could not be synced due to an input error: Failed to parse
'agent-install.openshift.io/install-config-overrides' annotation:
invalid character '{' looking for beginning of object key string

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Apply an AgentClusterInstall CRD with an invalid json in 'agent-install.openshift.io/install-config-overrides' annotaion.
A condition indicating a parsing error should be available in AgentClusterInstall status.

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @rollandf 
/cc @filanov 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ x Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ x Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
