### PR TITLE
MGMT-7287: Monitor user selection of networkType by setting usage whe…

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2037,6 +2037,9 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 		setMachineNetworkCIDRForUpdate(updates, machineCidr)
 	}
 	if params.ClusterUpdateParams.NetworkType != nil && params.ClusterUpdateParams.NetworkType != cluster.NetworkType {
+		b.setUsage(true, usage.NetworkTypeSelectionUsage, &map[string]interface{}{
+			"network_type": params.ClusterUpdateParams.NetworkType}, usages)
+
 		updates["network_type"] = swag.StringValue(params.ClusterUpdateParams.NetworkType)
 	}
 
@@ -2159,6 +2162,8 @@ func (b *bareMetalInventory) setDefaultUsage(cluster *models.Cluster) {
 	b.setOperatorsUsage(olmOperators, []*models.MonitoredOperator{}, usages)
 	featusage, _ := json.Marshal(usages)
 	cluster.FeatureUsage = string(featusage)
+	b.setUsage(false, usage.NetworkTypeSelectionUsage, &map[string]interface{}{
+		"network_type": cluster.NetworkType}, usages)
 }
 
 func (b *bareMetalInventory) setProxyUsage(httpProxy *string, httpsProxy *string, noProxy *string, usages map[string]models.Usage) {

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -15,4 +15,6 @@ const (
 	VipDhcpAllocationUsage string = "VIP auto alloc."
 	//usage of disk selection
 	DiskSelectionUsage string = "Disk Selection"
+	//user networkType selection
+	NetworkTypeSelectionUsage string = "NetworkType"
 )


### PR DESCRIPTION
…n user select

# Assisted Pull Request

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @slaviered 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
