### PR TITLE
[WIP] Bug 1976991: Add Spoke Machine ProviderSpec and BareMetalHost annotation

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1013,6 +1013,24 @@ func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, cluste
 		},
 	}
 	mutateFn := func() error {
+		if machine.ObjectMeta.Annotations == nil {
+			machine.ObjectMeta.Annotations = make(map[string]string)
+		}
+		machine.ObjectMeta.Annotations["metal3.io/BareMetalHost"] = fmt.Sprintf("%s/%s", "openshift-machine-api", bmh.Name)
+		machine.Spec = machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					// TODO: replace image checksum and url. Though, the current nonsensical values appear to still work.
+					Raw: []byte(`{
+						"apiVersion": "baremetal.cluster.k8s.io/v1alpha1",
+						"kind": "BareMetalMachineProviderSpec",
+						"image": {
+						"checksum": "http://to.be.determined",
+						"url": "http://to.be.determined"
+						}}`),
+				},
+			},
+		}
 		// Setting the same labels as the rest of the machines in the spoke cluster
 		machine.Labels = AddLabel(machine.Labels, machinev1beta1.MachineClusterIDLabel, clusterDeployment.Name)
 		machine.Labels = AddLabel(machine.Labels, MACHINE_ROLE, string(models.HostRoleWorker))

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -731,6 +731,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(machinev1beta1.MachineClusterIDLabel))
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(MACHINE_ROLE))
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(MACHINE_TYPE))
+				Expect(spokeMachine.ObjectMeta.Annotations).To(HaveKey("metal3.io/BareMetalHost"))
 
 				spokeSecret := &corev1.Secret{}
 				err = spokeClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: testNamespace}, spokeSecret)


### PR DESCRIPTION

## Description

The ProviderSpec and BareMetalHost annotation are required for
the machine-controller to reconcile the Machine. If they are
not provided, the Machine does not reconcile, and the Machine
status is unavailable.

The Machine status is required for Discovery CSR auto approval.
The status contains the machine address which is used to match
with the Node name during CSR approval.

This patch partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1976991.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
