### PR TITLE
MGMT-7082: Spoke namespace should be different than assisted-service namespace

### DIFF
--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -3,6 +3,7 @@
 set -xeo pipefail
 
 ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
+SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
 HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
 
 function gather_hive_data() {
@@ -28,7 +29,7 @@ function gather_operator_data() {
 }
 
 function gather_agentclusterinstall_data() {
-  readarray -t agentclusterinstall_objects < <(oc get agentclusterinstall -A -o json | jq -c '.items[]')
+  readarray -t agentclusterinstall_objects < <(oc get agentclusterinstall -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
   for agentclusterinstall in "${agentclusterinstall_objects[@]}"; do
     agentclusterinstall_name=$(echo ${agentclusterinstall} | jq -r .metadata.name)
     agentclusterinstall_namespace=$(echo ${agentclusterinstall} | jq -r .metadata.namespace)
@@ -54,10 +55,10 @@ function gather_bmh_data() {
   bmh_dir="${LOGS_DEST}/baremetalhosts"
   mkdir -p "${bmh_dir}"
 
-  readarray -t bmh_objects < <(oc get baremetalhost -n assisted-installer -o json | jq -c '.items[]')
+  readarray -t bmh_objects < <(oc get baremetalhost -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
   for bmh in "${bmh_objects[@]}"; do
     host_name=$(echo ${bmh} | jq -r .metadata.name)
-    oc get baremetalhost -n assisted-installer "${host_name}" -o yaml > "${bmh_dir}/${host_name}.yaml"
+    oc get baremetalhost -n "${SPOKE_NAMESPACE}" "${host_name}" -o yaml > "${bmh_dir}/${host_name}.yaml"
   done
 }
 
@@ -65,10 +66,10 @@ function gather_infraenv_data() {
   infraenv_dir="${LOGS_DEST}/infraenvs"
   mkdir -p "${infraenv_dir}"
 
-  readarray -t infraenv_objects < <(oc get infraenv -n assisted-installer -o json | jq -c '.items[]')
+  readarray -t infraenv_objects < <(oc get infraenv -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
   for infraenv in "${infraenv_objects[@]}"; do
     infraenv_name=$(echo ${infraenv} | jq -r .metadata.name)
-    oc get infraenv -n assisted-installer "${infraenv_name}" -o yaml > "${infraenv_dir}/${infraenv_name}.yaml"
+    oc get infraenv -n "${SPOKE_NAMESPACE}" "${infraenv_name}" -o yaml > "${infraenv_dir}/${infraenv_name}.yaml"
   done
 }
 
@@ -76,10 +77,10 @@ function gather_agent_data() {
   agent_dir="${LOGS_DEST}/agents"
   mkdir -p "${agent_dir}"
 
-  readarray -t agent_objects < <(oc get agents.agent-install.openshift.io -n assisted-installer -o json | jq -c '.items[]')
+  readarray -t agent_objects < <(oc get agents.agent-install.openshift.io -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
   for agent in "${agent_objects[@]}"; do
     agent_name=$(echo ${agent} | jq -r .metadata.name)
-    oc get agents.agent-install.openshift.io -n assisted-installer "${agent_name}" -o yaml > "${agent_dir}/${agent_name}.yaml"
+    oc get agents.agent-install.openshift.io -n "${SPOKE_NAMESPACE}" "${agent_name}" -o yaml > "${agent_dir}/${agent_name}.yaml"
   done
 }
 
@@ -87,10 +88,10 @@ function gather_clusterdeployment_data() {
   cd_dir="${LOGS_DEST}/clusterdeployment"
   mkdir -p "${cd_dir}"
 
-  readarray -t cd_objects < <(oc get clusterdeployments.hive.openshift.io -n assisted-installer -o json | jq -c '.items[]')
+  readarray -t cd_objects < <(oc get clusterdeployments.hive.openshift.io -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
   for cd in "${cd_objects[@]}"; do
     cd_name=$(echo ${cd} | jq -r .metadata.name)
-    oc get clusterdeployments.hive.openshift.io -n assisted-installer "${cd_name}" -o yaml > "${cd_dir}/${cd_name}.yaml"
+    oc get clusterdeployments.hive.openshift.io -n "${SPOKE_NAMESPACE}" "${cd_name}" -o yaml > "${cd_dir}/${cd_name}.yaml"
   done
 }
 

--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -2,7 +2,7 @@ apiVersion: extensions.hive.openshift.io/v1beta1
 kind: AgentClusterInstall
 metadata:
   name: '{{ agent_cluster_install_name }}'
-  namespace: '{{ assisted_namespace }}'
+  namespace: '{{ spoke_namespace }}'
 spec:
   clusterDeploymentRef:
     name: '{{ cluster_deployment_name }}'

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -4,7 +4,7 @@
    - community.general
   gather_facts: no
   vars:
-    - assisted_namespace: "{{ lookup('env', 'ASSISTED_NAMESPACE') }}"
+    - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
     - cluster_name: "{{ lookup('env', 'ASSISTED_CLUSTER_NAME') }}"
     - cluster_image_set_name: "{{ lookup('env', 'ASSISTED_OPENSHIFT_VERSION') }}"
     - cluster_release_image: "{{ lookup('env', 'ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE') }}"

--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: '{{ bmh_name }}-bmc-secret'
-  namespace: '{{ assisted_namespace }}'
+  namespace: '{{ spoke_namespace }}'
 type: Opaque
 data:
   username: '{{ encoded_username }}'
@@ -14,7 +14,7 @@ apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
   name: '{{ bmh_name }}'
-  namespace: '{{ assisted_namespace }}'
+  namespace: '{{ spoke_namespace }}'
   labels:
     infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
 spec:

--- a/deploy/operator/ztp/clusterDeployment.j2
+++ b/deploy/operator/ztp/clusterDeployment.j2
@@ -2,7 +2,7 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterDeployment
 metadata:
   name: '{{ cluster_deployment_name }}'
-  namespace: '{{ assisted_namespace }}'
+  namespace: '{{ spoke_namespace }}'
 spec:
   baseDomain: redhat.com
   clusterName: '{{ cluster_name }}'
@@ -18,4 +18,4 @@ spec:
       agentSelector: {}
   pullSecretRef:
     name: '{{ pull_secret_name }}'
-    namespace: '{{ assisted_namespace }}'
+    namespace: '{{ spoke_namespace }}'

--- a/deploy/operator/ztp/infraEnv.j2
+++ b/deploy/operator/ztp/infraEnv.j2
@@ -2,11 +2,11 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
   name: '{{ infraenv_name }}'
-  namespace: '{{ assisted_namespace }}'
+  namespace: '{{ spoke_namespace }}'
 spec:
   clusterRef:
     name: '{{ cluster_deployment_name }}'
-    namespace: '{{ assisted_namespace }}'
+    namespace: '{{ spoke_namespace }}'
   pullSecretRef:
     name: '{{ pull_secret_name }}'
   sshAuthorizedKey: '{{ ssh_public_key }}'


### PR DESCRIPTION
In the case of the hub and spoke clusters being installed on the same namespace,
and then a sysadmin would try to delete the namespace -
the deletion operation could get stuck.
Since the assisted-service might be deleted before AgentClusterInstall and
ClusterDeployment were deleted.
The CRs wouldn't be able to be deleted and the namespace deletion would get stuck.

# What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Operator Managed Deployments

# How was this code tested?

Please, select one or more if needed:

- [x] Waiting for CI to do a full test run

# Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
