### PR TITLE
MGMT-7083: Add additional timestamp to trigger monitoring and replace updated-at field with this timestamp for selective monitoring

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -464,8 +464,9 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			HighAvailabilityMode:     params.NewClusterParams.HighAvailabilityMode,
 			Hyperthreading:           swag.StringValue(params.NewClusterParams.Hyperthreading),
 		},
-		KubeKeyName:      kubeKey.Name,
-		KubeKeyNamespace: kubeKey.Namespace,
+		KubeKeyName:             kubeKey.Name,
+		KubeKeyNamespace:        kubeKey.Namespace,
+		TriggerMonitorTimestamp: time.Now(),
 	}
 
 	proxyHash, err := computeClusterProxyHash(params.NewClusterParams.HTTPProxy,
@@ -1966,10 +1967,12 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 			return common.NewApiError(http.StatusBadRequest, errors.Errorf(msg))
 		}
 	}
-
-	dbReply := db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
-	if dbReply.Error != nil {
-		return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "failed to update cluster: %s", params.ClusterID))
+	if len(updates) > 0 {
+		updates["trigger_monitor_timestamp"] = time.Now()
+		dbReply := db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
+		if dbReply.Error != nil {
+			return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "failed to update cluster: %s", params.ClusterID))
+		}
 	}
 
 	return nil

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -147,15 +147,18 @@ var _ = Describe("TestClusterMonitoring", func() {
 	})
 	Context("single cluster monitoring", func() {
 		createCluster := func(id *strfmt.UUID, status, statusInfo string) common.Cluster {
-			cluster := common.Cluster{Cluster: models.Cluster{
-				ID:                 id,
-				Status:             swag.String(status),
-				StatusInfo:         swag.String(statusInfo),
-				MachineNetworkCidr: "1.1.0.0/16",
-				BaseDNSDomain:      "test.com",
-				PullSecretSet:      true,
-				MonitoredOperators: []*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator},
-			}}
+			cluster := common.Cluster{
+				Cluster: models.Cluster{
+					ID:                 id,
+					Status:             swag.String(status),
+					StatusInfo:         swag.String(statusInfo),
+					MachineNetworkCidr: "1.1.0.0/16",
+					BaseDNSDomain:      "test.com",
+					PullSecretSet:      true,
+					MonitoredOperators: []*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator},
+				},
+				TriggerMonitorTimestamp: time.Now(),
+			}
 			Expect(common.LoadTableFromDB(db, common.MonitoredOperatorsTable).Create(&cluster).Error).ShouldNot(HaveOccurred())
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -387,19 +390,22 @@ var _ = Describe("TestClusterMonitoring", func() {
 			Context("from insufficient state", func() {
 				BeforeEach(func() {
 
-					c = common.Cluster{Cluster: models.Cluster{
-						ID:                       &id,
-						Status:                   swag.String("insufficient"),
-						MachineNetworkCidr:       "1.2.3.0/24",
-						APIVip:                   "1.2.3.5",
-						IngressVip:               "1.2.3.6",
-						BaseDNSDomain:            "test.com",
-						PullSecretSet:            true,
-						StatusInfo:               swag.String(StatusInfoInsufficient),
-						ClusterNetworkCidr:       "1.3.0.0/16",
-						ServiceNetworkCidr:       "1.2.5.0/24",
-						ClusterNetworkHostPrefix: 24,
-					}}
+					c = common.Cluster{
+						Cluster: models.Cluster{
+							ID:                       &id,
+							Status:                   swag.String("insufficient"),
+							MachineNetworkCidr:       "1.2.3.0/24",
+							APIVip:                   "1.2.3.5",
+							IngressVip:               "1.2.3.6",
+							BaseDNSDomain:            "test.com",
+							PullSecretSet:            true,
+							StatusInfo:               swag.String(StatusInfoInsufficient),
+							ClusterNetworkCidr:       "1.3.0.0/16",
+							ServiceNetworkCidr:       "1.2.5.0/24",
+							ClusterNetworkHostPrefix: 24,
+						},
+						TriggerMonitorTimestamp: time.Now(),
+					}
 
 					Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
 					Expect(err).ShouldNot(HaveOccurred())
@@ -461,19 +467,22 @@ var _ = Describe("TestClusterMonitoring", func() {
 			})
 			Context("from ready state", func() {
 				BeforeEach(func() {
-					c = common.Cluster{Cluster: models.Cluster{
-						ID:                       &id,
-						Status:                   swag.String(models.ClusterStatusReady),
-						StatusInfo:               swag.String(StatusInfoReady),
-						MachineNetworkCidr:       "1.2.3.0/24",
-						APIVip:                   "1.2.3.5",
-						IngressVip:               "1.2.3.6",
-						BaseDNSDomain:            "test.com",
-						PullSecretSet:            true,
-						ClusterNetworkCidr:       "1.3.0.0/16",
-						ServiceNetworkCidr:       "1.2.5.0/24",
-						ClusterNetworkHostPrefix: 24,
-					}}
+					c = common.Cluster{
+						Cluster: models.Cluster{
+							ID:                       &id,
+							Status:                   swag.String(models.ClusterStatusReady),
+							StatusInfo:               swag.String(StatusInfoReady),
+							MachineNetworkCidr:       "1.2.3.0/24",
+							APIVip:                   "1.2.3.5",
+							IngressVip:               "1.2.3.6",
+							BaseDNSDomain:            "test.com",
+							PullSecretSet:            true,
+							ClusterNetworkCidr:       "1.3.0.0/16",
+							ServiceNetworkCidr:       "1.2.5.0/24",
+							ClusterNetworkHostPrefix: 24,
+						},
+						TriggerMonitorTimestamp: time.Now(),
+					}
 
 					Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
 				})

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -57,6 +57,10 @@ func updateClusterStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.D
 		}
 	}
 
+	if newStatus != srcStatus {
+		extra = append(extra, "trigger_monitor_timestamp", time.Now())
+	}
+
 	if cluster, err = UpdateCluster(log, db, clusterId, srcStatus, extra...); err != nil ||
 		swag.StringValue(cluster.Status) != newStatus {
 		return nil, errors.Wrapf(err, "failed to update cluster %s state from %s to %s",

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -51,6 +51,9 @@ type Cluster struct {
 	// and the generation failed, the value of ImageGenerated will be set to 'false'. In that case, providing the
 	// same request with the same custom parameters will re-attempt to generate the image.
 	ImageGenerated bool `json:"image_generated"`
+
+	// Timestamp to trigger monitor. Monitor will be triggered if timestamp is recent
+	TriggerMonitorTimestamp time.Time
 }
 
 type Event struct {
@@ -68,6 +71,9 @@ type Host struct {
 
 	// Namespace of the KubeAPI resource
 	KubeKeyNamespace string `json:"kube_key_namespace"`
+
+	// Timestamp to trigger monitor. Monitor will be triggered if timestamp is recent
+	TriggerMonitorTimestamp time.Time
 }
 
 type EagerLoadingState bool

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -89,6 +89,7 @@ func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, db
 	if hostutil.IsDay2Host(h) && (h.MachineConfigPoolName == "" || h.MachineConfigPoolName == *srcRole) {
 		extras = append(extras, "machine_config_pool_name", role)
 	}
+	extras = append(extras, "trigger_monitor_timestamp", time.Now())
 
 	_, err := hostutil.UpdateHost(log, db, h.ClusterID, *h.ID, *h.Status, extras...)
 	return err

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1149,58 +1149,6 @@ var _ = Describe("UpdateInventory", func() {
 		})
 	})
 
-	Context("Inventory changes", func() {
-		BeforeEach(func() {
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
-			host.Inventory = common.GenerateTestDefaultInventory()
-			host.InstallationDiskPath = ""
-			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		})
-		It("Invariant changes to inventory", func() {
-			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
-				[]*models.Disk{},
-			).AnyTimes()
-			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
-			updatedAt := h.UpdatedAt
-			var inventory models.Inventory
-			Expect(json.Unmarshal([]byte(h.Inventory), &inventory)).ToNot(HaveOccurred())
-			inventory.Timestamp = 555
-			inventory.Disks[0].Smart = "kuku"
-			b, err := json.Marshal(&inventory)
-			Expect(err).ToNot(HaveOccurred())
-			time.Sleep(time.Second)
-			Expect(hapi.UpdateInventory(ctx, &host, string(b))).ToNot(HaveOccurred())
-			h = hostutil.GetHostFromDB(hostId, clusterId, db)
-			Expect(updatedAt).To(Equal(h.UpdatedAt))
-			Expect(h.Inventory).To(Equal(string(b)))
-		})
-
-		It("Variant changes to inventory", func() {
-			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
-				[]*models.Disk{},
-			).AnyTimes()
-			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
-			updatedAt := h.UpdatedAt
-			var inventory models.Inventory
-			Expect(json.Unmarshal([]byte(h.Inventory), &inventory)).ToNot(HaveOccurred())
-			inventory.Interfaces = append(inventory.Interfaces, &models.Interface{
-				HasCarrier: false,
-				Mtu:        1500,
-				Name:       "abcd",
-			})
-			b, err := json.Marshal(&inventory)
-			Expect(err).ToNot(HaveOccurred())
-			time.Sleep(time.Second)
-			Expect(hapi.UpdateInventory(ctx, &host, string(b))).ToNot(HaveOccurred())
-			h = hostutil.GetHostFromDB(hostId, clusterId, db)
-			Expect(updatedAt).ToNot(Equal(h.UpdatedAt))
-			Expect(h.Inventory).To(Equal(string(b)))
-		})
-	})
-
 	Context("enable host", func() {
 		var newInventoryBytes []byte
 

--- a/internal/host/hostutil/update_host.go
+++ b/internal/host/hostutil/update_host.go
@@ -60,6 +60,7 @@ func UpdateHostStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, 
 
 	if newStatus != srcStatus {
 		extra = append(extra, "status_updated_at", strfmt.DateTime(time.Now()))
+		extra = append(extra, "trigger_monitor_timestamp", time.Now())
 	}
 
 	if host, err = UpdateHost(log, db, clusterId, hostId, srcStatus, extra...); err != nil ||
@@ -93,7 +94,7 @@ func UpdateHost(_ logrus.FieldLogger, db *gorm.DB, clusterId strfmt.UUID, hostId
 
 	// Query by <cluster-id, host-id, status>
 	// Status is required as well to avoid races between different components.
-	dbReply := db.Model(&models.Host{}).Where("id = ? and cluster_id = ? and status = ?",
+	dbReply := db.Model(&common.Host{}).Where("id = ? and cluster_id = ? and status = ?",
 		hostId, clusterId, srcStatus).
 		Updates(updates)
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -70,11 +70,14 @@ func (th *transitionHandler) PostRegisterHost(sw stateswitch.StateSwitch, args s
 			return nil
 		}
 	}
-
 	hostParam.StatusUpdatedAt = strfmt.DateTime(time.Now())
 	hostParam.StatusInfo = swag.String(statusInfoDiscovering)
-	log.Infof("Register new host %s cluster %s", hostParam.ID.String(), hostParam.ClusterID)
-	return params.db.Create(hostParam).Error
+	hostToCreate := &common.Host{
+		Host:                    *hostParam,
+		TriggerMonitorTimestamp: time.Now(),
+	}
+	log.Infof("Register new host %s cluster %s", hostToCreate.ID.String(), hostToCreate.ClusterID)
+	return params.db.Create(hostToCreate).Error
 }
 
 func (th *transitionHandler) PostRegisterDuringInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {


### PR DESCRIPTION
# Description

Longer timeout monitoring is an approach during selective monitoring.  Instead of selecting entities by catching all changes that might cause status change and react accordingly, estimate the time to reach steady state and set it as timeout.  This means that instead of using 30 seconds timeout to react for every change that might cause change (inventory, connectivity etc.), use 5 minute timeout which we estimate as the duration to reach steady state.
The timestamp will be a specially dedicated field for this purpose in the database instead of the updated_at field.
The timestamp will be updated on the following events:

- Cluster registration
- Host registration
- Cluster update
- Status change


The monitoring will be done in the following manner:
Use a timeout of 5 minutes every 10s monitoring interval.
Use a timeout of 15 minutes every minute (no change).
Use a full cycle every 5 minutes (no change).

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @tsorya 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
