### PR TITLE
Bug 1965117: Keep assisted-service configmap mount updated

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -70,6 +70,9 @@ const (
 	defaultIngressCertCMNamespace string = "openshift-config-managed"
 
 	configmapAnnotation = "unsupported.agent-install.openshift.io/assisted-service-configmap"
+
+	assistedConfigHashAnnotation = "agent-install.openshift.io/config-hash"
+	mirrorConfigHashAnnotation   = "agent-install.openshift.io/mirror-hash"
 )
 
 // AgentServiceConfigReconciler reconciles a AgentServiceConfig object
@@ -672,6 +675,14 @@ func (r *AgentServiceConfigReconciler) newIngressCertCM(instance *aiv1beta1.Agen
 }
 
 func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, instance *aiv1beta1.AgentServiceConfig) (*appsv1.Deployment, controllerutil.MutateFn, error) {
+	var assistedConfigHash, mirrorConfigHash, userConfigHash string
+
+	// Get hash of generated assisted config
+	assistedConfigHash, err := r.getCMHash(ctx, types.NamespacedName{Name: serviceName, Namespace: r.Namespace})
+	if err != nil {
+		return nil, nil, err
+	}
+
 	envSecrets := []corev1.EnvVar{
 		// database
 		newSecretEnvVar("DB_HOST", "db.host", databaseName),
@@ -695,16 +706,17 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 		},
 	}
 
-	// User is responsible for knowing to restart assisted-service
-	annotations := instance.ObjectMeta.GetAnnotations()
-	configmapName, ok := annotations[configmapAnnotation]
+	// User is responsible for:
+	// - knowing to restart assisted-service when specifying the configmap via annotation
+	// - removing the annotation when the configmap is deleted
+	userConfigName, ok := instance.ObjectMeta.GetAnnotations()[configmapAnnotation]
 	if ok {
-		log.Infof("ConfigMap %s from namespace %s being used to configure assisted-service deployment", configmapName, r.Namespace)
+		log.Infof("ConfigMap %s from namespace %s being used to configure assisted-service deployment", userConfigName, r.Namespace)
 		envFrom = append(envFrom, []corev1.EnvFromSource{
 			{
 				ConfigMapRef: &corev1.ConfigMapEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: configmapName,
+						Name: userConfigName,
 					},
 				},
 			},
@@ -829,6 +841,11 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 			return nil, nil, err
 		}
 
+		mirrorConfigHash, err = checksumMap(cm.Data)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		// require that the registries config key be specified before continuing
 		if _, ok := cm.Data[mirrorRegistryRefRegistryConfKey]; !ok {
 			err = fmt.Errorf("Mirror registry configmap %s missing key %s", instance.Spec.MirrorRegistryRef.Name, mirrorRegistryRefRegistryConfKey)
@@ -917,6 +934,16 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 		var replicas int32 = 1
 		deployment.Spec.Replicas = &replicas
 		deployment.Spec.Strategy = deploymentStrategy
+
+		// Handle our hashed configMap(s)
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.Annotations[assistedConfigHashAnnotation] = assistedConfigHash
+		if mirrorConfigHash != "" {
+			deployment.Spec.Template.Annotations[mirrorConfigHashAnnotation] = mirrorConfigHash
+		}
+
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{serviceContainer, postgresContainer}
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
@@ -964,6 +991,15 @@ func (r *AgentServiceConfigReconciler) getOpenshiftVersions(log logrus.FieldLogg
 	}
 
 	return string(encodedVersions)
+}
+
+func (r *AgentServiceConfigReconciler) getCMHash(ctx context.Context, namespacedName types.NamespacedName) (string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, namespacedName, cm); err != nil {
+		r.Log.Error(err, "Failed to get configmap", "NamespacedName", namespacedName)
+		return "", err
+	}
+	return checksumMap(cm.Data)
 }
 
 func newSecretEnvVar(name, key, secretName string) corev1.EnvVar {

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -36,9 +37,12 @@ const (
 func newTestReconciler(initObjs ...runtime.Object) *AgentServiceConfigReconciler {
 	c := fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(initObjs...).Build()
 	return &AgentServiceConfigReconciler{
-		Client:    c,
-		Scheme:    scheme.Scheme,
-		Log:       logrus.New(),
+		Client: c,
+		Scheme: scheme.Scheme,
+		Log:    logrus.New(),
+		// TODO(djzager): If we need to verify emitted events
+		// https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/pkg/controller/statefulset/stateful_pod_control_test.go#L474
+		Recorder:  record.NewFakeRecorder(10),
 		Namespace: testNamespace,
 	}
 }
@@ -251,7 +255,16 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 		Context("with annotation on AgentServiceConfig", func() {
 			It("should modify assisted-service deployment", func() {
 				asc = newASCWithCMAnnotation()
-				ascr = newTestReconciler(asc, route, assistedCM)
+				userCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigmapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"foo": "bar",
+					},
+				}
+				ascr = newTestReconciler(asc, route, userCM, assistedCM)
 				Expect(ascr.ensureAssistedServiceDeployment(ctx, log, asc)).To(Succeed())
 				found := &appsv1.Deployment{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
@@ -374,7 +387,7 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 	})
 
 	Describe("ConfigMap hashing as annotations on assisted-service deployment", func() {
-		Context("without unsupported|mirror configMap", func() {
+		Context("with assisted-service configmap", func() {
 			It("should fail if assisted configMap not found", func() {
 				asc = newASCDefault()
 				ascr = newTestReconciler(asc, route)
@@ -388,8 +401,10 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 
 				found := &appsv1.Deployment{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
-				Expect(found.Spec.Template.Annotations).To(HaveLen(1))
-				Expect(found.Spec.Template.Annotations).To(HaveKey(assistedConfigHashAnnotation))
+				Expect(found.Spec.Template.Annotations).To(HaveLen(3))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(assistedConfigHashAnnotation, Not(Equal(""))))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(mirrorConfigHashAnnotation, Equal("")))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(userConfigHashAnnotation, Equal("")))
 			})
 		})
 
@@ -416,9 +431,40 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 
 				found := &appsv1.Deployment{}
 				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
-				Expect(found.Spec.Template.Annotations).To(HaveLen(2))
-				Expect(found.Spec.Template.Annotations).To(HaveKey(assistedConfigHashAnnotation))
-				Expect(found.Spec.Template.Annotations).To(HaveKey(mirrorConfigHashAnnotation))
+				Expect(found.Spec.Template.Annotations).To(HaveLen(3))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(assistedConfigHashAnnotation, Not(Equal(""))))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(mirrorConfigHashAnnotation, Not(Equal(""))))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(userConfigHashAnnotation, Equal("")))
+			})
+		})
+
+		Context("with unsupported configMap", func() {
+			It("should fail if not found", func() {
+				asc = newASCWithCMAnnotation()
+				ascr = newTestReconciler(asc, route, assistedCM)
+				Expect(ascr.ensureAssistedServiceDeployment(ctx, log, asc)).To(Not(Succeed()))
+			})
+
+			It("should add user config hash annotation by default", func() {
+				asc = newASCWithCMAnnotation()
+				userCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConfigmapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"foo": "bar",
+					},
+				}
+				ascr = newTestReconciler(asc, route, userCM, assistedCM)
+				Expect(ascr.ensureAssistedServiceDeployment(ctx, log, asc)).To(Succeed())
+
+				found := &appsv1.Deployment{}
+				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: testNamespace}, found)).To(Succeed())
+				Expect(found.Spec.Template.Annotations).To(HaveLen(3))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(assistedConfigHashAnnotation, Not(Equal(""))))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(mirrorConfigHashAnnotation, Equal("")))
+				Expect(found.Spec.Template.Annotations).To(HaveKeyWithValue(userConfigHashAnnotation, Not(Equal(""))))
 			})
 		})
 	})


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR hashes the generated, mirror registry, and unsupported configMap(s) and uses that information to restart the assisted-service deployment if necessary. The general rule is that, if it's a part of our supported configuration, then we will restart the assisted-service. This simply means that if there is a mismatch between the "unsupported" configmap and what is currently running with the assisted-service, we will log (and emit) a warning and move on...we will take no direct action.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md