### PR TITLE
MGMT-7306: Use local CI image for spectral if it is available

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -8,8 +8,15 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
 function lint_swagger() {
+    SPECTRAL_IMAGE_REPO="docker.io/stoplight/spectral"
+    # Check to see if we are running in Prow CI and use local CI registry
+    if command oc get is stoplight-spectral -n ci &> /dev/null; then
+        SPECTRAL_IMAGE_REPO=$(oc get is stoplight-spectral -n ci -o json | jq .status.dockerImageRepository)
+    fi
+
+    # Check to see if spectral is installed otherwise download docker image
     if ! command -v spectral &> /dev/null; then
-        docker run --rm -it docker.io/stoplight/spectral:latest lint swagger.yaml
+        docker run --rm -it ${SPECTRAL_IMAGE_REPO}:latest lint swagger.yaml
     else
         spectral lint swagger.yaml
     fi


### PR DESCRIPTION
# Assisted Pull Request

## Description

In Prow CI image pulls to the external image registry, docker.io, are rate limited. Check for the image in the local CI image registry and use it instead of pulling from docker.io.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I ran `make generate-all` locally on my machine while logged in to the CI OCP cluster. This will affect the jobs that use assisted-test-infra so we should wait for those to pass.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @YuviGold 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [x] Should this PR be backported?

RE: Backporting if this setting for spectral stays in the assisted-service repo will need to be backported at some point for ocm-2.3.z releases. 🤔 

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
