### PR TITLE
MGMT-7170: Adapt connectivity groups to support L3 connectivity

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -868,7 +868,7 @@ func (m *Manager) setConnectivityMajorityGroupsForClusterInternal(cluster *commo
 	})
 	majorityGroups := make(map[string][]strfmt.UUID)
 	for _, cidr := range network.GetClusterNetworks(hosts, m.log) {
-		majorityGroup, err := network.CreateMajorityGroup(cidr, hosts)
+		majorityGroup, err := network.CreateL2MajorityGroup(cidr, hosts)
 		if err != nil {
 			m.log.WithError(err).Warnf("Create majority group for %s", cidr)
 			continue

--- a/internal/network/connectivity_groups_test.go
+++ b/internal/network/connectivity_groups_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -18,26 +19,47 @@ type node struct {
 	addressNet2 string
 }
 
-func linkNet1(n *node) *models.L2Connectivity {
+func l2LinkNet1(n *node) *models.L2Connectivity {
 	return &models.L2Connectivity{
 		RemoteIPAddress: n.addressNet1,
 		Successful:      true,
 	}
 }
 
-func linkNet2(n *node) *models.L2Connectivity {
+func l2LinkNet2(n *node) *models.L2Connectivity {
 	return &models.L2Connectivity{
 		RemoteIPAddress: n.addressNet2,
 		Successful:      true,
 	}
 }
 
-func unLinkNet1(n *node) *models.L2Connectivity {
+func unL2LinkNet1(n *node) *models.L2Connectivity {
 	return &models.L2Connectivity{
 		RemoteIPAddress: n.addressNet1,
 		Successful:      false,
 	}
 }
+
+func l3LinkNet1(n *node) *models.L3Connectivity {
+	return &models.L3Connectivity{
+		RemoteIPAddress: n.addressNet1,
+		Successful:      true,
+	}
+}
+
+func l3LinkNet2(n *node) *models.L3Connectivity {
+	return &models.L3Connectivity{
+		RemoteIPAddress: n.addressNet2,
+		Successful:      true,
+	}
+}
+
+//func unL3LinkNet1(n *node) *models.L3Connectivity {
+//	return &models.L3Connectivity{
+//		RemoteIPAddress: n.addressNet1,
+//		Successful:      false,
+//	}
+//}
 
 func generateIPv4Nodes(count int, net1CIDR, net2CIDR string) []*node {
 
@@ -90,7 +112,7 @@ func generateIPv6Nodes(count int, net1CIDR, net2CIDR string) []*node {
 	return ret
 }
 
-func createRemote(remote *node, connFuncs ...func(h *node) *models.L2Connectivity) *models.ConnectivityRemoteHost {
+func createL2Remote(remote *node, connFuncs ...func(h *node) *models.L2Connectivity) *models.ConnectivityRemoteHost {
 
 	l2s := make([]*models.L2Connectivity, 0)
 	for _, f := range connFuncs {
@@ -103,12 +125,56 @@ func createRemote(remote *node, connFuncs ...func(h *node) *models.L2Connectivit
 	}
 }
 
-var _ = Describe("connectivity groups all", func() {
-	GenerateConnectivityGroupTests(true, "1.2.3.0/24", "2.2.3.0/24")
-	GenerateConnectivityGroupTests(false, "2001:db8::/120", "fe80:5054::/120")
+func createL3Remote(remote *node, connFuncs ...func(h *node) *models.L3Connectivity) *models.ConnectivityRemoteHost {
+
+	l2s := make([]*models.L3Connectivity, 0)
+	for _, f := range connFuncs {
+		l2s = append(l2s, f(remote))
+	}
+
+	return &models.ConnectivityRemoteHost{
+		HostID:         *remote.id,
+		L3Connectivity: l2s,
+	}
+}
+
+func createConnectivityReport(remoteHosts ...*models.ConnectivityRemoteHost) string {
+	report := models.ConnectivityReport{
+		RemoteHosts: remoteHosts,
+	}
+	b, err := json.Marshal(&report)
+	Expect(err).ToNot(HaveOccurred())
+	return string(b)
+}
+
+func makeInventory(node *node) string {
+	var inventory models.Inventory
+	for i, a := range []string{node.addressNet1, node.addressNet2} {
+		if a == "" {
+			continue
+		}
+		name := fmt.Sprintf("eth%d", i)
+		newInterface := &models.Interface{
+			Name: name,
+		}
+		if strings.Contains(a, ":") {
+			newInterface.IPV6Addresses = append(newInterface.IPV6Addresses, a+"/64")
+		} else {
+			newInterface.IPV4Addresses = append(newInterface.IPV4Addresses, a+"/24")
+		}
+		inventory.Interfaces = append(inventory.Interfaces, newInterface)
+	}
+	b, err := json.Marshal(&inventory)
+	Expect(err).ToNot(HaveOccurred())
+	return string(b)
+}
+
+var _ = Describe("L2 connectivity groups all", func() {
+	GenerateL2ConnectivityGroupTests(true, "1.2.3.0/24", "2.2.3.0/24")
+	GenerateL2ConnectivityGroupTests(false, "2001:db8::/120", "fe80:5054::/120")
 })
 
-func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
+func GenerateL2ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 
 	var ipVersion string
 	var nodes []*node
@@ -121,15 +187,6 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 	}
 
 	Describe(fmt.Sprintf("connectivity groups %s", ipVersion), func() {
-
-		createConnectivityReport := func(remoteHosts ...*models.ConnectivityRemoteHost) string {
-			report := models.ConnectivityReport{
-				RemoteHosts: remoteHosts,
-			}
-			b, err := json.Marshal(&report)
-			Expect(err).ToNot(HaveOccurred())
-			return string(b)
-		}
 
 		Context("connectivity groups", func() {
 			It("Empty", func() {
@@ -147,7 +204,7 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 						Connectivity: createConnectivityReport(),
 					},
 				}
-				ret, err := CreateMajorityGroup(net1CIDR, hosts)
+				ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ret).To(Equal([]strfmt.UUID{}))
 			})
@@ -163,7 +220,7 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 						ID: nodes[2].id,
 					},
 				}
-				ret, err := CreateMajorityGroup(net1CIDR, hosts)
+				ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ret).To(Equal([]strfmt.UUID{}))
 			})
@@ -173,8 +230,8 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID:           nodes[1].id,
@@ -185,7 +242,7 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Connectivity: createConnectivityReport(),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(Equal([]strfmt.UUID{}))
 		})
@@ -194,23 +251,23 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[2].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[1], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[1], l2LinkNet1)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -222,23 +279,23 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[2].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet2),
-						createRemote(nodes[1], linkNet2)),
+						createL2Remote(nodes[0], l2LinkNet2),
+						createL2Remote(nodes[1], l2LinkNet2)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(Equal([]strfmt.UUID{}))
 		})
@@ -247,39 +304,39 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1, linkNet2),
-						createRemote(nodes[2], linkNet1),
-						createRemote(nodes[3], linkNet2),
+						createL2Remote(nodes[1], l2LinkNet1, l2LinkNet2),
+						createL2Remote(nodes[2], l2LinkNet1),
+						createL2Remote(nodes[3], l2LinkNet2),
 					),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1, linkNet2),
-						createRemote(nodes[2], linkNet1),
-						createRemote(nodes[3], linkNet2),
+						createL2Remote(nodes[0], l2LinkNet1, l2LinkNet2),
+						createL2Remote(nodes[2], l2LinkNet1),
+						createL2Remote(nodes[3], l2LinkNet2),
 					),
 				},
 				{
 					ID: nodes[2].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1, linkNet2),
-						createRemote(nodes[1], linkNet1, linkNet2)),
+						createL2Remote(nodes[0], l2LinkNet1, l2LinkNet2),
+						createL2Remote(nodes[1], l2LinkNet1, l2LinkNet2)),
 				},
 				{
 					ID: nodes[3].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet2),
-						createRemote(nodes[1], linkNet2)),
+						createL2Remote(nodes[0], l2LinkNet2),
+						createL2Remote(nodes[1], l2LinkNet2)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))
 			Expect(ret).To(ContainElement(*nodes[1].id))
 			Expect(ret).To(ContainElement(*nodes[2].id))
-			ret, err = CreateMajorityGroup(net2CIDR, hosts)
+			ret, err = CreateL2MajorityGroup(net2CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -291,52 +348,52 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[2].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[1], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[1], l2LinkNet1)),
 				},
 				{
 					ID: nodes[3].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1),
 					),
 				},
 				{
 					ID: nodes[4].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[5].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[6].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(4))
 			Expect(ret).To(ContainElement(*nodes[3].id))
@@ -349,52 +406,52 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[2].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[1], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[1], l2LinkNet1)),
 				},
 				{
 					ID: nodes[3].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1),
 					),
 				},
 				{
 					ID: nodes[4].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[5].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[6].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], unLinkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], unL2LinkNet1)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -406,54 +463,364 @@ func GenerateConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 				{
 					ID: nodes[0].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[1], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[1], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[1].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[0], linkNet1),
-						createRemote(nodes[2], linkNet1)),
+						createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[2], l2LinkNet1)),
 				},
 				{
 					ID: nodes[2].id,
-					Connectivity: createConnectivityReport(createRemote(nodes[0], linkNet1),
-						createRemote(nodes[1], unLinkNet1)),
+					Connectivity: createConnectivityReport(createL2Remote(nodes[0], l2LinkNet1),
+						createL2Remote(nodes[1], unL2LinkNet1)),
 				},
 				{
 					ID: nodes[3].id,
-					Connectivity: createConnectivityReport(createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1),
+					Connectivity: createConnectivityReport(createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1),
 					),
 				},
 				{
 					ID: nodes[4].id,
-					Connectivity: createConnectivityReport(createRemote(nodes[3], linkNet1),
-						createRemote(nodes[5], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+					Connectivity: createConnectivityReport(createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[5], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[5].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[6], linkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[6], l2LinkNet1)),
 				},
 				{
 					ID: nodes[6].id,
 					Connectivity: createConnectivityReport(
-						createRemote(nodes[3], linkNet1),
-						createRemote(nodes[4], linkNet1),
-						createRemote(nodes[5], unLinkNet1)),
+						createL2Remote(nodes[3], l2LinkNet1),
+						createL2Remote(nodes[4], l2LinkNet1),
+						createL2Remote(nodes[5], unL2LinkNet1)),
 				},
 			}
-			ret, err := CreateMajorityGroup(net1CIDR, hosts)
+			ret, err := CreateL2MajorityGroup(net1CIDR, hosts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[3].id))
 			Expect(ret).To(ContainElement(*nodes[4].id))
 			Expect(ret).To(ContainElement(*nodes[5].id))
+		})
+	})
+}
+
+var _ = Describe("L3 connectivity groups all", func() {
+	GenerateL3ConnectivityGroupTests(true, "1.2.3.0/24", "2.2.3.0/24")
+	GenerateL3ConnectivityGroupTests(false, "2001:db8::/120", "fe80:5054::/120")
+})
+
+func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
+
+	var ipVersion string
+	var nodes []*node
+	var family AddressFamily
+	if ipV4 {
+		family = IPv4
+	} else {
+		family = IPv6
+	}
+	Describe(fmt.Sprintf("connectivity groups %s", ipVersion), func() {
+		BeforeEach(func() {
+			if ipV4 {
+				ipVersion = "IPv4"
+				nodes = generateIPv4Nodes(7, net1CIDR, net2CIDR)
+			} else {
+				ipVersion = "IPv6"
+				nodes = generateIPv6Nodes(7, net1CIDR, net2CIDR)
+			}
+		})
+
+		Context("connectivity groups", func() {
+			It("Empty", func() {
+				hosts := []*models.Host{
+					{
+						ID:           nodes[0].id,
+						Connectivity: createConnectivityReport(),
+						Inventory:    makeInventory(nodes[0]),
+					},
+					{
+						ID:           nodes[1].id,
+						Connectivity: createConnectivityReport(),
+						Inventory:    makeInventory(nodes[1]),
+					},
+					{
+						ID:           nodes[2].id,
+						Connectivity: createConnectivityReport(),
+						Inventory:    makeInventory(nodes[2]),
+					},
+				}
+				ret, err := CreateL3MajorityGroup(hosts, family)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ret).To(Equal([]strfmt.UUID{}))
+			})
+			It("Empty 2", func() {
+				hosts := []*models.Host{
+					{
+						ID:        nodes[0].id,
+						Inventory: makeInventory(nodes[0]),
+					},
+					{
+						ID:        nodes[1].id,
+						Inventory: makeInventory(nodes[1]),
+					},
+					{
+						ID:        nodes[2].id,
+						Inventory: makeInventory(nodes[2]),
+					},
+				}
+				ret, err := CreateL3MajorityGroup(hosts, family)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ret).To(Equal([]strfmt.UUID{}))
+			})
+		})
+		It("One with data", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1),
+						createL3Remote(nodes[2], l3LinkNet1)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID:           nodes[1].id,
+					Connectivity: createConnectivityReport(),
+					Inventory:    makeInventory(nodes[1]),
+				},
+				{
+					ID:           nodes[2].id,
+					Connectivity: createConnectivityReport(),
+					Inventory:    makeInventory(nodes[2]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(Equal([]strfmt.UUID{}))
+		})
+		It("3 with data", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1),
+						createL3Remote(nodes[2], l3LinkNet1)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1),
+						createL3Remote(nodes[2], l3LinkNet1)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1),
+						createL3Remote(nodes[1], l3LinkNet1)),
+					Inventory: makeInventory(nodes[2]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(0))
+		})
+		It("3 with data - two networks", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[2]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+		})
+		It("3 with data - two networks, one ip missing", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1)),
+					Inventory: makeInventory(nodes[2]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(0))
+		})
+		It("4 with data - two networks", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[2]),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[3]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(4))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+			Expect(ret).To(ContainElement(*nodes[3].id))
+		})
+		It("4 with data - two networks - one with single network", func() {
+			nodes[3].addressNet2 = ""
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1)),
+					Inventory: makeInventory(nodes[2]),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[3]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(4))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+			Expect(ret).To(ContainElement(*nodes[3].id))
+		})
+		It("4 with data - two networks, 1 disconnected", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[3], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[2]),
+				},
+				{
+					ID: nodes[3].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[3]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
 		})
 	})
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

- Separate connectivity groups to handle L2 and L3 with special code analyzing
  connectivity for each
 This is a refactoring of the connectivity groups code that it will support both L2 and L3.  For this, it was divided to 
 factory and implementation which are interfaces.  Their purpose is to analyze if there is connectivity from a specific 
 host to a remote host.  There are two implementations for this: L2, and L3.
 hostQueryFactory is the factory for hostQuery which checks the connectivity from a specific host to remote hosts.


## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x]  Unit Tests
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @empovit 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
