### PR TITLE
NO-ISSUE: Fix spectral linter

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -8,7 +8,11 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
 function lint_swagger() {
-    spectral lint swagger.yaml
+    if ! command -v spectral &> /dev/null; then
+        docker run --rm -it docker.io/stoplight/spectral:latest lint swagger.yaml
+    else
+        spectral lint swagger.yaml
+    fi
 }
 
 function generate_go_server() {

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -42,8 +42,6 @@ function assisted_service() {
   curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     | sh -s -- -b $(go env GOPATH)/bin v1.36.0
 
-  curl --retry 5 -L https://raw.githack.com/stoplightio/spectral/master/scripts/install.sh | sh
-
   ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
   OS=$(uname | awk '{print tolower($0)}')
   OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.7.2


### PR DESCRIPTION
# Assisted Pull Request

## Description

Instead of installing spectral in our build container, just use the container image if the binary isn't available.

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

- [x] No tests needed

## Assignees

/cc @slaviered 
/cc @djzager 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
