### PR TITLE
OCPBUGSM-30767: AI Pods throws errors cannot access the media (ISO) - me…

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -72,6 +72,7 @@ import (
 const DefaultUser = "kubeadmin"
 
 const WindowBetweenRequestsInSeconds = 10 * time.Second
+const mediaDisconnectionMessage = "Cannot read from the media (ISO) - media was likely disconnected"
 
 const (
 	MediaDisconnected int64 = 256
@@ -2857,7 +2858,7 @@ func (b *bareMetalInventory) PostStepReply(ctx context.Context, params installer
 			WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
 
-	logReplyReceived(params, log)
+	logReplyReceived(params, log, host)
 
 	if params.Reply.ExitCode != 0 {
 		handlingError := b.handleReplyError(params, ctx, log, &host.Host, params.Reply.ExitCode)
@@ -2917,8 +2918,7 @@ func (b *bareMetalInventory) handleReplyError(params installer.PostStepReplyPara
 }
 
 func (b *bareMetalInventory) handleMediaDisconnection(params installer.PostStepReplyParams, ctx context.Context, log logrus.FieldLogger, h *models.Host) error {
-	statusInfo := fmt.Sprintf("%s - %s", string(models.HostStageFailed),
-		"Cannot read from the media (ISO) - media was likely disconnected")
+	statusInfo := fmt.Sprintf("%s - %s", string(models.HostStageFailed), mediaDisconnectionMessage)
 
 	// Install command reports its status with a different API, directly from the assisted-installer.
 	// Just adding our diagnose to the existing error message.
@@ -3114,7 +3114,11 @@ func handleReplyByType(params installer.PostStepReplyParams, b *bareMetalInvento
 	return err
 }
 
-func logReplyReceived(params installer.PostStepReplyParams, log logrus.FieldLogger) {
+func logReplyReceived(params installer.PostStepReplyParams, log logrus.FieldLogger, host *common.Host) {
+	if !shouldStepReplyBeLogged(params, host) {
+		return
+	}
+
 	message := fmt.Sprintf("Received step reply <%s> from cluster <%s> host <%s> exit-code <%d> stderr <%s>",
 		params.Reply.StepID, params.ClusterID, params.HostID, params.Reply.ExitCode, params.Reply.Error)
 	messageWithOutput := fmt.Sprintf("%s stdout <%s>", message, params.Reply.Output)
@@ -3129,6 +3133,17 @@ func logReplyReceived(params installer.PostStepReplyParams, log logrus.FieldLogg
 	} else {
 		log.Info(messageWithOutput)
 	}
+}
+
+func shouldStepReplyBeLogged(params installer.PostStepReplyParams, host *common.Host) bool {
+	// Host with a disconnected ISO device is unstable and all the steps should be failed
+	// Currently the assisted-service logs are full with the media disconnection errors.
+	// Here we are filtering these errors and log the message once per host.
+	// TODO: Create a new state "unstable" in the state machine with no commands.
+	// TODO: Maybe we should collect the logs even in this state.
+	notFirstMediaDisconnectionFailure := *host.Status == models.HostStatusError && host.StatusInfo != nil &&
+		strings.Contains(*host.StatusInfo, mediaDisconnectionMessage)
+	return !(params.Reply.ExitCode == MediaDisconnected && notFirstMediaDisconnectionFailure)
 }
 
 func filterReplyByType(params installer.PostStepReplyParams) (string, error) {


### PR DESCRIPTION
# Description
When a media (ISO device) disconnection event has occurred, the host is unstable, and every command should fail.
The agent checks the device before every command and return a reply with the errorCode  "256" which indicates to the service that media disconnection event  has occurred.
The service changes the host status to "error", log the error message, and append the error message to the StatusInfo.
Our state machine keep send commands to the failed host and all those command failed (Virtual media disconnection requires a reboot) and the assist service logs are full with the message "cannot access the media (ISO)".
After this PR the service should log this message only once per host.
This is a short term solution and in the next version we should change the state machine and stop sending commands to an "unstable  hosts" or allow commands to run in this stage (for example we should collect the logs even after this failure) https://issues.redhat.com/browse/MGMT-7072

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
