### PR TITLE
Bug 1969391: Fix InfraEnv missing ACI msg formatting

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -248,9 +248,10 @@ func (r *InfraEnvReconciler) ensureISO(ctx context.Context, log logrus.FieldLogg
 			if clusterDeployment.Spec.ClusterInstallRef == nil {
 				msg += "AgentClusterInstall is not defined in ClusterDeployment"
 			} else {
-				msg += fmt.Sprintf("check AgentClusterInstall conditions: %+v",
-					clusterDeployment.Spec.ClusterInstallRef)
+				msg += fmt.Sprintf("check AgentClusterInstall conditions: name %s in namespace %s",
+					clusterDeployment.Spec.ClusterInstallRef.Name, clusterDeployment.Namespace)
 			}
+			log.Errorf(msg)
 			err = errors.Errorf(msg)
 
 			inventoryErr = common.NewApiError(http.StatusNotFound, err)

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -258,8 +258,8 @@ var _ = Describe("infraEnv reconcile", func() {
 			Name:      "infraEnvImage",
 		}
 		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
-		expectedState := fmt.Sprintf("%s: cluster does not exist: %s, check AgentClusterInstall conditions: %+v",
-			aiv1beta1.ImageStateFailedToCreate, clusterDeployment.Name, clusterDeployment.Spec.ClusterInstallRef)
+		expectedState := fmt.Sprintf("%s: cluster does not exist: clusterDeployment, check AgentClusterInstall conditions: name %s in namespace %s",
+			aiv1beta1.ImageStateFailedToCreate, clusterDeployment.Spec.ClusterInstallRef.Name, clusterDeployment.Namespace)
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Message).To(Equal(expectedState))
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Reason).To(Equal(aiv1beta1.ImageCreationErrorReason))
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Status).To(Equal(corev1.ConditionUnknown))


### PR DESCRIPTION
# Description
https://github.com/openshift/assisted-service/pull/2027 added a more precise indication that there is no backend cluster
and directs the user to inspect AgentClusterInstall conditions.

This PR fixes a formatting issue with that msg, which looked as follows:

```yaml
message: 'Failed to create image: cluster does not exist: single-node, check AgentClusterInstall
      conditions: &{Group:extensions.hive.openshift.io Version:v1beta1 Kind:AgentClusterInstall
      Name:test-agent-cluster-install}'
```

With this change:
```yaml
message: 'Failed to create image: cluster does not exist: single-node, check AgentClusterInstall
      conditions: name test-agent-cluster-install in namespace assisted-installer'
```
# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @RazRegev 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [x] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
