### PR TITLE
Bug 1969975: Create warning about Agent without corresponding BMH

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -834,6 +834,11 @@ func (r *BMACReconciler) findAgent(ctx context.Context, bmh *bmh_v1alpha1.BareMe
 // Only `BareMetalHost` resources that match one of the Agent's
 // MAC addresses will be returned.
 func (r *BMACReconciler) findBMHByAgent(ctx context.Context, agent *aiv1beta1.Agent) (*bmh_v1alpha1.BareMetalHost, error) {
+	log := logutil.FromContext(ctx, r.Log).WithFields(
+		logrus.Fields{
+			"agent": agent.Name,
+		})
+
 	bmhList := bmh_v1alpha1.BareMetalHostList{}
 	err := r.Client.List(ctx, &bmhList, client.InNamespace(agent.Namespace))
 	if err != nil {
@@ -847,6 +852,7 @@ func (r *BMACReconciler) findBMHByAgent(ctx context.Context, agent *aiv1beta1.Ag
 			}
 		}
 	}
+	log.Warn("Did not find BareMetalHost corresponding to the Agent")
 	return nil, nil
 }
 


### PR DESCRIPTION
# Description

Currently we do not detect in any way Agent CRs without corresponding
BMHs. This can happen in a scenario when an operator creates BMH with
BootMACAddress that is not present in the Agent.

In order to match BMHs and Agents we are using discovered MAC addresses
so that if one of the Agent's interfaces has an address expected by
BootMACAddress, we will match the BMH with this agent.

It is however possible that an Agent gets into the pool without a
corresponding BMH resource (either because the BMH does not exist and
the node was e.g. manually booted or because the BootMACAddress is
invalid). If we detect a scenario like this, we will print a warning so
that the operator can spot the issue before approving the Agent and
proceeding with the installation.

Given that installing an Agent without BMH is not recommended (because
we can't e.g. set the `baremetalhost.metal3.io/detached` annotation
correctly) but possible, we will not treat it as an error but only show
a warning.

Closes: [OCPBUGSM-30297](https://issues.redhat.com/browse/OCPBUGSM-30297)

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

Using `quay.io/mkowalski/assisted-service:bz1969975-1` I create the following BMH

```
apiVersion: metal3.io/v1alpha1
kind: BareMetalHost
metadata:
  name: ostest-extraworker-0
[...]
  labels:
    infraenvs.agent-install.openshift.io: myinfraenv
[...]
  bootMACAddress: 00:56:de:ad:be:ef
[...]
```

whereas the NICs have `00:56:89:d9:9d:b1` and `00:56:89:d9:9d:b3`.

The log shows the following shortly after the node boots from the generated ISO and registers a new Agent

```
time="2021-06-17T10:09:44Z" level=info msg="Agent Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*AgentReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/agent_controller.go:87" agent=8ca83c71-06d6-47e9-b503-646ed279d7b2 agent_namespace=assisted-installer-manual-bundle go-id=766 request_id=f75d1208-50f7-4e51-838f-55d5cb1af396

time="2021-06-17T10:09:44Z" level=warning msg="Did not find BareMetalHost corresponding to the Agent" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).findBMHByAgent" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:855" agent=8ca83c71-06d6-47e9-b503-646ed279d7b2 go-id=758 request_id=
```

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @nmagnezi 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?