### PR TITLE
Bug 1994060: Change IP version to golang's unix constant

### DIFF
--- a/internal/network/connectivity_groups.go
+++ b/internal/network/connectivity_groups.go
@@ -12,13 +12,14 @@ import (
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
+	"golang.org/x/sys/unix"
 )
 
 type AddressFamily int
 
 const (
-	IPv4 AddressFamily = 4
-	IPv6 AddressFamily = 6
+	IPv4 AddressFamily = unix.AF_INET
+	IPv6 AddressFamily = unix.AF_INET6
 )
 
 func (a AddressFamily) String() string {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR changes the IPv4 and IPv6 constants used for parsing the routing information coming from the agent, to use golang's unix constant `AF_INET` and `AF_INET6` for IPv4 and IPv6 respectively. This PR follows up on the [agent's side](https://github.com/openshift/assisted-installer-agent/pull/222), where the usage of the incorrect value causes the agent to be unable to filter out the routing information specific for IPv4 and IPv6, effectively duplicating the resulting values as the underlying library is unable to identify which protocol to filter for (because it expects `AF_INET` or `AF_INET6`) and it returns all entries on each call. 

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees


/cc @ori-amizur 
/assign @ori-amizur 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
