### PR TITLE
NO-ISSUE: Make dependabot commits prefixed with NO-ISSUE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
       - "ok-to-test"
       - "dependencies"
       - "go"
+    commit-message:
+      prefix: "NO-ISSUE"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -26,8 +28,12 @@ updates:
       - "ok-to-test"
       - "dependencies"
       - "python"
+    commit-message:
+      prefix: "NO-ISSUE"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "NO-ISSUE"


### PR DESCRIPTION
# Assisted Pull Request

## Description

Currently, dependabot PRs fail on the commit-message linter. We would like to prefix its commits with NO-ISSUE to be aligned with our other commit messages convention.

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @eliorerz 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
