### PR TITLE
Bug 1971654: InfraEnv should always requeue on HTTP 409 backend response

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -342,24 +342,26 @@ func (r *InfraEnvReconciler) handleEnsureISOErrors(
 	if currentCondition := conditionsv1.FindStatusCondition(infraEnv.Status.Conditions, aiv1beta1.ImageCreatedCondition); currentCondition != nil {
 		currentReason = currentCondition.Reason
 	}
-	if imageBeingCreated(err) && currentReason != aiv1beta1.ImageCreationErrorReason { // Not an actual error, just an image generation in progress.
-		err = nil
+	if imageBeingCreated(err) {
 		Requeue = true
 		RequeueAfter = defaultRequeueAfterPerRecoverableError
-		log.Infof("Image %s being prepared for cluster %s", infraEnv.Name, infraEnv.ClusterName)
-		conditionsv1.SetStatusConditionNoHeartbeat(&infraEnv.Status.Conditions, conditionsv1.Condition{
-			Type:    aiv1beta1.ImageCreatedCondition,
-			Status:  corev1.ConditionTrue,
-			Reason:  aiv1beta1.ImageCreatedReason,
-			Message: aiv1beta1.ImageStateCreated,
-		})
+		err = nil                                                // clear up the error so it will requeue with RequeueAfter we set
+		if currentReason != aiv1beta1.ImageCreationErrorReason { // Not an actual error, just an image generation in progress.
+			log.Infof("Image %s being prepared for cluster %s", infraEnv.Name, infraEnv.ClusterName)
+			conditionsv1.SetStatusConditionNoHeartbeat(&infraEnv.Status.Conditions, conditionsv1.Condition{
+				Type:    aiv1beta1.ImageCreatedCondition,
+				Status:  corev1.ConditionTrue,
+				Reason:  aiv1beta1.ImageCreatedReason,
+				Message: aiv1beta1.ImageStateCreated,
+			})
+		}
 	} else { // Actual errors
 		log.WithError(err).Error("infraEnv reconcile failed")
-		if isClientError(err) {
+		if isClientError(err) { // errors it can't recover from
 			Requeue = false
 			errMsg = ": " + err.Error()
 			err = nil // clear the error, to avoid requeue.
-		} else {
+		} else { // errors it may recover from
 			Requeue = true
 			RequeueAfter = defaultRequeueAfterPerRecoverableError
 			errMsg = ": internal error"

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -295,6 +295,47 @@ var _ = Describe("infraEnv reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Status).To(Equal(corev1.ConditionTrue))
 	})
 
+	It("create new image - client failure and retry immediately that results HTTP 409 StatusConflict", func() {
+		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
+		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
+
+		expectedClientError := common.NewApiError(http.StatusBadRequest, errors.New("client error"))
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
+		mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
+				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
+			}).Return(nil, expectedClientError).Times(1)
+		mockInstallerInternal.EXPECT().AddOpenshiftVersion(gomock.Any(), gomock.Any(), gomock.Any()).Return(openshiftVersion, nil).Times(2)
+		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
+			ClusterRef: &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
+		})
+		Expect(c.Create(ctx, infraEnvImage)).To(BeNil())
+
+		res, err := ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{Requeue: false}))
+
+		key := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      "infraEnvImage",
+		}
+
+		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
+		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Reason).To(Equal(aiv1beta1.ImageCreationErrorReason))
+
+		// retry immediately
+
+		expectedConflictError := common.NewApiError(http.StatusConflict, errors.New("Another request to generate an image has been recently submitted. Please wait a few seconds and try again."))
+		mockInstallerInternal.EXPECT().GenerateClusterISOInternal(gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, params installer.GenerateClusterISOParams) {
+				Expect(params.ClusterID).To(Equal(*backEndCluster.ID))
+			}).Return(nil, expectedConflictError).Times(1)
+		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
+
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{Requeue: true, RequeueAfter: defaultRequeueAfterPerRecoverableError}))
+	})
+
 	It("create new image - client failure", func() {
 		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())


### PR DESCRIPTION

InfraEnv controller should always requeue for backend response
HTTP StatusConflict (code 409).

The InfraEnv controller is expected to get HTTP StatusConflict (code 409)
from the backend for requests sent in a gap smaller than 10 seconds[1].

The backend generates that response without looking at the Generate ISO
request content (which may either be valid or not). The image should always
be on par with the spec. For that, each request must be served by the backend.

Currently, the controller will not requeue in a case of 409,
if the conditions indicate an error[2].

This PR modifies the InfraEnv controller to always requeue per 409, and set
RequeueAfter to 20 seconds to avoid repeated 409s.

Conflicts:
      internal/controller/controllers/infraenv_controller.go

[1] https://github.com/openshift/assisted-service/blob/5904203764b98b484b5e53b382c106939118f6fd/internal/bminventory/inventory.go#L912-L923
[2] https://github.com/openshift/assisted-service/blob/5904203764b98b484b5e53b382c106939118f6fd/internal/controller/controllers/infraenv_controller.go#L345-L348

(cherry picked from commit ee3da07fb0c0ee6c8ef952db870a3b64ebb26e35)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @filanov
/cc @rollandf 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
