### PR TITLE
MGMT-7382: Delete clusters using REST API on subsystem tests

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -496,13 +496,13 @@ func randomNameSuffix() string {
 	return fmt.Sprintf("-%s", strings.Split(uuid.New().String(), "-")[0])
 }
 
-func cleanUP(ctx context.Context, client k8sclient.Client) {
+func cleanUpCRs(ctx context.Context, client k8sclient.Client) {
 	Expect(client.DeleteAllOf(ctx, &hivev1.ClusterDeployment{}, k8sclient.InNamespace(Options.Namespace))).To(BeNil()) // Should also delete all agents
 	Expect(client.DeleteAllOf(ctx, &hivev1.ClusterImageSet{}, k8sclient.InNamespace(Options.Namespace))).To(BeNil())
 	Expect(client.DeleteAllOf(ctx, &v1beta1.InfraEnv{}, k8sclient.InNamespace(Options.Namespace))).To(BeNil())
 	Expect(client.DeleteAllOf(ctx, &v1beta1.NMStateConfig{}, k8sclient.InNamespace(Options.Namespace))).To(BeNil())
 	Expect(client.DeleteAllOf(ctx, &bmhv1alpha1.BareMetalHost{}, k8sclient.InNamespace(Options.Namespace))).To(BeNil())
-	ps := &corev1.Secret{
+	secret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -513,7 +513,7 @@ func cleanUP(ctx context.Context, client k8sclient.Client) {
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 	}
-	Expect(client.Delete(ctx, ps)).To(BeNil())
+	Expect(client.Delete(ctx, secret)).To(BeNil())
 }
 
 func verifyCleanUP(ctx context.Context, client k8sclient.Client) {
@@ -606,7 +606,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 	})
 
 	AfterEach(func() {
-		cleanUP(ctx, kubeClient)
+		cleanUpCRs(ctx, kubeClient)
 		verifyCleanUP(ctx, kubeClient)
 		clearDB()
 	})
@@ -2475,7 +2475,7 @@ var _ = Describe("bmac reconcile flow", func() {
 	})
 
 	AfterEach(func() {
-		cleanUP(ctx, kubeClient)
+		cleanUpCRs(ctx, kubeClient)
 		clearDB()
 	})
 

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -161,11 +161,15 @@ func getValidationMetricCounter(validationID, expectedMetric string) int {
 	if len(filteredMetrics) == 0 {
 		return 0
 	}
-	Expect(len(filteredMetrics)).To(Equal(1))
 
-	counter, err := strconv.Atoi(strings.ReplaceAll((strings.Split(filteredMetrics[0], "}")[1]), " ", ""))
-	Expect(err).NotTo(HaveOccurred())
-	return counter
+	totalCounter := 0
+	for _, metric := range filteredMetrics {
+		metricCounter, err := strconv.Atoi(strings.ReplaceAll((strings.Split(metric, "}")[1]), " ", ""))
+		Expect(err).NotTo(HaveOccurred())
+		totalCounter += metricCounter
+	}
+
+	return totalCounter
 }
 
 func getMetricRecord(name string) (string, error) {


### PR DESCRIPTION
# Assisted Pull Request

## Description

When clearing the DB in the subsystem tests, we should
use also the REST API in order to delete any clusters' resources
managed by the service. (e.g. discovery ISO)

`DeregisterCluster` API isn't necessarily available (e.g. cluster is being installed)
So we would log in case of a failure.

Bugfix: Metrics tests were relying on having a singluar metric and
return its counter when the total of all the metrics should be verified.

## List all the issues related to this PR

- [x] Tests

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
