### PR TITLE
MGMT-7098: Add installation_failed_at field for monitoring failed ins…

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -55,6 +55,9 @@ func updateClusterStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.D
 		if funk.ContainsString(installationCompletedStatuses, swag.StringValue(&newStatus)) {
 			extra = append(extra, "install_completed_at", now)
 		}
+		if swag.StringValue(&newStatus) == models.ClusterStatusError {
+			extra = append(extra, "install_failed_at", now)
+		}
 	}
 
 	if cluster, err = UpdateCluster(log, db, clusterId, srcStatus, extra...); err != nil ||

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -3325,6 +3325,9 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterAfterRefresh.Status).To(Equal(&t.dstState))
 				t.statusInfoChecker.check(clusterAfterRefresh.StatusInfo)
+				if t.dstState == models.ClusterStatusError && t.srcState != models.ClusterStatusError {
+					Expect(clusterAfterRefresh.InstallFailedAt).Should(Equal(clusterAfterRefresh.StatusUpdatedAt))
+				}
 			})
 		}
 	})

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -127,6 +127,10 @@ type Cluster struct {
 	// JSON-formatted string containing the user overrides for the install-config.yaml file.
 	InstallConfigOverrides string `json:"install_config_overrides,omitempty" gorm:"type:text"`
 
+	// The time that this cluster failed installation.
+	// Format: date-time
+	InstallFailedAt strfmt.DateTime `json:"install_failed_at,omitempty" gorm:"type:timestamp with time zone;default:'2000-01-01 00:00:00z'"`
+
 	// The time that this cluster started installation.
 	// Format: date-time
 	InstallStartedAt strfmt.DateTime `json:"install_started_at,omitempty" gorm:"type:timestamp with time zone;default:'2000-01-01 00:00:00z'"`
@@ -282,6 +286,10 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateInstallCompletedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateInstallFailedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -645,6 +653,19 @@ func (m *Cluster) validateInstallCompletedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("install_completed_at", "body", "date-time", m.InstallCompletedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Cluster) validateInstallFailedAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.InstallFailedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("install_failed_at", "body", "date-time", m.InstallFailedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5008,6 +5008,12 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
         },
+        "install_failed_at": {
+          "description": "The time that this cluster failed installation.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone;default:'2000-01-01 00:00:00z'\""
+        },
         "install_started_at": {
           "description": "The time that this cluster started installation.",
           "type": "string",
@@ -12738,6 +12744,12 @@ func init() {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
+        },
+        "install_failed_at": {
+          "description": "The time that this cluster failed installation.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone;default:'2000-01-01 00:00:00z'\""
         },
         "install_started_at": {
           "description": "The time that this cluster started installation.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4200,7 +4200,6 @@ definitions:
         format: int64
         description: All hosts associated to this cluster.
         x-go-custom-tag: gorm:"-"
-
       updated_at:
         type: string
         format: date-time
@@ -4216,6 +4215,11 @@ definitions:
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone;default:'2000-01-01 00:00:00z'"
         description: The time that this cluster started installation.
+      install_failed_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone;default:'2000-01-01 00:00:00z'"
+        description: The time that this cluster failed installation.
       install_completed_at:
         type: string
         format: date-time


### PR DESCRIPTION
…tallations

# Assisted Pull Request

## Description

this will help in two eras:
1. Give the option to locate clusters that have failed in the past and simplify the process of finding clusters that need to be examined (triaged)
2. Help monitor general activity in the service and help find bugs and issuse. 


## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @YuviGold 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
