### PR TITLE
[WIP] MGMT-7396: Add support for adding OVA template for RHCOS image

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2045,6 +2045,7 @@ func (b *bareMetalInventory) updatePlatformParams(params installer.UpdateCluster
 			updates["platform_vsphere_network"] = platform.Vsphere.Network
 			updates["platform_vsphere_vCenter"] = platform.Vsphere.VCenter
 			updates["platform_vsphere_folder"] = platform.Vsphere.Folder
+			updates["platform_vsphere_clusterOSImage"] = platform.Vsphere.ClusterOSImage
 		}
 	}
 
@@ -2058,6 +2059,7 @@ func (b *bareMetalInventory) updatePlatformParams(params installer.UpdateCluster
 		updates["platform_vsphere_network"] = nil
 		updates["platform_vsphere_vCenter"] = nil
 		updates["platform_vsphere_folder"] = nil
+		updates["platform_vsphere_clusterOSImage"] = nil
 	}
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3147,6 +3147,7 @@ var _ = Describe("cluster", func() {
 									Password:         &dummyPassword,
 									Username:         &dummy,
 									VCenter:          &dummy,
+									ClusterOSImage:   &dummy,
 								},
 							},
 						},

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -52,6 +52,7 @@ type platformVsphere struct {
 	Cluster          string          `yaml:"cluster"`
 	APIVIP           string          `yaml:"apiVIP"`
 	IngressVIP       string          `yaml:"ingressVIP"`
+	ClusterOSImage   string          `yaml:"clusterOSImage,omitempty"`
 }
 
 type platformNone struct {
@@ -273,8 +274,12 @@ func setVspherePlatformValues(platform *platformVsphere, clusterPlatform *models
 		platform.DefaultDatastore = *clusterPlatform.DefaultDatastore
 		platform.Network = *clusterPlatform.Network
 		platform.Cluster = *clusterPlatform.Cluster
+		platform.Cluster = *clusterPlatform.Cluster
 		if clusterPlatform.Folder != nil {
 			platform.Folder = *clusterPlatform.Folder
+		}
+		if clusterPlatform.ClusterOSImage != nil {
+			platform.ClusterOSImage = *clusterPlatform.ClusterOSImage
 		}
 	} else {
 		platform.Cluster = "clusterplaceholder"

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -598,6 +598,7 @@ var _ = Describe("Platform", func() {
 		password := strfmt.Password("password")
 		username := "username"
 		vCenter := "vCenter"
+		clusterOSImage := "clusterOSImage"
 		cluster.Platform = &models.Platform{Type: models.PlatformTypeVsphere,
 			Vsphere: &models.VspherePlatform{
 				Cluster:          &pcluster,
@@ -608,6 +609,7 @@ var _ = Describe("Platform", func() {
 				Password:         &password,
 				Username:         &username,
 				VCenter:          &vCenter,
+				ClusterOSImage:   &clusterOSImage,
 			}}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
 		data, err := installConfig.GetInstallConfig(&cluster, false, "")
@@ -627,7 +629,7 @@ var _ = Describe("Platform", func() {
 		Expect(result.Platform.Vsphere.Datacenter).Should(Equal(*cluster.Platform.Vsphere.Datacenter))
 		Expect(result.Platform.Vsphere.Network).Should(Equal(*cluster.Platform.Vsphere.Network))
 		Expect(result.Platform.Vsphere.Cluster).Should(Equal(*cluster.Platform.Vsphere.Cluster))
-
+		Expect(result.Platform.Vsphere.ClusterOSImage).Should(Equal(*cluster.Platform.Vsphere.ClusterOSImage))
 	})
 
 	AfterEach(func() {

--- a/models/vsphere_platform.go
+++ b/models/vsphere_platform.go
@@ -20,6 +20,9 @@ type VspherePlatform struct {
 	// The vCenter cluster to install the OpenShift Container Platform cluster in.
 	Cluster *string `json:"cluster,omitempty"`
 
+	// Optional. The location from which the installer downloads the RHCOS image. You must set this parameter to perform an installation in a restricted network.
+	ClusterOSImage *string `json:"clusterOSImage,omitempty"`
+
 	// The name of the datacenter to use in the vCenter instance.
 	Datacenter *string `json:"datacenter,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8308,6 +8308,11 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "clusterOSImage": {
+          "description": "Optional. The location from which the installer downloads the RHCOS image. You must set this parameter to perform an installation in a restricted network.",
+          "type": "string",
+          "x-nullable": true
+        },
         "datacenter": {
           "description": "The name of the datacenter to use in the vCenter instance.",
           "type": "string",
@@ -16754,6 +16759,11 @@ func init() {
       "properties": {
         "cluster": {
           "description": "The vCenter cluster to install the OpenShift Container Platform cluster in.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "clusterOSImage": {
+          "description": "Optional. The location from which the installer downloads the RHCOS image. You must set this parameter to perform an installation in a restricted network.",
           "type": "string",
           "x-nullable": true
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3497,6 +3497,10 @@ definitions:
         type: string
         description: Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the datacenter virtual machine folder.
         x-nullable: true
+      clusterOSImage:
+        type: string
+        description: Optional. The location from which the installer downloads the RHCOS image. You must set this parameter to perform an installation in a restricted network.
+        x-nullable: true
 
   monitored-operator:
     type: object


### PR DESCRIPTION
# Assisted Pull Request
Add vSphere platform property which defines the location from which the installer downloads the RHCOS image. If the user uses restricted network he must set this parameter to perform an installation.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @tsorya 
/cc @avishayt 

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
