### PR TITLE
Bug 1968423: Document kube api teardown process

### DIFF
--- a/docs/Kube-API.md
+++ b/docs/Kube-API.md
@@ -292,3 +292,20 @@ spec:
 If manifests provided in configmap data section will be in bad format or configmap will not exists but will be referenced
 we will set error in Sync condition only if cluster will be ready for installation. Changing configmap should fix the issue.
 
+## Teardown procedure
+
+Deleting the ClusterDeployment will automatically trigger the deletion of its referenced AgentClusterInstall and the deletion of all the Agents connected to it.
+Note that the installed OCP cluster, if exists, will not be affected by the deletion of the ClusterDeployment.
+
+Deleting only the AgentClusterInstall will delete the Agents connected to it, but the ClusterDeployment will remain.
+
+BareMetalHost, InfraEnv, ClusterImageSet and NMStateConfig deletion will not trigger deletion of other resources.
+
+
+In case that the assisted-service is not available, the deletion of ClusterDeployment, AgentClusterInstall and Agents resources will be blocked due to finalizers that are set on them.
+
+Here an example on how to remove finalizers on a resource:
+
+```bash
+kubectl -n assisted-installer patch agentclusterinstalls.extensions.hive.openshift.io my-aci -p '{"metadata":{"finalizers":null}}' --type=merge
+```


### PR DESCRIPTION
# Description

- Explain how to delete the CD, ACI and Agents CR
- If assisted-service is down, explain how to clean finalizers on CRs

Signed-off-by: Fred Rolland <frolland@redhat.com>

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @nmagnezi 
/cc @danielerez 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
