### PR TITLE
NO-ISSUE: increase timeout of waiting for pod for disconnected flow

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -35,7 +35,7 @@ function wait_for_pod() {
     namespace="${2:-}"
     selector="${3:-}"
 
-    wait_for_condition "pod" "Ready" "20m" "${namespace}" "${selector}"
+    wait_for_condition "pod" "Ready" "22m" "${namespace}" "${selector}"
 }
 
 function hash() {


### PR DESCRIPTION
# Description

Disconnected mode needs a bit more time for assisted-service pod to be ready, that's because all nodes need (semi-serially) to reload ``registry.conf`` configuration, restart crio and kubelet and wait to be ready.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
