### PR TITLE
OCPBUGSM-30258: Fix empty cluster name after applying InfraEnv.yaml

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -345,7 +345,7 @@ func (r *InfraEnvReconciler) handleEnsureISOErrors(
 		err = nil
 		Requeue = true
 		RequeueAfter = defaultRequeueAfterPerRecoverableError
-		log.Infof("Image %s being prepared for cluster %s", infraEnv.Name, infraEnv.ClusterName)
+		log.Infof("Image %s being prepared for cluster %s", infraEnv.Name, infraEnv.Spec.ClusterRef.Name)
 		conditionsv1.SetStatusConditionNoHeartbeat(&infraEnv.Status.Conditions, conditionsv1.Condition{
 			Type:    aiv1beta1.ImageCreatedCondition,
 			Status:  corev1.ConditionTrue,


### PR DESCRIPTION
[OCPBUGSM-30258](https://issues.redhat.com/browse/OCPBUGSM-30258) - Fix empty cluster name after applying InfraEnv.yaml

# Description
After applying `InfraEnv.yaml` the cluster name is empty on the log message:
`level=info msg="Image myinfraenv being prepared for cluster " `

/cc @nmagnezi 
