### PR TITLE
OCPBUGSM-32618: Create worker's spoke machines in the "openshift-machine-api" namespace

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -73,6 +73,7 @@ const (
 	MACHINE_ROLE                        = "machine.openshift.io/cluster-api-machine-role"
 	MACHINE_TYPE                        = "machine.openshift.io/cluster-api-machine-type"
 	MCS_CERT_NAME                       = "ca.crt"
+	OPENSHIFT_MACHINE_API_NAMESPACE     = "openshift-machine-api"
 )
 
 var (
@@ -700,6 +701,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 	}
 
 	_, err = r.ensureSpokeBMH(ctx, log, spokeClient, bmh, machine, agent)
+
 	if err != nil {
 		log.WithError(err).Errorf("failed to create or update spoke BareMetalHost")
 		return reconcileError{err}
@@ -1054,7 +1056,7 @@ func (r *BMACReconciler) ensureSpokeBMHSecret(ctx context.Context, log logrus.Fi
 	if err != nil {
 		return secret, err
 	}
-	secretSpoke, mutateFn := r.newSpokeBMHSecret(secret, bmh)
+	secretSpoke, mutateFn := r.newSpokeBMHSecret(secret)
 	if result, err := controllerutil.CreateOrUpdate(ctx, spokeClient, secretSpoke, mutateFn); err != nil {
 		return nil, err
 	} else if result != controllerutil.OperationResultNone {
@@ -1067,7 +1069,7 @@ func (r *BMACReconciler) newSpokeBMH(bmh *bmh_v1alpha1.BareMetalHost, machine *m
 	bmhSpoke := &bmh_v1alpha1.BareMetalHost{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bmh.Name,
-			Namespace: bmh.Namespace,
+			Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
 		},
 	}
 	mutateFn := func() error {
@@ -1099,11 +1101,11 @@ func (r *BMACReconciler) newSpokeBMH(bmh *bmh_v1alpha1.BareMetalHost, machine *m
 	return bmhSpoke, mutateFn
 }
 
-func (r *BMACReconciler) newSpokeBMHSecret(secret *corev1.Secret, bmh *bmh_v1alpha1.BareMetalHost) (*corev1.Secret, controllerutil.MutateFn) {
+func (r *BMACReconciler) newSpokeBMHSecret(secret *corev1.Secret) (*corev1.Secret, controllerutil.MutateFn) {
 	secretSpoke := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secret.Name,
-			Namespace: bmh.Namespace,
+			Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
 		},
 	}
 	mutateFn := func() error {
@@ -1119,7 +1121,7 @@ func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, cluste
 	machine := &machinev1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      machineName,
-			Namespace: bmh.Namespace,
+			Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
 		},
 	}
 	mutateFn := func() error {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -736,7 +736,7 @@ var _ = Describe("bmac reconcile", func() {
 
 				spokeBMH := &bmh_v1alpha1.BareMetalHost{}
 				spokeClient := bmhr.spokeClient
-				err = spokeClient.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, spokeBMH)
+				err = spokeClient.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: OPENSHIFT_MACHINE_API_NAMESPACE}, spokeBMH)
 				Expect(err).To(BeNil())
 				Expect(spokeBMH.ObjectMeta.Annotations).To(HaveKey(BMH_HARDWARE_DETAILS_ANNOTATION))
 				Expect(spokeBMH.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION]).To(Equal(updatedHost.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION]))
@@ -745,14 +745,14 @@ var _ = Describe("bmac reconcile", func() {
 
 				spokeMachine := &machinev1beta1.Machine{}
 				machineName := fmt.Sprintf("%s-%s", cluster.Name, spokeBMH.Name)
-				err = spokeClient.Get(ctx, types.NamespacedName{Name: machineName, Namespace: testNamespace}, spokeMachine)
+				err = spokeClient.Get(ctx, types.NamespacedName{Name: machineName, Namespace: OPENSHIFT_MACHINE_API_NAMESPACE}, spokeMachine)
 				Expect(err).To(BeNil())
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(machinev1beta1.MachineClusterIDLabel))
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(MACHINE_ROLE))
 				Expect(spokeMachine.ObjectMeta.Labels).To(HaveKey(MACHINE_TYPE))
 
 				spokeSecret := &corev1.Secret{}
-				err = spokeClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: testNamespace}, spokeSecret)
+				err = spokeClient.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: OPENSHIFT_MACHINE_API_NAMESPACE}, spokeSecret)
 				Expect(err).To(BeNil())
 				Expect(spokeSecret.Data).To(Equal(secret.Data))
 			})


### PR DESCRIPTION
# Assisted Pull Request

## Description
The previous code was trying to create spoke resources such as BMH, machine, secret, in the same namespace on the spoke cluster as in the hub cluster i.e. assisted-spoke-cluster namespace. This namespace is not present on the spoke cluster and results in a failure while creating a spoke BMH (surely we can create the namespace but we shouldn't).

This change fixes this bug and correctly creates the resources such as spoke BMH, and spoke machine on the spoke cluster when adding workers on day2. Use "openshift-machine-api" namespace just like the other master agent/BMH/machines on the spoke cluster. 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    Create OCP cluster using dev-scripts. Deploy assisted service operator and deploy spoke cluster. Create a BMH on the hub cluster with worker role on a day2 cluster.  Spoke BMH should be created in openshift-machine-api namespace on the spoke cluster.
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
