### PR TITLE
Bug 1978739: Fix requeue logic inside mapInfraEnvToBMH

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -485,7 +485,10 @@ func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.Inf
 	// This is a separate check because an existing
 	// InfraEnv with an empty ISODownloadURL means the
 	// global `Reconcile` function should also return
-	// as there is nothing left to do for it.
+	// as there is nothing left to do for it. Note that we
+	// do not have to explicitly requeue here. As soon as
+	// the InfraEnv gets its ISO, reconciliation will be
+	// triggered because of the watcher on the InfraEnv CR.
 	if infraEnv.Status.ISODownloadURL == "" {
 		return false, true, 0, "InfraEnv corresponding to the BMH has no image URL available."
 	}
@@ -1111,8 +1114,11 @@ func (r *BMACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 		for i, bmh := range bmhs {
 
-			queue, _, _, _ := shouldReconcileBMH(bmh, infraEnv)
-			if !queue {
+			// Don't queue if shouldReconcileBMH explicitly tells us not to do so. If the function
+			// returns a cooldown period, do not stop reconcile immediately here but let the
+			// requeue happen during the reconciliation.
+			queue, _, requeuePeriod, _ := shouldReconcileBMH(bmh, infraEnv)
+			if !queue && requeuePeriod == 0 {
 				continue
 			}
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

It has been discovered during scaling tests that it sometimes happen
that the cooldown period for InfraEnv's ISO is causing BMHs to be stuck
in Ready state.

This is caused by the fact that inside mapInfraEnvToBMH function the
returned cooldown period was ignored so that the requeueing was never
happening.

The change introduced in this PR modifies the logic inside
mapInfraEnvToBMH so that we check if requeueing is needed and if so, we
proceed with reconciliation. This effectively moves the requeue logic to
the reconciliation loop.

Closes: [OCPBUGSM-31727](https://issues.redhat.com/browse/OCPBUGSM-31727)



<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual test

```
    conditions:
    - lastTransitionTime: '2021-07-07T10:04:32Z'
      message: Image has been created
      reason: ImageCreated
      status: 'True'
      type: ImageCreated
  createdTime: '2021-07-07T10:11:45Z'
  isoDownloadURL: >-
    https://assisted-service-assisted-installer-manual-bundle.apps.ostest.test.metalkube.org/api/assisted-install/v1/clusters/434f[...]Cw
```
```
[...]
time="2021-07-07T10:11:44Z" level=info msg="InfraEnv Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:81" go-id=761 infra_env=myinfraenv infra_env_namespace=assisted-installer-manual-bundle request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
time="2021-07-07T10:11:44Z" level=info msg="the amount of nmStateConfigs included in the image is: 1" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).ensureISO" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:298" go-id=761 infra_env=myinfraenv infra_env_namespace=assisted-installer-manual-bundle request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
time="2021-07-07T10:11:44Z" level=info msg="prepare image for cluster 434f7f99-c452-4ad2-a342-f75ba9e51917" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).GenerateClusterISOInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:868" go-id=761 pkg=Inventory request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
time="2021-07-07T10:11:45Z" level=info msg="Successfully uploaded file 434f7f99-c452-4ad2-a342-f75ba9e51917/discovery.ign" func="github.com/openshift/assisted-service/pkg/s3wrapper.(*FSClient).Upload" file="/go/src/github.com/openshift/origin/pkg/s3wrapper/filesystem.go:76" go-id=761 request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
time="2021-07-07T10:11:45Z" level=info msg="Creating minimal ISO for cluster 434f7f99-c452-4ad2-a342-f75ba9e51917" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).generateClusterMinimalISO.func1" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:1105" go-id=761 pkg=Inventory request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
[...]
time="2021-07-07T10:11:45Z" level=info msg="ClusterDeployment Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*ClusterDeploymentsReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/clusterdeployments_controller.go:116" cluster_deployment=single-node cluster_deployment_namespace=assisted-installer-manual-bundle go-id=766 request_id=3a8d7db6-dcba-4763-8744-fb0a8124cf88
time="2021-07-07T10:11:45Z" level=info msg="ISODownloadURL changed from https://assisted-service-assisted-installer-manual-bundle.apps.ostest.test.metalkube.org/api/assisted-install/v1/clusters/434f7f99-c452-4ad2-a342-f75ba9e51917/downloads/image?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNDM0ZjdmOTktYzQ1Mi00YWQyLWEzNDItZjc1YmE5ZTUxOTE3In0.I1ZdLJchdXBYgM-NG_pGmvp3wL945tXvEBi0YICgEBbCPU8ehA2ngHhFytpFeQj7sw89wCaGdkTI1832y-UwNA to https://assisted-service-assisted-installer-manual-bundle.apps.ostest.test.metalkube.org/api/assisted-install/v1/clusters/434f7f99-c452-4ad2-a342-f75ba9e51917/downloads/image?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbHVzdGVyX2lkIjoiNDM0ZjdmOTktYzQ1Mi00YWQyLWEzNDItZjc1YmE5ZTUxOTE3In0.Zoy_-AmTwjsTGpJaNx2vQl24MTiM3NRKrX9XvziiEsDgujxJvYZJD48raGkOudd8EFJtChNYW3WizlHvucjyCw" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).updateEnsureISOSuccess" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:328" go-id=761 infra_env=myinfraenv infra_env_namespace=assisted-installer-manual-bundle request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
time="2021-07-07T10:11:46Z" level=info msg="InfraEnv Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:78" go-id=761 infra_env=myinfraenv infra_env_namespace=assisted-installer-manual-bundle request_id=5dc52e7e-381e-4e5e-aaaf-c43aca75fbe2
[...]
time="2021-07-07T10:11:46Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=9dd056eb-2914-46a8-b3a4-3ecf40a9f8c8
time="2021-07-07T10:11:46Z" level=info msg="Requeuing reconcileBMH: InfraEnv image is too recent. Requeuing and retrying again soon." func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:592" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=9dd056eb-2914-46a8-b3a4-3ecf40a9f8c8
time="2021-07-07T10:11:46Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=9dd056eb-2914-46a8-b3a4-3ecf40a9f8c8
[...]
time="2021-07-07T10:12:47Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=d65e591d-eed7-4400-a3c2-81643348f07d
time="2021-07-07T10:12:47Z" level=info msg="Image URL has been set in the BareMetalHost  assisted-installer-manual-bundle/ostest-extraworker-0" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:619"
time="2021-07-07T10:12:47Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=d65e591d-eed7-4400-a3c2-81643348f07d
[...]
time="2021-07-07T10:12:47Z" level=info msg="BareMetalHost Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:164" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=26a69c70-61c4-48c1-a441-248bc9bd1174
time="2021-07-07T10:12:47Z" level=info msg="Stopping reconcileBMH: BMH and InfraEnv images are in sync. Nothing to update." func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).reconcileBMH" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:595" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=26a69c70-61c4-48c1-a441-248bc9bd1174
time="2021-07-07T10:12:47Z" level=info msg="BareMetalHost Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*BMACReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/bmh_agent_controller.go:161" bare_metal_host=ostest-extraworker-0 bare_metal_host_namespace=assisted-installer-manual-bundle go-id=727 request_id=26a69c70-61c4-48c1-a441-248bc9bd1174
[...]
```
```
  image:
    format: live-iso
    url: >-
      https://assisted-service-assisted-installer-manual-bundle.apps.ostest.test.metalkube.org/api/assisted-install/v1/clusters/434f7f99-c452-4ad2-a342-f75ba9e51917/downloads/image?api_key=eyJhbG[...]cjyCw
  online: true
```

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
