### PR TITLE
MGMT-7308: Increase timeout for agents in ZTP flow

### DIFF
--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -63,7 +63,7 @@ wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "ImageCreated" "5m" "${S
 
 echo "Waiting until at least ${CONTROL_PLANE_COUNT} agents are available..."
 export -f wait_for_object_amount
-timeout 10m bash -c "wait_for_object_amount agent ${CONTROL_PLANE_COUNT} 30 ${SPOKE_NAMESPACE}"
+timeout 20m bash -c "wait_for_object_amount agent ${CONTROL_PLANE_COUNT} 30 ${SPOKE_NAMESPACE}"
 echo "All ${CONTROL_PLANE_COUNT} agents have joined!"
 
 wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "Completed" "60m" "${SPOKE_NAMESPACE}"


### PR DESCRIPTION

# Assisted Pull Request

## Description

We are noticing that it is taking longer for the agents to join in this flow. Increasing the timeout as a start towards debugging.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
