### PR TITLE
OCPBUGSM-30203: remove cluster_id from prometheus metrics + update tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,6 @@ require (
 	github.com/thedevsaddam/retry v0.0.0-20200324223450-9769a859cc6d
 	github.com/thoas/go-funk v0.8.0
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
-	go.elastic.co/apm v1.11.0
 	go.elastic.co/apm/module/apmhttp v1.11.0
 	go.elastic.co/apm/module/apmlogrus v1.11.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3043,7 +3043,7 @@ func (b *bareMetalInventory) processDiskSpeedCheckResponse(ctx context.Context, 
 	}
 
 	if exitCode == 0 {
-		b.metricApi.DiskSyncDuration(h.ClusterID, *h.ID, diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
+		b.metricApi.DiskSyncDuration(*h.ID, diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
 
 		thresholdMs, err := b.getInstallationDiskSpeedThresholdMs(ctx, h)
 		if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1637,7 +1637,7 @@ var _ = Describe("PostStepReply", func() {
 
 		It("Disk speed success", func() {
 			mockHostApi.EXPECT().SetDiskSpeed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(10), nil).Times(1)
 			params := makeStepReply(*clusterId, *hostId, "/dev/sda", 5, 0)
 			reply := bm.PostStepReply(ctx, params)

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -514,7 +514,7 @@ func (th *transitionHandler) InstallCluster(sw stateswitch.StateSwitch, args sta
 	}
 	// send metric and event that installation process has been started
 	params.metricApi.InstallationStarted(cluster.OpenshiftVersion, *cluster.ID, cluster.EmailDomain, strconv.FormatBool(swag.BoolValue(cluster.UserManagedNetworking)))
-	params.metricApi.ClusterHostInstallationCount(*cluster.ID, cluster.EmailDomain, len(cluster.Hosts), cluster.OpenshiftVersion)
+	params.metricApi.ClusterHostInstallationCount(cluster.EmailDomain, len(cluster.Hosts), cluster.OpenshiftVersion)
 	return nil
 }
 

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -1459,7 +1459,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 					}
 				}
 				mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any()).Times(1)
-				mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), nonDisabled, gomock.Any()).Times(1)
+				mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), nonDisabled, gomock.Any()).Times(1)
 			}
 			Expect(cluster.ValidationsInfo).To(BeEmpty())
 			clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
@@ -4374,7 +4374,7 @@ var _ = Describe("Single node", func() {
 					cluster.InstallationPreparationCompletionStatus = common.InstallationPreparationSucceeded
 
 					mockMetric.EXPECT().InstallationStarted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-					mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+					mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 				}
 				Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -710,7 +710,7 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 	} else {
 		common.SetImageStatus(hostImageStatuses, newImageStatus)
 		m.log.Infof("Adding new image status for %s with status %s to host %s", newImageStatus.Name, newImageStatus.Result, h.ID.String())
-		m.metricApi.ImagePullStatus(h.ClusterID, *h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
+		m.metricApi.ImagePullStatus(*h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
 
 		eventInfo := fmt.Sprintf("Host %s: New image status %s. result: %s.",
 			hostutil.GetHostnameForMsg(h), newImageStatus.Name, newImageStatus.Result)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1966,7 +1966,7 @@ var _ = Describe("UpdateImageStatus", func() {
 				}
 
 				mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo, eventMsg, gomock.Any()).Times(1)
-				mockMetric.EXPECT().ImagePullStatus(clusterId, hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
+				mockMetric.EXPECT().ImagePullStatus(hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
 			} else {
 				expectedImage.DownloadRate = t.originalImageStatuses[common.TestDefaultConfig.ImageName].DownloadRate
 				expectedImage.SizeBytes = t.originalImageStatuses[common.TestDefaultConfig.ImageName].SizeBytes
@@ -2553,7 +2553,7 @@ var _ = Describe("ResetHostValidation", func() {
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil)
 		h = registerTestHost(strfmt.UUID(uuid.New().String()))
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
-		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	})
 

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -99,12 +99,12 @@ type API interface {
 	ClusterValidationFailed(clusterVersion string, emailDomain string, clusterValidationType models.ClusterValidationID)
 	ClusterValidationChanged(clusterVersion string, emailDomain string, clusterValidationType models.ClusterValidationID)
 	InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string)
-	ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string)
+	ClusterHostInstallationCount(emailDomain string, hostCount int, clusterVersion string)
 	Duration(operation string, duration time.Duration)
 	ClusterInstallationFinished(ctx context.Context, result, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime)
 	ReportHostInstallationMetrics(ctx context.Context, clusterVersion string, clusterID strfmt.UUID, emailDomain string, boot *models.Disk, h *models.Host, previousProgress *models.HostProgressInfo, currentStage models.HostStage)
-	DiskSyncDuration(clusterID strfmt.UUID, hostID strfmt.UUID, diskPath string, syncDuration int64)
-	ImagePullStatus(clusterID, hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64)
+	DiskSyncDuration(hostID strfmt.UUID, diskPath string, syncDuration int64)
+	ImagePullStatus(hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64)
 	FileSystemUsage(usageInPercentage float64)
 	MonitoredHostsCount(monitoredHosts int64)
 	MonitoredClusterCount(monitoredClusters int64)
@@ -166,14 +166,14 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Subsystem: subsystem,
 			Name:      counterClusterHostInstallationCount,
 			Help:      counterDescriptionClusterHostInstallationCount,
-		}, []string{openshiftVersionLabel, clusterIdLabel, emailDomainLabel}),
+		}, []string{openshiftVersionLabel, emailDomainLabel}),
 
 		serviceLogicClusterHostNTPFailuresCount: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      counterClusterHostNTPFailuresCount,
 			Help:      counterDescriptionClusterHostNTPFailuresCount,
-		}, []string{clusterIdLabel, emailDomainLabel}),
+		}, []string{emailDomainLabel}),
 
 		serviceLogicClusterInstallationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -198,7 +198,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterHostInstallationPhaseSeconds,
 			Help:      counterDescriptionHostInstallationPhaseSeconds,
 			Buckets:   []float64{1, 5, 10, 30, 60, 120, 300, 600, 900, 1200, 1800},
-		}, []string{phaseLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel, discoveryAgentVersionLabel, hwVendorLabel, hwProductLabel, diskTypeLabel}),
+		}, []string{phaseLabel, resultLabel, openshiftVersionLabel, emailDomainLabel, discoveryAgentVersionLabel, hwVendorLabel, hwProductLabel, diskTypeLabel}),
 
 		serviceLogicClusterHosts: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -206,7 +206,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 				Subsystem: subsystem,
 				Name:      counterClusterHosts,
 				Help:      counterDescriptionClusterHosts,
-			}, []string{roleLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel, hwVendorLabel, hwProductLabel, diskTypeLabel}),
+			}, []string{roleLabel, resultLabel, openshiftVersionLabel, emailDomainLabel, hwVendorLabel, hwProductLabel, diskTypeLabel}),
 
 		serviceLogicClusterHostCores: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -214,7 +214,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostCores,
 			Help:      counterDescriptionClusterHostCores,
 			Buckets:   []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512},
-		}, []string{roleLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel}),
+		}, []string{roleLabel, resultLabel, openshiftVersionLabel, emailDomainLabel}),
 
 		serviceLogicClusterHostRAMGb: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -222,7 +222,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostRAMGb,
 			Help:      counterDescriptionClusterHostRAMGb,
 			Buckets:   []float64{8, 16, 32, 64, 128, 256, 512, 1024, 2048},
-		}, []string{roleLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel}),
+		}, []string{roleLabel, resultLabel, openshiftVersionLabel, emailDomainLabel}),
 
 		serviceLogicClusterHostDiskGb: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -230,7 +230,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostDiskGb,
 			Help:      counterDescriptionClusterHostDiskGb,
 			Buckets:   []float64{250, 500, 1000, 2000, 4000, 8000, 16000},
-		}, []string{diskTypeLabel, roleLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel}),
+		}, []string{diskTypeLabel, roleLabel, resultLabel, openshiftVersionLabel, emailDomainLabel}),
 
 		serviceLogicClusterHostNicGb: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -238,7 +238,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostNicGb,
 			Help:      counterDescriptionClusterHostNicGb,
 			Buckets:   []float64{1, 10, 20, 40, 100},
-		}, []string{roleLabel, resultLabel, openshiftVersionLabel, clusterIdLabel, emailDomainLabel}),
+		}, []string{roleLabel, resultLabel, openshiftVersionLabel, emailDomainLabel}),
 
 		serviceLogicClusterHostDiskSyncDurationMiliSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -246,7 +246,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostDiskSyncDurationMiliSeconds,
 			Help:      counterDescriptionClusterHostDiskSyncDurationMiliSeconds,
 			Buckets:   []float64{1, 5, 10, 15, 20},
-		}, []string{diskPathLabel, clusterIdLabel, hostIdLabel}),
+		}, []string{diskPathLabel, hostIdLabel}),
 
 		serviceLogicHostValidationFailed: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -286,7 +286,7 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 			Name:      counterClusterHostImagePullStatus,
 			Help:      counterDescriptionClusterHostImagePullStatus,
 			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50},
-		}, []string{resultLabel, imageLabel, clusterIdLabel, hostIdLabel}),
+		}, []string{resultLabel, imageLabel, hostIdLabel}),
 
 		serviceLogicFilesystemUsagePercentage: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -337,7 +337,6 @@ func NewMetricsManager(registry prometheus.Registerer, eventsHandler events.Hand
 }
 
 func (m *MetricsManager) ClusterRegistered(clusterVersion string, clusterID strfmt.UUID, emailDomain string) {
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	m.serviceLogicClusterCreation.WithLabelValues(clusterVersion, clusterID.String(), emailDomain).Inc()
 }
 
@@ -358,13 +357,11 @@ func (m *MetricsManager) ClusterValidationChanged(clusterVersion string, emailDo
 }
 
 func (m *MetricsManager) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain string, userManagedNetworking string) {
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	m.serviceLogicClusterInstallationStarted.WithLabelValues(clusterVersion, clusterID.String(), emailDomain, userManagedNetworking).Inc()
 }
 
-func (m *MetricsManager) ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string) {
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
-	m.serviceLogicClusterHostInstallationCount.WithLabelValues(clusterVersion, clusterID.String(), emailDomain).Observe(float64(hostCount))
+func (m *MetricsManager) ClusterHostInstallationCount(emailDomain string, hostCount int, clusterVersion string) {
+	m.serviceLogicClusterHostInstallationCount.WithLabelValues(clusterVersion, emailDomain).Observe(float64(hostCount))
 }
 
 func (m *MetricsManager) ClusterInstallationFinished(ctx context.Context, result, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime) {
@@ -372,23 +369,21 @@ func (m *MetricsManager) ClusterInstallationFinished(ctx context.Context, result
 	m.handler.AddMetricsEvent(ctx, clusterID, nil, models.EventSeverityInfo, "cluster.installation.results", time.Now(),
 		"duration", duration, "result", result)
 
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	log := logutil.FromContext(ctx, logrus.New())
 	log.Infof("Cluster %s Installation Finished result %s clusterVersion %s duration %f", clusterID.String(), result, clusterVersion, duration)
 	m.serviceLogicClusterInstallationSeconds.WithLabelValues(result, clusterVersion, clusterID.String(), emailDomain).Observe(duration)
 }
 
 func (m *MetricsManager) Duration(operation string, duration time.Duration) {
-	//MGMT-4526 TODO: Do not move this to ELK with events. It is called repeatedly over short periods of time
 	m.serviceLogicOperationDurationMiliSeconds.WithLabelValues(operation).Observe(float64(duration.Milliseconds()))
 }
 
-func (m *MetricsManager) DiskSyncDuration(clusterID strfmt.UUID, hostID strfmt.UUID, diskPath string, syncDuration int64) {
-	m.serviceLogicClusterHostDiskSyncDurationMiliSeconds.WithLabelValues(diskPath, clusterID.String(), hostID.String()).Observe(float64(syncDuration))
+func (m *MetricsManager) DiskSyncDuration(hostID strfmt.UUID, diskPath string, syncDuration int64) {
+	m.serviceLogicClusterHostDiskSyncDurationMiliSeconds.WithLabelValues(diskPath, hostID.String()).Observe(float64(syncDuration))
 }
 
-func (m *MetricsManager) ImagePullStatus(clusterID, hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
-	m.serviceLogicClusterHostImagePullStatus.WithLabelValues(imageName, resultStatus, clusterID.String(), hostID.String()).Observe(downloadRate)
+func (m *MetricsManager) ImagePullStatus(hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
+	m.serviceLogicClusterHostImagePullStatus.WithLabelValues(imageName, resultStatus, hostID.String()).Observe(downloadRate)
 }
 
 func (m *MetricsManager) ReportHostInstallationMetrics(ctx context.Context, clusterVersion string, clusterID strfmt.UUID, emailDomain string, boot *models.Disk,
@@ -431,9 +426,8 @@ func (m *MetricsManager) ReportHostInstallationMetrics(ctx context.Context, clus
 			m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.stage.duration", time.Now(),
 				"result", string(phaseResult), "duration", duration, "host_stage", string(previousProgress.CurrentStage), "vendor", hwVendor, "product", hwProduct, "disk_type", diskType, "host_role", roleStr)
 
-			//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 			m.serviceLogicHostInstallationPhaseSeconds.WithLabelValues(string(previousProgress.CurrentStage),
-				string(phaseResult), clusterVersion, clusterID.String(), emailDomain, h.DiscoveryAgentVersion, hwVendor, hwProduct, diskType).Observe(duration)
+				string(phaseResult), clusterVersion, emailDomain, h.DiscoveryAgentVersion, hwVendor, hwProduct, diskType).Observe(duration)
 		}
 	}
 }
@@ -443,10 +437,9 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	log := logutil.FromContext(ctx, logrus.New())
 
 	//increment the count of successful installed hosts
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	log.Infof("service Logic Cluster Hosts clusterVersion %s, roleStr %s, vendor %s, product %s, disk %s, result %s",
 		clusterVersion, roleStr, hwVendor, hwProduct, diskType, installationStageStr)
-	m.serviceLogicClusterHosts.WithLabelValues(roleStr, installationStageStr, clusterVersion, clusterID.String(), emailDomain, hwVendor, hwProduct, diskType).Inc()
+	m.serviceLogicClusterHosts.WithLabelValues(roleStr, installationStageStr, clusterVersion, emailDomain, hwVendor, hwProduct, diskType).Inc()
 
 	var hwInfo models.Inventory
 	err := json.Unmarshal([]byte(h.Inventory), &hwInfo)
@@ -458,17 +451,15 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	log.Infof("service Logic Cluster Host Cores role %s, result %s cpu %d",
 		roleStr, installationStageStr, hwInfo.CPU.Count)
 
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	m.serviceLogicClusterHostCores.WithLabelValues(roleStr, installationStageStr,
-		clusterVersion, clusterID.String(), emailDomain).Observe(float64(hwInfo.CPU.Count))
+		clusterVersion, emailDomain).Observe(float64(hwInfo.CPU.Count))
 
 	//collect the host's RAM data
 	log.Infof("service Logic Cluster Host RAMGb role %s, result %s ram %d",
 		roleStr, installationStageStr, bytesToGib(hwInfo.Memory.PhysicalBytes))
 
-	//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 	m.serviceLogicClusterHostRAMGb.WithLabelValues(roleStr, installationStageStr,
-		clusterVersion, clusterID.String(), emailDomain).Observe(float64(bytesToGib(hwInfo.Memory.PhysicalBytes)))
+		clusterVersion, emailDomain).Observe(float64(bytesToGib(hwInfo.Memory.PhysicalBytes)))
 
 	m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.mem.cpu", time.Now(),
 		"host_result", installationStageStr, "host_role", roleStr, "mem_bytes", bytesToGib(hwInfo.Memory.PhysicalBytes),
@@ -484,9 +475,8 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "disk.size.type", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "disk_type", diskTypeStr, "disk_size", bytesToGib(disk.SizeBytes))
 
-		//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 		m.serviceLogicClusterHostDiskGb.WithLabelValues(diskTypeStr, roleStr, installationStageStr,
-			clusterVersion, clusterID.String(), emailDomain).Observe(float64(bytesToGib(disk.SizeBytes)))
+			clusterVersion, emailDomain).Observe(float64(bytesToGib(disk.SizeBytes)))
 	}
 	//report NIC's speed. role for each NIC
 	for _, inter := range hwInfo.Interfaces {
@@ -495,9 +485,8 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "nic.speed", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "nic_speed", inter.SpeedMbps)
 
-		//MGMT-4526 TODO: remove this scrap after ELK dashboards are verified
 		m.serviceLogicClusterHostNicGb.WithLabelValues(roleStr, installationStageStr,
-			clusterVersion, clusterID.String(), emailDomain).Observe(float64(inter.SpeedMbps))
+			clusterVersion, emailDomain).Observe(float64(inter.SpeedMbps))
 	}
 }
 

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -109,15 +109,15 @@ func (mr *MockAPIMockRecorder) InstallationStarted(clusterVersion, clusterID, em
 }
 
 // ClusterHostInstallationCount mocks base method
-func (m *MockAPI) ClusterHostInstallationCount(clusterID strfmt.UUID, emailDomain string, hostCount int, clusterVersion string) {
+func (m *MockAPI) ClusterHostInstallationCount(emailDomain string, hostCount int, clusterVersion string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterHostInstallationCount", clusterID, emailDomain, hostCount, clusterVersion)
+	m.ctrl.Call(m, "ClusterHostInstallationCount", emailDomain, hostCount, clusterVersion)
 }
 
 // ClusterHostInstallationCount indicates an expected call of ClusterHostInstallationCount
-func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(clusterID, emailDomain, hostCount, clusterVersion interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(emailDomain, hostCount, clusterVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), clusterID, emailDomain, hostCount, clusterVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), emailDomain, hostCount, clusterVersion)
 }
 
 // Duration mocks base method
@@ -157,27 +157,27 @@ func (mr *MockAPIMockRecorder) ReportHostInstallationMetrics(ctx, clusterVersion
 }
 
 // DiskSyncDuration mocks base method
-func (m *MockAPI) DiskSyncDuration(clusterID, hostID strfmt.UUID, diskPath string, syncDuration int64) {
+func (m *MockAPI) DiskSyncDuration(hostID strfmt.UUID, diskPath string, syncDuration int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DiskSyncDuration", clusterID, hostID, diskPath, syncDuration)
+	m.ctrl.Call(m, "DiskSyncDuration", hostID, diskPath, syncDuration)
 }
 
 // DiskSyncDuration indicates an expected call of DiskSyncDuration
-func (mr *MockAPIMockRecorder) DiskSyncDuration(clusterID, hostID, diskPath, syncDuration interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) DiskSyncDuration(hostID, diskPath, syncDuration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), clusterID, hostID, diskPath, syncDuration)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), hostID, diskPath, syncDuration)
 }
 
 // ImagePullStatus mocks base method
-func (m *MockAPI) ImagePullStatus(clusterID, hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
+func (m *MockAPI) ImagePullStatus(hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ImagePullStatus", clusterID, hostID, imageName, resultStatus, downloadRate)
+	m.ctrl.Call(m, "ImagePullStatus", hostID, imageName, resultStatus, downloadRate)
 }
 
 // ImagePullStatus indicates an expected call of ImagePullStatus
-func (mr *MockAPIMockRecorder) ImagePullStatus(clusterID, hostID, imageName, resultStatus, downloadRate interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ImagePullStatus(hostID, imageName, resultStatus, downloadRate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), clusterID, hostID, imageName, resultStatus, downloadRate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), hostID, imageName, resultStatus, downloadRate)
 }
 
 // FileSystemUsage mocks base method


### PR DESCRIPTION
# Description
We need to remove cluster_id from the metrics we are sending to Prometheus because it causes overloading by assisted-installer pods and scraped by Prometheus.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed
* testing on deployment Prometheus DB 

# Assignees
/cc @nmagnezi 
/cc @slaviered 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md