### PR TITLE
Bug 1972525: CD controller to notify InfraEnv for backend cluster registration

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -776,6 +776,8 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	clusterDeployment *hivev1.ClusterDeployment,
 	clusterInstall *hiveext.AgentClusterInstall) (ctrl.Result, error) {
 
+	var infraEnv *aiv1beta1.InfraEnv
+
 	log.Infof("Creating a new cluster %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
 	spec := clusterDeployment.Spec
 
@@ -826,6 +828,16 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	c, err := r.Installer.RegisterClusterInternal(ctx, &key, installer.RegisterClusterParams{
 		NewClusterParams: clusterParams,
 	})
+	if err == nil { // Cluster registration succeeded
+		infraEnv, err = getInfraEnvByClusterDeployment(ctx, log, r.Client, clusterDeployment.Name, clusterDeployment.Namespace)
+		if err != nil {
+			log.Errorf("failed to search for infraEnv to notify, for clusterDeployment %s", clusterDeployment.Name)
+		} else if infraEnv != nil { // infraEnv exists for that clusterDeployment
+			log.Infof("Notify that infraEnv %s should re-generate the image for clusterDeployment %s",
+				infraEnv.Name, clusterDeployment.Name)
+			r.CRDEventsHandler.NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace)
+		}
+	}
 
 	return r.updateStatus(ctx, log, clusterInstall, c, err)
 }

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -294,6 +294,13 @@ func getAgentCRD(ctx context.Context, client k8sclient.Client, key types.Namespa
 	return agent
 }
 
+func getClusterImageSetCRD(ctx context.Context, client k8sclient.Client, key types.NamespacedName) *hivev1.ClusterImageSet {
+	clusterImageSet := &hivev1.ClusterImageSet{}
+	err := client.Get(ctx, key, clusterImageSet)
+	Expect(err).To(BeNil())
+	return clusterImageSet
+}
+
 func getBmhCRD(ctx context.Context, client k8sclient.Client, key types.NamespacedName) *bmhv1alpha1.BareMetalHost {
 	bmh := &bmhv1alpha1.BareMetalHost{}
 	err := client.Get(ctx, key, bmh)
@@ -695,6 +702,59 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		Eventually(func() string {
 			return getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName).Status.ISODownloadURL
 		}, "30s", "2s").ShouldNot(Equal(firstURL))
+
+		By("Verify InfraEnv Status CreatedTime has changed")
+		Expect(getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName).Status.CreatedTime).ShouldNot(Equal(firstCreatedAt))
+	})
+
+	It("verify InfraEnv image regenerated - ACI recreated", func() {
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		By("Deploy InfraEnv")
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+
+		infraEnvKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+
+		Eventually(func() string {
+			return getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName).Status.ISODownloadURL
+		}, "15s", "5s").Should(Not(BeEmpty()))
+
+		infraEnv := getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName)
+		firstURL := infraEnv.Status.ISODownloadURL
+		firstCreatedAt := infraEnv.Status.CreatedTime
+
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+
+		imageSetKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      aciSpec.ImageSetRef.Name,
+		}
+
+		By("Delete AgentClusterInstall")
+		err := kubeClient.Delete(ctx, getAgentClusterInstallCRD(ctx, kubeClient, installkey))
+		Expect(err).To(BeNil())
+		err = kubeClient.Delete(ctx, getClusterImageSetCRD(ctx, kubeClient, imageSetKey))
+		Expect(err).To(BeNil())
+
+		By("Verify AgentClusterInstall was deleted")
+		Eventually(func() bool {
+			aci := &hiveext.AgentClusterInstall{}
+			err := kubeClient.Get(ctx, installkey, aci)
+			return apierrors.IsNotFound(err)
+		}, "30s", "10s").Should(Equal(true))
+
+		By("Create AgentClusterInstall")
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		By("Verify InfraEnv Status ISODownloadURL has changed")
+		Eventually(func() string {
+			return getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName).Status.ISODownloadURL
+		}, "60s", "2s").ShouldNot(Equal(firstURL))
 
 		By("Verify InfraEnv Status CreatedTime has changed")
 		Expect(getInfraEnvCRD(ctx, kubeClient, infraEnvKubeName).Status.CreatedTime).ShouldNot(Equal(firstCreatedAt))


### PR DESCRIPTION


# Description
When an `AgentClusterInstall` is changed, the related `InfraEnv` resource should reconcile.

For example: if the user deletes and recreates the `AgentClusterInstall` resource, the
backend cluster ID will change (essentially deregister and register a new backend
cluster), and the `InfraEnv` image URL points to an image that no longer exists.

The `clusterDeployments` controller will now notify the `InfraEnv` controller via the
updates channel that it should reconcile. The `InfraEnv` controller will generate a
new image, to be later picked up by `BMH`. This scenario will also allow users to
retry a cluster installation.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @filanov 
/cc @rollandf 
/cc @danielerez  
/cc @eliorerz 
/cc @RazRegev 
## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
