### PR TITLE
Bug 1978691: Fix osImages reference passing

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -965,7 +965,7 @@ func (r *AgentServiceConfigReconciler) getOpenshiftVersions(log logrus.FieldLogg
 	}
 
 	openshiftVersions := make(models.OpenshiftVersions)
-	for _, image := range instance.Spec.OSImages {
+	for i, image := range instance.Spec.OSImages {
 		v, err := version.NewVersion(image.OpenshiftVersion)
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Problem parsing OpenShift version %v, skipping.", image.OpenshiftVersion))
@@ -976,9 +976,9 @@ func (r *AgentServiceConfigReconciler) getOpenshiftVersions(log logrus.FieldLogg
 		versionString := fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1])
 		openshiftVersion := models.OpenshiftVersion{
 			DisplayName:  &versionString,
-			RhcosVersion: &image.Version,
-			RhcosImage:   &image.Url,
-			RhcosRootfs:  &image.RootFSUrl,
+			RhcosVersion: &instance.Spec.OSImages[i].Version,
+			RhcosImage:   &instance.Spec.OSImages[i].Url,
+			RhcosRootfs:  &instance.Spec.OSImages[i].RootFSUrl,
 		}
 
 		// the last entry for a particular OpenShift version takes precedence.

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -604,9 +604,9 @@ func newASCWithOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, string) {
 	asc.Spec.OSImages = []aiv1beta1.OSImage{
 		{
 			OpenshiftVersion: "4.8",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "48",
+			Url:              "4.8.iso",
+			RootFSUrl:        "4.8.img",
 		},
 	}
 
@@ -614,9 +614,9 @@ func newASCWithOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, string) {
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.8": {
 			DisplayName:  s("4.8"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("48"),
+			RhcosImage:   s("4.8.iso"),
+			RhcosRootfs:  s("4.8.img"),
 		},
 	})
 
@@ -628,15 +628,15 @@ func newASCWithMultipleOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, strin
 	asc.Spec.OSImages = []aiv1beta1.OSImage{
 		{
 			OpenshiftVersion: "4.7",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "47",
+			Url:              "4.7.iso",
+			RootFSUrl:        "4.7.img",
 		},
 		{
 			OpenshiftVersion: "4.8",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "48",
+			Url:              "4.8.iso",
+			RootFSUrl:        "4.8.img",
 		},
 	}
 
@@ -644,15 +644,15 @@ func newASCWithMultipleOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, strin
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.7": {
 			DisplayName:  s("4.7"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("47"),
+			RhcosImage:   s("4.7.iso"),
+			RhcosRootfs:  s("4.7.img"),
 		},
 		"4.8": {
 			DisplayName:  s("4.8"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("48"),
+			RhcosImage:   s("4.8.iso"),
+			RhcosRootfs:  s("4.8.img"),
 		},
 	})
 
@@ -664,9 +664,9 @@ func newASCWithDuplicateOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, stri
 	asc.Spec.OSImages = []aiv1beta1.OSImage{
 		{
 			OpenshiftVersion: "4.7",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "47",
+			Url:              "4.7.iso",
+			RootFSUrl:        "4.7.img",
 		},
 		{
 			OpenshiftVersion: "4.8",
@@ -676,9 +676,9 @@ func newASCWithDuplicateOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, stri
 		},
 		{
 			OpenshiftVersion: "4.8",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "48",
+			Url:              "4.8.iso",
+			RootFSUrl:        "4.8.img",
 		},
 	}
 
@@ -686,15 +686,15 @@ func newASCWithDuplicateOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, stri
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.7": {
 			DisplayName:  s("4.7"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("47"),
+			RhcosImage:   s("4.7.iso"),
+			RhcosRootfs:  s("4.7.img"),
 		},
 		"4.8": {
 			DisplayName:  s("4.8"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("48"),
+			RhcosImage:   s("4.8.iso"),
+			RhcosRootfs:  s("4.8.img"),
 		},
 	})
 
@@ -707,9 +707,9 @@ func newASCWithInvalidOpenshiftVersion() *aiv1beta1.AgentServiceConfig {
 	asc.Spec.OSImages = []aiv1beta1.OSImage{
 		{
 			OpenshiftVersion: "invalidVersion",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "48",
+			Url:              "4.8.iso",
+			RootFSUrl:        "4.8.img",
 		},
 	}
 
@@ -722,9 +722,9 @@ func newASCWithLongOpenshiftVersion() (*aiv1beta1.AgentServiceConfig, string) {
 	asc.Spec.OSImages = []aiv1beta1.OSImage{
 		{
 			OpenshiftVersion: "4.8.0",
-			Version:          "47.83.202103251640-0",
-			Url:              "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-			RootFSUrl:        "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
+			Version:          "48",
+			Url:              "4.8.iso",
+			RootFSUrl:        "4.8.img",
 		},
 	}
 
@@ -732,9 +732,9 @@ func newASCWithLongOpenshiftVersion() (*aiv1beta1.AgentServiceConfig, string) {
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.8": {
 			DisplayName:  s("4.8"),
-			RhcosVersion: s("47.83.202103251640-0"),
-			RhcosImage:   s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso"),
-			RhcosRootfs:  s("https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img"),
+			RhcosVersion: s("48"),
+			RhcosImage:   s("4.8.iso"),
+			RhcosRootfs:  s("4.8.img"),
 		},
 	})
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Currently, when constructing OPENSHIFT_VERSIONS from the osImages on the
AgentServiceConfig, the values are passed by reference clumsily. This causes a
problem where the last in the `osImages` slice is used to determine the
root filesystem URL and ISO URL for all OPENSHIFT_VERSIONS.

If we use the reference directly from the agentserviceconfig, we should
avoid this problem.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @flaper87
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
