### PR TITLE
MGMT-7319 remove ntp validation from kube-api test

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1658,18 +1658,6 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return aci.Status.DebugInfo.LogsURL
 		}, "30s", "10s").Should(Equal(""))
 
-		By("Check NTP Source")
-		generateNTPPostStepReply(ctx, host, []*models.NtpSource{
-			{SourceName: common.TestNTPSourceSynced.SourceName, SourceState: models.SourceStateUnreachable},
-		})
-		Eventually(func() bool {
-			agent := getAgentCRD(ctx, kubeClient, key)
-			return agent.Status.NtpSources != nil &&
-				agent.Status.NtpSources[0].SourceName == common.TestNTPSourceSynced.SourceName &&
-				agent.Status.NtpSources[0].SourceState == models.SourceStateUnreachable
-
-		}, "60s", "1s").Should(BeTrue())
-
 		By("Verify Agent labels")
 		labels[v1beta1.InfraEnvNameLabel] = infraNsName.Name
 		Eventually(func() map[string]string {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Remove ntp validation from 'SNO deploy clusterDeployment full install
and validate MetaData'
because ntp doesn't affect agent state there are some reces that can
cause this validation to fail for example:
1. Host is registered and get inventory
2. Monitor set the host to known state
3. Test set ntp to success then to failure (time diff less the a sec)
4. Monitor triggered again but when comparing the old validation info
   with the new he see only the failed state, current status is empty
   so the controller doesn't get any notification.
There is a unit test that check that NTP info is copied from the backend
so this test case covered in unit tests.

It's possible to resolve it by reporting the ntp before reporting inventory but it feels hacky

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @YuviGold 
/cc @rollandf 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
