### PR TITLE
WIP: MGMT-7340: add labels to the cluster update api

### DIFF
--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -184,6 +184,19 @@ var _ = Describe("update_role", func() {
 		Expect(h.Role).To(Equal(models.HostRoleWorker))
 	})
 
+	It("update label to a host", func() {
+		labels := map[string]string{
+			"cluster.ocs.openshift.io/openshift-storage": "",
+		}
+		host = hostutil.GenerateTestHost(id, infraEnvID, clusterID, models.HostStatusKnown)
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+		Expect(state.UpdateLabels(ctx, &host, labels, nil)).NotTo(HaveOccurred())
+
+		h := hostutil.GetHostFromDB(id, infraEnvID, db)
+		jsonLables, _ := json.Marshal(labels)
+		Expect(string(jsonLables)).To(Equal(h.Labels))
+	})
+
 	Context("update machine config pool", func() {
 		tests := []struct {
 			name                      string

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -603,6 +603,20 @@ func (mr *MockAPIMockRecorder) UpdateKubeKeyNS(arg0, arg1, arg2 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubeKeyNS", reflect.TypeOf((*MockAPI)(nil).UpdateKubeKeyNS), arg0, arg1, arg2)
 }
 
+// UpdateLabels mocks base method.
+func (m *MockAPI) UpdateLabels(arg0 context.Context, arg1 *models.Host, arg2 map[string]string, arg3 *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLabels", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLabels indicates an expected call of UpdateLabels.
+func (mr *MockAPIMockRecorder) UpdateLabels(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabels", reflect.TypeOf((*MockAPI)(nil).UpdateLabels), arg0, arg1, arg2, arg3)
+}
+
 // UpdateLogsProgress mocks base method.
 func (m *MockAPI) UpdateLogsProgress(arg0 context.Context, arg1 *models.Host, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/models/cluster_update_params.go
+++ b/models/cluster_update_params.go
@@ -52,6 +52,9 @@ type ClusterUpdateParams struct {
 	// disks selected config
 	DisksSelectedConfig []*ClusterUpdateParamsDisksSelectedConfigItems0 `json:"disks_selected_config"`
 
+	// The desired nodes which should be labeled for OCS.
+	HostLabels []*ClusterUpdateParamsHostLabelsItems0 `json:"host_labels"`
+
 	// The desired machine config pool for hosts associated with the cluster.
 	HostsMachineConfigPoolNames []*ClusterUpdateParamsHostsMachineConfigPoolNamesItems0 `json:"hosts_machine_config_pool_names"`
 
@@ -155,6 +158,10 @@ func (m *ClusterUpdateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateDisksSelectedConfig(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateHostLabels(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -321,6 +328,31 @@ func (m *ClusterUpdateParams) validateDisksSelectedConfig(formats strfmt.Registr
 					return ve.ValidateName("disks_selected_config" + "." + strconv.Itoa(i))
 				} else if ce, ok := err.(*errors.CompositeError); ok {
 					return ce.ValidateName("disks_selected_config" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterUpdateParams) validateHostLabels(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.HostLabels) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.HostLabels); i++ {
+		if swag.IsZero(m.HostLabels[i]) { // not required
+			continue
+		}
+
+		if m.HostLabels[i] != nil {
+			if err := m.HostLabels[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("host_labels" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -1061,6 +1093,64 @@ func (m *ClusterUpdateParamsDisksSelectedConfigItems0) MarshalBinary() ([]byte, 
 // UnmarshalBinary interface implementation
 func (m *ClusterUpdateParamsDisksSelectedConfigItems0) UnmarshalBinary(b []byte) error {
 	var res ClusterUpdateParamsDisksSelectedConfigItems0
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// ClusterUpdateParamsHostLabelsItems0 cluster update params host labels items0
+//
+// swagger:model ClusterUpdateParamsHostLabelsItems0
+type ClusterUpdateParamsHostLabelsItems0 struct {
+
+	// id
+	// Format: uuid
+	ID strfmt.UUID `json:"id,omitempty"`
+
+	// Indicate if label should be set.
+	Label bool `json:"label,omitempty"`
+}
+
+// Validate validates this cluster update params host labels items0
+func (m *ClusterUpdateParamsHostLabelsItems0) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ClusterUpdateParamsHostLabelsItems0) validateID(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.ID) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("id", "body", "uuid", m.ID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *ClusterUpdateParamsHostLabelsItems0) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *ClusterUpdateParamsHostLabelsItems0) UnmarshalBinary(b []byte) error {
+	var res ClusterUpdateParamsHostLabelsItems0
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/models/host.go
+++ b/models/host.go
@@ -105,6 +105,9 @@ type Host struct {
 	// Enum: [Host AddToExistingClusterHost]
 	Kind *string `json:"kind"`
 
+	// Json containing host's labels.
+	Labels string `json:"labels,omitempty" gorm:"type:text"`
+
 	// logs collected at
 	// Format: datetime
 	LogsCollectedAt strfmt.DateTime `json:"logs_collected_at,omitempty" gorm:"type:timestamp with time zone"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10215,6 +10215,24 @@ func init() {
           },
           "x-nullable": true
         },
+        "host_labels": {
+          "description": "The desired nodes which should be labeled for OCS.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "label": {
+                "description": "Indicate if label should be set.",
+                "type": "boolean"
+              }
+            }
+          },
+          "x-nullable": true
+        },
         "hosts_machine_config_pool_names": {
           "description": "The desired machine config pool for hosts associated with the cluster.",
           "type": "array",
@@ -11343,6 +11361,11 @@ func init() {
             "Host",
             "AddToExistingClusterHost"
           ]
+        },
+        "labels": {
+          "description": "Json containing host's labels.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "logs_collected_at": {
           "type": "string",
@@ -22796,6 +22819,19 @@ func init() {
         }
       }
     },
+    "ClusterUpdateParamsHostLabelsItems0": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "label": {
+          "description": "Indicate if label should be set.",
+          "type": "boolean"
+        }
+      }
+    },
     "ClusterUpdateParamsHostsMachineConfigPoolNamesItems0": {
       "type": "object",
       "properties": {
@@ -23765,6 +23801,14 @@ func init() {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ClusterUpdateParamsDisksSelectedConfigItems0"
+          },
+          "x-nullable": true
+        },
+        "host_labels": {
+          "description": "The desired nodes which should be labeled for OCS.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClusterUpdateParamsHostLabelsItems0"
           },
           "x-nullable": true
         },
@@ -24800,6 +24844,11 @@ func init() {
             "Host",
             "AddToExistingClusterHost"
           ]
+        },
+        "labels": {
+          "description": "Json containing host's labels.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "logs_collected_at": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6840,6 +6840,10 @@ definitions:
         type: string
       user_name:
         type: string
+      labels:
+        x-go-custom-tag: gorm:"type:text"
+        type: string
+        description: Json containing host's labels.
       deleted_at:
         type: string
         format: date-time
@@ -7235,6 +7239,19 @@ definitions:
               format: uuid
             role:
               $ref: '#/definitions/host-role-update-params'
+      host_labels:
+        type: array
+        description: The desired nodes which should be labeled for OCS.
+        x-nullable: true
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            label:
+              description: Indicate if label should be set.
+              type: boolean
       hosts_names:
         type: array
         description: The desired hostname for hosts associated with the cluster.


### PR DESCRIPTION
## Description

In order to customize where OCS/ODF is deployed we need to state which nodes needs to be labeled. The label     `cluster.ocs.openshift.io/openshift-storage` is recognized by OCS/ODF.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
