### PR TITLE
NO-ISSUE: Add common module for operator deployment scripts

### DIFF
--- a/deploy/operator/common.sh
+++ b/deploy/operator/common.sh
@@ -1,0 +1,35 @@
+__dir=${__dir:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"}
+__root=${__root:-"$(realpath ${__dir}/../..)"}
+
+if [ -z "${DISKS:-}" ]; then
+    export DISKS=$(echo sd{b..f})
+fi
+
+export DISCONNECTED="${DISCONNECTED:-false}"
+export ASSISTED_DEPLOYMENT_METHOD="${ASSISTED_DEPLOYMENT_METHOD:-from_index_image}"
+export HIVE_DEPLOYMENT_METHOD="${HIVE_DEPLOYMENT_METHOD:-with_olm}"
+
+export OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-$(cat ${__root}/data/default_ocp_versions.json)}"
+
+if [ -z "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-}" ]; then
+    export ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE=$(echo ${OPENSHIFT_VERSIONS} | jq -rc '[.[].release_image]|max')
+fi
+
+export LOCAL_REGISTRY="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}"
+export RELEASE_IMAGE_REPOSITORY_TAG=${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE#*/}
+export RELEASE_IMAGE_REPOSITORY=$(echo ${RELEASE_IMAGE_REPOSITORY_TAG} | cut -d':' -f1)
+export ASSISTED_OPENSHIFT_VERSION="${ASSISTED_OPENSHIFT_VERSION:-openshift-v4.8.0}"
+
+OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
+    jq -rc 'with_entries(.key = "4.8") | with_entries(
+    {
+        key: .key,
+        value: {rhcos_image:   .value.rhcos_image,
+                rhcos_version: .value.rhcos_version,
+                rhcos_rootfs:  .value.rhcos_rootfs}
+    }
+    )')
+
+export ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
+export SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
+export HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"

--- a/deploy/operator/destroy.sh
+++ b/deploy/operator/destroy.sh
@@ -1,16 +1,29 @@
 
 #!/usr/bin/env bash
 
-__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -o nounset
 
-if [ -z "${DISKS:-}" ]; then
-    export DISKS=$(echo sd{b..f})
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/common.sh
+
+function destroy_spoke() {
+    kubectl delete namespace "${SPOKE_NAMESPACE}"
+    kubectl delete clusterimageset "${ASSISTED_OPENSHIFT_VERSION}"
+}
+
+function destroy_hub() {
+    kubectl delete namespace "${ASSISTED_NAMESPACE}"
+    kubectl delete agentserviceconfigs.agent-install.openshift.io agent
+    kubectl delete localvolume -n openshift-local-storage assisted-service
+    kubectl delete catalogsource assisted-service-catalog -n openshift-marketplace
+
+    ${__dir}/libvirt_disks.sh destroy
+    kubectl get pv -o=name | xargs -r kubectl delete
+}
+
+if [ -z "$@" ]; then
+  destroy_spoke
+  destroy_hub
 fi
 
-kubectl delete namespace assisted-installer
-kubectl delete agentserviceconfigs.agent-install.openshift.io agent
-kubectl delete localvolume -n openshift-local-storage assisted-service
-kubectl delete catalogsource assisted-service-catalog -n openshift-marketplace
-
-${__dir}/libvirt_disks.sh destroy
-kubectl get pv -o=name | xargs -r kubectl delete
+"$@"

--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -2,9 +2,8 @@
 
 set -xeo pipefail
 
-ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
-SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
-HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/common.sh
 
 function gather_hive_data() {
   hive_dir="${LOGS_DEST}/hive"

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -1,15 +1,14 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/common.sh
 source ${__dir}/utils.sh
 source ${__dir}/mirror_utils.sh
 
 set -x
 
-ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
 INDEX_IMAGE="${INDEX_IMAGE:-quay.io/ocpmetal/assisted-service-index:latest}"
 STORAGE_CLASS_NAME="${STORAGE_CLASS_NAME:-assisted-service}"
 
 INDEX_TAG="${INDEX_TAG:-latest}"
-DISCONNECTED="${DISCONNECTED:-false}"
 
 function print_help() {
   ALL_FUNCS="from_community_operators|from_index_image|print_help"
@@ -126,7 +125,7 @@ data:
 $(configmap_config)
 EOCR
 
-tee << EOCR >(oc apply -f -)
+  tee << EOCR >(oc apply -f -)
 apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
@@ -151,6 +150,7 @@ spec:
 EOCR
 
   wait_for_operator "assisted-service-operator" "${ASSISTED_NAMESPACE}"
+  wait_for_condition "agentserviceconfigs/agent" "ReconcileCompleted" "5m"
   wait_for_pod "assisted-service" "${ASSISTED_NAMESPACE}" "app=assisted-service"
 
   echo "Enabling configuration of BMH resources outside of openshift-machine-api namespace"

--- a/deploy/operator/setup_hive.sh
+++ b/deploy/operator/setup_hive.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source ${__dir}/common.sh
 source ${__dir}/utils.sh
 
 set -o xtrace
 
-DISCONNECTED="${DISCONNECTED:-false}"
 HIVE_IMAGE="${HIVE_IMAGE:-registry.ci.openshift.org/openshift/hive-v4.0:hive}"
-HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
 
 function print_help() {
     ALL_FUNCS="with_olm|from_upstream|enable_agent_install_strategy|print_help"

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -74,7 +74,6 @@ function wait_for_object_amount() {
     namespace="${4:-}"
 
     until [ $(oc get ${object} -n "${namespace}" --no-headers | wc -l) -eq ${amount} ]; do
-        echo $(oc get ${object} -n "${namespace}" --no-headers | wc -l)
         sleep ${interval}
     done
     echo "done" $(oc get ${object} -n "${namespace}" --no-headers | wc -l)

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root="$(realpath ${__dir}/../../..)"
+source ${__dir}/../common.sh
 source ${__dir}/../utils.sh
 
-export SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
 export ASSISTED_CLUSTER_NAME="${ASSISTED_CLUSTER_NAME:-assisted-test-cluster}"
-export ASSISTED_OPENSHIFT_VERSION="${ASSISTED_OPENSHIFT_VERSION:-openshift-v4.8.0}"
-export ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE="${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64}"
 export ASSISTED_CLUSTER_DEPLOYMENT_NAME="${ASSISTED_CLUSTER_DEPLOYMENT_NAME:-assisted-test-cluster}"
 export ASSISTED_AGENT_CLUSTER_INSTALL_NAME="${ASSISTED_AGENT_CLUSTER_INSTALL_NAME:-assisted-agent-cluster-install}"
 export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
 export ASSISTED_PULLSECRET_NAME="${ASSISTED_PULLSECRET_NAME:-assisted-pull-secret}"
-export ASSISTED_PULLSECRET_JSON="${ASSISTED_PULLSECRET_JSON:-/home/test/dev-scripts/pull_secret.json}"
+export ASSISTED_PULLSECRET_JSON="${ASSISTED_PULLSECRET_JSON:-${PULL_SECRET_FILE}}"
 export ASSISTED_PRIVATEKEY_NAME="${ASSISTED_PRIVATEKEY_NAME:-assisted-ssh-private-key}"
 export EXTRA_BAREMETALHOSTS_FILE="${EXTRA_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/extra_baremetalhosts.json}"
 export CONTROL_PLANE_COUNT="${CONTROL_PLANE_COUNT:-1}"
@@ -26,6 +25,10 @@ elif [[ "${IP_STACK}" == "v6" ]]; then
     export CLUSTER_HOST_PREFIX="${CLUSTER_HOST_PREFIX_V6}"
     export EXTERNAL_SUBNET="${EXTERNAL_SUBNET_V6}"
     export SERVICE_SUBNET="${SERVICE_SUBNET_V6}"
+fi
+
+if [ "${DISCONNECTED}" = "true" ]; then
+    ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE="${LOCAL_REGISTRY}/${RELEASE_IMAGE_REPOSITORY_TAG}"
 fi
 
 # TODO: make SSH public key configurable
@@ -45,7 +48,7 @@ echo "Running Ansible playbook to create kubernetes objects"
 export BMH_NAME MAC_ADDRESS ENCODED_USERNAME ENCODED_PASSWORD ADDRESS
 ansible-playbook "${__dir}/assisted-installer-crds-playbook.yaml"
 
-oc create namespace "${SPOKE_NAMESPACE}"
+oc get namespace "${SPOKE_NAMESPACE}" || oc create namespace "${SPOKE_NAMESPACE}"
 
 oc get secret "${ASSISTED_PULLSECRET_NAME}" -n "${SPOKE_NAMESPACE}" || \
     oc create secret generic "${ASSISTED_PULLSECRET_NAME}" --from-file=.dockerconfigjson="${ASSISTED_PULLSECRET_JSON}" --type=kubernetes.io/dockerconfigjson -n "${SPOKE_NAMESPACE}"
@@ -56,9 +59,11 @@ for manifest in $(find ${__dir}/generated -type f); do
     tee < "${manifest}" >(oc apply -f -)
 done
 
+wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "ImageCreated" "5m" "${SPOKE_NAMESPACE}"
+
 echo "Waiting until at least ${CONTROL_PLANE_COUNT} agents are available..."
 export -f wait_for_object_amount
-timeout 10m bash -c "wait_for_object_amount agent ${CONTROL_PLANE_COUNT} 10 ${SPOKE_NAMESPACE}"
+timeout 10m bash -c "wait_for_object_amount agent ${CONTROL_PLANE_COUNT} 30 ${SPOKE_NAMESPACE}"
 echo "All ${CONTROL_PLANE_COUNT} agents have joined!"
 
 wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "Completed" "60m" "${SPOKE_NAMESPACE}"


### PR DESCRIPTION
# Assisted Pull Request

## Description

Improve integration between assisted operator deployment module and
spoke cluster deployment module.
Add more conditions steps for better monitoring.

- Add a `common.sh` module with common variables for the operator scripts.
- Fix `wait_for_object_amount` util not to spam numbers.
- Assisted operator deployment: Wait for `AgentServiceConfig`'s
  `ReconcileCompleted` condition.
- Spoke deployment: Check namespace before creation.
- Spoke deployment: Wait for `InfraEnv`'s `ImageCreated` condition.
- Spoke deployment: Extend intervals waiting for agents from 10s to 30s.

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual disconnected workflow

## Assignees

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
