### PR TITLE
OCPBUGSM-30272: Clear ACI LogsURL and EventsURL in ClusterConditionsUnknown

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1450,6 +1450,8 @@ func clusterValidated(clusterInstall *hiveext.AgentClusterInstall, status string
 func setClusterConditionsUnknown(clusterInstall *hiveext.AgentClusterInstall) {
 	clusterInstall.Status.DebugInfo.State = ""
 	clusterInstall.Status.DebugInfo.StateInfo = ""
+	clusterInstall.Status.DebugInfo.LogsURL = ""
+	clusterInstall.Status.DebugInfo.EventsURL = ""
 	setClusterCondition(&clusterInstall.Status.Conditions, hivev1.ClusterInstallCondition{
 		Type:    hiveext.ClusterValidatedCondition,
 		Status:  corev1.ConditionUnknown,


### PR DESCRIPTION
# Assisted Pull Request

## Description

The `setClusterConditionsUnknown` function is being invoked in two scenarios:

1. `AgentClusterInstall` controller: There is no `clusterDeployment` resource
to match the reconciled `AgentClusterInstall`, and thus no backend cluster is defined.

2. `ClusterDeployments `controller: the `updateStatus` function about to update
the `AgentClusterInstall` conditions, although there is no backend cluster
retrieved from the database.

In both scenarios, the indication is that the backend doesn't currently hold any
information about this cluster, and thus the controllers will clean up
`DebugInfo.State` and `DebugInfo.StateInfo`.

This change will also add a cleanup for `DebugInfo.LogsURL` and `DebugInfo.EventsURL`,
which, if had any URLs set, are currently broken. An example of such a scenario
is described in the referenced bug.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @rollandf 
/cc @danielerez 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
