### PR TITLE
MGMT-5171: Deploy assisted operator in disconnected ipv6 env

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -3,24 +3,72 @@
 set -o nounset
 set -o pipefail
 set -o errexit
-set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root="$(realpath ${__dir}/../..)"
+
+source ${__dir}/mirror_utils.sh
+
+function setup_disconnected_parameters() {
+    # Some of the variables over here can be sourced from dev-scripts
+    # source common.sh utils.sh
+    # set +x
+    # export -f wrap_if_ipv6 ipversion
+
+    if [ "${OPENSHIFT_CI:-false}" = "false" ] then
+        export ASSISTED_DEPLOYMENT_METHOD="from_community_operators"
+    fi
+
+    export HIVE_DEPLOYMENT_METHOD="from_upstream"
+
+    export MIRROR_BASE_URL="http://$(wrap_if_ipv6 ${PROVISIONING_HOST_IP})/images"
+    export AUTHFILE="${XDG_RUNTIME_DIR}/containers/auth.json"
+    mkdir -p $(dirname ${AUTHFILE})
+
+    export LOCAL_REGISTRY="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}"
+
+    merge_authfiles "${PULL_SECRET_FILE}" "${REGISTRY_CREDS}" "${AUTHFILE}"
+
+    ${__root}/hack/setup_env.sh hive_from_upstream
+}
+
+set -o xtrace
 
 if [ -z "${DISKS:-}" ]; then
     export DISKS=$(echo sd{b..f})
 fi
 
+DISCONNECTED="${DISCONNECTED:-false}"
+ASSISTED_DEPLOYMENT_METHOD="${ASSISTED_DEPLOYMENT_METHOD:-from_index_image}"
+HIVE_DEPLOYMENT_METHOD="${HIVE_DEPLOYMENT_METHOD:-with_olm}"
+
+if [ "${DISCONNECTED}" = "true" ]; then
+    setup_disconnected_parameters
+fi
+
+#######
+# LSO #
+#######
+
 ${__dir}/libvirt_disks.sh create
 
-if [ "${INSTALL_LSO:-true}" == "true" ]; then
+if [ "${INSTALL_LSO:-true}" = "true" ]; then
     ${__dir}/setup_lso.sh install_lso
 fi
 
 ${__dir}/setup_lso.sh create_local_volume
-${__dir}/setup_hive.sh with_olm
 
-export OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-$(cat ${__dir}/../../data/default_ocp_versions.json)}"
+########
+# Hive #
+########
+
+${__dir}/setup_hive.sh "${HIVE_DEPLOYMENT_METHOD}"
+
+############
+# Assisted #
+############
+
+export OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-$(cat ${__root}/data/default_ocp_versions.json)}"
 OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
     jq -rc 'with_entries(.key = "4.8") | with_entries(
     {
@@ -30,4 +78,5 @@ OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
                 rhcos_rootfs:  .value.rhcos_rootfs}
     }
     )')
-${__dir}/setup_assisted_operator.sh from_index_image
+
+${__dir}/setup_assisted_operator.sh "${ASSISTED_DEPLOYMENT_METHOD}"

--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -11,12 +11,6 @@ if [ -z "${NODES:-}" ]; then
     export NODES=$(virsh list --name | grep worker || virsh list --name | grep master)
 fi
 
-if [ -z "${DISKS:-}" ]; then
-    echo "You must provide DISKS env-var."
-    print_help
-    exit 1
-fi
-
 function create() {
     export SIZE=${SIZE:-50G}
 

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -2,7 +2,7 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/utils.sh
 source ${__dir}/mirror_utils.sh
 
-set -xeo pipefail
+set -x
 
 ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
 INDEX_IMAGE="${INDEX_IMAGE:-quay.io/ocpmetal/assisted-service-index:latest}"
@@ -13,42 +13,12 @@ DISCONNECTED="${DISCONNECTED:-false}"
 
 function print_help() {
   ALL_FUNCS="from_community_operators|from_index_image|print_help"
-  if [ "${DISCONNECTED}" == "true" ]; then
+  if [ "${DISCONNECTED}" = "true" ]; then
     echo "Usage: DISCONNECTED=true LOCAL_REGISTRY=... AUTHFILE=... IRONIC_IMAGES_DIR=... MIRROR_BASE_URL=... bash ${0} (${ALL_FUNCS})"
   else
     echo "Usage: OPENSHIFT_VERSIONS=... bash ${0} (${ALL_FUNCS})"
   fi
 }
-
-if [ -z "${OPENSHIFT_VERSIONS:-}" ]; then
-  echo "You must provide OPENSHIFT_VERSIONS env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE:-}" ]; then
-  echo "On disconnected mode, you must provide AUTHFILE env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY:-}" ]; then
-  echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${IRONIC_IMAGES_DIR:-}" ]; then
-  echo "On disconnected mode, you must provide IRONIC_IMAGES_DIR env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${MIRROR_BASE_URL:-}" ]; then
-  echo "On disconnected mode, you must provide MIRROR_BASE_URL env-var."
-  print_help
-  exit 1
-fi
 
 function subscription_config() {
     # Notice that this list of env variables is alphabetically ordered due to OLM bug
@@ -190,20 +160,11 @@ EOCR
 }
 
 function from_index_image() {
-  if [ "${DISCONNECTED}" = true ]; then
+  if [ "${DISCONNECTED}" = "true" ]; then
     catalog_source_name="mirror-catalog-for-assisted-service-operator"
     mirror_package "assisted-service-operator" \
         "${INDEX_IMAGE}" "${LOCAL_REGISTRY}" "${AUTHFILE}" "${catalog_source_name}"
-
-    rhcos_image=$(echo ${OPENSHIFT_VERSIONS} | jq -r '.[].rhcos_image')
-    mirror_rhcos_image=$(mirror_file "${rhcos_image}" "${IRONIC_IMAGES_DIR}" "${MIRROR_BASE_URL}")
-
-    rhcos_rootfs=$(echo ${OPENSHIFT_VERSIONS} | jq -r '.[].rhcos_rootfs')
-    mirror_rhcos_rootfs=$(mirror_file "${rhcos_rootfs}" "${IRONIC_IMAGES_DIR}" "${MIRROR_BASE_URL}")
-
-    OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
-      jq ".[].rhcos_image=\"${mirror_rhcos_image}\" | .[].rhcos_rootfs=\"${mirror_rhcos_rootfs}\"")
-
+    mirror_rhcos
   else
     catalog_source_name="assisted-service-operator-catalog"
     tee << EOCR >(oc apply -f -)
@@ -224,15 +185,27 @@ EOCR
 }
 
 function from_community_operators() {
-  if [ "${DISCONNECTED}" = true ]; then
+  if [ "${DISCONNECTED}" = "true" ]; then
     catalog_source_name="mirror-catalog-for-assisted-service-operator"
     mirror_package_from_official_index "assisted-service-operator" "community-operator-index" \
         "${INDEX_TAG}" "${LOCAL_REGISTRY}" "${AUTHFILE}" "${catalog_source_name}"
+    mirror_rhcos
   else
     catalog_source_name="community-operators"
   fi
 
   install_from_catalog_source "${catalog_source_name}"
+}
+
+function mirror_rhcos() {
+    rhcos_image=$(echo ${OPENSHIFT_VERSIONS} | jq -r '.[].rhcos_image')
+    mirror_rhcos_image=$(mirror_file "${rhcos_image}" "${IRONIC_IMAGES_DIR}" "${MIRROR_BASE_URL}")
+
+    rhcos_rootfs=$(echo ${OPENSHIFT_VERSIONS} | jq -r '.[].rhcos_rootfs')
+    mirror_rhcos_rootfs=$(mirror_file "${rhcos_rootfs}" "${IRONIC_IMAGES_DIR}" "${MIRROR_BASE_URL}")
+
+    OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
+      jq ".[].rhcos_image=\"${mirror_rhcos_image}\" | .[].rhcos_rootfs=\"${mirror_rhcos_rootfs}\"")
 }
 
 if [ -z "$@" ]; then

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -3,9 +3,6 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/utils.sh
 
-set -o nounset
-set -o pipefail
-set -o errexit
 set -o xtrace
 
 DISCONNECTED="${DISCONNECTED:-false}"
@@ -14,24 +11,12 @@ HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
 
 function print_help() {
     ALL_FUNCS="with_olm|from_upstream|enable_agent_install_strategy|print_help"
-    if [ "${DISCONNECTED}" == "true" ]; then
+    if [ "${DISCONNECTED}" = "true" ]; then
         echo "Usage: DISCONNECTED=true AUTHFILE=... LOCAL_REGISTRY=... bash ${0} (${ALL_FUNCS})"
     else
         echo "Usage: bash ${0} (${ALL_FUNCS})"
     fi
 }
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE:-}" ]; then
-    echo "On disconnected mode, you must provide AUTHFILE env-var."
-    print_help
-    exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY:-}" ]; then
-    echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
-    print_help
-    exit 1
-fi
 
 function with_olm() {
     if [ "${DISCONNECTED}" = "true" ]; then

--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -15,24 +15,6 @@ function print_help() {
   fi
 }
 
-if [ -z "${DISKS:-}" ]; then
-  echo "You must provide DISKS env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${AUTHFILE:-}" ]; then
-  echo "On disconnected mode, you must provide AUTHFILE env-var."
-  print_help
-  exit 1
-fi
-
-if [ "${DISCONNECTED}" = "true" ] && [ -z "${LOCAL_REGISTRY:-}" ]; then
-  echo "On disconnected mode, you must provide LOCAL_REGISTRY env-var."
-  print_help
-  exit 1
-fi
-
 function install_lso() {
   oc adm new-project openshift-local-storage || true
 


### PR DESCRIPTION
# Description
    
The entire disconnected logic should be implemented in the same place
as where the connected logic is located.
Currently that's assisted-service repository hence moving the logic
from openshift/release.
    
- Patch nodes mirror-by-digest-only to be false. This would be
  configurable in OCP 4.9 https://issues.redhat.com/browse/OCPNODE-521 .
  The script goes over all the cluster nodes (currently supports a
  single dev-scripts cluster), and modifies
  /etc/containers/registries.conf if necessary.
  This solution is mainly for local deployment since the CI images pull
  specs are with digest.
    
- mirror_rhcos for assisted operator from_community_operators.
    
- Call setup_assisted_operator.sh from_community_operators function in
  case of a disconnected.
    
- Merge authfiles for disconnected env.
    
- No need to check variables are set since using bash nounset option.

# What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
