### PR TITLE
OCPBUGSM-29100 Set OcpReleaseImage for RegisterAddHostsCluster

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -619,6 +619,7 @@ func (b *bareMetalInventory) RegisterAddHostsClusterInternal(ctx context.Context
 		Kind:             swag.String(models.ClusterKindAddHostsCluster),
 		Name:             clusterName,
 		OpenshiftVersion: *openshiftVersion.ReleaseVersion,
+		OcpReleaseImage:  *openshiftVersion.ReleaseImage,
 		UserName:         ocm.UserNameFromContext(ctx),
 		OrgID:            ocm.OrgIDFromContext(ctx),
 		EmailDomain:      ocm.EmailDomainFromContext(ctx),

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5507,6 +5507,8 @@ var _ = Describe("Register AddHostsCluster test", func() {
 
 		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.ReleaseVersion))
+		Expect(actual.Payload.OcpReleaseImage).To(Equal(common.TestDefaultConfig.ReleaseImage))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewRegisterAddHostsClusterCreated()))
 	})
 

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -39,6 +39,8 @@ var _ = Describe("Day2 cluster tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(swag.StringValue(cluster.GetPayload().Status)).Should(Equal("adding-hosts"))
 		Expect(swag.StringValue(cluster.GetPayload().StatusInfo)).Should(Equal(statusInfoAddingHosts))
+		Expect(swag.StringValue(&cluster.GetPayload().OpenshiftVersion)).Should(ContainSubstring(openshiftVersion))
+		Expect(swag.StringValue(&cluster.GetPayload().OcpReleaseImage)).Should(ContainSubstring(openshiftVersion))
 		Expect(cluster.GetPayload().StatusUpdatedAt).ShouldNot(Equal(strfmt.DateTime(time.Time{})))
 
 		_, err = userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{


### PR DESCRIPTION
# Description

When an AddHosts (Day2) Cluster is created, the ocp_release_image
is not transferred from the original installed cluster. This commit
ensures that ocp_release_image is set using the params'
OpenshiftVersion.

When OcpReleaseImage is missing for the Day2 cluster, the InfraEnv
controller reconcile results in error: "no releaseImage nor
releaseImageMirror provided." And this prevents
InfraEnv.Status.ISODownloadURL from being set and blocks remote
worker nodes from booting into discovery ISO.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @filanov 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
