### PR TITLE
MGMT-6735: Update ZTP script to allow for multiple baremetal hosts

### DIFF
--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -17,15 +17,11 @@
     - pull_secret_name: "{{ lookup('env', 'ASSISTED_PULLSECRET_NAME') }}"
     - ssh_private_key_name: "{{ lookup('env', 'ASSISTED_PRIVATEKEY_NAME') }}"
     - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
-    - bmh_name: "{{ lookup('env', 'BMH_NAME') }}"
-    - mac_address: "{{ lookup('env', 'MAC_ADDRESS') }}"
-    - encoded_username: "{{ lookup('env', 'ENCODED_USERNAME') }}"
-    - encoded_password: "{{ lookup('env', 'ENCODED_PASSWORD') }}"
-    - address: "{{ lookup('env', 'ADDRESS') }}"
     - cluster_subnet: "{{ lookup('env', 'CLUSTER_SUBNET') }}"
     - cluster_host_prefix: "{{ lookup('env', 'CLUSTER_HOST_PREFIX') }}"
     - external_subnet: "{{ lookup('env', 'EXTERNAL_SUBNET') }}"
     - service_subnet: "{{ lookup('env', 'SERVICE_SUBNET') }}"
+    - extra_baremetalhosts: "{{ lookup('file', lookup('env', 'EXTRA_BAREMETALHOSTS_FILE')) | from_json }}"
 
   tasks:
   - name: create directory for generated CRDs

--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -1,27 +1,30 @@
+{% for host in extra_baremetalhosts %}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: '{{ bmh_name }}-bmc-secret'
+  name: '{{ host["name"] }}-bmc-secret'
   namespace: '{{ spoke_namespace }}'
 type: Opaque
 data:
-  username: '{{ encoded_username }}'
-  password: '{{ encoded_password }}'
+  username: '{{ host["driver_info"]["username"] | b64encode }}'
+  password: '{{ host["driver_info"]["password"] | b64encode }}'
 
 ---
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: '{{ bmh_name }}'
+  name: '{{ host["name"] }}'
   namespace: '{{ spoke_namespace }}'
   labels:
     infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
   annotations:
-    bmac.agent-install.openshift.io/hostname: '{{ bmh_name }}'
+    bmac.agent-install.openshift.io/hostname: '{{ host["name"] }}'
 spec:
   online: true
-  bootMACAddress: '{{ mac_address }}'
+  bootMACAddress: '{{ host["ports"][0]["address"] }}'
   bmc:
-    address: '{{ address }}'
-    credentialsName: '{{ bmh_name }}-bmc-secret'
+    address: '{{ host["driver_info"]["address"] }}'
+    credentialsName: '{{ host["name"] }}-bmc-secret'
+
+{% endfor %}

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -46,14 +46,7 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-echo "Extract information about extra worker nodes..."
-config=$(jq --raw-output '.[] | .name + " " + .ports[0].address + " " + .driver_info.username + " " + .driver_info.password + " " + .driver_info.address' "${EXTRA_BAREMETALHOSTS_FILE}")
-IFS=" " read BMH_NAME MAC_ADDRESS username password ADDRESS <<<"${config}"
-ENCODED_USERNAME=$(echo -n "${username}" | base64)
-ENCODED_PASSWORD=$(echo -n "${password}" | base64)
-
 echo "Running Ansible playbook to create kubernetes objects"
-export BMH_NAME MAC_ADDRESS ENCODED_USERNAME ENCODED_PASSWORD ADDRESS
 ansible-playbook "${__dir}/assisted-installer-crds-playbook.yaml"
 
 oc get namespace "${SPOKE_NAMESPACE}" || oc create namespace "${SPOKE_NAMESPACE}"


### PR DESCRIPTION
# Assisted Pull Request

## Description

Currently the ZTP script only pulls info on the first host. This will update it to add all the baremetal hosts defined in the `extra_baremetalhosts.json` created by dev-scripts.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [X] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [X] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @osherdp 
/cc @djzager 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
