### PR TITLE
NO-ISSUE: Revert "Don't lint swagger for now to make tests green (#2190)

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -52,8 +52,7 @@ function generate_keys() {
 }
 
 function generate_from_swagger() {
-    #TODO: Add this back when https://github.com/stoplightio/spectral/issues/1745 is resolved
-    #lint_swagger
+    lint_swagger
     generate_go_client
     generate_go_server
 }

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -46,8 +46,7 @@ function assisted_service() {
   curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     | sh -s -- -b $(go env GOPATH)/bin v1.36.0
 
-  #TODO: Add this back when https://github.com/stoplightio/spectral/issues/1745 is resolved
-  #curl --retry 5 -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
+  curl --retry 5 -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
 
   ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
   OS=$(uname | awk '{print tolower($0)}')


### PR DESCRIPTION


# Assisted Pull Request

## Description

This reverts commit e399ac41aefb1b26afc955603414f01b0dd4dcb5.

This should go green and can be merged if/when
https://github.com/stoplightio/spectral/issues/1745 is resolved.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @jordigilh 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
