### PR TITLE
MGMT-5171: Fix setup-disconnected function if condition lacking a semi-colon

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -11,11 +11,12 @@ source ${__dir}/mirror_utils.sh
 
 function setup_disconnected_parameters() {
     # Some of the variables over here can be sourced from dev-scripts
-    # source common.sh utils.sh
+    # source common.sh
+    # source utils.sh
     # set +x
     # export -f wrap_if_ipv6 ipversion
 
-    if [ "${OPENSHIFT_CI:-false}" = "false" ] then
+    if [ "${OPENSHIFT_CI:-false}" = "false" ]; then
         export ASSISTED_DEPLOYMENT_METHOD="from_community_operators"
     fi
 


### PR DESCRIPTION
# Description

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Operator Managed Deployments

# How was this code tested?

Please, select one or more if needed:

- [x] Manual (Elaborate on how it was tested)

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
