### PR TITLE
Bug 1974077: Improve validation message for network latency and packe…

### DIFF
--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -4464,10 +4464,10 @@ var _ = Describe("Refresh Host", func() {
 				IPAddressPool:          hostutil.GenerateIPv4Addresses(3, "1.2.3.1/24"),
 				machineNetworkCIDR:     "1.2.3.0/24",
 				ipType:                 ipv4,
-				statusInfoChecker:      makeRegexChecker("Network latency requirements of less or equals than 100.000 ms not met for connectivity between.*Packet loss percentage requirement of less or equals than 0.00% not met for connectivity between"),
+				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): Network latency requirements of less than or equals 100.00 ms not met for connectivity between.*Packet loss percentage requirement of equals 0.00% not met for connectivity between.*"),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
-					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less or equals than 100.000 ms not met for connectivity between (.*?) and master-1,master-2."},
-					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of less or equals than 0.00% not met for connectivity between (.*?) and master-1,master-2."},
+					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less than or equals 100.00 ms not met for connectivity between .*? and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
+					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of equals 0.00% not met for connectivity between .*? and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
 				}),
 			}, {name: "insufficient with IPv6 and 3 masters with high latency and packet loss",
 				srcState:               models.HostStatusDiscovering,
@@ -4478,10 +4478,10 @@ var _ = Describe("Refresh Host", func() {
 				IPAddressPool:          hostutil.GenerateIPv6Addresses(3, "1001:db8::1/120"),
 				machineNetworkCIDR:     "1001:db8::/120",
 				ipType:                 ipv6,
-				statusInfoChecker:      makeRegexChecker("Network latency requirements of less or equals than 100.000 ms not met for connectivity between.*Packet loss percentage requirement of less or equals than 0.00% not met for connectivity between"),
+				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): Network latency requirements of less than or equals 100.00 ms not met for connectivity between.*Packet loss percentage requirement of equals 0.00% not met for connectivity between.*"),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
-					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less or equals than 100.000 ms not met for connectivity between.*and master-1,master-2."},
-					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of less or equals than 0.00% not met for connectivity between.*and master-1,master-2."},
+					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less than or equals 100.00 ms not met for connectivity between .*? and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
+					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of equals 0.00% not met for connectivity between .*? and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
 				}),
 			},
 		}
@@ -4981,6 +4981,15 @@ var _ = Describe("validationResult sort", func() {
 		Expect(validationResults[1].ID.String()).Should(Equal("acb"))
 		Expect(validationResults[2].ID.String()).Should(Equal("bac"))
 		Expect(validationResults[3].ID.String()).Should(Equal("cab"))
+	})
+})
+
+var _ = Describe("Comparison builder", func() {
+	It("should return 'equals' when value is == 0", func() {
+		Expect(comparisonBuilder(0)).To(Equal("equals"))
+	})
+	It("should return 'less than or equals' when value is > 0", func() {
+		Expect(comparisonBuilder(1)).To(Equal("less than or equals"))
 	})
 })
 


### PR DESCRIPTION
…t loss

# Assisted Pull Request

## Description

Improve the validation failure message for host's network latency and packet loss validations based on feedback from QE.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @lalon4 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
