### PR TITLE
MGMT-7315: Make ACI CR accept multiple subnets

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -194,6 +194,7 @@ type DebugInfo struct {
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
 	// MachineNetwork is the list of IP address pools for machines.
+	//
 	// +optional
 	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`
 
@@ -205,9 +206,7 @@ type Networking struct {
 
 	// ServiceNetwork is the list of IP address pools for services.
 	// Default is 172.30.0.0/16.
-	// NOTE: currently only one entry is supported.
 	//
-	// +kubebuilder:validation:MaxItems=1
 	// +optional
 	ServiceNetwork []string `json:"serviceNetwork,omitempty"`
 

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -170,10 +170,9 @@ spec:
                     - OVNKubernetes
                     type: string
                   serviceNetwork:
-                    description: 'ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16. NOTE: currently only one entry is supported.'
+                    description: ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16.
                     items:
                       type: string
-                    maxItems: 1
                     type: array
                 type: object
               provisionRequirements:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -168,10 +168,9 @@ spec:
                     - OVNKubernetes
                     type: string
                   serviceNetwork:
-                    description: 'ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16. NOTE: currently only one entry is supported.'
+                    description: ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16.
                     items:
                       type: string
-                    maxItems: 1
                     type: array
                 type: object
               provisionRequirements:

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -168,10 +168,9 @@ spec:
                     - OVNKubernetes
                     type: string
                   serviceNetwork:
-                    description: 'ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16. NOTE: currently only one entry is supported.'
+                    description: ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16.
                     items:
                       type: string
-                    maxItems: 1
                     type: array
                 type: object
               provisionRequirements:


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR changes the definition of the ACI CR so that clusterNetwork,
serviceNetwork and machineNetwork accept unlimited number of entries.

Contributes-to: [MGMT-7315](https://issues.redhat.com/browse/MGMT-7315)

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
