### PR TITLE
NO-ISSUE: Adding BE progress for day2 hosts.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3821,8 +3821,6 @@ func (b *bareMetalInventory) UpdateHostInstallProgress(ctx context.Context, para
 			WithPayload(common.GenerateError(http.StatusNotFound, err))
 	}
 
-	//FIXME: do we need a transaction here? I am guessing that if the call failed the host will retry anyway no?!
-	// Adding a transaction will require to update all lower layer to work with tx instead of db.
 	if params.HostProgress.CurrentStage != host.Progress.CurrentStage || params.HostProgress.ProgressInfo != host.Progress.ProgressInfo {
 		if err := b.hostApi.UpdateInstallProgress(ctx, &host.Host, params.HostProgress); err != nil {
 			log.WithError(err).Errorf("failed to update host %s progress", params.HostID)

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -489,6 +489,11 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 		}
 
 		stages := m.GetStagesByRole(h.Role, h.Bootstrap)
+		// for day2 hosts, rebooting stage is considered as the last state as we don't have any way to follow up on it further.
+		if *h.Kind == models.HostKindAddToExistingClusterHost {
+			rebootingIndex := m.IndexOfStage(models.HostStageRebooting, stages)
+			stages = stages[:rebootingIndex+1]
+		}
 		currentIndex := m.IndexOfStage(progress.CurrentStage, stages)
 		installationPercentage := (float64(currentIndex+1) / float64(len(stages))) * 100
 		extra = append(extra, "progress_installation_percentage", installationPercentage)


### PR DESCRIPTION
# Assisted Pull Request

For day2 hosts, 'Rebooting' stage is the last known stage as the
controller doesn't run anymore on the client's cluster, and even if
it did we shouldn't access user's clusters, therefore, it should be
taken into consideration when computing the host progress percentage.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
