### PR TITLE
MGMT-7297: Add view agent logs command to the agent message of the day

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -77,8 +77,12 @@ const agentMessageOfTheDay = `
 **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  ** **  **  **  **  **  **  **
 This is a host being installed by the OpenShift Assisted Installer.
 It will be installed from scratch during the installation.
-The primary service is agent.service.  To watch its status run e.g
+
+The primary service is agent.service. To watch its status, run:
 sudo journalctl -u agent.service
+
+To view the agent log, run:
+sudo journalctl TAG=agent
 **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  ** **  **  **  **  **  **  **
 `
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

The message of the day is shown whenever logging into the agent node.

It should provide information about how to debug the agent in case necessary. Currently it guides how to watch the agent status. it should include as well how to monitor the agent logs.
```
This is a host being installed by the OpenShift Assisted Installer.
It will be installed from scratch during the installation.

The primary service is agent.service. To watch its status, run:
sudo journalctl -u agent.service

To view the agent log, run:
sudo journalctl TAG=agent
```

## List all the issues related to this PR

- [x] Documentation

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments

## How was this code tested?

- [x] No tests needed

## Assignees

/cc @empovit 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
