### PR TITLE
MGMT-7445: During update-cluster CIDRs are checked for overlap even if they were not provided as part of the update

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2283,8 +2283,12 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 		updates["machine_network_cidr_updated_at"] = time.Now()
 	}
 
-	if err = network.VerifyClusterCIDRsNotOverlap(primaryMachineNetworkCIDR, clusterCidr, serviceCidr, userManagedNetworking); err != nil {
-		return common.NewApiError(http.StatusBadRequest, err)
+	if primaryMachineNetworkCIDR != cluster.MachineNetworkCidr ||
+		serviceCidr != cluster.ServiceNetworkCidr ||
+		clusterCidr != cluster.ClusterNetworkCidr {
+		if err = network.VerifyClusterCIDRsNotOverlap(primaryMachineNetworkCIDR, clusterCidr, serviceCidr, userManagedNetworking); err != nil {
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
 	}
 
 	if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, primaryMachineNetworkCIDR); err != nil {


### PR DESCRIPTION

# Assisted Pull Request

## Description


- Make the verification during update-cluster only if at least one of the CIDRs was part of the update

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] Unit tests

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
