### PR TITLE
MGMT-5171: Support IPv6 networking params on ZTP spoke cluster

### DIFF
--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -12,12 +12,12 @@ spec:
   ingressVIP: ""
   networking:
     clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
+    - cidr: {{ cluster_subnet }}
+      hostPrefix: {{ cluster_host_prefix }}
     machineNetwork:
-    - cidr: 192.168.111.0/24
+    - cidr: {{ external_subnet }}
     serviceNetwork:
-    - 172.30.0.0/16
+    - {{ service_subnet }}
   provisionRequirements:
     controlPlaneAgents: 1
   sshPublicKey: '{{ ssh_public_key }}'

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -19,6 +19,10 @@
     - encoded_username: "{{ lookup('env', 'ENCODED_USERNAME') }}"
     - encoded_password: "{{ lookup('env', 'ENCODED_PASSWORD') }}"
     - address: "{{ lookup('env', 'ADDRESS') }}"
+    - cluster_subnet: "{{ lookup('env', 'CLUSTER_SUBNET') }}"
+    - cluster_host_prefix: "{{ lookup('env', 'CLUSTER_HOST_PREFIX') }}"
+    - external_subnet: "{{ lookup('env', 'EXTERNAL_SUBNET') }}"
+    - service_subnet: "{{ lookup('env', 'SERVICE_SUBNET') }}"
 
   tasks:
   - name: create directory for generated CRDs

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -11,6 +11,10 @@ function print_help() {
 }
 
 function kustomize() {
+  if which kustomize; then
+    return
+  fi
+
   (cd /usr/bin &&
     curl --retry 5 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
       | bash -s -- 3.8.8)


### PR DESCRIPTION
# Description

Instead of maintaing hardcoded values, since in any case the ZTP
workflow is dependant on dev-scripts, we use dev-scripts networking
variables defaults for ZTP workflow.

The networking params includes cluster network cidr, host prefix,
machine network cidr, and service network cidr. All are assigned to
AgentClusterInstall.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Operator Managed Deployments

# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
