### PR TITLE
MGMT-4540: Support schedulable masters cluster property

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -329,6 +329,9 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 	if params.NewClusterParams.Hyperthreading == nil {
 		params.NewClusterParams.Hyperthreading = swag.String(models.ClusterHyperthreadingAll)
 	}
+	if params.NewClusterParams.SchedulableMasters == nil {
+		params.NewClusterParams.SchedulableMasters = swag.Bool(false)
+	}
 
 	return params
 }
@@ -464,6 +467,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			MonitoredOperators:       monitoredOperators,
 			HighAvailabilityMode:     params.NewClusterParams.HighAvailabilityMode,
 			Hyperthreading:           swag.StringValue(params.NewClusterParams.Hyperthreading),
+			SchedulableMasters:       params.NewClusterParams.SchedulableMasters,
 		},
 		KubeKeyName:             kubeKey.Name,
 		KubeKeyNamespace:        kubeKey.Namespace,
@@ -1967,6 +1971,9 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 			log.Error(msg)
 			return common.NewApiError(http.StatusBadRequest, errors.Errorf(msg))
 		}
+	}
+	if params.ClusterUpdateParams.SchedulableMasters != nil {
+		updates["schedulable_masters"] = swag.BoolValue(params.ClusterUpdateParams.SchedulableMasters)
 	}
 	if len(updates) > 0 {
 		updates["trigger_monitor_timestamp"] = time.Now()

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1063,6 +1063,12 @@ func (m *Manager) GenerateAdditionalManifests(ctx context.Context, cluster *comm
 		return errors.Wrap(err, "failed to add telemeter manifest")
 	}
 
+	if common.AreMastersSchedulable(cluster) {
+		if err := m.manifestsGeneratorAPI.AddSchedulableMastersManifest(ctx, log, cluster); err != nil {
+			return errors.Wrap(err, "failed to add schedulable masters manifest")
+		}
+	}
+
 	return nil
 }
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -88,6 +88,10 @@ func IsSingleNodeCluster(cluster *Cluster) bool {
 	return swag.StringValue(cluster.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone
 }
 
+func AreMastersSchedulable(cluster *Cluster) bool {
+	return swag.BoolValue(cluster.SchedulableMasters)
+}
+
 func GetConsoleUrl(clusterName, baseDomain string) string {
 	return fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, clusterName, baseDomain)
 }

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -24,6 +24,7 @@ type ManifestsGeneratorAPI interface {
 	AddChronyManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
 	AddDnsmasqForSingleNode(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
 	AddTelemeterManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
+	AddSchedulableMastersManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error
 }
 
 type Config struct {
@@ -157,6 +158,18 @@ spec:
             WantedBy=multi-user.target
 `
 
+const schedulableMastersManifest = `
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+  mastersSchedulable: true
+  policy:
+    name: ""
+status: {}
+`
+
 func createChronyManifestContent(c *common.Cluster, role models.HostRole, log logrus.FieldLogger) ([]byte, error) {
 	sources := make([]string, 0)
 
@@ -211,6 +224,16 @@ func (m *ManifestsGenerator) AddChronyManifest(ctx context.Context, log logrus.F
 		}
 	}
 
+	return nil
+}
+
+func (m *ManifestsGenerator) AddSchedulableMastersManifest(ctx context.Context, log logrus.FieldLogger, cluster *common.Cluster) error {
+	content := []byte(schedulableMastersManifest)
+	schedulableMastersManifestFile := "50-schedulable_masters.yaml"
+	err := m.createManifests(ctx, cluster, schedulableMastersManifestFile, content)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/network/mock_manifests_generator.go
+++ b/internal/network/mock_manifests_generator.go
@@ -76,3 +76,17 @@ func (mr *MockManifestsGeneratorAPIMockRecorder) AddTelemeterManifest(ctx, log, 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTelemeterManifest", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddTelemeterManifest), ctx, log, c)
 }
+
+// AddSchedulableMastersManifest mocks base method
+func (m *MockManifestsGeneratorAPI) AddSchedulableMastersManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddSchedulableMastersManifest", ctx, log, c)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddSchedulableMastersManifest indicates an expected call of AddSchedulableMastersManifest
+func (mr *MockManifestsGeneratorAPIMockRecorder) AddSchedulableMastersManifest(ctx, log, c interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSchedulableMastersManifest", reflect.TypeOf((*MockManifestsGeneratorAPI)(nil).AddSchedulableMastersManifest), ctx, log, c)
+}

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -177,6 +177,9 @@ type Cluster struct {
 	// hosts associated to this cluster that are in 'known' state.
 	ReadyHostCount int64 `json:"ready_host_count,omitempty" gorm:"-"`
 
+	// Schedule workloads on masters
+	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -86,6 +86,9 @@ type ClusterCreateParams struct {
 	// Required: true
 	PullSecret *string `json:"pull_secret"`
 
+	// Schedule workloads on masters
+	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr *string `json:"service_network_cidr,omitempty"`

--- a/models/cluster_update_params.go
+++ b/models/cluster_update_params.go
@@ -94,6 +94,9 @@ type ClusterUpdateParams struct {
 	// The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.
 	PullSecret *string `json:"pull_secret,omitempty"`
 
+	// Schedule workloads on masters
+	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr *string `json:"service_network_cidr,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5169,6 +5169,11 @@ func init() {
           "format": "int64",
           "x-go-custom-tag": "gorm:\"-\""
         },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
+        },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
           "type": "string",
@@ -5342,6 +5347,11 @@ func init() {
         "pull_secret": {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.",
           "type": "string"
+        },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -5611,6 +5621,11 @@ func init() {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.",
           "type": "string",
           "x-nullable": true
+        },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -13171,6 +13186,11 @@ func init() {
           "format": "int64",
           "x-go-custom-tag": "gorm:\"-\""
         },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
+        },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
           "type": "string",
@@ -13344,6 +13364,11 @@ func init() {
         "pull_secret": {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.",
           "type": "string"
+        },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -13573,6 +13598,11 @@ func init() {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at cloud.redhat.com/openshift/install/pull-secret.",
           "type": "string",
           "x-nullable": true
+        },
+        "schedulable_masters": {
+          "description": "Schedule workloads on masters",
+          "type": "boolean",
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3951,6 +3951,10 @@ definitions:
         description: "The desired network type used."
         enum: ['OpenShiftSDN', 'OVNKubernetes', 'auto-assign']
         default: 'auto-assign'
+      schedulable_masters:
+        type: boolean
+        description: Schedule workloads on masters
+        default: false
 
   cluster-update-params:
     type: object
@@ -4101,6 +4105,10 @@ definitions:
         description: The desired network type used.
         enum: ['OpenShiftSDN', 'OVNKubernetes', 'auto-assign']
         x-nullable: true
+      schedulable_masters:
+        type: boolean
+        description: Schedule workloads on masters
+        default: false
 
   add-hosts-cluster-create-params:
     type: object
@@ -4272,6 +4280,10 @@ definitions:
         format: int64
         description: All hosts associated to this cluster.
         x-go-custom-tag: gorm:"-"
+      schedulable_masters:
+        type: boolean
+        description: Schedule workloads on masters
+        default: false
 
       updated_at:
         type: string


### PR DESCRIPTION
# Description

Allow the scheduling of workloads on masters at installation time. This will make the installations with 3 masters and 1 worker nodes possible.

The implementation adds a new boolean cluster property ("schedulable_masters") which is disabled by default if not specified at cluster creation time.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? No
- Is this PR relying on CI for an e2e test run? No
- Should this PR be tested in a specific environment? No
- Any logs, screenshots, etc that can help with the review process? No, but can be provided if needed

# Assignees

/cc @YuviGold 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
