### PR TITLE
Bug 1979906: Fix requeue logic inside mapInfraEnvToBMH

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -485,7 +485,10 @@ func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.Inf
 	// This is a separate check because an existing
 	// InfraEnv with an empty ISODownloadURL means the
 	// global `Reconcile` function should also return
-	// as there is nothing left to do for it.
+	// as there is nothing left to do for it. Note that we
+	// do not have to explicitly requeue here. As soon as
+	// the InfraEnv gets its ISO, reconciliation will be
+	// triggered because of the watcher on the InfraEnv CR.
 	if infraEnv.Status.ISODownloadURL == "" {
 		return false, true, 0, "InfraEnv corresponding to the BMH has no image URL available."
 	}
@@ -1125,8 +1128,11 @@ func (r *BMACReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 		for i, bmh := range bmhs {
 
-			queue, _, _, _ := shouldReconcileBMH(bmh, infraEnv)
-			if !queue {
+			// Don't queue if shouldReconcileBMH explicitly tells us not to do so. If the function
+			// returns a cooldown period, do not stop reconcile immediately here but let the
+			// requeue happen during the reconciliation.
+			queue, _, requeuePeriod, _ := shouldReconcileBMH(bmh, infraEnv)
+			if !queue && requeuePeriod == 0 {
 				continue
 			}
 


### PR DESCRIPTION
This is a manual backport of #2173. We do not wait for the bot so that we can save some time and start CI run already in parallel as we wait for the master to merge.

/cc @flaper87 
/cc @rollandf 
/cc @akrzos