### PR TITLE
Bug 1985449: Use report variable for unmarshaling

### DIFF
--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -533,7 +533,7 @@ func (m *MetricsManager) NetworkLatencyBetweenHosts(openshiftVersion string, sou
 	m.serviceLogicNetworkLatencyMilliseconds.WithLabelValues(openshiftVersion, string(sourceRole), string(targetRole)).Observe(latency)
 }
 func (m *MetricsManager) PacketLossBetweenHosts(openshiftVersion string, sourceRole, targetRole models.HostRole, packetLoss float64) {
-	m.serviceLogicNetworkLatencyMilliseconds.WithLabelValues(openshiftVersion, string(sourceRole), string(targetRole)).Observe(packetLoss)
+	m.serviceLogicPacketLossPercentage.WithLabelValues(openshiftVersion, string(sourceRole), string(targetRole)).Observe(packetLoss)
 }
 
 func bytesToGib(bytes int64) int64 {

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -31,6 +31,8 @@ const (
 	hostValidationChangedMetric    = "assisted_installer_host_validation_failed_after_success_before_installation"
 	clusterValidationFailedMetric  = "assisted_installer_cluster_validation_is_in_failed_status_on_cluster_deletion"
 	clusterValidationChangedMetric = "assisted_installer_cluster_validation_failed_after_success_before_installation"
+	networkLatencyMetric           = "service_assisted_installer_host_network_latency_in_ms_bucket"
+	packetLossMetric               = "service_assisted_installer_packet_loss_percentage_bucket"
 )
 
 var (
@@ -898,6 +900,27 @@ var _ = Describe("Metrics tests", func() {
 
 			// check generated events
 			assertHostValidationEvent(ctx, clusterID, string(*h.ID), models.HostValidationIDNtpSynced, false)
+		})
+		Context("for network latency and packet loss", func() {
+			BeforeEach(func() {
+				// create hosts and report connectivity metrics
+				ips := hostutil.GenerateIPv4Addresses(3, defaultCIDRv4)
+				h1 := registerNode(ctx, clusterID, "h1", ips[0])
+				h2 := registerNode(ctx, clusterID, "h2", ips[1])
+				h3 := registerNode(ctx, clusterID, "h3", ips[2])
+				updateVipParams(ctx, clusterID)
+				generateFullMeshConnectivity(ctx, ips[0], h1, h2, h3)
+			}, 0)
+			It("validates 'sufficient-network-latency-requirement-for-role' is generated", func() {
+				record, err := getMetricRecord(networkLatencyMetric)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(record).NotTo(BeEmpty())
+			})
+			It("validates 'sufficient-packet-loss-requirement-for-role' is generated", func() {
+				record, err := getMetricRecord(packetLossMetric)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(record).NotTo(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

When capturing the connectivity report metrics, the method used to process the information contains the new report metrics, but the code inside discards it in favor of the old information in the host structure. This causes errors the first time the code runs, as there is no data available in the host to process.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/assign @filanov 
/cc @ori-amizur 
/cc @gamli75 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
