### PR TITLE
MGMT-6664: Fixes problem when DISABLED_HOST_VALIDATIONS variable is empty

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1209,6 +1209,10 @@ type DisabledHostValidations map[string]struct{}
 
 func (d *DisabledHostValidations) Decode(value string) error {
 	disabledHostValidations := DisabledHostValidations{}
+	if len(strings.Trim(value, "")) == 0 {
+		*d = disabledHostValidations
+		return nil
+	}
 	for _, element := range strings.Split(value, ",") {
 		if len(element) == 0 {
 			return fmt.Errorf("empty host validation ID found in '%s'", value)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Due to missing cherry-pick of #1853 on ocm-2.3 branch that included a fix for injecting an empty DISABLED_HOST_VALIDATIONS environment variable, the e2e builds for ocm-2.3 are failing as the default value of this variable is now empty.

This PR fixes just this issue, allowing an empty variable to be provided. This is just a snippet of the code delivered in #1853, which unfortunately include more changes that are not relevant to this release.



## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [X] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @YuviGold 


## Checklist

- [X] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [X] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
