### PR TITLE
Bug 1968552: Wait for ISO for 1 minute before using it

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
@@ -68,6 +69,10 @@ const (
 	MACHINE_TYPE                        = "machine.openshift.io/cluster-api-machine-type"
 )
 
+var (
+	InfraEnvImageCooldownPeriod = 60 * time.Second
+)
+
 // reconcileResult is an interface that encapsulates the result of a Reconcile
 // call, as returned by the action corresponding to the current state.
 //
@@ -101,6 +106,26 @@ func (r reconcileComplete) Dirty() bool {
 
 func (r reconcileComplete) Stop(ctx context.Context) bool {
 	return r.stop || ctx.Err() != nil
+}
+
+type reconcileRequeue struct {
+	requeueAfter time.Duration
+}
+
+func (r reconcileRequeue) Result() (result reconcile.Result, err error) {
+	result = reconcile.Result{
+		Requeue:      true,
+		RequeueAfter: r.requeueAfter,
+	}
+	return result, err
+}
+
+func (r reconcileRequeue) Dirty() bool {
+	return false
+}
+
+func (r reconcileRequeue) Stop(ctx context.Context) bool {
+	return true
 }
 
 // reconcileError is a result indicating that an error occurred while attempting
@@ -428,26 +453,33 @@ func (r *BMACReconciler) reconcileAgentInventory(bmh *bmh_v1alpha1.BareMetalHost
 
 // Utility to verify whether a BMH should be reconciled based on the InfraEnv
 //
-// This function verifies three things:
+// This function verifies the following things:
 //
-// 1. InfraEnv existsD
+// 1. InfraEnv exists
 // 2. InfraEnv's ISODownloadURL exists
 // 3. The BMH.Spec.URL is the same to the InfraEnv's ISODownload URL
+// 4. The InfraEnv's ISO is at least 60 seconds old
 //
-// If the three checks above are true, then the reconcile won't happen
+// If all the checks above are true, then the reconcile won't happen
 // and the reconcileBMH function will return.
 //
 // Note that this function is also used to decide whether a BMH reconcile should be queued
 // or not. This will help queuing fewer reconciles when we know the BMH is not ready.
 //
-// The function returns 2 booleans:
+// The function returns 2 booleans, time.Duration and a string:
 //
 // 1. Should we proceed with the BMH's reconcile
 // 2. Should the full `Reconcile` stop as well
-func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.InfraEnv) (bool, bool) {
+// 3. If requeueing is needed, for how long should we back off
+// 4. If reconciling should not continue, a reason that will be printed in the log
+//
+// TODO: This function should return `reconcileResult` or some other interface suitable
+//       to contain multiple informations instead of a bunch of variables that are later on
+//       separately interpreted.
+func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.InfraEnv) (bool, bool, time.Duration, string) {
 	// Stop `Reconcile` if BMH does not have an InfraEnv.
 	if infraEnv == nil {
-		return false, false
+		return false, false, 0, "BMH does not have an InfraEnv"
 	}
 
 	// This is a separate check because an existing
@@ -455,16 +487,22 @@ func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.Inf
 	// global `Reconcile` function should also return
 	// as there is nothing left to do for it.
 	if infraEnv.Status.ISODownloadURL == "" {
-		return false, true
+		return false, true, 0, "InfraEnv corresponding to the BMH has no image URL available."
 	}
 
 	// The Image URL exists and InfraEnv's URL has not changed
 	// nothing else to do.
 	if bmh.Spec.Image != nil && bmh.Spec.Image.URL == infraEnv.Status.ISODownloadURL {
-		return false, false
+		return false, false, 0, "BMH and InfraEnv images are in sync. Nothing to update."
 	}
 
-	return true, false
+	// The image has been created sooner than the specified cooldown period
+	imageTime := infraEnv.Status.CreatedTime.Time.Add(InfraEnvImageCooldownPeriod)
+	if imageTime.After(time.Now()) {
+		return false, false, time.Until(imageTime), "InfraEnv image is too recent. Requeuing and retrying again soon."
+	}
+
+	return true, false, 0, ""
 }
 
 func (r *BMACReconciler) findInfraEnvForBMH(ctx context.Context, log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost) (*aiv1beta1.InfraEnv, error) {
@@ -544,10 +582,14 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 		dirty = true
 	}
 
-	proceed, stopReconcileLoop := shouldReconcileBMH(bmh, infraEnv)
+	proceed, stopReconcileLoop, requeuePeriod, reason := shouldReconcileBMH(bmh, infraEnv)
 
 	if !proceed {
-		log.Infof("Stopping reconcileBMH: Either the InfraEnv image is not ready or there is nothing to update.")
+		if requeuePeriod != 0 {
+			log.Infof("Requeuing reconcileBMH: %s", reason)
+			return reconcileRequeue{requeueAfter: requeuePeriod}
+		}
+		log.Infof("Stopping reconcileBMH: %s", reason)
 		return reconcileComplete{dirty: dirty, stop: stopReconcileLoop}
 	}
 
@@ -556,6 +598,7 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	// and, therefore, removed from Ironic's cache. The deprovision step is critical
 	// to guarantee that Ironic will fetch the latest version of the image.
 	if bmh.Status.Provisioning.State != bmh_v1alpha1.StateReady && bmh.Status.Provisioning.State != bmh_v1alpha1.StateAvailable {
+		log.Infof("Removing BMH image field to trigger Ironic image refresh")
 		bmh.Spec.Image = nil
 		return reconcileComplete{stop: true, dirty: true}
 	}
@@ -1069,7 +1112,7 @@ func (r *BMACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 		for i, bmh := range bmhs {
 
-			queue, _ := shouldReconcileBMH(bmh, infraEnv)
+			queue, _, _, _ := shouldReconcileBMH(bmh, infraEnv)
 			if !queue {
 				continue
 			}


### PR DESCRIPTION
# Description

Because in some cases we do not have a control over the order of
creation between different resources, it helps to wait some time before
BMAC is using the generated ISO image so that we are sure all the
configuration is applied.

Closes: [OCPBUGSM-30125](https://issues.redhat.com/browse/OCPBUGSM-30125)

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Manual test

```
  conditions:
    - lastTransitionTime: '2021-06-22T12:38:46Z'
      message: Image has been created
      reason: ImageCreated
      status: 'True'
      type: ImageCreated
  createdTime: '2021-06-22T12:38:46Z'
  isoDownloadURL: >-
    https://assisted-service-assisted-installer-manual-bundle.apps.ostest.test.metalkube.org/api/assisted-install/v1/clusters/71deabca-da7e-4440-bfab-7eb0f7fb4219/downloads/image?api_key=ey[...]VA
```

```
[...]
time="2021-06-22T12:39:07Z" level=info msg="prepare image for cluster 71deabca-da7e-4440-bfab-7eb0f7fb4219" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).GenerateClusterISOInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:865" go-id=797 pkg=Inventory request_id=2301e879-d4ea-4608-8c9f-949f5c2703c3
time="2021-06-22T12:39:07Z" level=info msg="Updating timestamp of file /data/discovery-image-71deabca-da7e-4440-bfab-7eb0f7fb4219.iso" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*FSClient).UpdateObjectTimestamp" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/filesystem.go:242" go-id=797 request_id=2301e879-d4ea-4608-8c9f-949f5c2703c3
time="2021-06-22T12:39:07Z" level=info msg="Re-used existing cluster <71deabca-da7e-4440-bfab-7eb0f7fb4219> image" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).GenerateClusterISOInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:997" go-id=797 pkg=Inventory request_id=2301e879-d4ea-4608-8c9f-949f5c2703c3
time="2021-06-22T12:39:07Z" level=info msg="ClusterDeployment Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*ClusterDeploymentsReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/clusterdeployments_controller.go:113" cluster_deployment=single-node cluster_deployment_namespace=assisted-installer-manual-bundle go-id=818 request_id=9174f497-8df3-4b31-bf0b-13a060f0ff18
time="2021-06-22T12:39:07Z" level=info msg="InfraEnv Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:78" go-id=797 infra_env=myinfraenv infra_env_namespace=assisted-installer-manual-bundle request_id=2301e879-d4ea-4608-8c9f-949f5c2703c3
time="2021-06-22T12:39:07Z" level=info msg="ClusterDeployment Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*ClusterDeploymentsReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/clusterdeployments_controller.go:110" agent_cluster_install=bmac-test agent_cluster_install_namespace=assisted-installer-manual-bundle cluster_deployment=single-node cluster_deployment_namespace=assisted-installer-manual-bundle go-id=818 request_id=9174f497-8df3-4b31-bf0b-13a060f0ff18
time="2021-06-22T12:39:15Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=06643cbb-728f-4173-a5e5-2cb0c53d6cc6
time="2021-06-22T12:39:15Z" level=info msg="Requeuing reconcileBMH: BMH has InfraEnv with too recent ISO, will requeue with delay" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:584" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=06643cbb-728f-4173-a5e5-2cb0c53d6cc6
time="2021-06-22T12:39:15Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=06643cbb-728f-4173-a5e5-2cb0c53d6cc6
[...]
time="2021-06-22T12:39:46Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=5be4cf59-3d71-4176-a74a-d1f36c2a8e80
time="2021-06-22T12:39:46Z" level=info msg="Image URL has been set in the BareMetalHost  assisted-installer-manual-bundle/ostest-extraworker-0" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:611"
time="2021-06-22T12:39:46Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=5be4cf59-3d71-4176-a74a-d1f36c2a8e80
[...]
time="2021-06-22T12:40:09Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=41b36675-faa7-40e5-9d97-dcd4a4178894
time="2021-06-22T12:40:09Z" level=info msg="Stopping reconcileBMH: BMH and InfraEnv ISO are in sync" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:587" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=41b36675-faa7-40e5-9d97-dcd4a4178894
time="2021-06-22T12:40:09Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=786 request_id=41b36675-faa7-40e5-9d97-dcd4a4178894
[...]
```

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @flaper87 
/cc @mhrivnak 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?
