### PR TITLE
MGMT-5443: Reduced reboot timeout to 40 minutes

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -72,6 +72,8 @@ var InstallationProgressTimeout = map[models.HostStage]time.Duration{
 	"DEFAULT":                              60 * time.Minute,
 }
 
+const singleNodeRebootTimeout = 80 * time.Minute
+
 var disconnectionValidationStages = []models.HostStage{
 	models.HostStageWritingImageToDisk,
 	models.HostStageInstalling,
@@ -1149,30 +1151,12 @@ func (m Manager) PermanentHostsDeletion(olderThan strfmt.DateTime) error {
 	return nil
 }
 
-func (m *Manager) getHostCluster(host *models.Host) (*common.Cluster, error) {
-	var cluster common.Cluster
-	err := m.db.First(&cluster, "id = ?", host.ClusterID).Error
-	if err != nil {
-		m.log.WithError(err).Errorf("Failed to find cluster %s", host.ClusterID)
-		return nil, errors.Errorf("Failed to find cluster %s", host.ClusterID)
-	}
-	return &cluster, nil
-}
-
 func (m *Manager) allowStageOutOfOrder(h *models.Host, stage models.HostStage) bool {
 	// Return True in case the given stage order is exceptional in case of SNO
 	if stage != models.HostStageWritingImageToDisk {
 		return false
 	}
-	cluster, err := m.getHostCluster(h)
-	if err != nil {
-		m.log.Debug("Can't check if host is part of single node OpenShift")
-		return false
-	}
-	if !common.IsSingleNodeCluster(cluster) {
-		return false
-	}
-	return true
+	return hostutil.IsSingleNode(m.log, m.db, h)
 }
 
 type DisabledHostValidations map[string]struct{}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -66,7 +66,7 @@ var InstallationProgressTimeout = map[models.HostStage]time.Duration{
 	models.HostStageInstalling:             60 * time.Minute,
 	models.HostStageJoined:                 60 * time.Minute,
 	models.HostStageWritingImageToDisk:     30 * time.Minute,
-	models.HostStageRebooting:              70 * time.Minute,
+	models.HostStageRebooting:              40 * time.Minute,
 	models.HostStageConfiguring:            60 * time.Minute,
 	models.HostStageWaitingForIgnition:     24 * time.Hour,
 	"DEFAULT":                              60 * time.Minute,

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -528,6 +528,13 @@ func (th *transitionHandler) HasInstallationInProgressTimedOut(sw stateswitch.St
 	if !ok {
 		maxDuration = InstallationProgressTimeout["DEFAULT"]
 	}
+	if sHost.host.Progress.CurrentStage == models.HostStageRebooting {
+		if hostutil.IsSingleNode(th.log, th.db, sHost.host) {
+			// use extended reboot timeout for SNO
+			maxDuration += singleNodeRebootTimeout
+		}
+	}
+
 	return time.Since(time.Time(sHost.host.Progress.StageUpdatedAt)) > maxDuration, nil
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Since https://github.com/openshift/assisted-service/pull/2343 was merged reboot timeout leads to installing-pending-user-action status
So now that the timeout during reboot no longer fails the installation we can lower it to 40 minutes.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes for regression
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment - pending
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ x Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
