### PR TITLE
OCPBUGSM-30214: add controller for AgentClusterInstall

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -481,6 +481,12 @@ func main() {
 				Scheme: ctrlMgr.GetScheme(),
 			}).SetupWithManager(ctrlMgr), "unable to create controller BMH")
 
+			failOnError((&controllers.AgentClusterInstallReconciler{
+				Client:           ctrlMgr.GetClient(),
+				Log:              log,
+				CRDEventsHandler: crdEventsHandler,
+			}).SetupWithManager(ctrlMgr), "unable to create controller AgentClusterInstall")
+
 			log.Info("waiting for REST api readiness before starting controllers")
 			apiEnabler.WaitForEnabled()
 

--- a/internal/controller/controllers/agentclusterinstall_controller.go
+++ b/internal/controller/controllers/agentclusterinstall_controller.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openshift/assisted-service/internal/common"
+	hiveext "github.com/openshift/assisted-service/internal/controller/api/hiveextension/v1beta1"
+	logutil "github.com/openshift/assisted-service/pkg/log"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// AgentClusterInstallReconciler reconciles a AgentClusterInstall object
+type AgentClusterInstallReconciler struct {
+	client.Client
+	Log              logrus.FieldLogger
+	CRDEventsHandler CRDEventsHandler
+}
+
+// +kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=agentclusterinstalls,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=extensions.hive.openshift.io,resources=agentclusterinstalls/status,verbs=get;update;patch
+
+func (r *AgentClusterInstallReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx := addRequestIdIfNeeded(origCtx)
+	log := logutil.FromContext(ctx, r.Log).WithFields(
+		logrus.Fields{
+			"agent_cluster_install":           req.Name,
+			"agent_cluster_install_namespace": req.Namespace,
+		})
+
+	defer func() {
+		log.Info("AgentClusterInstall Reconcile ended")
+	}()
+
+	log.Info("AgentClusterInstall Reconcile started")
+
+	// Retrieve AgentClusterInstall
+	clusterInstall := &hiveext.AgentClusterInstall{}
+	if err := r.Get(ctx, req.NamespacedName, clusterInstall); err != nil {
+		log.WithError(err).Errorf("Failed to get resource %s", req.NamespacedName)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Retrieve ClusterDeployment
+	clusterDeploymentKubeKey := types.NamespacedName{
+		Namespace: clusterInstall.Namespace,
+		Name:      clusterInstall.Spec.ClusterDeploymentRef.Name,
+	}
+	clusterDeployment := &hivev1.ClusterDeployment{}
+	if err := r.Get(ctx, clusterDeploymentKubeKey, clusterDeployment); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			log.WithError(err).Error(fmt.Sprintf(
+				"failed to get ClusterDeployment with name '%s' in namespace '%s'",
+				clusterDeploymentKubeKey.Name, clusterDeploymentKubeKey.Namespace))
+			return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
+		}
+
+		apiErr := errors.New(fmt.Sprintf(
+			"ClusterDeployment with name '%s' in namespace '%s' not found. Ensure that the CRD is already applied.",
+			clusterDeploymentKubeKey.Name, clusterDeploymentKubeKey.Namespace))
+		err = common.NewApiError(http.StatusBadRequest, apiErr)
+		log.Error(err)
+
+		// Set conditions
+		clusterSpecSynced(clusterInstall, err)
+		setClusterConditionsUnknown(clusterInstall)
+
+		if updateErr := r.Status().Update(ctx, clusterInstall); updateErr != nil {
+			log.WithError(updateErr).Error("failed to update AgentClusterInstall Status")
+			return ctrl.Result{Requeue: true}, nil
+		}
+	}
+
+	log.Info("AgentClusterInstall Reconcile successfully retrieved the associated ClusterDeployment")
+	return ctrl.Result{}, nil
+}
+
+func (r *AgentClusterInstallReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&hiveext.AgentClusterInstall{}).
+		Watches(&source.Kind{Type: &hiveext.AgentClusterInstall{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}

--- a/internal/controller/controllers/agentclusterinstall_controller_test.go
+++ b/internal/controller/controllers/agentclusterinstall_controller_test.go
@@ -1,0 +1,98 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	hiveext "github.com/openshift/assisted-service/internal/controller/api/hiveextension/v1beta1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newAgentClusterInstallRequest(agentClusterInstall *hiveext.AgentClusterInstall) ctrl.Request {
+	namespacedName := types.NamespacedName{
+		Namespace: agentClusterInstall.Namespace,
+		Name:      agentClusterInstall.Name,
+	}
+	return ctrl.Request{NamespacedName: namespacedName}
+}
+
+var _ = Describe("AgentClusterInstall reconcile", func() {
+	var (
+		c                              client.Client
+		ir                             *AgentClusterInstallReconciler
+		mockCtrl                       *gomock.Controller
+		ctx                            = context.Background()
+		clusterName                    = "test-cluster"
+		agentClusterInstallName        = "test-cluster-aci"
+		pullSecretName                 = "pull-secret"
+		defaultClusterSpec             hivev1.ClusterDeploymentSpec
+		defaultAgentClusterInstallSpec hiveext.AgentClusterInstallSpec
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		mockCtrl = gomock.NewController(GinkgoT())
+		ir = &AgentClusterInstallReconciler{
+			Client: c,
+			Log:    common.GetTestLog(),
+		}
+
+		defaultClusterSpec = getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName)
+		defaultAgentClusterInstallSpec = getDefaultAgentClusterInstallSpec(clusterName)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	getTestClusterInstall := func() *hiveext.AgentClusterInstall {
+		clusterInstall := &hiveext.AgentClusterInstall{}
+		Expect(c.Get(ctx,
+			types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      agentClusterInstallName,
+			},
+			clusterInstall)).To(BeNil())
+		return clusterInstall
+	}
+
+	It("create AgentClusterInstall - success", func() {
+		clusterDeployment := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+		Expect(c.Create(ctx, clusterDeployment)).ShouldNot(HaveOccurred())
+		aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, clusterDeployment)
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		result, err := ir.Reconcile(ctx, newAgentClusterInstallRequest(aci))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
+	})
+
+	It("create AgentClusterInstall - missing ClusterDeployment", func() {
+		clusterDeployment := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+		aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, clusterDeployment)
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		result, err := ir.Reconcile(ctx, newAgentClusterInstallRequest(aci))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		aci = getTestClusterInstall()
+		Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterInputErrorReason))
+		Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
+		Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Message).To(ContainSubstring(
+			fmt.Sprintf("ClusterDeployment with name '%s' in namespace '%s' not found", clusterDeployment.Name, clusterDeployment.Namespace)))
+
+		Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Reason).To(Equal(hiveext.ClusterNotAvailableReason))
+		Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Status).To(Equal(corev1.ConditionUnknown))
+	})
+})


### PR DESCRIPTION
# Description

Added AgentClusterInstallReconciler for watching the CRD
and set sync condition in case of a missing ClusterDeployment.

If the specified ClusterDeployment is missing the following message should be set for SpecSynced condition:
"The Spec could not be synced due to an input error: ClusterDeployment with name <name> in namespace <namespace> not found. Ensure that the CRD is already applied."

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

* Apply an AgentClusterInstall CRD, without creating the correlated ClusterDeployment CRD.
* Status.Conditions should include the following condition:
```
     Message:               The Spec could not be synced due to an input error: ClusterDeployment with name <name> in namespace <namespace> not found. Ensure that the CRD is already applied.
     Reason:                InputError
     Status:                False
     Type:                  SpecSynced
```
* Other conditions should be in status Unknown

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
