### PR TITLE
NO-ISSUE: Remove unused srcStatus from updateLogsProgress func

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -671,7 +671,7 @@ func (m *Manager) CancelInstallation(ctx context.Context, c *common.Cluster, rea
 }
 
 func (m *Manager) UpdateLogsProgress(ctx context.Context, c *common.Cluster, progress string) error {
-	err := updateLogsProgress(logutil.FromContext(ctx, m.log), m.db, c, swag.StringValue(c.Status), progress)
+	err := updateLogsProgress(logutil.FromContext(ctx, m.log), m.db, c, progress)
 	return err
 }
 

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -76,8 +76,7 @@ func updateClusterStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.D
 	return cluster, nil
 }
 
-func updateLogsProgress(log logrus.FieldLogger, db *gorm.DB, c *common.Cluster, srcStatus string,
-	progress string) error {
+func updateLogsProgress(log logrus.FieldLogger, db *gorm.DB, c *common.Cluster, progress string) error {
 	var updates map[string]interface{}
 
 	switch progress {

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -534,7 +534,7 @@ func (th *transitionHandler) InstallCluster(sw stateswitch.StateSwitch, args sta
 func (th *transitionHandler) PostRefreshLogsProgress(progress string) stateswitch.PostTransition {
 	return func(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 		sCluster, _ := sw.(*stateCluster)
-		return updateLogsProgress(th.log, th.db, sCluster.cluster, swag.StringValue(sCluster.cluster.Status), progress)
+		return updateLogsProgress(th.log, th.db, sCluster.cluster, progress)
 	}
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Remove unused srcStatus from `updateLogsProgress()` func

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @rollandf 
/cc @slaviered 
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
