### PR TITLE
MGMT-7294: Remove v1 from swagger basePath

### DIFF
--- a/client/assisted_install_client.go
+++ b/client/assisted_install_client.go
@@ -28,7 +28,7 @@ const (
 	DefaultHost string = "api.openshift.com"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
-	DefaultBasePath string = "/api/assisted-install/v1"
+	DefaultBasePath string = "/api/assisted-install"
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file

--- a/client/assisted_service_iso/assisted_service_iso_client.go
+++ b/client/assisted_service_iso/assisted_service_iso_client.go
@@ -55,7 +55,7 @@ func (a *Client) CreateISOAndUploadToS3(ctx context.Context, params *CreateISOAn
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "CreateISOAndUploadToS3",
 		Method:             "POST",
-		PathPattern:        "/assisted-service-iso",
+		PathPattern:        "/v1/assisted-service-iso",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -80,7 +80,7 @@ func (a *Client) DownloadISO(ctx context.Context, params *DownloadISOParams, wri
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadISO",
 		Method:             "GET",
-		PathPattern:        "/assisted-service-iso/data",
+		PathPattern:        "/v1/assisted-service-iso/data",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -105,7 +105,7 @@ func (a *Client) GetPresignedForAssistedServiceISO(ctx context.Context, params *
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetPresignedForAssistedServiceISO",
 		Method:             "GET",
-		PathPattern:        "/assisted-service-iso/presigned",
+		PathPattern:        "/v1/assisted-service-iso/presigned",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
+++ b/client/assisted_service_iso/create_i_s_o_and_upload_to_s3_responses.go
@@ -72,7 +72,7 @@ type CreateISOAndUploadToS3Created struct {
 }
 
 func (o *CreateISOAndUploadToS3Created) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3Created ", 201)
+	return fmt.Sprintf("[POST /v1/assisted-service-iso][%d] createISOAndUploadToS3Created ", 201)
 }
 
 func (o *CreateISOAndUploadToS3Created) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -94,7 +94,7 @@ type CreateISOAndUploadToS3BadRequest struct {
 }
 
 func (o *CreateISOAndUploadToS3BadRequest) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3BadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/assisted-service-iso][%d] createISOAndUploadToS3BadRequest  %+v", 400, o.Payload)
 }
 
 func (o *CreateISOAndUploadToS3BadRequest) GetPayload() *models.Error {
@@ -127,7 +127,7 @@ type CreateISOAndUploadToS3Unauthorized struct {
 }
 
 func (o *CreateISOAndUploadToS3Unauthorized) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3Unauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/assisted-service-iso][%d] createISOAndUploadToS3Unauthorized  %+v", 401, o.Payload)
 }
 
 func (o *CreateISOAndUploadToS3Unauthorized) GetPayload() *models.InfraError {
@@ -160,7 +160,7 @@ type CreateISOAndUploadToS3Forbidden struct {
 }
 
 func (o *CreateISOAndUploadToS3Forbidden) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3Forbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/assisted-service-iso][%d] createISOAndUploadToS3Forbidden  %+v", 403, o.Payload)
 }
 
 func (o *CreateISOAndUploadToS3Forbidden) GetPayload() *models.InfraError {
@@ -193,7 +193,7 @@ type CreateISOAndUploadToS3InternalServerError struct {
 }
 
 func (o *CreateISOAndUploadToS3InternalServerError) Error() string {
-	return fmt.Sprintf("[POST /assisted-service-iso][%d] createISOAndUploadToS3InternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/assisted-service-iso][%d] createISOAndUploadToS3InternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *CreateISOAndUploadToS3InternalServerError) GetPayload() *models.Error {

--- a/client/assisted_service_iso/download_i_s_o_responses.go
+++ b/client/assisted_service_iso/download_i_s_o_responses.go
@@ -76,7 +76,7 @@ type DownloadISOOK struct {
 }
 
 func (o *DownloadISOOK) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/data][%d] downloadISOOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/data][%d] downloadISOOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadISOOK) GetPayload() io.Writer {
@@ -107,7 +107,7 @@ type DownloadISOUnauthorized struct {
 }
 
 func (o *DownloadISOUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/data][%d] downloadISOUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/data][%d] downloadISOUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadISOUnauthorized) GetPayload() *models.InfraError {
@@ -140,7 +140,7 @@ type DownloadISOForbidden struct {
 }
 
 func (o *DownloadISOForbidden) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/data][%d] downloadISOForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/data][%d] downloadISOForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadISOForbidden) GetPayload() *models.InfraError {
@@ -173,7 +173,7 @@ type DownloadISONotFound struct {
 }
 
 func (o *DownloadISONotFound) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/data][%d] downloadISONotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/data][%d] downloadISONotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadISONotFound) GetPayload() *models.Error {
@@ -206,7 +206,7 @@ type DownloadISOInternalServerError struct {
 }
 
 func (o *DownloadISOInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/data][%d] downloadISOInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/data][%d] downloadISOInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadISOInternalServerError) GetPayload() *models.Error {

--- a/client/assisted_service_iso/get_presigned_for_assisted_service_i_s_o_responses.go
+++ b/client/assisted_service_iso/get_presigned_for_assisted_service_i_s_o_responses.go
@@ -73,7 +73,7 @@ type GetPresignedForAssistedServiceISOOK struct {
 }
 
 func (o *GetPresignedForAssistedServiceISOOK) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOOK  %+v", 200, o.Payload)
 }
 
 func (o *GetPresignedForAssistedServiceISOOK) GetPayload() *models.Presigned {
@@ -106,7 +106,7 @@ type GetPresignedForAssistedServiceISOUnauthorized struct {
 }
 
 func (o *GetPresignedForAssistedServiceISOUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetPresignedForAssistedServiceISOUnauthorized) GetPayload() *models.InfraError {
@@ -139,7 +139,7 @@ type GetPresignedForAssistedServiceISOForbidden struct {
 }
 
 func (o *GetPresignedForAssistedServiceISOForbidden) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetPresignedForAssistedServiceISOForbidden) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type GetPresignedForAssistedServiceISONotFound struct {
 }
 
 func (o *GetPresignedForAssistedServiceISONotFound) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISONotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISONotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetPresignedForAssistedServiceISONotFound) GetPayload() *models.Error {
@@ -205,7 +205,7 @@ type GetPresignedForAssistedServiceISOInternalServerError struct {
 }
 
 func (o *GetPresignedForAssistedServiceISOInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/assisted-service-iso/presigned][%d] getPresignedForAssistedServiceISOInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetPresignedForAssistedServiceISOInternalServerError) GetPayload() *models.Error {

--- a/client/events/events_client.go
+++ b/client/events/events_client.go
@@ -48,7 +48,7 @@ func (a *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*Lis
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListEvents",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/events",
+		PathPattern:        "/v1/clusters/{cluster_id}/events",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/events/list_events_responses.go
+++ b/client/events/list_events_responses.go
@@ -79,7 +79,7 @@ type ListEventsOK struct {
 }
 
 func (o *ListEventsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListEventsOK) GetPayload() models.EventList {
@@ -110,7 +110,7 @@ type ListEventsUnauthorized struct {
 }
 
 func (o *ListEventsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListEventsUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type ListEventsForbidden struct {
 }
 
 func (o *ListEventsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListEventsForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type ListEventsNotFound struct {
 }
 
 func (o *ListEventsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ListEventsNotFound) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type ListEventsMethodNotAllowed struct {
 }
 
 func (o *ListEventsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ListEventsMethodNotAllowed) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type ListEventsInternalServerError struct {
 }
 
 func (o *ListEventsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/events][%d] listEventsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/events][%d] listEventsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListEventsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/cancel_installation_responses.go
+++ b/client/installer/cancel_installation_responses.go
@@ -85,7 +85,7 @@ type CancelInstallationAccepted struct {
 }
 
 func (o *CancelInstallationAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationAccepted  %+v", 202, o.Payload)
 }
 
 func (o *CancelInstallationAccepted) GetPayload() *models.Cluster {
@@ -118,7 +118,7 @@ type CancelInstallationUnauthorized struct {
 }
 
 func (o *CancelInstallationUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *CancelInstallationUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type CancelInstallationForbidden struct {
 }
 
 func (o *CancelInstallationForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationForbidden  %+v", 403, o.Payload)
 }
 
 func (o *CancelInstallationForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type CancelInstallationNotFound struct {
 }
 
 func (o *CancelInstallationNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationNotFound  %+v", 404, o.Payload)
 }
 
 func (o *CancelInstallationNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type CancelInstallationMethodNotAllowed struct {
 }
 
 func (o *CancelInstallationMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *CancelInstallationMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type CancelInstallationConflict struct {
 }
 
 func (o *CancelInstallationConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationConflict  %+v", 409, o.Payload)
 }
 
 func (o *CancelInstallationConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type CancelInstallationInternalServerError struct {
 }
 
 func (o *CancelInstallationInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/cancel][%d] cancelInstallationInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/cancel][%d] cancelInstallationInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *CancelInstallationInternalServerError) GetPayload() *models.Error {

--- a/client/installer/complete_installation_responses.go
+++ b/client/installer/complete_installation_responses.go
@@ -91,7 +91,7 @@ type CompleteInstallationAccepted struct {
 }
 
 func (o *CompleteInstallationAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationAccepted  %+v", 202, o.Payload)
 }
 
 func (o *CompleteInstallationAccepted) GetPayload() *models.Cluster {
@@ -124,7 +124,7 @@ type CompleteInstallationUnauthorized struct {
 }
 
 func (o *CompleteInstallationUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *CompleteInstallationUnauthorized) GetPayload() *models.InfraError {
@@ -157,7 +157,7 @@ type CompleteInstallationForbidden struct {
 }
 
 func (o *CompleteInstallationForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationForbidden  %+v", 403, o.Payload)
 }
 
 func (o *CompleteInstallationForbidden) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type CompleteInstallationNotFound struct {
 }
 
 func (o *CompleteInstallationNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationNotFound  %+v", 404, o.Payload)
 }
 
 func (o *CompleteInstallationNotFound) GetPayload() *models.Error {
@@ -223,7 +223,7 @@ type CompleteInstallationMethodNotAllowed struct {
 }
 
 func (o *CompleteInstallationMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *CompleteInstallationMethodNotAllowed) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type CompleteInstallationConflict struct {
 }
 
 func (o *CompleteInstallationConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationConflict  %+v", 409, o.Payload)
 }
 
 func (o *CompleteInstallationConflict) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type CompleteInstallationInternalServerError struct {
 }
 
 func (o *CompleteInstallationInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *CompleteInstallationInternalServerError) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type CompleteInstallationServiceUnavailable struct {
 }
 
 func (o *CompleteInstallationServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/complete_installation][%d] completeInstallationServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *CompleteInstallationServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/deregister_cluster_responses.go
+++ b/client/installer/deregister_cluster_responses.go
@@ -84,7 +84,7 @@ type DeregisterClusterNoContent struct {
 }
 
 func (o *DeregisterClusterNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterNoContent ", 204)
 }
 
 func (o *DeregisterClusterNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type DeregisterClusterUnauthorized struct {
 }
 
 func (o *DeregisterClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DeregisterClusterUnauthorized) GetPayload() *models.InfraError {
@@ -139,7 +139,7 @@ type DeregisterClusterForbidden struct {
 }
 
 func (o *DeregisterClusterForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DeregisterClusterForbidden) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type DeregisterClusterNotFound struct {
 }
 
 func (o *DeregisterClusterNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeregisterClusterNotFound) GetPayload() *models.Error {
@@ -205,7 +205,7 @@ type DeregisterClusterMethodNotAllowed struct {
 }
 
 func (o *DeregisterClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DeregisterClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type DeregisterClusterConflict struct {
 }
 
 func (o *DeregisterClusterConflict) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterConflict  %+v", 409, o.Payload)
 }
 
 func (o *DeregisterClusterConflict) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type DeregisterClusterInternalServerError struct {
 }
 
 func (o *DeregisterClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}][%d] deregisterClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}][%d] deregisterClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DeregisterClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/deregister_host_responses.go
+++ b/client/installer/deregister_host_responses.go
@@ -84,7 +84,7 @@ type DeregisterHostNoContent struct {
 }
 
 func (o *DeregisterHostNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostNoContent ", 204)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostNoContent ", 204)
 }
 
 func (o *DeregisterHostNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type DeregisterHostBadRequest struct {
 }
 
 func (o *DeregisterHostBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *DeregisterHostBadRequest) GetPayload() *models.Error {
@@ -139,7 +139,7 @@ type DeregisterHostUnauthorized struct {
 }
 
 func (o *DeregisterHostUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DeregisterHostUnauthorized) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type DeregisterHostForbidden struct {
 }
 
 func (o *DeregisterHostForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DeregisterHostForbidden) GetPayload() *models.InfraError {
@@ -205,7 +205,7 @@ type DeregisterHostNotFound struct {
 }
 
 func (o *DeregisterHostNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeregisterHostNotFound) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type DeregisterHostMethodNotAllowed struct {
 }
 
 func (o *DeregisterHostMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DeregisterHostMethodNotAllowed) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type DeregisterHostInternalServerError struct {
 }
 
 func (o *DeregisterHostInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}][%d] deregisterHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DeregisterHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/disable_host_responses.go
+++ b/client/installer/disable_host_responses.go
@@ -85,7 +85,7 @@ type DisableHostOK struct {
 }
 
 func (o *DisableHostOK) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostOK  %+v", 200, o.Payload)
 }
 
 func (o *DisableHostOK) GetPayload() *models.Cluster {
@@ -118,7 +118,7 @@ type DisableHostUnauthorized struct {
 }
 
 func (o *DisableHostUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DisableHostUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type DisableHostForbidden struct {
 }
 
 func (o *DisableHostForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DisableHostForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type DisableHostNotFound struct {
 }
 
 func (o *DisableHostNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DisableHostNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type DisableHostMethodNotAllowed struct {
 }
 
 func (o *DisableHostMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DisableHostMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type DisableHostConflict struct {
 }
 
 func (o *DisableHostConflict) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostConflict  %+v", 409, o.Payload)
 }
 
 func (o *DisableHostConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type DisableHostInternalServerError struct {
 }
 
 func (o *DisableHostInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] disableHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DisableHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/download_cluster_files_responses.go
+++ b/client/installer/download_cluster_files_responses.go
@@ -94,7 +94,7 @@ type DownloadClusterFilesOK struct {
 }
 
 func (o *DownloadClusterFilesOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadClusterFilesOK) GetPayload() io.Writer {
@@ -125,7 +125,7 @@ type DownloadClusterFilesUnauthorized struct {
 }
 
 func (o *DownloadClusterFilesUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterFilesUnauthorized) GetPayload() *models.InfraError {
@@ -158,7 +158,7 @@ type DownloadClusterFilesForbidden struct {
 }
 
 func (o *DownloadClusterFilesForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterFilesForbidden) GetPayload() *models.InfraError {
@@ -191,7 +191,7 @@ type DownloadClusterFilesNotFound struct {
 }
 
 func (o *DownloadClusterFilesNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterFilesNotFound) GetPayload() *models.Error {
@@ -224,7 +224,7 @@ type DownloadClusterFilesMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterFilesMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadClusterFilesMethodNotAllowed) GetPayload() *models.Error {
@@ -257,7 +257,7 @@ type DownloadClusterFilesConflict struct {
 }
 
 func (o *DownloadClusterFilesConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterFilesConflict) GetPayload() *models.Error {
@@ -290,7 +290,7 @@ type DownloadClusterFilesInternalServerError struct {
 }
 
 func (o *DownloadClusterFilesInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterFilesInternalServerError) GetPayload() *models.Error {
@@ -323,7 +323,7 @@ type DownloadClusterFilesServiceUnavailable struct {
 }
 
 func (o *DownloadClusterFilesServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files][%d] downloadClusterFilesServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *DownloadClusterFilesServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/download_cluster_i_s_o_headers_responses.go
+++ b/client/installer/download_cluster_i_s_o_headers_responses.go
@@ -95,7 +95,7 @@ type DownloadClusterISOHeadersOK struct {
 }
 
 func (o *DownloadClusterISOHeadersOK) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersOK ", 200)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersOK ", 200)
 }
 
 func (o *DownloadClusterISOHeadersOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -124,7 +124,7 @@ type DownloadClusterISOHeadersBadRequest struct {
 }
 
 func (o *DownloadClusterISOHeadersBadRequest) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type DownloadClusterISOHeadersUnauthorized struct {
 }
 
 func (o *DownloadClusterISOHeadersUnauthorized) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type DownloadClusterISOHeadersForbidden struct {
 }
 
 func (o *DownloadClusterISOHeadersForbidden) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type DownloadClusterISOHeadersNotFound struct {
 }
 
 func (o *DownloadClusterISOHeadersNotFound) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersNotFound) GetPayload() *models.Error {
@@ -255,7 +255,7 @@ type DownloadClusterISOHeadersMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterISOHeadersMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersMethodNotAllowed ", 405)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersMethodNotAllowed ", 405)
 }
 
 func (o *DownloadClusterISOHeadersMethodNotAllowed) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -277,7 +277,7 @@ type DownloadClusterISOHeadersConflict struct {
 }
 
 func (o *DownloadClusterISOHeadersConflict) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersConflict) GetPayload() *models.Error {
@@ -310,7 +310,7 @@ type DownloadClusterISOHeadersInternalServerError struct {
 }
 
 func (o *DownloadClusterISOHeadersInternalServerError) Error() string {
-	return fmt.Sprintf("[HEAD /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[HEAD /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOHeadersInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterISOHeadersInternalServerError) GetPayload() *models.Error {

--- a/client/installer/download_cluster_i_s_o_responses.go
+++ b/client/installer/download_cluster_i_s_o_responses.go
@@ -94,7 +94,7 @@ type DownloadClusterISOOK struct {
 }
 
 func (o *DownloadClusterISOOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadClusterISOOK) GetPayload() io.Writer {
@@ -125,7 +125,7 @@ type DownloadClusterISOBadRequest struct {
 }
 
 func (o *DownloadClusterISOBadRequest) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *DownloadClusterISOBadRequest) GetPayload() *models.Error {
@@ -158,7 +158,7 @@ type DownloadClusterISOUnauthorized struct {
 }
 
 func (o *DownloadClusterISOUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterISOUnauthorized) GetPayload() *models.InfraError {
@@ -191,7 +191,7 @@ type DownloadClusterISOForbidden struct {
 }
 
 func (o *DownloadClusterISOForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterISOForbidden) GetPayload() *models.InfraError {
@@ -224,7 +224,7 @@ type DownloadClusterISONotFound struct {
 }
 
 func (o *DownloadClusterISONotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISONotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISONotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterISONotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type DownloadClusterISOMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterISOMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOMethodNotAllowed ", 405)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOMethodNotAllowed ", 405)
 }
 
 func (o *DownloadClusterISOMethodNotAllowed) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -278,7 +278,7 @@ type DownloadClusterISOConflict struct {
 }
 
 func (o *DownloadClusterISOConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterISOConflict) GetPayload() *models.Error {
@@ -311,7 +311,7 @@ type DownloadClusterISOInternalServerError struct {
 }
 
 func (o *DownloadClusterISOInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/image][%d] downloadClusterISOInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterISOInternalServerError) GetPayload() *models.Error {

--- a/client/installer/download_cluster_kubeconfig_responses.go
+++ b/client/installer/download_cluster_kubeconfig_responses.go
@@ -88,7 +88,7 @@ type DownloadClusterKubeconfigOK struct {
 }
 
 func (o *DownloadClusterKubeconfigOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigOK) GetPayload() io.Writer {
@@ -119,7 +119,7 @@ type DownloadClusterKubeconfigUnauthorized struct {
 }
 
 func (o *DownloadClusterKubeconfigUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigUnauthorized) GetPayload() *models.InfraError {
@@ -152,7 +152,7 @@ type DownloadClusterKubeconfigForbidden struct {
 }
 
 func (o *DownloadClusterKubeconfigForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigForbidden) GetPayload() *models.InfraError {
@@ -185,7 +185,7 @@ type DownloadClusterKubeconfigNotFound struct {
 }
 
 func (o *DownloadClusterKubeconfigNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigNotFound) GetPayload() *models.Error {
@@ -218,7 +218,7 @@ type DownloadClusterKubeconfigMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterKubeconfigMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigMethodNotAllowed) GetPayload() *models.Error {
@@ -251,7 +251,7 @@ type DownloadClusterKubeconfigConflict struct {
 }
 
 func (o *DownloadClusterKubeconfigConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigConflict) GetPayload() *models.Error {
@@ -284,7 +284,7 @@ type DownloadClusterKubeconfigInternalServerError struct {
 }
 
 func (o *DownloadClusterKubeconfigInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/kubeconfig][%d] downloadClusterKubeconfigInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterKubeconfigInternalServerError) GetPayload() *models.Error {

--- a/client/installer/download_cluster_logs_responses.go
+++ b/client/installer/download_cluster_logs_responses.go
@@ -88,7 +88,7 @@ type DownloadClusterLogsOK struct {
 }
 
 func (o *DownloadClusterLogsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadClusterLogsOK) GetPayload() io.Writer {
@@ -119,7 +119,7 @@ type DownloadClusterLogsUnauthorized struct {
 }
 
 func (o *DownloadClusterLogsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterLogsUnauthorized) GetPayload() *models.InfraError {
@@ -152,7 +152,7 @@ type DownloadClusterLogsForbidden struct {
 }
 
 func (o *DownloadClusterLogsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterLogsForbidden) GetPayload() *models.InfraError {
@@ -185,7 +185,7 @@ type DownloadClusterLogsNotFound struct {
 }
 
 func (o *DownloadClusterLogsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterLogsNotFound) GetPayload() *models.Error {
@@ -218,7 +218,7 @@ type DownloadClusterLogsMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterLogsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadClusterLogsMethodNotAllowed) GetPayload() *models.Error {
@@ -251,7 +251,7 @@ type DownloadClusterLogsConflict struct {
 }
 
 func (o *DownloadClusterLogsConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterLogsConflict) GetPayload() *models.Error {
@@ -284,7 +284,7 @@ type DownloadClusterLogsInternalServerError struct {
 }
 
 func (o *DownloadClusterLogsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/logs][%d] downloadClusterLogsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/logs][%d] downloadClusterLogsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterLogsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/download_host_ignition_responses.go
+++ b/client/installer/download_host_ignition_responses.go
@@ -94,7 +94,7 @@ type DownloadHostIgnitionOK struct {
 }
 
 func (o *DownloadHostIgnitionOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadHostIgnitionOK) GetPayload() io.Writer {
@@ -125,7 +125,7 @@ type DownloadHostIgnitionUnauthorized struct {
 }
 
 func (o *DownloadHostIgnitionUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadHostIgnitionUnauthorized) GetPayload() *models.InfraError {
@@ -158,7 +158,7 @@ type DownloadHostIgnitionForbidden struct {
 }
 
 func (o *DownloadHostIgnitionForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadHostIgnitionForbidden) GetPayload() *models.InfraError {
@@ -191,7 +191,7 @@ type DownloadHostIgnitionNotFound struct {
 }
 
 func (o *DownloadHostIgnitionNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadHostIgnitionNotFound) GetPayload() *models.Error {
@@ -224,7 +224,7 @@ type DownloadHostIgnitionMethodNotAllowed struct {
 }
 
 func (o *DownloadHostIgnitionMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadHostIgnitionMethodNotAllowed) GetPayload() *models.Error {
@@ -257,7 +257,7 @@ type DownloadHostIgnitionConflict struct {
 }
 
 func (o *DownloadHostIgnitionConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadHostIgnitionConflict) GetPayload() *models.Error {
@@ -290,7 +290,7 @@ type DownloadHostIgnitionInternalServerError struct {
 }
 
 func (o *DownloadHostIgnitionInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadHostIgnitionInternalServerError) GetPayload() *models.Error {
@@ -323,7 +323,7 @@ type DownloadHostIgnitionServiceUnavailable struct {
 }
 
 func (o *DownloadHostIgnitionServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition][%d] downloadHostIgnitionServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *DownloadHostIgnitionServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/download_host_logs_responses.go
+++ b/client/installer/download_host_logs_responses.go
@@ -88,7 +88,7 @@ type DownloadHostLogsOK struct {
 }
 
 func (o *DownloadHostLogsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadHostLogsOK) GetPayload() io.Writer {
@@ -119,7 +119,7 @@ type DownloadHostLogsUnauthorized struct {
 }
 
 func (o *DownloadHostLogsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadHostLogsUnauthorized) GetPayload() *models.InfraError {
@@ -152,7 +152,7 @@ type DownloadHostLogsForbidden struct {
 }
 
 func (o *DownloadHostLogsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadHostLogsForbidden) GetPayload() *models.InfraError {
@@ -185,7 +185,7 @@ type DownloadHostLogsNotFound struct {
 }
 
 func (o *DownloadHostLogsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadHostLogsNotFound) GetPayload() *models.Error {
@@ -218,7 +218,7 @@ type DownloadHostLogsMethodNotAllowed struct {
 }
 
 func (o *DownloadHostLogsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadHostLogsMethodNotAllowed) GetPayload() *models.Error {
@@ -251,7 +251,7 @@ type DownloadHostLogsConflict struct {
 }
 
 func (o *DownloadHostLogsConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadHostLogsConflict) GetPayload() *models.Error {
@@ -284,7 +284,7 @@ type DownloadHostLogsInternalServerError struct {
 }
 
 func (o *DownloadHostLogsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] downloadHostLogsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadHostLogsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/enable_host_responses.go
+++ b/client/installer/enable_host_responses.go
@@ -85,7 +85,7 @@ type EnableHostOK struct {
 }
 
 func (o *EnableHostOK) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostOK  %+v", 200, o.Payload)
 }
 
 func (o *EnableHostOK) GetPayload() *models.Cluster {
@@ -118,7 +118,7 @@ type EnableHostUnauthorized struct {
 }
 
 func (o *EnableHostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *EnableHostUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type EnableHostForbidden struct {
 }
 
 func (o *EnableHostForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *EnableHostForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type EnableHostNotFound struct {
 }
 
 func (o *EnableHostNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *EnableHostNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type EnableHostMethodNotAllowed struct {
 }
 
 func (o *EnableHostMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *EnableHostMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type EnableHostConflict struct {
 }
 
 func (o *EnableHostConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostConflict  %+v", 409, o.Payload)
 }
 
 func (o *EnableHostConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type EnableHostInternalServerError struct {
 }
 
 func (o *EnableHostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable][%d] enableHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *EnableHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/generate_cluster_i_s_o_responses.go
+++ b/client/installer/generate_cluster_i_s_o_responses.go
@@ -91,7 +91,7 @@ type GenerateClusterISOCreated struct {
 }
 
 func (o *GenerateClusterISOCreated) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOCreated  %+v", 201, o.Payload)
 }
 
 func (o *GenerateClusterISOCreated) GetPayload() *models.Cluster {
@@ -124,7 +124,7 @@ type GenerateClusterISOBadRequest struct {
 }
 
 func (o *GenerateClusterISOBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *GenerateClusterISOBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type GenerateClusterISOUnauthorized struct {
 }
 
 func (o *GenerateClusterISOUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GenerateClusterISOUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type GenerateClusterISOForbidden struct {
 }
 
 func (o *GenerateClusterISOForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GenerateClusterISOForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type GenerateClusterISONotFound struct {
 }
 
 func (o *GenerateClusterISONotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISONotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISONotFound  %+v", 404, o.Payload)
 }
 
 func (o *GenerateClusterISONotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type GenerateClusterISOMethodNotAllowed struct {
 }
 
 func (o *GenerateClusterISOMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GenerateClusterISOMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type GenerateClusterISOConflict struct {
 }
 
 func (o *GenerateClusterISOConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOConflict  %+v", 409, o.Payload)
 }
 
 func (o *GenerateClusterISOConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type GenerateClusterISOInternalServerError struct {
 }
 
 func (o *GenerateClusterISOInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/downloads/image][%d] generateClusterISOInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/downloads/image][%d] generateClusterISOInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GenerateClusterISOInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_cluster_default_config_responses.go
+++ b/client/installer/get_cluster_default_config_responses.go
@@ -67,7 +67,7 @@ type GetClusterDefaultConfigOK struct {
 }
 
 func (o *GetClusterDefaultConfigOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/default-config][%d] getClusterDefaultConfigOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/default-config][%d] getClusterDefaultConfigOK  %+v", 200, o.Payload)
 }
 
 func (o *GetClusterDefaultConfigOK) GetPayload() *models.ClusterDefaultConfig {
@@ -100,7 +100,7 @@ type GetClusterDefaultConfigUnauthorized struct {
 }
 
 func (o *GetClusterDefaultConfigUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/default-config][%d] getClusterDefaultConfigUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/default-config][%d] getClusterDefaultConfigUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetClusterDefaultConfigUnauthorized) GetPayload() *models.InfraError {
@@ -133,7 +133,7 @@ type GetClusterDefaultConfigForbidden struct {
 }
 
 func (o *GetClusterDefaultConfigForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/default-config][%d] getClusterDefaultConfigForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/default-config][%d] getClusterDefaultConfigForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetClusterDefaultConfigForbidden) GetPayload() *models.InfraError {
@@ -166,7 +166,7 @@ type GetClusterDefaultConfigInternalServerError struct {
 }
 
 func (o *GetClusterDefaultConfigInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/default-config][%d] getClusterDefaultConfigInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/default-config][%d] getClusterDefaultConfigInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetClusterDefaultConfigInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_cluster_host_requirements_responses.go
+++ b/client/installer/get_cluster_host_requirements_responses.go
@@ -79,7 +79,7 @@ type GetClusterHostRequirementsOK struct {
 }
 
 func (o *GetClusterHostRequirementsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsOK) GetPayload() models.ClusterHostRequirementsList {
@@ -110,7 +110,7 @@ type GetClusterHostRequirementsUnauthorized struct {
 }
 
 func (o *GetClusterHostRequirementsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type GetClusterHostRequirementsForbidden struct {
 }
 
 func (o *GetClusterHostRequirementsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type GetClusterHostRequirementsNotFound struct {
 }
 
 func (o *GetClusterHostRequirementsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsNotFound) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type GetClusterHostRequirementsMethodNotAllowed struct {
 }
 
 func (o *GetClusterHostRequirementsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsMethodNotAllowed) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type GetClusterHostRequirementsInternalServerError struct {
 }
 
 func (o *GetClusterHostRequirementsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/host-requirements][%d] getClusterHostRequirementsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetClusterHostRequirementsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_cluster_install_config_responses.go
+++ b/client/installer/get_cluster_install_config_responses.go
@@ -79,7 +79,7 @@ type GetClusterInstallConfigOK struct {
 }
 
 func (o *GetClusterInstallConfigOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigOK  %+v", 200, o.Payload)
 }
 
 func (o *GetClusterInstallConfigOK) GetPayload() string {
@@ -110,7 +110,7 @@ type GetClusterInstallConfigUnauthorized struct {
 }
 
 func (o *GetClusterInstallConfigUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetClusterInstallConfigUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type GetClusterInstallConfigForbidden struct {
 }
 
 func (o *GetClusterInstallConfigForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetClusterInstallConfigForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type GetClusterInstallConfigNotFound struct {
 }
 
 func (o *GetClusterInstallConfigNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetClusterInstallConfigNotFound) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type GetClusterInstallConfigMethodNotAllowed struct {
 }
 
 func (o *GetClusterInstallConfigMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetClusterInstallConfigMethodNotAllowed) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type GetClusterInstallConfigInternalServerError struct {
 }
 
 func (o *GetClusterInstallConfigInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/install-config][%d] getClusterInstallConfigInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/install-config][%d] getClusterInstallConfigInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetClusterInstallConfigInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_cluster_responses.go
+++ b/client/installer/get_cluster_responses.go
@@ -85,7 +85,7 @@ type GetClusterOK struct {
 }
 
 func (o *GetClusterOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterOK  %+v", 200, o.Payload)
 }
 
 func (o *GetClusterOK) GetPayload() *models.Cluster {
@@ -118,7 +118,7 @@ type GetClusterUnauthorized struct {
 }
 
 func (o *GetClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetClusterUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type GetClusterForbidden struct {
 }
 
 func (o *GetClusterForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetClusterForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type GetClusterNotFound struct {
 }
 
 func (o *GetClusterNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetClusterNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type GetClusterMethodNotAllowed struct {
 }
 
 func (o *GetClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type GetClusterInternalServerError struct {
 }
 
 func (o *GetClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetClusterInternalServerError) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type GetClusterServiceUnavailable struct {
 }
 
 func (o *GetClusterServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}][%d] getClusterServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}][%d] getClusterServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *GetClusterServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/get_credentials_responses.go
+++ b/client/installer/get_credentials_responses.go
@@ -85,7 +85,7 @@ type GetCredentialsOK struct {
 }
 
 func (o *GetCredentialsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetCredentialsOK) GetPayload() *models.Credentials {
@@ -118,7 +118,7 @@ type GetCredentialsUnauthorized struct {
 }
 
 func (o *GetCredentialsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetCredentialsUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type GetCredentialsForbidden struct {
 }
 
 func (o *GetCredentialsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetCredentialsForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type GetCredentialsNotFound struct {
 }
 
 func (o *GetCredentialsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetCredentialsNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type GetCredentialsMethodNotAllowed struct {
 }
 
 func (o *GetCredentialsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetCredentialsMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type GetCredentialsConflict struct {
 }
 
 func (o *GetCredentialsConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsConflict  %+v", 409, o.Payload)
 }
 
 func (o *GetCredentialsConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type GetCredentialsInternalServerError struct {
 }
 
 func (o *GetCredentialsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/credentials][%d] getCredentialsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/credentials][%d] getCredentialsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetCredentialsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_discovery_ignition_responses.go
+++ b/client/installer/get_discovery_ignition_responses.go
@@ -79,7 +79,7 @@ type GetDiscoveryIgnitionOK struct {
 }
 
 func (o *GetDiscoveryIgnitionOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionOK  %+v", 200, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionOK) GetPayload() *models.DiscoveryIgnitionParams {
@@ -112,7 +112,7 @@ type GetDiscoveryIgnitionUnauthorized struct {
 }
 
 func (o *GetDiscoveryIgnitionUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type GetDiscoveryIgnitionForbidden struct {
 }
 
 func (o *GetDiscoveryIgnitionForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type GetDiscoveryIgnitionNotFound struct {
 }
 
 func (o *GetDiscoveryIgnitionNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type GetDiscoveryIgnitionMethodNotAllowed struct {
 }
 
 func (o *GetDiscoveryIgnitionMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type GetDiscoveryIgnitionInternalServerError struct {
 }
 
 func (o *GetDiscoveryIgnitionInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/discovery-ignition][%d] getDiscoveryIgnitionInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetDiscoveryIgnitionInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_free_addresses_responses.go
+++ b/client/installer/get_free_addresses_responses.go
@@ -79,7 +79,7 @@ type GetFreeAddressesOK struct {
 }
 
 func (o *GetFreeAddressesOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesOK  %+v", 200, o.Payload)
 }
 
 func (o *GetFreeAddressesOK) GetPayload() models.FreeAddressesList {
@@ -110,7 +110,7 @@ type GetFreeAddressesUnauthorized struct {
 }
 
 func (o *GetFreeAddressesUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetFreeAddressesUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type GetFreeAddressesForbidden struct {
 }
 
 func (o *GetFreeAddressesForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetFreeAddressesForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type GetFreeAddressesNotFound struct {
 }
 
 func (o *GetFreeAddressesNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetFreeAddressesNotFound) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type GetFreeAddressesMethodNotAllowed struct {
 }
 
 func (o *GetFreeAddressesMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetFreeAddressesMethodNotAllowed) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type GetFreeAddressesInternalServerError struct {
 }
 
 func (o *GetFreeAddressesInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/free_addresses][%d] getFreeAddressesInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/free_addresses][%d] getFreeAddressesInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetFreeAddressesInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_host_ignition_responses.go
+++ b/client/installer/get_host_ignition_responses.go
@@ -85,7 +85,7 @@ type GetHostIgnitionOK struct {
 }
 
 func (o *GetHostIgnitionOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionOK  %+v", 200, o.Payload)
 }
 
 func (o *GetHostIgnitionOK) GetPayload() *models.HostIgnitionParams {
@@ -118,7 +118,7 @@ type GetHostIgnitionUnauthorized struct {
 }
 
 func (o *GetHostIgnitionUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetHostIgnitionUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type GetHostIgnitionForbidden struct {
 }
 
 func (o *GetHostIgnitionForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetHostIgnitionForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type GetHostIgnitionNotFound struct {
 }
 
 func (o *GetHostIgnitionNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetHostIgnitionNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type GetHostIgnitionMethodNotAllowed struct {
 }
 
 func (o *GetHostIgnitionMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetHostIgnitionMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type GetHostIgnitionConflict struct {
 }
 
 func (o *GetHostIgnitionConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionConflict  %+v", 409, o.Payload)
 }
 
 func (o *GetHostIgnitionConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type GetHostIgnitionInternalServerError struct {
 }
 
 func (o *GetHostIgnitionInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] getHostIgnitionInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetHostIgnitionInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_host_responses.go
+++ b/client/installer/get_host_responses.go
@@ -79,7 +79,7 @@ type GetHostOK struct {
 }
 
 func (o *GetHostOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostOK  %+v", 200, o.Payload)
 }
 
 func (o *GetHostOK) GetPayload() *models.Host {
@@ -112,7 +112,7 @@ type GetHostUnauthorized struct {
 }
 
 func (o *GetHostUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetHostUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type GetHostForbidden struct {
 }
 
 func (o *GetHostForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetHostForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type GetHostNotFound struct {
 }
 
 func (o *GetHostNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetHostNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type GetHostMethodNotAllowed struct {
 }
 
 func (o *GetHostMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetHostMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type GetHostInternalServerError struct {
 }
 
 func (o *GetHostInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}][%d] getHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}][%d] getHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_next_steps_responses.go
+++ b/client/installer/get_next_steps_responses.go
@@ -85,7 +85,7 @@ type GetNextStepsOK struct {
 }
 
 func (o *GetNextStepsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetNextStepsOK) GetPayload() *models.Steps {
@@ -118,7 +118,7 @@ type GetNextStepsUnauthorized struct {
 }
 
 func (o *GetNextStepsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetNextStepsUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type GetNextStepsForbidden struct {
 }
 
 func (o *GetNextStepsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetNextStepsForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type GetNextStepsNotFound struct {
 }
 
 func (o *GetNextStepsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetNextStepsNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type GetNextStepsMethodNotAllowed struct {
 }
 
 func (o *GetNextStepsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetNextStepsMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type GetNextStepsInternalServerError struct {
 }
 
 func (o *GetNextStepsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetNextStepsInternalServerError) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type GetNextStepsServiceUnavailable struct {
 }
 
 func (o *GetNextStepsServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] getNextStepsServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *GetNextStepsServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/get_preflight_requirements_responses.go
+++ b/client/installer/get_preflight_requirements_responses.go
@@ -79,7 +79,7 @@ type GetPreflightRequirementsOK struct {
 }
 
 func (o *GetPreflightRequirementsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsOK  %+v", 200, o.Payload)
 }
 
 func (o *GetPreflightRequirementsOK) GetPayload() *models.PreflightHardwareRequirements {
@@ -112,7 +112,7 @@ type GetPreflightRequirementsUnauthorized struct {
 }
 
 func (o *GetPreflightRequirementsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetPreflightRequirementsUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type GetPreflightRequirementsForbidden struct {
 }
 
 func (o *GetPreflightRequirementsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetPreflightRequirementsForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type GetPreflightRequirementsNotFound struct {
 }
 
 func (o *GetPreflightRequirementsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetPreflightRequirementsNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type GetPreflightRequirementsMethodNotAllowed struct {
 }
 
 func (o *GetPreflightRequirementsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetPreflightRequirementsMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type GetPreflightRequirementsInternalServerError struct {
 }
 
 func (o *GetPreflightRequirementsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/preflight-requirements][%d] getPreflightRequirementsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetPreflightRequirementsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/get_presigned_for_cluster_files_responses.go
+++ b/client/installer/get_presigned_for_cluster_files_responses.go
@@ -91,7 +91,7 @@ type GetPresignedForClusterFilesOK struct {
 }
 
 func (o *GetPresignedForClusterFilesOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesOK  %+v", 200, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesOK) GetPayload() *models.Presigned {
@@ -124,7 +124,7 @@ type GetPresignedForClusterFilesBadRequest struct {
 }
 
 func (o *GetPresignedForClusterFilesBadRequest) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type GetPresignedForClusterFilesUnauthorized struct {
 }
 
 func (o *GetPresignedForClusterFilesUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type GetPresignedForClusterFilesForbidden struct {
 }
 
 func (o *GetPresignedForClusterFilesForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesForbidden  %+v", 403, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type GetPresignedForClusterFilesNotFound struct {
 }
 
 func (o *GetPresignedForClusterFilesNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesNotFound  %+v", 404, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type GetPresignedForClusterFilesMethodNotAllowed struct {
 }
 
 func (o *GetPresignedForClusterFilesMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type GetPresignedForClusterFilesConflict struct {
 }
 
 func (o *GetPresignedForClusterFilesConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesConflict  %+v", 409, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type GetPresignedForClusterFilesInternalServerError struct {
 }
 
 func (o *GetPresignedForClusterFilesInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/files-presigned][%d] getPresignedForClusterFilesInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *GetPresignedForClusterFilesInternalServerError) GetPayload() *models.Error {

--- a/client/installer/install_cluster_responses.go
+++ b/client/installer/install_cluster_responses.go
@@ -91,7 +91,7 @@ type InstallClusterAccepted struct {
 }
 
 func (o *InstallClusterAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterAccepted  %+v", 202, o.Payload)
 }
 
 func (o *InstallClusterAccepted) GetPayload() *models.Cluster {
@@ -124,7 +124,7 @@ type InstallClusterBadRequest struct {
 }
 
 func (o *InstallClusterBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *InstallClusterBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type InstallClusterUnauthorized struct {
 }
 
 func (o *InstallClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *InstallClusterUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type InstallClusterForbidden struct {
 }
 
 func (o *InstallClusterForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *InstallClusterForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type InstallClusterNotFound struct {
 }
 
 func (o *InstallClusterNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *InstallClusterNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type InstallClusterMethodNotAllowed struct {
 }
 
 func (o *InstallClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *InstallClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type InstallClusterConflict struct {
 }
 
 func (o *InstallClusterConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterConflict  %+v", 409, o.Payload)
 }
 
 func (o *InstallClusterConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type InstallClusterInternalServerError struct {
 }
 
 func (o *InstallClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install][%d] installClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install][%d] installClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *InstallClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/install_host_responses.go
+++ b/client/installer/install_host_responses.go
@@ -79,7 +79,7 @@ type InstallHostAccepted struct {
 }
 
 func (o *InstallHostAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostAccepted  %+v", 202, o.Payload)
 }
 
 func (o *InstallHostAccepted) GetPayload() *models.Host {
@@ -112,7 +112,7 @@ type InstallHostUnauthorized struct {
 }
 
 func (o *InstallHostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *InstallHostUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type InstallHostForbidden struct {
 }
 
 func (o *InstallHostForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *InstallHostForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type InstallHostNotFound struct {
 }
 
 func (o *InstallHostNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *InstallHostNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type InstallHostConflict struct {
 }
 
 func (o *InstallHostConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostConflict  %+v", 409, o.Payload)
 }
 
 func (o *InstallHostConflict) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type InstallHostInternalServerError struct {
 }
 
 func (o *InstallHostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install][%d] installHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *InstallHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/install_hosts_responses.go
+++ b/client/installer/install_hosts_responses.go
@@ -91,7 +91,7 @@ type InstallHostsAccepted struct {
 }
 
 func (o *InstallHostsAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsAccepted  %+v", 202, o.Payload)
 }
 
 func (o *InstallHostsAccepted) GetPayload() *models.Cluster {
@@ -124,7 +124,7 @@ type InstallHostsBadRequest struct {
 }
 
 func (o *InstallHostsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *InstallHostsBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type InstallHostsUnauthorized struct {
 }
 
 func (o *InstallHostsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *InstallHostsUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type InstallHostsForbidden struct {
 }
 
 func (o *InstallHostsForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *InstallHostsForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type InstallHostsNotFound struct {
 }
 
 func (o *InstallHostsNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *InstallHostsNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type InstallHostsMethodNotAllowed struct {
 }
 
 func (o *InstallHostsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *InstallHostsMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type InstallHostsConflict struct {
 }
 
 func (o *InstallHostsConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsConflict  %+v", 409, o.Payload)
 }
 
 func (o *InstallHostsConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type InstallHostsInternalServerError struct {
 }
 
 func (o *InstallHostsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/install_hosts][%d] installHostsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/install_hosts][%d] installHostsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *InstallHostsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/installer_client.go
+++ b/client/installer/installer_client.go
@@ -201,7 +201,7 @@ func (a *Client) CancelInstallation(ctx context.Context, params *CancelInstallat
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "CancelInstallation",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/actions/cancel",
+		PathPattern:        "/v1/clusters/{cluster_id}/actions/cancel",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -226,7 +226,7 @@ func (a *Client) CompleteInstallation(ctx context.Context, params *CompleteInsta
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "CompleteInstallation",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/actions/complete_installation",
+		PathPattern:        "/v1/clusters/{cluster_id}/actions/complete_installation",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -251,7 +251,7 @@ func (a *Client) DeregisterCluster(ctx context.Context, params *DeregisterCluste
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DeregisterCluster",
 		Method:             "DELETE",
-		PathPattern:        "/clusters/{cluster_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -276,7 +276,7 @@ func (a *Client) DeregisterHost(ctx context.Context, params *DeregisterHostParam
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DeregisterHost",
 		Method:             "DELETE",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -301,7 +301,7 @@ func (a *Client) DisableHost(ctx context.Context, params *DisableHostParams) (*D
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DisableHost",
 		Method:             "DELETE",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/actions/enable",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -326,7 +326,7 @@ func (a *Client) DownloadClusterFiles(ctx context.Context, params *DownloadClust
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterFiles",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/downloads/files",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/files",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -351,7 +351,7 @@ func (a *Client) DownloadClusterISO(ctx context.Context, params *DownloadCluster
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterISO",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/downloads/image",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/image",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -376,7 +376,7 @@ func (a *Client) DownloadClusterISOHeaders(ctx context.Context, params *Download
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterISOHeaders",
 		Method:             "HEAD",
-		PathPattern:        "/clusters/{cluster_id}/downloads/image",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/image",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -401,7 +401,7 @@ func (a *Client) DownloadClusterKubeconfig(ctx context.Context, params *Download
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterKubeconfig",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/downloads/kubeconfig",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/kubeconfig",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -426,7 +426,7 @@ func (a *Client) DownloadClusterLogs(ctx context.Context, params *DownloadCluste
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterLogs",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/logs",
+		PathPattern:        "/v1/clusters/{cluster_id}/logs",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -451,7 +451,7 @@ func (a *Client) DownloadHostIgnition(ctx context.Context, params *DownloadHostI
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadHostIgnition",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -476,7 +476,7 @@ func (a *Client) DownloadHostLogs(ctx context.Context, params *DownloadHostLogsP
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadHostLogs",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/logs",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/logs",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -501,7 +501,7 @@ func (a *Client) EnableHost(ctx context.Context, params *EnableHostParams) (*Ena
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "EnableHost",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/actions/enable",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -526,7 +526,7 @@ func (a *Client) GenerateClusterISO(ctx context.Context, params *GenerateCluster
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GenerateClusterISO",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/downloads/image",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/image",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -551,7 +551,7 @@ func (a *Client) GetCluster(ctx context.Context, params *GetClusterParams) (*Get
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetCluster",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -576,7 +576,7 @@ func (a *Client) GetClusterDefaultConfig(ctx context.Context, params *GetCluster
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetClusterDefaultConfig",
 		Method:             "GET",
-		PathPattern:        "/clusters/default-config",
+		PathPattern:        "/v1/clusters/default-config",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -601,7 +601,7 @@ func (a *Client) GetClusterHostRequirements(ctx context.Context, params *GetClus
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetClusterHostRequirements",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/host-requirements",
+		PathPattern:        "/v1/clusters/{cluster_id}/host-requirements",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -626,7 +626,7 @@ func (a *Client) GetClusterInstallConfig(ctx context.Context, params *GetCluster
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetClusterInstallConfig",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/install-config",
+		PathPattern:        "/v1/clusters/{cluster_id}/install-config",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -651,7 +651,7 @@ func (a *Client) GetCredentials(ctx context.Context, params *GetCredentialsParam
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetCredentials",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/credentials",
+		PathPattern:        "/v1/clusters/{cluster_id}/credentials",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -679,7 +679,7 @@ func (a *Client) GetDiscoveryIgnition(ctx context.Context, params *GetDiscoveryI
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetDiscoveryIgnition",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/discovery-ignition",
+		PathPattern:        "/v1/clusters/{cluster_id}/discovery-ignition",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -704,7 +704,7 @@ func (a *Client) GetFreeAddresses(ctx context.Context, params *GetFreeAddressesP
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetFreeAddresses",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/free_addresses",
+		PathPattern:        "/v1/clusters/{cluster_id}/free_addresses",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -729,7 +729,7 @@ func (a *Client) GetHost(ctx context.Context, params *GetHostParams) (*GetHostOK
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetHost",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -754,7 +754,7 @@ func (a *Client) GetHostIgnition(ctx context.Context, params *GetHostIgnitionPar
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetHostIgnition",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/ignition",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -779,7 +779,7 @@ func (a *Client) GetNextSteps(ctx context.Context, params *GetNextStepsParams) (
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetNextSteps",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/instructions",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -804,7 +804,7 @@ func (a *Client) GetPreflightRequirements(ctx context.Context, params *GetPrefli
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetPreflightRequirements",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/preflight-requirements",
+		PathPattern:        "/v1/clusters/{cluster_id}/preflight-requirements",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -829,7 +829,7 @@ func (a *Client) GetPresignedForClusterFiles(ctx context.Context, params *GetPre
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "GetPresignedForClusterFiles",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/downloads/files-presigned",
+		PathPattern:        "/v1/clusters/{cluster_id}/downloads/files-presigned",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -854,7 +854,7 @@ func (a *Client) InstallCluster(ctx context.Context, params *InstallClusterParam
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "InstallCluster",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/actions/install",
+		PathPattern:        "/v1/clusters/{cluster_id}/actions/install",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -879,7 +879,7 @@ func (a *Client) InstallHost(ctx context.Context, params *InstallHostParams) (*I
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "InstallHost",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/actions/install",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/install",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -904,7 +904,7 @@ func (a *Client) InstallHosts(ctx context.Context, params *InstallHostsParams) (
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "InstallHosts",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/actions/install_hosts",
+		PathPattern:        "/v1/clusters/{cluster_id}/actions/install_hosts",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -929,7 +929,7 @@ func (a *Client) ListClusters(ctx context.Context, params *ListClustersParams) (
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListClusters",
 		Method:             "GET",
-		PathPattern:        "/clusters",
+		PathPattern:        "/v1/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -954,7 +954,7 @@ func (a *Client) ListHosts(ctx context.Context, params *ListHostsParams) (*ListH
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListHosts",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/hosts",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -979,7 +979,7 @@ func (a *Client) PostStepReply(ctx context.Context, params *PostStepReplyParams)
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "PostStepReply",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/instructions",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1004,7 +1004,7 @@ func (a *Client) RegisterAddHostsCluster(ctx context.Context, params *RegisterAd
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "RegisterAddHostsCluster",
 		Method:             "POST",
-		PathPattern:        "/add_hosts_clusters",
+		PathPattern:        "/v1/add_hosts_clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1029,7 +1029,7 @@ func (a *Client) RegisterCluster(ctx context.Context, params *RegisterClusterPar
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "RegisterCluster",
 		Method:             "POST",
-		PathPattern:        "/clusters",
+		PathPattern:        "/v1/clusters",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1054,7 +1054,7 @@ func (a *Client) RegisterHost(ctx context.Context, params *RegisterHostParams) (
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "RegisterHost",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1079,7 +1079,7 @@ func (a *Client) ResetCluster(ctx context.Context, params *ResetClusterParams) (
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ResetCluster",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/actions/reset",
+		PathPattern:        "/v1/clusters/{cluster_id}/actions/reset",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1104,7 +1104,7 @@ func (a *Client) ResetHost(ctx context.Context, params *ResetHostParams) (*Reset
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ResetHost",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/actions/reset",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1131,7 +1131,7 @@ func (a *Client) ResetHostValidation(ctx context.Context, params *ResetHostValid
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ResetHostValidation",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1156,7 +1156,7 @@ func (a *Client) UpdateCluster(ctx context.Context, params *UpdateClusterParams)
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateCluster",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}",
+		PathPattern:        "/v1/clusters/{cluster_id}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1181,7 +1181,7 @@ func (a *Client) UpdateClusterInstallConfig(ctx context.Context, params *UpdateC
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateClusterInstallConfig",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}/install-config",
+		PathPattern:        "/v1/clusters/{cluster_id}/install-config",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1206,7 +1206,7 @@ func (a *Client) UpdateClusterLogsProgress(ctx context.Context, params *UpdateCl
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateClusterLogsProgress",
 		Method:             "PUT",
-		PathPattern:        "/clusters/{cluster_id}/logs_progress",
+		PathPattern:        "/v1/clusters/{cluster_id}/logs_progress",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1231,7 +1231,7 @@ func (a *Client) UpdateDiscoveryIgnition(ctx context.Context, params *UpdateDisc
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateDiscoveryIgnition",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}/discovery-ignition",
+		PathPattern:        "/v1/clusters/{cluster_id}/discovery-ignition",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1256,7 +1256,7 @@ func (a *Client) UpdateHostIgnition(ctx context.Context, params *UpdateHostIgnit
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateHostIgnition",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/ignition",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1281,7 +1281,7 @@ func (a *Client) UpdateHostInstallProgress(ctx context.Context, params *UpdateHo
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateHostInstallProgress",
 		Method:             "PUT",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/progress",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/progress",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1306,7 +1306,7 @@ func (a *Client) UpdateHostInstallerArgs(ctx context.Context, params *UpdateHost
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateHostInstallerArgs",
 		Method:             "PATCH",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/installer-args",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/installer-args",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1331,7 +1331,7 @@ func (a *Client) UpdateHostLogsProgress(ctx context.Context, params *UpdateHostL
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UpdateHostLogsProgress",
 		Method:             "PUT",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/logs_progress",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1356,7 +1356,7 @@ func (a *Client) UploadClusterIngressCert(ctx context.Context, params *UploadClu
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UploadClusterIngressCert",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/uploads/ingress-cert",
+		PathPattern:        "/v1/clusters/{cluster_id}/uploads/ingress-cert",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -1381,7 +1381,7 @@ func (a *Client) UploadHostLogs(ctx context.Context, params *UploadHostLogsParam
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UploadHostLogs",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/hosts/{host_id}/logs",
+		PathPattern:        "/v1/clusters/{cluster_id}/hosts/{host_id}/logs",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"multipart/form-data"},
 		Schemes:            []string{"http", "https"},
@@ -1406,7 +1406,7 @@ func (a *Client) UploadLogs(ctx context.Context, params *UploadLogsParams) (*Upl
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "UploadLogs",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/logs",
+		PathPattern:        "/v1/clusters/{cluster_id}/logs",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"multipart/form-data"},
 		Schemes:            []string{"http", "https"},
@@ -1431,7 +1431,7 @@ func (a *Client) V2RegisterInfraEnv(ctx context.Context, params *V2RegisterInfra
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "v2RegisterInfraEnv",
 		Method:             "POST",
-		PathPattern:        "/infra-envs",
+		PathPattern:        "/v2/infra-envs",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/installer/list_clusters_responses.go
+++ b/client/installer/list_clusters_responses.go
@@ -79,7 +79,7 @@ type ListClustersOK struct {
 }
 
 func (o *ListClustersOK) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersOK  %+v", 200, o.Payload)
 }
 
 func (o *ListClustersOK) GetPayload() models.ClusterList {
@@ -110,7 +110,7 @@ type ListClustersUnauthorized struct {
 }
 
 func (o *ListClustersUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListClustersUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type ListClustersForbidden struct {
 }
 
 func (o *ListClustersForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListClustersForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type ListClustersMethodNotAllowed struct {
 }
 
 func (o *ListClustersMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ListClustersMethodNotAllowed) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type ListClustersInternalServerError struct {
 }
 
 func (o *ListClustersInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListClustersInternalServerError) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type ListClustersServiceUnavailable struct {
 }
 
 func (o *ListClustersServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters][%d] listClustersServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters][%d] listClustersServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *ListClustersServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/list_hosts_responses.go
+++ b/client/installer/list_hosts_responses.go
@@ -79,7 +79,7 @@ type ListHostsOK struct {
 }
 
 func (o *ListHostsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListHostsOK) GetPayload() models.HostList {
@@ -110,7 +110,7 @@ type ListHostsUnauthorized struct {
 }
 
 func (o *ListHostsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListHostsUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type ListHostsForbidden struct {
 }
 
 func (o *ListHostsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListHostsForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type ListHostsMethodNotAllowed struct {
 }
 
 func (o *ListHostsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ListHostsMethodNotAllowed) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type ListHostsInternalServerError struct {
 }
 
 func (o *ListHostsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListHostsInternalServerError) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type ListHostsServiceUnavailable struct {
 }
 
 func (o *ListHostsServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/hosts][%d] listHostsServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/hosts][%d] listHostsServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *ListHostsServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/post_step_reply_responses.go
+++ b/client/installer/post_step_reply_responses.go
@@ -90,7 +90,7 @@ type PostStepReplyNoContent struct {
 }
 
 func (o *PostStepReplyNoContent) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyNoContent ", 204)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyNoContent ", 204)
 }
 
 func (o *PostStepReplyNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -112,7 +112,7 @@ type PostStepReplyBadRequest struct {
 }
 
 func (o *PostStepReplyBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *PostStepReplyBadRequest) GetPayload() *models.Error {
@@ -145,7 +145,7 @@ type PostStepReplyUnauthorized struct {
 }
 
 func (o *PostStepReplyUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *PostStepReplyUnauthorized) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type PostStepReplyForbidden struct {
 }
 
 func (o *PostStepReplyForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyForbidden  %+v", 403, o.Payload)
 }
 
 func (o *PostStepReplyForbidden) GetPayload() *models.InfraError {
@@ -211,7 +211,7 @@ type PostStepReplyNotFound struct {
 }
 
 func (o *PostStepReplyNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyNotFound  %+v", 404, o.Payload)
 }
 
 func (o *PostStepReplyNotFound) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type PostStepReplyMethodNotAllowed struct {
 }
 
 func (o *PostStepReplyMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *PostStepReplyMethodNotAllowed) GetPayload() *models.Error {
@@ -277,7 +277,7 @@ type PostStepReplyInternalServerError struct {
 }
 
 func (o *PostStepReplyInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *PostStepReplyInternalServerError) GetPayload() *models.Error {
@@ -310,7 +310,7 @@ type PostStepReplyServiceUnavailable struct {
 }
 
 func (o *PostStepReplyServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions][%d] postStepReplyServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *PostStepReplyServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/register_add_hosts_cluster_responses.go
+++ b/client/installer/register_add_hosts_cluster_responses.go
@@ -73,7 +73,7 @@ type RegisterAddHostsClusterCreated struct {
 }
 
 func (o *RegisterAddHostsClusterCreated) Error() string {
-	return fmt.Sprintf("[POST /add_hosts_clusters][%d] registerAddHostsClusterCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/add_hosts_clusters][%d] registerAddHostsClusterCreated  %+v", 201, o.Payload)
 }
 
 func (o *RegisterAddHostsClusterCreated) GetPayload() *models.Cluster {
@@ -106,7 +106,7 @@ type RegisterAddHostsClusterBadRequest struct {
 }
 
 func (o *RegisterAddHostsClusterBadRequest) Error() string {
-	return fmt.Sprintf("[POST /add_hosts_clusters][%d] registerAddHostsClusterBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/add_hosts_clusters][%d] registerAddHostsClusterBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *RegisterAddHostsClusterBadRequest) GetPayload() *models.Error {
@@ -139,7 +139,7 @@ type RegisterAddHostsClusterUnauthorized struct {
 }
 
 func (o *RegisterAddHostsClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /add_hosts_clusters][%d] registerAddHostsClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/add_hosts_clusters][%d] registerAddHostsClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *RegisterAddHostsClusterUnauthorized) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type RegisterAddHostsClusterForbidden struct {
 }
 
 func (o *RegisterAddHostsClusterForbidden) Error() string {
-	return fmt.Sprintf("[POST /add_hosts_clusters][%d] registerAddHostsClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/add_hosts_clusters][%d] registerAddHostsClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *RegisterAddHostsClusterForbidden) GetPayload() *models.InfraError {
@@ -205,7 +205,7 @@ type RegisterAddHostsClusterInternalServerError struct {
 }
 
 func (o *RegisterAddHostsClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /add_hosts_clusters][%d] registerAddHostsClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/add_hosts_clusters][%d] registerAddHostsClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *RegisterAddHostsClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/register_cluster_responses.go
+++ b/client/installer/register_cluster_responses.go
@@ -79,7 +79,7 @@ type RegisterClusterCreated struct {
 }
 
 func (o *RegisterClusterCreated) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterCreated  %+v", 201, o.Payload)
 }
 
 func (o *RegisterClusterCreated) GetPayload() *models.Cluster {
@@ -112,7 +112,7 @@ type RegisterClusterBadRequest struct {
 }
 
 func (o *RegisterClusterBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *RegisterClusterBadRequest) GetPayload() *models.Error {
@@ -145,7 +145,7 @@ type RegisterClusterUnauthorized struct {
 }
 
 func (o *RegisterClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *RegisterClusterUnauthorized) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type RegisterClusterForbidden struct {
 }
 
 func (o *RegisterClusterForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *RegisterClusterForbidden) GetPayload() *models.InfraError {
@@ -211,7 +211,7 @@ type RegisterClusterMethodNotAllowed struct {
 }
 
 func (o *RegisterClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *RegisterClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type RegisterClusterInternalServerError struct {
 }
 
 func (o *RegisterClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters][%d] registerClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters][%d] registerClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *RegisterClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/register_host_responses.go
+++ b/client/installer/register_host_responses.go
@@ -97,7 +97,7 @@ type RegisterHostCreated struct {
 }
 
 func (o *RegisterHostCreated) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostCreated  %+v", 201, o.Payload)
 }
 
 func (o *RegisterHostCreated) GetPayload() *models.HostRegistrationResponse {
@@ -130,7 +130,7 @@ type RegisterHostBadRequest struct {
 }
 
 func (o *RegisterHostBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *RegisterHostBadRequest) GetPayload() *models.Error {
@@ -163,7 +163,7 @@ type RegisterHostUnauthorized struct {
 }
 
 func (o *RegisterHostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *RegisterHostUnauthorized) GetPayload() *models.InfraError {
@@ -196,7 +196,7 @@ type RegisterHostForbidden struct {
 }
 
 func (o *RegisterHostForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *RegisterHostForbidden) GetPayload() *models.InfraError {
@@ -229,7 +229,7 @@ type RegisterHostNotFound struct {
 }
 
 func (o *RegisterHostNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *RegisterHostNotFound) GetPayload() *models.Error {
@@ -262,7 +262,7 @@ type RegisterHostMethodNotAllowed struct {
 }
 
 func (o *RegisterHostMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *RegisterHostMethodNotAllowed) GetPayload() *models.Error {
@@ -295,7 +295,7 @@ type RegisterHostConflict struct {
 }
 
 func (o *RegisterHostConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostConflict  %+v", 409, o.Payload)
 }
 
 func (o *RegisterHostConflict) GetPayload() *models.Error {
@@ -328,7 +328,7 @@ type RegisterHostInternalServerError struct {
 }
 
 func (o *RegisterHostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *RegisterHostInternalServerError) GetPayload() *models.Error {
@@ -361,7 +361,7 @@ type RegisterHostServiceUnavailable struct {
 }
 
 func (o *RegisterHostServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts][%d] registerHostServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts][%d] registerHostServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *RegisterHostServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/reset_cluster_responses.go
+++ b/client/installer/reset_cluster_responses.go
@@ -85,7 +85,7 @@ type ResetClusterAccepted struct {
 }
 
 func (o *ResetClusterAccepted) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterAccepted  %+v", 202, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterAccepted  %+v", 202, o.Payload)
 }
 
 func (o *ResetClusterAccepted) GetPayload() *models.Cluster {
@@ -118,7 +118,7 @@ type ResetClusterUnauthorized struct {
 }
 
 func (o *ResetClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ResetClusterUnauthorized) GetPayload() *models.InfraError {
@@ -151,7 +151,7 @@ type ResetClusterForbidden struct {
 }
 
 func (o *ResetClusterForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ResetClusterForbidden) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type ResetClusterNotFound struct {
 }
 
 func (o *ResetClusterNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ResetClusterNotFound) GetPayload() *models.Error {
@@ -217,7 +217,7 @@ type ResetClusterMethodNotAllowed struct {
 }
 
 func (o *ResetClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ResetClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type ResetClusterConflict struct {
 }
 
 func (o *ResetClusterConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterConflict  %+v", 409, o.Payload)
 }
 
 func (o *ResetClusterConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type ResetClusterInternalServerError struct {
 }
 
 func (o *ResetClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/actions/reset][%d] resetClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/actions/reset][%d] resetClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ResetClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/reset_host_responses.go
+++ b/client/installer/reset_host_responses.go
@@ -79,7 +79,7 @@ type ResetHostOK struct {
 }
 
 func (o *ResetHostOK) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostOK  %+v", 200, o.Payload)
 }
 
 func (o *ResetHostOK) GetPayload() *models.Host {
@@ -112,7 +112,7 @@ type ResetHostUnauthorized struct {
 }
 
 func (o *ResetHostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ResetHostUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type ResetHostForbidden struct {
 }
 
 func (o *ResetHostForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ResetHostForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type ResetHostNotFound struct {
 }
 
 func (o *ResetHostNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ResetHostNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type ResetHostConflict struct {
 }
 
 func (o *ResetHostConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostConflict  %+v", 409, o.Payload)
 }
 
 func (o *ResetHostConflict) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type ResetHostInternalServerError struct {
 }
 
 func (o *ResetHostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset][%d] resetHostInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ResetHostInternalServerError) GetPayload() *models.Error {

--- a/client/installer/reset_host_validation_responses.go
+++ b/client/installer/reset_host_validation_responses.go
@@ -85,7 +85,7 @@ type ResetHostValidationOK struct {
 }
 
 func (o *ResetHostValidationOK) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationOK  %+v", 200, o.Payload)
 }
 
 func (o *ResetHostValidationOK) GetPayload() *models.Host {
@@ -118,7 +118,7 @@ type ResetHostValidationBadRequest struct {
 }
 
 func (o *ResetHostValidationBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *ResetHostValidationBadRequest) GetPayload() *models.Error {
@@ -151,7 +151,7 @@ type ResetHostValidationUnauthorized struct {
 }
 
 func (o *ResetHostValidationUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ResetHostValidationUnauthorized) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type ResetHostValidationForbidden struct {
 }
 
 func (o *ResetHostValidationForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ResetHostValidationForbidden) GetPayload() *models.InfraError {
@@ -217,7 +217,7 @@ type ResetHostValidationNotFound struct {
 }
 
 func (o *ResetHostValidationNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ResetHostValidationNotFound) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type ResetHostValidationConflict struct {
 }
 
 func (o *ResetHostValidationConflict) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationConflict  %+v", 409, o.Payload)
 }
 
 func (o *ResetHostValidationConflict) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type ResetHostValidationInternalServerError struct {
 }
 
 func (o *ResetHostValidationInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}][%d] resetHostValidationInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ResetHostValidationInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_cluster_install_config_responses.go
+++ b/client/installer/update_cluster_install_config_responses.go
@@ -84,7 +84,7 @@ type UpdateClusterInstallConfigCreated struct {
 }
 
 func (o *UpdateClusterInstallConfigCreated) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigCreated ", 201)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigCreated ", 201)
 }
 
 func (o *UpdateClusterInstallConfigCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateClusterInstallConfigBadRequest struct {
 }
 
 func (o *UpdateClusterInstallConfigBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigBadRequest) GetPayload() *models.Error {
@@ -139,7 +139,7 @@ type UpdateClusterInstallConfigUnauthorized struct {
 }
 
 func (o *UpdateClusterInstallConfigUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigUnauthorized) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type UpdateClusterInstallConfigForbidden struct {
 }
 
 func (o *UpdateClusterInstallConfigForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigForbidden) GetPayload() *models.InfraError {
@@ -205,7 +205,7 @@ type UpdateClusterInstallConfigNotFound struct {
 }
 
 func (o *UpdateClusterInstallConfigNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigNotFound) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type UpdateClusterInstallConfigMethodNotAllowed struct {
 }
 
 func (o *UpdateClusterInstallConfigMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigMethodNotAllowed) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type UpdateClusterInstallConfigInternalServerError struct {
 }
 
 func (o *UpdateClusterInstallConfigInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/install-config][%d] updateClusterInstallConfigInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateClusterInstallConfigInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_cluster_logs_progress_responses.go
+++ b/client/installer/update_cluster_logs_progress_responses.go
@@ -90,7 +90,7 @@ type UpdateClusterLogsProgressNoContent struct {
 }
 
 func (o *UpdateClusterLogsProgressNoContent) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressNoContent ", 204)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressNoContent ", 204)
 }
 
 func (o *UpdateClusterLogsProgressNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -112,7 +112,7 @@ type UpdateClusterLogsProgressUnauthorized struct {
 }
 
 func (o *UpdateClusterLogsProgressUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type UpdateClusterLogsProgressForbidden struct {
 }
 
 func (o *UpdateClusterLogsProgressForbidden) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type UpdateClusterLogsProgressNotFound struct {
 }
 
 func (o *UpdateClusterLogsProgressNotFound) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type UpdateClusterLogsProgressMethodNotAllowed struct {
 }
 
 func (o *UpdateClusterLogsProgressMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type UpdateClusterLogsProgressConflict struct {
 }
 
 func (o *UpdateClusterLogsProgressConflict) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressConflict  %+v", 409, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressConflict) GetPayload() *models.Error {
@@ -277,7 +277,7 @@ type UpdateClusterLogsProgressInternalServerError struct {
 }
 
 func (o *UpdateClusterLogsProgressInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressInternalServerError) GetPayload() *models.Error {
@@ -310,7 +310,7 @@ type UpdateClusterLogsProgressServiceUnavailable struct {
 }
 
 func (o *UpdateClusterLogsProgressServiceUnavailable) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/logs_progress][%d] updateClusterLogsProgressServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UpdateClusterLogsProgressServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/update_cluster_responses.go
+++ b/client/installer/update_cluster_responses.go
@@ -91,7 +91,7 @@ type UpdateClusterCreated struct {
 }
 
 func (o *UpdateClusterCreated) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterCreated  %+v", 201, o.Payload)
 }
 
 func (o *UpdateClusterCreated) GetPayload() *models.Cluster {
@@ -124,7 +124,7 @@ type UpdateClusterBadRequest struct {
 }
 
 func (o *UpdateClusterBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateClusterBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type UpdateClusterUnauthorized struct {
 }
 
 func (o *UpdateClusterUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateClusterUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type UpdateClusterForbidden struct {
 }
 
 func (o *UpdateClusterForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateClusterForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type UpdateClusterNotFound struct {
 }
 
 func (o *UpdateClusterNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateClusterNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type UpdateClusterMethodNotAllowed struct {
 }
 
 func (o *UpdateClusterMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateClusterMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type UpdateClusterConflict struct {
 }
 
 func (o *UpdateClusterConflict) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterConflict  %+v", 409, o.Payload)
 }
 
 func (o *UpdateClusterConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type UpdateClusterInternalServerError struct {
 }
 
 func (o *UpdateClusterInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}][%d] updateClusterInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}][%d] updateClusterInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateClusterInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_discovery_ignition_responses.go
+++ b/client/installer/update_discovery_ignition_responses.go
@@ -84,7 +84,7 @@ type UpdateDiscoveryIgnitionCreated struct {
 }
 
 func (o *UpdateDiscoveryIgnitionCreated) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionCreated ", 201)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionCreated ", 201)
 }
 
 func (o *UpdateDiscoveryIgnitionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateDiscoveryIgnitionBadRequest struct {
 }
 
 func (o *UpdateDiscoveryIgnitionBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionBadRequest) GetPayload() *models.Error {
@@ -139,7 +139,7 @@ type UpdateDiscoveryIgnitionUnauthorized struct {
 }
 
 func (o *UpdateDiscoveryIgnitionUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionUnauthorized) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type UpdateDiscoveryIgnitionForbidden struct {
 }
 
 func (o *UpdateDiscoveryIgnitionForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionForbidden) GetPayload() *models.InfraError {
@@ -205,7 +205,7 @@ type UpdateDiscoveryIgnitionNotFound struct {
 }
 
 func (o *UpdateDiscoveryIgnitionNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionNotFound) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type UpdateDiscoveryIgnitionMethodNotAllowed struct {
 }
 
 func (o *UpdateDiscoveryIgnitionMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionMethodNotAllowed) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type UpdateDiscoveryIgnitionInternalServerError struct {
 }
 
 func (o *UpdateDiscoveryIgnitionInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/discovery-ignition][%d] updateDiscoveryIgnitionInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateDiscoveryIgnitionInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_host_ignition_responses.go
+++ b/client/installer/update_host_ignition_responses.go
@@ -84,7 +84,7 @@ type UpdateHostIgnitionCreated struct {
 }
 
 func (o *UpdateHostIgnitionCreated) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionCreated ", 201)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionCreated ", 201)
 }
 
 func (o *UpdateHostIgnitionCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateHostIgnitionBadRequest struct {
 }
 
 func (o *UpdateHostIgnitionBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateHostIgnitionBadRequest) GetPayload() *models.Error {
@@ -139,7 +139,7 @@ type UpdateHostIgnitionUnauthorized struct {
 }
 
 func (o *UpdateHostIgnitionUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateHostIgnitionUnauthorized) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type UpdateHostIgnitionForbidden struct {
 }
 
 func (o *UpdateHostIgnitionForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateHostIgnitionForbidden) GetPayload() *models.InfraError {
@@ -205,7 +205,7 @@ type UpdateHostIgnitionNotFound struct {
 }
 
 func (o *UpdateHostIgnitionNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateHostIgnitionNotFound) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type UpdateHostIgnitionMethodNotAllowed struct {
 }
 
 func (o *UpdateHostIgnitionMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateHostIgnitionMethodNotAllowed) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type UpdateHostIgnitionInternalServerError struct {
 }
 
 func (o *UpdateHostIgnitionInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition][%d] updateHostIgnitionInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateHostIgnitionInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_host_install_progress_responses.go
+++ b/client/installer/update_host_install_progress_responses.go
@@ -84,7 +84,7 @@ type UpdateHostInstallProgressOK struct {
 }
 
 func (o *UpdateHostInstallProgressOK) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressOK ", 200)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressOK ", 200)
 }
 
 func (o *UpdateHostInstallProgressOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type UpdateHostInstallProgressUnauthorized struct {
 }
 
 func (o *UpdateHostInstallProgressUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressUnauthorized) GetPayload() *models.InfraError {
@@ -139,7 +139,7 @@ type UpdateHostInstallProgressForbidden struct {
 }
 
 func (o *UpdateHostInstallProgressForbidden) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressForbidden) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type UpdateHostInstallProgressNotFound struct {
 }
 
 func (o *UpdateHostInstallProgressNotFound) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressNotFound) GetPayload() *models.Error {
@@ -205,7 +205,7 @@ type UpdateHostInstallProgressMethodNotAllowed struct {
 }
 
 func (o *UpdateHostInstallProgressMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressMethodNotAllowed) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type UpdateHostInstallProgressInternalServerError struct {
 }
 
 func (o *UpdateHostInstallProgressInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressInternalServerError) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type UpdateHostInstallProgressServiceUnavailable struct {
 }
 
 func (o *UpdateHostInstallProgressServiceUnavailable) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress][%d] updateHostInstallProgressServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UpdateHostInstallProgressServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/update_host_installer_args_responses.go
+++ b/client/installer/update_host_installer_args_responses.go
@@ -91,7 +91,7 @@ type UpdateHostInstallerArgsCreated struct {
 }
 
 func (o *UpdateHostInstallerArgsCreated) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsCreated  %+v", 201, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsCreated) GetPayload() *models.Host {
@@ -124,7 +124,7 @@ type UpdateHostInstallerArgsBadRequest struct {
 }
 
 func (o *UpdateHostInstallerArgsBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type UpdateHostInstallerArgsUnauthorized struct {
 }
 
 func (o *UpdateHostInstallerArgsUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type UpdateHostInstallerArgsForbidden struct {
 }
 
 func (o *UpdateHostInstallerArgsForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type UpdateHostInstallerArgsNotFound struct {
 }
 
 func (o *UpdateHostInstallerArgsNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type UpdateHostInstallerArgsMethodNotAllowed struct {
 }
 
 func (o *UpdateHostInstallerArgsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type UpdateHostInstallerArgsConflict struct {
 }
 
 func (o *UpdateHostInstallerArgsConflict) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsConflict  %+v", 409, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type UpdateHostInstallerArgsInternalServerError struct {
 }
 
 func (o *UpdateHostInstallerArgsInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args][%d] updateHostInstallerArgsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateHostInstallerArgsInternalServerError) GetPayload() *models.Error {

--- a/client/installer/update_host_logs_progress_responses.go
+++ b/client/installer/update_host_logs_progress_responses.go
@@ -90,7 +90,7 @@ type UpdateHostLogsProgressNoContent struct {
 }
 
 func (o *UpdateHostLogsProgressNoContent) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressNoContent ", 204)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressNoContent ", 204)
 }
 
 func (o *UpdateHostLogsProgressNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -112,7 +112,7 @@ type UpdateHostLogsProgressUnauthorized struct {
 }
 
 func (o *UpdateHostLogsProgressUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressUnauthorized) GetPayload() *models.InfraError {
@@ -145,7 +145,7 @@ type UpdateHostLogsProgressForbidden struct {
 }
 
 func (o *UpdateHostLogsProgressForbidden) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressForbidden) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type UpdateHostLogsProgressNotFound struct {
 }
 
 func (o *UpdateHostLogsProgressNotFound) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressNotFound) GetPayload() *models.Error {
@@ -211,7 +211,7 @@ type UpdateHostLogsProgressMethodNotAllowed struct {
 }
 
 func (o *UpdateHostLogsProgressMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressMethodNotAllowed) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type UpdateHostLogsProgressConflict struct {
 }
 
 func (o *UpdateHostLogsProgressConflict) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressConflict  %+v", 409, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressConflict) GetPayload() *models.Error {
@@ -277,7 +277,7 @@ type UpdateHostLogsProgressInternalServerError struct {
 }
 
 func (o *UpdateHostLogsProgressInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressInternalServerError) GetPayload() *models.Error {
@@ -310,7 +310,7 @@ type UpdateHostLogsProgressServiceUnavailable struct {
 }
 
 func (o *UpdateHostLogsProgressServiceUnavailable) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress][%d] updateHostLogsProgressServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UpdateHostLogsProgressServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/upload_cluster_ingress_cert_responses.go
+++ b/client/installer/upload_cluster_ingress_cert_responses.go
@@ -90,7 +90,7 @@ type UploadClusterIngressCertCreated struct {
 }
 
 func (o *UploadClusterIngressCertCreated) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertCreated ", 201)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertCreated ", 201)
 }
 
 func (o *UploadClusterIngressCertCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -112,7 +112,7 @@ type UploadClusterIngressCertBadRequest struct {
 }
 
 func (o *UploadClusterIngressCertBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *UploadClusterIngressCertBadRequest) GetPayload() *models.Error {
@@ -145,7 +145,7 @@ type UploadClusterIngressCertUnauthorized struct {
 }
 
 func (o *UploadClusterIngressCertUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UploadClusterIngressCertUnauthorized) GetPayload() *models.InfraError {
@@ -178,7 +178,7 @@ type UploadClusterIngressCertForbidden struct {
 }
 
 func (o *UploadClusterIngressCertForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UploadClusterIngressCertForbidden) GetPayload() *models.InfraError {
@@ -211,7 +211,7 @@ type UploadClusterIngressCertNotFound struct {
 }
 
 func (o *UploadClusterIngressCertNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UploadClusterIngressCertNotFound) GetPayload() *models.Error {
@@ -244,7 +244,7 @@ type UploadClusterIngressCertMethodNotAllowed struct {
 }
 
 func (o *UploadClusterIngressCertMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *UploadClusterIngressCertMethodNotAllowed) GetPayload() *models.Error {
@@ -277,7 +277,7 @@ type UploadClusterIngressCertInternalServerError struct {
 }
 
 func (o *UploadClusterIngressCertInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UploadClusterIngressCertInternalServerError) GetPayload() *models.Error {
@@ -310,7 +310,7 @@ type UploadClusterIngressCertServiceUnavailable struct {
 }
 
 func (o *UploadClusterIngressCertServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/uploads/ingress-cert][%d] uploadClusterIngressCertServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UploadClusterIngressCertServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/upload_host_logs_responses.go
+++ b/client/installer/upload_host_logs_responses.go
@@ -78,7 +78,7 @@ type UploadHostLogsNoContent struct {
 }
 
 func (o *UploadHostLogsNoContent) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsNoContent ", 204)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsNoContent ", 204)
 }
 
 func (o *UploadHostLogsNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -100,7 +100,7 @@ type UploadHostLogsUnauthorized struct {
 }
 
 func (o *UploadHostLogsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UploadHostLogsUnauthorized) GetPayload() *models.InfraError {
@@ -133,7 +133,7 @@ type UploadHostLogsForbidden struct {
 }
 
 func (o *UploadHostLogsForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UploadHostLogsForbidden) GetPayload() *models.InfraError {
@@ -166,7 +166,7 @@ type UploadHostLogsNotFound struct {
 }
 
 func (o *UploadHostLogsNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UploadHostLogsNotFound) GetPayload() *models.Error {
@@ -199,7 +199,7 @@ type UploadHostLogsInternalServerError struct {
 }
 
 func (o *UploadHostLogsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UploadHostLogsInternalServerError) GetPayload() *models.Error {
@@ -232,7 +232,7 @@ type UploadHostLogsServiceUnavailable struct {
 }
 
 func (o *UploadHostLogsServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs][%d] uploadHostLogsServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UploadHostLogsServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/upload_logs_responses.go
+++ b/client/installer/upload_logs_responses.go
@@ -78,7 +78,7 @@ type UploadLogsNoContent struct {
 }
 
 func (o *UploadLogsNoContent) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsNoContent ", 204)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsNoContent ", 204)
 }
 
 func (o *UploadLogsNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -100,7 +100,7 @@ type UploadLogsUnauthorized struct {
 }
 
 func (o *UploadLogsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *UploadLogsUnauthorized) GetPayload() *models.InfraError {
@@ -133,7 +133,7 @@ type UploadLogsForbidden struct {
 }
 
 func (o *UploadLogsForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *UploadLogsForbidden) GetPayload() *models.InfraError {
@@ -166,7 +166,7 @@ type UploadLogsNotFound struct {
 }
 
 func (o *UploadLogsNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *UploadLogsNotFound) GetPayload() *models.Error {
@@ -199,7 +199,7 @@ type UploadLogsInternalServerError struct {
 }
 
 func (o *UploadLogsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *UploadLogsInternalServerError) GetPayload() *models.Error {
@@ -232,7 +232,7 @@ type UploadLogsServiceUnavailable struct {
 }
 
 func (o *UploadLogsServiceUnavailable) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/logs][%d] uploadLogsServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/logs][%d] uploadLogsServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *UploadLogsServiceUnavailable) GetPayload() *models.Error {

--- a/client/installer/v2_register_infra_env_responses.go
+++ b/client/installer/v2_register_infra_env_responses.go
@@ -97,7 +97,7 @@ type V2RegisterInfraEnvCreated struct {
 }
 
 func (o *V2RegisterInfraEnvCreated) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvCreated  %+v", 201, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvCreated) GetPayload() *models.InfraEnv {
@@ -130,7 +130,7 @@ type V2RegisterInfraEnvBadRequest struct {
 }
 
 func (o *V2RegisterInfraEnvBadRequest) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvBadRequest) GetPayload() *models.Error {
@@ -163,7 +163,7 @@ type V2RegisterInfraEnvUnauthorized struct {
 }
 
 func (o *V2RegisterInfraEnvUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvUnauthorized) GetPayload() *models.InfraError {
@@ -196,7 +196,7 @@ type V2RegisterInfraEnvForbidden struct {
 }
 
 func (o *V2RegisterInfraEnvForbidden) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvForbidden  %+v", 403, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvForbidden) GetPayload() *models.InfraError {
@@ -229,7 +229,7 @@ type V2RegisterInfraEnvNotFound struct {
 }
 
 func (o *V2RegisterInfraEnvNotFound) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvNotFound  %+v", 404, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvNotFound) GetPayload() *models.Error {
@@ -262,7 +262,7 @@ type V2RegisterInfraEnvMethodNotAllowed struct {
 }
 
 func (o *V2RegisterInfraEnvMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvMethodNotAllowed) GetPayload() *models.Error {
@@ -295,7 +295,7 @@ type V2RegisterInfraEnvConflict struct {
 }
 
 func (o *V2RegisterInfraEnvConflict) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvConflict  %+v", 409, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvConflict) GetPayload() *models.Error {
@@ -328,7 +328,7 @@ type V2RegisterInfraEnvInternalServerError struct {
 }
 
 func (o *V2RegisterInfraEnvInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvInternalServerError) GetPayload() *models.Error {
@@ -361,7 +361,7 @@ type V2RegisterInfraEnvNotImplemented struct {
 }
 
 func (o *V2RegisterInfraEnvNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /infra-envs][%d] v2RegisterInfraEnvNotImplemented  %+v", 501, o.Payload)
+	return fmt.Sprintf("[POST /v2/infra-envs][%d] v2RegisterInfraEnvNotImplemented  %+v", 501, o.Payload)
 }
 
 func (o *V2RegisterInfraEnvNotImplemented) GetPayload() *models.Error {

--- a/client/managed_domains/list_managed_domains_responses.go
+++ b/client/managed_domains/list_managed_domains_responses.go
@@ -55,7 +55,7 @@ type ListManagedDomainsOK struct {
 }
 
 func (o *ListManagedDomainsOK) Error() string {
-	return fmt.Sprintf("[GET /domains][%d] listManagedDomainsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/domains][%d] listManagedDomainsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListManagedDomainsOK) GetPayload() models.ListManagedDomains {
@@ -86,7 +86,7 @@ type ListManagedDomainsInternalServerError struct {
 }
 
 func (o *ListManagedDomainsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /domains][%d] listManagedDomainsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/domains][%d] listManagedDomainsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListManagedDomainsInternalServerError) GetPayload() *models.Error {

--- a/client/managed_domains/managed_domains_client.go
+++ b/client/managed_domains/managed_domains_client.go
@@ -48,7 +48,7 @@ func (a *Client) ListManagedDomains(ctx context.Context, params *ListManagedDoma
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListManagedDomains",
 		Method:             "GET",
-		PathPattern:        "/domains",
+		PathPattern:        "/v1/domains",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/manifests/create_cluster_manifest_responses.go
+++ b/client/manifests/create_cluster_manifest_responses.go
@@ -91,7 +91,7 @@ type CreateClusterManifestCreated struct {
 }
 
 func (o *CreateClusterManifestCreated) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestCreated  %+v", 201, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestCreated  %+v", 201, o.Payload)
 }
 
 func (o *CreateClusterManifestCreated) GetPayload() *models.Manifest {
@@ -124,7 +124,7 @@ type CreateClusterManifestBadRequest struct {
 }
 
 func (o *CreateClusterManifestBadRequest) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *CreateClusterManifestBadRequest) GetPayload() *models.Error {
@@ -157,7 +157,7 @@ type CreateClusterManifestUnauthorized struct {
 }
 
 func (o *CreateClusterManifestUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *CreateClusterManifestUnauthorized) GetPayload() *models.InfraError {
@@ -190,7 +190,7 @@ type CreateClusterManifestForbidden struct {
 }
 
 func (o *CreateClusterManifestForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestForbidden  %+v", 403, o.Payload)
 }
 
 func (o *CreateClusterManifestForbidden) GetPayload() *models.InfraError {
@@ -223,7 +223,7 @@ type CreateClusterManifestNotFound struct {
 }
 
 func (o *CreateClusterManifestNotFound) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestNotFound  %+v", 404, o.Payload)
 }
 
 func (o *CreateClusterManifestNotFound) GetPayload() *models.Error {
@@ -256,7 +256,7 @@ type CreateClusterManifestMethodNotAllowed struct {
 }
 
 func (o *CreateClusterManifestMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *CreateClusterManifestMethodNotAllowed) GetPayload() *models.Error {
@@ -289,7 +289,7 @@ type CreateClusterManifestConflict struct {
 }
 
 func (o *CreateClusterManifestConflict) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestConflict  %+v", 409, o.Payload)
 }
 
 func (o *CreateClusterManifestConflict) GetPayload() *models.Error {
@@ -322,7 +322,7 @@ type CreateClusterManifestInternalServerError struct {
 }
 
 func (o *CreateClusterManifestInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /clusters/{cluster_id}/manifests][%d] createClusterManifestInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[POST /v1/clusters/{cluster_id}/manifests][%d] createClusterManifestInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *CreateClusterManifestInternalServerError) GetPayload() *models.Error {

--- a/client/manifests/delete_cluster_manifest_responses.go
+++ b/client/manifests/delete_cluster_manifest_responses.go
@@ -84,7 +84,7 @@ type DeleteClusterManifestOK struct {
 }
 
 func (o *DeleteClusterManifestOK) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestOK ", 200)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestOK ", 200)
 }
 
 func (o *DeleteClusterManifestOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -106,7 +106,7 @@ type DeleteClusterManifestUnauthorized struct {
 }
 
 func (o *DeleteClusterManifestUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DeleteClusterManifestUnauthorized) GetPayload() *models.InfraError {
@@ -139,7 +139,7 @@ type DeleteClusterManifestForbidden struct {
 }
 
 func (o *DeleteClusterManifestForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DeleteClusterManifestForbidden) GetPayload() *models.InfraError {
@@ -172,7 +172,7 @@ type DeleteClusterManifestNotFound struct {
 }
 
 func (o *DeleteClusterManifestNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DeleteClusterManifestNotFound) GetPayload() *models.Error {
@@ -205,7 +205,7 @@ type DeleteClusterManifestMethodNotAllowed struct {
 }
 
 func (o *DeleteClusterManifestMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DeleteClusterManifestMethodNotAllowed) GetPayload() *models.Error {
@@ -238,7 +238,7 @@ type DeleteClusterManifestConflict struct {
 }
 
 func (o *DeleteClusterManifestConflict) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestConflict  %+v", 409, o.Payload)
 }
 
 func (o *DeleteClusterManifestConflict) GetPayload() *models.Error {
@@ -271,7 +271,7 @@ type DeleteClusterManifestInternalServerError struct {
 }
 
 func (o *DeleteClusterManifestInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /clusters/{cluster_id}/manifests][%d] deleteClusterManifestInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[DELETE /v1/clusters/{cluster_id}/manifests][%d] deleteClusterManifestInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DeleteClusterManifestInternalServerError) GetPayload() *models.Error {

--- a/client/manifests/download_cluster_manifest_responses.go
+++ b/client/manifests/download_cluster_manifest_responses.go
@@ -88,7 +88,7 @@ type DownloadClusterManifestOK struct {
 }
 
 func (o *DownloadClusterManifestOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestOK  %+v", 200, o.Payload)
 }
 
 func (o *DownloadClusterManifestOK) GetPayload() io.Writer {
@@ -119,7 +119,7 @@ type DownloadClusterManifestUnauthorized struct {
 }
 
 func (o *DownloadClusterManifestUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *DownloadClusterManifestUnauthorized) GetPayload() *models.InfraError {
@@ -152,7 +152,7 @@ type DownloadClusterManifestForbidden struct {
 }
 
 func (o *DownloadClusterManifestForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestForbidden  %+v", 403, o.Payload)
 }
 
 func (o *DownloadClusterManifestForbidden) GetPayload() *models.InfraError {
@@ -185,7 +185,7 @@ type DownloadClusterManifestNotFound struct {
 }
 
 func (o *DownloadClusterManifestNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestNotFound  %+v", 404, o.Payload)
 }
 
 func (o *DownloadClusterManifestNotFound) GetPayload() *models.Error {
@@ -218,7 +218,7 @@ type DownloadClusterManifestMethodNotAllowed struct {
 }
 
 func (o *DownloadClusterManifestMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *DownloadClusterManifestMethodNotAllowed) GetPayload() *models.Error {
@@ -251,7 +251,7 @@ type DownloadClusterManifestConflict struct {
 }
 
 func (o *DownloadClusterManifestConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestConflict  %+v", 409, o.Payload)
 }
 
 func (o *DownloadClusterManifestConflict) GetPayload() *models.Error {
@@ -284,7 +284,7 @@ type DownloadClusterManifestInternalServerError struct {
 }
 
 func (o *DownloadClusterManifestInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests/files][%d] downloadClusterManifestInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *DownloadClusterManifestInternalServerError) GetPayload() *models.Error {

--- a/client/manifests/list_cluster_manifests_responses.go
+++ b/client/manifests/list_cluster_manifests_responses.go
@@ -85,7 +85,7 @@ type ListClusterManifestsOK struct {
 }
 
 func (o *ListClusterManifestsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListClusterManifestsOK) GetPayload() models.ListManifests {
@@ -116,7 +116,7 @@ type ListClusterManifestsUnauthorized struct {
 }
 
 func (o *ListClusterManifestsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListClusterManifestsUnauthorized) GetPayload() *models.InfraError {
@@ -149,7 +149,7 @@ type ListClusterManifestsForbidden struct {
 }
 
 func (o *ListClusterManifestsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListClusterManifestsForbidden) GetPayload() *models.InfraError {
@@ -182,7 +182,7 @@ type ListClusterManifestsNotFound struct {
 }
 
 func (o *ListClusterManifestsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ListClusterManifestsNotFound) GetPayload() *models.Error {
@@ -215,7 +215,7 @@ type ListClusterManifestsMethodNotAllowed struct {
 }
 
 func (o *ListClusterManifestsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ListClusterManifestsMethodNotAllowed) GetPayload() *models.Error {
@@ -248,7 +248,7 @@ type ListClusterManifestsConflict struct {
 }
 
 func (o *ListClusterManifestsConflict) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsConflict  %+v", 409, o.Payload)
 }
 
 func (o *ListClusterManifestsConflict) GetPayload() *models.Error {
@@ -281,7 +281,7 @@ type ListClusterManifestsInternalServerError struct {
 }
 
 func (o *ListClusterManifestsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/manifests][%d] listClusterManifestsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/manifests][%d] listClusterManifestsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListClusterManifestsInternalServerError) GetPayload() *models.Error {

--- a/client/manifests/manifests_client.go
+++ b/client/manifests/manifests_client.go
@@ -58,7 +58,7 @@ func (a *Client) CreateClusterManifest(ctx context.Context, params *CreateCluste
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "CreateClusterManifest",
 		Method:             "POST",
-		PathPattern:        "/clusters/{cluster_id}/manifests",
+		PathPattern:        "/v1/clusters/{cluster_id}/manifests",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -83,7 +83,7 @@ func (a *Client) DeleteClusterManifest(ctx context.Context, params *DeleteCluste
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DeleteClusterManifest",
 		Method:             "DELETE",
-		PathPattern:        "/clusters/{cluster_id}/manifests",
+		PathPattern:        "/v1/clusters/{cluster_id}/manifests",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -108,7 +108,7 @@ func (a *Client) DownloadClusterManifest(ctx context.Context, params *DownloadCl
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "DownloadClusterManifest",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/manifests/files",
+		PathPattern:        "/v1/clusters/{cluster_id}/manifests/files",
 		ProducesMediaTypes: []string{"application/octet-stream"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -133,7 +133,7 @@ func (a *Client) ListClusterManifests(ctx context.Context, params *ListClusterMa
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListClusterManifests",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/manifests",
+		PathPattern:        "/v1/clusters/{cluster_id}/manifests",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/operators/list_of_cluster_operators_responses.go
+++ b/client/operators/list_of_cluster_operators_responses.go
@@ -79,7 +79,7 @@ type ListOfClusterOperatorsOK struct {
 }
 
 func (o *ListOfClusterOperatorsOK) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsOK) GetPayload() models.MonitoredOperatorsList {
@@ -110,7 +110,7 @@ type ListOfClusterOperatorsUnauthorized struct {
 }
 
 func (o *ListOfClusterOperatorsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsUnauthorized) GetPayload() *models.InfraError {
@@ -143,7 +143,7 @@ type ListOfClusterOperatorsForbidden struct {
 }
 
 func (o *ListOfClusterOperatorsForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsForbidden) GetPayload() *models.InfraError {
@@ -176,7 +176,7 @@ type ListOfClusterOperatorsNotFound struct {
 }
 
 func (o *ListOfClusterOperatorsNotFound) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsNotFound) GetPayload() *models.Error {
@@ -209,7 +209,7 @@ type ListOfClusterOperatorsMethodNotAllowed struct {
 }
 
 func (o *ListOfClusterOperatorsMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsMethodNotAllowed) GetPayload() *models.Error {
@@ -242,7 +242,7 @@ type ListOfClusterOperatorsInternalServerError struct {
 }
 
 func (o *ListOfClusterOperatorsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/monitored_operators][%d] listOfClusterOperatorsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListOfClusterOperatorsInternalServerError) GetPayload() *models.Error {

--- a/client/operators/list_operator_properties_responses.go
+++ b/client/operators/list_operator_properties_responses.go
@@ -73,7 +73,7 @@ type ListOperatorPropertiesOK struct {
 }
 
 func (o *ListOperatorPropertiesOK) Error() string {
-	return fmt.Sprintf("[GET /supported-operators/{operator_name}][%d] listOperatorPropertiesOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators/{operator_name}][%d] listOperatorPropertiesOK  %+v", 200, o.Payload)
 }
 
 func (o *ListOperatorPropertiesOK) GetPayload() models.OperatorProperties {
@@ -104,7 +104,7 @@ type ListOperatorPropertiesUnauthorized struct {
 }
 
 func (o *ListOperatorPropertiesUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /supported-operators/{operator_name}][%d] listOperatorPropertiesUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators/{operator_name}][%d] listOperatorPropertiesUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListOperatorPropertiesUnauthorized) GetPayload() *models.InfraError {
@@ -137,7 +137,7 @@ type ListOperatorPropertiesForbidden struct {
 }
 
 func (o *ListOperatorPropertiesForbidden) Error() string {
-	return fmt.Sprintf("[GET /supported-operators/{operator_name}][%d] listOperatorPropertiesForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators/{operator_name}][%d] listOperatorPropertiesForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListOperatorPropertiesForbidden) GetPayload() *models.InfraError {
@@ -170,7 +170,7 @@ type ListOperatorPropertiesNotFound struct {
 }
 
 func (o *ListOperatorPropertiesNotFound) Error() string {
-	return fmt.Sprintf("[GET /supported-operators/{operator_name}][%d] listOperatorPropertiesNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators/{operator_name}][%d] listOperatorPropertiesNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ListOperatorPropertiesNotFound) GetPayload() *models.Error {
@@ -203,7 +203,7 @@ type ListOperatorPropertiesInternalServerError struct {
 }
 
 func (o *ListOperatorPropertiesInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /supported-operators/{operator_name}][%d] listOperatorPropertiesInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators/{operator_name}][%d] listOperatorPropertiesInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListOperatorPropertiesInternalServerError) GetPayload() *models.Error {

--- a/client/operators/list_supported_operators_responses.go
+++ b/client/operators/list_supported_operators_responses.go
@@ -67,7 +67,7 @@ type ListSupportedOperatorsOK struct {
 }
 
 func (o *ListSupportedOperatorsOK) Error() string {
-	return fmt.Sprintf("[GET /supported-operators][%d] listSupportedOperatorsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators][%d] listSupportedOperatorsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListSupportedOperatorsOK) GetPayload() []string {
@@ -98,7 +98,7 @@ type ListSupportedOperatorsUnauthorized struct {
 }
 
 func (o *ListSupportedOperatorsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /supported-operators][%d] listSupportedOperatorsUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators][%d] listSupportedOperatorsUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ListSupportedOperatorsUnauthorized) GetPayload() *models.InfraError {
@@ -131,7 +131,7 @@ type ListSupportedOperatorsForbidden struct {
 }
 
 func (o *ListSupportedOperatorsForbidden) Error() string {
-	return fmt.Sprintf("[GET /supported-operators][%d] listSupportedOperatorsForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators][%d] listSupportedOperatorsForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ListSupportedOperatorsForbidden) GetPayload() *models.InfraError {
@@ -164,7 +164,7 @@ type ListSupportedOperatorsInternalServerError struct {
 }
 
 func (o *ListSupportedOperatorsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /supported-operators][%d] listSupportedOperatorsInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[GET /v1/supported-operators][%d] listSupportedOperatorsInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ListSupportedOperatorsInternalServerError) GetPayload() *models.Error {

--- a/client/operators/operators_client.go
+++ b/client/operators/operators_client.go
@@ -57,7 +57,7 @@ func (a *Client) ListOfClusterOperators(ctx context.Context, params *ListOfClust
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListOfClusterOperators",
 		Method:             "GET",
-		PathPattern:        "/clusters/{cluster_id}/monitored_operators",
+		PathPattern:        "/v1/clusters/{cluster_id}/monitored_operators",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -82,7 +82,7 @@ func (a *Client) ListOperatorProperties(ctx context.Context, params *ListOperato
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListOperatorProperties",
 		Method:             "GET",
-		PathPattern:        "/supported-operators/{operator_name}",
+		PathPattern:        "/v1/supported-operators/{operator_name}",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -107,7 +107,7 @@ func (a *Client) ListSupportedOperators(ctx context.Context, params *ListSupport
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListSupportedOperators",
 		Method:             "GET",
-		PathPattern:        "/supported-operators",
+		PathPattern:        "/v1/supported-operators",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -132,7 +132,7 @@ func (a *Client) ReportMonitoredOperatorStatus(ctx context.Context, params *Repo
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ReportMonitoredOperatorStatus",
 		Method:             "PUT",
-		PathPattern:        "/clusters/{cluster_id}/monitored_operators",
+		PathPattern:        "/v1/clusters/{cluster_id}/monitored_operators",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/client/operators/report_monitored_operator_status_responses.go
+++ b/client/operators/report_monitored_operator_status_responses.go
@@ -96,7 +96,7 @@ type ReportMonitoredOperatorStatusOK struct {
 }
 
 func (o *ReportMonitoredOperatorStatusOK) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusOK ", 200)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusOK ", 200)
 }
 
 func (o *ReportMonitoredOperatorStatusOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
@@ -118,7 +118,7 @@ type ReportMonitoredOperatorStatusBadRequest struct {
 }
 
 func (o *ReportMonitoredOperatorStatusBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusBadRequest  %+v", 400, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusBadRequest  %+v", 400, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusBadRequest) GetPayload() *models.Error {
@@ -151,7 +151,7 @@ type ReportMonitoredOperatorStatusUnauthorized struct {
 }
 
 func (o *ReportMonitoredOperatorStatusUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusUnauthorized  %+v", 401, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusUnauthorized  %+v", 401, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusUnauthorized) GetPayload() *models.InfraError {
@@ -184,7 +184,7 @@ type ReportMonitoredOperatorStatusForbidden struct {
 }
 
 func (o *ReportMonitoredOperatorStatusForbidden) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusForbidden  %+v", 403, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusForbidden  %+v", 403, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusForbidden) GetPayload() *models.InfraError {
@@ -217,7 +217,7 @@ type ReportMonitoredOperatorStatusNotFound struct {
 }
 
 func (o *ReportMonitoredOperatorStatusNotFound) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusNotFound  %+v", 404, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusNotFound  %+v", 404, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusNotFound) GetPayload() *models.Error {
@@ -250,7 +250,7 @@ type ReportMonitoredOperatorStatusMethodNotAllowed struct {
 }
 
 func (o *ReportMonitoredOperatorStatusMethodNotAllowed) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusMethodNotAllowed  %+v", 405, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusMethodNotAllowed  %+v", 405, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusMethodNotAllowed) GetPayload() *models.Error {
@@ -283,7 +283,7 @@ type ReportMonitoredOperatorStatusConflict struct {
 }
 
 func (o *ReportMonitoredOperatorStatusConflict) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusConflict  %+v", 409, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusConflict  %+v", 409, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusConflict) GetPayload() *models.Error {
@@ -316,7 +316,7 @@ type ReportMonitoredOperatorStatusInternalServerError struct {
 }
 
 func (o *ReportMonitoredOperatorStatusInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusInternalServerError  %+v", 500, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusInternalServerError  %+v", 500, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusInternalServerError) GetPayload() *models.Error {
@@ -349,7 +349,7 @@ type ReportMonitoredOperatorStatusServiceUnavailable struct {
 }
 
 func (o *ReportMonitoredOperatorStatusServiceUnavailable) Error() string {
-	return fmt.Sprintf("[PUT /clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[PUT /v1/clusters/{cluster_id}/monitored_operators][%d] reportMonitoredOperatorStatusServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *ReportMonitoredOperatorStatusServiceUnavailable) GetPayload() *models.Error {

--- a/client/versions/list_component_versions_responses.go
+++ b/client/versions/list_component_versions_responses.go
@@ -49,7 +49,7 @@ type ListComponentVersionsOK struct {
 }
 
 func (o *ListComponentVersionsOK) Error() string {
-	return fmt.Sprintf("[GET /component_versions][%d] listComponentVersionsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/component_versions][%d] listComponentVersionsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListComponentVersionsOK) GetPayload() *models.ListVersions {

--- a/client/versions/list_supported_openshift_versions_responses.go
+++ b/client/versions/list_supported_openshift_versions_responses.go
@@ -55,7 +55,7 @@ type ListSupportedOpenshiftVersionsOK struct {
 }
 
 func (o *ListSupportedOpenshiftVersionsOK) Error() string {
-	return fmt.Sprintf("[GET /openshift_versions][%d] listSupportedOpenshiftVersionsOK  %+v", 200, o.Payload)
+	return fmt.Sprintf("[GET /v1/openshift_versions][%d] listSupportedOpenshiftVersionsOK  %+v", 200, o.Payload)
 }
 
 func (o *ListSupportedOpenshiftVersionsOK) GetPayload() models.OpenshiftVersions {
@@ -86,7 +86,7 @@ type ListSupportedOpenshiftVersionsServiceUnavailable struct {
 }
 
 func (o *ListSupportedOpenshiftVersionsServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /openshift_versions][%d] listSupportedOpenshiftVersionsServiceUnavailable  %+v", 503, o.Payload)
+	return fmt.Sprintf("[GET /v1/openshift_versions][%d] listSupportedOpenshiftVersionsServiceUnavailable  %+v", 503, o.Payload)
 }
 
 func (o *ListSupportedOpenshiftVersionsServiceUnavailable) GetPayload() *models.Error {

--- a/client/versions/versions_client.go
+++ b/client/versions/versions_client.go
@@ -51,7 +51,7 @@ func (a *Client) ListComponentVersions(ctx context.Context, params *ListComponen
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListComponentVersions",
 		Method:             "GET",
-		PathPattern:        "/component_versions",
+		PathPattern:        "/v1/component_versions",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},
@@ -76,7 +76,7 @@ func (a *Client) ListSupportedOpenshiftVersions(ctx context.Context, params *Lis
 	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "ListSupportedOpenshiftVersions",
 		Method:             "GET",
-		PathPattern:        "/openshift_versions",
+		PathPattern:        "/v1/openshift_versions",
 		ProducesMediaTypes: []string{"application/json"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http", "https"},

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -305,7 +305,7 @@ func (r *AgentReconciler) populateEventsURL(log logrus.FieldLogger, agent *aiv1b
 }
 
 func (r *AgentReconciler) eventsURL(log logrus.FieldLogger, clusterId, agentId string) (string, error) {
-	eventsURL := fmt.Sprintf("%s%s/clusters/%s/events?host_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId, agentId)
+	eventsURL := fmt.Sprintf("%s%s/v1/clusters/%s/events?host_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId, agentId)
 	if r.AuthType != auth.TypeLocal {
 		return eventsURL, nil
 	}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1199,7 +1199,7 @@ func (r *ClusterDeploymentsReconciler) populateLogsURL(log logrus.FieldLogger, c
 }
 
 func (r *ClusterDeploymentsReconciler) eventsURL(log logrus.FieldLogger, clusterId string) (string, error) {
-	eventsURL := fmt.Sprintf("%s%s/clusters/%s/events", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId)
+	eventsURL := fmt.Sprintf("%s%s/v1/clusters/%s/events", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId)
 	if r.AuthType != auth.TypeLocal {
 		return eventsURL, nil
 	}
@@ -1558,7 +1558,7 @@ func (r *ClusterDeploymentsReconciler) setControllerLogsDownloadURL(
 }
 
 func (r *ClusterDeploymentsReconciler) generateControllerLogsDownloadURL(cluster *common.Cluster) (string, error) {
-	downloadURL := fmt.Sprintf("%s%s/clusters/%s/logs",
+	downloadURL := fmt.Sprintf("%s%s/v1/clusters/%s/logs",
 		r.ServiceBaseURL, restclient.DefaultBasePath, cluster.ID.String())
 
 	if r.AuthType != auth.TypeLocal {

--- a/restapi/doc.go
+++ b/restapi/doc.go
@@ -7,7 +7,7 @@
 //    http
 //    https
 //  Host: api.openshift.com
-//  BasePath: /api/assisted-install/v1
+//  BasePath: /api/assisted-install
 //  Version: 1.0.0
 //  License: Apache 2.0 http://www.apache.org/licenses/LICENSE-2.0.html
 //

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -39,9 +39,9 @@ func init() {
     "version": "1.0.0"
   },
   "host": "api.openshift.com",
-  "basePath": "/api/assisted-install/v1",
+  "basePath": "/api/assisted-install",
   "paths": {
-    "/add_hosts_clusters": {
+    "/v1/add_hosts_clusters": {
       "post": {
         "description": "Creates a new OpenShift cluster definition for adding nodes to and existing OCP cluster.",
         "tags": [
@@ -93,7 +93,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso": {
+    "/v1/assisted-service-iso": {
       "post": {
         "description": "Creates ISO for the user and uploads to S3.",
         "tags": [
@@ -142,7 +142,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso/data": {
+    "/v1/assisted-service-iso/data": {
       "get": {
         "security": [
           {
@@ -196,7 +196,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso/presigned": {
+    "/v1/assisted-service-iso/presigned": {
       "get": {
         "security": [
           {
@@ -246,7 +246,7 @@ func init() {
         }
       }
     },
-    "/clusters": {
+    "/v1/clusters": {
       "get": {
         "security": [
           {
@@ -391,7 +391,7 @@ func init() {
         }
       }
     },
-    "/clusters/default-config": {
+    "/v1/clusters/default-config": {
       "get": {
         "security": [
           {
@@ -435,7 +435,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}": {
+    "/v1/clusters/{cluster_id}": {
       "get": {
         "security": [
           {
@@ -657,7 +657,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/cancel": {
+    "/v1/clusters/{cluster_id}/actions/cancel": {
       "post": {
         "description": "Cancels an ongoing installation.",
         "tags": [
@@ -720,7 +720,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/complete_installation": {
+    "/v1/clusters/{cluster_id}/actions/complete_installation": {
       "post": {
         "security": [
           {
@@ -809,7 +809,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/install": {
+    "/v1/clusters/{cluster_id}/actions/install": {
       "post": {
         "description": "Installs the OpenShift cluster.",
         "tags": [
@@ -878,7 +878,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/install_hosts": {
+    "/v1/clusters/{cluster_id}/actions/install_hosts": {
       "post": {
         "description": "Installs the OpenShift cluster.",
         "tags": [
@@ -947,7 +947,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/reset": {
+    "/v1/clusters/{cluster_id}/actions/reset": {
       "post": {
         "description": "Resets a failed installation.",
         "tags": [
@@ -1010,7 +1010,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/credentials": {
+    "/v1/clusters/{cluster_id}/credentials": {
       "get": {
         "security": [
           {
@@ -1082,7 +1082,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/discovery-ignition": {
+    "/v1/clusters/{cluster_id}/discovery-ignition": {
       "get": {
         "security": [
           {
@@ -1215,7 +1215,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/files": {
+    "/v1/clusters/{cluster_id}/downloads/files": {
       "get": {
         "security": [
           {
@@ -1327,7 +1327,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/files-presigned": {
+    "/v1/clusters/{cluster_id}/downloads/files-presigned": {
       "get": {
         "security": [
           {
@@ -1448,7 +1448,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/image": {
+    "/v1/clusters/{cluster_id}/downloads/image": {
       "get": {
         "security": [
           {
@@ -1685,7 +1685,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/kubeconfig": {
+    "/v1/clusters/{cluster_id}/downloads/kubeconfig": {
       "get": {
         "security": [
           {
@@ -1764,7 +1764,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/events": {
+    "/v1/clusters/{cluster_id}/events": {
       "get": {
         "security": [
           {
@@ -1849,7 +1849,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/free_addresses": {
+    "/v1/clusters/{cluster_id}/free_addresses": {
       "get": {
         "security": [
           {
@@ -1938,7 +1938,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/host-requirements": {
+    "/v1/clusters/{cluster_id}/host-requirements": {
       "get": {
         "security": [
           {
@@ -2004,7 +2004,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts": {
+    "/v1/clusters/{cluster_id}/hosts": {
       "get": {
         "security": [
           {
@@ -2172,7 +2172,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}": {
       "get": {
         "security": [
           {
@@ -2312,7 +2312,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/enable": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable": {
       "post": {
         "description": "Enables a host for inclusion in the cluster.",
         "tags": [
@@ -2452,7 +2452,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/install": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/install": {
       "post": {
         "description": "install specific host for day2 cluster.",
         "tags": [
@@ -2517,7 +2517,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/reset": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset": {
       "post": {
         "description": "reset a failed host for day2 cluster.",
         "tags": [
@@ -2582,7 +2582,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}": {
       "patch": {
         "description": "Reset failed host validation.  It may be performed on any host validation with persistent validation result.",
         "tags": [
@@ -2661,7 +2661,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition": {
       "get": {
         "security": [
           {
@@ -2753,7 +2753,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/ignition": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition": {
       "get": {
         "description": "Get the customized ignition file for this host",
         "tags": [
@@ -2899,7 +2899,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/installer-args": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/installer-args": {
       "patch": {
         "description": "Updates a host's installer arguments.",
         "tags": [
@@ -2985,7 +2985,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/instructions": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions": {
       "get": {
         "security": [
           {
@@ -3158,7 +3158,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/logs": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/logs": {
       "get": {
         "security": [
           {
@@ -3327,7 +3327,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/logs_progress": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress": {
       "put": {
         "security": [
           {
@@ -3415,7 +3415,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/progress": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/progress": {
       "put": {
         "security": [
           {
@@ -3503,7 +3503,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/install-config": {
+    "/v1/clusters/{cluster_id}/install-config": {
       "get": {
         "security": [
           {
@@ -3636,7 +3636,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/logs": {
+    "/v1/clusters/{cluster_id}/logs": {
       "get": {
         "security": [
           {
@@ -3818,7 +3818,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/logs_progress": {
+    "/v1/clusters/{cluster_id}/logs_progress": {
       "put": {
         "security": [
           {
@@ -3898,7 +3898,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/manifests": {
+    "/v1/clusters/{cluster_id}/manifests": {
       "get": {
         "security": [
           {
@@ -4123,7 +4123,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/manifests/files": {
+    "/v1/clusters/{cluster_id}/manifests/files": {
       "get": {
         "security": [
           {
@@ -4212,7 +4212,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/monitored_operators": {
+    "/v1/clusters/{cluster_id}/monitored_operators": {
       "get": {
         "security": [
           {
@@ -4366,7 +4366,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/preflight-requirements": {
+    "/v1/clusters/{cluster_id}/preflight-requirements": {
       "get": {
         "security": [
           {
@@ -4432,7 +4432,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/uploads/ingress-cert": {
+    "/v1/clusters/{cluster_id}/uploads/ingress-cert": {
       "post": {
         "security": [
           {
@@ -4518,7 +4518,7 @@ func init() {
         }
       }
     },
-    "/component_versions": {
+    "/v1/component_versions": {
       "get": {
         "security": [
           {
@@ -4544,7 +4544,7 @@ func init() {
         }
       }
     },
-    "/domains": {
+    "/v1/domains": {
       "get": {
         "security": [
           {
@@ -4576,7 +4576,136 @@ func init() {
         }
       }
     },
-    "/infra-envs": {
+    "/v1/openshift_versions": {
+      "get": {
+        "security": [
+          {
+            "userAuth": [
+              "admin",
+              "read-only-admin",
+              "user"
+            ]
+          }
+        ],
+        "description": "Retrieves the list of OpenShift supported versions.",
+        "tags": [
+          "versions"
+        ],
+        "operationId": "ListSupportedOpenshiftVersions",
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/openshift-versions"
+            }
+          },
+          "503": {
+            "description": "Unavailable.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/supported-operators": {
+      "get": {
+        "description": "Retrieves the list of supported operators.",
+        "tags": [
+          "operators"
+        ],
+        "operationId": "ListSupportedOperators",
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/supported-operators/{operator_name}": {
+      "get": {
+        "security": [
+          {
+            "userAuth": [
+              "admin",
+              "read-only-admin",
+              "user"
+            ]
+          }
+        ],
+        "description": "Lists properties for an operator.",
+        "tags": [
+          "operators"
+        ],
+        "operationId": "ListOperatorProperties",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The operator name.",
+            "name": "operator_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/operator-properties"
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "404": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v2/infra-envs": {
       "post": {
         "description": "Creates a new OpenShift Discovery ISO.",
         "tags": [
@@ -4645,135 +4774,6 @@ func init() {
           },
           "501": {
             "description": "Not implemented.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/openshift_versions": {
-      "get": {
-        "security": [
-          {
-            "userAuth": [
-              "admin",
-              "read-only-admin",
-              "user"
-            ]
-          }
-        ],
-        "description": "Retrieves the list of OpenShift supported versions.",
-        "tags": [
-          "versions"
-        ],
-        "operationId": "ListSupportedOpenshiftVersions",
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "$ref": "#/definitions/openshift-versions"
-            }
-          },
-          "503": {
-            "description": "Unavailable.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/supported-operators": {
-      "get": {
-        "description": "Retrieves the list of supported operators.",
-        "tags": [
-          "operators"
-        ],
-        "operationId": "ListSupportedOperators",
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "500": {
-            "description": "Error.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/supported-operators/{operator_name}": {
-      "get": {
-        "security": [
-          {
-            "userAuth": [
-              "admin",
-              "read-only-admin",
-              "user"
-            ]
-          }
-        ],
-        "description": "Lists properties for an operator.",
-        "tags": [
-          "operators"
-        ],
-        "operationId": "ListOperatorProperties",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "The operator name.",
-            "name": "operator_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "$ref": "#/definitions/operator-properties"
-            }
-          },
-          "401": {
-            "description": "Unauthorized.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "404": {
-            "description": "Error.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Error.",
             "schema": {
               "$ref": "#/definitions/error"
             }
@@ -7895,9 +7895,9 @@ func init() {
     "version": "1.0.0"
   },
   "host": "api.openshift.com",
-  "basePath": "/api/assisted-install/v1",
+  "basePath": "/api/assisted-install",
   "paths": {
-    "/add_hosts_clusters": {
+    "/v1/add_hosts_clusters": {
       "post": {
         "description": "Creates a new OpenShift cluster definition for adding nodes to and existing OCP cluster.",
         "tags": [
@@ -7949,7 +7949,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso": {
+    "/v1/assisted-service-iso": {
       "post": {
         "description": "Creates ISO for the user and uploads to S3.",
         "tags": [
@@ -7998,7 +7998,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso/data": {
+    "/v1/assisted-service-iso/data": {
       "get": {
         "security": [
           {
@@ -8052,7 +8052,7 @@ func init() {
         }
       }
     },
-    "/assisted-service-iso/presigned": {
+    "/v1/assisted-service-iso/presigned": {
       "get": {
         "security": [
           {
@@ -8102,7 +8102,7 @@ func init() {
         }
       }
     },
-    "/clusters": {
+    "/v1/clusters": {
       "get": {
         "security": [
           {
@@ -8247,7 +8247,7 @@ func init() {
         }
       }
     },
-    "/clusters/default-config": {
+    "/v1/clusters/default-config": {
       "get": {
         "security": [
           {
@@ -8291,7 +8291,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}": {
+    "/v1/clusters/{cluster_id}": {
       "get": {
         "security": [
           {
@@ -8513,7 +8513,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/cancel": {
+    "/v1/clusters/{cluster_id}/actions/cancel": {
       "post": {
         "description": "Cancels an ongoing installation.",
         "tags": [
@@ -8576,7 +8576,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/complete_installation": {
+    "/v1/clusters/{cluster_id}/actions/complete_installation": {
       "post": {
         "security": [
           {
@@ -8665,7 +8665,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/install": {
+    "/v1/clusters/{cluster_id}/actions/install": {
       "post": {
         "description": "Installs the OpenShift cluster.",
         "tags": [
@@ -8734,7 +8734,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/install_hosts": {
+    "/v1/clusters/{cluster_id}/actions/install_hosts": {
       "post": {
         "description": "Installs the OpenShift cluster.",
         "tags": [
@@ -8803,7 +8803,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/actions/reset": {
+    "/v1/clusters/{cluster_id}/actions/reset": {
       "post": {
         "description": "Resets a failed installation.",
         "tags": [
@@ -8866,7 +8866,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/credentials": {
+    "/v1/clusters/{cluster_id}/credentials": {
       "get": {
         "security": [
           {
@@ -8938,7 +8938,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/discovery-ignition": {
+    "/v1/clusters/{cluster_id}/discovery-ignition": {
       "get": {
         "security": [
           {
@@ -9071,7 +9071,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/files": {
+    "/v1/clusters/{cluster_id}/downloads/files": {
       "get": {
         "security": [
           {
@@ -9183,7 +9183,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/files-presigned": {
+    "/v1/clusters/{cluster_id}/downloads/files-presigned": {
       "get": {
         "security": [
           {
@@ -9304,7 +9304,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/image": {
+    "/v1/clusters/{cluster_id}/downloads/image": {
       "get": {
         "security": [
           {
@@ -9541,7 +9541,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/downloads/kubeconfig": {
+    "/v1/clusters/{cluster_id}/downloads/kubeconfig": {
       "get": {
         "security": [
           {
@@ -9620,7 +9620,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/events": {
+    "/v1/clusters/{cluster_id}/events": {
       "get": {
         "security": [
           {
@@ -9705,7 +9705,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/free_addresses": {
+    "/v1/clusters/{cluster_id}/free_addresses": {
       "get": {
         "security": [
           {
@@ -9794,7 +9794,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/host-requirements": {
+    "/v1/clusters/{cluster_id}/host-requirements": {
       "get": {
         "security": [
           {
@@ -9860,7 +9860,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts": {
+    "/v1/clusters/{cluster_id}/hosts": {
       "get": {
         "security": [
           {
@@ -10028,7 +10028,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}": {
       "get": {
         "security": [
           {
@@ -10168,7 +10168,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/enable": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable": {
       "post": {
         "description": "Enables a host for inclusion in the cluster.",
         "tags": [
@@ -10308,7 +10308,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/install": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/install": {
       "post": {
         "description": "install specific host for day2 cluster.",
         "tags": [
@@ -10373,7 +10373,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/reset": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset": {
       "post": {
         "description": "reset a failed host for day2 cluster.",
         "tags": [
@@ -10438,7 +10438,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}": {
       "patch": {
         "description": "Reset failed host validation.  It may be performed on any host validation with persistent validation result.",
         "tags": [
@@ -10517,7 +10517,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition": {
       "get": {
         "security": [
           {
@@ -10609,7 +10609,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/ignition": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition": {
       "get": {
         "description": "Get the customized ignition file for this host",
         "tags": [
@@ -10755,7 +10755,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/installer-args": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/installer-args": {
       "patch": {
         "description": "Updates a host's installer arguments.",
         "tags": [
@@ -10841,7 +10841,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/instructions": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions": {
       "get": {
         "security": [
           {
@@ -11014,7 +11014,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/logs": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/logs": {
       "get": {
         "security": [
           {
@@ -11183,7 +11183,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/logs_progress": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress": {
       "put": {
         "security": [
           {
@@ -11271,7 +11271,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/hosts/{host_id}/progress": {
+    "/v1/clusters/{cluster_id}/hosts/{host_id}/progress": {
       "put": {
         "security": [
           {
@@ -11359,7 +11359,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/install-config": {
+    "/v1/clusters/{cluster_id}/install-config": {
       "get": {
         "security": [
           {
@@ -11492,7 +11492,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/logs": {
+    "/v1/clusters/{cluster_id}/logs": {
       "get": {
         "security": [
           {
@@ -11674,7 +11674,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/logs_progress": {
+    "/v1/clusters/{cluster_id}/logs_progress": {
       "put": {
         "security": [
           {
@@ -11754,7 +11754,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/manifests": {
+    "/v1/clusters/{cluster_id}/manifests": {
       "get": {
         "security": [
           {
@@ -11979,7 +11979,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/manifests/files": {
+    "/v1/clusters/{cluster_id}/manifests/files": {
       "get": {
         "security": [
           {
@@ -12068,7 +12068,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/monitored_operators": {
+    "/v1/clusters/{cluster_id}/monitored_operators": {
       "get": {
         "security": [
           {
@@ -12222,7 +12222,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/preflight-requirements": {
+    "/v1/clusters/{cluster_id}/preflight-requirements": {
       "get": {
         "security": [
           {
@@ -12288,7 +12288,7 @@ func init() {
         }
       }
     },
-    "/clusters/{cluster_id}/uploads/ingress-cert": {
+    "/v1/clusters/{cluster_id}/uploads/ingress-cert": {
       "post": {
         "security": [
           {
@@ -12374,7 +12374,7 @@ func init() {
         }
       }
     },
-    "/component_versions": {
+    "/v1/component_versions": {
       "get": {
         "security": [
           {
@@ -12400,7 +12400,7 @@ func init() {
         }
       }
     },
-    "/domains": {
+    "/v1/domains": {
       "get": {
         "security": [
           {
@@ -12432,7 +12432,136 @@ func init() {
         }
       }
     },
-    "/infra-envs": {
+    "/v1/openshift_versions": {
+      "get": {
+        "security": [
+          {
+            "userAuth": [
+              "admin",
+              "read-only-admin",
+              "user"
+            ]
+          }
+        ],
+        "description": "Retrieves the list of OpenShift supported versions.",
+        "tags": [
+          "versions"
+        ],
+        "operationId": "ListSupportedOpenshiftVersions",
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/openshift-versions"
+            }
+          },
+          "503": {
+            "description": "Unavailable.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/supported-operators": {
+      "get": {
+        "description": "Retrieves the list of supported operators.",
+        "tags": [
+          "operators"
+        ],
+        "operationId": "ListSupportedOperators",
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v1/supported-operators/{operator_name}": {
+      "get": {
+        "security": [
+          {
+            "userAuth": [
+              "admin",
+              "read-only-admin",
+              "user"
+            ]
+          }
+        ],
+        "description": "Lists properties for an operator.",
+        "tags": [
+          "operators"
+        ],
+        "operationId": "ListOperatorProperties",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "The operator name.",
+            "name": "operator_name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/operator-properties"
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "schema": {
+              "$ref": "#/definitions/infra_error"
+            }
+          },
+          "404": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    },
+    "/v2/infra-envs": {
       "post": {
         "description": "Creates a new OpenShift Discovery ISO.",
         "tags": [
@@ -12501,135 +12630,6 @@ func init() {
           },
           "501": {
             "description": "Not implemented.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/openshift_versions": {
-      "get": {
-        "security": [
-          {
-            "userAuth": [
-              "admin",
-              "read-only-admin",
-              "user"
-            ]
-          }
-        ],
-        "description": "Retrieves the list of OpenShift supported versions.",
-        "tags": [
-          "versions"
-        ],
-        "operationId": "ListSupportedOpenshiftVersions",
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "$ref": "#/definitions/openshift-versions"
-            }
-          },
-          "503": {
-            "description": "Unavailable.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/supported-operators": {
-      "get": {
-        "description": "Retrieves the list of supported operators.",
-        "tags": [
-          "operators"
-        ],
-        "operationId": "ListSupportedOperators",
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "500": {
-            "description": "Error.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
-    },
-    "/supported-operators/{operator_name}": {
-      "get": {
-        "security": [
-          {
-            "userAuth": [
-              "admin",
-              "read-only-admin",
-              "user"
-            ]
-          }
-        ],
-        "description": "Lists properties for an operator.",
-        "tags": [
-          "operators"
-        ],
-        "operationId": "ListOperatorProperties",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "The operator name.",
-            "name": "operator_name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "schema": {
-              "$ref": "#/definitions/operator-properties"
-            }
-          },
-          "401": {
-            "description": "Unauthorized.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "schema": {
-              "$ref": "#/definitions/infra_error"
-            }
-          },
-          "404": {
-            "description": "Error.",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "500": {
-            "description": "Error.",
             "schema": {
               "$ref": "#/definitions/error"
             }

--- a/restapi/operations/assisted_install_api.go
+++ b/restapi/operations/assisted_install_api.go
@@ -846,263 +846,263 @@ func (o *AssistedInstallAPI) initHandlerCache() {
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/actions/cancel"] = installer.NewCancelInstallation(o.context, o.InstallerCancelInstallationHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/actions/cancel"] = installer.NewCancelInstallation(o.context, o.InstallerCancelInstallationHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/actions/complete_installation"] = installer.NewCompleteInstallation(o.context, o.InstallerCompleteInstallationHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/actions/complete_installation"] = installer.NewCompleteInstallation(o.context, o.InstallerCompleteInstallationHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/manifests"] = manifests.NewCreateClusterManifest(o.context, o.ManifestsCreateClusterManifestHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/manifests"] = manifests.NewCreateClusterManifest(o.context, o.ManifestsCreateClusterManifestHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/assisted-service-iso"] = assisted_service_iso.NewCreateISOAndUploadToS3(o.context, o.AssistedServiceIsoCreateISOAndUploadToS3Handler)
+	o.handlers["POST"]["/v1/assisted-service-iso"] = assisted_service_iso.NewCreateISOAndUploadToS3(o.context, o.AssistedServiceIsoCreateISOAndUploadToS3Handler)
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/clusters/{cluster_id}/manifests"] = manifests.NewDeleteClusterManifest(o.context, o.ManifestsDeleteClusterManifestHandler)
+	o.handlers["DELETE"]["/v1/clusters/{cluster_id}/manifests"] = manifests.NewDeleteClusterManifest(o.context, o.ManifestsDeleteClusterManifestHandler)
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/clusters/{cluster_id}"] = installer.NewDeregisterCluster(o.context, o.InstallerDeregisterClusterHandler)
+	o.handlers["DELETE"]["/v1/clusters/{cluster_id}"] = installer.NewDeregisterCluster(o.context, o.InstallerDeregisterClusterHandler)
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/clusters/{cluster_id}/hosts/{host_id}"] = installer.NewDeregisterHost(o.context, o.InstallerDeregisterHostHandler)
+	o.handlers["DELETE"]["/v1/clusters/{cluster_id}/hosts/{host_id}"] = installer.NewDeregisterHost(o.context, o.InstallerDeregisterHostHandler)
 	if o.handlers["DELETE"] == nil {
 		o.handlers["DELETE"] = make(map[string]http.Handler)
 	}
-	o.handlers["DELETE"]["/clusters/{cluster_id}/hosts/{host_id}/actions/enable"] = installer.NewDisableHost(o.context, o.InstallerDisableHostHandler)
+	o.handlers["DELETE"]["/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable"] = installer.NewDisableHost(o.context, o.InstallerDisableHostHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/downloads/files"] = installer.NewDownloadClusterFiles(o.context, o.InstallerDownloadClusterFilesHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/downloads/files"] = installer.NewDownloadClusterFiles(o.context, o.InstallerDownloadClusterFilesHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/downloads/image"] = installer.NewDownloadClusterISO(o.context, o.InstallerDownloadClusterISOHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/downloads/image"] = installer.NewDownloadClusterISO(o.context, o.InstallerDownloadClusterISOHandler)
 	if o.handlers["HEAD"] == nil {
 		o.handlers["HEAD"] = make(map[string]http.Handler)
 	}
-	o.handlers["HEAD"]["/clusters/{cluster_id}/downloads/image"] = installer.NewDownloadClusterISOHeaders(o.context, o.InstallerDownloadClusterISOHeadersHandler)
+	o.handlers["HEAD"]["/v1/clusters/{cluster_id}/downloads/image"] = installer.NewDownloadClusterISOHeaders(o.context, o.InstallerDownloadClusterISOHeadersHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/downloads/kubeconfig"] = installer.NewDownloadClusterKubeconfig(o.context, o.InstallerDownloadClusterKubeconfigHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/downloads/kubeconfig"] = installer.NewDownloadClusterKubeconfig(o.context, o.InstallerDownloadClusterKubeconfigHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/logs"] = installer.NewDownloadClusterLogs(o.context, o.InstallerDownloadClusterLogsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/logs"] = installer.NewDownloadClusterLogs(o.context, o.InstallerDownloadClusterLogsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/manifests/files"] = manifests.NewDownloadClusterManifest(o.context, o.ManifestsDownloadClusterManifestHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/manifests/files"] = manifests.NewDownloadClusterManifest(o.context, o.ManifestsDownloadClusterManifestHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition"] = installer.NewDownloadHostIgnition(o.context, o.InstallerDownloadHostIgnitionHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition"] = installer.NewDownloadHostIgnition(o.context, o.InstallerDownloadHostIgnitionHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts/{host_id}/logs"] = installer.NewDownloadHostLogs(o.context, o.InstallerDownloadHostLogsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts/{host_id}/logs"] = installer.NewDownloadHostLogs(o.context, o.InstallerDownloadHostLogsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/assisted-service-iso/data"] = assisted_service_iso.NewDownloadISO(o.context, o.AssistedServiceIsoDownloadISOHandler)
+	o.handlers["GET"]["/v1/assisted-service-iso/data"] = assisted_service_iso.NewDownloadISO(o.context, o.AssistedServiceIsoDownloadISOHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts/{host_id}/actions/enable"] = installer.NewEnableHost(o.context, o.InstallerEnableHostHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable"] = installer.NewEnableHost(o.context, o.InstallerEnableHostHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/downloads/image"] = installer.NewGenerateClusterISO(o.context, o.InstallerGenerateClusterISOHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/downloads/image"] = installer.NewGenerateClusterISO(o.context, o.InstallerGenerateClusterISOHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}"] = installer.NewGetCluster(o.context, o.InstallerGetClusterHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}"] = installer.NewGetCluster(o.context, o.InstallerGetClusterHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/default-config"] = installer.NewGetClusterDefaultConfig(o.context, o.InstallerGetClusterDefaultConfigHandler)
+	o.handlers["GET"]["/v1/clusters/default-config"] = installer.NewGetClusterDefaultConfig(o.context, o.InstallerGetClusterDefaultConfigHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/host-requirements"] = installer.NewGetClusterHostRequirements(o.context, o.InstallerGetClusterHostRequirementsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/host-requirements"] = installer.NewGetClusterHostRequirements(o.context, o.InstallerGetClusterHostRequirementsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/install-config"] = installer.NewGetClusterInstallConfig(o.context, o.InstallerGetClusterInstallConfigHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/install-config"] = installer.NewGetClusterInstallConfig(o.context, o.InstallerGetClusterInstallConfigHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/credentials"] = installer.NewGetCredentials(o.context, o.InstallerGetCredentialsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/credentials"] = installer.NewGetCredentials(o.context, o.InstallerGetCredentialsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/discovery-ignition"] = installer.NewGetDiscoveryIgnition(o.context, o.InstallerGetDiscoveryIgnitionHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/discovery-ignition"] = installer.NewGetDiscoveryIgnition(o.context, o.InstallerGetDiscoveryIgnitionHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/free_addresses"] = installer.NewGetFreeAddresses(o.context, o.InstallerGetFreeAddressesHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/free_addresses"] = installer.NewGetFreeAddresses(o.context, o.InstallerGetFreeAddressesHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts/{host_id}"] = installer.NewGetHost(o.context, o.InstallerGetHostHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts/{host_id}"] = installer.NewGetHost(o.context, o.InstallerGetHostHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts/{host_id}/ignition"] = installer.NewGetHostIgnition(o.context, o.InstallerGetHostIgnitionHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts/{host_id}/ignition"] = installer.NewGetHostIgnition(o.context, o.InstallerGetHostIgnitionHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts/{host_id}/instructions"] = installer.NewGetNextSteps(o.context, o.InstallerGetNextStepsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts/{host_id}/instructions"] = installer.NewGetNextSteps(o.context, o.InstallerGetNextStepsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/preflight-requirements"] = installer.NewGetPreflightRequirements(o.context, o.InstallerGetPreflightRequirementsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/preflight-requirements"] = installer.NewGetPreflightRequirements(o.context, o.InstallerGetPreflightRequirementsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/assisted-service-iso/presigned"] = assisted_service_iso.NewGetPresignedForAssistedServiceISO(o.context, o.AssistedServiceIsoGetPresignedForAssistedServiceISOHandler)
+	o.handlers["GET"]["/v1/assisted-service-iso/presigned"] = assisted_service_iso.NewGetPresignedForAssistedServiceISO(o.context, o.AssistedServiceIsoGetPresignedForAssistedServiceISOHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/downloads/files-presigned"] = installer.NewGetPresignedForClusterFiles(o.context, o.InstallerGetPresignedForClusterFilesHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/downloads/files-presigned"] = installer.NewGetPresignedForClusterFiles(o.context, o.InstallerGetPresignedForClusterFilesHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/actions/install"] = installer.NewInstallCluster(o.context, o.InstallerInstallClusterHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/actions/install"] = installer.NewInstallCluster(o.context, o.InstallerInstallClusterHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts/{host_id}/actions/install"] = installer.NewInstallHost(o.context, o.InstallerInstallHostHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts/{host_id}/actions/install"] = installer.NewInstallHost(o.context, o.InstallerInstallHostHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/actions/install_hosts"] = installer.NewInstallHosts(o.context, o.InstallerInstallHostsHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/actions/install_hosts"] = installer.NewInstallHosts(o.context, o.InstallerInstallHostsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/manifests"] = manifests.NewListClusterManifests(o.context, o.ManifestsListClusterManifestsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/manifests"] = manifests.NewListClusterManifests(o.context, o.ManifestsListClusterManifestsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters"] = installer.NewListClusters(o.context, o.InstallerListClustersHandler)
+	o.handlers["GET"]["/v1/clusters"] = installer.NewListClusters(o.context, o.InstallerListClustersHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/component_versions"] = versions.NewListComponentVersions(o.context, o.VersionsListComponentVersionsHandler)
+	o.handlers["GET"]["/v1/component_versions"] = versions.NewListComponentVersions(o.context, o.VersionsListComponentVersionsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/events"] = events.NewListEvents(o.context, o.EventsListEventsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/events"] = events.NewListEvents(o.context, o.EventsListEventsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/hosts"] = installer.NewListHosts(o.context, o.InstallerListHostsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/hosts"] = installer.NewListHosts(o.context, o.InstallerListHostsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/domains"] = managed_domains.NewListManagedDomains(o.context, o.ManagedDomainsListManagedDomainsHandler)
+	o.handlers["GET"]["/v1/domains"] = managed_domains.NewListManagedDomains(o.context, o.ManagedDomainsListManagedDomainsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/clusters/{cluster_id}/monitored_operators"] = operators.NewListOfClusterOperators(o.context, o.OperatorsListOfClusterOperatorsHandler)
+	o.handlers["GET"]["/v1/clusters/{cluster_id}/monitored_operators"] = operators.NewListOfClusterOperators(o.context, o.OperatorsListOfClusterOperatorsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/supported-operators/{operator_name}"] = operators.NewListOperatorProperties(o.context, o.OperatorsListOperatorPropertiesHandler)
+	o.handlers["GET"]["/v1/supported-operators/{operator_name}"] = operators.NewListOperatorProperties(o.context, o.OperatorsListOperatorPropertiesHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/openshift_versions"] = versions.NewListSupportedOpenshiftVersions(o.context, o.VersionsListSupportedOpenshiftVersionsHandler)
+	o.handlers["GET"]["/v1/openshift_versions"] = versions.NewListSupportedOpenshiftVersions(o.context, o.VersionsListSupportedOpenshiftVersionsHandler)
 	if o.handlers["GET"] == nil {
 		o.handlers["GET"] = make(map[string]http.Handler)
 	}
-	o.handlers["GET"]["/supported-operators"] = operators.NewListSupportedOperators(o.context, o.OperatorsListSupportedOperatorsHandler)
+	o.handlers["GET"]["/v1/supported-operators"] = operators.NewListSupportedOperators(o.context, o.OperatorsListSupportedOperatorsHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts/{host_id}/instructions"] = installer.NewPostStepReply(o.context, o.InstallerPostStepReplyHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts/{host_id}/instructions"] = installer.NewPostStepReply(o.context, o.InstallerPostStepReplyHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/add_hosts_clusters"] = installer.NewRegisterAddHostsCluster(o.context, o.InstallerRegisterAddHostsClusterHandler)
+	o.handlers["POST"]["/v1/add_hosts_clusters"] = installer.NewRegisterAddHostsCluster(o.context, o.InstallerRegisterAddHostsClusterHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters"] = installer.NewRegisterCluster(o.context, o.InstallerRegisterClusterHandler)
+	o.handlers["POST"]["/v1/clusters"] = installer.NewRegisterCluster(o.context, o.InstallerRegisterClusterHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts"] = installer.NewRegisterHost(o.context, o.InstallerRegisterHostHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts"] = installer.NewRegisterHost(o.context, o.InstallerRegisterHostHandler)
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/clusters/{cluster_id}/monitored_operators"] = operators.NewReportMonitoredOperatorStatus(o.context, o.OperatorsReportMonitoredOperatorStatusHandler)
+	o.handlers["PUT"]["/v1/clusters/{cluster_id}/monitored_operators"] = operators.NewReportMonitoredOperatorStatus(o.context, o.OperatorsReportMonitoredOperatorStatusHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/actions/reset"] = installer.NewResetCluster(o.context, o.InstallerResetClusterHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/actions/reset"] = installer.NewResetCluster(o.context, o.InstallerResetClusterHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts/{host_id}/actions/reset"] = installer.NewResetHost(o.context, o.InstallerResetHostHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset"] = installer.NewResetHost(o.context, o.InstallerResetHostHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}"] = installer.NewResetHostValidation(o.context, o.InstallerResetHostValidationHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}"] = installer.NewResetHostValidation(o.context, o.InstallerResetHostValidationHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}"] = installer.NewUpdateCluster(o.context, o.InstallerUpdateClusterHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}"] = installer.NewUpdateCluster(o.context, o.InstallerUpdateClusterHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}/install-config"] = installer.NewUpdateClusterInstallConfig(o.context, o.InstallerUpdateClusterInstallConfigHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}/install-config"] = installer.NewUpdateClusterInstallConfig(o.context, o.InstallerUpdateClusterInstallConfigHandler)
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/clusters/{cluster_id}/logs_progress"] = installer.NewUpdateClusterLogsProgress(o.context, o.InstallerUpdateClusterLogsProgressHandler)
+	o.handlers["PUT"]["/v1/clusters/{cluster_id}/logs_progress"] = installer.NewUpdateClusterLogsProgress(o.context, o.InstallerUpdateClusterLogsProgressHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}/discovery-ignition"] = installer.NewUpdateDiscoveryIgnition(o.context, o.InstallerUpdateDiscoveryIgnitionHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}/discovery-ignition"] = installer.NewUpdateDiscoveryIgnition(o.context, o.InstallerUpdateDiscoveryIgnitionHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}/hosts/{host_id}/ignition"] = installer.NewUpdateHostIgnition(o.context, o.InstallerUpdateHostIgnitionHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}/hosts/{host_id}/ignition"] = installer.NewUpdateHostIgnition(o.context, o.InstallerUpdateHostIgnitionHandler)
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/clusters/{cluster_id}/hosts/{host_id}/progress"] = installer.NewUpdateHostInstallProgress(o.context, o.InstallerUpdateHostInstallProgressHandler)
+	o.handlers["PUT"]["/v1/clusters/{cluster_id}/hosts/{host_id}/progress"] = installer.NewUpdateHostInstallProgress(o.context, o.InstallerUpdateHostInstallProgressHandler)
 	if o.handlers["PATCH"] == nil {
 		o.handlers["PATCH"] = make(map[string]http.Handler)
 	}
-	o.handlers["PATCH"]["/clusters/{cluster_id}/hosts/{host_id}/installer-args"] = installer.NewUpdateHostInstallerArgs(o.context, o.InstallerUpdateHostInstallerArgsHandler)
+	o.handlers["PATCH"]["/v1/clusters/{cluster_id}/hosts/{host_id}/installer-args"] = installer.NewUpdateHostInstallerArgs(o.context, o.InstallerUpdateHostInstallerArgsHandler)
 	if o.handlers["PUT"] == nil {
 		o.handlers["PUT"] = make(map[string]http.Handler)
 	}
-	o.handlers["PUT"]["/clusters/{cluster_id}/hosts/{host_id}/logs_progress"] = installer.NewUpdateHostLogsProgress(o.context, o.InstallerUpdateHostLogsProgressHandler)
+	o.handlers["PUT"]["/v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress"] = installer.NewUpdateHostLogsProgress(o.context, o.InstallerUpdateHostLogsProgressHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/uploads/ingress-cert"] = installer.NewUploadClusterIngressCert(o.context, o.InstallerUploadClusterIngressCertHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/uploads/ingress-cert"] = installer.NewUploadClusterIngressCert(o.context, o.InstallerUploadClusterIngressCertHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/hosts/{host_id}/logs"] = installer.NewUploadHostLogs(o.context, o.InstallerUploadHostLogsHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/hosts/{host_id}/logs"] = installer.NewUploadHostLogs(o.context, o.InstallerUploadHostLogsHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/clusters/{cluster_id}/logs"] = installer.NewUploadLogs(o.context, o.InstallerUploadLogsHandler)
+	o.handlers["POST"]["/v1/clusters/{cluster_id}/logs"] = installer.NewUploadLogs(o.context, o.InstallerUploadLogsHandler)
 	if o.handlers["POST"] == nil {
 		o.handlers["POST"] = make(map[string]http.Handler)
 	}
-	o.handlers["POST"]["/infra-envs"] = installer.NewV2RegisterInfraEnv(o.context, o.InstallerV2RegisterInfraEnvHandler)
+	o.handlers["POST"]["/v2/infra-envs"] = installer.NewV2RegisterInfraEnv(o.context, o.InstallerV2RegisterInfraEnvHandler)
 }
 
 // Serve creates a http handler to serve the API over HTTP

--- a/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3.go
+++ b/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3.go
@@ -29,7 +29,7 @@ func NewCreateISOAndUploadToS3(ctx *middleware.Context, handler CreateISOAndUplo
 	return &CreateISOAndUploadToS3{Context: ctx, Handler: handler}
 }
 
-/*CreateISOAndUploadToS3 swagger:route POST /assisted-service-iso assisted-service-iso createISOAndUploadToS3
+/*CreateISOAndUploadToS3 swagger:route POST /v1/assisted-service-iso assisted-service-iso createISOAndUploadToS3
 
 Creates ISO for the user and uploads to S3.
 

--- a/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3_urlbuilder.go
+++ b/restapi/operations/assisted_service_iso/create_i_s_o_and_upload_to_s3_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *CreateISOAndUploadToS3URL) SetBasePath(bp string) {
 func (o *CreateISOAndUploadToS3URL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/assisted-service-iso"
+	var _path = "/v1/assisted-service-iso"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/assisted_service_iso/download_i_s_o.go
+++ b/restapi/operations/assisted_service_iso/download_i_s_o.go
@@ -29,7 +29,7 @@ func NewDownloadISO(ctx *middleware.Context, handler DownloadISOHandler) *Downlo
 	return &DownloadISO{Context: ctx, Handler: handler}
 }
 
-/*DownloadISO swagger:route GET /assisted-service-iso/data assisted-service-iso downloadISO
+/*DownloadISO swagger:route GET /v1/assisted-service-iso/data assisted-service-iso downloadISO
 
 Downloads the Assisted Service ISO.
 

--- a/restapi/operations/assisted_service_iso/download_i_s_o_urlbuilder.go
+++ b/restapi/operations/assisted_service_iso/download_i_s_o_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *DownloadISOURL) SetBasePath(bp string) {
 func (o *DownloadISOURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/assisted-service-iso/data"
+	var _path = "/v1/assisted-service-iso/data"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/assisted_service_iso/get_presigned_for_assisted_service_i_s_o.go
+++ b/restapi/operations/assisted_service_iso/get_presigned_for_assisted_service_i_s_o.go
@@ -29,7 +29,7 @@ func NewGetPresignedForAssistedServiceISO(ctx *middleware.Context, handler GetPr
 	return &GetPresignedForAssistedServiceISO{Context: ctx, Handler: handler}
 }
 
-/*GetPresignedForAssistedServiceISO swagger:route GET /assisted-service-iso/presigned assisted-service-iso getPresignedForAssistedServiceISO
+/*GetPresignedForAssistedServiceISO swagger:route GET /v1/assisted-service-iso/presigned assisted-service-iso getPresignedForAssistedServiceISO
 
 Retrieves a pre-signed S3 URL for downloading assisted-service ISO.
 

--- a/restapi/operations/assisted_service_iso/get_presigned_for_assisted_service_i_s_o_urlbuilder.go
+++ b/restapi/operations/assisted_service_iso/get_presigned_for_assisted_service_i_s_o_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *GetPresignedForAssistedServiceISOURL) SetBasePath(bp string) {
 func (o *GetPresignedForAssistedServiceISOURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/assisted-service-iso/presigned"
+	var _path = "/v1/assisted-service-iso/presigned"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/events/list_events.go
+++ b/restapi/operations/events/list_events.go
@@ -29,7 +29,7 @@ func NewListEvents(ctx *middleware.Context, handler ListEventsHandler) *ListEven
 	return &ListEvents{Context: ctx, Handler: handler}
 }
 
-/*ListEvents swagger:route GET /clusters/{cluster_id}/events events listEvents
+/*ListEvents swagger:route GET /v1/clusters/{cluster_id}/events events listEvents
 
 Lists events for a cluster.
 

--- a/restapi/operations/events/list_events_urlbuilder.go
+++ b/restapi/operations/events/list_events_urlbuilder.go
@@ -46,7 +46,7 @@ func (o *ListEventsURL) SetBasePath(bp string) {
 func (o *ListEventsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/events"
+	var _path = "/v1/clusters/{cluster_id}/events"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -57,7 +57,7 @@ func (o *ListEventsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/cancel_installation.go
+++ b/restapi/operations/installer/cancel_installation.go
@@ -29,7 +29,7 @@ func NewCancelInstallation(ctx *middleware.Context, handler CancelInstallationHa
 	return &CancelInstallation{Context: ctx, Handler: handler}
 }
 
-/*CancelInstallation swagger:route POST /clusters/{cluster_id}/actions/cancel installer cancelInstallation
+/*CancelInstallation swagger:route POST /v1/clusters/{cluster_id}/actions/cancel installer cancelInstallation
 
 Cancels an ongoing installation.
 

--- a/restapi/operations/installer/cancel_installation_urlbuilder.go
+++ b/restapi/operations/installer/cancel_installation_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *CancelInstallationURL) SetBasePath(bp string) {
 func (o *CancelInstallationURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/actions/cancel"
+	var _path = "/v1/clusters/{cluster_id}/actions/cancel"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *CancelInstallationURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/complete_installation.go
+++ b/restapi/operations/installer/complete_installation.go
@@ -29,7 +29,7 @@ func NewCompleteInstallation(ctx *middleware.Context, handler CompleteInstallati
 	return &CompleteInstallation{Context: ctx, Handler: handler}
 }
 
-/*CompleteInstallation swagger:route POST /clusters/{cluster_id}/actions/complete_installation installer completeInstallation
+/*CompleteInstallation swagger:route POST /v1/clusters/{cluster_id}/actions/complete_installation installer completeInstallation
 
 Agent API to mark a finalizing installation as complete.
 

--- a/restapi/operations/installer/complete_installation_urlbuilder.go
+++ b/restapi/operations/installer/complete_installation_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *CompleteInstallationURL) SetBasePath(bp string) {
 func (o *CompleteInstallationURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/actions/complete_installation"
+	var _path = "/v1/clusters/{cluster_id}/actions/complete_installation"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *CompleteInstallationURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/deregister_cluster.go
+++ b/restapi/operations/installer/deregister_cluster.go
@@ -29,7 +29,7 @@ func NewDeregisterCluster(ctx *middleware.Context, handler DeregisterClusterHand
 	return &DeregisterCluster{Context: ctx, Handler: handler}
 }
 
-/*DeregisterCluster swagger:route DELETE /clusters/{cluster_id} installer deregisterCluster
+/*DeregisterCluster swagger:route DELETE /v1/clusters/{cluster_id} installer deregisterCluster
 
 Deletes an OpenShift cluster definition.
 

--- a/restapi/operations/installer/deregister_cluster_urlbuilder.go
+++ b/restapi/operations/installer/deregister_cluster_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *DeregisterClusterURL) SetBasePath(bp string) {
 func (o *DeregisterClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}"
+	var _path = "/v1/clusters/{cluster_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *DeregisterClusterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/deregister_host.go
+++ b/restapi/operations/installer/deregister_host.go
@@ -29,7 +29,7 @@ func NewDeregisterHost(ctx *middleware.Context, handler DeregisterHostHandler) *
 	return &DeregisterHost{Context: ctx, Handler: handler}
 }
 
-/*DeregisterHost swagger:route DELETE /clusters/{cluster_id}/hosts/{host_id} installer deregisterHost
+/*DeregisterHost swagger:route DELETE /v1/clusters/{cluster_id}/hosts/{host_id} installer deregisterHost
 
 Deregisters an OpenShift host.
 

--- a/restapi/operations/installer/deregister_host_urlbuilder.go
+++ b/restapi/operations/installer/deregister_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *DeregisterHostURL) SetBasePath(bp string) {
 func (o *DeregisterHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *DeregisterHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/disable_host.go
+++ b/restapi/operations/installer/disable_host.go
@@ -29,7 +29,7 @@ func NewDisableHost(ctx *middleware.Context, handler DisableHostHandler) *Disabl
 	return &DisableHost{Context: ctx, Handler: handler}
 }
 
-/*DisableHost swagger:route DELETE /clusters/{cluster_id}/hosts/{host_id}/actions/enable installer disableHost
+/*DisableHost swagger:route DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable installer disableHost
 
 Disables a host for inclusion in the cluster.
 

--- a/restapi/operations/installer/disable_host_urlbuilder.go
+++ b/restapi/operations/installer/disable_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *DisableHostURL) SetBasePath(bp string) {
 func (o *DisableHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/actions/enable"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *DisableHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_cluster_files.go
+++ b/restapi/operations/installer/download_cluster_files.go
@@ -29,7 +29,7 @@ func NewDownloadClusterFiles(ctx *middleware.Context, handler DownloadClusterFil
 	return &DownloadClusterFiles{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterFiles swagger:route GET /clusters/{cluster_id}/downloads/files installer downloadClusterFiles
+/*DownloadClusterFiles swagger:route GET /v1/clusters/{cluster_id}/downloads/files installer downloadClusterFiles
 
 Downloads files relating to the installed/installing cluster.
 

--- a/restapi/operations/installer/download_cluster_files_urlbuilder.go
+++ b/restapi/operations/installer/download_cluster_files_urlbuilder.go
@@ -44,7 +44,7 @@ func (o *DownloadClusterFilesURL) SetBasePath(bp string) {
 func (o *DownloadClusterFilesURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/files"
+	var _path = "/v1/clusters/{cluster_id}/downloads/files"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -55,7 +55,7 @@ func (o *DownloadClusterFilesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_cluster_i_s_o.go
+++ b/restapi/operations/installer/download_cluster_i_s_o.go
@@ -29,7 +29,7 @@ func NewDownloadClusterISO(ctx *middleware.Context, handler DownloadClusterISOHa
 	return &DownloadClusterISO{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterISO swagger:route GET /clusters/{cluster_id}/downloads/image installer downloadClusterISO
+/*DownloadClusterISO swagger:route GET /v1/clusters/{cluster_id}/downloads/image installer downloadClusterISO
 
 Downloads the OpenShift per-cluster Discovery ISO.
 

--- a/restapi/operations/installer/download_cluster_i_s_o_headers.go
+++ b/restapi/operations/installer/download_cluster_i_s_o_headers.go
@@ -29,7 +29,7 @@ func NewDownloadClusterISOHeaders(ctx *middleware.Context, handler DownloadClust
 	return &DownloadClusterISOHeaders{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterISOHeaders swagger:route HEAD /clusters/{cluster_id}/downloads/image installer downloadClusterISOHeaders
+/*DownloadClusterISOHeaders swagger:route HEAD /v1/clusters/{cluster_id}/downloads/image installer downloadClusterISOHeaders
 
 Downloads the OpenShift per-cluster Discovery ISO Headers only.
 

--- a/restapi/operations/installer/download_cluster_i_s_o_headers_urlbuilder.go
+++ b/restapi/operations/installer/download_cluster_i_s_o_headers_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *DownloadClusterISOHeadersURL) SetBasePath(bp string) {
 func (o *DownloadClusterISOHeadersURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/image"
+	var _path = "/v1/clusters/{cluster_id}/downloads/image"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *DownloadClusterISOHeadersURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_cluster_i_s_o_urlbuilder.go
+++ b/restapi/operations/installer/download_cluster_i_s_o_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *DownloadClusterISOURL) SetBasePath(bp string) {
 func (o *DownloadClusterISOURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/image"
+	var _path = "/v1/clusters/{cluster_id}/downloads/image"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *DownloadClusterISOURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_cluster_kubeconfig.go
+++ b/restapi/operations/installer/download_cluster_kubeconfig.go
@@ -29,7 +29,7 @@ func NewDownloadClusterKubeconfig(ctx *middleware.Context, handler DownloadClust
 	return &DownloadClusterKubeconfig{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterKubeconfig swagger:route GET /clusters/{cluster_id}/downloads/kubeconfig installer downloadClusterKubeconfig
+/*DownloadClusterKubeconfig swagger:route GET /v1/clusters/{cluster_id}/downloads/kubeconfig installer downloadClusterKubeconfig
 
 Downloads the kubeconfig file for this cluster.
 

--- a/restapi/operations/installer/download_cluster_kubeconfig_urlbuilder.go
+++ b/restapi/operations/installer/download_cluster_kubeconfig_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *DownloadClusterKubeconfigURL) SetBasePath(bp string) {
 func (o *DownloadClusterKubeconfigURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/kubeconfig"
+	var _path = "/v1/clusters/{cluster_id}/downloads/kubeconfig"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *DownloadClusterKubeconfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_cluster_logs.go
+++ b/restapi/operations/installer/download_cluster_logs.go
@@ -29,7 +29,7 @@ func NewDownloadClusterLogs(ctx *middleware.Context, handler DownloadClusterLogs
 	return &DownloadClusterLogs{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterLogs swagger:route GET /clusters/{cluster_id}/logs installer downloadClusterLogs
+/*DownloadClusterLogs swagger:route GET /v1/clusters/{cluster_id}/logs installer downloadClusterLogs
 
 Download cluster logs.
 

--- a/restapi/operations/installer/download_cluster_logs_urlbuilder.go
+++ b/restapi/operations/installer/download_cluster_logs_urlbuilder.go
@@ -45,7 +45,7 @@ func (o *DownloadClusterLogsURL) SetBasePath(bp string) {
 func (o *DownloadClusterLogsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/logs"
+	var _path = "/v1/clusters/{cluster_id}/logs"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -56,7 +56,7 @@ func (o *DownloadClusterLogsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_host_ignition.go
+++ b/restapi/operations/installer/download_host_ignition.go
@@ -29,7 +29,7 @@ func NewDownloadHostIgnition(ctx *middleware.Context, handler DownloadHostIgniti
 	return &DownloadHostIgnition{Context: ctx, Handler: handler}
 }
 
-/*DownloadHostIgnition swagger:route GET /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition installer downloadHostIgnition
+/*DownloadHostIgnition swagger:route GET /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition installer downloadHostIgnition
 
 Downloads the customized ignition file for this host
 

--- a/restapi/operations/installer/download_host_ignition_urlbuilder.go
+++ b/restapi/operations/installer/download_host_ignition_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *DownloadHostIgnitionURL) SetBasePath(bp string) {
 func (o *DownloadHostIgnitionURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *DownloadHostIgnitionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/download_host_logs.go
+++ b/restapi/operations/installer/download_host_logs.go
@@ -29,7 +29,7 @@ func NewDownloadHostLogs(ctx *middleware.Context, handler DownloadHostLogsHandle
 	return &DownloadHostLogs{Context: ctx, Handler: handler}
 }
 
-/*DownloadHostLogs swagger:route GET /clusters/{cluster_id}/hosts/{host_id}/logs installer downloadHostLogs
+/*DownloadHostLogs swagger:route GET /v1/clusters/{cluster_id}/hosts/{host_id}/logs installer downloadHostLogs
 
 Download host logs.
 

--- a/restapi/operations/installer/download_host_logs_urlbuilder.go
+++ b/restapi/operations/installer/download_host_logs_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *DownloadHostLogsURL) SetBasePath(bp string) {
 func (o *DownloadHostLogsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/logs"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/logs"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *DownloadHostLogsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/enable_host.go
+++ b/restapi/operations/installer/enable_host.go
@@ -29,7 +29,7 @@ func NewEnableHost(ctx *middleware.Context, handler EnableHostHandler) *EnableHo
 	return &EnableHost{Context: ctx, Handler: handler}
 }
 
-/*EnableHost swagger:route POST /clusters/{cluster_id}/hosts/{host_id}/actions/enable installer enableHost
+/*EnableHost swagger:route POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable installer enableHost
 
 Enables a host for inclusion in the cluster.
 

--- a/restapi/operations/installer/enable_host_urlbuilder.go
+++ b/restapi/operations/installer/enable_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *EnableHostURL) SetBasePath(bp string) {
 func (o *EnableHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/actions/enable"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *EnableHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/generate_cluster_i_s_o.go
+++ b/restapi/operations/installer/generate_cluster_i_s_o.go
@@ -29,7 +29,7 @@ func NewGenerateClusterISO(ctx *middleware.Context, handler GenerateClusterISOHa
 	return &GenerateClusterISO{Context: ctx, Handler: handler}
 }
 
-/*GenerateClusterISO swagger:route POST /clusters/{cluster_id}/downloads/image installer generateClusterISO
+/*GenerateClusterISO swagger:route POST /v1/clusters/{cluster_id}/downloads/image installer generateClusterISO
 
 Creates a new OpenShift per-cluster Discovery ISO.
 

--- a/restapi/operations/installer/generate_cluster_i_s_o_urlbuilder.go
+++ b/restapi/operations/installer/generate_cluster_i_s_o_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GenerateClusterISOURL) SetBasePath(bp string) {
 func (o *GenerateClusterISOURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/image"
+	var _path = "/v1/clusters/{cluster_id}/downloads/image"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GenerateClusterISOURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_cluster.go
+++ b/restapi/operations/installer/get_cluster.go
@@ -29,7 +29,7 @@ func NewGetCluster(ctx *middleware.Context, handler GetClusterHandler) *GetClust
 	return &GetCluster{Context: ctx, Handler: handler}
 }
 
-/*GetCluster swagger:route GET /clusters/{cluster_id} installer getCluster
+/*GetCluster swagger:route GET /v1/clusters/{cluster_id} installer getCluster
 
 Retrieves the details of the OpenShift cluster.
 

--- a/restapi/operations/installer/get_cluster_default_config.go
+++ b/restapi/operations/installer/get_cluster_default_config.go
@@ -29,7 +29,7 @@ func NewGetClusterDefaultConfig(ctx *middleware.Context, handler GetClusterDefau
 	return &GetClusterDefaultConfig{Context: ctx, Handler: handler}
 }
 
-/*GetClusterDefaultConfig swagger:route GET /clusters/default-config installer getClusterDefaultConfig
+/*GetClusterDefaultConfig swagger:route GET /v1/clusters/default-config installer getClusterDefaultConfig
 
 Get the default values for various cluster properties.
 

--- a/restapi/operations/installer/get_cluster_default_config_urlbuilder.go
+++ b/restapi/operations/installer/get_cluster_default_config_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *GetClusterDefaultConfigURL) SetBasePath(bp string) {
 func (o *GetClusterDefaultConfigURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/default-config"
+	var _path = "/v1/clusters/default-config"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_cluster_host_requirements.go
+++ b/restapi/operations/installer/get_cluster_host_requirements.go
@@ -29,7 +29,7 @@ func NewGetClusterHostRequirements(ctx *middleware.Context, handler GetClusterHo
 	return &GetClusterHostRequirements{Context: ctx, Handler: handler}
 }
 
-/*GetClusterHostRequirements swagger:route GET /clusters/{cluster_id}/host-requirements installer getClusterHostRequirements
+/*GetClusterHostRequirements swagger:route GET /v1/clusters/{cluster_id}/host-requirements installer getClusterHostRequirements
 
 Get host requirements of a cluster.
 

--- a/restapi/operations/installer/get_cluster_host_requirements_urlbuilder.go
+++ b/restapi/operations/installer/get_cluster_host_requirements_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetClusterHostRequirementsURL) SetBasePath(bp string) {
 func (o *GetClusterHostRequirementsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/host-requirements"
+	var _path = "/v1/clusters/{cluster_id}/host-requirements"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetClusterHostRequirementsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_cluster_install_config.go
+++ b/restapi/operations/installer/get_cluster_install_config.go
@@ -29,7 +29,7 @@ func NewGetClusterInstallConfig(ctx *middleware.Context, handler GetClusterInsta
 	return &GetClusterInstallConfig{Context: ctx, Handler: handler}
 }
 
-/*GetClusterInstallConfig swagger:route GET /clusters/{cluster_id}/install-config installer getClusterInstallConfig
+/*GetClusterInstallConfig swagger:route GET /v1/clusters/{cluster_id}/install-config installer getClusterInstallConfig
 
 Get the cluster's install config YAML.
 

--- a/restapi/operations/installer/get_cluster_install_config_urlbuilder.go
+++ b/restapi/operations/installer/get_cluster_install_config_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetClusterInstallConfigURL) SetBasePath(bp string) {
 func (o *GetClusterInstallConfigURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/install-config"
+	var _path = "/v1/clusters/{cluster_id}/install-config"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetClusterInstallConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_cluster_urlbuilder.go
+++ b/restapi/operations/installer/get_cluster_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetClusterURL) SetBasePath(bp string) {
 func (o *GetClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}"
+	var _path = "/v1/clusters/{cluster_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetClusterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_credentials.go
+++ b/restapi/operations/installer/get_credentials.go
@@ -29,7 +29,7 @@ func NewGetCredentials(ctx *middleware.Context, handler GetCredentialsHandler) *
 	return &GetCredentials{Context: ctx, Handler: handler}
 }
 
-/*GetCredentials swagger:route GET /clusters/{cluster_id}/credentials installer getCredentials
+/*GetCredentials swagger:route GET /v1/clusters/{cluster_id}/credentials installer getCredentials
 
 Get the cluster admin credentials.
 

--- a/restapi/operations/installer/get_credentials_urlbuilder.go
+++ b/restapi/operations/installer/get_credentials_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetCredentialsURL) SetBasePath(bp string) {
 func (o *GetCredentialsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/credentials"
+	var _path = "/v1/clusters/{cluster_id}/credentials"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetCredentialsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_discovery_ignition.go
+++ b/restapi/operations/installer/get_discovery_ignition.go
@@ -29,7 +29,7 @@ func NewGetDiscoveryIgnition(ctx *middleware.Context, handler GetDiscoveryIgniti
 	return &GetDiscoveryIgnition{Context: ctx, Handler: handler}
 }
 
-/*GetDiscoveryIgnition swagger:route GET /clusters/{cluster_id}/discovery-ignition installer getDiscoveryIgnition
+/*GetDiscoveryIgnition swagger:route GET /v1/clusters/{cluster_id}/discovery-ignition installer getDiscoveryIgnition
 
 Get the discovery ignition for the cluster based on its attributes and overridden ignition value before generating the discovery ISO.
 Used to test the validity of the discovery ignition when it is being overridden.

--- a/restapi/operations/installer/get_discovery_ignition_urlbuilder.go
+++ b/restapi/operations/installer/get_discovery_ignition_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetDiscoveryIgnitionURL) SetBasePath(bp string) {
 func (o *GetDiscoveryIgnitionURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/discovery-ignition"
+	var _path = "/v1/clusters/{cluster_id}/discovery-ignition"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetDiscoveryIgnitionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_free_addresses.go
+++ b/restapi/operations/installer/get_free_addresses.go
@@ -29,7 +29,7 @@ func NewGetFreeAddresses(ctx *middleware.Context, handler GetFreeAddressesHandle
 	return &GetFreeAddresses{Context: ctx, Handler: handler}
 }
 
-/*GetFreeAddresses swagger:route GET /clusters/{cluster_id}/free_addresses installer getFreeAddresses
+/*GetFreeAddresses swagger:route GET /v1/clusters/{cluster_id}/free_addresses installer getFreeAddresses
 
 Retrieves the free address list for a network.
 

--- a/restapi/operations/installer/get_free_addresses_urlbuilder.go
+++ b/restapi/operations/installer/get_free_addresses_urlbuilder.go
@@ -47,7 +47,7 @@ func (o *GetFreeAddressesURL) SetBasePath(bp string) {
 func (o *GetFreeAddressesURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/free_addresses"
+	var _path = "/v1/clusters/{cluster_id}/free_addresses"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -58,7 +58,7 @@ func (o *GetFreeAddressesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_host.go
+++ b/restapi/operations/installer/get_host.go
@@ -29,7 +29,7 @@ func NewGetHost(ctx *middleware.Context, handler GetHostHandler) *GetHost {
 	return &GetHost{Context: ctx, Handler: handler}
 }
 
-/*GetHost swagger:route GET /clusters/{cluster_id}/hosts/{host_id} installer getHost
+/*GetHost swagger:route GET /v1/clusters/{cluster_id}/hosts/{host_id} installer getHost
 
 Retrieves the details of the OpenShift host.
 

--- a/restapi/operations/installer/get_host_ignition.go
+++ b/restapi/operations/installer/get_host_ignition.go
@@ -29,7 +29,7 @@ func NewGetHostIgnition(ctx *middleware.Context, handler GetHostIgnitionHandler)
 	return &GetHostIgnition{Context: ctx, Handler: handler}
 }
 
-/*GetHostIgnition swagger:route GET /clusters/{cluster_id}/hosts/{host_id}/ignition installer getHostIgnition
+/*GetHostIgnition swagger:route GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition installer getHostIgnition
 
 Get the customized ignition file for this host
 

--- a/restapi/operations/installer/get_host_ignition_urlbuilder.go
+++ b/restapi/operations/installer/get_host_ignition_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *GetHostIgnitionURL) SetBasePath(bp string) {
 func (o *GetHostIgnitionURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/ignition"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *GetHostIgnitionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_host_urlbuilder.go
+++ b/restapi/operations/installer/get_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *GetHostURL) SetBasePath(bp string) {
 func (o *GetHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *GetHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_next_steps.go
+++ b/restapi/operations/installer/get_next_steps.go
@@ -29,7 +29,7 @@ func NewGetNextSteps(ctx *middleware.Context, handler GetNextStepsHandler) *GetN
 	return &GetNextSteps{Context: ctx, Handler: handler}
 }
 
-/*GetNextSteps swagger:route GET /clusters/{cluster_id}/hosts/{host_id}/instructions installer getNextSteps
+/*GetNextSteps swagger:route GET /v1/clusters/{cluster_id}/hosts/{host_id}/instructions installer getNextSteps
 
 Retrieves the next operations that the host agent needs to perform.
 

--- a/restapi/operations/installer/get_next_steps_urlbuilder.go
+++ b/restapi/operations/installer/get_next_steps_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *GetNextStepsURL) SetBasePath(bp string) {
 func (o *GetNextStepsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/instructions"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *GetNextStepsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_preflight_requirements.go
+++ b/restapi/operations/installer/get_preflight_requirements.go
@@ -29,7 +29,7 @@ func NewGetPreflightRequirements(ctx *middleware.Context, handler GetPreflightRe
 	return &GetPreflightRequirements{Context: ctx, Handler: handler}
 }
 
-/*GetPreflightRequirements swagger:route GET /clusters/{cluster_id}/preflight-requirements installer getPreflightRequirements
+/*GetPreflightRequirements swagger:route GET /v1/clusters/{cluster_id}/preflight-requirements installer getPreflightRequirements
 
 Get preflight requirements for a cluster.
 

--- a/restapi/operations/installer/get_preflight_requirements_urlbuilder.go
+++ b/restapi/operations/installer/get_preflight_requirements_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *GetPreflightRequirementsURL) SetBasePath(bp string) {
 func (o *GetPreflightRequirementsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/preflight-requirements"
+	var _path = "/v1/clusters/{cluster_id}/preflight-requirements"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *GetPreflightRequirementsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/get_presigned_for_cluster_files.go
+++ b/restapi/operations/installer/get_presigned_for_cluster_files.go
@@ -29,7 +29,7 @@ func NewGetPresignedForClusterFiles(ctx *middleware.Context, handler GetPresigne
 	return &GetPresignedForClusterFiles{Context: ctx, Handler: handler}
 }
 
-/*GetPresignedForClusterFiles swagger:route GET /clusters/{cluster_id}/downloads/files-presigned installer getPresignedForClusterFiles
+/*GetPresignedForClusterFiles swagger:route GET /v1/clusters/{cluster_id}/downloads/files-presigned installer getPresignedForClusterFiles
 
 Retrieves a pre-signed S3 URL for downloading cluster files.
 

--- a/restapi/operations/installer/get_presigned_for_cluster_files_urlbuilder.go
+++ b/restapi/operations/installer/get_presigned_for_cluster_files_urlbuilder.go
@@ -47,7 +47,7 @@ func (o *GetPresignedForClusterFilesURL) SetBasePath(bp string) {
 func (o *GetPresignedForClusterFilesURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/downloads/files-presigned"
+	var _path = "/v1/clusters/{cluster_id}/downloads/files-presigned"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -58,7 +58,7 @@ func (o *GetPresignedForClusterFilesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/install_cluster.go
+++ b/restapi/operations/installer/install_cluster.go
@@ -29,7 +29,7 @@ func NewInstallCluster(ctx *middleware.Context, handler InstallClusterHandler) *
 	return &InstallCluster{Context: ctx, Handler: handler}
 }
 
-/*InstallCluster swagger:route POST /clusters/{cluster_id}/actions/install installer installCluster
+/*InstallCluster swagger:route POST /v1/clusters/{cluster_id}/actions/install installer installCluster
 
 Installs the OpenShift cluster.
 

--- a/restapi/operations/installer/install_cluster_urlbuilder.go
+++ b/restapi/operations/installer/install_cluster_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *InstallClusterURL) SetBasePath(bp string) {
 func (o *InstallClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/actions/install"
+	var _path = "/v1/clusters/{cluster_id}/actions/install"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *InstallClusterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/install_host.go
+++ b/restapi/operations/installer/install_host.go
@@ -29,7 +29,7 @@ func NewInstallHost(ctx *middleware.Context, handler InstallHostHandler) *Instal
 	return &InstallHost{Context: ctx, Handler: handler}
 }
 
-/*InstallHost swagger:route POST /clusters/{cluster_id}/hosts/{host_id}/actions/install installer installHost
+/*InstallHost swagger:route POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install installer installHost
 
 install specific host for day2 cluster.
 

--- a/restapi/operations/installer/install_host_urlbuilder.go
+++ b/restapi/operations/installer/install_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *InstallHostURL) SetBasePath(bp string) {
 func (o *InstallHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/actions/install"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/install"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *InstallHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/install_hosts.go
+++ b/restapi/operations/installer/install_hosts.go
@@ -29,7 +29,7 @@ func NewInstallHosts(ctx *middleware.Context, handler InstallHostsHandler) *Inst
 	return &InstallHosts{Context: ctx, Handler: handler}
 }
 
-/*InstallHosts swagger:route POST /clusters/{cluster_id}/actions/install_hosts installer installHosts
+/*InstallHosts swagger:route POST /v1/clusters/{cluster_id}/actions/install_hosts installer installHosts
 
 Installs the OpenShift cluster.
 

--- a/restapi/operations/installer/install_hosts_urlbuilder.go
+++ b/restapi/operations/installer/install_hosts_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *InstallHostsURL) SetBasePath(bp string) {
 func (o *InstallHostsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/actions/install_hosts"
+	var _path = "/v1/clusters/{cluster_id}/actions/install_hosts"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *InstallHostsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/list_clusters.go
+++ b/restapi/operations/installer/list_clusters.go
@@ -29,7 +29,7 @@ func NewListClusters(ctx *middleware.Context, handler ListClustersHandler) *List
 	return &ListClusters{Context: ctx, Handler: handler}
 }
 
-/*ListClusters swagger:route GET /clusters installer listClusters
+/*ListClusters swagger:route GET /v1/clusters installer listClusters
 
 Retrieves the list of OpenShift clusters.
 

--- a/restapi/operations/installer/list_clusters_urlbuilder.go
+++ b/restapi/operations/installer/list_clusters_urlbuilder.go
@@ -44,11 +44,11 @@ func (o *ListClustersURL) SetBasePath(bp string) {
 func (o *ListClustersURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters"
+	var _path = "/v1/clusters"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/list_hosts.go
+++ b/restapi/operations/installer/list_hosts.go
@@ -29,7 +29,7 @@ func NewListHosts(ctx *middleware.Context, handler ListHostsHandler) *ListHosts 
 	return &ListHosts{Context: ctx, Handler: handler}
 }
 
-/*ListHosts swagger:route GET /clusters/{cluster_id}/hosts installer listHosts
+/*ListHosts swagger:route GET /v1/clusters/{cluster_id}/hosts installer listHosts
 
 Retrieves the list of OpenShift hosts.
 

--- a/restapi/operations/installer/list_hosts_urlbuilder.go
+++ b/restapi/operations/installer/list_hosts_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *ListHostsURL) SetBasePath(bp string) {
 func (o *ListHostsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts"
+	var _path = "/v1/clusters/{cluster_id}/hosts"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *ListHostsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/post_step_reply.go
+++ b/restapi/operations/installer/post_step_reply.go
@@ -29,7 +29,7 @@ func NewPostStepReply(ctx *middleware.Context, handler PostStepReplyHandler) *Po
 	return &PostStepReply{Context: ctx, Handler: handler}
 }
 
-/*PostStepReply swagger:route POST /clusters/{cluster_id}/hosts/{host_id}/instructions installer postStepReply
+/*PostStepReply swagger:route POST /v1/clusters/{cluster_id}/hosts/{host_id}/instructions installer postStepReply
 
 Posts the result of the operations from the host agent.
 

--- a/restapi/operations/installer/post_step_reply_urlbuilder.go
+++ b/restapi/operations/installer/post_step_reply_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *PostStepReplyURL) SetBasePath(bp string) {
 func (o *PostStepReplyURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/instructions"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/instructions"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *PostStepReplyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/register_add_hosts_cluster.go
+++ b/restapi/operations/installer/register_add_hosts_cluster.go
@@ -29,7 +29,7 @@ func NewRegisterAddHostsCluster(ctx *middleware.Context, handler RegisterAddHost
 	return &RegisterAddHostsCluster{Context: ctx, Handler: handler}
 }
 
-/*RegisterAddHostsCluster swagger:route POST /add_hosts_clusters installer registerAddHostsCluster
+/*RegisterAddHostsCluster swagger:route POST /v1/add_hosts_clusters installer registerAddHostsCluster
 
 Creates a new OpenShift cluster definition for adding nodes to and existing OCP cluster.
 

--- a/restapi/operations/installer/register_add_hosts_cluster_urlbuilder.go
+++ b/restapi/operations/installer/register_add_hosts_cluster_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *RegisterAddHostsClusterURL) SetBasePath(bp string) {
 func (o *RegisterAddHostsClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/add_hosts_clusters"
+	var _path = "/v1/add_hosts_clusters"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/register_cluster.go
+++ b/restapi/operations/installer/register_cluster.go
@@ -29,7 +29,7 @@ func NewRegisterCluster(ctx *middleware.Context, handler RegisterClusterHandler)
 	return &RegisterCluster{Context: ctx, Handler: handler}
 }
 
-/*RegisterCluster swagger:route POST /clusters installer registerCluster
+/*RegisterCluster swagger:route POST /v1/clusters installer registerCluster
 
 Creates a new OpenShift cluster definition.
 

--- a/restapi/operations/installer/register_cluster_urlbuilder.go
+++ b/restapi/operations/installer/register_cluster_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *RegisterClusterURL) SetBasePath(bp string) {
 func (o *RegisterClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters"
+	var _path = "/v1/clusters"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/register_host.go
+++ b/restapi/operations/installer/register_host.go
@@ -29,7 +29,7 @@ func NewRegisterHost(ctx *middleware.Context, handler RegisterHostHandler) *Regi
 	return &RegisterHost{Context: ctx, Handler: handler}
 }
 
-/*RegisterHost swagger:route POST /clusters/{cluster_id}/hosts installer registerHost
+/*RegisterHost swagger:route POST /v1/clusters/{cluster_id}/hosts installer registerHost
 
 Registers a new OpenShift host.
 

--- a/restapi/operations/installer/register_host_urlbuilder.go
+++ b/restapi/operations/installer/register_host_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *RegisterHostURL) SetBasePath(bp string) {
 func (o *RegisterHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts"
+	var _path = "/v1/clusters/{cluster_id}/hosts"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *RegisterHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/reset_cluster.go
+++ b/restapi/operations/installer/reset_cluster.go
@@ -29,7 +29,7 @@ func NewResetCluster(ctx *middleware.Context, handler ResetClusterHandler) *Rese
 	return &ResetCluster{Context: ctx, Handler: handler}
 }
 
-/*ResetCluster swagger:route POST /clusters/{cluster_id}/actions/reset installer resetCluster
+/*ResetCluster swagger:route POST /v1/clusters/{cluster_id}/actions/reset installer resetCluster
 
 Resets a failed installation.
 

--- a/restapi/operations/installer/reset_cluster_urlbuilder.go
+++ b/restapi/operations/installer/reset_cluster_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *ResetClusterURL) SetBasePath(bp string) {
 func (o *ResetClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/actions/reset"
+	var _path = "/v1/clusters/{cluster_id}/actions/reset"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *ResetClusterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/reset_host.go
+++ b/restapi/operations/installer/reset_host.go
@@ -29,7 +29,7 @@ func NewResetHost(ctx *middleware.Context, handler ResetHostHandler) *ResetHost 
 	return &ResetHost{Context: ctx, Handler: handler}
 }
 
-/*ResetHost swagger:route POST /clusters/{cluster_id}/hosts/{host_id}/actions/reset installer resetHost
+/*ResetHost swagger:route POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset installer resetHost
 
 reset a failed host for day2 cluster.
 

--- a/restapi/operations/installer/reset_host_urlbuilder.go
+++ b/restapi/operations/installer/reset_host_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *ResetHostURL) SetBasePath(bp string) {
 func (o *ResetHostURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/actions/reset"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *ResetHostURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/reset_host_validation.go
+++ b/restapi/operations/installer/reset_host_validation.go
@@ -29,7 +29,7 @@ func NewResetHostValidation(ctx *middleware.Context, handler ResetHostValidation
 	return &ResetHostValidation{Context: ctx, Handler: handler}
 }
 
-/*ResetHostValidation swagger:route PATCH /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id} installer resetHostValidation
+/*ResetHostValidation swagger:route PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id} installer resetHostValidation
 
 Reset failed host validation.
 

--- a/restapi/operations/installer/reset_host_validation_urlbuilder.go
+++ b/restapi/operations/installer/reset_host_validation_urlbuilder.go
@@ -44,7 +44,7 @@ func (o *ResetHostValidationURL) SetBasePath(bp string) {
 func (o *ResetHostValidationURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -69,7 +69,7 @@ func (o *ResetHostValidationURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_cluster.go
+++ b/restapi/operations/installer/update_cluster.go
@@ -29,7 +29,7 @@ func NewUpdateCluster(ctx *middleware.Context, handler UpdateClusterHandler) *Up
 	return &UpdateCluster{Context: ctx, Handler: handler}
 }
 
-/*UpdateCluster swagger:route PATCH /clusters/{cluster_id} installer updateCluster
+/*UpdateCluster swagger:route PATCH /v1/clusters/{cluster_id} installer updateCluster
 
 Updates an OpenShift cluster definition.
 

--- a/restapi/operations/installer/update_cluster_install_config.go
+++ b/restapi/operations/installer/update_cluster_install_config.go
@@ -29,7 +29,7 @@ func NewUpdateClusterInstallConfig(ctx *middleware.Context, handler UpdateCluste
 	return &UpdateClusterInstallConfig{Context: ctx, Handler: handler}
 }
 
-/*UpdateClusterInstallConfig swagger:route PATCH /clusters/{cluster_id}/install-config installer updateClusterInstallConfig
+/*UpdateClusterInstallConfig swagger:route PATCH /v1/clusters/{cluster_id}/install-config installer updateClusterInstallConfig
 
 Override values in the install config.
 

--- a/restapi/operations/installer/update_cluster_install_config_urlbuilder.go
+++ b/restapi/operations/installer/update_cluster_install_config_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UpdateClusterInstallConfigURL) SetBasePath(bp string) {
 func (o *UpdateClusterInstallConfigURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/install-config"
+	var _path = "/v1/clusters/{cluster_id}/install-config"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *UpdateClusterInstallConfigURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_cluster_logs_progress.go
+++ b/restapi/operations/installer/update_cluster_logs_progress.go
@@ -29,7 +29,7 @@ func NewUpdateClusterLogsProgress(ctx *middleware.Context, handler UpdateCluster
 	return &UpdateClusterLogsProgress{Context: ctx, Handler: handler}
 }
 
-/*UpdateClusterLogsProgress swagger:route PUT /clusters/{cluster_id}/logs_progress installer updateClusterLogsProgress
+/*UpdateClusterLogsProgress swagger:route PUT /v1/clusters/{cluster_id}/logs_progress installer updateClusterLogsProgress
 
 Update log collection state and progress.
 

--- a/restapi/operations/installer/update_cluster_logs_progress_urlbuilder.go
+++ b/restapi/operations/installer/update_cluster_logs_progress_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UpdateClusterLogsProgressURL) SetBasePath(bp string) {
 func (o *UpdateClusterLogsProgressURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/logs_progress"
+	var _path = "/v1/clusters/{cluster_id}/logs_progress"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *UpdateClusterLogsProgressURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_cluster_urlbuilder.go
+++ b/restapi/operations/installer/update_cluster_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UpdateClusterURL) SetBasePath(bp string) {
 func (o *UpdateClusterURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}"
+	var _path = "/v1/clusters/{cluster_id}"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *UpdateClusterURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_discovery_ignition.go
+++ b/restapi/operations/installer/update_discovery_ignition.go
@@ -29,7 +29,7 @@ func NewUpdateDiscoveryIgnition(ctx *middleware.Context, handler UpdateDiscovery
 	return &UpdateDiscoveryIgnition{Context: ctx, Handler: handler}
 }
 
-/*UpdateDiscoveryIgnition swagger:route PATCH /clusters/{cluster_id}/discovery-ignition installer updateDiscoveryIgnition
+/*UpdateDiscoveryIgnition swagger:route PATCH /v1/clusters/{cluster_id}/discovery-ignition installer updateDiscoveryIgnition
 
 Override values in the discovery ignition config.
 

--- a/restapi/operations/installer/update_discovery_ignition_urlbuilder.go
+++ b/restapi/operations/installer/update_discovery_ignition_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UpdateDiscoveryIgnitionURL) SetBasePath(bp string) {
 func (o *UpdateDiscoveryIgnitionURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/discovery-ignition"
+	var _path = "/v1/clusters/{cluster_id}/discovery-ignition"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *UpdateDiscoveryIgnitionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_host_ignition.go
+++ b/restapi/operations/installer/update_host_ignition.go
@@ -29,7 +29,7 @@ func NewUpdateHostIgnition(ctx *middleware.Context, handler UpdateHostIgnitionHa
 	return &UpdateHostIgnition{Context: ctx, Handler: handler}
 }
 
-/*UpdateHostIgnition swagger:route PATCH /clusters/{cluster_id}/hosts/{host_id}/ignition installer updateHostIgnition
+/*UpdateHostIgnition swagger:route PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition installer updateHostIgnition
 
 Patch the ignition file for this host
 

--- a/restapi/operations/installer/update_host_ignition_urlbuilder.go
+++ b/restapi/operations/installer/update_host_ignition_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *UpdateHostIgnitionURL) SetBasePath(bp string) {
 func (o *UpdateHostIgnitionURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/ignition"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/ignition"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *UpdateHostIgnitionURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_host_install_progress.go
+++ b/restapi/operations/installer/update_host_install_progress.go
@@ -29,7 +29,7 @@ func NewUpdateHostInstallProgress(ctx *middleware.Context, handler UpdateHostIns
 	return &UpdateHostInstallProgress{Context: ctx, Handler: handler}
 }
 
-/*UpdateHostInstallProgress swagger:route PUT /clusters/{cluster_id}/hosts/{host_id}/progress installer updateHostInstallProgress
+/*UpdateHostInstallProgress swagger:route PUT /v1/clusters/{cluster_id}/hosts/{host_id}/progress installer updateHostInstallProgress
 
 Update installation progress.
 

--- a/restapi/operations/installer/update_host_install_progress_urlbuilder.go
+++ b/restapi/operations/installer/update_host_install_progress_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *UpdateHostInstallProgressURL) SetBasePath(bp string) {
 func (o *UpdateHostInstallProgressURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/progress"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/progress"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *UpdateHostInstallProgressURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_host_installer_args.go
+++ b/restapi/operations/installer/update_host_installer_args.go
@@ -29,7 +29,7 @@ func NewUpdateHostInstallerArgs(ctx *middleware.Context, handler UpdateHostInsta
 	return &UpdateHostInstallerArgs{Context: ctx, Handler: handler}
 }
 
-/*UpdateHostInstallerArgs swagger:route PATCH /clusters/{cluster_id}/hosts/{host_id}/installer-args installer updateHostInstallerArgs
+/*UpdateHostInstallerArgs swagger:route PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args installer updateHostInstallerArgs
 
 Updates a host's installer arguments.
 

--- a/restapi/operations/installer/update_host_installer_args_urlbuilder.go
+++ b/restapi/operations/installer/update_host_installer_args_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *UpdateHostInstallerArgsURL) SetBasePath(bp string) {
 func (o *UpdateHostInstallerArgsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/installer-args"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/installer-args"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *UpdateHostInstallerArgsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/update_host_logs_progress.go
+++ b/restapi/operations/installer/update_host_logs_progress.go
@@ -29,7 +29,7 @@ func NewUpdateHostLogsProgress(ctx *middleware.Context, handler UpdateHostLogsPr
 	return &UpdateHostLogsProgress{Context: ctx, Handler: handler}
 }
 
-/*UpdateHostLogsProgress swagger:route PUT /clusters/{cluster_id}/hosts/{host_id}/logs_progress installer updateHostLogsProgress
+/*UpdateHostLogsProgress swagger:route PUT /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress installer updateHostLogsProgress
 
 Update log collection state and progress.
 

--- a/restapi/operations/installer/update_host_logs_progress_urlbuilder.go
+++ b/restapi/operations/installer/update_host_logs_progress_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *UpdateHostLogsProgressURL) SetBasePath(bp string) {
 func (o *UpdateHostLogsProgressURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/logs_progress"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *UpdateHostLogsProgressURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/upload_cluster_ingress_cert.go
+++ b/restapi/operations/installer/upload_cluster_ingress_cert.go
@@ -29,7 +29,7 @@ func NewUploadClusterIngressCert(ctx *middleware.Context, handler UploadClusterI
 	return &UploadClusterIngressCert{Context: ctx, Handler: handler}
 }
 
-/*UploadClusterIngressCert swagger:route POST /clusters/{cluster_id}/uploads/ingress-cert installer uploadClusterIngressCert
+/*UploadClusterIngressCert swagger:route POST /v1/clusters/{cluster_id}/uploads/ingress-cert installer uploadClusterIngressCert
 
 Transfer the ingress certificate for the cluster.
 

--- a/restapi/operations/installer/upload_cluster_ingress_cert_urlbuilder.go
+++ b/restapi/operations/installer/upload_cluster_ingress_cert_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *UploadClusterIngressCertURL) SetBasePath(bp string) {
 func (o *UploadClusterIngressCertURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/uploads/ingress-cert"
+	var _path = "/v1/clusters/{cluster_id}/uploads/ingress-cert"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *UploadClusterIngressCertURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/upload_host_logs.go
+++ b/restapi/operations/installer/upload_host_logs.go
@@ -29,7 +29,7 @@ func NewUploadHostLogs(ctx *middleware.Context, handler UploadHostLogsHandler) *
 	return &UploadHostLogs{Context: ctx, Handler: handler}
 }
 
-/*UploadHostLogs swagger:route POST /clusters/{cluster_id}/hosts/{host_id}/logs installer uploadHostLogs
+/*UploadHostLogs swagger:route POST /v1/clusters/{cluster_id}/hosts/{host_id}/logs installer uploadHostLogs
 
 Agent API to upload logs.
 

--- a/restapi/operations/installer/upload_host_logs_urlbuilder.go
+++ b/restapi/operations/installer/upload_host_logs_urlbuilder.go
@@ -43,7 +43,7 @@ func (o *UploadHostLogsURL) SetBasePath(bp string) {
 func (o *UploadHostLogsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/hosts/{host_id}/logs"
+	var _path = "/v1/clusters/{cluster_id}/hosts/{host_id}/logs"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -61,7 +61,7 @@ func (o *UploadHostLogsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/upload_logs.go
+++ b/restapi/operations/installer/upload_logs.go
@@ -29,7 +29,7 @@ func NewUploadLogs(ctx *middleware.Context, handler UploadLogsHandler) *UploadLo
 	return &UploadLogs{Context: ctx, Handler: handler}
 }
 
-/*UploadLogs swagger:route POST /clusters/{cluster_id}/logs installer uploadLogs
+/*UploadLogs swagger:route POST /v1/clusters/{cluster_id}/logs installer uploadLogs
 
 Agent API to upload logs.
 

--- a/restapi/operations/installer/upload_logs_urlbuilder.go
+++ b/restapi/operations/installer/upload_logs_urlbuilder.go
@@ -45,7 +45,7 @@ func (o *UploadLogsURL) SetBasePath(bp string) {
 func (o *UploadLogsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/logs"
+	var _path = "/v1/clusters/{cluster_id}/logs"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -56,7 +56,7 @@ func (o *UploadLogsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/installer/v2_register_infra_env.go
+++ b/restapi/operations/installer/v2_register_infra_env.go
@@ -29,7 +29,7 @@ func NewV2RegisterInfraEnv(ctx *middleware.Context, handler V2RegisterInfraEnvHa
 	return &V2RegisterInfraEnv{Context: ctx, Handler: handler}
 }
 
-/*V2RegisterInfraEnv swagger:route POST /infra-envs installer v2RegisterInfraEnv
+/*V2RegisterInfraEnv swagger:route POST /v2/infra-envs installer v2RegisterInfraEnv
 
 Creates a new OpenShift Discovery ISO.
 

--- a/restapi/operations/installer/v2_register_infra_env_urlbuilder.go
+++ b/restapi/operations/installer/v2_register_infra_env_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *V2RegisterInfraEnvURL) SetBasePath(bp string) {
 func (o *V2RegisterInfraEnvURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/infra-envs"
+	var _path = "/v2/infra-envs"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/managed_domains/list_managed_domains.go
+++ b/restapi/operations/managed_domains/list_managed_domains.go
@@ -29,7 +29,7 @@ func NewListManagedDomains(ctx *middleware.Context, handler ListManagedDomainsHa
 	return &ListManagedDomains{Context: ctx, Handler: handler}
 }
 
-/*ListManagedDomains swagger:route GET /domains managed_domains listManagedDomains
+/*ListManagedDomains swagger:route GET /v1/domains managed_domains listManagedDomains
 
 List of managed DNS domains.
 

--- a/restapi/operations/managed_domains/list_managed_domains_urlbuilder.go
+++ b/restapi/operations/managed_domains/list_managed_domains_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *ListManagedDomainsURL) SetBasePath(bp string) {
 func (o *ListManagedDomainsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/domains"
+	var _path = "/v1/domains"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/manifests/create_cluster_manifest.go
+++ b/restapi/operations/manifests/create_cluster_manifest.go
@@ -29,7 +29,7 @@ func NewCreateClusterManifest(ctx *middleware.Context, handler CreateClusterMani
 	return &CreateClusterManifest{Context: ctx, Handler: handler}
 }
 
-/*CreateClusterManifest swagger:route POST /clusters/{cluster_id}/manifests manifests createClusterManifest
+/*CreateClusterManifest swagger:route POST /v1/clusters/{cluster_id}/manifests manifests createClusterManifest
 
 Creates a manifest for customizing cluster installation.
 

--- a/restapi/operations/manifests/create_cluster_manifest_urlbuilder.go
+++ b/restapi/operations/manifests/create_cluster_manifest_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *CreateClusterManifestURL) SetBasePath(bp string) {
 func (o *CreateClusterManifestURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/manifests"
+	var _path = "/v1/clusters/{cluster_id}/manifests"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *CreateClusterManifestURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/manifests/delete_cluster_manifest.go
+++ b/restapi/operations/manifests/delete_cluster_manifest.go
@@ -29,7 +29,7 @@ func NewDeleteClusterManifest(ctx *middleware.Context, handler DeleteClusterMani
 	return &DeleteClusterManifest{Context: ctx, Handler: handler}
 }
 
-/*DeleteClusterManifest swagger:route DELETE /clusters/{cluster_id}/manifests manifests deleteClusterManifest
+/*DeleteClusterManifest swagger:route DELETE /v1/clusters/{cluster_id}/manifests manifests deleteClusterManifest
 
 Deletes a manifest from the cluster.
 

--- a/restapi/operations/manifests/delete_cluster_manifest_urlbuilder.go
+++ b/restapi/operations/manifests/delete_cluster_manifest_urlbuilder.go
@@ -45,7 +45,7 @@ func (o *DeleteClusterManifestURL) SetBasePath(bp string) {
 func (o *DeleteClusterManifestURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/manifests"
+	var _path = "/v1/clusters/{cluster_id}/manifests"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -56,7 +56,7 @@ func (o *DeleteClusterManifestURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/manifests/download_cluster_manifest.go
+++ b/restapi/operations/manifests/download_cluster_manifest.go
@@ -29,7 +29,7 @@ func NewDownloadClusterManifest(ctx *middleware.Context, handler DownloadCluster
 	return &DownloadClusterManifest{Context: ctx, Handler: handler}
 }
 
-/*DownloadClusterManifest swagger:route GET /clusters/{cluster_id}/manifests/files manifests downloadClusterManifest
+/*DownloadClusterManifest swagger:route GET /v1/clusters/{cluster_id}/manifests/files manifests downloadClusterManifest
 
 Downloads cluster manifest.
 

--- a/restapi/operations/manifests/download_cluster_manifest_urlbuilder.go
+++ b/restapi/operations/manifests/download_cluster_manifest_urlbuilder.go
@@ -45,7 +45,7 @@ func (o *DownloadClusterManifestURL) SetBasePath(bp string) {
 func (o *DownloadClusterManifestURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/manifests/files"
+	var _path = "/v1/clusters/{cluster_id}/manifests/files"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -56,7 +56,7 @@ func (o *DownloadClusterManifestURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/manifests/list_cluster_manifests.go
+++ b/restapi/operations/manifests/list_cluster_manifests.go
@@ -29,7 +29,7 @@ func NewListClusterManifests(ctx *middleware.Context, handler ListClusterManifes
 	return &ListClusterManifests{Context: ctx, Handler: handler}
 }
 
-/*ListClusterManifests swagger:route GET /clusters/{cluster_id}/manifests manifests listClusterManifests
+/*ListClusterManifests swagger:route GET /v1/clusters/{cluster_id}/manifests manifests listClusterManifests
 
 Lists manifests for customizing cluster installation.
 

--- a/restapi/operations/manifests/list_cluster_manifests_urlbuilder.go
+++ b/restapi/operations/manifests/list_cluster_manifests_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *ListClusterManifestsURL) SetBasePath(bp string) {
 func (o *ListClusterManifestsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/manifests"
+	var _path = "/v1/clusters/{cluster_id}/manifests"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *ListClusterManifestsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/operators/list_of_cluster_operators.go
+++ b/restapi/operations/operators/list_of_cluster_operators.go
@@ -29,7 +29,7 @@ func NewListOfClusterOperators(ctx *middleware.Context, handler ListOfClusterOpe
 	return &ListOfClusterOperators{Context: ctx, Handler: handler}
 }
 
-/*ListOfClusterOperators swagger:route GET /clusters/{cluster_id}/monitored_operators operators installer listOfClusterOperators
+/*ListOfClusterOperators swagger:route GET /v1/clusters/{cluster_id}/monitored_operators operators installer listOfClusterOperators
 
 Lists operators to be monitored for a cluster.
 

--- a/restapi/operations/operators/list_of_cluster_operators_urlbuilder.go
+++ b/restapi/operations/operators/list_of_cluster_operators_urlbuilder.go
@@ -44,7 +44,7 @@ func (o *ListOfClusterOperatorsURL) SetBasePath(bp string) {
 func (o *ListOfClusterOperatorsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/monitored_operators"
+	var _path = "/v1/clusters/{cluster_id}/monitored_operators"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -55,7 +55,7 @@ func (o *ListOfClusterOperatorsURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/operators/list_operator_properties.go
+++ b/restapi/operations/operators/list_operator_properties.go
@@ -29,7 +29,7 @@ func NewListOperatorProperties(ctx *middleware.Context, handler ListOperatorProp
 	return &ListOperatorProperties{Context: ctx, Handler: handler}
 }
 
-/*ListOperatorProperties swagger:route GET /supported-operators/{operator_name} operators listOperatorProperties
+/*ListOperatorProperties swagger:route GET /v1/supported-operators/{operator_name} operators listOperatorProperties
 
 Lists properties for an operator.
 

--- a/restapi/operations/operators/list_operator_properties_urlbuilder.go
+++ b/restapi/operations/operators/list_operator_properties_urlbuilder.go
@@ -40,7 +40,7 @@ func (o *ListOperatorPropertiesURL) SetBasePath(bp string) {
 func (o *ListOperatorPropertiesURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/supported-operators/{operator_name}"
+	var _path = "/v1/supported-operators/{operator_name}"
 
 	operatorName := o.OperatorName
 	if operatorName != "" {
@@ -51,7 +51,7 @@ func (o *ListOperatorPropertiesURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/operators/list_supported_operators.go
+++ b/restapi/operations/operators/list_supported_operators.go
@@ -29,7 +29,7 @@ func NewListSupportedOperators(ctx *middleware.Context, handler ListSupportedOpe
 	return &ListSupportedOperators{Context: ctx, Handler: handler}
 }
 
-/*ListSupportedOperators swagger:route GET /supported-operators operators listSupportedOperators
+/*ListSupportedOperators swagger:route GET /v1/supported-operators operators listSupportedOperators
 
 Retrieves the list of supported operators.
 

--- a/restapi/operations/operators/list_supported_operators_urlbuilder.go
+++ b/restapi/operations/operators/list_supported_operators_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *ListSupportedOperatorsURL) SetBasePath(bp string) {
 func (o *ListSupportedOperatorsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/supported-operators"
+	var _path = "/v1/supported-operators"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/operators/report_monitored_operator_status.go
+++ b/restapi/operations/operators/report_monitored_operator_status.go
@@ -29,7 +29,7 @@ func NewReportMonitoredOperatorStatus(ctx *middleware.Context, handler ReportMon
 	return &ReportMonitoredOperatorStatus{Context: ctx, Handler: handler}
 }
 
-/*ReportMonitoredOperatorStatus swagger:route PUT /clusters/{cluster_id}/monitored_operators operators installer reportMonitoredOperatorStatus
+/*ReportMonitoredOperatorStatus swagger:route PUT /v1/clusters/{cluster_id}/monitored_operators operators installer reportMonitoredOperatorStatus
 
 Controller API to report of monitored operators.
 

--- a/restapi/operations/operators/report_monitored_operator_status_urlbuilder.go
+++ b/restapi/operations/operators/report_monitored_operator_status_urlbuilder.go
@@ -42,7 +42,7 @@ func (o *ReportMonitoredOperatorStatusURL) SetBasePath(bp string) {
 func (o *ReportMonitoredOperatorStatusURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/clusters/{cluster_id}/monitored_operators"
+	var _path = "/v1/clusters/{cluster_id}/monitored_operators"
 
 	clusterID := o.ClusterID.String()
 	if clusterID != "" {
@@ -53,7 +53,7 @@ func (o *ReportMonitoredOperatorStatusURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/versions/list_component_versions.go
+++ b/restapi/operations/versions/list_component_versions.go
@@ -29,7 +29,7 @@ func NewListComponentVersions(ctx *middleware.Context, handler ListComponentVers
 	return &ListComponentVersions{Context: ctx, Handler: handler}
 }
 
-/*ListComponentVersions swagger:route GET /component_versions versions listComponentVersions
+/*ListComponentVersions swagger:route GET /v1/component_versions versions listComponentVersions
 
 List of component versions.
 

--- a/restapi/operations/versions/list_component_versions_urlbuilder.go
+++ b/restapi/operations/versions/list_component_versions_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *ListComponentVersionsURL) SetBasePath(bp string) {
 func (o *ListComponentVersionsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/component_versions"
+	var _path = "/v1/component_versions"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/restapi/operations/versions/list_supported_openshift_versions.go
+++ b/restapi/operations/versions/list_supported_openshift_versions.go
@@ -29,7 +29,7 @@ func NewListSupportedOpenshiftVersions(ctx *middleware.Context, handler ListSupp
 	return &ListSupportedOpenshiftVersions{Context: ctx, Handler: handler}
 }
 
-/*ListSupportedOpenshiftVersions swagger:route GET /openshift_versions versions listSupportedOpenshiftVersions
+/*ListSupportedOpenshiftVersions swagger:route GET /v1/openshift_versions versions listSupportedOpenshiftVersions
 
 Retrieves the list of OpenShift supported versions.
 

--- a/restapi/operations/versions/list_supported_openshift_versions_urlbuilder.go
+++ b/restapi/operations/versions/list_supported_openshift_versions_urlbuilder.go
@@ -35,11 +35,11 @@ func (o *ListSupportedOpenshiftVersionsURL) SetBasePath(bp string) {
 func (o *ListSupportedOpenshiftVersionsURL) Build() (*url.URL, error) {
 	var _result url.URL
 
-	var _path = "/openshift_versions"
+	var _path = "/v1/openshift_versions"
 
 	_basePath := o._basePath
 	if _basePath == "" {
-		_basePath = "/api/assisted-install/v1"
+		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7,7 +7,7 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
 host: api.openshift.com
-basePath: /api/assisted-install/v1
+basePath: /api/assisted-install
 tags:
   - name: Assisted installation
     description: Agent-driven installation
@@ -52,7 +52,7 @@ security:
   - userAuth: [admin, user]
 
 paths:
-  /clusters:
+  /v1/clusters:
     post:
       tags:
         - installer
@@ -150,7 +150,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}:
+  /v1/clusters/{cluster_id}:
     get:
       tags:
         - installer
@@ -299,7 +299,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/downloads/image:
+  /v1/clusters/{cluster_id}/downloads/image:
     post:
       tags:
         - installer
@@ -452,7 +452,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/downloads/files:
+  /v1/clusters/{cluster_id}/downloads/files:
     get:
       tags:
         - installer
@@ -516,7 +516,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/downloads/files-presigned:
+  /v1/clusters/{cluster_id}/downloads/files-presigned:
     get:
       tags:
         - installer
@@ -588,7 +588,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/credentials:
+  /v1/clusters/{cluster_id}/credentials:
     get:
       tags:
         - installer
@@ -633,7 +633,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/downloads/kubeconfig:
+  /v1/clusters/{cluster_id}/downloads/kubeconfig:
     get:
       tags:
         - installer
@@ -681,7 +681,7 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
-  /clusters/default-config:
+  /v1/clusters/default-config:
     get:
       tags:
         - installer
@@ -707,7 +707,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/install-config:
+  /v1/clusters/{cluster_id}/install-config:
     get:
       tags:
         - installer
@@ -793,7 +793,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/discovery-ignition:
+  /v1/clusters/{cluster_id}/discovery-ignition:
     get:
       tags:
         - installer
@@ -882,7 +882,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/manifests:
+  /v1/clusters/{cluster_id}/manifests:
     get:
       tags:
         - manifests
@@ -1033,7 +1033,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/manifests/files:
+  /v1/clusters/{cluster_id}/manifests/files:
     get:
       tags:
         - manifests
@@ -1092,7 +1092,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/uploads/ingress-cert:
+  /v1/clusters/{cluster_id}/uploads/ingress-cert:
     post:
       tags:
         - installer
@@ -1150,7 +1150,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/actions/install:
+  /v1/clusters/{cluster_id}/actions/install:
     post:
       tags:
         - installer
@@ -1197,7 +1197,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/actions/cancel:
+  /v1/clusters/{cluster_id}/actions/cancel:
     post:
       tags:
         - installer
@@ -1240,7 +1240,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/actions/install_hosts:
+  /v1/clusters/{cluster_id}/actions/install_hosts:
     post:
       tags:
         - installer
@@ -1287,7 +1287,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/actions/reset:
+  /v1/clusters/{cluster_id}/actions/reset:
     post:
       tags:
         - installer
@@ -1330,7 +1330,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/actions/complete_installation:
+  /v1/clusters/{cluster_id}/actions/complete_installation:
     post:
       tags:
         - installer
@@ -1390,7 +1390,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts:
+  /v1/clusters/{cluster_id}/hosts:
     post:
       tags:
         - installer
@@ -1500,7 +1500,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}:
+  /v1/clusters/{cluster_id}/hosts/{host_id}:
     get:
       tags:
         - installer
@@ -1593,7 +1593,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/installer-args:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args:
     patch:
       tags:
         - installer
@@ -1652,7 +1652,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/progress:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/progress:
     put:
       tags:
         - installer
@@ -1712,7 +1712,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/actions/enable:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable:
     post:
       tags:
         - installer
@@ -1809,7 +1809,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/actions/install:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install:
     post:
       tags:
         - installer
@@ -1854,7 +1854,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/actions/reset:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset:
     post:
       tags:
         - installer
@@ -1899,7 +1899,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id}:
     patch:
       tags:
         - installer
@@ -1954,7 +1954,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/instructions:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/instructions:
     get:
       tags:
         - installer
@@ -2072,7 +2072,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/logs_progress:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/logs_progress:
     put:
       tags:
         - installer
@@ -2131,7 +2131,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/logs:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/logs:
     post:
       tags:
         - installer
@@ -2247,7 +2247,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/ignition:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/ignition:
     get:
       tags:
         - installer
@@ -2347,7 +2347,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/hosts/{host_id}/downloads/ignition:
+  /v1/clusters/{cluster_id}/hosts/{host_id}/downloads/ignition:
     get:
       tags:
         - installer
@@ -2405,7 +2405,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/logs_progress:
+  /v1/clusters/{cluster_id}/logs_progress:
     put:
       tags:
         - installer
@@ -2458,7 +2458,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/logs:
+  /v1/clusters/{cluster_id}/logs:
     post:
       tags:
         - installer
@@ -2578,7 +2578,7 @@ paths:
             $ref: '#/definitions/error'
 
   # The following API call should be admin only
-  /clusters/{cluster_id}/free_addresses:
+  /v1/clusters/{cluster_id}/free_addresses:
     get:
       tags:
         - installer
@@ -2638,7 +2638,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/events:
+  /v1/clusters/{cluster_id}/events:
     get:
       tags:
         - events
@@ -2693,7 +2693,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/monitored_operators:
+  /v1/clusters/{cluster_id}/monitored_operators:
     get:
       tags:
         - operators
@@ -2796,7 +2796,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/host-requirements:
+  /v1/clusters/{cluster_id}/host-requirements:
     get:
       tags:
         - installer
@@ -2837,7 +2837,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /clusters/{cluster_id}/preflight-requirements:
+  /v1/clusters/{cluster_id}/preflight-requirements:
     get:
       tags:
         - installer
@@ -2878,7 +2878,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /domains:
+  /v1/domains:
     get:
       tags:
         - managed_domains
@@ -2896,7 +2896,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /component_versions:
+  /v1/component_versions:
     get:
       tags:
         - versions
@@ -2910,7 +2910,7 @@ paths:
           schema:
             $ref: '#/definitions/list-versions'
 
-  /openshift_versions:
+  /v1/openshift_versions:
     get:
       tags:
         - versions
@@ -2928,7 +2928,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /supported-operators:
+  /v1/supported-operators:
     get:
       tags:
         - operators
@@ -2954,7 +2954,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /supported-operators/{operator_name}:
+  /v1/supported-operators/{operator_name}:
     get:
       tags:
         - operators
@@ -2990,7 +2990,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /add_hosts_clusters:
+  /v1/add_hosts_clusters:
     post:
       tags:
         - installer
@@ -3025,7 +3025,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /assisted-service-iso:
+  /v1/assisted-service-iso:
     post:
       tags:
         - assisted-service-iso
@@ -3058,7 +3058,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /assisted-service-iso/data:
+  /v1/assisted-service-iso/data:
     get:
       tags:
         - assisted-service-iso
@@ -3092,7 +3092,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /assisted-service-iso/presigned:
+  /v1/assisted-service-iso/presigned:
     get:
       tags:
         - assisted-service-iso
@@ -3122,7 +3122,7 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
-  /infra-envs:
+  /v2/infra-envs:
     post:
       tags:
         - installer


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR removed "/v1" from the basePath in the swagger and add /v1 or /v2 prefix to each path in the swagger

## List all the issues related to this PR

- [X] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

@avishayt @yevgeny-shnaidman @ori-amizur @eliorerz 

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
