### PR TITLE
NO-ISSUE: Removing Install() method from cluster's API.

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -69,8 +69,6 @@ type RegistrationAPI interface {
 }
 
 type InstallationAPI interface {
-	// Install cluster
-	Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error
 	// Get the cluster master nodes ID's
 	GetMasterNodesIds(ctx context.Context, c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, error)
 }
@@ -390,10 +388,6 @@ func (m *Manager) SetUploadControllerLogsAt(ctx context.Context, c *common.Clust
 		return errors.Wrapf(err, "failed to set controller_logs_collected_at to cluster %s", c.ID.String())
 	}
 	return nil
-}
-
-func (m *Manager) Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
-	return m.installationAPI.Install(ctx, c, db)
 }
 
 func (m *Manager) GetMasterNodesIds(ctx context.Context, c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -83,10 +83,6 @@ var _ = Describe("stateMachine", func() {
 			refreshedCluster, stateErr = state.RefreshStatus(ctx, cluster, db)
 		})
 
-		It("install_cluster", func() {
-			stateErr = state.Install(ctx, cluster, db)
-		})
-
 		AfterEach(func() {
 			common.DeleteTestDB(db, dbName)
 			Expect(refreshedCluster).To(BeNil())

--- a/internal/cluster/installer.go
+++ b/internal/cluster/installer.go
@@ -4,13 +4,9 @@ import (
 	context "context"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 	"github.com/jinzhu/gorm"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/events"
-	"github.com/openshift/assisted-service/models"
-	logutil "github.com/openshift/assisted-service/pkg/log"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,42 +22,6 @@ type installer struct {
 	log           logrus.FieldLogger
 	db            *gorm.DB
 	eventsHandler events.Handler
-}
-
-func (i *installer) Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
-	log := logutil.FromContext(ctx, i.log)
-
-	switch swag.StringValue(c.Status) {
-	case "":
-	case models.ClusterStatusPreparingForInstallation:
-		log.Infof("cluster %s is starting installation", c.ID)
-	case models.ClusterStatusInsufficient:
-		masterKnownHosts, err := i.GetMasterNodesIds(ctx, c, db)
-		if err != nil {
-			return err
-		}
-		return errors.Errorf("cluster %s is expected to have exactly %d known master to be installed, got %d",
-			c.ID, common.MinMasterHostsNeededForInstallation, len(masterKnownHosts))
-	case models.ClusterStatusReady:
-		return errors.Errorf("cluster %s is ready expected %s", c.ID, models.ClusterStatusPreparingForInstallation)
-	case models.ClusterStatusInstalling:
-		return errors.Errorf("cluster %s is already installing", c.ID)
-	case models.ClusterStatusFinalizing:
-		return errors.Errorf("cluster %s is already %s", c.ID, models.ClusterStatusFinalizing)
-	case models.ClusterStatusInstalled:
-		return errors.Errorf("cluster %s is already installed", c.ID)
-	case models.ClusterStatusError:
-		return errors.Errorf("cluster %s has a error", c.ID)
-	default:
-		return errors.Errorf("cluster %s state is unclear - cluster state: %s", c.ID, swag.StringValue(c.Status))
-	}
-
-	if _, err := updateClusterStatus(ctx, i.log, db, *c.ID, swag.StringValue(c.Status),
-		models.ClusterStatusInstalling, statusInfoInstalling, i.eventsHandler); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (i *installer) GetMasterNodesIds(ctx context.Context, cluster *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -117,20 +117,6 @@ func (m *MockInstallationAPI) EXPECT() *MockInstallationAPIMockRecorder {
 	return m.recorder
 }
 
-// Install mocks base method
-func (m *MockInstallationAPI) Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", ctx, c, db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Install indicates an expected call of Install
-func (mr *MockInstallationAPIMockRecorder) Install(ctx, c, db interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockInstallationAPI)(nil).Install), ctx, c, db)
-}
-
 // GetMasterNodesIds mocks base method
 func (m *MockInstallationAPI) GetMasterNodesIds(ctx context.Context, c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, error) {
 	m.ctrl.T.Helper()
@@ -223,20 +209,6 @@ func (m *MockAPI) DeregisterCluster(ctx context.Context, c *common.Cluster) erro
 func (mr *MockAPIMockRecorder) DeregisterCluster(ctx, c interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterCluster", reflect.TypeOf((*MockAPI)(nil).DeregisterCluster), ctx, c)
-}
-
-// Install mocks base method
-func (m *MockAPI) Install(ctx context.Context, c *common.Cluster, db *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Install", ctx, c, db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Install indicates an expected call of Install
-func (mr *MockAPIMockRecorder) Install(ctx, c, db interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Install", reflect.TypeOf((*MockAPI)(nil).Install), ctx, c, db)
 }
 
 // GetMasterNodesIds mocks base method


### PR DESCRIPTION


# Assisted Pull Request

This code isn't used anymore.

Old implementation:

    When the user press "install cluster" we called that method.

New implementation:

    When the user press "install cluster", the cluster moves to
    prepare-for-installation stage and when it is ready to be installed it
    will be installed by the monitoring process.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
