### PR TITLE
MGMT-7333 Add a HoldInstallation flag to AgentClusterInstall

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -55,6 +55,8 @@ const (
 	ClusterInstallationFailedMsg        string = "The installation has failed:"
 	ClusterInstallationNotStartedReason string = "InstallationNotStarted"
 	ClusterInstallationNotStartedMsg    string = "The installation has not yet started"
+	ClusterInstallationOnHoldReason     string = "InstallationOnHold"
+	ClusterInstallationOnHoldMsg        string = "The installation is on hold. To unhold set holdInstallation to false"
 	ClusterInstallationInProgressReason string = "InstallationInProgress"
 	ClusterInstallationInProgressMsg    string = "The installation is in progress:"
 	ClusterUnknownStatusReason          string = "UnknownStatus"
@@ -138,6 +140,12 @@ type AgentClusterInstallSpec struct {
 	// IngressVIP is the virtual IP used for cluster ingress traffic.
 	// +optional
 	IngressVIP string `json:"ingressVIP,omitempty"`
+
+	// HoldInstallation will prevent installation from happening when true.
+	// Inspection and validation will proceed as usual, but once the RequirementsMet condition is true,
+	// installation will not begin until this field is set to false.
+	// +optional
+	HoldInstallation bool `json:"holdInstallation,omitempty"`
 }
 
 // AgentClusterInstallStatus defines the observed state of the AgentClusterInstall.

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -110,6 +110,9 @@ spec:
                 required:
                 - name
                 type: object
+              holdInstallation:
+                description: HoldInstallation will prevent installation from happening when true. Inspection and validation will proceed as usual, but once the RequirementsMet condition is true, installation will not begin until this field is set to false.
+                type: boolean
               imageSetRef:
                 description: ImageSetRef is a reference to a ClusterImageSet. The release image specified in the ClusterImageSet will be used to install the cluster.
                 properties:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -108,6 +108,9 @@ spec:
                 required:
                 - name
                 type: object
+              holdInstallation:
+                description: HoldInstallation will prevent installation from happening when true. Inspection and validation will proceed as usual, but once the RequirementsMet condition is true, installation will not begin until this field is set to false.
+                type: boolean
               imageSetRef:
                 description: ImageSetRef is a reference to a ClusterImageSet. The release image specified in the ClusterImageSet will be used to install the cluster.
                 properties:

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -108,6 +108,9 @@ spec:
                 required:
                 - name
                 type: object
+              holdInstallation:
+                description: HoldInstallation will prevent installation from happening when true. Inspection and validation will proceed as usual, but once the RequirementsMet condition is true, installation will not begin until this field is set to false.
+                type: boolean
               imageSetRef:
                 description: ImageSetRef is a reference to a ClusterImageSet. The release image specified in the ClusterImageSet will be used to install the cluster.
                 properties:

--- a/docs/hive-integration/kube-api-conditions.md
+++ b/docs/hive-integration/kube-api-conditions.md
@@ -28,6 +28,7 @@ AgentClusterInstall supported condition types are: `SpecSynced`, `RequirementsMe
 |Completed|True|InstallationCompleted|The installation has completed: "status_info"|If the cluster status is "installed"|
 |Completed|False|InstallationFailed|The installation has failed: "status_info"|If the cluster status is "error"|
 |Completed|False|InstallationNotStarted|The installation has not yet started|If the cluster is before installation ("insufficient"/"pending-for-input"/"ready")|
+|Completed|False|InstallationOnHold|The installation is on hold, to unhold set holdInstallation to false|If the cluster is before installation and holdInstallation is set to true in the spec ("ready")|
 |Completed|False|InstallationInProgress|The installation is in progress: "status_info"|If the cluster is installing ("preparing-for-installation", "installing", "finalizing", "installing-pending-user-action")|
 ||||||
 |Failed|True|InstallationFailed|The installation failed: "status_info"|if the cluster status is "error"|


### PR DESCRIPTION

# Assisted Pull Request

## Description

Hold day1 instalaltion
This feature is relevant mostly for UI, to give users an option to
review the deployment before we trigger the intallation
day2 flow will start installation automatically once hosts are added to
the cluster when they are in a ready state.

No effect on ZTP

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @rollandf 
/cc @avishayt 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
