### PR TITLE
MGMT-5171: Call set_ca_bundle.py script from the correct path

### DIFF
--- a/deploy/operator/common.sh
+++ b/deploy/operator/common.sh
@@ -6,8 +6,24 @@ if [ -z "${DISKS:-}" ]; then
 fi
 
 export DISCONNECTED="${DISCONNECTED:-false}"
+if [ "${DISCONNECTED}" = "true" ]; then
+    export LOCAL_REGISTRY="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}"
+fi
+
+##############
+# Deployment #
+##############
+
 export ASSISTED_DEPLOYMENT_METHOD="${ASSISTED_DEPLOYMENT_METHOD:-from_index_image}"
 export HIVE_DEPLOYMENT_METHOD="${HIVE_DEPLOYMENT_METHOD:-with_olm}"
+
+export ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
+export SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
+export HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
+
+############
+# Versions #
+############
 
 export OPENSHIFT_VERSIONS="${OPENSHIFT_VERSIONS:-$(cat ${__root}/data/default_ocp_versions.json)}"
 
@@ -15,7 +31,6 @@ if [ -z "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-}" ]; then
     export ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE=$(echo ${OPENSHIFT_VERSIONS} | jq -rc '[.[].release_image]|max')
 fi
 
-export LOCAL_REGISTRY="${LOCAL_REGISTRY_DNS_NAME}:${LOCAL_REGISTRY_PORT}"
 export ASSISTED_OPENSHIFT_VERSION="${ASSISTED_OPENSHIFT_VERSION:-openshift-v4.8.0}"
 
 OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
@@ -27,7 +42,3 @@ OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
                 rhcos_rootfs:  .value.rhcos_rootfs}
     }
     )')
-
-export ASSISTED_NAMESPACE="${ASSISTED_NAMESPACE:-assisted-installer}"
-export SPOKE_NAMESPACE="${SPOKE_NAMESPACE:-assisted-spoke-cluster}"
-export HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -214,7 +214,7 @@ data:
     done)
 EOCR
 
-  python ./set_ca_bundle.py '${WORKING_DIR}/registry/certs/registry.2.crt' './assisted-mirror-config'
+  python ${__dir}/set_ca_bundle.py '${WORKING_DIR}/registry/certs/registry.2.crt' './assisted-mirror-config'
   tee < ./assisted-mirror-config >(oc apply -f -)
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Fixes https://github.com/openshift/assisted-service/pull/2148 calling `set_ca_bundle.py` script from relative path.

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
