### PR TITLE
MGMT-7321: Move the AI code to address the host using its IfraEnvID i…

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4805,7 +4805,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		return common.GenerateErrorResponder(err)
 	}
 
-	_, err = common.GetV2HostFromDB(tx, params.InfraEnvID.String(), params.NewHostParams.HostID.String())
+	_, err = common.GetHostFromDB(tx, params.InfraEnvID.String(), params.NewHostParams.HostID.String())
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		log.WithError(err).Errorf("failed to get host %s in infra-env: %s",
 			*params.NewHostParams.HostID, params.InfraEnvID.String())
@@ -4932,7 +4932,7 @@ func (b *bareMetalInventory) V2GetNextSteps(ctx context.Context, params installe
 	}
 
 	//TODO check the error type
-	host, err := common.GetV2HostFromDB(tx, params.InfraEnvID.String(), params.HostID.String())
+	host, err := common.GetHostFromDB(tx, params.InfraEnvID.String(), params.HostID.String())
 	if err != nil {
 		log.WithError(err).Errorf("failed to find host: %s", params.HostID)
 		return installer.NewGetNextStepsNotFound().
@@ -4962,7 +4962,7 @@ func (b *bareMetalInventory) V2GetNextSteps(ctx context.Context, params installe
 func (b *bareMetalInventory) V2PostStepReply(ctx context.Context, v2Params installer.V2PostStepReplyParams) middleware.Responder {
 	log := logutil.FromContext(ctx, b.log)
 
-	host, err := common.GetV2HostFromDB(b.db, v2Params.InfraEnvID.String(), v2Params.HostID.String())
+	host, err := common.GetHostFromDB(b.db, v2Params.InfraEnvID.String(), v2Params.HostID.String())
 
 	if err != nil {
 		log.WithError(err).Errorf("Failed to find host <%s> infra-env <%s> step <%s> exit code %d stdout <%s> stderr <%s>",

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -198,16 +198,6 @@ func GetHostFromDB(db *gorm.DB, infraEnvId, hostId string) (*Host, error) {
 	return &host, nil
 }
 
-func GetV2HostFromDB(db *gorm.DB, infraEnvId, hostId string) (*Host, error) {
-	var host Host
-
-	err := db.Take(&host, "id = ? and infra_env_id = ?", hostId, infraEnvId).Error
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get host %s in infra-env %s", hostId, infraEnvId)
-	}
-	return &host, nil
-}
-
 func GetHostFromDBWhere(db *gorm.DB, where ...interface{}) (*Host, error) {
 	var host Host
 

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -87,9 +87,10 @@ var _ = Describe("Disk eligibility", func() {
 	BeforeEach(func() {
 
 		clusterID := strfmt.UUID(uuid.New().String())
+		infraEnvID := strfmt.UUID(uuid.New().String())
 		cluster = hostutil.GenerateTestCluster(clusterID, "10.0.0.1/24")
 		hostID := strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(hostID, clusterID, models.HostStatusDiscovering)
+		host = hostutil.GenerateTestHost(hostID, infraEnvID, clusterID, models.HostStatusDiscovering)
 
 		cfg := ValidatorCfg{VersionedRequirements: versionRequirements}
 

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -51,18 +51,18 @@ type UpdateReply struct {
 func refreshHostStageUpdateTime(
 	log logrus.FieldLogger,
 	db *gorm.DB,
-	clusterId strfmt.UUID,
+	infraEnvId strfmt.UUID,
 	hostId strfmt.UUID,
 	srcStatus string) (*common.Host, error) {
 	var host *common.Host
 	var err error
 
 	now := strfmt.DateTime(time.Now())
-	if host, err = hostutil.UpdateHost(log, db, clusterId, hostId, srcStatus, "progress_stage_updated_at", now); err != nil {
+	if host, err = hostutil.UpdateHost(log, db, infraEnvId, hostId, srcStatus, "progress_stage_updated_at", now); err != nil {
 		return nil, errors.Wrapf(
 			err,
-			"failed to refresh host status update time %s from cluster %s state from %s",
-			hostId, clusterId, srcStatus)
+			"failed to refresh host status update time %s from infraEnv %s state from %s",
+			hostId, infraEnvId, srcStatus)
 	}
 
 	return host, nil
@@ -84,7 +84,7 @@ func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, db
 	}
 	extras = append(extras, "trigger_monitor_timestamp", time.Now())
 
-	_, err := hostutil.UpdateHost(log, db, *h.ClusterID, *h.ID, *h.Status, extras...)
+	_, err := hostutil.UpdateHost(log, db, h.InfraEnvID, *h.ID, *h.Status, extras...)
 	return err
 }
 

--- a/internal/host/common_test.go
+++ b/internal/host/common_test.go
@@ -23,6 +23,7 @@ var _ = Describe("GetHostnameAndRoleByIP", func() {
 	hostRolesIpv4 := []hostNetProfile{{role: models.HostRoleMaster, hostname: "master-0", ip: "1.2.3.1"}, {role: models.HostRoleWorker, hostname: "worker-0", ip: "1.2.3.2"}}
 	hostrolesIpv6 := []hostNetProfile{{role: models.HostRoleMaster, hostname: "master-1", ip: "1001:db8::11"}, {role: models.HostRoleWorker, hostname: "worker-1", ip: "1001:db8::12"}}
 	clusterID := strfmt.UUID(uuid.New().String())
+	infraEnvID := strfmt.UUID(uuid.New().String())
 
 	Context("resolves hostname and role based on IP", func() {
 
@@ -71,12 +72,12 @@ var _ = Describe("GetHostnameAndRoleByIP", func() {
 				hosts := []*models.Host{}
 				for _, v := range test.hostRolesIpv4 {
 					netAddr := common.NetAddress{Hostname: v.hostname, IPv4Address: []string{fmt.Sprintf("%s/%d", v.ip, 24)}}
-					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), clusterID, v.role, models.HostStatusKnown, netAddr)
+					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, v.role, models.HostStatusKnown, netAddr)
 					hosts = append(hosts, h)
 				}
 				for _, v := range test.hostRolesIpv6 {
 					netAddr := common.NetAddress{Hostname: v.hostname, IPv6Address: []string{fmt.Sprintf("%s/%d", v.ip, 120)}}
-					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), clusterID, v.role, models.HostStatusKnown, netAddr)
+					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, v.role, models.HostStatusKnown, netAddr)
 					hosts = append(hosts, h)
 				}
 				hostname, role, err := GetHostnameAndRoleByIP(test.targetIP, hosts)

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -47,12 +47,12 @@ var (
 
 var _ = Describe("update_role", func() {
 	var (
-		ctx           = context.Background()
-		db            *gorm.DB
-		state         API
-		host          models.Host
-		id, clusterID strfmt.UUID
-		dbName        string
+		ctx                       = context.Background()
+		db                        *gorm.DB
+		state                     API
+		host                      models.Host
+		id, clusterID, infraEnvID strfmt.UUID
+		dbName                    string
 	)
 
 	BeforeEach(func() {
@@ -61,6 +61,7 @@ var _ = Describe("update_role", func() {
 		state = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
+		infraEnvID = strfmt.UUID(uuid.New().String())
 	})
 
 	AfterEach(func() {
@@ -69,18 +70,18 @@ var _ = Describe("update_role", func() {
 
 	Context("update role by src state", func() {
 		success := func(srcState string) {
-			host = hostutil.GenerateTestHost(id, clusterID, srcState)
+			host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, srcState)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, nil)).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(id, clusterID, db)
+			h := hostutil.GetHostFromDB(id, infraEnvID, db)
 			Expect(h.Role).To(Equal(models.HostRoleMaster))
 		}
 
 		failure := func(srcState string) {
-			host = hostutil.GenerateTestHost(id, clusterID, srcState)
+			host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, srcState)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, nil)).To(HaveOccurred())
-			h := hostutil.GetHostFromDB(id, clusterID, db)
+			h := hostutil.GetHostFromDB(id, infraEnvID, db)
 			Expect(h.Role).To(Equal(models.HostRoleWorker))
 		}
 
@@ -145,14 +146,14 @@ var _ = Describe("update_role", func() {
 	})
 
 	It("update role with transaction", func() {
-		host = hostutil.GenerateTestHost(id, clusterID, models.HostStatusKnown)
+		host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, models.HostStatusKnown)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		By("rollback transaction", func() {
 			tx := db.Begin()
 			Expect(tx.Error).ShouldNot(HaveOccurred())
 			Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, tx)).NotTo(HaveOccurred())
 			Expect(tx.Rollback().Error).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(id, clusterID, db)
+			h := hostutil.GetHostFromDB(id, infraEnvID, db)
 			Expect(h.Role).Should(Equal(models.HostRoleWorker))
 		})
 		By("commit transaction", func() {
@@ -160,19 +161,19 @@ var _ = Describe("update_role", func() {
 			Expect(tx.Error).ShouldNot(HaveOccurred())
 			Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, tx)).NotTo(HaveOccurred())
 			Expect(tx.Commit().Error).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(id, clusterID, db)
+			h := hostutil.GetHostFromDB(id, infraEnvID, db)
 			Expect(h.Role).Should(Equal(models.HostRoleMaster))
 		})
 	})
 
 	It("update role master to worker", func() {
-		host = hostutil.GenerateTestHost(id, clusterID, models.HostStatusKnown)
+		host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, models.HostStatusKnown)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, nil)).NotTo(HaveOccurred())
-		h := hostutil.GetHostFromDB(id, clusterID, db)
+		h := hostutil.GetHostFromDB(id, infraEnvID, db)
 		Expect(h.Role).To(Equal(models.HostRoleMaster))
 		Expect(state.UpdateRole(ctx, &host, models.HostRoleWorker, nil)).NotTo(HaveOccurred())
-		h = hostutil.GetHostFromDB(id, clusterID, db)
+		h = hostutil.GetHostFromDB(id, infraEnvID, db)
 		Expect(h.Role).To(Equal(models.HostRoleWorker))
 	})
 
@@ -235,9 +236,9 @@ var _ = Describe("update_role", func() {
 			It(t.name, func() {
 				// Setup
 				if t.day2 {
-					host = hostutil.GenerateTestHostAddedToCluster(id, clusterID, models.HostStatusKnown)
+					host = hostutil.GenerateTestHostAddedToCluster(id, infraEnvID, clusterID, models.HostStatusKnown)
 				} else {
-					host = hostutil.GenerateTestHost(id, clusterID, models.HostStatusKnown)
+					host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, models.HostStatusKnown)
 				}
 
 				host.Role = t.previousRole
@@ -252,7 +253,7 @@ var _ = Describe("update_role", func() {
 
 				// Test
 				Expect(state.UpdateRole(ctx, &host, t.role, nil)).NotTo(HaveOccurred())
-				h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(h.Role).To(Equal(t.role))
 				Expect(h.MachineConfigPoolName).Should(Equal(t.expectedMachineConfigPool))
 			})
@@ -285,7 +286,8 @@ var _ = Describe("update_progress", func() {
 		state = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), mockMetric, defaultConfig, dummy, nil)
 		id := strfmt.UUID(uuid.New().String())
 		clusterId := strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, "")
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, "")
 	})
 
 	AfterEach(func() {
@@ -315,7 +317,7 @@ var _ = Describe("update_progress", func() {
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (default progress stage)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 			})
 
@@ -325,12 +327,12 @@ var _ = Describe("update_progress", func() {
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (default progress stage)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 				updatedAt := hostFromDB.StageUpdatedAt.String()
 
 				Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*hostFromDB.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*hostFromDB.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 				Expect(hostFromDB.StageUpdatedAt.String()).Should(Equal(updatedAt))
 			})
@@ -338,22 +340,22 @@ var _ = Describe("update_progress", func() {
 			It("writing to disk", func() {
 				progress.CurrentStage = models.HostStageWritingImageToDisk
 				progress.ProgressInfo = "20%"
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (Writing image to disk)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 			})
 
 			It("done", func() {
 				progress.CurrentStage = models.HostStageDone
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"installed\" (Done)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstalled))
 			})
@@ -369,11 +371,11 @@ var _ = Describe("update_progress", func() {
 			It("progress_failed", func() {
 				progress.CurrentStage = models.HostStageFailed
 				progress.ProgressInfo = "reason"
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityError,
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityError,
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"error\" (Failed - reason)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusError))
 				Expect(*hostFromDB.StatusInfo).Should(Equal(fmt.Sprintf("%s - %s", progress.CurrentStage, progress.ProgressInfo)))
@@ -382,12 +384,12 @@ var _ = Describe("update_progress", func() {
 			It("progress_failed_empty_reason", func() {
 				progress.CurrentStage = models.HostStageFailed
 				progress.ProgressInfo = ""
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityError,
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityError,
 					fmt.Sprintf("Host %s: updated status from \"installing\" to \"error\" "+
 						"(Failed)", host.ID.String()),
 					gomock.Any())
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-				hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusError))
 				Expect(*hostFromDB.StatusInfo).Should(Equal(string(progress.CurrentStage)))
 			})
@@ -396,12 +398,12 @@ var _ = Describe("update_progress", func() {
 				By("Some stage", func() {
 					progress.CurrentStage = models.HostStageWritingImageToDisk
 					progress.ProgressInfo = "20%"
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 						fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" "+
 							"(Writing image to disk)", host.ID.String()),
 						gomock.Any())
 					Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-					hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 					Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 					Expect(*hostFromDB.StatusInfo).Should(Equal(string(progress.CurrentStage)))
 
@@ -414,12 +416,12 @@ var _ = Describe("update_progress", func() {
 						CurrentStage: models.HostStageFailed,
 						ProgressInfo: "reason",
 					}
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityError,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityError,
 						fmt.Sprintf("Host %s: updated status from \"installing-in-progress\" to \"error\" "+
 							"(Failed - reason)", host.ID.String()),
 						gomock.Any())
 					Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &newProgress)).ShouldNot(HaveOccurred())
-					hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 					Expect(*hostFromDB.Status).Should(Equal(models.HostStatusError))
 					Expect(*hostFromDB.StatusInfo).Should(Equal(fmt.Sprintf("%s - %s", newProgress.CurrentStage, newProgress.ProgressInfo)))
 
@@ -432,7 +434,7 @@ var _ = Describe("update_progress", func() {
 		Context("Invalid progress", func() {
 			It("lower_stage", func() {
 				verifyDb := func() {
-					hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 					Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 					Expect(*hostFromDB.StatusInfo).Should(Equal(string(progress.CurrentStage)))
 
@@ -444,7 +446,7 @@ var _ = Describe("update_progress", func() {
 					progress.CurrentStage = models.HostStageWritingImageToDisk
 					progress.ProgressInfo = "20%"
 					mockMetric.EXPECT().ReportHostInstallationMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 						fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" "+
 							"(Writing image to disk)", host.ID.String()),
 						gomock.Any())
@@ -456,7 +458,7 @@ var _ = Describe("update_progress", func() {
 					newProgress := models.HostProgress{
 						CurrentStage: models.HostStageInstalling,
 					}
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 						fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" "+
 							"(Writing image to disk)", host.ID.String()),
 						gomock.Any())
@@ -467,7 +469,7 @@ var _ = Describe("update_progress", func() {
 
 			It("update_on_installed", func() {
 				verifyDb := func() {
-					hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 					Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstalled))
 					Expect(hostFromDB.StatusInfo).Should(BeNil())
@@ -503,6 +505,7 @@ var _ = Describe("update progress special cases", func() {
 		mockMetric *metrics.MockAPI
 		dbName     string
 		clusterId  strfmt.UUID
+		infraEnvId strfmt.UUID
 	)
 
 	setDefaultReportHostInstallationMetrics := func(mockMetricApi *metrics.MockAPI) {
@@ -519,7 +522,8 @@ var _ = Describe("update progress special cases", func() {
 		state = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), mockMetric, defaultConfig, dummy, nil)
 		id := strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHostByKind(id, clusterId, models.HostStatusInstalling, models.HostKindHost, models.HostRoleMaster)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHostByKind(id, infraEnvId, clusterId, models.HostStatusInstalling, models.HostKindHost, models.HostRoleMaster)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, host.ID, models.EventSeverityInfo,
 			fmt.Sprintf("Host %s: set as bootstrap", host.ID.String()),
@@ -543,18 +547,18 @@ var _ = Describe("update progress special cases", func() {
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 
 			progress.CurrentStage = models.HostStageWaitingForBootkube
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (Waiting for bootkube)", host.ID.String()),
 				gomock.Any())
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-			hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 			Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageWaitingForBootkube))
 
 			progress.CurrentStage = models.HostStageWritingImageToDisk
 			progress.ProgressInfo = "20%"
 			Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &progress)).ShouldNot(HaveOccurred())
-			hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageWritingImageToDisk))
 		})
 		It("Single node special stage order - not allowed", func() {
@@ -563,11 +567,11 @@ var _ = Describe("update progress special cases", func() {
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 
 			progress.CurrentStage = models.HostStageWaitingForBootkube
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (Waiting for bootkube)", host.ID.String()),
 				gomock.Any())
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-			hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 			Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageWaitingForBootkube))
 
@@ -580,11 +584,11 @@ var _ = Describe("update progress special cases", func() {
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 
 			progress.CurrentStage = models.HostStageWaitingForBootkube
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"installing\" to \"installing-in-progress\" (Waiting for bootkube)", host.ID.String()),
 				gomock.Any())
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
-			hostFromDB = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
 			Expect(hostFromDB.Progress.CurrentStage).Should(Equal(models.HostStageWaitingForBootkube))
 
@@ -612,7 +616,8 @@ var _ = Describe("cancel installation", func() {
 		state = NewManager(common.GetTestLog(), db, eventsHandler, nil, nil, nil, nil, defaultConfig, dummy, nil)
 		id := strfmt.UUID(uuid.New().String())
 		clusterId := strfmt.UUID(uuid.New().String())
-		h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDiscovering)
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDiscovering)
 	})
 
 	AfterEach(func() {
@@ -665,7 +670,8 @@ var _ = Describe("cancel installation", func() {
 		It("cancel disabled host", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDisabled)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDisabled)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			Expect(state.CancelInstallation(ctx, &h, "some reason", db)).ShouldNot(HaveOccurred())
 			db.First(&h, "id = ? and cluster_id = ?", h.ID, *h.ClusterID)
@@ -703,7 +709,8 @@ var _ = Describe("reset host", func() {
 		It("reset installation success", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusError)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusError)
 			h.LogsCollectedAt = strfmt.DateTime(time.Now())
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			Expect(h.LogsCollectedAt).ShouldNot(Equal(strfmt.DateTime(time.Time{})))
@@ -723,7 +730,8 @@ var _ = Describe("reset host", func() {
 		It("register resetting host", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusResetting)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusResetting)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			Expect(state.RegisterHost(ctx, &h, db)).ShouldNot(HaveOccurred())
 			db.First(&h, "id = ? and cluster_id = ?", h.ID, *h.ClusterID)
@@ -733,7 +741,8 @@ var _ = Describe("reset host", func() {
 		It("reset pending user action - passed timeout", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusResetting)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusResetting)
 			then := time.Now().Add(-config.ResetTimeout)
 			h.StatusUpdatedAt = strfmt.DateTime(then)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
@@ -753,7 +762,8 @@ var _ = Describe("reset host", func() {
 		It("reset pending user action - host in reboot", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusResetting)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusResetting)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			h.Progress.CurrentStage = models.HostStageRebooting
 			Expect(state.IsRequireUserActionReset(&h)).Should(Equal(true))
@@ -772,7 +782,8 @@ var _ = Describe("reset host", func() {
 		It("reset disabled host", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDisabled)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDisabled)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			Expect(state.ResetHost(ctx, &h, "some reason", db)).ShouldNot(HaveOccurred())
 			db.First(&h, "id = ? and cluster_id = ?", h.ID, *h.ClusterID)
@@ -787,7 +798,8 @@ var _ = Describe("reset host", func() {
 		It("nothing_to_reset", func() {
 			id := strfmt.UUID(uuid.New().String())
 			clusterId := strfmt.UUID(uuid.New().String())
-			h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDiscovering)
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDiscovering)
 			reply := state.ResetHost(ctx, &h, "some reason", db)
 			Expect(int(reply.StatusCode())).Should(Equal(http.StatusConflict))
 			events, err := eventsHandler.GetEvents(*h.ClusterID, h.ID)
@@ -824,7 +836,8 @@ var _ = Describe("register host", func() {
 	BeforeEach(func() {
 		id := strfmt.UUID(uuid.New().String())
 		clusterId := strfmt.UUID(uuid.New().String())
-		h = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDiscovering)
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		h = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDiscovering)
 	})
 
 	It("register host success", func() {
@@ -948,14 +961,14 @@ func workerInventory() string {
 
 var _ = Describe("UpdateInventory", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockValidator     *hardware.MockValidator
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockValidator                 *hardware.MockValidator
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -967,6 +980,7 @@ var _ = Describe("UpdateInventory", func() {
 			nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 		cluster := hostutil.GenerateTestCluster(clusterId, "10.0.0.1/24")
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 	})
@@ -1006,14 +1020,14 @@ var _ = Describe("UpdateInventory", func() {
 		} {
 			test := test
 			It(test.testName, func() {
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
 				inventoryStr, err := hostutil.MarshalInventory(&test.inventory)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hapi.(*Manager).UpdateInventory(ctx, &host, inventoryStr)).ToNot(HaveOccurred())
-				h := hostutil.GetHostFromDB(hostId, clusterId, db)
+				h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 				Expect(h.Inventory).To(Not(BeEmpty()))
 				inventory, err := hostutil.UnmarshalInventory(h.Inventory)
 				Expect(err).ToNot(HaveOccurred())
@@ -1098,7 +1112,7 @@ var _ = Describe("UpdateInventory", func() {
 		)
 
 		BeforeEach(func() {
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 			host.Inventory = common.GenerateTestDefaultInventory()
 			host.InstallationDiskPath = ""
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -1113,7 +1127,7 @@ var _ = Describe("UpdateInventory", func() {
 
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
 
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))
 			Expect(h.InstallationDiskID).To(Equal(diskId))
 
@@ -1124,7 +1138,7 @@ var _ = Describe("UpdateInventory", func() {
 			)
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
 
-			h = hostutil.GetHostFromDB(hostId, clusterId, db)
+			h = hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(""))
 			Expect(h.InstallationDiskID).To(Equal(""))
 		})
@@ -1134,7 +1148,7 @@ var _ = Describe("UpdateInventory", func() {
 				[]*models.Disk{{Name: diskName}},
 			)
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))
 			Expect(h.InstallationDiskID).To(Equal(diskPath))
 
@@ -1143,7 +1157,7 @@ var _ = Describe("UpdateInventory", func() {
 			)
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
-			h = hostutil.GetHostFromDB(hostId, clusterId, db)
+			h = hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))
 			Expect(h.InstallationDiskID).To(Equal(diskId))
 		})
@@ -1168,13 +1182,13 @@ var _ = Describe("UpdateInventory", func() {
 
 		success := func(err error) {
 			Expect(err).To(BeNil())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.Inventory).To(Equal(string(newInventoryBytes)))
 		}
 
 		failure := func(err error) {
 			Expect(err).To(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.Inventory).To(Equal(common.GenerateTestDefaultInventory()))
 		}
 
@@ -1248,7 +1262,7 @@ var _ = Describe("UpdateInventory", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				host = hostutil.GenerateTestHost(hostId, clusterId, t.srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				host.Inventory = common.GenerateTestDefaultInventory()
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				t.validation(hapi.UpdateInventory(ctx, &host, string(newInventoryBytes)))
@@ -1259,12 +1273,12 @@ var _ = Describe("UpdateInventory", func() {
 
 var _ = Describe("Update hostname", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1273,6 +1287,7 @@ var _ = Describe("Update hostname", func() {
 		hapi = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	AfterEach(func() {
@@ -1282,13 +1297,13 @@ var _ = Describe("Update hostname", func() {
 	Context("set hostname", func() {
 		success := func(reply error) {
 			Expect(reply).To(BeNil())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.RequestedHostname).To(Equal("my-hostname"))
 		}
 
 		failure := func(reply error) {
 			Expect(reply).To(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.RequestedHostname).To(Equal(""))
 		}
 
@@ -1362,7 +1377,7 @@ var _ = Describe("Update hostname", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				host = hostutil.GenerateTestHost(hostId, clusterId, t.srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				t.validation(hapi.UpdateHostname(ctx, &host, "my-hostname", db))
 			})
@@ -1372,14 +1387,14 @@ var _ = Describe("Update hostname", func() {
 
 var _ = Describe("Update disk installation path", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		ctrl              *gomock.Controller
-		mockValidator     *hardware.MockValidator
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		ctrl                          *gomock.Controller
+		mockValidator                 *hardware.MockValidator
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1391,6 +1406,7 @@ var _ = Describe("Update disk installation path", func() {
 		hapi = NewManager(logger, db, nil, mockValidator, nil, createValidatorCfg(), nil, defaultConfig, leader, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	AfterEach(func() {
@@ -1400,21 +1416,21 @@ var _ = Describe("Update disk installation path", func() {
 
 	success := func(reply error) {
 		Expect(reply).To(BeNil())
-		h := hostutil.GetHostFromDB(hostId, clusterId, db)
+		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 		Expect(h.InstallationDiskID).To(Equal(common.TestDiskId))
 		Expect(h.InstallationDiskPath).To(Equal(common.TestDiskPath))
 	}
 
 	failure := func(reply error) {
 		Expect(reply).To(HaveOccurred())
-		h := hostutil.GetHostFromDB(hostId, clusterId, db)
+		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 		Expect(h.InstallationDiskID).To(Equal(""))
 		Expect(h.InstallationDiskPath).To(Equal(""))
 	}
 
 	Context("validate disk installation path", func() {
 		It("illegal disk installation path", func() {
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusKnown)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusKnown)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.Disk{common.TestDefaultConfig.Disks}, nil)
 			failure(hapi.UpdateInstallationDisk(ctx, db, &host, "/no/such/disk"))
@@ -1424,7 +1440,7 @@ var _ = Describe("Update disk installation path", func() {
 
 	Context("validate get host valid disks error", func() {
 		It("get host valid disks returns an error", func() {
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusKnown)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusKnown)
 			expectedError := errors.New("bad inventory")
 			mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.Disk{common.TestDefaultConfig.Disks}, expectedError)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -1510,7 +1526,7 @@ var _ = Describe("Update disk installation path", func() {
 					mockValidator.EXPECT().GetHostValidDisks(gomock.Any()).Return([]*models.Disk{common.TestDefaultConfig.Disks}, nil).AnyTimes()
 				}
 
-				host = hostutil.GenerateTestHost(hostId, clusterId, t.srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				err := hapi.UpdateInstallationDisk(ctx, db, &host, common.TestDiskId)
 
@@ -1526,14 +1542,14 @@ var _ = Describe("Update disk installation path", func() {
 
 var _ = Describe("SetBootstrap", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1544,11 +1560,12 @@ var _ = Describe("SetBootstrap", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 
-		host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusResetting)
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusResetting)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
-		h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+		h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 		Expect(h.Bootstrap).Should(Equal(false))
 	})
 
@@ -1574,7 +1591,7 @@ var _ = Describe("SetBootstrap", func() {
 			}
 			Expect(hapi.SetBootstrap(ctx, &host, t.IsBootstrap, db)).ShouldNot(HaveOccurred())
 
-			h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(h.Bootstrap).Should(Equal(t.IsBootstrap))
 		})
 	}
@@ -1587,14 +1604,14 @@ var _ = Describe("SetBootstrap", func() {
 
 var _ = Describe("UpdateNTP", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1605,11 +1622,12 @@ var _ = Describe("UpdateNTP", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 
-		host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusResetting)
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusResetting)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
-		h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+		h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 		Expect(h.NtpSources).Should(BeEmpty())
 	})
 
@@ -1632,7 +1650,7 @@ var _ = Describe("UpdateNTP", func() {
 		It(t.name, func() {
 			Expect(hapi.UpdateNTP(ctx, &host, t.ntpSources, db)).ShouldNot(HaveOccurred())
 
-			h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 			marshalled, err := json.Marshal(t.ntpSources)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -1649,14 +1667,14 @@ var _ = Describe("UpdateNTP", func() {
 
 var _ = Describe("UpdateMachineConfigPoolName", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1667,6 +1685,7 @@ var _ = Describe("UpdateMachineConfigPoolName", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	tests := []struct {
@@ -1700,19 +1719,19 @@ var _ = Describe("UpdateMachineConfigPoolName", func() {
 		It(t.name, func() {
 			// Setup
 			if t.day2 {
-				host = hostutil.GenerateTestHostAddedToCluster(hostId, clusterId, t.status)
+				host = hostutil.GenerateTestHostAddedToCluster(hostId, infraEnvId, clusterId, t.status)
 			} else {
-				host = hostutil.GenerateTestHost(hostId, clusterId, t.status)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.status)
 			}
 
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
-			h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 			Expect(h.MachineConfigPoolName).Should(BeEmpty())
 
 			// Test
 			err := hapi.UpdateMachineConfigPoolName(ctx, db, &host, t.name)
-			h = hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			h = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 			if t.isValid {
 				Expect(err).ShouldNot(HaveOccurred())
@@ -1733,13 +1752,13 @@ var _ = Describe("UpdateMachineConfigPoolName", func() {
 
 var _ = Describe("update logs_info", func() {
 	var (
-		ctx               = context.Background()
-		ctrl              *gomock.Controller
-		db                *gorm.DB
-		hapi              API
-		host              models.Host
-		hostId, clusterId strfmt.UUID
-		dbName            string
+		ctx                           = context.Background()
+		ctrl                          *gomock.Controller
+		db                            *gorm.DB
+		hapi                          API
+		host                          models.Host
+		hostId, clusterId, infraEnvId strfmt.UUID
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1749,7 +1768,8 @@ var _ = Describe("update logs_info", func() {
 		hapi = NewManager(common.GetTestLog(), db, nil, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, mockOperators)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusInstallingInProgress)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusInstallingInProgress)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 
@@ -1760,10 +1780,6 @@ var _ = Describe("update logs_info", func() {
 	validateLogsStartedAt := func(h *models.Host) {
 		Expect(h.LogsStartedAt).NotTo(Equal(strfmt.DateTime(time.Time{})))
 	}
-
-	// validateLogsCollectedAt := func(h *models.Host) {
-	// 	Expect(h.LogsCollectedAt).NotTo(Equal(strfmt.DateTime(time.Time{})))
-	// }
 
 	validateCollectedAtNotUpdated := func(h *models.Host) {
 		Expect(h.LogsCollectedAt).To(Equal(strfmt.DateTime(time.Time{})))
@@ -1796,7 +1812,7 @@ var _ = Describe("update logs_info", func() {
 		It(t.name, func() {
 			err := hapi.UpdateLogsProgress(ctx, &host, string(t.logsInfo))
 			Expect(err).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.LogsInfo).To(Equal(t.logsInfo))
 			t.validateTimestamp(&h.Host)
 		})
@@ -1805,15 +1821,15 @@ var _ = Describe("update logs_info", func() {
 
 var _ = Describe("UpdateImageStatus", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		mockMetric        *metrics.MockAPI
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		mockMetric                    *metrics.MockAPI
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1825,11 +1841,12 @@ var _ = Describe("UpdateImageStatus", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), mockMetric, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 
-		host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusResetting)
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusResetting)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
-		h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+		h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 		Expect(h.ImagesStatus).Should(BeEmpty())
 	})
 
@@ -1931,7 +1948,7 @@ var _ = Describe("UpdateImageStatus", func() {
 			}
 
 			Expect(hapi.UpdateImageStatus(ctx, &host, t.newImageStatus, db)).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(*host.ID, *host.ClusterID, db)
+			h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 
 			if t.changeInDB {
 				var statusInDb map[string]*models.ContainerImageAvailability
@@ -1949,14 +1966,14 @@ var _ = Describe("UpdateImageStatus", func() {
 
 var _ = Describe("UpdateKubeKeyNS", func() {
 	var (
-		ctx               = context.Background()
-		hostApi           API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		dbName            string
-		host              common.Host
+		ctx                           = context.Background()
+		hostApi                       API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		dbName                        string
+		host                          common.Host
 	)
 
 	BeforeEach(func() {
@@ -1967,9 +1984,10 @@ var _ = Describe("UpdateKubeKeyNS", func() {
 		hostApi = NewManager(common.GetTestLog(), db, mockEvents, nil, nil, createValidatorCfg(), nil, defaultConfig, dummy, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 
 		host = common.Host{
-			Host:             hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusKnown),
+			Host:             hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusKnown),
 			KubeKeyNamespace: "namespace",
 		}
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -1997,7 +2015,7 @@ var _ = Describe("UpdateKubeKeyNS", func() {
 		t := tests[i]
 		It(t.name, func() {
 			Expect(hostApi.UpdateKubeKeyNS(ctx, hostId.String(), t.namespace)).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.KubeKeyNamespace).Should(Equal(t.namespace))
 		})
 	}
@@ -2012,6 +2030,7 @@ var _ = Describe("AutoAssignRole", func() {
 	var (
 		ctx             = context.Background()
 		clusterId       strfmt.UUID
+		infraEnvId      strfmt.UUID
 		hapi            API
 		db              *gorm.DB
 		ctrl            *gomock.Controller
@@ -2026,6 +2045,7 @@ var _ = Describe("AutoAssignRole", func() {
 		mockOperators := operators.NewMockAPI(ctrl)
 		db, dbName = common.PrepareTestDB()
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 		dummy := &leader.DummyElector{}
 		hapi = NewManager(
 			common.GetTestLog(),
@@ -2130,7 +2150,7 @@ var _ = Describe("AutoAssignRole", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterId, models.HostStatusKnown)
+				h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvId, clusterId, models.HostStatusKnown)
 				h.Inventory = t.inventory
 				h.Role = t.srcRole
 				Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
@@ -2140,41 +2160,43 @@ var _ = Describe("AutoAssignRole", func() {
 				} else {
 					Expect(err).ShouldNot(HaveOccurred())
 				}
-				Expect(hostutil.GetHostFromDB(*h.ID, clusterId, db).Role).Should(Equal(t.expectedRole))
+				Expect(hostutil.GetHostFromDB(*h.ID, infraEnvId, db).Role).Should(Equal(t.expectedRole))
 			})
 		}
 	})
 
 	It("cluster already have enough master nodes", func() {
 		for i := 0; i < common.MinMasterHostsNeededForInstallation; i++ {
-			h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterId, models.HostStatusKnown)
+			h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvId, clusterId, models.HostStatusKnown)
 			h.Inventory = hostutil.GenerateMasterInventory()
 			h.Role = models.HostRoleAutoAssign
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 			Expect(hapi.AutoAssignRole(ctx, &h, db)).ShouldNot(HaveOccurred())
-			Expect(hostutil.GetHostFromDB(*h.ID, clusterId, db).Role).Should(Equal(models.HostRoleMaster))
+			Expect(hostutil.GetHostFromDB(*h.ID, infraEnvId, db).Role).Should(Equal(models.HostRoleMaster))
 		}
 
-		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterId, models.HostStatusKnown)
+		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvId, clusterId, models.HostStatusKnown)
 		h.Inventory = hostutil.GenerateMasterInventory()
 		h.Role = models.HostRoleAutoAssign
 		Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 		Expect(hapi.AutoAssignRole(ctx, &h, db)).ShouldNot(HaveOccurred())
-		Expect(hostutil.GetHostFromDB(*h.ID, clusterId, db).Role).Should(Equal(models.HostRoleWorker))
+		Expect(hostutil.GetHostFromDB(*h.ID, infraEnvId, db).Role).Should(Equal(models.HostRoleWorker))
 	})
 })
 
 var _ = Describe("IsValidMasterCandidate", func() {
 	var (
-		clusterId strfmt.UUID
-		hapi      API
-		db        *gorm.DB
-		dbName    string
-		ctrl      *gomock.Controller
+		clusterId  strfmt.UUID
+		infraEnvId strfmt.UUID
+		hapi       API
+		db         *gorm.DB
+		dbName     string
+		ctrl       *gomock.Controller
 	)
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 		dummy := &leader.DummyElector{}
 		testLog := common.GetTestLog()
 		hwValidatorCfg := createValidatorCfg()
@@ -2259,7 +2281,7 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterId, t.srcState)
+				h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvId, clusterId, t.srcState)
 				h.Inventory = t.inventory
 				h.Role = t.srcRole
 				Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
@@ -2305,10 +2327,10 @@ var _ = Describe("Validation metrics and events", func() {
 		return validationRes
 	}
 
-	registerTestHostWithValidations := func(clusterID strfmt.UUID) *models.Host {
+	registerTestHostWithValidations := func(infraEnvID, clusterID strfmt.UUID) *models.Host {
 
 		hostID := strfmt.UUID(uuid.New().String())
-		h := hostutil.GenerateTestHost(hostID, clusterID, models.HostStatusInsufficient)
+		h := hostutil.GenerateTestHost(hostID, infraEnvID, clusterID, models.HostStatusInsufficient)
 
 		validationRes := generateTestValidationResult(ValidationFailure)
 		bytes, err := json.Marshal(validationRes)
@@ -2343,7 +2365,7 @@ var _ = Describe("Validation metrics and events", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		validatorCfg = createValidatorCfg()
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil)
-		h = registerTestHostWithValidations(strfmt.UUID(uuid.New().String()))
+		h = registerTestHostWithValidations(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()))
 	})
 
 	AfterEach(func() {
@@ -2392,10 +2414,10 @@ var _ = Describe("SetDiskSpeed", func() {
 		h               *models.Host
 	)
 
-	registerTestHost := func(clusterID strfmt.UUID) *models.Host {
+	registerTestHost := func(infraEnvID, clusterID strfmt.UUID) *models.Host {
 
 		hostID := strfmt.UUID(uuid.New().String())
-		h := hostutil.GenerateTestHost(hostID, clusterID, models.HostStatusInsufficient)
+		h := hostutil.GenerateTestHost(hostID, infraEnvID, clusterID, models.HostStatusInsufficient)
 
 		h.Inventory = hostutil.GenerateMasterInventory()
 
@@ -2411,7 +2433,7 @@ var _ = Describe("SetDiskSpeed", func() {
 		mockHwValidator = hardware.NewMockValidator(ctrl)
 		validatorCfg = createValidatorCfg()
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, nil, defaultConfig, nil, nil)
-		h = registerTestHost(strfmt.UUID(uuid.New().String()))
+		h = registerTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()))
 	})
 
 	verifyValidResult := func(h *models.Host, path string, exitCode int64, speedMs int64) {
@@ -2482,10 +2504,10 @@ var _ = Describe("ResetHostValidation", func() {
 		h               *models.Host
 	)
 
-	registerTestHost := func(clusterID strfmt.UUID) *models.Host {
+	registerTestHost := func(infraEnvID, clusterID strfmt.UUID) *models.Host {
 
 		hostID := strfmt.UUID(uuid.New().String())
-		h := hostutil.GenerateTestHost(hostID, clusterID, models.HostStatusInsufficient)
+		h := hostutil.GenerateTestHost(hostID, infraEnvID, clusterID, models.HostStatusInsufficient)
 
 		h.Inventory = hostutil.GenerateMasterInventory()
 		h.InstallationDiskID = "/dev/sda"
@@ -2503,7 +2525,7 @@ var _ = Describe("ResetHostValidation", func() {
 		validatorCfg = createValidatorCfg()
 		mockMetric := metrics.NewMockAPI(ctrl)
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil)
-		h = registerTestHost(strfmt.UUID(uuid.New().String()))
+		h = registerTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()))
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		mockEvents.EXPECT().AddEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -2536,10 +2558,10 @@ var _ = Describe("ResetHostValidation", func() {
 	It("One disk in error", func() {
 		Expect(m.SetDiskSpeed(ctx, h, "/dev/sda", 2, 5, nil)).ToNot(HaveOccurred())
 		var newHost models.Host
-		Expect(db.Take(&newHost, "id = ? and cluster_id = ?", h.ID.String(), h.ClusterID.String()).Error).ToNot(HaveOccurred())
+		Expect(db.Take(&newHost, "id = ? and infra_env_id = ?", h.ID.String(), h.InfraEnvID.String()).Error).ToNot(HaveOccurred())
 		verifyExistingDiskResult(&newHost, "/dev/sda", 5, 2)
-		Expect(m.ResetHostValidation(ctx, *h.ID, *h.ClusterID, string(models.HostValidationIDSufficientInstallationDiskSpeed), nil)).ToNot(HaveOccurred())
-		Expect(db.Take(&newHost, "id = ? and cluster_id = ?", h.ID.String(), h.ClusterID.String()).Error).ToNot(HaveOccurred())
+		Expect(m.ResetHostValidation(ctx, *h.ID, h.InfraEnvID, string(models.HostValidationIDSufficientInstallationDiskSpeed), nil)).ToNot(HaveOccurred())
+		Expect(db.Take(&newHost, "id = ? and infra_env_id = ?", h.ID.String(), h.InfraEnvID.String()).Error).ToNot(HaveOccurred())
 		verifyNonExistentDiskResult(&newHost, "/dev/sda")
 	})
 	It("One image in error", func() {
@@ -2554,7 +2576,7 @@ var _ = Describe("ResetHostValidation", func() {
 		imageStatus, exists := common.GetImageStatus(imageStatuses, "a.b.c")
 		Expect(exists).To(BeTrue())
 		Expect(imageStatus.Result).To(Equal(models.ContainerImageAvailabilityResultFailure))
-		Expect(m.ResetHostValidation(ctx, *h.ID, *h.ClusterID, string(models.HostValidationIDContainerImagesAvailable), nil)).ToNot(HaveOccurred())
+		Expect(m.ResetHostValidation(ctx, *h.ID, h.InfraEnvID, string(models.HostValidationIDContainerImagesAvailable), nil)).ToNot(HaveOccurred())
 		Expect(db.Take(&newHost, "id = ? and cluster_id = ?", h.ID.String(), h.ClusterID.String()).Error).ToNot(HaveOccurred())
 		imageStatuses, err = common.UnmarshalImageStatuses(newHost.ImagesStatus)
 		Expect(err).ToNot(HaveOccurred())
@@ -2562,13 +2584,13 @@ var _ = Describe("ResetHostValidation", func() {
 		Expect(exists).To(BeFalse())
 	})
 	It("Unsupported validation", func() {
-		Expect(m.ResetHostValidation(ctx, *h.ID, *h.ClusterID, string(models.HostValidationIDAPIVipConnected), nil)).To(HaveOccurred())
+		Expect(m.ResetHostValidation(ctx, *h.ID, h.InfraEnvID, string(models.HostValidationIDAPIVipConnected), nil)).To(HaveOccurred())
 	})
 	It("Nonexistant validation", func() {
-		Expect(m.ResetHostValidation(ctx, *h.ID, *h.ClusterID, "abcd", nil)).To(HaveOccurred())
+		Expect(m.ResetHostValidation(ctx, *h.ID, h.InfraEnvID, "abcd", nil)).To(HaveOccurred())
 	})
 	It("Host not found", func() {
-		err := m.ResetHostValidation(ctx, strfmt.UUID(uuid.New().String()), *h.ClusterID, string(models.HostValidationIDContainerImagesAvailable), nil)
+		err := m.ResetHostValidation(ctx, strfmt.UUID(uuid.New().String()), h.InfraEnvID, string(models.HostValidationIDContainerImagesAvailable), nil)
 		Expect(err).To(HaveOccurred())
 		apiErr, ok := err.(*common.ApiErrorResponse)
 		Expect(ok).To(BeTrue())
@@ -2691,7 +2713,7 @@ var _ = Describe("Installation stages", func() {
 
 	It("UpdateInstallProgress test - day1 hosts", func() {
 
-		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), models.HostStatusInstalling)
+		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), models.HostStatusInstalling)
 		h.Role = models.HostRoleMaster
 		Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
 
@@ -2708,7 +2730,7 @@ var _ = Describe("Installation stages", func() {
 			err := api.UpdateInstallProgress(ctx, &h, &progress)
 			Expect(err).NotTo(HaveOccurred())
 
-			hFromDB := hostutil.GetHostFromDB(*h.ID, *h.ClusterID, db)
+			hFromDB := hostutil.GetHostFromDB(*h.ID, h.InfraEnvID, db)
 			h = hFromDB.Host
 			expectedInstallationPercentage := int64(float64(api.IndexOfStage(newStage, MasterStages[:])+1) / float64(len(MasterStages[:])) * 100)
 			Expect(h.Progress.InstallationPercentage).To(Equal(expectedInstallationPercentage))
@@ -2727,7 +2749,7 @@ var _ = Describe("Installation stages", func() {
 			err := api.UpdateInstallProgress(ctx, &h, &progress)
 			Expect(err).NotTo(HaveOccurred())
 
-			hFromDB := hostutil.GetHostFromDB(*h.ID, *h.ClusterID, db)
+			hFromDB := hostutil.GetHostFromDB(*h.ID, h.InfraEnvID, db)
 			h = hFromDB.Host
 			expectedInstallationPercentage := int64(float64(api.IndexOfStage(newStage, MasterStages[:])+1) / float64(len(MasterStages[:])) * 100)
 			Expect(h.Progress.InstallationPercentage).To(Equal(expectedInstallationPercentage))
@@ -2736,7 +2758,7 @@ var _ = Describe("Installation stages", func() {
 
 	It("UpdateInstallProgress test - day2 hosts", func() {
 
-		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), models.HostStatusInstalling)
+		h := hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), strfmt.UUID(uuid.New().String()), models.HostStatusInstalling)
 		hostKindDay2 := models.HostKindAddToExistingClusterHost
 		h.Kind = &hostKindDay2
 		h.Role = models.HostRoleWorker

--- a/internal/host/hostcommands/api_vip_connectivity_check_cmd_test.go
+++ b/internal/host/hostcommands/api_vip_connectivity_check_cmd_test.go
@@ -19,7 +19,7 @@ var _ = Describe("apivipconnectivitycheckcmd", func() {
 	var cluster common.Cluster
 	var db *gorm.DB
 	var apivipConnectivityCheckCmd *apivipConnectivityCheckCmd
-	var id, clusterID strfmt.UUID
+	var id, clusterID, infraEnvID strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -30,7 +30,8 @@ var _ = Describe("apivipconnectivitycheckcmd", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHostAddedToCluster(id, clusterID, models.HostStatusInsufficient)
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHostAddedToCluster(id, infraEnvID, clusterID, models.HostStatusInsufficient)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		apiVipDNSName := "test.com"
 		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, APIVipDNSName: &apiVipDNSName}}

--- a/internal/host/hostcommands/connectivity_check_cmd_test.go
+++ b/internal/host/hostcommands/connectivity_check_cmd_test.go
@@ -18,7 +18,7 @@ var _ = Describe("connectivitycheckcmd", func() {
 	var host models.Host
 	var db *gorm.DB
 	var connectivityCheckCmd *connectivityCheckCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -29,7 +29,8 @@ var _ = Describe("connectivitycheckcmd", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusInsufficient)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/hostcommands/connectivity_check_convertor_test.go
+++ b/internal/host/hostcommands/connectivity_check_convertor_test.go
@@ -14,11 +14,11 @@ import (
 
 var _ = Describe("connectivitycheckconvertor", func() {
 	var (
-		ctrl                                       *gomock.Controller
-		mockValidator                              *connectivity.MockValidator
-		currentHostId, hostId2, hostId3, clusterId strfmt.UUID
-		hosts                                      []*models.Host
-		interfaces                                 []*models.Interface
+		ctrl                                                   *gomock.Controller
+		mockValidator                                          *connectivity.MockValidator
+		currentHostId, hostId2, hostId3, clusterId, infraEnvId strfmt.UUID
+		hosts                                                  []*models.Host
+		interfaces                                             []*models.Interface
 	)
 
 	BeforeEach(func() {
@@ -27,14 +27,15 @@ var _ = Describe("connectivitycheckconvertor", func() {
 		mockValidator = connectivity.NewMockValidator(ctrl)
 
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 		currentHostId = strfmt.UUID(uuid.New().String())
 		hostId2 = strfmt.UUID(uuid.New().String())
 		hostId3 = strfmt.UUID(uuid.New().String())
 		currentHostId = strfmt.UUID(uuid.New().String())
 		hosts = []*models.Host{
-			{ID: &currentHostId, ClusterID: &clusterId},
-			{ID: &hostId2, ClusterID: &clusterId},
-			{ID: &hostId3, ClusterID: &clusterId},
+			{ID: &currentHostId, ClusterID: &clusterId, InfraEnvID: infraEnvId},
+			{ID: &hostId2, ClusterID: &clusterId, InfraEnvID: infraEnvId},
+			{ID: &hostId3, ClusterID: &clusterId, InfraEnvID: infraEnvId},
 		}
 
 		interfaces = []*models.Interface{

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -25,16 +25,16 @@ const (
 
 var _ = Describe("container_image_availability_cmd", func() {
 	var (
-		ctx           = context.Background()
-		host          models.Host
-		cluster       common.Cluster
-		db            *gorm.DB
-		cmd           *imageAvailabilityCmd
-		id, clusterID strfmt.UUID
-		dbName        string
-		ctrl          *gomock.Controller
-		mockRelease   *oc.MockRelease
-		mockVersions  *versions.MockHandler
+		ctx                       = context.Background()
+		host                      models.Host
+		cluster                   common.Cluster
+		db                        *gorm.DB
+		cmd                       *imageAvailabilityCmd
+		id, clusterID, infraEnvID strfmt.UUID
+		dbName                    string
+		ctrl                      *gomock.Controller
+		mockRelease               *oc.MockRelease
+		mockVersions              *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -47,7 +47,8 @@ var _ = Describe("container_image_availability_cmd", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHostAddedToCluster(id, clusterID, models.HostStatusInsufficient)
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHostAddedToCluster(id, infraEnvID, clusterID, models.HostStatusInsufficient)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/host/hostcommands/dhcp_allocate_cmd_test.go
+++ b/internal/host/hostcommands/dhcp_allocate_cmd_test.go
@@ -20,7 +20,7 @@ var _ = Describe("dhcpallocate", func() {
 	var cluster common.Cluster
 	var db *gorm.DB
 	var dCmd *dhcpAllocateCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -31,7 +31,8 @@ var _ = Describe("dhcpallocate", func() {
 
 		id = strfmt.UUID("32b4463e-5f94-4245-87cf-a6948014045c")
 		clusterId = strfmt.UUID("bd9d3b83-80a3-4b94-8b61-c12b2f1a2373")
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+		infraEnvId = strfmt.UUID("bd9d3b83-80a3-4b94-8b61-c12b2f1a2375")
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusInsufficient)
 		host.Inventory = hostutil.GenerateMasterInventory()
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})

--- a/internal/host/hostcommands/disk_performance_cmd_test.go
+++ b/internal/host/hostcommands/disk_performance_cmd_test.go
@@ -20,7 +20,7 @@ var _ = Describe("disk_performance", func() {
 	var host models.Host
 	var db *gorm.DB
 	var dCmd *diskPerfCheckCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -36,7 +36,8 @@ var _ = Describe("disk_performance", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusPreparingForInstallation)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusPreparingForInstallation)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/hostcommands/domain_name_resolution_cmd_test.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd_test.go
@@ -19,7 +19,7 @@ var _ = Describe("domainNameResolution", func() {
 	var cluster common.Cluster
 	var db *gorm.DB
 	var dCmd *domainNameResolutionCmd
-	var id, clusterID strfmt.UUID
+	var id, clusterID, infraEnvID strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -31,7 +31,8 @@ var _ = Describe("domainNameResolution", func() {
 		dCmd = NewDomainNameResolutionCmd(common.GetTestLog(), "quay.io/ocpmetal/assisted-installer-agent:latest", db)
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterID, models.HostStatusPreparingForInstallation)
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, models.HostStatusPreparingForInstallation)
 		host.Inventory = hostutil.GenerateMasterInventory()
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		name = "example"

--- a/internal/host/hostcommands/free_addresses_cmd_test.go
+++ b/internal/host/hostcommands/free_addresses_cmd_test.go
@@ -18,7 +18,7 @@ var _ = Describe("free_addresses", func() {
 	var host models.Host
 	var db *gorm.DB
 	var fCmd CommandGetter
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -28,7 +28,8 @@ var _ = Describe("free_addresses", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusInsufficient)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusInsufficient)
 		host.Inventory = common.GenerateTestDefaultInventory()
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -86,7 +86,7 @@ func (i *installCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models
 
 	step.Args = []string{"-c", unbootableCmd + fullCmd}
 
-	if _, err := hostutil.UpdateHost(i.log, i.db, *host.ClusterID, *host.ID, *host.Status,
+	if _, err := hostutil.UpdateHost(i.log, i.db, host.InfraEnvID, *host.ID, *host.Status,
 		"installer_version", i.instructionConfig.InstallerImage); err != nil {
 		return nil, err
 	}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -49,6 +49,7 @@ var _ = Describe("installcmd", func() {
 		db                *gorm.DB
 		installCmd        *installCmd
 		clusterId         strfmt.UUID
+		infraEnvId        strfmt.UUID
 		stepReply         []*models.Step
 		stepErr           error
 		ctrl              *gomock.Controller
@@ -70,7 +71,8 @@ var _ = Describe("installcmd", func() {
 		installCmd = NewInstallCmd(common.GetTestLog(), db, mockValidator, mockRelease, instructionConfig, mockEvents, mockVersions)
 		cluster = createClusterInDb(db, models.ClusterHighAvailabilityModeFull)
 		clusterId = *cluster.ID
-		host = createHostInDb(db, clusterId, models.HostRoleMaster, false, "")
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = createHostInDb(db, infraEnvId, clusterId, models.HostRoleMaster, false, "")
 	})
 
 	mockGetReleaseImage := func(times int) {
@@ -97,7 +99,7 @@ var _ = Describe("installcmd", func() {
 			stepReply, stepErr = installCmd.GetSteps(ctx, &host)
 			Expect(stepReply).To(BeNil())
 			postvalidation(true, true, nil, stepErr, "")
-			hostFromDb := hostutil.GetHostFromDB(*host.ID, clusterId, db)
+			hostFromDb := hostutil.GetHostFromDB(*host.ID, infraEnvId, db)
 			Expect(hostFromDb.InstallerVersion).Should(BeEmpty())
 		})
 	})
@@ -109,13 +111,13 @@ var _ = Describe("installcmd", func() {
 		stepReply, stepErr = installCmd.GetSteps(ctx, &host)
 		postvalidation(false, false, stepReply[0], stepErr, models.HostRoleMaster)
 		validateInstallCommand(installCmd, stepReply[0], models.HostRoleMaster, clusterId, *host.ID, common.TestDiskId, nil, models.ClusterHighAvailabilityModeFull)
-		hostFromDb := hostutil.GetHostFromDB(*host.ID, clusterId, db)
+		hostFromDb := hostutil.GetHostFromDB(*host.ID, infraEnvId, db)
 		Expect(hostFromDb.InstallerVersion).Should(Equal(DefaultInstructionConfig.InstallerImage))
 	})
 
 	It("get_step_three_master_success", func() {
-		host2 := createHostInDb(db, clusterId, models.HostRoleMaster, false, "")
-		host3 := createHostInDb(db, clusterId, models.HostRoleMaster, true, "some_hostname")
+		host2 := createHostInDb(db, infraEnvId, clusterId, models.HostRoleMaster, false, "")
+		host3 := createHostInDb(db, infraEnvId, clusterId, models.HostRoleMaster, true, "some_hostname")
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return(common.TestDiskId).Times(3)
 		mockGetReleaseImage(3)
 		mockImages(3)
@@ -164,7 +166,7 @@ var _ = Describe("installcmd", func() {
 		stepReply, stepErr = installCmd.GetSteps(ctx, &host)
 		postvalidation(false, false, stepReply[0], stepErr, models.HostRoleMaster)
 		validateInstallCommand(installCmd, stepReply[0], models.HostRoleMaster, clusterId, *host.ID, sdb.ID, getBootableDiskNames(disks), models.ClusterHighAvailabilityModeFull)
-		hostFromDb := hostutil.GetHostFromDB(*host.ID, clusterId, db)
+		hostFromDb := hostutil.GetHostFromDB(*host.ID, infraEnvId, db)
 		Expect(hostFromDb.InstallerVersion).Should(Equal(DefaultInstructionConfig.InstallerImage))
 	})
 
@@ -200,7 +202,7 @@ var _ = Describe("installcmd", func() {
 		stepReply, stepErr = installCmd.GetSteps(ctx, &host)
 		postvalidation(false, false, stepReply[0], stepErr, models.HostRoleMaster)
 		validateInstallCommand(installCmd, stepReply[0], models.HostRoleMaster, clusterId, *host.ID, sdb.ID, []string{sda.ID, sdc.ID}, models.ClusterHighAvailabilityModeFull)
-		hostFromDb := hostutil.GetHostFromDB(*host.ID, clusterId, db)
+		hostFromDb := hostutil.GetHostFromDB(*host.ID, infraEnvId, db)
 		Expect(hostFromDb.InstallerVersion).Should(Equal(DefaultInstructionConfig.InstallerImage))
 	})
 
@@ -227,7 +229,7 @@ var _ = Describe("installcmd", func() {
 		postvalidation(false, false, stepReply[0], stepErr, models.HostRoleMaster)
 		postvalidation(false, false, stepReply[0], stepErr, models.HostRoleMaster)
 		validateInstallCommand(installCmd, stepReply[0], models.HostRoleMaster, clusterId, *host.ID, sdb.ID, getBootableDiskNames(disks), models.ClusterHighAvailabilityModeFull)
-		hostFromDb := hostutil.GetHostFromDB(*host.ID, clusterId, db)
+		hostFromDb := hostutil.GetHostFromDB(*host.ID, infraEnvId, db)
 		Expect(hostFromDb.InstallerVersion).Should(Equal(DefaultInstructionConfig.InstallerImage))
 	})
 
@@ -253,6 +255,7 @@ var _ = Describe("installcmd arguments", func() {
 		ctrl         *gomock.Controller
 		mockEvents   *events.MockHandler
 		mockVersions *versions.MockHandler
+		infraEnvId   strfmt.UUID
 	)
 
 	mockImages := func() {
@@ -263,7 +266,8 @@ var _ = Describe("installcmd arguments", func() {
 	BeforeSuite(func() {
 		db, dbName = common.PrepareTestDB()
 		cluster = createClusterInDb(db, models.ClusterHighAvailabilityModeNone)
-		host = createHostInDb(db, *cluster.ID, models.HostRoleMaster, false, "")
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = createHostInDb(db, infraEnvId, *cluster.ID, models.HostRoleMaster, false, "")
 		ctrl = gomock.NewController(GinkgoT())
 		validator = hardware.NewMockValidator(ctrl)
 		validator.EXPECT().GetHostInstallationPath(gomock.Any()).Return(common.TestDiskId).AnyTimes()
@@ -919,12 +923,12 @@ func createClusterInDb(db *gorm.DB, haMode string) common.Cluster {
 	return cluster
 }
 
-func createHostInDb(db *gorm.DB, clusterId strfmt.UUID, role models.HostRole, bootstrap bool, hostname string) models.Host {
+func createHostInDb(db *gorm.DB, infraEnvId, clusterId strfmt.UUID, role models.HostRole, bootstrap bool, hostname string) models.Host {
 	id := strfmt.UUID(uuid.New().String())
 	host := models.Host{
 		ID:                &id,
 		ClusterID:         &clusterId,
-		InfraEnvID:        clusterId,
+		InfraEnvID:        infraEnvId,
 		Status:            swag.String(models.HostStatusDiscovering),
 		Role:              role,
 		Bootstrap:         bootstrap,

--- a/internal/host/hostcommands/inventory_cmd_test.go
+++ b/internal/host/hostcommands/inventory_cmd_test.go
@@ -19,7 +19,7 @@ var _ = Describe("inventory", func() {
 	var host models.Host
 	var db *gorm.DB
 	var invCmd *inventoryCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -30,7 +30,8 @@ var _ = Describe("inventory", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusDiscovering)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusDiscovering)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/hostcommands/logs_cmd_test.go
+++ b/internal/host/hostcommands/logs_cmd_test.go
@@ -21,7 +21,7 @@ var _ = Describe("upload_logs", func() {
 	var host models.Host
 	var db *gorm.DB
 	var logsCmd *logsCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -32,7 +32,8 @@ var _ = Describe("upload_logs", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusError)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusError)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 
@@ -54,7 +55,7 @@ var _ = Describe("upload_logs", func() {
 		host.Bootstrap = true
 		db.Save(&host)
 		id = strfmt.UUID(uuid.New().String())
-		host2 := hostutil.GenerateTestHost(id, clusterId, models.HostStatusError)
+		host2 := hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusError)
 		host2.Inventory = common.GenerateTestDefaultInventory()
 		host2.Role = models.HostRoleMaster
 		Expect(db.Create(&host2).Error).ToNot(HaveOccurred())
@@ -68,7 +69,7 @@ var _ = Describe("upload_logs", func() {
 		host.Bootstrap = true
 		db.Save(&host)
 		id = strfmt.UUID(uuid.New().String())
-		host2 := hostutil.GenerateTestHost(id, clusterId, models.HostStatusError)
+		host2 := hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusError)
 		inventory := models.Inventory{
 			Interfaces: []*models.Interface{
 				{

--- a/internal/host/hostcommands/reset_installation_cmd_test.go
+++ b/internal/host/hostcommands/reset_installation_cmd_test.go
@@ -18,7 +18,7 @@ var _ = Describe("reset", func() {
 	var host models.Host
 	var db *gorm.DB
 	var rstCmd *resetInstallationCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -29,7 +29,8 @@ var _ = Describe("reset", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusResetting)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusResetting)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/hostcommands/stop_installation_cmd_test.go
+++ b/internal/host/hostcommands/stop_installation_cmd_test.go
@@ -18,7 +18,7 @@ var _ = Describe("stop-podman", func() {
 	var host models.Host
 	var db *gorm.DB
 	var stopCmd *stopInstallationCmd
-	var id, clusterId strfmt.UUID
+	var id, clusterId, infraEnvId strfmt.UUID
 	var stepReply []*models.Step
 	var stepErr error
 	var dbName string
@@ -29,7 +29,8 @@ var _ = Describe("stop-podman", func() {
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(id, clusterId, models.HostStatusError)
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(id, infraEnvId, clusterId, models.HostStatusError)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -41,19 +41,19 @@ func GenerateTestInfraEnv(infraEnvID strfmt.UUID) common.InfraEnv {
 
 /* Host */
 
-func GenerateTestHost(hostID, clusterID strfmt.UUID, state string) models.Host {
-	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindHost, models.HostRoleWorker)
+func GenerateTestHost(hostID, infraEnvID, clusterID strfmt.UUID, state string) models.Host {
+	return GenerateTestHostByKind(hostID, infraEnvID, clusterID, state, models.HostKindHost, models.HostRoleWorker)
 }
 
-func GenerateTestHostAddedToCluster(hostID, clusterID strfmt.UUID, state string) models.Host {
-	return GenerateTestHostByKind(hostID, clusterID, state, models.HostKindAddToExistingClusterHost, models.HostRoleWorker)
+func GenerateTestHostAddedToCluster(hostID, infraEnvID, clusterID strfmt.UUID, state string) models.Host {
+	return GenerateTestHostByKind(hostID, infraEnvID, clusterID, state, models.HostKindAddToExistingClusterHost, models.HostRoleWorker)
 }
 
-func GenerateTestHostByKind(hostID, clusterID strfmt.UUID, state, kind string, role models.HostRole) models.Host {
+func GenerateTestHostByKind(hostID, infraEnvID, clusterID strfmt.UUID, state, kind string, role models.HostRole) models.Host {
 	now := strfmt.DateTime(time.Now())
 	return models.Host{
 		ID:              &hostID,
-		InfraEnvID:      clusterID,
+		InfraEnvID:      infraEnvID,
 		ClusterID:       &clusterID,
 		Status:          swag.String(state),
 		Inventory:       common.GenerateTestDefaultInventory(),
@@ -70,13 +70,13 @@ func GenerateTestHostByKind(hostID, clusterID strfmt.UUID, state, kind string, r
 	}
 }
 
-func GenerateTestHostWithNetworkAddress(hostID, clusterID strfmt.UUID, role models.HostRole, status string, netAddr common.NetAddress) *models.Host {
+func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUID, role models.HostRole, status string, netAddr common.NetAddress) *models.Host {
 	now := strfmt.DateTime(time.Now())
 	h := models.Host{
 		ID:                &hostID,
 		RequestedHostname: netAddr.Hostname,
 		ClusterID:         &clusterID,
-		InfraEnvID:        clusterID,
+		InfraEnvID:        infraEnvID,
 		Status:            swag.String(status),
 		Inventory:         common.GenerateTestInventoryWithNetwork(netAddr),
 		Role:              role,

--- a/internal/host/hostutil/update_host.go
+++ b/internal/host/hostutil/update_host.go
@@ -17,7 +17,7 @@ import (
 
 var ResetLogsField = []interface{}{"logs_info", "", "logs_started_at", strfmt.DateTime(time.Time{}), "logs_collected_at", strfmt.DateTime(time.Time{})}
 
-func UpdateHostProgress(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, clusterId strfmt.UUID, hostId strfmt.UUID,
+func UpdateHostProgress(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, eventsHandler events.Handler, infraEnvId strfmt.UUID, hostId strfmt.UUID,
 	srcStatus string, newStatus string, statusInfo string,
 	srcStage models.HostStage, newStage models.HostStage, progressInfo string, extra ...interface{}) (*common.Host, error) {
 
@@ -28,10 +28,10 @@ func UpdateHostProgress(ctx context.Context, log logrus.FieldLogger, db *gorm.DB
 		extra = append(extra, "progress_stage_started_at", strfmt.DateTime(time.Now()))
 	}
 
-	return UpdateHostStatus(ctx, log, db, eventsHandler, clusterId, hostId, srcStatus, newStatus, statusInfo, extra...)
+	return UpdateHostStatus(ctx, log, db, eventsHandler, infraEnvId, hostId, srcStatus, newStatus, statusInfo, extra...)
 }
 
-func UpdateLogsProgress(_ context.Context, log logrus.FieldLogger, db *gorm.DB, _ events.Handler, clusterId strfmt.UUID, hostId strfmt.UUID, srcStatus string, progress string, extra ...interface{}) (*common.Host, error) {
+func UpdateLogsProgress(_ context.Context, log logrus.FieldLogger, db *gorm.DB, _ events.Handler, infraEnvId strfmt.UUID, hostId strfmt.UUID, srcStatus string, progress string, extra ...interface{}) (*common.Host, error) {
 	var host *common.Host
 	var err error
 
@@ -43,7 +43,7 @@ func UpdateLogsProgress(_ context.Context, log logrus.FieldLogger, db *gorm.DB, 
 		extra = append(append(make([]interface{}, 0), "logs_info", progress), extra...)
 	}
 
-	if host, err = UpdateHost(log, db, clusterId, hostId, srcStatus, extra...); err != nil {
+	if host, err = UpdateHost(log, db, infraEnvId, hostId, srcStatus, extra...); err != nil {
 		log.WithError(err).Errorf("failed to update log progress %+v on host %s", extra, hostId)
 		return nil, err
 	}

--- a/internal/host/hostutil/update_host_test.go
+++ b/internal/host/hostutil/update_host_test.go
@@ -37,7 +37,8 @@ var _ = Describe("update_host_state", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		id := strfmt.UUID(uuid.New().String())
 		clusterId := strfmt.UUID(uuid.New().String())
-		host = GenerateTestHost(id, clusterId, common.TestDefaultConfig.Status)
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		host = GenerateTestHost(id, infraEnvId, clusterId, common.TestDefaultConfig.Status)
 		host.StatusInfo = &common.TestDefaultConfig.StatusInfo
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		lastUpdatedTime = host.StatusUpdatedAt
@@ -45,10 +46,10 @@ var _ = Describe("update_host_state", func() {
 
 	Describe("UpdateHostStatus", func() {
 		It("change_status", func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"status\" to \"newStatus\" (newStatusInfo)", host.ID.String()),
 				gomock.Any())
-			returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, common.TestDefaultConfig.Status,
+			returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, common.TestDefaultConfig.Status,
 				newStatus, newStatusInfo)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(*returnedHost.Status).Should(Equal(newStatus))
@@ -58,16 +59,16 @@ var _ = Describe("update_host_state", func() {
 
 		Describe("negative", func() {
 			It("invalid_extras_amount", func() {
-				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status,
+				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status,
 					newStatus, newStatusInfo, "1")
 				Expect(err).Should(HaveOccurred())
 				Expect(returnedHost).Should(BeNil())
-				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status,
+				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status,
 					newStatus, newStatusInfo, "1", "2", "3")
 			})
 
 			It("no_matching_rows", func() {
-				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, "otherStatus",
+				returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, "otherStatus",
 					newStatus, newStatusInfo)
 			})
 
@@ -75,7 +76,7 @@ var _ = Describe("update_host_state", func() {
 				Expect(err).Should(HaveOccurred())
 				Expect(returnedHost).Should(BeNil())
 
-				hostFromDb := GetHostFromDB(*host.ID, *host.ClusterID, db)
+				hostFromDb := GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDb.Status).ShouldNot(Equal(newStatus))
 				Expect(*hostFromDb.StatusInfo).ShouldNot(Equal(newStatusInfo))
 				Expect(hostFromDb.StatusUpdatedAt.String()).Should(Equal(lastUpdatedTime.String()))
@@ -84,7 +85,7 @@ var _ = Describe("update_host_state", func() {
 
 		It("db_failure", func() {
 			db.Close()
-			_, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status,
+			_, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status,
 				newStatus, newStatusInfo)
 			Expect(err).Should(HaveOccurred())
 		})
@@ -93,7 +94,7 @@ var _ = Describe("update_host_state", func() {
 	Describe("UpdateHostProgress", func() {
 		Describe("same_status", func() {
 			It("new_stage", func() {
-				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
+				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
 					host.Progress.CurrentStage, common.TestDefaultConfig.HostProgressStage, host.Progress.ProgressInfo)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -105,7 +106,7 @@ var _ = Describe("update_host_state", func() {
 
 			It("same_stage", func() {
 				// Still updates because stage_updated_at is being updated
-				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
+				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
 					host.Progress.CurrentStage, host.Progress.CurrentStage, host.Progress.ProgressInfo)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -125,10 +126,10 @@ var _ = Describe("update_host_state", func() {
 		})
 
 		It("new_status_new_stage", func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"status\" to \"newStatus\" (newStatusInfo)", host.ID.String()),
 				gomock.Any())
-			returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status, newStatus, newStatusInfo,
+			returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status, newStatus, newStatusInfo,
 				host.Progress.CurrentStage, common.TestDefaultConfig.HostProgressStage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -146,7 +147,7 @@ var _ = Describe("update_host_state", func() {
 
 		It("update_info", func() {
 			for _, i := range []int{5, 10, 15} {
-				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, *host.ClusterID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
+				returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status, common.TestDefaultConfig.Status, common.TestDefaultConfig.StatusInfo,
 					host.Progress.CurrentStage, host.Progress.CurrentStage, fmt.Sprintf("%d%%", i))
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(returnedHost.Progress.ProgressInfo).Should(Equal(fmt.Sprintf("%d%%", i)))

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -63,7 +63,8 @@ var _ = Describe("monitor_disconnection", func() {
 		state = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(),
 			mockMetricApi, defaultConfig, dummy, mockOperators)
 		clusterID := strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterID, models.HostStatusDiscovering)
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, models.HostStatusDiscovering)
 		cluster := hostutil.GenerateTestCluster(clusterID, "1.1.0.0/16")
 		Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
 		host.Inventory = workerInventory()
@@ -105,7 +106,7 @@ var _ = Describe("monitor_disconnection", func() {
 		})
 
 		AfterEach(func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityWarning,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityWarning,
 				fmt.Sprintf("Host %s: updated status from \"%s\" to \"disconnected\" (Host has stopped communicating with the installation service)",
 					host.ID.String(), *host.Status),
 				gomock.Any())
@@ -124,7 +125,7 @@ var _ = Describe("monitor_disconnection", func() {
 		})
 
 		AfterEach(func() {
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, host.ID, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, host.ID, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"disconnected\" to \"discovering\" (Waiting for host to send hardware details)", host.ID.String()),
 				gomock.Any())
 			state.HostMonitoring()
@@ -150,6 +151,7 @@ var _ = Describe("TestHostMonitoring", func() {
 		mockEvents    *events.MockHandler
 		dbName        string
 		clusterID     = strfmt.UUID(uuid.New().String())
+		infraEnvID    = strfmt.UUID(uuid.New().String())
 		mockMetricApi *metrics.MockAPI
 	)
 
@@ -204,7 +206,7 @@ var _ = Describe("TestHostMonitoring", func() {
 					cluster := hostutil.GenerateTestCluster(clusterID, "1.1.0.0/16")
 					Expect(db.Save(&cluster).Error).ToNot(HaveOccurred())
 				}
-				host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), clusterID, models.HostStatusDiscovering)
+				host = hostutil.GenerateTestHost(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, models.HostStatusDiscovering)
 				host.Inventory = workerInventory()
 				Expect(state.RegisterHost(ctx, &host, db)).ShouldNot(HaveOccurred())
 				host.CheckedInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -445,7 +445,7 @@ func (th *transitionHandler) PostRefreshLogsProgress(progress string) stateswitc
 		}
 		var err error
 		_, err = hostutil.UpdateLogsProgress(params.ctx, logutil.FromContext(params.ctx, th.log),
-			params.db, th.eventsHandler, *sHost.host.ClusterID, *sHost.host.ID, sHost.srcState, progress)
+			params.db, th.eventsHandler, sHost.host.InfraEnvID, *sHost.host.ID, sHost.srcState, progress)
 		return err
 	}
 	return ret
@@ -612,7 +612,7 @@ func (th *transitionHandler) PostRefreshHostRefreshStageUpdateTime(
 	_, err = refreshHostStageUpdateTime(
 		logutil.FromContext(params.ctx, th.log),
 		params.db,
-		*sHost.host.ClusterID,
+		sHost.host.InfraEnvID,
 		*sHost.host.ID,
 		sHost.srcState)
 	return err

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -74,13 +74,13 @@ func createValidatorCfg() *hardware.ValidatorCfg {
 
 var _ = Describe("RegisterHost", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -92,11 +92,12 @@ var _ = Describe("RegisterHost", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	It("register_new", func() {
-		Expect(hapi.RegisterHost(ctx, &models.Host{ID: &hostId, ClusterID: &clusterId, InfraEnvID: clusterId, DiscoveryAgentVersion: "v1.0.1"}, db)).ShouldNot(HaveOccurred())
-		h := hostutil.GetHostFromDB(hostId, clusterId, db)
+		Expect(hapi.RegisterHost(ctx, &models.Host{ID: &hostId, ClusterID: &clusterId, InfraEnvID: infraEnvId, DiscoveryAgentVersion: "v1.0.1"}, db)).ShouldNot(HaveOccurred())
+		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 		Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusDiscovering))
 		Expect(h.DiscoveryAgentVersion).To(Equal("v1.0.1"))
 	})
@@ -142,7 +143,7 @@ var _ = Describe("RegisterHost", func() {
 			It(t.name, func() {
 				Expect(db.Create(&models.Host{
 					ID:         &hostId,
-					InfraEnvID: clusterId,
+					InfraEnvID: infraEnvId,
 					ClusterID:  &clusterId,
 					Role:       models.HostRoleMaster,
 					Inventory:  defaultHwInfo,
@@ -153,13 +154,13 @@ var _ = Describe("RegisterHost", func() {
 				}).Error).ShouldNot(HaveOccurred())
 
 				if t.expectedEventInfo != "" && t.expectedEventStatus != "" {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, t.expectedEventStatus, fmt.Sprintf(t.expectedEventInfo, hostId.String()), gomock.Any())
+					mockEvents.EXPECT().AddEvent(gomock.Any(), infraEnvId, &hostId, t.expectedEventStatus, fmt.Sprintf(t.expectedEventInfo, hostId.String()), gomock.Any())
 				}
 
 				err := hapi.RegisterHost(ctx, &models.Host{
 					ID:         &hostId,
 					ClusterID:  &clusterId,
-					InfraEnvID: clusterId,
+					InfraEnvID: infraEnvId,
 					Status:     swag.String(t.srcState),
 				},
 					db)
@@ -172,7 +173,7 @@ var _ = Describe("RegisterHost", func() {
 					Expect(ok).Should(Equal(true))
 					Expect(serr.StatusCode()).Should(Equal(t.errorCode))
 				}
-				h := hostutil.GetHostFromDB(hostId, clusterId, db)
+				h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 				Expect(swag.StringValue(h.Status)).Should(Equal(t.dstState))
 				Expect(h.Role).Should(Equal(models.HostRoleMaster))
 				Expect(h.Inventory).Should(Equal(defaultHwInfo))
@@ -188,7 +189,7 @@ var _ = Describe("RegisterHost", func() {
 	It("register disabled host", func() {
 		Expect(db.Create(&models.Host{
 			ID:         &hostId,
-			InfraEnvID: clusterId,
+			InfraEnvID: infraEnvId,
 			ClusterID:  &clusterId,
 			Role:       models.HostRoleMaster,
 			Inventory:  defaultHwInfo,
@@ -207,7 +208,7 @@ var _ = Describe("RegisterHost", func() {
 	It("register host in error state", func() {
 		Expect(db.Create(&models.Host{
 			ID:         &hostId,
-			InfraEnvID: clusterId,
+			InfraEnvID: infraEnvId,
 			ClusterID:  &clusterId,
 			Role:       models.HostRoleMaster,
 			Inventory:  defaultHwInfo,
@@ -216,6 +217,7 @@ var _ = Describe("RegisterHost", func() {
 
 		Expect(hapi.RegisterHost(ctx, &models.Host{
 			ID:                    &hostId,
+			InfraEnvID:            infraEnvId,
 			ClusterID:             &clusterId,
 			Status:                swag.String(models.HostStatusError),
 			DiscoveryAgentVersion: "v2.0.5",
@@ -248,7 +250,7 @@ var _ = Describe("RegisterHost", func() {
 		}
 
 		AfterEach(func() {
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusDiscovering))
 			Expect(h.Role).Should(Equal(models.HostRoleMaster))
 			Expect(h.DiscoveryAgentVersion).To(Equal(discoveryAgentVersion))
@@ -267,7 +269,7 @@ var _ = Describe("RegisterHost", func() {
 			It(t.name, func() {
 				Expect(db.Create(&models.Host{
 					ID:         &hostId,
-					InfraEnvID: clusterId,
+					InfraEnvID: infraEnvId,
 					ClusterID:  &clusterId,
 					Role:       models.HostRoleMaster,
 					Inventory:  defaultHwInfo,
@@ -280,7 +282,7 @@ var _ = Describe("RegisterHost", func() {
 					NtpSources: "some ntp sources",
 				}).Error).ShouldNot(HaveOccurred())
 				if t.srcState != models.HostStatusDiscovering {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityInfo,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), infraEnvId, &hostId, models.EventSeverityInfo,
 						fmt.Sprintf("Host %s: updated status from \"%s\" to \"discovering\" (%s)",
 							hostId.String(), t.srcState, statusInfoDiscovering),
 						gomock.Any())
@@ -288,7 +290,7 @@ var _ = Describe("RegisterHost", func() {
 
 				Expect(hapi.RegisterHost(ctx, &models.Host{
 					ID:                    &hostId,
-					InfraEnvID:            clusterId,
+					InfraEnvID:            infraEnvId,
 					ClusterID:             &clusterId,
 					Status:                swag.String(t.srcState),
 					DiscoveryAgentVersion: discoveryAgentVersion,
@@ -316,7 +318,7 @@ var _ = Describe("RegisterHost", func() {
 			It(t.name, func() {
 				Expect(db.Create(&models.Host{
 					ID:         &hostId,
-					InfraEnvID: clusterId,
+					InfraEnvID: infraEnvId,
 					ClusterID:  &clusterId,
 					Role:       models.HostRoleMaster,
 					Inventory:  defaultHwInfo,
@@ -324,13 +326,14 @@ var _ = Describe("RegisterHost", func() {
 				}).Error).ShouldNot(HaveOccurred())
 
 				Expect(hapi.RegisterHost(ctx, &models.Host{
-					ID:        &hostId,
-					ClusterID: &clusterId,
-					Status:    swag.String(t.srcState),
+					ID:         &hostId,
+					InfraEnvID: infraEnvId,
+					ClusterID:  &clusterId,
+					Status:     swag.String(t.srcState),
 				},
 					db)).Should(HaveOccurred())
 
-				h := hostutil.GetHostFromDB(hostId, clusterId, db)
+				h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 				Expect(swag.StringValue(h.Status)).Should(Equal(t.srcState))
 				Expect(h.Role).Should(Equal(models.HostRoleMaster))
 				Expect(h.Inventory).Should(Equal(defaultHwInfo))
@@ -419,7 +422,7 @@ var _ = Describe("RegisterHost", func() {
 				Expect(db.Create(&models.Host{
 					ID:                   &hostId,
 					ClusterID:            &clusterId,
-					InfraEnvID:           clusterId,
+					InfraEnvID:           infraEnvId,
 					Role:                 t.origRole,
 					Inventory:            common.GenerateTestDefaultInventory(),
 					Status:               swag.String(t.srcState),
@@ -431,7 +434,7 @@ var _ = Describe("RegisterHost", func() {
 				if t.eventSeverity != "" && t.eventMessage != "" {
 					mockEvents.EXPECT().AddEvent(
 						gomock.Any(),
-						clusterId,
+						infraEnvId,
 						&hostId,
 						t.eventSeverity,
 						fmt.Sprintf(t.eventMessage, hostId.String()),
@@ -440,13 +443,13 @@ var _ = Describe("RegisterHost", func() {
 
 				Expect(hapi.RegisterHost(ctx, &models.Host{
 					ID:         &hostId,
-					InfraEnvID: clusterId,
+					InfraEnvID: infraEnvId,
 					ClusterID:  &clusterId,
 					Status:     swag.String(t.srcState),
 				},
 					db)).ShouldNot(HaveOccurred())
 
-				h := hostutil.GetHostFromDB(hostId, clusterId, db)
+				h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 				Expect(swag.StringValue(h.Status)).Should(Equal(t.dstState))
 				Expect(h.Role).Should(Equal(t.expectedRole))
 				Expect(h.Inventory).Should(Equal(t.expectedInventory))
@@ -458,11 +461,13 @@ var _ = Describe("RegisterHost", func() {
 	Context("register unbound host", func() {
 		var (
 			infraEnvId strfmt.UUID
+			clusterId  strfmt.UUID
 			host       models.Host
 		)
 
 		BeforeEach(func() {
 			infraEnvId = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
 		})
 
 		tests := []struct {
@@ -520,7 +525,7 @@ var _ = Describe("RegisterHost", func() {
 
 			It(t.name, func() {
 				if !t.newHost {
-					host = hostutil.GenerateTestHost(hostId, infraEnvId, t.srcState)
+					host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 					host.ClusterID = nil
 					Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				}
@@ -550,15 +555,15 @@ var _ = Describe("RegisterHost", func() {
 
 var _ = Describe("HostInstallationFailed", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		ctrl              *gomock.Controller
-		mockMetric        *metrics.MockAPI
-		mockEvents        *events.MockHandler
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		ctrl                          *gomock.Controller
+		mockMetric                    *metrics.MockAPI
+		mockEvents                    *events.MockHandler
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -571,18 +576,19 @@ var _ = Describe("HostInstallationFailed", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(hostId, clusterId, "")
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, "")
 		host.Status = swag.String(models.HostStatusInstalling)
 		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 	})
 
 	It("handle_installation_error", func() {
-		mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, models.EventSeverityError,
+		mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, models.EventSeverityError,
 			fmt.Sprintf("Host %s: updated status from \"installing\" to \"error\" (installation command failed)", host.ID.String()),
 			gomock.Any())
 		mockMetric.EXPECT().ReportHostInstallationMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		Expect(hapi.HandleInstallationFailure(ctx, &host)).ShouldNot(HaveOccurred())
-		h := hostutil.GetHostFromDB(hostId, clusterId, db)
+		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 		Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusError))
 		Expect(swag.StringValue(h.StatusInfo)).Should(Equal("installation command failed"))
 	})
@@ -594,15 +600,15 @@ var _ = Describe("HostInstallationFailed", func() {
 
 var _ = Describe("RegisterInstalledOCPHost", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		ctrl              *gomock.Controller
-		mockMetric        *metrics.MockAPI
-		mockEvents        *events.MockHandler
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		ctrl                          *gomock.Controller
+		mockMetric                    *metrics.MockAPI
+		mockEvents                    *events.MockHandler
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -615,12 +621,13 @@ var _ = Describe("RegisterInstalledOCPHost", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(hostId, clusterId, "")
+		infraEnvId = strfmt.UUID(uuid.New().String())
+		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, "")
 	})
 
 	It("register_installed_host", func() {
 		Expect(hapi.RegisterInstalledOCPHost(ctx, &host, db)).ShouldNot(HaveOccurred())
-		h := hostutil.GetHostFromDB(hostId, clusterId, db)
+		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 		Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusInstalled))
 	})
 
@@ -631,14 +638,14 @@ var _ = Describe("RegisterInstalledOCPHost", func() {
 
 var _ = Describe("Cancel host installation", func() {
 	var (
-		ctx               = context.Background()
-		dbName            string
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		ctrl              *gomock.Controller
-		mockEventsHandler *events.MockHandler
+		ctx                           = context.Background()
+		dbName                        string
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		ctrl                          *gomock.Controller
+		mockEventsHandler             *events.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -682,7 +689,8 @@ var _ = Describe("Cancel host installation", func() {
 		It(fmt.Sprintf("cancel from state %s", t.state), func() {
 			hostId = strfmt.UUID(uuid.New().String())
 			clusterId = strfmt.UUID(uuid.New().String())
-			host = hostutil.GenerateTestHost(hostId, clusterId, "")
+			infraEnvId = strfmt.UUID(uuid.New().String())
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, "")
 			host.Status = swag.String(t.state)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			eventsNum := 1
@@ -694,7 +702,7 @@ var _ = Describe("Cancel host installation", func() {
 			}
 			acceptNewEvents(eventsNum)
 			err := hapi.CancelInstallation(ctx, &host, "reason", db)
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			if t.success {
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -723,14 +731,14 @@ var _ = Describe("Cancel host installation", func() {
 
 var _ = Describe("Reset host", func() {
 	var (
-		ctx               = context.Background()
-		dbName            string
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		ctrl              *gomock.Controller
-		mockEventsHandler *events.MockHandler
+		ctx                           = context.Background()
+		dbName                        string
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		ctrl                          *gomock.Controller
+		mockEventsHandler             *events.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -774,7 +782,8 @@ var _ = Describe("Reset host", func() {
 		It(fmt.Sprintf("reset from state %s", t.state), func() {
 			hostId = strfmt.UUID(uuid.New().String())
 			clusterId = strfmt.UUID(uuid.New().String())
-			host = hostutil.GenerateTestHost(hostId, clusterId, "")
+			infraEnvId = strfmt.UUID(uuid.New().String())
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, "")
 			host.Status = swag.String(t.state)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			eventsNum := 1
@@ -786,7 +795,7 @@ var _ = Describe("Reset host", func() {
 			}
 			acceptNewEvents(eventsNum)
 			err := hapi.ResetHost(ctx, &host, "reason", db)
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			if t.success {
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -815,16 +824,16 @@ var _ = Describe("Reset host", func() {
 
 var _ = Describe("Install", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		cluster           common.Cluster
-		mockHwValidator   *hardware.MockValidator
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		cluster                       common.Cluster
+		mockHwValidator               *hardware.MockValidator
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -836,6 +845,7 @@ var _ = Describe("Install", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	Context("install host", func() {
@@ -845,7 +855,7 @@ var _ = Describe("Install", func() {
 
 		noChange := func(reply error) {
 			Expect(reply).To(BeNil())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(*h.Status).Should(Equal(models.HostStatusDisabled))
 		}
 
@@ -919,7 +929,7 @@ var _ = Describe("Install", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				host = hostutil.GenerateTestHost(hostId, clusterId, t.srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, models.EventSeverityInfo,
 					fmt.Sprintf("Host %s: updated status from \"%s\" to \"installing\" (Installation is in progress)", host.ID.String(), t.srcState),
@@ -931,7 +941,7 @@ var _ = Describe("Install", func() {
 
 	Context("install with transaction", func() {
 		BeforeEach(func() {
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusPreparingSuccessful)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusPreparingSuccessful)
 			host.StatusInfo = swag.String(statusInfoHostPreparationSuccessful)
 			host.Inventory = hostutil.GenerateMasterInventory()
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -954,12 +964,12 @@ var _ = Describe("Install", func() {
 		It("success", func() {
 			tx := db.Begin()
 			Expect(tx.Error).To(BeNil())
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"preparing-successful\" to \"installing\" (Installation is in progress)", "master-hostname"),
 				gomock.Any())
 			Expect(hapi.RefreshStatus(ctx, &host, tx)).ShouldNot(HaveOccurred())
 			Expect(tx.Commit().Error).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(*h.Status).Should(Equal(models.HostStatusInstalling))
 			Expect(*h.StatusInfo).Should(Equal(statusInfoInstalling))
 		})
@@ -967,12 +977,12 @@ var _ = Describe("Install", func() {
 		It("rollback transition", func() {
 			tx := db.Begin()
 			Expect(tx.Error).To(BeNil())
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, models.EventSeverityInfo,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, models.EventSeverityInfo,
 				fmt.Sprintf("Host %s: updated status from \"preparing-successful\" to \"installing\" (Installation is in progress)", "master-hostname"),
 				gomock.Any())
 			Expect(hapi.RefreshStatus(ctx, &host, tx)).ShouldNot(HaveOccurred())
 			Expect(tx.Rollback().Error).ShouldNot(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(*h.Status).Should(Equal(models.HostStatusPreparingSuccessful))
 			Expect(*h.StatusInfo).Should(Equal(statusInfoHostPreparationSuccessful))
 		})
@@ -1141,7 +1151,7 @@ var _ = Describe("Disable", func() {
 			t := tests[i]
 			It(t.name, func() {
 				srcState = t.srcState
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				dstState := models.HostStatusDisabled
 				if t.poolHost {
 					host.ClusterID = nil
@@ -1164,14 +1174,14 @@ var _ = Describe("Disable", func() {
 
 var _ = Describe("Enable", func() {
 	var (
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		ctrl              *gomock.Controller
-		mockEvents        *events.MockHandler
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		dbName            string
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		ctrl                          *gomock.Controller
+		mockEvents                    *events.MockHandler
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		dbName                        string
 	)
 
 	BeforeEach(func() {
@@ -1183,13 +1193,14 @@ var _ = Describe("Enable", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	Context("enable host", func() {
 		var srcState string
 		success := func(reply error, dstState string) {
 			Expect(reply).To(BeNil())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(*h.Status).Should(Equal(dstState))
 			Expect(*h.StatusInfo).Should(Equal(statusInfoDiscovering))
 			Expect(h.Inventory).Should(BeEmpty())
@@ -1199,7 +1210,7 @@ var _ = Describe("Enable", func() {
 
 		failure := func(reply error, _ string) {
 			Expect(reply).Should(HaveOccurred())
-			h := hostutil.GetHostFromDB(hostId, clusterId, db)
+			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(*h.Status).Should(Equal(srcState))
 			Expect(h.Inventory).Should(Equal(defaultHwInfo))
 			Expect(h.Bootstrap).Should(Equal(true))
@@ -1290,7 +1301,7 @@ var _ = Describe("Enable", func() {
 			It(t.name, func() {
 				// Test setup - Host creation
 				srcState = t.srcState
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = defaultHwInfo
 				host.Bootstrap = true
 				dstState := models.HostStatusDiscovering
@@ -1411,19 +1422,19 @@ var _ = Describe("Refresh Host", func() {
 		minDiskSizeGb = 120
 	)
 	var (
-		supportedGPU      = models.Gpu{VendorID: "10de", DeviceID: "1db6"}
-		ctx               = context.Background()
-		hapi              API
-		db                *gorm.DB
-		hostId, clusterId strfmt.UUID
-		host              models.Host
-		cluster           common.Cluster
-		mockEvents        *events.MockHandler
-		ctrl              *gomock.Controller
-		dbName            string
-		mockHwValidator   *hardware.MockValidator
-		validatorCfg      *hardware.ValidatorCfg
-		operatorsManager  *operators.Manager
+		supportedGPU                  = models.Gpu{VendorID: "10de", DeviceID: "1db6"}
+		ctx                           = context.Background()
+		hapi                          API
+		db                            *gorm.DB
+		hostId, clusterId, infraEnvId strfmt.UUID
+		host                          models.Host
+		cluster                       common.Cluster
+		mockEvents                    *events.MockHandler
+		ctrl                          *gomock.Controller
+		dbName                        string
+		mockHwValidator               *hardware.MockValidator
+		validatorCfg                  *hardware.ValidatorCfg
+		operatorsManager              *operators.Manager
 	)
 
 	BeforeEach(func() {
@@ -1450,6 +1461,7 @@ var _ = Describe("Refresh Host", func() {
 		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, nil, defaultConfig, nil, operatorsManager)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
+		infraEnvId = strfmt.UUID(uuid.New().String())
 	})
 
 	Context("host installation timeout - cluster is pending user action", func() {
@@ -1482,7 +1494,7 @@ var _ = Describe("Refresh Host", func() {
 			t := t
 			It(fmt.Sprintf("checking timeout from stage %s", t.stage), func() {
 				hostCheckInAt := strfmt.DateTime(time.Now())
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusInstallingInProgress)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusInstallingInProgress)
 				host.Inventory = hostutil.GenerateMasterInventory()
 				host.Role = models.HostRoleMaster
 				host.CheckedInAt = hostCheckInAt
@@ -1499,7 +1511,7 @@ var _ = Describe("Refresh Host", func() {
 				if t.expectTimeout {
 					mockEvents.EXPECT().AddEvent(
 						gomock.Any(),
-						*host.ClusterID,
+						host.InfraEnvID,
 						&hostId,
 						hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
 						gomock.Any(),
@@ -1544,7 +1556,7 @@ var _ = Describe("Refresh Host", func() {
 			passedTime := 90 * time.Minute
 			It(name, func() {
 				srcState = models.HostStatusInstallingInProgress
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = hostutil.GenerateMasterInventory()
 				host.Role = models.HostRoleMaster
 				host.CheckedInAt = strfmt.DateTime(time.Now().Add(-MaxHostDisconnectionTime - time.Minute))
@@ -1561,7 +1573,7 @@ var _ = Describe("Refresh Host", func() {
 				cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
 					gomock.Any(), gomock.Any())
 				err := hapi.RefreshStatus(ctx, &host, db)
 
@@ -1588,7 +1600,7 @@ var _ = Describe("Refresh Host", func() {
 			name := fmt.Sprintf("disconnection while host  %s", stage)
 			It(name, func() {
 				srcState = models.HostStatusInstalled
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = hostutil.GenerateMasterInventory()
 				host.Role = models.HostRoleWorker
 				host.CheckedInAt = strfmt.DateTime(time.Now().Add(-MaxHostDisconnectionTime - time.Minute))
@@ -1634,7 +1646,7 @@ var _ = Describe("Refresh Host", func() {
 		passedTime := 90 * time.Minute
 		It("host disconnected & preparing for installation", func() {
 			srcState = models.HostStatusPreparingForInstallation
-			host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 			host.Inventory = hostutil.GenerateMasterInventory()
 			host.Role = models.HostRoleMaster
 			host.CheckedInAt = strfmt.DateTime(time.Now().Add(-MaxHostDisconnectionTime - time.Minute))
@@ -1650,7 +1662,7 @@ var _ = Describe("Refresh Host", func() {
 			cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusDisconnected),
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusDisconnected),
 				gomock.Any(), gomock.Any())
 			err := hapi.RefreshStatus(ctx, &host, db)
 
@@ -1683,7 +1695,7 @@ var _ = Describe("Refresh Host", func() {
 				passedTimeKind := passedTimeKey
 				passedTime := passedTimeValue
 				hostCheckInAt := strfmt.DateTime(time.Now())
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = hostutil.GenerateMasterInventory()
 				host.Role = models.HostRoleMaster
 				host.CheckedInAt = hostCheckInAt
@@ -1693,7 +1705,7 @@ var _ = Describe("Refresh Host", func() {
 				cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 				if passedTimeKind == "over_timeout" {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
 						gomock.Any(), gomock.Any())
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -1743,7 +1755,7 @@ var _ = Describe("Refresh Host", func() {
 				It(name, func() {
 					hostCheckInAt := strfmt.DateTime(time.Now())
 					srcState = models.HostStatusInstallingInProgress
-					host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+					host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 					host.Inventory = hostutil.GenerateMasterInventory()
 					host.Role = models.HostRoleMaster
 					host.CheckedInAt = hostCheckInAt
@@ -1761,7 +1773,7 @@ var _ = Describe("Refresh Host", func() {
 					Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
 					if passedTimeKind == "over_timeout" {
-						mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
+						mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(models.HostStatusError),
 							gomock.Any(), gomock.Any())
 					}
 					err := hapi.RefreshStatus(ctx, &host, db)
@@ -1787,7 +1799,7 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
 			masterID := strfmt.UUID("1")
-			master := hostutil.GenerateTestHost(masterID, clusterId, models.HostStatusInstallingInProgress)
+			master := hostutil.GenerateTestHost(masterID, infraEnvId, clusterId, models.HostStatusInstallingInProgress)
 			master.Inventory = hostutil.GenerateMasterInventory()
 			master.Role = models.HostRoleMaster
 			master.CheckedInAt = strfmt.DateTime(time.Now())
@@ -1799,7 +1811,7 @@ var _ = Describe("Refresh Host", func() {
 			Expect(db.Create(&master).Error).ShouldNot(HaveOccurred())
 
 			hostId = strfmt.UUID("2")
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusInstallingInProgress)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusInstallingInProgress)
 			host.Inventory = hostutil.GenerateMasterInventory()
 			host.Role = models.HostRoleWorker
 			host.CheckedInAt = strfmt.DateTime(time.Now())
@@ -1811,7 +1823,7 @@ var _ = Describe("Refresh Host", func() {
 			host.Progress = &progress
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID,
 				gomock.Any(), hostutil.GetEventSeverityFromHostStatus(models.HostStatusError), gomock.Any(), gomock.Any()).
 				AnyTimes()
 
@@ -2040,7 +2052,7 @@ var _ = Describe("Refresh Host", func() {
 				}
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 
-				host = hostutil.GenerateTestHost(t.hostID, clusterId, t.srcState)
+				host = hostutil.GenerateTestHost(t.hostID, infraEnvId, clusterId, t.srcState)
 				host.Inventory = t.inventory
 				host.Role = t.role
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -2050,7 +2062,7 @@ var _ = Describe("Refresh Host", func() {
 				} else {
 					mockDefaultClusterHostRequirements(mockHwValidator)
 				}
-				mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID,
+				mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID,
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					AnyTimes()
 
@@ -2097,9 +2109,9 @@ var _ = Describe("Refresh Host", func() {
 		return ret
 	}
 
-	getHost := func(clusterID, hostID strfmt.UUID) *models.Host {
+	getHost := func(infraEnvID, hostID strfmt.UUID) *models.Host {
 		var h models.Host
-		Expect(db.First(&h, "id = ? and cluster_id = ?", hostID, clusterID).Error).ToNot(HaveOccurred())
+		Expect(db.First(&h, "id = ? and infra_env_id = ?", hostID, infraEnvID).Error).ToNot(HaveOccurred())
 		return &h
 	}
 
@@ -2215,7 +2227,7 @@ var _ = Describe("Refresh Host", func() {
 					// Timeout for checkin is 3 minutes so subtract 4 minutes from the current time
 					hostCheckInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 				}
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusPreparingForInstallation)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusPreparingForInstallation)
 				host.StatusInfo = swag.String(statusInfoPreparingForInstallation)
 				host.Inventory = hostutil.GenerateMasterInventoryWithHostname("master-0")
 				host.CheckedInAt = hostCheckInAt
@@ -2232,16 +2244,16 @@ var _ = Describe("Refresh Host", func() {
 
 				// Test definition
 				if t.dstState != models.HostStatusPreparingForInstallation {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
-				Expect(getHost(clusterId, hostId).ValidationsInfo).To(BeEmpty())
+				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
 				err := hapi.RefreshStatus(ctx, &host, db)
 				if t.errorExpected {
 					Expect(err).To(HaveOccurred())
 				} else {
 					Expect(err).ToNot(HaveOccurred())
-					Expect(getHost(clusterId, hostId).ValidationsInfo).ToNot(BeEmpty())
+					Expect(getHost(infraEnvId, hostId).ValidationsInfo).ToNot(BeEmpty())
 				}
 				var resultHost models.Host
 				Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
@@ -2295,7 +2307,7 @@ var _ = Describe("Refresh Host", func() {
 					// Timeout for checkin is 3 minutes so subtract 4 minutes from the current time
 					hostCheckInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 				}
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusPreparingSuccessful)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusPreparingSuccessful)
 				host.StatusInfo = swag.String(statusInfoHostPreparationSuccessful)
 				host.Inventory = hostutil.GenerateMasterInventoryWithHostname("master-0")
 				host.CheckedInAt = hostCheckInAt
@@ -2311,16 +2323,16 @@ var _ = Describe("Refresh Host", func() {
 
 				// Test definition
 				if t.dstState != models.HostStatusPreparingSuccessful {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
-				Expect(getHost(clusterId, hostId).ValidationsInfo).To(BeEmpty())
+				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
 				err := hapi.RefreshStatus(ctx, &host, db)
 				if t.errorExpected {
 					Expect(err).To(HaveOccurred())
 				} else {
 					Expect(err).ToNot(HaveOccurred())
-					Expect(getHost(clusterId, hostId).ValidationsInfo).ToNot(BeEmpty())
+					Expect(getHost(infraEnvId, hostId).ValidationsInfo).ToNot(BeEmpty())
 				}
 				var resultHost models.Host
 				Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
@@ -3485,7 +3497,7 @@ var _ = Describe("Refresh Host", func() {
 					hostCheckInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 				}
 				srcState = t.srcState
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = t.inventory
 				host.Role = t.role
 				host.CheckedInAt = hostCheckInAt
@@ -3505,7 +3517,7 @@ var _ = Describe("Refresh Host", func() {
 
 				for i := 0; i < t.numAdditionalHosts; i++ {
 					id := strfmt.UUID(uuid.New().String())
-					h := hostutil.GenerateTestHost(id, clusterId, srcState)
+					h := hostutil.GenerateTestHost(id, infraEnvId, clusterId, srcState)
 					h.Inventory = t.inventory
 					h.Role = t.role
 					h.CheckedInAt = hostCheckInAt
@@ -3537,16 +3549,16 @@ var _ = Describe("Refresh Host", func() {
 
 				// Test definition
 				if srcState != t.dstState {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
-				Expect(getHost(clusterId, hostId).ValidationsInfo).To(BeEmpty())
+				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
 				err = hapi.RefreshStatus(ctx, &host, db)
 				if t.errorExpected {
 					Expect(err).To(HaveOccurred())
 				} else {
 					Expect(err).ToNot(HaveOccurred())
-					Expect(getHost(clusterId, hostId).ValidationsInfo).ToNot(BeEmpty())
+					Expect(getHost(infraEnvId, hostId).ValidationsInfo).ToNot(BeEmpty())
 				}
 				var resultHost models.Host
 				Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
@@ -3586,14 +3598,14 @@ var _ = Describe("Refresh Host", func() {
 		for i := range tests {
 			t := tests[i]
 			It(t.name, func() {
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusPreparingForInstallation)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusPreparingForInstallation)
 				host.Inventory = hostutil.GenerateMasterInventory()
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 				cluster.Status = &t.clusterStatus
 				Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
 				if *host.Status != t.dstState {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, hostutil.GetEventSeverityFromHostStatus(t.dstState),
 						gomock.Any(), gomock.Any())
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -3995,7 +4007,7 @@ var _ = Describe("Refresh Host", func() {
 			It(t.name, func() {
 				// Test setup - Host creation
 				srcState = t.srcState
-				host = hostutil.GenerateTestHost(hostId, clusterId, srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 				host.Inventory = t.inventory
 				host.Role = t.role
 				host.CheckedInAt = strfmt.DateTime(time.Now())
@@ -4013,7 +4025,7 @@ var _ = Describe("Refresh Host", func() {
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
 				// Test setup - 2nd Host creation
-				otherHost := hostutil.GenerateTestHost(otherHostID, clusterId, t.otherState)
+				otherHost := hostutil.GenerateTestHost(otherHostID, infraEnvId, clusterId, t.otherState)
 				otherHost.RequestedHostname = t.otherRequestedHostname
 				otherHost.Inventory = t.otherInventory
 				Expect(db.Create(&otherHost).Error).ShouldNot(HaveOccurred())
@@ -4029,7 +4041,7 @@ var _ = Describe("Refresh Host", func() {
 					expectedSeverity = models.EventSeverityWarning
 				}
 				if !t.errorExpected && srcState != t.dstState {
-					mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID, &hostId, expectedSeverity,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID, &hostId, expectedSeverity,
 						gomock.Any(), gomock.Any())
 				}
 
@@ -4080,7 +4092,7 @@ var _ = Describe("Refresh Host", func() {
 				srcState := srcState
 
 				It(fmt.Sprintf("host src: %s cluster error: false", srcState), func() {
-					h := hostutil.GenerateTestHost(hostId, clusterId, srcState)
+					h := hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 					h.Progress.CurrentStage = installationStage
 					h.Inventory = hostutil.GenerateMasterInventory()
 					Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
@@ -4094,7 +4106,7 @@ var _ = Describe("Refresh Host", func() {
 					Expect(swag.StringValue(h.Status)).Should(Equal(srcState))
 				})
 				It(fmt.Sprintf("host src: %s cluster error: true", srcState), func() {
-					h := hostutil.GenerateTestHost(hostId, clusterId, srcState)
+					h := hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, srcState)
 					h.Progress.CurrentStage = installationStage
 					h.Inventory = hostutil.GenerateMasterInventory()
 					Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
@@ -4102,7 +4114,7 @@ var _ = Describe("Refresh Host", func() {
 					c.Status = swag.String(models.ClusterStatusError)
 					Expect(db.Create(&c).Error).ToNot(HaveOccurred())
 
-					mockEvents.EXPECT().AddEvent(gomock.Any(), clusterId, &hostId, models.EventSeverityError,
+					mockEvents.EXPECT().AddEvent(gomock.Any(), infraEnvId, &hostId, models.EventSeverityError,
 						fmt.Sprintf("Host master-hostname: updated status from \"%s\" to \"error\" (Host is part of a cluster that failed to install)", srcState),
 						gomock.Any())
 
@@ -4127,7 +4139,7 @@ var _ = Describe("Refresh Host", func() {
 			domainNameResolutions := common.TestDomainNameResolutionSuccess
 			cluster = hostutil.GenerateTestCluster(clusterId, "1.2.3.0/24")
 			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
-			host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
+			host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 			host.Inventory = hostutil.GenerateInventoryWithResourcesWithBytes(4, conversions.GibToBytes(16), conversions.GibToBytes(16), "master")
 			host.Role = models.HostRoleMaster
 			host.NtpSources = string(defaultNTPSourcesInBytes)
@@ -4135,7 +4147,7 @@ var _ = Describe("Refresh Host", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			host.DomainNameResolutions = string(bytes)
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-			mockEvents.EXPECT().AddEvent(gomock.Any(), *host.ClusterID,
+			mockEvents.EXPECT().AddEvent(gomock.Any(), host.InfraEnvID,
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				AnyTimes()
 		})
@@ -4350,7 +4362,7 @@ var _ = Describe("Refresh Host", func() {
 					} else {
 						netAddr.IPv6Address = []string{t.IPAddressPool[n]}
 					}
-					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), clusterId, t.hostRole, t.srcState, netAddr)
+					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), infraEnvId, clusterId, t.hostRole, t.srcState, netAddr)
 					h.NtpSources = string(defaultNTPSourcesInBytes)
 					hosts = append(hosts, h)
 				}
@@ -4560,7 +4572,7 @@ var _ = Describe("Refresh Host", func() {
 					inventory, err = hostutil.MarshalInventory(inv)
 					Expect(err).To(Not(HaveOccurred()))
 				}
-				host = hostutil.GenerateTestHost(hostId, clusterId, models.HostStatusDiscovering)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 				host.Inventory = inventory
 				host.NtpSources = string(defaultNTPSourcesInBytes)
 				bytes, err := json.Marshal(domainNameResolutions)
@@ -4585,10 +4597,14 @@ var _ = Describe("Refresh Host", func() {
 
 	Context("unbound host", func() {
 
-		var infraEnvId strfmt.UUID
+		var (
+			infraEnvId strfmt.UUID
+			clusterId  strfmt.UUID
+		)
 
 		BeforeEach(func() {
 			infraEnvId = strfmt.UUID(uuid.New().String())
+			clusterId = strfmt.UUID(uuid.New().String())
 			infraEnv := &common.InfraEnv{
 				InfraEnv: models.InfraEnv{
 					ID: infraEnvId,
@@ -4772,7 +4788,7 @@ var _ = Describe("Refresh Host", func() {
 			t := tests[i]
 			It(t.name, func() {
 				hostCheckInAt := strfmt.DateTime(time.Now())
-				host = hostutil.GenerateTestHost(hostId, infraEnvId, t.srcState)
+				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				host.Inventory = t.inventory
 				host.ClusterID = nil
 				if !t.validCheckInTime {


### PR DESCRIPTION
…nstead of ClusterID

Once  the AI code was moved to use InfraEnv DB, we can now update the code to address Host using InfraEnvID and not ClusterID.
Access to the host data in the DB must be done using Host ID and InfraEnv ID, and not Host ID and Cluster ID.
In addition, update the unit test to use infra-env-id different then cluster-id ( this will be the real flow once uers starts creating InfraEnv using V2 CRUD API),
to find any potential bugs

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
