### PR TITLE
MGMT-7424: Remove undeeded network validations for day2 hosts

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1356,9 +1356,6 @@ func (b *bareMetalInventory) InstallSingleDay2HostInternal(ctx context.Context, 
 	var cluster *common.Cluster
 	var h *common.Host
 
-	if cluster, err = common.GetClusterFromDB(b.db, clusterId, common.UseEagerLoading); err != nil {
-		return err
-	}
 	if h, err = b.getHost(ctx, clusterId.String(), hostId.String()); err != nil {
 		return err
 	}
@@ -1373,9 +1370,6 @@ func (b *bareMetalInventory) InstallSingleDay2HostInternal(ctx context.Context, 
 		return err
 	}
 
-	if err = b.setMajorityGroupForCluster(cluster.ID, b.db); err != nil {
-		return err
-	}
 	if err = b.hostApi.RefreshStatus(ctx, &h.Host, b.db); err != nil {
 		return err
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6679,7 +6679,6 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		bm = createInventory(db, cfg)
-		mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 	})
 
 	AfterEach(func() {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -769,7 +769,7 @@ func (v *validator) hasSufficientNetworkLatencyRequirementForRole(c *validationC
 		return ValidationSuccessSuppressOutput
 	}
 
-	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.NetworkLatencyThresholdMs == nil || c.host.Role == models.HostRoleAutoAssign {
+	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.NetworkLatencyThresholdMs == nil || c.host.Role == models.HostRoleAutoAssign || hostutil.IsDay2Host(c.host) {
 		// Single Node use case || no requirements defined || role is auto assign
 		return ValidationSuccess
 	}
@@ -838,7 +838,7 @@ func (v *validator) hasSufficientPacketLossRequirementForRole(c *validationConte
 		return ValidationSuccessSuppressOutput
 	}
 
-	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.PacketLossPercentage == nil || c.host.Role == models.HostRoleAutoAssign {
+	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.PacketLossPercentage == nil || c.host.Role == models.HostRoleAutoAssign || hostutil.IsDay2Host(c.host) {
 		// Single Node use case || no requirements defined || role is auto assign
 		return ValidationSuccess
 	}


### PR DESCRIPTION
# Assisted Pull Request

## Description

Day2 hosts should not be validated for:
- `hasSufficientNetworkLatencyRequirementForRole`
- `hasSufficientPacketLossRequirementForRole`

Additionaly, `InstallSingleDay2HostInternal` should not call `setMajorityGroupForCluster`.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
