### PR TITLE
OCPBUGSM-31584: added columns to Agent CRD

### DIFF
--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -25,6 +25,24 @@ spec:
       jsonPath: .spec.approved
       name: Approved
       type: boolean
+    - description: The role (master/worker) of the Agent.
+      jsonPath: .status.role
+      name: Role
+      type: string
+    - description: The HostStage of the Agent.
+      jsonPath: .status.progress.currentStage
+      name: Stage
+      type: string
+    - description: The hostname of the Agent.
+      jsonPath: .status.inventory.hostname
+      name: Hostname
+      priority: 1
+      type: string
+    - description: The requested hostname for the Agent.
+      jsonPath: .spec.hostname
+      name: Requested Hostname
+      priority: 1
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -288,6 +288,24 @@ spec:
       jsonPath: .spec.approved
       name: Approved
       type: boolean
+    - description: The role (master/worker) of the Agent.
+      jsonPath: .status.role
+      name: Role
+      type: string
+    - description: The HostStage of the Agent.
+      jsonPath: .status.progress.currentStage
+      name: Stage
+      type: string
+    - description: The hostname of the Agent.
+      jsonPath: .status.inventory.hostname
+      name: Hostname
+      priority: 1
+      type: string
+    - description: The requested hostname for the Agent.
+      jsonPath: .spec.hostname
+      name: Requested Hostname
+      priority: 1
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -23,6 +23,24 @@ spec:
       jsonPath: .spec.approved
       name: Approved
       type: boolean
+    - description: The role (master/worker) of the Agent.
+      jsonPath: .status.role
+      name: Role
+      type: string
+    - description: The HostStage of the Agent.
+      jsonPath: .status.progress.currentStage
+      name: Stage
+      type: string
+    - description: The hostname of the Agent.
+      jsonPath: .status.inventory.hostname
+      name: Hostname
+      priority: 1
+      type: string
+    - description: The requested hostname for the Agent.
+      jsonPath: .spec.hostname
+      name: Requested Hostname
+      priority: 1
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -222,6 +222,10 @@ type DebugInfo struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.clusterDeploymentName.name",description="The name of the cluster the Agent registered to."
 // +kubebuilder:printcolumn:name="Approved",type="boolean",JSONPath=".spec.approved",description="The `Approve` state of the Agent."
+// +kubebuilder:printcolumn:name="Role",type="string",JSONPath=".status.role",description="The role (master/worker) of the Agent."
+// +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".status.progress.currentStage",description="The HostStage of the Agent."
+// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".status.inventory.hostname",description="The hostname of the Agent.",priority=1
+// +kubebuilder:printcolumn:name="Requested Hostname",type="string",JSONPath=".spec.hostname",description="The requested hostname for the Agent.",priority=1
 
 // Agent is the Schema for the hosts API
 type Agent struct {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added the following columns to 'additionalPrinterColumns'
in Agents CRD:
* Role: The role (master/worker) of the Agent.
* Stage: The HostStage of the Agent.
* Hostname: The hostname of the Agent.
* Requested Hostname: The requested hostname for the Agent.

Note:
Adding a complex jsonPath is not supported yet[*],
so can't add columns that are consist of arrays (as IP/MAC).

[*] https://github.com/kubernetes/kubernetes/pull/101205

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

The following columns should be printed:
* oc -n assisted-installer get agents:
  * NAME,  CLUSTER, APPROVED,  ROLE,  STAGE
* oc -n assisted-installer get agents -o wide:
  * NAME,  CLUSTER, APPROVED,  ROLE,  STAGE,  HOSTNAME, REQUESTED HOSTNAME

## Assignees

/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
