### PR TITLE
OCPBUGSM-32941: Cache secrets for spoke cluster

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -505,9 +505,10 @@ func main() {
 			}).SetupWithManager(ctrlMgr), "unable to create controller Agent")
 
 			failOnError((&controllers.BMACReconciler{
-				Client: ctrlMgr.GetClient(),
-				Log:    log,
-				Scheme: ctrlMgr.GetScheme(),
+				Client:    ctrlMgr.GetClient(),
+				APIReader: ctrlMgr.GetAPIReader(),
+				Log:       log,
+				Scheme:    ctrlMgr.GetScheme(),
 			}).SetupWithManager(ctrlMgr), "unable to create controller BMH")
 
 			failOnError((&controllers.AgentClusterInstallReconciler{
@@ -753,7 +754,11 @@ func createControllerManager() (manager.Manager, error) {
 			NewCache: cache.BuilderWithOptions(cache.Options{
 				SelectorsByObject: cache.SelectorsByObject{
 					&corev1.Secret{}: {
-						Label: labels.SelectorFromSet(labels.Set{controllers.SecretLabelName: controllers.SecretLabelValue}),
+						Label: labels.SelectorFromSet(
+							labels.Set{
+								controllers.WatchResourceLabel: controllers.WatchResourceValue,
+							},
+						),
 					},
 				},
 			}),

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -530,7 +530,7 @@ var _ = Describe("cluster reconcile", func() {
 		Expect(result).To(Equal(ctrl.Result{}))
 
 		Expect(c.Get(ctx, secretKey, secret)).To(BeNil())
-		Expect(secret.Labels[SecretLabelName]).To(Equal(SecretLabelValue))
+		Expect(secret.Labels[WatchResourceLabel]).To(Equal(WatchResourceValue))
 	})
 
 	It("validate Event URL", func() {


### PR DESCRIPTION
# Assisted Pull Request

## Description
The internal cache now filters out secrets without the AI custom label "agent-install.openshift.io/watch": "true". Secrets are retrieved using the non-caching client if it fails to find the Secret in the current cache.

This is a combined fix for [OCPBUGSM-32941](https://issues.redhat.com/browse/OCPBUGSM-32941) and [OCPBUGSM-32966](https://issues.redhat.com/browse/OCPBUGSM-32966). 

Without this fix, the BMAC and ClusterDeployment controllers can't find the required secrets even if they are actually present.

Ref: 
https://issues.redhat.com/browse/OCPBUGSM-32941
https://issues.redhat.com/browse/OCPBUGSM-32966

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
