### PR TITLE
Bug 1975452: Fix spoke BMH provisioned registration error

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -964,8 +964,7 @@ func (r *BMACReconciler) newSpokeBMH(bmh *bmh_v1alpha1.BareMetalHost, machine *m
 		// The host is created by the baremetal operator on hub cluster. So BMH on the spoke cluster needs
 		// to be set to externally provisioned
 		bmhSpoke.Spec.ExternallyProvisioned = true
-		// If the Image field is filled in, ExternallyProvisioned is ignored. So remove the Image field from spec
-		bmhSpoke.Spec.Image = &bmh_v1alpha1.Image{}
+		bmhSpoke.Spec.Image = bmh.Spec.Image
 		bmhSpoke.Spec.ConsumerRef = &corev1.ObjectReference{
 			Name:      machine.Name,
 			Namespace: machine.Namespace,

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -723,6 +723,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(spokeBMH.ObjectMeta.Annotations).To(HaveKey(BMH_HARDWARE_DETAILS_ANNOTATION))
 				Expect(spokeBMH.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION]).To(Equal(updatedHost.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION]))
 				Expect(spokeBMH.ObjectMeta.Annotations).ToNot(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(spokeBMH.Spec.Image).To(Equal(updatedHost.Spec.Image))
 
 				spokeMachine := &machinev1beta1.Machine{}
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, spokeBMH.Name)


### PR DESCRIPTION
## Description

Sets the spoke BMH Spec.Image.URL to the hub BMH's Spec.Image.URL.

This fixes the spoke BMH error:

  errorMessage: 'Host adoption failed: Error while attempting to
    adopt node b3bb59f8-8728-43c7-b31d-5346bf9dc700: Cannot
    validate image information for node b3bb59f8-8728-43c7-b31d-5346bf9dc700
    because one or more parameters are missing from its
    instance_info and insufficent information is present to boot
    from a remote volume. Missing are: [''image_source'',
    ''kernel'', ''ramdisk''].'
  errorType: provisioned registration error

The deleted comment mentions that if the Image field is filled in
then externallyProvisioned is ignored, that doesn't appear to be
the case. The spoke BMH still has externally provision status
with Spec.Image.URL set.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @mkowalski 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
