### PR TITLE
NO-ISSUE: Deploy MinIO as a LoadBalancer

### DIFF
--- a/deploy/s3/deployment.yaml
+++ b/deploy/s3/deployment.yaml
@@ -56,7 +56,12 @@ metadata:
   namespace: REPLACE_NAMESPACE
 spec:
   ports:
-    - port: 9000
+    - name: object-store
+      port: 9000
       protocol: TCP
+      targetPort: 9000
   selector:
     app: object-store
+  type: LoadBalancer
+status:
+  loadBalancer: {}


### PR DESCRIPTION
# Assisted Pull Request

## Description

It would allow reaching the MinIO UI from outside the cluster.
This way, a developer would be able to browse the storage easily.

![Screenshot from 2021-07-27 16-17-10](https://user-images.githubusercontent.com/29873449/127161170-cc8dc8f2-4ab2-4d66-a7ad-ef162777d8dc.png)


## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
