### PR TITLE
MGMT-6735: Add configurations for multi node spoke in ZTP

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -127,3 +127,10 @@ function get_image_repository_only() {
     # return "<repository>/<project>"
     get_image_without_registry $(get_image_without_tag "${1}")
 }
+
+function nth_ip() {
+  network=$1
+  idx=$2
+
+  python -c "from ansible.plugins.filter import ipaddr; print(ipaddr.nthhost('"$network"', $idx))"
+}

--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -8,8 +8,8 @@ spec:
     name: '{{ cluster_deployment_name }}'
   imageSetRef:
     name: '{{ cluster_image_set_name }}'
-  apiVIP: ""
-  ingressVIP: ""
+  apiVIP: '{{ spoke_api_vip }}'
+  ingressVIP: '{{ spoke_ingress_vip }}'
   networking:
     clusterNetwork:
     - cidr: {{ cluster_subnet }}
@@ -19,5 +19,5 @@ spec:
     serviceNetwork:
     - {{ service_subnet }}
   provisionRequirements:
-    controlPlaneAgents: 1
+    controlPlaneAgents: {{ spoke_controlplane_agents }}
   sshPublicKey: '{{ ssh_public_key }}'

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -5,6 +5,9 @@
   gather_facts: no
   vars:
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
+    - spoke_controlplane_agents: "{{ lookup('env', 'SPOKE_CONTROLPLANE_AGENTS') }}"
+    - spoke_api_vip: "{{ lookup('env', 'SPOKE_API_VIP') }}"
+    - spoke_ingress_vip: "{{ lookup('env', 'SPOKE_INGRESS_VIP') }}"
     - cluster_name: "{{ lookup('env', 'ASSISTED_CLUSTER_NAME') }}"
     - cluster_image_set_name: "{{ lookup('env', 'ASSISTED_OPENSHIFT_VERSION') }}"
     - cluster_release_image: "{{ lookup('env', 'ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE') }}"


### PR DESCRIPTION
# Assisted Pull Request

## Description

For [MGMT-6735](https://issues.redhat.com/browse/MGMT-6735) we are adding a multi node spoke cluster in the ZTP flow. This is configuration changes made in my local dev-scripts environment to support spoke clusters.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @osherdp
/cc @djzager 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
