### PR TITLE
Bug 1975383: Add a ntp source validation in OCS

### DIFF
--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -44,7 +44,8 @@ var _ = BeforeEach(func() {
 	clusterID := strfmt.UUID(uuid.New().String())
 	cluster = &common.Cluster{
 		Cluster: models.Cluster{
-			ID: &clusterID,
+			AdditionalNtpSource: "1.1.1.1,clock.redhat.com",
+			ID:                  &clusterID,
 		},
 	}
 	cluster.ImageInfo = &models.ImageInfo{}

--- a/internal/operators/ocs/validations.go
+++ b/internal/operators/ocs/validations.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/models"
@@ -35,6 +36,11 @@ func (o *operator) validateRequirements(cluster *models.Cluster) (api.Validation
 	var status string
 	hosts := cluster.Hosts
 	numAvailableHosts := int64(len(hosts))
+
+	if !validations.ValidateAdditionalNTPSource(cluster.AdditionalNtpSource) {
+		status = "NTP source must be provided for OCS."
+		return api.Failure, status
+	}
 
 	if numAvailableHosts < o.config.OCSNumMinimumHosts {
 		status = "A minimum of 3 hosts is required to deploy OCS."


### PR DESCRIPTION
# Assisted Pull Request

## Description
If NTP is not configured but the host's time is in sync then OCP installation will succeed and OCS will be deployed but CEPH will be in HealthWarn status. So, OCS should enforce the validation that NTP is configured, before installation.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @gobindadas 
/cc @ronniel1 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

Signed-off-by: Rewant Soni <resoni@redhat.com>