### PR TITLE
MGMT-7054: Use a network LB to avoid download issue

### DIFF
--- a/deploy/assisted-service-service.yaml
+++ b/deploy/assisted-service-service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     app: assisted-service
   name: assisted-service

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/assisted-service/models"
 )
 
-var _ = PDescribe("system-test image tests", func() {
+var _ = Describe("system-test image tests", func() {
 	var (
 		ctx         = context.Background()
 		ocpVersions models.OpenshiftVersions


### PR DESCRIPTION
## Description

The service.beta.kubernetes.io/aws-load-balancer-type=nlb annotation
results in a "Network" load balancer rather than a "Classic" one which
seems to work better for our use case.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1982447

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
