### PR TITLE
Bug 1967956: Propagate proxy config to service

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 
 	"github.com/go-openapi/swag"
@@ -410,10 +411,19 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(log logrus.FieldLogger, ins
 			"SKIP_CERT_VERIFICATION": "False",
 		}
 
+		copyEnv(cm.Data, "HTTP_PROXY")
+		copyEnv(cm.Data, "HTTPS_PROXY")
+		copyEnv(cm.Data, "NO_PROXY")
 		return nil
 	}
 
 	return cm, mutateFn
+}
+
+func copyEnv(config map[string]string, key string) {
+	if value, ok := os.LookupEnv(key); ok {
+		config[key] = value
+	}
 }
 
 func (r *AgentServiceConfigReconciler) ensureAssistedCM(ctx context.Context, log logrus.FieldLogger, instance *aiv1beta1.AgentServiceConfig) error {


### PR DESCRIPTION
# Description

Cluster-wide proxy configuration (if exists) is automatically injected by OLM into the operators. But it is the responsibility of an operator to propagate the configuration to its operands. By copying proxy configuration from assisted installer operator to assisted service we make sure assisted service pods can communicate outside, for instance for extracting data from the OCP release image.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Method 1

1. Deploy an IPv6-only cluster using test infra `make run_full_flow_with_install IPv6=yes IPv4=no VIP_DHCP_ALLOCATION=no PROXY=yes OPENSHIFT_VERSION=4.8`. The cluster cannot directly access quay.io.
2. Build a custom operator index image that includes the fix.
3.  Deploy the custom operator image `make deploy_assisted_operator INDEX_IMAGE=<fixed-index-image> KUBECONFIG=./build/kubeconfig NAMESPACE=assisted-installer`.
4. Create valid CRs as if installing a cluster (no need to have hosts). 
5. Check the conditions, e.g. `oc get agentclusterinstall sno-agent-cluster-install -o json | jq ".status.conditions"`. There is no error about quay.io being unreacheable.

## Method 2

Monitoring access log of the proxy before and after the fix.

1. Deploy a cluster with a cluster-wide proxy configuration. It does not matter if IPv4 or IPv6 is used. For example, `make run_full_flow_with_install PROXY=yes`. 
2. Deploy an old (before the fix) operator image `make deploy_assisted_operator  INDEX_IMAGE=<old-index-image> KUBECONFIG=./build/kubeconfig NAMESPACE=assisted-installer`.
3. In a new terminal window, monitor the proxy log `tail -f /var/log/squid/access.log`.
4. Open the shell in the assisted service pod `oc exec -ti assisted-service-xxxx-xxxx -c assisted-service -- /bin/bash`.
5. Run `oc adm release info -o template --template '{{.metadata.version}}' --insecure=false fake.io/openshift-release-dev/ocp-release:4.8.0-fc.7-x86_64`. You will see nothing related to _fake.io_ in the proxy log, meaning the service pod isn't trying to access the domain via the proxy.
6. Build a custom operator index image that includes the fix.
7. Remove the old operator `operator-sdk cleanup --namespace assisted-installer assisted-service-operator`
8. Deploy the custom operator image `make deploy_assisted_operator INDEX_IMAGE=<fixed-index-image> KUBECONFIG=./build/kubeconfig NAMESPACE=assisted-installer`.
9. Repeat steps 4 and 5. You will see the command trying to access _fake.io_ via the proxy (`CONNECT fake.io:443`).

# Assignees

/cc @djzager 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md