### PR TITLE
Bug 1973315: Fix logging Image URL when regenerating ISO

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -313,8 +313,8 @@ func (r *InfraEnvReconciler) updateEnsureISOSuccess(
 	})
 
 	if infraEnv.Status.ISODownloadURL != imageInfo.DownloadURL {
-		infraEnv.Status.ISODownloadURL = imageInfo.DownloadURL
 		log.Infof("ISODownloadURL changed from %s to %s", imageInfo.DownloadURL, infraEnv.Status.ISODownloadURL)
+		infraEnv.Status.ISODownloadURL = imageInfo.DownloadURL
 	}
 
 	if updateErr := r.Status().Update(ctx, infraEnv); updateErr != nil {


### PR DESCRIPTION
# Description

Currently when a new ISO is generated for an InfraEnv, instead of
logging both old and new URL we are logging new URL twice.

This PR fixes that so that assisted-service logs will contain a clear
message containing both previous and the current URL.

Closes: [OCPBUGSM-31080](https://issues.redhat.com/browse/OCPBUGSM-31080)

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?