### PR TITLE
MGMT-7086: Migrate data from Cluster to IngraEnv

### DIFF
--- a/internal/migrations/20210713123129_populate_infra_env.go
+++ b/internal/migrations/20210713123129_populate_infra_env.go
@@ -12,7 +12,7 @@ func populateInfraEnv() *gormigrate.Migration {
 
 		if tx.HasTable(&common.Host{}) {
 			// Generate the infra_env_id column
-			if err := tx.Exec("ALTER TABLE hosts ADD infra_env_id text NULL;").Error; err != nil {
+			if err := tx.Exec("ALTER TABLE hosts ADD COLUMN IF NOT EXISTS infra_env_id text NULL;").Error; err != nil {
 				return err
 			}
 			// Populate the infra_env_id column

--- a/internal/migrations/20210713123129_populate_infra_env_test.go
+++ b/internal/migrations/20210713123129_populate_infra_env_test.go
@@ -52,8 +52,6 @@ var _ = Describe("populateInfraEnv", func() {
 		}
 		err := db.Create(&host).Error
 		Expect(err).NotTo(HaveOccurred())
-		err = db.Exec("ALTER TABLE hosts DROP infra_env_id;").Error
-		Expect(err).NotTo(HaveOccurred())
 
 		cluster := common.Cluster{
 			PullSecret:     PullSecret,


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR fixes a bug in the migration of Cluster DB entries to InfraEnv DB entries

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

@yevgeny-shnaidman @gamli75 

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
