### PR TITLE
BUG 1970063: Don't force ca-bundle.crt when mirroring

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -220,9 +220,9 @@ oc rollout restart deployment/assisted-service
 
 ### Mirror Registry Configuration
 
-A ConfigMap can be used to configure assisted service to create installations using a mirror registry. The ConfigMap contains two keys:
+A ConfigMap can be used to configure assisted service to create installations using mirrored content. The ConfigMap contains two keys:
 
-- *ca-bundle.crt* - This key contains the contents of the certificate for accessing the mirror registry. It may be a certificate bundle and is defined as a single string.
+- *ca-bundle.crt* - This key contains the contents of the certificate for accessing the mirror registry, if necessary. It may be a certificate bundle and is defined as a single string.
 - *registries.conf* - This key contains the contents of the registries.conf file that configures mappings to the mirror registry.
 
 The mirror registry configuration changes the discovery image's ignition config, with *ca-bundle.crt* written out to */etc/pki/ca-trust/source/anchors/domain.crt* and with *registries.conf* written out to */etc/containers/registries.conf*. The configuration also changes the *install-config.yaml* file used to install a new cluster, with the contents of *ca-bundle.crt* added to *additionalTrustBundle* and with the registries defined *registries.conf* added to *imageContentSources* as mirrors.

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -26,8 +26,7 @@ import (
 const (
 	mirrorRegistryRefCertKey         = "ca-bundle.crt"
 	mirrorRegistryRefRegistryConfKey = "registries.conf"
-	mirrorRegistryConfVolume         = "mirror-registry-conf"
-	mirrorRegistryCertVolume         = "mirror-registry-ca"
+	mirrorRegistryConfigVolume       = "mirror-registry-config"
 )
 
 func getPullSecret(ctx context.Context, c client.Client, ref *corev1.LocalObjectReference, namespace string) (string, error) {


### PR DESCRIPTION
# Description

We shouldn't force users to provide a ca-bundle when mirroring content.

Potential Use Cases:
1. Mirror registry has an official CA signed certificate, so no need for additional certificate.
2. Mirrored content into a network-unrestricted environment. Need an image mapping via registries.conf but bundle is not required.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I manually tested all of the relevant scenarios that I could think of with respect to the mirror-registry configuration:
1. [User specifies a mirror-registry configmap that doesn't exist](https://github.com/openshift/assisted-service/pull/2081#issuecomment-868933476) - working as expected
2. [User specifies a mirror-registry configmap that is missing the registries.conf](https://github.com/openshift/assisted-service/pull/2081#issuecomment-868933486) - working as expected
3. [User specifies a mirror-registry configmap that is missing the ca-bundle.crt key](https://github.com/openshift/assisted-service/pull/2081#issuecomment-868934713) - this is the new use-case we are trying to support...working as expected
4. [User specifies a mirror-registry configmap that contains both the registries.conf and ca-bundle.crt keys](https://github.com/openshift/assisted-service/pull/2081#issuecomment-868946740) - this is the expected use case...working as expected

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @mkowalski 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change **DOES** require a documentation update (docstring, `docs`, README, etc) **AND** documentation is updated
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
