### PR TITLE
Bug 1976983: Add docs explaining automatedCleaningMode overrides

### DIFF
--- a/docs/hive-integration/baremetal-agent-controller.md
+++ b/docs/hive-integration/baremetal-agent-controller.md
@@ -197,6 +197,11 @@ It is possible to specify `RootDeviceHints` for the `BareMetalHost` resource. Ro
 used to tell the installer what disk to use as the installation disk. Refer to the
 [baremetal-operator documentation](https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md#rootdevicehints) to know more.
 
+---
+**NOTE**
+
+We are always setting `automatedCleaningMode: disabled` even if the `BareMetalHost` manifest specifies another value (e.g. `automatedCleaningMode: metadata`). This may be changed in the future releases, but currently we do not support using Ironic to clean the node.
+
 Installation flow
 ===
 

--- a/docs/hive-integration/kube-api-getting-started.md
+++ b/docs/hive-integration/kube-api-getting-started.md
@@ -22,9 +22,9 @@ This document is a step-by-step guide that demonstrates how to deploy a single-n
 ## Assumptions
 * You have deployed both the operator and assisted-service by, for example, [using these instructions](../operator.md).  Alternatively, you may choose to deploy via OLM or as a part of ACM, which is also applicable.
 * Using the discovery image:
-  
+
     * **Boot it yourself**: You are able to use the generated discovery image to boot your host.
-    
+
     * **Zero Touch Provisioning (ZTP)**:  Detailed in the [advanced section](#advanced-zero-touch-provisioning). Configure `BMH` / `BareMetalHost` to automate the host discovery procedure. This document uses [dev-scripts](https://github.com/openshift-metal3/dev-scripts/) for that. [read about it here](baremetal-agent-controller.md).
 
 
@@ -444,10 +444,18 @@ spec:
 EOF
 ```
 
+---
+**NOTE**
+
+We are always setting `automatedCleaningMode: disabled` even if the `BareMetalHost` manifest specifies another value (e.g. `automatedCleaningMode: metadata`). This may be changed in the future releases, but currently we do not support using Ironic to clean the node.
+
+---
+
+
 ##### Result
 * Host turned on.
 * Image download started. This might take a while.
-* Host discovery happened. An `Agent` CR got created automatically. 
+* Host discovery happened. An `Agent` CR got created automatically.
 
 Having issues? try this [troubleshooting section](baremetal-agent-controller.md#Troubleshooting)
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR adds an explicit explanation to the documentation describing
lack of support for `automatedCleaningMode: metadata` in the
BareMetalHost CRs.

Closes: [OCPBUGSM-31542](https://issues.redhat.com/browse/OCPBUGSM-31542)

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @nshidlin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
