### PR TITLE
Bug 1983412: Wrong validation status for network&packet loss

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -701,8 +701,9 @@ func (v *validator) hasSufficientNetworkLatencyRequirementForRole(c *validationC
 	}
 
 	if len(c.host.Connectivity) == 0 {
-		return ValidationFailure
+		return ValidationPending
 	}
+
 	status, _, _ := v.validateNetworkLatencyForRole(c.host, c.clusterHostRequirements, c.cluster.Hosts)
 	return status
 }
@@ -748,6 +749,8 @@ func (v *validator) printSufficientNetworkLatencyRequirementForRole(c *validatio
 		}
 		sort.Strings(hostNames)
 		return fmt.Sprintf("Network latency requirements of less or equals than %.3f ms not met for connectivity between %s and %s.", *c.clusterHostRequirements.Total.NetworkLatencyThresholdMs, c.host.ID, strings.Join(hostNames, ","))
+	case ValidationPending:
+		return "Missing network latency information."
 	default:
 		return fmt.Sprintf("Unexpected status %s", status)
 	}
@@ -761,8 +764,9 @@ func (v *validator) hasSufficientPacketLossRequirementForRole(c *validationConte
 	}
 
 	if len(c.host.Connectivity) == 0 {
-		return ValidationFailure
+		return ValidationPending
 	}
+
 	status, _, _ := v.validatePacketLossForRole(c.host, c.clusterHostRequirements, c.cluster.Hosts)
 	return status
 }
@@ -809,6 +813,8 @@ func (v *validator) printSufficientPacketLossRequirementForRole(c *validationCon
 		}
 		sort.Strings(hostNames)
 		return fmt.Sprintf("Packet loss percentage requirement of less or equals than %.2f%% not met for connectivity between %s and %s.", *c.clusterHostRequirements.Total.PacketLossPercentage, c.host.ID, strings.Join(hostNames, ","))
+	case ValidationPending:
+		return "Missing packet loss information."
 	default:
 		return fmt.Sprintf("Unexpected status %s", status)
 	}


### PR DESCRIPTION
# Assisted Pull Request

## Description

When connectivity report is missing in the host, the validation should be `ValidationPending`. This PR changes the status from `ValidationFailure` to `ValidationPending`.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @lalon4 

/assign @ori-amizur 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
