### PR TITLE
MGMT-5171: Mirror all available ICSP on script

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -206,7 +206,7 @@ data:
 
     $(registry_config "$(get_image_namespace ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})" "${LOCAL_REGISTRY}/$(get_image_namespace_without_registry ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
     $(registry_config "$(get_image_namespace ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_namespace_without_registry ${cli_image})")
-    $(for row in $(kubectl get imagecontentsourcepolicy -o json | jq -rc '.items[] | select(.metadata.name | test("community-operator-")).spec.repositoryDigestMirrors[] | [.mirrors[0], .source]'); do
+    $(for row in $(kubectl get imagecontentsourcepolicy -o json | jq -rc '.items[] | .spec.repositoryDigestMirrors[] | [.mirrors[0], .source]'); do
       row=$(echo ${row} | tr -d '[]"');
       source=$(echo ${row} | cut -d',' -f2);
       mirror=$(echo ${row} | cut -d',' -f1);


### PR DESCRIPTION
# Assisted Pull Request

## Description

The ICSP name is derived from the index image.
We shouldn't depend on specific name.

For example, on OpenShift CI the index image looks like the following:
'registry.build01.ci.openshift.org/ci-op-bqxvrsmm/pipeline'
and the ICSP name would be 'pipeline-0'

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
