### PR TITLE
OCPBUGSM-31406: Validate log collection before displaying LogsURL

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4359,6 +4359,15 @@ func (b *bareMetalInventory) uploadLogs(ctx context.Context, params installer.Up
 		if err != nil {
 			return err
 		}
+
+		dbHost, err := b.GetCommonHostInternal(ctx, params.ClusterID.String(), params.HostID.String())
+		if err != nil {
+			return err
+		}
+
+		b.eventsHandler.AddEvent(ctx, params.ClusterID, params.HostID, models.EventSeverityInfo,
+			fmt.Sprintf("Uploaded logs for host %s cluster %s",
+				hostutil.GetHostnameForMsg(&dbHost.Host), params.ClusterID.String()), time.Now())
 		return nil
 	}
 
@@ -4384,6 +4393,9 @@ func (b *bareMetalInventory) uploadLogs(ctx context.Context, params installer.Up
 			log.WithError(err).Errorf("Failed update cluster %s log progress %s", params.ClusterID, string(models.LogsStateCollecting))
 			return common.NewApiError(http.StatusInternalServerError, err)
 		}
+		b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityInfo,
+			fmt.Sprintf("Uploaded logs for cluster %s",
+				params.ClusterID.String()), time.Now())
 	}
 
 	log.Infof("Done uploading file %s", fileName)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4966,6 +4966,7 @@ var _ = Describe("Upload and Download logs test", func() {
 			HTTPRequest: request,
 		}
 		fileName := bm.getLogsFullName(clusterID.String(), host.ID.String())
+		mockEvents.EXPECT().AddEvent(gomock.Any(), clusterID, host.ID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
 		mockS3Client.EXPECT().UploadStream(gomock.Any(), gomock.Any(), fileName).Return(nil).Times(1)
 		mockHostApi.EXPECT().SetUploadLogsAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().UpdateLogsProgress(gomock.Any(), gomock.Any(), string(models.LogsStateCollecting)).Return(nil).Times(1)
@@ -5011,6 +5012,7 @@ var _ = Describe("Upload and Download logs test", func() {
 			LogsType:    string(models.LogsTypeController),
 		}
 		fileName := bm.getLogsFullName(clusterID.String(), string(models.LogsTypeController))
+		mockEvents.EXPECT().AddEvent(gomock.Any(), clusterID, nil, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
 		mockS3Client.EXPECT().UploadStream(gomock.Any(), gomock.Any(), fileName).Return(nil).Times(1)
 		mockClusterApi.EXPECT().SetUploadControllerLogsAt(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().UpdateLogsProgress(gomock.Any(), gomock.Any(), string(models.LogsStateCollecting)).Return(nil).Times(1)


### PR DESCRIPTION
# Assisted Pull Request

## Description

`Status.DebugInfo.LogsURL` used to be added to `ACI` as soon as
`clusterDeployments` controller reconciles with a valid backend cluster.

This scenario created an issue where it displayed the `LogsURL` before
host(s) or controller logs were collected and uploaded to storage,
creating a bad user experience with a "broken" link.

This change adds a function that validates logs collection before
displaying `Status.DebugInfo.Logs` to the user. It checks both
`ControllerLogsCollectedAt` (cluster) and `LogsCollectedAt` (host).

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
