### PR TITLE
Bug 1966586: 200 OK returned when setting invalid BaseDNSdomain via API

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -192,14 +192,14 @@ func (h *handler) GetDNSDomain(clusterName, baseDNSDomainName string) (*DNSDomai
 	}, nil
 }
 
-//ValidateDNSName checks if a combination of cluster name and base DNS domain
+// ValidateDNSName checks baseDNSDomainName and the combination of cluster name and base DNS domain
 // leaves enough room for automatically added domain names,
 // e.g. "alertmanager-main-openshift-monitoring.apps.test-infra-cluster-assisted-installer.example.com").
 // The max total length of a domain name is 255 bytes, including the dots. An individual label can be
 // up to 63 bytes. A single char may occupy more than one byte in Internationalized Domain Names (IDNs).
 func (h *handler) ValidateDNSName(clusterName, baseDNSDomainName string) error {
 	appsDomainNameSuffix := fmt.Sprintf(appsDomainNameFormat, clusterName, baseDNSDomainName)
-	if err := validations.ValidateDomainNameFormat(appsDomainNameSuffix); err != nil {
+	if err := validations.ValidateDomainNameFormat(baseDNSDomainName); err != nil {
 		return err
 	}
 	if len(appsDomainNameSuffix) > dnsDomainPrefixMaxLen {


### PR DESCRIPTION
# Description

Updated `ValidateDNSName`.                                                                 
The function was validating against `apps.<clusterName>.<baseDNSDomain>` .
This is why via the API `baseDNSDomain=example` is responding with 200. because it actually validates `apps.<cluster_name>.example`.

The update adds a validation on the baseDNS itself in addition to the validations we already have.

Updated subsytem tests to ensure validation

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
