### PR TITLE
MGMT-5443 Set host status to pending-user-input in case of reboot tim…

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -35,7 +35,7 @@ const (
 	statusInfoInstallationInProgressTimedOut                   = "Host failed to install because its installation stage $STAGE took longer than expected $MAX_TIME"
 	statusInfoInstallationInProgressWritingImageToDiskTimedOut = "Host failed to install because its installation stage $STAGE did not sufficiently progress in the last $MAX_TIME."
 	statusInfoHostReadyToBeMoved                               = "Host is part of pool and is ready to be moved"
-	statusInfoBinding                                          = "Host is waiting tobe bound to the cluster"
+	statusInfoBinding                                          = "Host is waiting to be bound to the cluster"
 	statusRebootTimeout                                        = "Host failed to reboot within timeout, the installation will resume once the host reboot"
 )
 

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -36,6 +36,7 @@ const (
 	statusInfoInstallationInProgressWritingImageToDiskTimedOut = "Host failed to install because its installation stage $STAGE did not sufficiently progress in the last $MAX_TIME."
 	statusInfoHostReadyToBeMoved                               = "Host is part of pool and is ready to be moved"
 	statusInfoBinding                                          = "Host is waiting tobe bound to the cluster"
+	statusRebootTimeout                                        = "Host failed to reboot within timeout, the installation will resume once the host reboot"
 )
 
 var hostStatusesBeforeInstallation = [...]string{


### PR DESCRIPTION
## Description

Set host status to pending-user-input in case of reboot timeout.

Reboot timeout shouldn't be different from wrong boot order. 
Once the node boot properly the installation will resume


It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no


## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @tsorya 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [?] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
