### PR TITLE
OCPBUGSM-30844 NTP status is Unreachable after disable - enable host

### DIFF
--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -29,7 +29,7 @@ type transitionHandler struct {
 	eventsHandler events.Handler
 }
 
-var resetFields = [...]interface{}{"inventory", "", "bootstrap", false, "ntp_sources", ""}
+var resetFields = [...]interface{}{"inventory", "", "bootstrap", false}
 var resetLogsField = []interface{}{"logs_info", "", "logs_started_at", strfmt.DateTime(time.Time{}), "logs_collected_at", strfmt.DateTime(time.Time{})}
 
 ////////////////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ func (th *transitionHandler) PostRegisterHost(sw stateswitch.StateSwitch, args s
 	if _, err := common.GetHostFromDB(params.db, hostParam.ClusterID.String(), hostParam.ID.String()); err == nil {
 		// The reason for the double register is unknown (HW might have changed) -
 		// so we reset the hw info and progress, and start the discovery process again.
-		extra := append(resetFields[:], "discovery_agent_version", params.discoveryAgentVersion)
+		extra := append(resetFields[:], "discovery_agent_version", params.discoveryAgentVersion, "ntp_sources", "")
 		var dbHost *common.Host
 		if dbHost, err = hostutil.UpdateHostProgress(params.ctx, log, params.db, th.eventsHandler, hostParam.ClusterID, *hostParam.ID, sHost.srcState,
 			swag.StringValue(hostParam.Status), statusInfoDiscovering, hostParam.Progress.CurrentStage, "", "", extra...); err != nil {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1050,7 +1050,7 @@ var _ = Describe("Enable", func() {
 			Expect(*h.StatusInfo).Should(Equal(statusInfoDiscovering))
 			Expect(h.Inventory).Should(BeEmpty())
 			Expect(h.Bootstrap).Should(BeFalse())
-			Expect(h.NtpSources).Should(BeEmpty())
+			Expect(h.NtpSources).ShouldNot(BeEmpty())
 		}
 
 		failure := func(reply error) {


### PR DESCRIPTION
# Description

This is caused by agent caching and the fact that ntp_sources are reset when host is re-enabled.
When this happens, the agent caching blocks sending ntp result message which is identical to the previous one
while the service clears this field during enable.
The solution is to remove the reset of the ntp_sources during enable host operation. This will prevent the
 host field "ntp_sources" to be out of sync from the ntp_sources in the agent.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] Unit tests

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? No
- Is this PR relying on CI for an e2e test run? No
- Should this PR be tested in a specific environment? No
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @YuviGold 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
