### PR TITLE
MGMT-6911: Validate that DNS wildcard entry is not configured.

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -86,7 +86,7 @@ var TestDefaultConfig = &TestConfiguration{
 
 	ImageName: "image",
 
-	ClusterName: "test",
+	ClusterName: "test-cluster",
 
 	BaseDNSDomain: "example.com",
 
@@ -110,9 +110,10 @@ var TestImageStatusesFailure = &models.ContainerImageAvailability{
 	Result: models.ContainerImageAvailabilityResultFailure,
 }
 
-var DomainAPI = "api.test.example.com"
-var DomainAPIInternal = "api-int.test.example.com"
-var DomainApps = fmt.Sprintf("%s.apps.test.example.com", constants.AppsSubDomainNameHostDNSValidation)
+var DomainAPI = "api.test-cluster.example.com"
+var DomainAPIInternal = "api-int.test-cluster.example.com"
+var DomainApps = fmt.Sprintf("%s.apps.test-cluster.example.com", constants.AppsSubDomainNameHostDNSValidation)
+var WildcardDomain = fmt.Sprintf("%s.test-cluster.example.com", constants.DNSWildcardFalseDomainName)
 
 var DomainResolution = []*models.DomainResolutionResponseDomain{
 	{
@@ -129,6 +130,11 @@ var DomainResolution = []*models.DomainResolutionResponseDomain{
 		DomainName:    &DomainApps,
 		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
 		IPV6Addresses: []strfmt.IPv6{"1003:db8::10/120"},
+	},
+	{
+		DomainName:    &WildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{},
+		IPV6Addresses: []strfmt.IPv6{},
 	}}
 
 var TestDomainNameResolutionSuccess = &models.DomainResolutionResponse{
@@ -231,6 +237,23 @@ func GenerateTestDefaultVmwareInventory() string {
 	b, err := json.Marshal(inventory)
 	Expect(err).To(Not(HaveOccurred()))
 	return string(b)
+}
+
+func CreateWildcardDomainNameResolutionReply(name string, baseDomain string) *models.DomainResolutionResponse {
+
+	domain := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, name, baseDomain)
+
+	var domainNameWildcardConfig = []*models.DomainResolutionResponseDomain{
+		{
+			DomainName:    &domain,
+			IPV4Addresses: []strfmt.IPv4{},
+			IPV6Addresses: []strfmt.IPv6{},
+		}}
+
+	var testDomainNameResolutionWildcard = &models.DomainResolutionResponse{
+		Resolutions: domainNameWildcardConfig}
+
+	return testDomainNameResolutionWildcard
 }
 
 type NetAddress struct {

--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -7,3 +7,6 @@ const KubeconfigNoIngress = "kubeconfig-noingress"
 const AppsSubDomainNameHostDNSValidation = "console-openshift-console"
 const APIName = "api"
 const APIInternalName = "api-int"
+
+//Non existing domain name under clusterName.baseDomain for wildcard configuration check
+const DNSWildcardFalseDomainName = "validateNoWildcardDNS"

--- a/internal/host/hostcommands/domain_name_resolution_cmd.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd.go
@@ -44,6 +44,7 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	apiDomainName := fmt.Sprintf("api.%s.%s", clusterName, baseDNSDomain)
 	apiInternalDomainName := fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain)
 	appsDomainName := fmt.Sprintf("%s.apps.%s.%s", constants.AppsSubDomainNameHostDNSValidation, clusterName, baseDNSDomain)
+	wildcardDomainName := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
 
 	apiDomain := models.DomainResolutionRequestDomain{
 		DomainName: &apiDomainName,
@@ -54,9 +55,12 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	appsDomain := models.DomainResolutionRequestDomain{
 		DomainName: &appsDomainName,
 	}
+	wildcardDomain := models.DomainResolutionRequestDomain{
+		DomainName: &wildcardDomainName,
+	}
 
 	var domains []*models.DomainResolutionRequestDomain
-	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain)
+	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain, &wildcardDomain)
 
 	request := models.DomainResolutionRequest{
 		Domains: domains,

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -255,6 +255,11 @@ func newValidations(v *validator) []validation {
 			condition: v.compatibleWithClusterPlatform,
 			formatter: v.printCompatibleWithClusterPlatform,
 		},
+		{
+			id:        IsDNSWildcardNotConfigured,
+			condition: v.isDNSWildcardNotConfigured,
+			formatter: v.printIsDNSWildcardNotConfigured,
+		},
 	}
 }
 

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -552,7 +552,8 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler) sta
 	var requiredInputFieldsExist = stateswitch.And(If(IsMachineCidrDefined))
 
 	var isSufficientForInstall = stateswitch.And(If(HasMemoryForRole), If(HasCPUCoresForRole), If(BelongsToMachineCidr), If(IsHostnameUnique), If(IsHostnameValid), If(IsAPIVipConnected), If(BelongsToMajorityGroup),
-		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole), If(HasDefaultRoute), If(IsAPIDomainNameResolvedCorrectly), If(IsAPIInternalDomainNameResolvedCorrectly), If(IsAppsDomainNameResolvedCorrectly))
+		If(AreOcsRequirementsSatisfied), If(AreLsoRequirementsSatisfied), If(AreCnvRequirementsSatisfied), If(SufficientOrUnknownInstallationDiskSpeed), If(SucessfullOrUnknownContainerImagesAvailability), If(HasSufficientNetworkLatencyRequirementForRole), If(HasSufficientPacketLossRequirementForRole), If(HasDefaultRoute),
+		If(IsAPIDomainNameResolvedCorrectly), If(IsAPIInternalDomainNameResolvedCorrectly), If(IsAppsDomainNameResolvedCorrectly), If(IsDNSWildcardNotConfigured))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -3691,18 +3691,16 @@ var _ = Describe("Refresh Host", func() {
 	})
 	Context("Unique hostname", func() {
 		var (
-			srcState              string
-			otherHostID           strfmt.UUID
-			ntpSources            []*models.NtpSource
-			imageStatuses         map[string]*models.ContainerImageAvailability
-			domainNameResolutions *models.DomainResolutionResponse
+			srcState      string
+			otherHostID   strfmt.UUID
+			ntpSources    []*models.NtpSource
+			imageStatuses map[string]*models.ContainerImageAvailability
 		)
 
 		BeforeEach(func() {
 			otherHostID = strfmt.UUID(uuid.New().String())
 			ntpSources = defaultNTPSources
 			imageStatuses = map[string]*models.ContainerImageAvailability{common.TestDefaultConfig.ImageName: common.TestImageStatusesSuccess}
-			domainNameResolutions = common.TestDomainNameResolutionSuccess
 			mockDefaultClusterHostRequirements(mockHwValidator)
 		})
 
@@ -4096,6 +4094,7 @@ var _ = Describe("Refresh Host", func() {
 				bytes, err = json.Marshal(imageStatuses)
 				Expect(err).ShouldNot(HaveOccurred())
 				host.ImagesStatus = string(bytes)
+				domainNameResolutions := common.TestDomainNameResolutionSuccess
 				bytes, err = json.Marshal(domainNameResolutions)
 				Expect(err).ShouldNot(HaveOccurred())
 				host.DomainNameResolutions = string(bytes)
@@ -4111,6 +4110,8 @@ var _ = Describe("Refresh Host", func() {
 				// Test setup - Cluster creation
 				cluster = hostutil.GenerateTestCluster(clusterId, t.primaryMachineNetworkCidr)
 				cluster.ConnectivityMajorityGroups = fmt.Sprintf("{\"%s\":[\"%s\"]}", t.primaryMachineNetworkCidr, hostId.String())
+				cluster.Name = common.TestDefaultConfig.ClusterName
+				cluster.BaseDNSDomain = common.TestDefaultConfig.BaseDNSDomain
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
 				// Test definition
@@ -4216,6 +4217,8 @@ var _ = Describe("Refresh Host", func() {
 			Expect(err).NotTo(HaveOccurred())
 			domainNameResolutions := common.TestDomainNameResolutionSuccess
 			cluster = hostutil.GenerateTestCluster(clusterId, common.TestIPv4Networking.PrimaryMachineNetworkCidr)
+			cluster.Name = common.TestDefaultConfig.ClusterName
+			cluster.BaseDNSDomain = common.TestDefaultConfig.BaseDNSDomain
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 			host.Inventory = hostutil.GenerateInventoryWithResourcesWithBytes(4, conversions.GibToBytes(16), conversions.GibToBytes(16), "master")
@@ -4312,6 +4315,10 @@ var _ = Describe("Refresh Host", func() {
 				defaultNTPSourcesInBytes, err := json.Marshal(defaultNTPSources)
 				Expect(err).ShouldNot(HaveOccurred())
 				host.NtpSources = string(defaultNTPSourcesInBytes)
+				defaultDomainNameResolutions := common.TestDomainNameResolutionSuccess
+				domainNameResolutions, err := json.Marshal(defaultDomainNameResolutions)
+				Expect(err).ShouldNot(HaveOccurred())
+				host.DomainNameResolutions = string(domainNameResolutions)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				cluster = hostutil.GenerateTestCluster(clusterId, common.TestIPv4Networking.PrimaryMachineNetworkCidr)
 				cluster.UserManagedNetworking = swag.Bool(t.userManagedNetworking)

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -38,12 +38,14 @@ const (
 	IsAPIInternalDomainNameResolvedCorrectly       = validationID(models.HostValidationIDAPIIntDomainNameResolvedCorrectly)
 	IsAppsDomainNameResolvedCorrectly              = validationID(models.HostValidationIDAppsDomainNameResolvedCorrectly)
 	CompatibleWithClusterPlatform                  = validationID(models.HostValidationIDCompatibleWithClusterPlatform)
+	IsDNSWildcardNotConfigured                     = validationID(models.HostValidationIDDNSWildcardNotConfigured)
 )
 
 func (v validationID) category() (string, error) {
 	switch v {
 	case IsConnected, IsMachineCidrDefined, BelongsToMachineCidr,
-		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole, HasDefaultRoute, IsAPIDomainNameResolvedCorrectly, IsAPIInternalDomainNameResolvedCorrectly, IsAppsDomainNameResolvedCorrectly:
+		IsAPIVipConnected, BelongsToMajorityGroup, IsNTPSynced, SucessfullOrUnknownContainerImagesAvailability, HasSufficientNetworkLatencyRequirementForRole, HasSufficientPacketLossRequirementForRole, HasDefaultRoute,
+		IsAPIDomainNameResolvedCorrectly, IsAPIInternalDomainNameResolvedCorrectly, IsAppsDomainNameResolvedCorrectly, IsDNSWildcardNotConfigured:
 		return "network", nil
 	case HasInventory, HasMinCPUCores, HasMinValidDisks, HasMinMemory, SufficientOrUnknownInstallationDiskSpeed,
 		HasCPUCoresForRole, HasMemoryForRole, IsHostnameUnique, IsHostnameValid, IsPlatformValid, CompatibleWithClusterPlatform:

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1113,3 +1113,34 @@ func printIsDomainNameResolvedCorrectly(c *validationContext, status ValidationS
 		return "Unexpected status"
 	}
 }
+
+func (v *validator) isDNSWildcardNotConfigured(c *validationContext) ValidationStatus {
+	var response *models.DomainResolutionResponse
+	if err := json.Unmarshal([]byte(c.host.DomainNameResolutions), &response); err != nil {
+		return ValidationError
+	}
+	dnsWildcardName := domainNameToResolve(c, constants.DNSWildcardFalseDomainName)
+
+	// Note that we're validating that the wildcard DNS *.<cluster_name>.<base_domain> is NOT configured, since this causes known problems for OpenShift
+	for _, domain := range response.Resolutions {
+		if domain.DomainName != nil && *domain.DomainName == dnsWildcardName {
+			if len(domain.IPV4Addresses) == 0 && len(domain.IPV6Addresses) == 0 {
+				return ValidationSuccess
+			}
+		}
+	}
+	return ValidationFailure
+}
+
+func (v *validator) printIsDNSWildcardNotConfigured(c *validationContext, status ValidationStatus) string {
+	switch status {
+	case ValidationSuccess:
+		return "DNS wildcard check was succesful"
+	case ValidationFailure:
+		return fmt.Sprintf("DNS wildcard configuration was detected for domain *.%s.%s The installation will not be able to complete while the entry exists. Please remove it to proceed.", c.cluster.Name, c.cluster.BaseDNSDomain)
+	case ValidationError:
+		return "Parse error for domain name resolutions result"
+	default:
+		return "Unexpected status"
+	}
+}

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -100,6 +100,9 @@ const (
 
 	// HostValidationIDCompatibleWithClusterPlatform captures enum value "compatible-with-cluster-platform"
 	HostValidationIDCompatibleWithClusterPlatform HostValidationID = "compatible-with-cluster-platform"
+
+	// HostValidationIDDNSWildcardNotConfigured captures enum value "dns-wildcard-not-configured"
+	HostValidationIDDNSWildcardNotConfigured HostValidationID = "dns-wildcard-not-configured"
 )
 
 // for schema
@@ -107,7 +110,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","api-vip-connected","belongs-to-majority-group","valid-platform","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8714,7 +8714,8 @@ func init() {
         "api-domain-name-resolved-correctly",
         "api-int-domain-name-resolved-correctly",
         "apps-domain-name-resolved-correctly",
-        "compatible-with-cluster-platform"
+        "compatible-with-cluster-platform",
+        "dns-wildcard-not-configured"
       ]
     },
     "host_network": {
@@ -18853,7 +18854,8 @@ func init() {
         "api-domain-name-resolved-correctly",
         "api-int-domain-name-resolved-correctly",
         "apps-domain-name-resolved-correctly",
-        "compatible-with-cluster-platform"
+        "compatible-with-cluster-platform",
+        "dns-wildcard-not-configured"
       ]
     },
     "host_network": {

--- a/subsystem/ams_subscriptions_test.go
+++ b/subsystem/ams_subscriptions_test.go
@@ -25,6 +25,20 @@ var _ = Describe("test AMS subscriptions", func() {
 	})
 
 	AfterEach(func() {
+		err := wiremock.createStubsForCreatingAMSSubscription(http.StatusOK)
+		Expect(err).ToNot(HaveOccurred())
+		err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusReserved)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateDisplayName)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateOpenshiftClusterID)
+		Expect(err).ToNot(HaveOccurred())
+
 		clearDB()
 	})
 
@@ -32,7 +46,7 @@ var _ = Describe("test AMS subscriptions", func() {
 
 		It("happy flow", func() {
 
-			clusterID, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+			clusterID, err := registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 			Expect(err).ToNot(HaveOccurred())
 			log.Infof("Register cluster %s", clusterID)
 			cc := getCommonCluster(ctx, clusterID)
@@ -48,7 +62,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			})
 
 			By("register cluster", func() {
-				_, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				_, err := registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -58,13 +72,8 @@ var _ = Describe("test AMS subscriptions", func() {
 			})
 
 			By("register cluster", func() {
-				_, err := registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				_, err := registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).To(HaveOccurred())
-			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err := wiremock.createStubsForCreatingAMSSubscription(http.StatusOK)
-				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -78,7 +87,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription (in 'reserved' status)", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -95,11 +104,6 @@ var _ = Describe("test AMS subscriptions", func() {
 				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
 				Expect(err).To(HaveOccurred())
 			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-				Expect(err).ToNot(HaveOccurred())
-			})
 		})
 
 		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
@@ -109,7 +113,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -133,11 +137,6 @@ var _ = Describe("test AMS subscriptions", func() {
 				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
 				Expect(err).ToNot(HaveOccurred())
 			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-				Expect(err).ToNot(HaveOccurred())
-			})
 		})
 
 		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
@@ -147,7 +146,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -171,11 +170,6 @@ var _ = Describe("test AMS subscriptions", func() {
 				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
 				Expect(err).To(HaveOccurred())
 			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForGettingAMSSubscription(http.StatusOK, ocm.SubscriptionStatusReserved)
-				Expect(err).ToNot(HaveOccurred())
-			})
 		})
 
 		// ATTENTION: this test override a wiremock stub - DO NOT RUN IN PARALLEL
@@ -185,7 +179,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -209,11 +203,6 @@ var _ = Describe("test AMS subscriptions", func() {
 				_, err = userBMClient.Installer.DeregisterCluster(ctx, &installer.DeregisterClusterParams{ClusterID: clusterID})
 				Expect(err).To(HaveOccurred())
 			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForDeletingAMSSubscription(http.StatusOK)
-				Expect(err).ToNot(HaveOccurred())
-			})
 		})
 	})
 
@@ -225,7 +214,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -249,7 +238,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -268,11 +257,6 @@ var _ = Describe("test AMS subscriptions", func() {
 					},
 				})
 				Expect(err).To(HaveOccurred())
-			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateDisplayName)
-				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})
@@ -295,7 +279,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -303,7 +287,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			By("update subscription with openshfit (external) cluster ID", func() {
 				// in order to simulate infra env generation
 				generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-				registerHostsAndSetRoles(clusterID, minHosts)
+				registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 				setClusterAsInstalling(ctx, clusterID)
 			})
 
@@ -330,7 +314,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			var err error
 
 			By("create subscription", func() {
-				clusterID, err = registerCluster(ctx, userBMClient, "test-ams-subscriptions-cluster", pullSecret)
+				clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 				Expect(err).ToNot(HaveOccurred())
 				log.Infof("Register cluster %s", clusterID)
 			})
@@ -343,18 +327,13 @@ var _ = Describe("test AMS subscriptions", func() {
 			By("update subscription with openshfit (external) cluster ID", func() {
 				// in order to simulate infra env generation
 				generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-				registerHostsAndSetRoles(clusterID, minHosts)
+				registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 				reply, err = userBMClient.Installer.InstallCluster(context.Background(), &installer.InstallClusterParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				c := reply.GetPayload()
 				Expect(*c.Status).Should(Equal(models.ClusterStatusPreparingForInstallation))
 				generateEssentialPrepareForInstallationSteps(ctx, c.Hosts...)
 				waitForInstallationPreparationCompletionStatus(clusterID, common.InstallationPreparationFailed)
-			})
-
-			By("override back to keep other tests consistent tests", func() {
-				err = wiremock.createStubsForUpdatingAMSSubscription(http.StatusOK, subscriptionUpdateOpenshiftClusterID)
-				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Make sure that sensitive files are accessible only by owners o
 		Expect(err).ToNot(HaveOccurred())
 		clusterID = cID
 		generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-		registerHostsAndSetRoles(clusterID, minHosts)
+		registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 		setClusterAsFinalizing(ctx, clusterID)
 		res, err := agentBMClient.Installer.UploadClusterIngressCert(ctx, &installer.UploadClusterIngressCertParams{ClusterID: clusterID, IngressCertParams: models.IngressCertParams(ingressCa)})
 		Expect(err).NotTo(HaveOccurred())
@@ -191,7 +191,7 @@ var _ = Describe("Cluster credentials should be accessed only by cluster owner",
 		Expect(err).ToNot(HaveOccurred())
 		clusterID = cID
 		generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-		registerHostsAndSetRoles(clusterID, minHosts)
+		registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 		setClusterAsFinalizing(ctx, clusterID)
 		res, err := agentBMClient.Installer.UploadClusterIngressCert(ctx, &installer.UploadClusterIngressCertParams{ClusterID: clusterID, IngressCertParams: models.IngressCertParams(ingressCa)})
 		Expect(err).NotTo(HaveOccurred())

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -141,6 +141,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		By("checking insufficient state state - one host, no connectivity check")
 		ips := hostutil.GenerateIPv4Addresses(2, defaultCIDRv4)
 		generateEssentialHostSteps(ctx, h, "h1host", ips[0])
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		steps = getNextSteps(clusterID, *host.ID)
 		checkStepsInList(steps, []models.StepType{models.StepTypeInventory, models.StepTypeAPIVipConnectivityCheck}, 2)
@@ -170,6 +171,7 @@ var _ = Describe("Day2 cluster tests", func() {
 
 		By("checking insufficient state state host2 ")
 		generateEssentialHostSteps(ctx, h2, "h2host", ips[1])
+		generateDomainResolution(ctx, h2, "test-cluster", "")
 		generateConnectivityCheckPostStepReply(ctx, h2, ips[0], true)
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h2)
 		steps = getNextSteps(clusterID, *h2.ID)
@@ -178,6 +180,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		By("checking insufficient state state")
 		generateEssentialHostSteps(ctx, h1, "h1host", ips[0])
 		generateConnectivityCheckPostStepReply(ctx, h1, ips[1], true)
+		generateDomainResolution(ctx, h1, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h1)
 		steps = getNextSteps(clusterID, *h1.ID)
 		checkStepsInList(steps, []models.StepType{models.StepTypeInventory, models.StepTypeAPIVipConnectivityCheck, models.StepTypeConnectivityCheck}, 3)
@@ -193,6 +196,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -213,6 +217,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -238,12 +243,14 @@ var _ = Describe("Day2 cluster tests", func() {
 		h2 := getHost(clusterID, *host.ID)
 		ips := hostutil.GenerateIPv4Addresses(2, defaultCIDRv4)
 		generateEssentialHostSteps(ctx, h1, "hostname1", ips[0])
+		generateDomainResolution(ctx, h1, "test-cluster", "")
 		generateConnectivityCheckPostStepReply(ctx, h1, ips[1], true)
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h1)
 		generateApiVipPostStepReply(ctx, h1, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h1)
 
 		generateEssentialHostSteps(ctx, h2, "hostname2", ips[1])
+		generateDomainResolution(ctx, h2, "test-cluster", "")
 		generateConnectivityCheckPostStepReply(ctx, h2, ips[0], true)
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h2)
 		generateApiVipPostStepReply(ctx, h2, true)
@@ -284,9 +291,11 @@ var _ = Describe("Day2 cluster tests", func() {
 		h2 := getHost(clusterID, *host.ID)
 		ips := hostutil.GenerateIPv4Addresses(2, defaultCIDRv4)
 		generateEssentialHostSteps(ctx, h1, "hostname1", ips[0])
+		generateDomainResolution(ctx, h1, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h1)
 
 		generateEssentialHostSteps(ctx, h2, "hostname2", ips[1])
+		generateDomainResolution(ctx, h2, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h2)
 
 		_, err := userBMClient.Installer.InstallHosts(ctx, &installer.InstallHostsParams{ClusterID: clusterID})
@@ -307,6 +316,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -327,6 +337,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -354,6 +365,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -383,6 +395,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -407,6 +420,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		host := &registerHost(clusterID).Host
 		h := getHost(clusterID, *host.ID)
 		generateEssentialHostSteps(ctx, h, "hostname", defaultCIDRv4)
+		generateDomainResolution(ctx, h, "test-cluster", "")
 		waitForHostState(ctx, clusterID, "insufficient", 60*time.Second, h)
 		generateApiVipPostStepReply(ctx, h, true)
 		waitForHostState(ctx, clusterID, "known", 60*time.Second, h)
@@ -489,6 +503,7 @@ var _ = Describe("Installation progress", func() {
 		By("install hosts", func() {
 
 			generateEssentialHostSteps(ctx, c.Hosts[0], "hostname", defaultCIDRv4)
+			generateDomainResolution(ctx, c.Hosts[0], "day2-cluster", "")
 			generateApiVipPostStepReply(ctx, c.Hosts[0], true)
 			waitForHostState(ctx, *c.ID, "known", 60*time.Second, c.Hosts[0])
 

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -691,6 +691,9 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			hosts = append(hosts, host)
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
+		for _, h := range hosts {
+			generateDomainResolution(ctx, h, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		}
 
 		By("verify validations are successfull")
 		installkey := types.NamespacedName{
@@ -736,6 +739,10 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			checkAgentCondition(ctx, host.ID.String(), v1beta1.ValidatedCondition, v1beta1.ValidationsFailingReason)
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
+		for _, h := range hosts {
+			generateDomainResolution(ctx, h, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		}
+
 		By("Approve Agents")
 		for _, host := range hosts {
 			hostkey := types.NamespacedName{
@@ -912,6 +919,10 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			checkAgentCondition(ctx, host.ID.String(), v1beta1.ValidatedCondition, v1beta1.ValidationsFailingReason)
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
+		for _, h := range hosts {
+			generateDomainResolution(ctx, h, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		}
+
 		By("Approve Agents")
 		for _, host := range hosts {
 			hostkey := types.NamespacedName{
@@ -1402,6 +1413,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Namespace: Options.Namespace,
 			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
 		}
+		generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
 
 		By("Approve Agent")
 		Eventually(func() error {
@@ -1749,6 +1761,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Namespace: Options.Namespace,
 			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
 		}
+		generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
 		By("Check ACI Event URL exists")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
@@ -1989,6 +2002,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Namespace: Options.Namespace,
 			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
 		}
+		generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
 		By("Approve Agent")
 		Eventually(func() error {
 			agent := getAgentCRD(ctx, kubeClient, key)
@@ -2030,6 +2044,9 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKey, waitForReconcileTimeout)
 		configureLocalAgentClient(cluster.ID.String())
 		hosts := make([]*models.Host, 0)
+		for _, host := range hosts {
+			checkAgentCondition(ctx, host.ID.String(), v1beta1.ValidatedCondition, v1beta1.ValidationsPassingReason)
+		}
 		ips := hostutil.GenerateIPv4Addresses(3, defaultCIDRv4)
 		for i := 0; i < 3; i++ {
 			hostname := fmt.Sprintf("h%d", i)
@@ -2041,7 +2058,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
 		for _, host := range hosts {
-			checkAgentCondition(ctx, host.ID.String(), v1beta1.ValidatedCondition, v1beta1.ValidationsPassingReason)
+			generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
 		}
 
 		By("Approve Agents")
@@ -2145,6 +2162,9 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			hosts = append(hosts, host)
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
+		for _, h := range hosts {
+			generateDomainResolution(ctx, h, clusterDeploymentSpec.ClusterName, "hive.example.com")
+		}
 		By("Check ACI Logs URL is empty")
 		// Should not show the URL since no logs yet to be collected
 		installkey := types.NamespacedName{
@@ -2246,10 +2266,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		configureLocalAgentClient(cluster.ID.String())
 		day2Host1 := registerNode(ctx, *cluster.ID, "firsthostnameday2", ips[3])
 		generateApiVipPostStepReply(ctx, day2Host1, true)
+		generateDomainResolution(ctx, day2Host1, clusterDeploymentSpec.ClusterName, "hive.example.com")
 
 		By("Add a second Day 2 host")
 		day2Host2 := registerNode(ctx, *cluster.ID, "secondhostnameday2", ips[4])
 		generateApiVipPostStepReply(ctx, day2Host2, true)
+		generateDomainResolution(ctx, day2Host2, clusterDeploymentSpec.ClusterName, "hive.example.com")
 
 		By("Approve Day 2 agents")
 		k1 := types.NamespacedName{
@@ -2394,6 +2416,7 @@ spec:
 			Namespace: Options.Namespace,
 			Name:      host.ID.String(),
 		}
+		generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
 		By("Approve Agent")
 		Eventually(func() error {
 			agent := getAgentCRD(ctx, kubeClient, key)

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -149,7 +149,7 @@ spec:
 		clusterID := *cluster.ID
 
 		By("install cluster", func() {
-			registerHostsAndSetRoles(clusterID, minHosts)
+			registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 			reply, err := userBMClient.Installer.InstallCluster(context.Background(), &installer.InstallClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
 			c := reply.GetPayload()

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Metrics tests", func() {
 
 	BeforeEach(func() {
 		var err error
-		clusterID, err = registerCluster(ctx, userBMClient, "test-metrics-cluster", pullSecret)
+		clusterID, err = registerCluster(ctx, userBMClient, "test-cluster", pullSecret)
 		Expect(err).NotTo(HaveOccurred())
 		// in order to simulate infra env generation
 		generateClusterISO(clusterID, models.ImageTypeMinimalIso)
@@ -345,7 +345,7 @@ var _ = Describe("Metrics tests", func() {
 
 		BeforeEach(func() {
 			//start host installation process
-			registerHostsAndSetRoles(clusterID, 3)
+			registerHostsAndSetRoles(clusterID, 3, "test-cluster", "example.com")
 			c = installCluster(clusterID)
 			for _, host := range c.Hosts {
 				waitForHostState(ctx, clusterID, "installing", defaultWaitForHostStateTimeout, host)
@@ -938,6 +938,10 @@ var _ = Describe("Metrics tests", func() {
 
 			// create a validation success
 			hosts, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+			c := getCluster(clusterID)
+			for _, h := range c.Hosts {
+				generateDomainResolution(ctx, h, "test-cluster", "example.com")
+			}
 			waitForClusterValidationStatus(clusterID, "success", models.ClusterValidationIDAllHostsAreReadyToInstall)
 
 			oldChangedMetricCounter := getValidationMetricCounter(string(models.ClusterValidationIDAllHostsAreReadyToInstall), clusterValidationChangedMetric)
@@ -949,6 +953,7 @@ var _ = Describe("Metrics tests", func() {
 				HostID:    *hosts[0].ID,
 			})
 			Expect(err).NotTo(HaveOccurred())
+
 			waitForClusterValidationStatus(clusterID, "failure", models.ClusterValidationIDAllHostsAreReadyToInstall)
 
 			// check generated events
@@ -964,6 +969,11 @@ var _ = Describe("Metrics tests", func() {
 
 			// create a validation failure
 			hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+			c := getCluster(clusterID)
+			for _, h := range c.Hosts {
+				generateDomainResolution(ctx, h, "test-cluster", "example.com")
+			}
+
 			_, err := userBMClient.Installer.DisableHost(ctx, &installer.DisableHostParams{
 				ClusterID: clusterID,
 				HostID:    *hosts[0].ID,
@@ -978,6 +988,9 @@ var _ = Describe("Metrics tests", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			generateEssentialHostSteps(ctx, hosts[0], "h1", ips[0])
+			for _, h := range c.Hosts {
+				generateDomainResolution(ctx, h, "test-cluster", "example.com")
+			}
 			waitForClusterValidationStatus(clusterID, "success", models.ClusterValidationIDAllHostsAreReadyToInstall)
 
 			// check generated events

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			clusterID = cID
 			// in order to simulate infra env generation
 			generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-			registerHostsAndSetRoles(clusterID, minHosts)
+			registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
 		})
 
 		It("All OLM operators available", func() {

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -314,6 +314,11 @@ func generateEssentialHostStepsWithInventory(ctx context.Context, h *models.Host
 	generateHWPostStepReply(ctx, h, inventory, name)
 	generateFAPostStepReply(ctx, h, validFreeAddresses)
 	generateNTPPostStepReply(ctx, h, []*models.NtpSource{common.TestNTPSourceSynced})
+	generateDomainNameResolutionReply(ctx, h, *common.TestDomainNameResolutionSuccess)
+}
+
+func generateDomainResolution(ctx context.Context, h *models.Host, name string, baseDomain string) {
+	generateDomainNameResolutionReply(ctx, h, *common.CreateWildcardDomainNameResolutionReply(name, baseDomain))
 }
 
 func generateEssentialPrepareForInstallationSteps(ctx context.Context, hosts ...*models.Host) {
@@ -382,6 +387,22 @@ func generateFailedDiskSpeedResponses(ctx context.Context, path string, hosts ..
 	for _, h := range hosts {
 		generateDiskSpeedChekResponse(ctx, h, path, -1)
 	}
+}
+
+func generateDomainNameResolutionReply(ctx context.Context, h *models.Host, domainNameResolution models.DomainResolutionResponse) {
+	dnsResolotion, err := json.Marshal(&domainNameResolution)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = agentBMClient.Installer.V2PostStepReply(ctx, &installer.V2PostStepReplyParams{
+		InfraEnvID: *h.ClusterID,
+		HostID:     *h.ID,
+		Reply: &models.StepReply{
+			ExitCode: 0,
+			Output:   string(dnsResolotion),
+			StepID:   string(models.StepTypeDomainResolution),
+			StepType: models.StepTypeDomainResolution,
+		},
+	})
+	Expect(err).To(BeNil())
 }
 
 func updateVipParams(ctx context.Context, clusterID strfmt.UUID) {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6394,6 +6394,7 @@ definitions:
       - 'api-int-domain-name-resolved-correctly'
       - 'apps-domain-name-resolved-correctly'
       - 'compatible-with-cluster-platform'
+      - 'dns-wildcard-not-configured'
 
   dhcp_allocation_request:
     type: object


### PR DESCRIPTION
Add new validation that checks if the host has DNS wildcard entry for
*.cluster_name.base_dns_domain_name

If a wildcard was configured in the cluster network
it will cause insight pods to fail report to cloud.redhat.com
And cluster version will complain about the insight operator's degraded status.

By testing domain name resolution for a non-existing domain name under 
cluster_name.base_dns_domain_name we can determine if wildcard was
configured and alert the user accordingly.

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees
/cc @tsorya 
/cc @omertuc 
/cc @eranco74 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?