### PR TITLE
Bug 1975383: Update the defaultChronyConf

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -44,6 +44,7 @@ func NewManifestsGenerator(manifestsApi restapi.ManifestsAPI, config Config) *Ma
 }
 
 const defaultChronyConf = `
+pool 0.rhel.pool.ntp.org iburst
 driftfile /var/lib/chrony/drift
 makestep 1.0 3
 rtcsync


### PR DESCRIPTION
Add `pool 0.rhel.pool.ntp.org iburst` to defaultChronyConf
as suggested [here](https://docs.openshift.com/container-platform/4.5/installing/install_config/installing-customizing.html#installation-special-config-chrony_installing-customizing) 

Closes: [OCPBUGSM-31319](https://issues.redhat.com/browse/OCPBUGSM-31319)


# Assisted Pull Request

## Description

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

Signed-off-by: Rewant Soni <resoni@redhat.com>