### PR TITLE
OCPBUGSM-30766: Removing "Unauthorized access to cluster *" log.

### DIFF
--- a/pkg/auth/rhsso_authenticator.go
+++ b/pkg/auth/rhsso_authenticator.go
@@ -312,7 +312,6 @@ func (a *RHSSOAuthenticator) CreateAuthenticator() func(name, in string, authent
 				return true, nil, common.NewApiError(http.StatusInternalServerError, err)
 			}
 			if !ownedBy {
-				log.Errorf("Unauthorized access to cluster %s by a user other than the owner\n", clusterID)
 				return true, nil, common.NewApiError(http.StatusNotFound, errors.New("Cluster Not Found"))
 			}
 


### PR DESCRIPTION
# Assisted Pull Request

## Description


This log is printed in one of 2 cases:

    * A user tries to access a non-existing cluster
    * A user tries to access a cluster that he doesn't own

The UI is getting a list of subscriptions from AMS which contains all the
clusters in the user's organization, then for each cluster it queries AI
in order to get some additional information, therefore it may:

    * Try to access a GC cluster
    * Try to access a cluster that someone else in the organization owns

Until we have an organization model in AI aligned with OCM we should
remove this log, otherwise, we will be spammed.

    Signed-off-by: Yoni Bettan <ybettan@redhat.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed


On the new code, I didn't get this log.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
