### PR TITLE
MGMT-6977: Make sure that preparing for installation timeout is more than the tools timeouts

### DIFF
--- a/internal/host/hostcommands/container_image_availability_cmd.go
+++ b/internal/host/hostcommands/container_image_availability_cmd.go
@@ -20,6 +20,7 @@ type imageAvailabilityCmd struct {
 	ocRelease         oc.Release
 	versionsHandler   versions.Handler
 	instructionConfig InstructionConfig
+	timeoutSeconds    float64
 }
 
 type Images struct {
@@ -28,18 +29,15 @@ type Images struct {
 	MustGatherImage string
 }
 
-const (
-	defaultImageAvailabilityTimeoutSeconds = 60 * 30
-)
-
 func NewImageAvailabilityCmd(log logrus.FieldLogger, db *gorm.DB, ocRelease oc.Release, versionsHandler versions.Handler,
-	instructionConfig InstructionConfig) *imageAvailabilityCmd {
+	instructionConfig InstructionConfig, timeoutSeconds float64) *imageAvailabilityCmd {
 	return &imageAvailabilityCmd{
 		baseCmd:           baseCmd{log: log},
 		db:                db,
 		instructionConfig: instructionConfig,
 		ocRelease:         ocRelease,
 		versionsHandler:   versionsHandler,
+		timeoutSeconds:    timeoutSeconds,
 	}
 }
 
@@ -89,7 +87,7 @@ func (cmd *imageAvailabilityCmd) prepareParam(host *models.Host) (string, error)
 
 	request := models.ContainerImageAvailabilityRequest{
 		Images:  imagesToCheck,
-		Timeout: defaultImageAvailabilityTimeoutSeconds,
+		Timeout: int64(cmd.timeoutSeconds),
 	}
 
 	b, err := json.Marshal(&request)

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
+const (
+	defaultImageAvailabilityTimeoutSeconds = 60 * 30
+)
+
 var _ = Describe("container_image_availability_cmd", func() {
 	var (
 		ctx           = context.Background()
@@ -39,7 +43,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 		mockRelease = oc.NewMockRelease(ctrl)
 
 		db, dbName = common.PrepareTestDB()
-		cmd = NewImageAvailabilityCmd(common.GetTestLog(), db, mockRelease, mockVersions, DefaultInstructionConfig)
+		cmd = NewImageAvailabilityCmd(common.GetTestLog(), db, mockRelease, mockVersions, DefaultInstructionConfig, defaultImageAvailabilityTimeoutSeconds)
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
@@ -117,7 +121,7 @@ var _ = Describe("get images", func() {
 		mockRelease = oc.NewMockRelease(ctrl)
 		db = &gorm.DB{}
 		cluster = &common.Cluster{}
-		cmd = NewImageAvailabilityCmd(common.GetTestLog(), db, mockRelease, mockVersions, DefaultInstructionConfig)
+		cmd = NewImageAvailabilityCmd(common.GetTestLog(), db, mockRelease, mockVersions, DefaultInstructionConfig, defaultImageAvailabilityTimeoutSeconds)
 	})
 
 	It("get_step_get_must_gather_failure", func() {

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -46,20 +46,21 @@ type InstructionManager struct {
 }
 
 type InstructionConfig struct {
-	ServiceBaseURL       string            `envconfig:"SERVICE_BASE_URL"`
-	ServiceCACertPath    string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
-	ServiceIPs           string            `envconfig:"SERVICE_IPS" default:""`
-	InstallerImage       string            `envconfig:"INSTALLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer:latest"`
-	ControllerImage      string            `envconfig:"CONTROLLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-controller:latest"`
-	AgentImage           string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
-	SkipCertVerification bool              `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
-	SupportL2            bool              `envconfig:"SUPPORT_L2" default:"true"`
-	InstallationTimeout  uint              `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
-	DiskCheckTimeout     time.Duration     `envconfig:"DISK_CHECK_TIMEOUT" default:"8m"`
-	SupportFreeAddresses bool              `envconfig:"SUPPORT_FREE_ADDRESSES" default:"true"`
-	DisabledSteps        []models.StepType `envconfig:"DISABLED_STEPS" default:""`
-	ReleaseImageMirror   string
-	CheckClusterVersion  bool
+	ServiceBaseURL           string            `envconfig:"SERVICE_BASE_URL"`
+	ServiceCACertPath        string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
+	ServiceIPs               string            `envconfig:"SERVICE_IPS" default:""`
+	InstallerImage           string            `envconfig:"INSTALLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer:latest"`
+	ControllerImage          string            `envconfig:"CONTROLLER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-controller:latest"`
+	AgentImage               string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
+	SkipCertVerification     bool              `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	SupportL2                bool              `envconfig:"SUPPORT_L2" default:"true"`
+	InstallationTimeout      uint              `envconfig:"INSTALLATION_TIMEOUT" default:"0"`
+	DiskCheckTimeout         time.Duration     `envconfig:"DISK_CHECK_TIMEOUT" default:"8m"`
+	ImageAvailabilityTimeout time.Duration     `envconfig:"IMAGE_AVAILABILITY_TIMEOUT" default:"16m"`
+	SupportFreeAddresses     bool              `envconfig:"SUPPORT_FREE_ADDRESSES" default:"true"`
+	DisabledSteps            []models.StepType `envconfig:"DISABLED_STEPS" default:""`
+	ReleaseImageMirror       string
+	CheckClusterVersion      bool
 }
 
 func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, ocRelease oc.Release,
@@ -75,7 +76,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	apivipConnectivityCmd := NewAPIVIPConnectivityCheckCmd(log, db, instructionConfig.AgentImage, instructionConfig.SupportL2)
 	ntpSynchronizerCmd := NewNtpSyncCmd(log, instructionConfig.AgentImage, db)
 	diskPerfCheckCmd := NewDiskPerfCheckCmd(log, instructionConfig.AgentImage, hwValidator, instructionConfig.DiskCheckTimeout.Seconds())
-	imageAvailabilityCmd := NewImageAvailabilityCmd(log, db, ocRelease, versionHandler, instructionConfig)
+	imageAvailabilityCmd := NewImageAvailabilityCmd(log, db, ocRelease, versionHandler, instructionConfig, instructionConfig.ImageAvailabilityTimeout.Seconds())
 
 	return &InstructionManager{
 		log:              log,


### PR DESCRIPTION
# Assisted Pull Request

## Description
We want to verify that the timeout of all underlying tools in preparing--for-installation is
less than the global timeout in that status.  The reason for that is that we want the tools
to terminate on timeout before the global termination on timeout.  This way the failure reason
will be clearer.


## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 


## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
