### PR TITLE
NO-ISSUE: Show full command on release.go execture error

### DIFF
--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -218,16 +218,16 @@ func (r *release) execute(log logrus.FieldLogger, pullSecret string, command str
 	}
 	// flush the buffer to ensure the file can be read
 	ps.Close()
-	args := strings.Split(command, " ")
-	args = append(args, "--registry-config="+ps.Name())
+	executeCommand := command[:] + " --registry-config=" + ps.Name()
+	args := strings.Split(executeCommand, " ")
 
 	stdout, stderr, exitCode := r.executer.Execute(args[0], args[1:]...)
 
 	if exitCode == 0 {
 		return strings.TrimSpace(stdout), nil
 	} else {
-		err = fmt.Errorf("command %s exited with non-zero exit code %d: %s\n%s", command, exitCode, stdout, stderr)
-		log.WithError(err).Errorf("error running \"%s\"", command)
+		err = fmt.Errorf("command '%s' exited with non-zero exit code %d: %s\n%s", executeCommand, exitCode, stdout, stderr)
+		log.Error(err)
 		return "", err
 	}
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

The execute function on release.go is appending the registry-config as
an additional parameter to the given command parameter.
In case of an error, we would like to show the full command that was
executed.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 
/cc @eranco74 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
