### PR TITLE
MGMT-5171: Mirror OCP release image to a single repository

### DIFF
--- a/deploy/operator/deploy.sh
+++ b/deploy/operator/deploy.sh
@@ -37,15 +37,10 @@ function setup_disconnected_parameters() {
 
     ${__root}/hack/setup_env.sh hive_from_upstream
 
-    # The mirror should point all the release images and not just the OpenShift release image itself.
-    # An arbitrary image (cli) is chosen to retreive its pull spec, in order to mirror its repository.
-    cli_image=$(podman run --quiet --rm --net=none "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}" image cli)
-
     ocp_mirror_release \
         "${PULL_SECRET_FILE}" \
         "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}" \
-        "${LOCAL_REGISTRY}/$(get_image_repository_only ${cli_image})" \
-        "${LOCAL_REGISTRY}/$(get_image_without_registry ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})"
+        "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})"
 }
 
 set -o xtrace

--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -118,10 +118,8 @@ function ocp_mirror_release() {
   pull_secret_file="${1}"
   source_image="${2}"
   dest_mirror_repo="${3}"
-  dest_mirror_image="${4}"
 
-  oc adm -a ${pull_secret_file} release mirror \
-         --from=${source_image} \
-         --to=${dest_mirror_repo} \
-         --to-release-image=${dest_mirror_image}
+  oc adm -a "${pull_secret_file}" release mirror \
+         --from="${source_image}" \
+         --to="${dest_mirror_repo}"
 }

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -207,7 +207,7 @@ data:
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 
     $(registry_config "$(get_image_without_tag ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
-    $(registry_config "$(get_image_without_tag ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${cli_image})")
+    $(registry_config "$(get_image_without_tag ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
     $(for row in $(kubectl get imagecontentsourcepolicy -o json |
         jq -rc ".items[] | select(.metadata.name | test(\"${assisted_index_image}\")).spec.repositoryDigestMirrors[] | [.mirrors[0], .source]"); do
       row=$(echo ${row} | tr -d '[]"');


### PR DESCRIPTION
# Assisted Pull Request

## Description

No reason to use `--to-release-image` flag that just confuses the release
images into 2 different repositories. It would be much simpler if the
release image and the operators images would be in the same place

From the help message:

```
      --to-release-image='': Specify an alternate locations for the release image instead as tag 'release' in --to.
```

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Waiting for CI to do a full test run

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @lranjbar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
