### PR TITLE
Bug 1977354: Move agent to different cluster same NS

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -145,7 +145,7 @@ type InstallerInternals interface {
 
 //go:generate mockgen -package bminventory -destination mock_crd_utils.go . CRDUtils
 type CRDUtils interface {
-	CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string) error
+	CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string, clusterID *strfmt.UUID) error
 }
 type bareMetalInventory struct {
 	Config
@@ -2603,7 +2603,7 @@ func (b *bareMetalInventory) RegisterHost(ctx context.Context, params installer.
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
-	if err := b.crdUtils.CreateAgentCR(ctx, log, params.NewHostParams.HostID.String(), cluster.KubeKeyNamespace, cluster.KubeKeyName); err != nil {
+	if err := b.crdUtils.CreateAgentCR(ctx, log, params.NewHostParams.HostID.String(), cluster.KubeKeyNamespace, cluster.KubeKeyName, cluster.ID); err != nil {
 		log.WithError(err).Errorf("Fail to create Agent CR. Namespace: %s, Cluster: %s, HostID: %s", cluster.KubeKeyNamespace, cluster.KubeKeyName, params.NewHostParams.HostID.String())
 		return installer.NewRegisterHostInternalServerError().
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
@@ -2674,7 +2674,7 @@ func (b *bareMetalInventory) DeregisterHostInternal(ctx context.Context, params 
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Deregister host: %s cluster %s", params.HostID, params.ClusterID)
 
-	if err := b.db.Where("id = ? and cluster_id = ?", params.HostID, params.ClusterID).Delete(&common.Host{}).Error; err != nil {
+	if err := b.hostApi.UnRegisterHost(ctx, params.HostID.String(), params.ClusterID.String()); err != nil {
 		// TODO: check error type
 		return common.NewApiError(http.StatusBadRequest, err)
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -975,7 +975,7 @@ var _ = Describe("RegisterHost", func() {
 						Expect(h.Role).Should(Equal(test.expectedRole))
 						return nil
 					}).Times(1)
-				mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockEvents.EXPECT().
 					AddEvent(gomock.Any(), *cluster.ID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
@@ -1019,7 +1019,7 @@ var _ = Describe("RegisterHost", func() {
 				Expect(h.Role).Should(Equal(models.HostRoleAutoAssign))
 				return nil
 			}).Times(1)
-		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
+		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEvents.EXPECT().
 			AddEvent(gomock.Any(), *cluster.ID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
 			Times(1)

--- a/internal/bminventory/mock_crd_utils.go
+++ b/internal/bminventory/mock_crd_utils.go
@@ -6,6 +6,7 @@ package bminventory
 
 import (
 	context "context"
+	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
 	reflect "reflect"
@@ -35,15 +36,15 @@ func (m *MockCRDUtils) EXPECT() *MockCRDUtilsMockRecorder {
 }
 
 // CreateAgentCR mocks base method
-func (m *MockCRDUtils) CreateAgentCR(arg0 context.Context, arg1 logrus.FieldLogger, arg2, arg3, arg4 string) error {
+func (m *MockCRDUtils) CreateAgentCR(arg0 context.Context, arg1 logrus.FieldLogger, arg2, arg3, arg4 string, arg5 *strfmt.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAgentCR", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "CreateAgentCR", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAgentCR indicates an expected call of CreateAgentCR
-func (mr *MockCRDUtilsMockRecorder) CreateAgentCR(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockCRDUtilsMockRecorder) CreateAgentCR(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAgentCR", reflect.TypeOf((*MockCRDUtils)(nil).CreateAgentCR), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAgentCR", reflect.TypeOf((*MockCRDUtils)(nil).CreateAgentCR), arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -293,7 +293,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 }
 
 func (r *AgentReconciler) populateEventsURL(log logrus.FieldLogger, agent *aiv1beta1.Agent, clusterId string) error {
-	if agent.Status.DebugInfo.EventsURL == "" {
+	if agent.Status.DebugInfo.EventsURL == "" || !strings.Contains(agent.Status.DebugInfo.EventsURL, clusterId) {
 		eventUrl, err := r.eventsURL(log, clusterId, agent.Name)
 		if err != nil {
 			log.WithError(err).Error("failed to generate Events URL")

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/jinzhu/gorm"
 	aiv1beta1 "github.com/openshift/assisted-service/internal/controller/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/pkg/errors"
@@ -25,7 +27,7 @@ func NewCRDUtils(client client.Client, hostApi host.API) *CRDUtils {
 // CreateAgentCR Creates an Agent CR representing a Host/Agent.
 // If the Host is already registered, the CR creation will be skipped.
 // if the Cluster was not created via K8s API, then the Cluster NameSpace will be empty and Agent CR creation will be skipped
-func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string) error {
+func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string, clusterID *strfmt.UUID) error {
 
 	if clusterNamespace == "" {
 		return nil
@@ -47,12 +49,12 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 	}
 
 	err = u.client.Get(ctx, namespacedName, host)
-	if err == nil {
-		log.Infof("Skip Agent CR creation. %s already exists", hostId)
-		return nil
+
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
 	}
 
-	if k8serrors.IsNotFound(err) {
+	if err != nil && k8serrors.IsNotFound(err) {
 		labels := map[string]string{aiv1beta1.InfraEnvNameLabel: infraEnv.Name}
 		if infraEnv.Spec.AgentLabels != nil {
 			for k, v := range infraEnv.Spec.AgentLabels {
@@ -60,7 +62,7 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 			}
 		}
 
-		host := &aiv1beta1.Agent{
+		host = &aiv1beta1.Agent{
 			Spec: aiv1beta1.AgentSpec{
 				ClusterDeploymentName: &aiv1beta1.ClusterReference{
 					Name:      clusterName,
@@ -77,13 +79,72 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 
 		// Update 'kube_key_namespace' in Host
 		if err1 := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnv.Namespace); err1 != nil {
-			return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
+			return errors.Wrapf(err1, "Failed to update 'kube_key_namespace' in host %s", hostId)
 		}
 
 		log.Infof("Creating Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnv.Namespace, clusterName, hostId)
 		return u.client.Create(ctx, host)
 	}
-	return err
+
+	if err == nil {
+		log.Infof("Agent CR %s already exists", hostId)
+		key := types.NamespacedName{Name: hostId, Namespace: infraEnv.Namespace}
+		// fetch previous by KubeKey
+		h, err2 := u.hostApi.GetHostByKubeKey(key)
+		if err2 != nil && !errors.Is(err2, gorm.ErrRecordNotFound) {
+			return errors.Wrapf(err2, "Failed to GetHostByKubeKey Name: %s Namespace: %s", key.Name, key.Namespace)
+		}
+
+		if err2 == nil {
+			if h.ClusterID == *clusterID {
+				log.Infof("Agent CR %s already exists, same cluster %s", hostId, h.ClusterID)
+				return nil
+			}
+			//delete previous host
+			if err3 := u.hostApi.UnRegisterHost(ctx, h.ID.String(), h.ClusterID.String()); err3 != nil {
+				return errors.Wrapf(err3, "Failed to UnRegisterHost ID: %s ClusterID: %s", h.ID.String(), h.ClusterID.String())
+			}
+		}
+		//Reset spec
+		labels := map[string]string{aiv1beta1.InfraEnvNameLabel: infraEnv.Name}
+		if infraEnv.Spec.AgentLabels != nil {
+			for k, v := range infraEnv.Spec.AgentLabels {
+				labels[k] = v
+			}
+		}
+
+		updatedhost := &aiv1beta1.Agent{
+			Spec: aiv1beta1.AgentSpec{
+				ClusterDeploymentName: &aiv1beta1.ClusterReference{
+					Name:      clusterName,
+					Namespace: clusterNamespace,
+				},
+				Approved:                false,
+				Hostname:                "",
+				MachineConfigPool:       "",
+				Role:                    "",
+				InstallationDiskID:      "",
+				InstallerArgs:           "",
+				IgnitionConfigOverrides: "",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            hostId,
+				Namespace:       infraEnv.Namespace,
+				Labels:          labels,
+				ResourceVersion: host.ResourceVersion,
+			},
+		}
+
+		// Update 'kube_key_namespace' in Host
+		if err1 := u.hostApi.UpdateKubeKeyNS(ctx, hostId, infraEnv.Namespace); err1 != nil {
+			return errors.Wrapf(err, "Failed to update 'kube_key_namespace' in host %s", hostId)
+		}
+
+		log.Infof("Updating Agent CR. Namespace: %s, Cluster: %s, HostID: %s", infraEnv.Namespace, clusterName, hostId)
+		return u.client.Update(ctx, updatedhost)
+	}
+
+	return nil
 }
 
 type DummyCRDUtils struct{}
@@ -92,7 +153,7 @@ func NewDummyCRDUtils() *DummyCRDUtils {
 	return &DummyCRDUtils{}
 }
 
-func (u *DummyCRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string) error {
+func (u *DummyCRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, hostId, clusterNamespace, clusterName string, clusterID *strfmt.UUID) error {
 	return nil
 }
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -106,6 +106,7 @@ type API interface {
 	hostcommands.InstructionApi
 	// Register a new host
 	RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB) error
+	UnRegisterHost(ctx context.Context, hostID, clusterID string) error
 	RegisterInstalledOCPHost(ctx context.Context, h *models.Host, db *gorm.DB) error
 	HandleInstallationFailure(ctx context.Context, h *models.Host) error
 	UpdateInstallProgress(ctx context.Context, h *models.Host, progress *models.HostProgress) error
@@ -1233,4 +1234,8 @@ func (m *Manager) GetHostByKubeKey(key types.NamespacedName) (*common.Host, erro
 		return nil, errors.Wrapf(err, "failed to get host from DB: %+v", key)
 	}
 	return host, nil
+}
+
+func (m *Manager) UnRegisterHost(ctx context.Context, hostID, clusterID string) error {
+	return m.db.Where("id = ? and cluster_id = ?", hostID, clusterID).Delete(&common.Host{}).Error
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -405,6 +405,20 @@ func (mr *MockAPIMockRecorder) SetUploadLogsAt(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUploadLogsAt", reflect.TypeOf((*MockAPI)(nil).SetUploadLogsAt), arg0, arg1, arg2)
 }
 
+// UnRegisterHost mocks base method
+func (m *MockAPI) UnRegisterHost(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnRegisterHost", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnRegisterHost indicates an expected call of UnRegisterHost
+func (mr *MockAPIMockRecorder) UnRegisterHost(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRegisterHost", reflect.TypeOf((*MockAPI)(nil).UnRegisterHost), arg0, arg1, arg2)
+}
+
 // UpdateApiVipConnectivityReport mocks base method
 func (m *MockAPI) UpdateApiVipConnectivityReport(arg0 context.Context, arg1 *models.Host, arg2 string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

In case a host is booted with a new ISO generated by an InfraEnv located
in the same namespace, the following steps are performed:

- Check if Host with same KubeKey exists, and delete it
- Clear the Spec of the Agent and update the ClusterDeployment Name
- Verify that the Event URL contains the new cluster ID

Signed-off-by: Fred Rolland <frolland@redhat.com>


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nmagnezi 
/cc @danielerez 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
