### PR TITLE
OCPBUGSM-31346: Production logs are spammed on "Found unpreparing host"

### DIFF
--- a/internal/cluster/conditions.go
+++ b/internal/cluster/conditions.go
@@ -47,7 +47,6 @@ func (v *clusterValidator) isUnPreparingHostsExist(c *clusterPreprocessContext) 
 	}
 	for _, h := range c.cluster.Hosts {
 		if !funk.ContainsString(validStates, swag.StringValue(h.Status)) {
-			v.log.Warnf("Found unpreparing host: id %s status %s", h.ID.String(), swag.StringValue(h.Status))
 			return true
 		}
 	}


### PR DESCRIPTION

# Description

- Remove unneeded log message

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? No
- Is this PR relying on CI for an e2e test run? No
- Should this PR be tested in a specific environment? No
- Any logs, screenshots, etc that can help with the review process? No


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @gamli75 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
