### PR TITLE
MGMT-5171: Mirror OCP release repositories instead of namespaces

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -206,8 +206,8 @@ data:
   registries.conf: |
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 
-    $(registry_config "$(get_image_namespace ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})" "${LOCAL_REGISTRY}/$(get_image_namespace_without_registry ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
-    $(registry_config "$(get_image_namespace ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_namespace_without_registry ${cli_image})")
+    $(registry_config "$(get_image_without_tag ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
+    $(registry_config "$(get_image_without_tag ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${cli_image})")
     $(for row in $(kubectl get imagecontentsourcepolicy -o json |
         jq -rc ".items[] | select(.metadata.name | test(\"${assisted_index_image}\")).spec.repositoryDigestMirrors[] | [.mirrors[0], .source]"); do
       row=$(echo ${row} | tr -d '[]"');


### PR DESCRIPTION
# Assisted Pull Request

## Description

Using namespaces looked as a good solution at first, but images might be
on different repositories and we should mirror the right ones to avoid
confusion.

For example, on CI the release image looks like that:
registry.build01.ci.openshift.org/ci-op-89v28h20/release@sha256:<sha>
While its images are on a different repository:
registry.build01.ci.openshift.org/ci-op-89v28h20/stable@sha256:<sha>

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] dev-scripts environment

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
