### PR TITLE
NO-ISSUE: Remove deprecated IMAGE_BUILDER var

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -33,9 +33,6 @@ parameters:
   required: false
 - name: S3_USE_SSL
   value: "true"
-- name: IMAGE_BUILDER
-  value: ''
-  required: true
 - name: HW_VALIDATOR_REQUIREMENTS
   value: ''
   required: true
@@ -242,8 +239,6 @@ objects:
                 value: ${OCM_BASE_URL}
               - name: OCM_LOG_LEVEL
                 value: ${OCM_LOG_LEVEL}
-              - name: IMAGE_BUILDER
-                value: ${IMAGE_BUILDER}:${IMAGE_TAG}
               - name: HW_VALIDATOR_REQUIREMENTS
                 value: ${HW_VALIDATOR_REQUIREMENTS}
               - name: INSTALLER_IMAGE


### PR DESCRIPTION
# Assisted Pull Request

## Description

Remove deprecated `IMAGE_BUILDER` var

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Cloud

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @gamli75 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
