### PR TITLE
Bug 1975491: Added network latency and packet loss to /host-requirements

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4538,6 +4538,8 @@ func hostRequirementsRoleFrom(requirements *models.ClusterHostRequirementsDetail
 		DiskSizeGb:                       requirements.DiskSizeGb,
 		InstallationDiskSpeedThresholdMs: requirements.InstallationDiskSpeedThresholdMs,
 		RAMGib:                           conversions.MibToGiB(requirements.RAMMib),
+		NetworkLatencyThresholdMs:        requirements.NetworkLatencyThresholdMs,
+		PacketLossPercentage:             requirements.PacketLossPercentage,
 	}
 }
 

--- a/models/host_requirements_role.go
+++ b/models/host_requirements_role.go
@@ -24,6 +24,12 @@ type HostRequirementsRole struct {
 	// installation disk speed threshold ms
 	InstallationDiskSpeedThresholdMs int64 `json:"installation_disk_speed_threshold_ms,omitempty"`
 
+	// network latency threshold ms
+	NetworkLatencyThresholdMs *float64 `json:"network_latency_threshold_ms,omitempty"`
+
+	// packet loss percentage
+	PacketLossPercentage *float64 `json:"packet_loss_percentage,omitempty"`
+
 	// ram gib
 	RAMGib int64 `json:"ram_gib,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6526,6 +6526,16 @@ func init() {
         "installation_disk_speed_threshold_ms": {
           "type": "integer"
         },
+        "network_latency_threshold_ms": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
+        "packet_loss_percentage": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
         "ram_gib": {
           "type": "integer"
         }
@@ -14170,6 +14180,16 @@ func init() {
         },
         "installation_disk_speed_threshold_ms": {
           "type": "integer"
+        },
+        "network_latency_threshold_ms": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
+        },
+        "packet_loss_percentage": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true
         },
         "ram_gib": {
           "type": "integer"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3406,7 +3406,14 @@ definitions:
         type: integer
       installation_disk_speed_threshold_ms:
         type: integer
-
+      network_latency_threshold_ms:
+        type: number
+        format: double
+        x-nullable: true        
+      packet_loss_percentage:
+        type: number
+        format: double
+        x-nullable: true
   event-list:
     type: array
     items:


### PR DESCRIPTION
# Assisted Pull Request

## Description

Adds 2 fields to the `/host-requirements` endpoint to expose the network latency and packet loss for the default host requirements.

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @jakub-dzon 
/cc @YuviGold 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
