### PR TITLE
MGMT-5171: Fix quotes on setup_assisted_operator.sh

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -214,7 +214,7 @@ data:
     done)
 EOCR
 
-  python ${__dir}/set_ca_bundle.py '${WORKING_DIR}/registry/certs/registry.2.crt' './assisted-mirror-config'
+  python ${__dir}/set_ca_bundle.py "${WORKING_DIR}/registry/certs/registry.2.crt" "./assisted-mirror-config"
   tee < ./assisted-mirror-config >(oc apply -f -)
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Waiting for CI to do a full test run

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
