### PR TITLE
NO-ISSUE: Add an issue type section to PR template & hide explanations

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,30 +1,14 @@
-# Description
+# Assisted Pull Request
 
+## Description
+
+<!--
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
 You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.
 
 Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
 information on how to link a PR to an existing issue.
-
-# What environments does this code impact?
-
-- [ ] Automation (CI, tools, etc)
-- [ ] Cloud
-- [ ] Operator Managed Deployments
-- [x] None
-
-
-# How was this code tested?
-
-Please, select one or more if needed:
-
-- [ ] assisted-test-infra environment
-- [ ] dev-scripts environment
-- [ ] Reviewer's test appreciated
-- [ ] Waiting for CI to do a full test run
-- [ ] Manual (Elaborate on how it was tested)
-- [x] No tests needed
 
 It's recommended to take a few extra minutes to provide more information about
 how this code was tested. Here are some questions that may be worth answering:
@@ -34,11 +18,40 @@ how this code was tested. Here are some questions that may be worth answering:
 - Should this PR be tested in a specific environment?
 - Any logs, screenshots, etc that can help with the review process?
 
+-->
 
-# Assignees
+## List all the issues related to this PR
 
+- [ ] New Feature
+- [ ] Bug fix
+- [ ] Tests
+- [ ] Documentation
+- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->
+
+## What environments does this code impact?
+
+- [ ] Automation (CI, tools, etc)
+- [ ] Cloud
+- [ ] Operator Managed Deployments
+- [x] None
+
+## How was this code tested?
+
+<!-- Please, select one or more if needed: -->
+
+- [ ] assisted-test-infra environment
+- [ ] dev-scripts environment
+- [ ] Reviewer's test appreciated
+- [ ] Waiting for CI to do a full test run
+- [ ] Manual (Elaborate on how it was tested)
+- [x] No tests needed
+
+## Assignees
+
+<!--
 Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
 this PR directly to someone.
+-->
 
 /cc @
 /cc @
@@ -56,7 +69,6 @@ this PR directly to someone.
 - [ ] Are the title and description (in both PR and commit) meaningful and clear?
 - [ ] Is there a bug required (and linked) for this change?
 - [ ] Should this PR be backported?
-
 
 [Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
 [CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
# Assisted Pull Request

## Description

- Add an issue section to the PR template
- Hide explanations from the shown PR body (using comments).

## List all the issues related to this PR

- [X] Docuemntation

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
