### PR TITLE
MGMT-7357: Add unit tests that ensure DISABLED_STEPS variable parsing

### DIFF
--- a/internal/host/hostcommands/spawnable_test_runners/disabled_steps/disabled_steps_env_parsing_tester.go
+++ b/internal/host/hostcommands/spawnable_test_runners/disabled_steps/disabled_steps_env_parsing_tester.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/openshift/assisted-service/internal/host/hostcommands"
+	"github.com/openshift/assisted-service/models"
+)
+
+func main() {
+	var config hostcommands.InstructionConfig
+	err := envconfig.Process("", &config)
+	if err != nil {
+		panic(err)
+	}
+	env, exists := os.LookupEnv("DISABLED_STEPS")
+	if !exists {
+		if len(config.DisabledSteps) != 0 {
+			panic("DISABLED_STEPS Values are not parsed correctly. DisabledSteps should be empty")
+		}
+		return
+	}
+	var envVarParsed = strings.Split(env, ",")
+	if len(envVarParsed) != len(config.DisabledSteps) {
+		panic("DISABLED_STEPS Values are not parsed correctly. DisabledSteps and env variable have different length")
+	}
+	for i := range envVarParsed {
+		if models.StepType(envVarParsed[i]) != config.DisabledSteps[i] {
+			panic("DISABLED_STEPS Values are not parsed correctly")
+		}
+	}
+}


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added a unit tests that spawns a new process
with DISABLED_STEPS environment variable.
If the new process panics, the test will fail.

The new process only parses InstructionConfig and checks validity of
InstructionConfig.DisabledSteps array.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @michaellevy101 
/cc @YuviGold 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
