### PR TITLE
Bug 1964471: Add AdditionalAgent Reason to condition

### DIFF
--- a/docs/hive-integration/kube-api-conditions.md
+++ b/docs/hive-integration/kube-api-conditions.md
@@ -23,6 +23,7 @@ AgentClusterInstall supported condition types are: `SpecSynced`, `RequirementsMe
 |RequirementsMet|True|ClusterInstallationStopped|The cluster installation stopped|If the cluster has stopped installing ("installed", "error") |
 |RequirementsMet|False|InsufficientAgents|The cluster currently requires `X` agents but only `Y` are ready|If the cluster is ready but we don't have the expected number of ready agents |
 |RequirementsMet|False|UnapprovedAgents|The installation is pending on the approval of `X` agents|If the cluster is ready with the expected number of ready agents, but not all have been approved |
+|RequirementsMet|False|AdditionalAgents|The cluster currently requires exactly `X` agents but have `Y` registered|If the cluster is ready but more agents are registered than the number or required |
 ||||||
 |Completed|True|InstallationCompleted|The installation has completed: "status_info"|If the cluster status is "installed"|
 |Completed|False|InstallationFailed|The installation has failed: "status_info"|If the cluster status is "error"|

--- a/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/internal/controller/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -24,6 +24,8 @@ const (
 	ClusterInsufficientAgentsMsg     string = "The cluster currently requires %d agents but only %d have registered"
 	ClusterUnapprovedAgentsReason    string = "UnapprovedAgents"
 	ClusterUnapprovedAgentsMsg       string = "The installation is pending on the approval of %d agents"
+	ClusterAdditionalAgentsReason    string = "AdditionalAgents"
+	ClusterAdditionalAgentsMsg       string = "The cluster currently requires exactly %d agents but have %d registered"
 
 	ClusterValidatedCondition        string = "Validated"
 	ClusterValidationsOKMsg          string = "The cluster's validations are passing"


### PR DESCRIPTION
# Description
In Kube API, in case that more agents than the required are registered,
the RequirementsMet condition will not be True with AdditionalAgents
reason.
Signed-off-by: Fred Rolland <frolland@redhat.com>

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @danielerez 
/cc @nmagnezi 
/cc @filanov

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
