### PR TITLE
OCPBUGSM-29517: use UsableBytes instead of PhysicalBytes

### DIFF
--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -251,7 +251,7 @@ func GenerateInventoryWithResourcesAndMultipleDisk(cpu, memory int64, hostname s
 	return string(b)
 }
 
-func GenerateInventoryWithResourcesWithBytes(cpu, memory int64, hostname string) string {
+func GenerateInventoryWithResourcesWithBytes(cpu, physicalMemory int64, usableMemory int64, hostname string) string {
 	inventory := models.Inventory{
 		CPU: &models.CPU{Count: cpu, Flags: []string{"vmx"}},
 		Disks: []*models.Disk{
@@ -268,7 +268,7 @@ func GenerateInventoryWithResourcesWithBytes(cpu, memory int64, hostname string)
 				},
 			},
 		},
-		Memory:       &models.Memory{PhysicalBytes: memory, UsableBytes: memory},
+		Memory:       &models.Memory{PhysicalBytes: physicalMemory, UsableBytes: usableMemory},
 		Hostname:     hostname,
 		SystemVendor: &models.SystemVendor{Manufacturer: "Red Hat", ProductName: "RHEL", SerialNumber: "3534"},
 		Timestamp:    1601835002,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1689,7 +1689,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient worker memory",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(4, 104857600, "worker"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(4, conversions.MibToBytes(150), conversions.MibToBytes(100), "worker"),
 				role:          models.HostRoleWorker,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,
@@ -1720,7 +1720,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient master memory",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(8, 104857600, "master"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(8, conversions.MibToBytes(150), conversions.MibToBytes(100), "master"),
 				role:          models.HostRoleMaster,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,
@@ -1751,7 +1751,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient worker cpu",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(16), "worker"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(16), conversions.GibToBytes(16), "worker"),
 				role:          models.HostRoleWorker,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,
@@ -1782,7 +1782,7 @@ var _ = Describe("Refresh Host", func() {
 			{
 				name:          "insufficient master cpu",
 				hostID:        strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d"),
-				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(17), "master"),
+				inventory:     hostutil.GenerateInventoryWithResourcesWithBytes(1, conversions.GibToBytes(17), conversions.GibToBytes(17), "master"),
 				role:          models.HostRoleMaster,
 				srcState:      models.HostStatusDiscovering,
 				dstState:      models.HostStatusInsufficient,
@@ -3899,7 +3899,7 @@ var _ = Describe("Refresh Host", func() {
 			cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
-			host.Inventory = hostutil.GenerateInventoryWithResourcesWithBytes(4, conversions.GibToBytes(16), "master")
+			host.Inventory = hostutil.GenerateInventoryWithResourcesWithBytes(4, conversions.GibToBytes(16), conversions.GibToBytes(16), "master")
 			host.Role = models.HostRoleMaster
 			host.NtpSources = string(defaultNTPSourcesInBytes)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -357,7 +357,7 @@ func (v *validator) printHasMemoryForRole(c *validationContext, status Validatio
 		return fmt.Sprintf("Sufficient RAM for role %s", c.host.Role)
 	case ValidationFailure:
 		return fmt.Sprintf("Require at least %s RAM for role %s, found only %s",
-			conversions.BytesToString(conversions.MibToBytes(c.clusterHostRequirements.Total.RAMMib)), c.host.Role, conversions.BytesToString(c.inventory.Memory.PhysicalBytes))
+			conversions.BytesToString(conversions.MibToBytes(c.clusterHostRequirements.Total.RAMMib)), c.host.Role, conversions.BytesToString(c.inventory.Memory.UsableBytes))
 	case ValidationPending:
 		return "Missing inventory or role"
 	default:


### PR DESCRIPTION
# Description

As discussed in the bug ticket,
Our memory requirements for nodes actually depend on free memory rather than the
actual physical memory.

Updated  backed error message to use
`UsableBytes` instead of `PhysicalBytes` to indicate to the user the actual memory inventory issue.

Updated `insufficient worker memory` and `insufficient master memory` tests
to validate against UsableBytes.

# What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


# How was this code tested?

Please, select one or more if needed:

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?


# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
