### PR TITLE
Bug 1974931: infrastructure operator rename

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,25 +2,25 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: assisted-service-operator
+    control-plane: infrastructure-operator
   name: assisted-installer
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: assisted-service-operator
+  name: infrastructure-operator
   namespace: assisted-installer
   labels:
-    control-plane: assisted-service-operator
+    control-plane: infrastructure-operator
 spec:
   selector:
     matchLabels:
-      control-plane: assisted-service-operator
+      control-plane: infrastructure-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: assisted-service-operator
+        control-plane: infrastructure-operator
     spec:
       containers:
       - command:

--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     createdAt: ""
-    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
+    description: The Infrastructure Operator for Red Hat OpenShift is responsible for managing the deployment of the Assisted Service.
     olm.skipRange: '>=0.0.0 <0.0.5'
     operatorframework.io/suggested-namespace: assisted-installer
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
@@ -49,12 +49,14 @@ spec:
       name: nmstateconfigs.agent-install.openshift.io
       version: v1beta1
   description: |-
-    Assisted Service is used to orchestrate baremetal OpenShift installations.
+    The Infrastructure Operator for Red Hat OpenShift is responsible for managing
+    the deployment of the Assisted Service. Assisted Service is used to orchestrate
+    baremetal OpenShift installations.
 
     When creating the AgentServiceConfig CR. It is important to note that the
     controller will only ever reconcile an AgentServiceConfig named "agent".
     No other name will be accepted.
-  displayName: Assisted Service Operator
+  displayName: Infrastructure Operator for Red Hat OpenShift
   icon:
   - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
     mediatype: image/svg+xml

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -45,7 +45,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     createdAt: ""
-    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
+    description: The Infrastructure Operator for Red Hat OpenShift is responsible for managing the deployment of the Assisted Service.
     olm.skipRange: '>=0.0.0 <0.0.5'
     operatorframework.io/suggested-namespace: assisted-installer
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
@@ -91,12 +91,14 @@ spec:
       name: nmstateconfigs.agent-install.openshift.io
       version: v1beta1
   description: |-
-    Assisted Service is used to orchestrate baremetal OpenShift installations.
+    The Infrastructure Operator for Red Hat OpenShift is responsible for managing
+    the deployment of the Assisted Service. Assisted Service is used to orchestrate
+    baremetal OpenShift installations.
 
     When creating the AgentServiceConfig CR. It is important to note that the
     controller will only ever reconcile an AgentServiceConfig named "agent".
     No other name will be accepted.
-  displayName: Assisted Service Operator
+  displayName: Infrastructure Operator for Red Hat OpenShift
   icon:
   - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
     mediatype: image/svg+xml
@@ -407,17 +409,17 @@ spec:
           - watch
         serviceAccountName: assisted-service
       deployments:
-      - name: assisted-service-operator
+      - name: infrastructure-operator
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: assisted-service-operator
+              control-plane: infrastructure-operator
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: assisted-service-operator
+                control-plane: infrastructure-operator
             spec:
               containers:
               - args:

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -65,7 +65,7 @@ operator-sdk run bundle \
   ${BUNDLE_IMAGE:-quay.io/ocpmetal/assisted-service-operator-bundle:latest}
 ```
 
-Now you should see the `assisted-service-operator` deployment running in the
+Now you should see the `infrastructure-operator` deployment running in the
 `assisted-installer` namespace.
 
 **NOTE**
@@ -266,7 +266,7 @@ EOF
 
 **NOTE**
 
-The ConfigMap should be installed in the same namespace as the assisted-service-operator (ie. `assisted-installer`).
+The ConfigMap should be installed in the same namespace as the infrastructure-operator (ie. `assisted-installer`).
 
 Registries defined in the *registries.conf* file should use "mirror-by-digest-only = false" mode.
 


### PR DESCRIPTION
# Description

Manual cherry-pick of #2070 

Moves us more closely in line with the new name "Infrastructure Operator for Red Hat OpenShift".

A manual cherry-pick was required because of the following conflicts:

```diff
diff --cc config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
index 7c828a8e,bb0302bb..00000000
--- a/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/assisted-service-operator.clusterserviceversion.yaml
@@@ -6,8 -6,8 +6,16 @@@ metadata
      capabilities: Basic Install
      categories: OpenShift Optional
      createdAt: ""
++<<<<<<< HEAD
 +    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
 +    olm.skipRange: '>=0.0.0 <0.0.5'
++||||||| parent of d2c0aa43 (Bug 1974501: infrastructure operator rename)
++    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
++    olm.skipRange: '>=0.0.0 <99.0.0'
++=======
+     description: The Infrastructure Operator for Red Hat OpenShift is responsible for managing the deployment of the Assisted Service.
+     olm.skipRange: '>=0.0.0 <99.0.0'
++>>>>>>> d2c0aa43 (Bug 1974501: infrastructure operator rename)
      operatorframework.io/suggested-namespace: assisted-installer
      operators.operatorframework.io/builder: operator-sdk-v1.3.0
      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
diff --cc deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
index a6f2392a,71320c4d..00000000
--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@@ -45,8 -45,8 +45,16 @@@ metadata
      capabilities: Basic Install
      categories: OpenShift Optional
      createdAt: ""
++<<<<<<< HEAD
 +    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
 +    olm.skipRange: '>=0.0.0 <0.0.5'
++||||||| parent of d2c0aa43 (Bug 1974501: infrastructure operator rename)
++    description: Assisted Service is used to orchestrate baremetal OpenShift installations.
++    olm.skipRange: '>=0.0.0 <99.0.0'
++=======
+     description: The Infrastructure Operator for Red Hat OpenShift is responsible for managing the deployment of the Assisted Service.
+     olm.skipRange: '>=0.0.0 <99.0.0'
++>>>>>>> d2c0aa43 (Bug 1974501: infrastructure operator rename)
      operatorframework.io/suggested-namespace: assisted-installer
      operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
      operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
```

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @flaper87 
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change includes documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
