### PR TITLE
MGMT-6961: optional argument to cluster_list REST API

### DIFF
--- a/client/installer/list_clusters_parameters.go
+++ b/client/installer/list_clusters_parameters.go
@@ -22,9 +22,11 @@ import (
 func NewListClustersParams() *ListClustersParams {
 	var (
 		getUnregisteredClustersDefault = bool(false)
+		withHostsDefault               = bool(false)
 	)
 	return &ListClustersParams{
 		GetUnregisteredClusters: &getUnregisteredClustersDefault,
+		WithHosts:               withHostsDefault,
 
 		timeout: cr.DefaultTimeout,
 	}
@@ -35,9 +37,11 @@ func NewListClustersParams() *ListClustersParams {
 func NewListClustersParamsWithTimeout(timeout time.Duration) *ListClustersParams {
 	var (
 		getUnregisteredClustersDefault = bool(false)
+		withHostsDefault               = bool(false)
 	)
 	return &ListClustersParams{
 		GetUnregisteredClusters: &getUnregisteredClustersDefault,
+		WithHosts:               withHostsDefault,
 
 		timeout: timeout,
 	}
@@ -48,9 +52,11 @@ func NewListClustersParamsWithTimeout(timeout time.Duration) *ListClustersParams
 func NewListClustersParamsWithContext(ctx context.Context) *ListClustersParams {
 	var (
 		getUnregisteredClustersDefault = bool(false)
+		withHostsDefault               = bool(false)
 	)
 	return &ListClustersParams{
 		GetUnregisteredClusters: &getUnregisteredClustersDefault,
+		WithHosts:               withHostsDefault,
 
 		Context: ctx,
 	}
@@ -61,9 +67,11 @@ func NewListClustersParamsWithContext(ctx context.Context) *ListClustersParams {
 func NewListClustersParamsWithHTTPClient(client *http.Client) *ListClustersParams {
 	var (
 		getUnregisteredClustersDefault = bool(false)
+		withHostsDefault               = bool(false)
 	)
 	return &ListClustersParams{
 		GetUnregisteredClusters: &getUnregisteredClustersDefault,
+		WithHosts:               withHostsDefault,
 		HTTPClient:              client,
 	}
 }
@@ -88,6 +96,11 @@ type ListClustersParams struct {
 
 	*/
 	OpenshiftClusterID *strfmt.UUID
+	/*WithHosts
+	  Include hosts in the returned list.
+
+	*/
+	WithHosts bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -160,6 +173,17 @@ func (o *ListClustersParams) SetOpenshiftClusterID(openshiftClusterID *strfmt.UU
 	o.OpenshiftClusterID = openshiftClusterID
 }
 
+// WithWithHosts adds the withHosts to the list clusters params
+func (o *ListClustersParams) WithWithHosts(withHosts bool) *ListClustersParams {
+	o.SetWithHosts(withHosts)
+	return o
+}
+
+// SetWithHosts adds the withHosts to the list clusters params
+func (o *ListClustersParams) SetWithHosts(withHosts bool) {
+	o.WithHosts = withHosts
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListClustersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -199,6 +223,13 @@ func (o *ListClustersParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 			}
 		}
 
+	}
+
+	// query param with_hosts
+	qrWithHosts := o.WithHosts
+	qWithHosts := swag.FormatBool(qrWithHosts)
+	if err := r.SetQueryParam("with_hosts", qWithHosts); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2467,7 +2467,13 @@ func (b *bareMetalInventory) ListClusters(ctx context.Context, params installer.
 
 	// we need to fetch Hosts association to allow AfterFind hook to run
 	for _, c := range dbClusters {
-		c.Hosts = []*models.Host{}
+		if !params.WithHosts {
+			c.Hosts = []*models.Host{}
+		}
+		for _, h := range c.Hosts {
+			// Clear this field as it is not needed to be sent via API
+			h.FreeAddresses = ""
+		}
 		clusters = append(clusters, &c.Cluster)
 	}
 	return installer.NewListClustersOK().WithPayload(clusters)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4622,6 +4622,17 @@ var _ = Describe("List clusters", func() {
 		Expect(len(payload[0].Hosts)).Should(Equal(0))
 	})
 
+	It("List unregistered clusters with hosts success", func() {
+		Expect(db.Delete(&c).Error).ShouldNot(HaveOccurred())
+		Expect(db.Delete(&host1).Error).ShouldNot(HaveOccurred())
+		resp := bm.ListClusters(ctx, installer.ListClustersParams{GetUnregisteredClusters: swag.Bool(true), WithHosts: true})
+		clusterList := resp.(*installer.ListClustersOK).Payload
+		Expect(len(clusterList)).Should(Equal(1))
+		Expect(clusterList[0].ID.String()).Should(Equal(clusterID.String()))
+		Expect(len(clusterList[0].Hosts)).Should(Equal(1))
+		Expect(clusterList[0].Hosts[0].ID.String()).Should(Equal(hostID.String()))
+	})
+
 	It("List unregistered clusters failure - cluster was permanently deleted", func() {
 		Expect(db.Unscoped().Delete(&c).Error).ShouldNot(HaveOccurred())
 		Expect(db.Unscoped().Delete(&host1).Error).ShouldNot(HaveOccurred())

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -285,6 +285,14 @@ func init() {
             "description": "If non-empty, returned Clusters are filtered to those with matching subscription IDs.",
             "name": "ams_subscription_ids",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Include hosts in the returned list.",
+            "name": "with_hosts",
+            "in": "query",
+            "allowEmptyValue": true
           }
         ],
         "responses": {
@@ -7872,6 +7880,14 @@ func init() {
             "description": "If non-empty, returned Clusters are filtered to those with matching subscription IDs.",
             "name": "ams_subscription_ids",
             "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Include hosts in the returned list.",
+            "name": "with_hosts",
+            "in": "query",
+            "allowEmptyValue": true
           }
         ],
         "responses": {

--- a/restapi/operations/installer/list_clusters_parameters.go
+++ b/restapi/operations/installer/list_clusters_parameters.go
@@ -24,10 +24,14 @@ func NewListClustersParams() ListClustersParams {
 		// initialize parameters with default values
 
 		getUnregisteredClustersDefault = bool(false)
+
+		withHostsDefault = bool(false)
 	)
 
 	return ListClustersParams{
 		GetUnregisteredClusters: &getUnregisteredClustersDefault,
+
+		WithHosts: withHostsDefault,
 	}
 }
 
@@ -53,6 +57,11 @@ type ListClustersParams struct {
 	  In: query
 	*/
 	OpenshiftClusterID *strfmt.UUID
+	/*Include hosts in the returned list.
+	  In: query
+	  Default: false
+	*/
+	WithHosts bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -77,6 +86,11 @@ func (o *ListClustersParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	qOpenshiftClusterID, qhkOpenshiftClusterID, _ := qs.GetOK("openshift_cluster_id")
 	if err := o.bindOpenshiftClusterID(qOpenshiftClusterID, qhkOpenshiftClusterID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qWithHosts, qhkWithHosts, _ := qs.GetOK("with_hosts")
+	if err := o.bindWithHosts(qWithHosts, qhkWithHosts, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -170,5 +184,28 @@ func (o *ListClustersParams) validateOpenshiftClusterID(formats strfmt.Registry)
 	if err := validate.FormatOf("openshift_cluster_id", "query", "uuid", o.OpenshiftClusterID.String(), formats); err != nil {
 		return err
 	}
+	return nil
+}
+
+// bindWithHosts binds and validates parameter WithHosts from query.
+func (o *ListClustersParams) bindWithHosts(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: true
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewListClustersParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("with_hosts", "query", "bool", raw)
+	}
+	o.WithHosts = value
+
 	return nil
 }

--- a/restapi/operations/installer/list_clusters_urlbuilder.go
+++ b/restapi/operations/installer/list_clusters_urlbuilder.go
@@ -18,6 +18,7 @@ import (
 type ListClustersURL struct {
 	AmsSubscriptionIds []string
 	OpenshiftClusterID *strfmt.UUID
+	WithHosts          bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -76,6 +77,11 @@ func (o *ListClustersURL) Build() (*url.URL, error) {
 	}
 	if openshiftClusterIDQ != "" {
 		qs.Set("openshift_cluster_id", openshiftClusterIDQ)
+	}
+
+	withHostsQ := swag.FormatBool(o.WithHosts)
+	if withHostsQ != "" {
+		qs.Set("with_hosts", withHostsQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -118,6 +118,12 @@ paths:
           type: array
           items:
             type: string
+        - in: query
+          name: with_hosts
+          description: Include hosts in the returned list.
+          type: boolean
+          allowEmptyValue: true
+          default: false
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
# Assisted Pull Request

## Description

added new `with_hosts` optional parameter to the cluster_list API, defaults to `false`.
When `true`, the hosts array will include all hosts in cluster. otherwise the array will be empty.

Updated inventory and subsystem tests.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @michaellevy101 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
