### PR TITLE
Bug 1980901: Gateway is '<nil>' in route

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -838,6 +838,9 @@ func (v *validator) hasDefaultRoute(c *validationContext) ValidationStatus {
 
 func (v *validator) validateDefaultRoute(routes []*models.Route) bool {
 	for _, r := range routes {
+		if len(r.Destination) == 0 || len(r.Gateway) == 0 {
+			continue
+		}
 		dst := net.ParseIP(r.Destination)
 		if dst == nil {
 			v.log.Errorf("unable to parse destination IP: %s", r.Destination)


### PR DESCRIPTION
# Assisted Pull Request

## Description

The library used in the agent to capture the network routes can return a "nil" in the Gateway or Destination field if they are not available in the OS routing table. When this happens, the agent will return an empty string instead of a nil (because we store the value as a string and not as a pointer to string/IP).

This PR adapts the service to evaluate the value of the gateway and the destination for empty strings, and ignore the entry when any of these 2 fields is empty. 

The agent's counterpart PR can be found here:

https://github.com/openshift/assisted-installer-agent/pull/217

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
