### PR TITLE
MGMT-7268: Remove SupportFreeAddresses

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -256,7 +256,7 @@ func main() {
 	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler)
 	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
-	Options.InstructionConfig.SupportFreeAddresses = Options.InstructionConfig.SupportFreeAddresses && !Options.EnableKubeAPI
+	Options.InstructionConfig.DisabledSteps = disableFreeAddressesIfNeeded(Options.EnableKubeAPI, Options.InstructionConfig.DisabledSteps)
 	instructionApi := hostcommands.NewInstructionManager(log.WithField("pkg", "instructions"), db, hwValidator,
 		releaseHandler, Options.InstructionConfig, connectivityValidator, eventsHandler, versionHandler)
 
@@ -744,4 +744,12 @@ func createControllerManager() (manager.Manager, error) {
 		})
 	}
 	return nil, nil
+}
+
+func disableFreeAddressesIfNeeded(enableKubeAPI bool, disabledSteps []models.StepType) []models.StepType {
+	if enableKubeAPI {
+		// If this step was already disabled via environment, it wont matter once parsed.
+		return append(disabledSteps, models.StepTypeFreeNetworkAddresses)
+	}
+	return disabledSteps
 }

--- a/internal/host/hostcommands/free_addresses_cmd.go
+++ b/internal/host/hostcommands/free_addresses_cmd.go
@@ -17,10 +17,7 @@ type freeAddressesCmd struct {
 	freeAddressesImage string
 }
 
-func newFreeAddressesCmd(log logrus.FieldLogger, freeAddressesImage string, enabled bool) CommandGetter {
-	if !enabled {
-		return NewNoopCmd()
-	}
+func newFreeAddressesCmd(log logrus.FieldLogger, freeAddressesImage string) CommandGetter {
 	return &freeAddressesCmd{
 		baseCmd:            baseCmd{log: log},
 		freeAddressesImage: freeAddressesImage,

--- a/internal/host/hostcommands/free_addresses_cmd_test.go
+++ b/internal/host/hostcommands/free_addresses_cmd_test.go
@@ -22,84 +22,42 @@ var _ = Describe("free_addresses", func() {
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		fCmd = newFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest")
 
-	Context("Enabled", func() {
-		BeforeEach(func() {
-			db, dbName = common.PrepareTestDB()
-			fCmd = newFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest", true)
-
-			id = strfmt.UUID(uuid.New().String())
-			clusterId = strfmt.UUID(uuid.New().String())
-			host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
-			host.Inventory = common.GenerateTestDefaultInventory()
-			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-		})
-
-		It("happy flow", func() {
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).ToNot(BeNil())
-			Expect(stepReply[0].StepType).To(Equal(models.StepTypeFreeNetworkAddresses))
-			Expect(stepErr).ShouldNot(HaveOccurred())
-		})
-
-		It("Illegal inventory", func() {
-			host.Inventory = "blah"
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).To(BeNil())
-			Expect(stepErr).To(HaveOccurred())
-		})
-
-		It("Missing networks", func() {
-			host.Inventory = "{}"
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).To(BeNil())
-			Expect(stepErr).To(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			// cleanup
-			common.DeleteTestDB(db, dbName)
-			stepReply = nil
-			stepErr = nil
-		})
+		id = strfmt.UUID(uuid.New().String())
+		clusterId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+		host.Inventory = common.GenerateTestDefaultInventory()
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
-	Context("Disabled", func() {
-		BeforeEach(func() {
-			db, dbName = common.PrepareTestDB()
-			fCmd = newFreeAddressesCmd(common.GetTestLog(), "quay.io/ocpmetal/free_addresses:latest", false)
 
-			id = strfmt.UUID(uuid.New().String())
-			clusterId = strfmt.UUID(uuid.New().String())
-			host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
-			host.Inventory = common.GenerateTestDefaultInventory()
-			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-		})
+	It("happy flow", func() {
+		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+		Expect(stepReply).ToNot(BeNil())
+		Expect(stepReply[0].StepType).To(Equal(models.StepTypeFreeNetworkAddresses))
+		Expect(stepErr).ShouldNot(HaveOccurred())
+	})
 
-		It("happy flow", func() {
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).To(BeNil())
-			Expect(stepErr).ShouldNot(HaveOccurred())
-		})
+	It("Illegal inventory", func() {
+		host.Inventory = "blah"
+		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+		Expect(stepReply).To(BeNil())
+		Expect(stepErr).To(HaveOccurred())
+	})
 
-		It("Illegal inventory", func() {
-			host.Inventory = "blah"
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).To(BeNil())
-			Expect(stepErr).ShouldNot(HaveOccurred())
-		})
+	It("Missing networks", func() {
+		host.Inventory = "{}"
+		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+		Expect(stepReply).To(BeNil())
+		Expect(stepErr).To(HaveOccurred())
+	})
 
-		It("Missing networks", func() {
-			host.Inventory = "{}"
-			stepReply, stepErr = fCmd.GetSteps(ctx, &host)
-			Expect(stepReply).To(BeNil())
-			Expect(stepErr).ShouldNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			// cleanup
-			common.DeleteTestDB(db, dbName)
-			stepReply = nil
-			stepErr = nil
-		})
+	AfterEach(func() {
+		// cleanup
+		common.DeleteTestDB(db, dbName)
+		stepReply = nil
+		stepErr = nil
 	})
 })

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -50,7 +50,6 @@ var _ = Describe("instruction_manager", func() {
 		hwValidator = hardware.NewMockValidator(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		cnValidator = connectivity.NewMockValidator(ctrl)
-		instructionConfig.SupportFreeAddresses = true
 		instMng = NewInstructionManager(common.GetTestLog(), db, hwValidator, mockRelease, instructionConfig, cnValidator, mockEvents, mockVersions)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
@@ -255,6 +254,17 @@ var _ = Describe("instruction_manager", func() {
 					models.StepTypeDhcpLeaseAllocate,
 				})
 				checkStep(models.HostStatusError, []models.StepType{})
+			})
+			It("Should skip 'StepTypeFreeNetworkAddresses' when: HostState=insufficient DisabledSteps=StepTypeFreeNetworkAddresses", func() {
+				instMng = createInstMngWithDisabledSteps([]models.StepType{
+					models.StepTypeFreeNetworkAddresses,
+				})
+				checkStep(models.HostStatusInsufficient, []models.StepType{
+					models.StepTypeInventory,
+					models.StepTypeConnectivityCheck,
+					models.StepTypeDhcpLeaseAllocate,
+					models.StepTypeNtpSynchronizer,
+				})
 			})
 		})
 	})


### PR DESCRIPTION
# Assisted Pull Request

## Description
using DISABLED_STEPS to achieve what SupportFreeAddresses did.

Removed the need for `SUPPORT_FREE_ADDRESSES` environment variable.
SUPPORT_FREE_ADDRESSES was true by default. this aligns with the fact that `StepTypeFreeNetworkAddresses` is enabled by default (all steps are).

When running with `enableKubeAPI=true` we force `StepTypeFreeNetworkAddresses` to be disabled.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @YuviGold 
/cc @ori-amizur 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/hold
