### PR TITLE
OCPBUGSM-31522: Bug 1976776: Change agent's ReadyForInstallation condition into RequirementsMet

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -112,7 +112,7 @@ test-infra-cluster-assisted-installer
 test-infra-cluster-assisted-installer-master-2
 SpecSynced	The Spec has been successfully applied
 Connected	The agent's connection to the installation service is unimpaired
-ReadyForInstallation	The agent cannot begin the installation because it has already started
+RequirementsMet	Installation already started and is in progress
 Validated	The agent's validations are passing
 Installed	The installation is in progress: Configuring
 
@@ -120,7 +120,7 @@ test-infra-cluster-assisted-installer
 test-infra-cluster-assisted-installer-master-0
 SpecSynced	The Spec has been successfully applied
 Connected	The agent's connection to the installation service is unimpaired
-ReadyForInstallation	The agent cannot begin the installation because it has already started
+RequirementsMet	Installation already started and is in progress
 Validated	The agent's validations are passing
 Installed	The installation is in progress: Configuring
 
@@ -128,7 +128,7 @@ test-infra-cluster-assisted-installer
 test-infra-cluster-assisted-installer-master-1
 SpecSynced	The Spec has been successfully applied
 Connected	The agent's connection to the installation service is unimpaired
-ReadyForInstallation	The agent cannot begin the installation because it has already started
+RequirementsMet	Installation already started and is in progress
 Validated	The agent's validations are passing
 Installed	The installation is in progress: Waiting for control plane
 ```

--- a/docs/hive-integration/kube-api-conditions.md
+++ b/docs/hive-integration/kube-api-conditions.md
@@ -83,7 +83,7 @@ Status:
 
 ## Agent Conditions
 
-The Agent condition types supported are: `SpecSynced`, `Connected`, `ReadyForInstallation`, `Validated` and `Installed`
+The Agent condition types supported are: `SpecSynced`, `Connected`, `RequirementsMet`, `Validated` and `Installed`
 
 |Type|Status|Reason|Message|Description|
 |----|----|-----|-------------------|-------------------|
@@ -96,12 +96,11 @@ The Agent condition types supported are: `SpecSynced`, `Connected`, `ReadyForIns
 |Validated|False|ValidationsUserPending|The agent's validations are pending for user: "summary of not-succeeded validations"|If the host status is "pending-for-input"|
 |Validated|Unknown|ValidationsUnknown|The agent's validations have not yet been calculated|If the validations have not yet been calculated|
 ||||||
-|ReadyForInstallation|True|AgentIsReady|The agent is ready to begin the installation|If the host is approved and in status "known"|
-|ReadyForInstallation|False|AgentNotReady|The agent is not ready to begin the installation|If the host is before installation ("discovering"/"insufficient"/"disconnected"/"pending-input")|
-|ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing") |
-|ReadyForInstallation|False|AgentIsNotApproved|The agent is not approved|If the host is not approved and in status "known"|
-|ReadyForInstallation|False|AgentAlreadyInstalling|The agent cannot begin the installation because it has already started|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing") |
-|ReadyForInstallation|False|AgentInstallationStopped|The agent installation stopped|If the agent has stopped installing ("installed", "error") |
+|RequirementsMet|True|AgentIsReady|The agent is ready to begin the installation|If the host is approved and in status "known"|
+|RequirementsMet|False|AgentNotReady|The agent is not ready to begin the installation|If the host is before installation ("discovering"/"insufficient"/"disconnected"/"pending-input")|
+|RequirementsMet|False|AgentIsNotApproved|The agent is not approved|If the host is not approved and in status "known"|
+|RequirementsMet|True|AgentAlreadyInstalling|Installation already started and is in progress|If the agent has begun installing ("preparing-successful","preparing-for-installation", "installing") |
+|RequirementsMet|True|AgentInstallationStopped|The agent installation stopped|If the agent has stopped installing ("installed", "error") |
 ||||||
 |Installed|True|InstallationCompleted|The installation has completed: "status_info"|If the host status is "installed"|
 |Installed|False|InstallationFailed|The installation has failed: "status_info"|If the host status is "error"|
@@ -128,10 +127,10 @@ Status:
     Status:                True
     Type:                  Connected
     Last Transition Time:  2021-04-22T15:50:33Z
-    Message:               The agent cannot begin the installation because it has already started
+    Message:               Installation already started and is in progress
     Reason:                AgentAlreadyInstalling
-    Status:                False
-    Type:                  ReadyForInstallation
+    Status:                True
+    Type:                  RequirementsMet
     Last Transition Time:  2021-04-22T15:50:26Z
     Message:               The agent's validations are passing
     Reason:                ValidationsPassing

--- a/internal/controller/api/v1beta1/agent_types.go
+++ b/internal/controller/api/v1beta1/agent_types.go
@@ -33,13 +33,13 @@ const (
 
 	InstalledCondition conditionsv1.ConditionType = "Installed"
 
-	ReadyForInstallationCondition  conditionsv1.ConditionType = "ReadyForInstallation"
+	RequirementsMetCondition       conditionsv1.ConditionType = "RequirementsMet"
 	AgentReadyReason               string                     = "AgentIsReady"
 	AgentReadyMsg                  string                     = "The agent is ready to begin the installation"
 	AgentNotReadyReason            string                     = "AgentNotReady"
 	AgentNotReadyMsg               string                     = "The agent is not ready to begin the installation"
 	AgentAlreadyInstallingReason   string                     = "AgentAlreadyInstalling"
-	AgentAlreadyInstallingMsg      string                     = "The agent cannot begin the installation because it has already started"
+	AgentAlreadyInstallingMsg      string                     = "Installation already started and is in progress"
 	AgentIsNotApprovedReason       string                     = "AgentIsNotApproved"
 	AgentIsNotApprovedMsg          string                     = "The agent is not approved"
 	AgentInstallationStoppedReason string                     = "AgentInstallationStopped"

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -276,7 +276,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 			}
 		}
 		connected(agent, status)
-		readyForInstallation(agent, status)
+		requirementsMet(agent, status)
 		validated(agent, status, h)
 		installed(agent, status, swag.StringValue(h.StatusInfo))
 	} else {
@@ -333,7 +333,7 @@ func setConditionsUnknown(agent *aiv1beta1.Agent) {
 		Message: aiv1beta1.NotAvailableMsg,
 	})
 	conditionsv1.SetStatusConditionNoHeartbeat(&agent.Status.Conditions, conditionsv1.Condition{
-		Type:    aiv1beta1.ReadyForInstallationCondition,
+		Type:    aiv1beta1.RequirementsMetCondition,
 		Status:  corev1.ConditionUnknown,
 		Reason:  aiv1beta1.NotAvailableReason,
 		Message: aiv1beta1.NotAvailableMsg,
@@ -517,7 +517,7 @@ func connected(agent *aiv1beta1.Agent, status string) {
 	})
 }
 
-func readyForInstallation(agent *aiv1beta1.Agent, status string) {
+func requirementsMet(agent *aiv1beta1.Agent, status string) {
 	var condStatus corev1.ConditionStatus
 	var reason string
 	var msg string
@@ -539,11 +539,11 @@ func readyForInstallation(agent *aiv1beta1.Agent, status string) {
 		msg = aiv1beta1.AgentNotReadyMsg
 	case models.HostStatusPreparingForInstallation, models.HostStatusPreparingSuccessful, models.HostStatusInstalling,
 		models.HostStatusInstallingInProgress, models.HostStatusInstallingPendingUserAction:
-		condStatus = corev1.ConditionFalse
+		condStatus = corev1.ConditionTrue
 		reason = aiv1beta1.AgentAlreadyInstallingReason
 		msg = aiv1beta1.AgentAlreadyInstallingMsg
 	case models.HostStatusInstalled, models.HostStatusError:
-		condStatus = corev1.ConditionFalse
+		condStatus = corev1.ConditionTrue
 		reason = aiv1beta1.AgentInstallationStoppedReason
 		msg = aiv1beta1.AgentInstallationStoppedMsg
 	default:
@@ -552,7 +552,7 @@ func readyForInstallation(agent *aiv1beta1.Agent, status string) {
 		msg = fmt.Sprintf("%s %s", aiv1beta1.UnknownStatusMsg, status)
 	}
 	conditionsv1.SetStatusConditionNoHeartbeat(&agent.Status.Conditions, conditionsv1.Condition{
-		Type:    aiv1beta1.ReadyForInstallationCondition,
+		Type:    aiv1beta1.RequirementsMetCondition,
 		Status:  condStatus,
 		Reason:  reason,
 		Message: msg,

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -313,7 +313,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Reason).To(Equal(v1beta1.BackendErrorReason))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.InstalledCondition).Status).To(Equal(corev1.ConditionUnknown))
-		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.ReadyForInstallationCondition).Status).To(Equal(corev1.ConditionUnknown))
+		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.RequirementsMetCondition).Status).To(Equal(corev1.ConditionUnknown))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.ValidatedCondition).Status).To(Equal(corev1.ConditionUnknown))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.ConnectedCondition).Status).To(Equal(corev1.ConditionUnknown))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.ConnectedCondition).Message).To(Equal(v1beta1.NotAvailableMsg))
@@ -816,7 +816,7 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking1\",\"status\":\"failure\",\"message\":\"Host check1 is not OK\"},{\"id\":\"checking2\",\"status\":\"success\",\"message\":\"Host check2 is OK\"},{\"id\":\"checking3\",\"status\":\"failure\",\"message\":\"Host check3 is not OK\"},{\"id\":\"checking4\",\"status\":\"pending\",\"message\":\"Host check4 is pending\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentNotReadyMsg,
 					Reason:  v1beta1.AgentNotReadyReason,
 					Status:  corev1.ConditionFalse,
@@ -848,7 +848,7 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking1\",\"status\":\"failure\",\"message\":\"Host check1 is not OK\"},{\"id\":\"checking2\",\"status\":\"success\",\"message\":\"Host check2 is OK\"},{\"id\":\"checking3\",\"status\":\"failure\",\"message\":\"Host check3 is not OK\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentNotReadyMsg,
 					Reason:  v1beta1.AgentNotReadyReason,
 					Status:  corev1.ConditionFalse,
@@ -881,7 +881,7 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentReadyMsg,
 					Reason:  v1beta1.AgentReadyReason,
 					Status:  corev1.ConditionTrue,
@@ -914,7 +914,7 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentIsNotApprovedMsg,
 					Reason:  v1beta1.AgentIsNotApprovedReason,
 					Status:  corev1.ConditionFalse,
@@ -946,10 +946,10 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentInstallationStoppedMsg,
 					Reason:  v1beta1.AgentInstallationStoppedReason,
-					Status:  corev1.ConditionFalse,
+					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    v1beta1.ConnectedCondition,
@@ -978,10 +978,10 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentAlreadyInstallingMsg,
 					Reason:  v1beta1.AgentAlreadyInstallingReason,
-					Status:  corev1.ConditionFalse,
+					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    v1beta1.ConnectedCondition,
@@ -1010,10 +1010,10 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentInstallationStoppedMsg,
 					Reason:  v1beta1.AgentInstallationStoppedReason,
-					Status:  corev1.ConditionFalse,
+					Status:  corev1.ConditionTrue,
 				},
 				{
 					Type:    v1beta1.ConnectedCondition,
@@ -1042,7 +1042,7 @@ var _ = Describe("TestConditions", func() {
 			validationInfo: "{\"some-check\":[{\"id\":\"checking\",\"status\":\"success\",\"message\":\"Host is checked\"}]}",
 			conditions: []conditionsv1.Condition{
 				{
-					Type:    v1beta1.ReadyForInstallationCondition,
+					Type:    v1beta1.RequirementsMetCondition,
 					Message: v1beta1.AgentNotReadyMsg,
 					Reason:  v1beta1.AgentNotReadyReason,
 					Status:  corev1.ConditionFalse,

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -2022,7 +2022,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		// }, "30s", "10s").Should(BeNil())
 
 		// checkAgentCondition(ctx, host.ID.String(), controllers.InstalledCondition, controllers.InstallationInProgressReason)
-		// checkAgentCondition(ctx, host.ID.String(), controllers.ReadyForInstallationCondition, controllers.AgentAlreadyInstallingReason)
+		// checkAgentCondition(ctx, host.ID.String(), controllers.RequirementsMetCondition, controllers.AgentAlreadyInstallingReason)
 		// checkAgentCondition(ctx, host.ID.String(), v1beta1.SpecSyncedCondition, controllers.SyncedOkReason)
 		// checkAgentCondition(ctx, host.ID.String(), controllers.ConnectedCondition, controllers.AgentConnectedReason)
 		// checkAgentCondition(ctx, host.ID.String(), controllers.ValidatedCondition, controllers.ValidationsPassingReason)


### PR DESCRIPTION
Similar to  AgentClusterInstall, the condition `ReadyForInstallation` is changed `RequirementsMet` and set it to True after installation started/finished

Related discussion here https://coreos.slack.com/archives/C01FT9E4Q10/p1624783430043300?thread_ts=1624783425.043200&cid=C01FT9E4Q10

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1976776
Jira: https://issues.redhat.com/browse/OCPBUGSM-31522

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [X] Tests
- [X] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested): Ran unit tests locally
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
