### PR TITLE
MGMT-5171: Mirror only assisted index image

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -86,31 +86,6 @@ EOF
   fi
 }
 
-function mirror_package_from_official_index() {
-  # e.g. "local-storage-operator"
-  package="${1}"
-
-  # e.g. "redhat-operator-index", "certified-operator-index",
-  # "community-operator-index", "redhat-marketplace-index"
-  index="${2}"
-
-  # e.g. "v4.8", "latest"
-  index_tag="${3}"
-
-  # e.g. "virthost.ostest.test.metalkube.org:5000"
-  local_registry="${4}"
-
-  # e.g. "/run/user/0/containers/auth.json", "~/.docker/config.json"
-  # should have authentication information for both official registry
-  # (pull-secret) and for the local registry
-  authfile="${5}"
-
-  catalog_source_name="${6}"
-
-  remote_index="registry.redhat.io/redhat/${index}:${index_tag}"
-  mirror_package "${package}" "${remote_index}" "${local_registry}" "${authfile}" "${catalog_source_name}"
-}
-
 function mirror_file() {
   remote_url="${1}"
   httpd_path="${2}"

--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -28,9 +28,10 @@ function install_lso() {
 
     disable_default_indexes
 
+    index_image="registry.redhat.io/redhat/redhat-operator-index:${INDEX_TAG}"
     catalog_source_name="mirror-catalog-for-local-storage-operator"
-    mirror_package_from_official_index "local-storage-operator" "redhat-operator-index" \
-        "${INDEX_TAG}" "${LOCAL_REGISTRY}" "${AUTHFILE}" "${catalog_source_name}"
+    mirror_package "local-storage-operator" \
+      "${index_image}" "${LOCAL_REGISTRY}" "${AUTHFILE}" "${catalog_source_name}"
   fi
 
   tee << EOCR >(oc apply -f -)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Remove `mirror_package_from_official_index` function as it is just
a minor wrapper for `mirror_package` that causes confusion.

No need to mirror all available ICSPs for assisted configmap.
The ISCP name is derived from the index image, and only the assisted
`INDEX_IMAGE` should be used.
`INDEX_IMAGE` would be overriden with community-operator-index image in
case used.

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->
- [x] dev-scripts environment

## Assignees

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
