### PR TITLE
NO-ISSUE: add cherrypick bot to reviewers list to allow CI jobs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ filters:
       - approvers
     reviewers:
       - approvers
+      - openshift-cherrypick-robot
   Jenkinsfile:
     approvers:
       - ci-approvers


### PR DESCRIPTION
# Description

This is mainly to kick cherrypicking process with an earlier testing.
Code still needs to be approved and lgtm-ed by one of the other users in reviewers and approvers list, because cherrypick bot is not part of the approvers and lgtm is not fulfilled from self author.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @YuviGold 
/cc @ronniel1 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
