### PR TITLE
NO-ISSUE: Create BMH resources equal to the spoke controlpane agents.

### DIFF
--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -1,4 +1,6 @@
+{% set ns = namespace(counter=1) %}
 {% for host in extra_baremetalhosts %}
+{% if ns.counter <= spoke_controlplane_agents|int %}
 ---
 apiVersion: v1
 kind: Secret
@@ -27,4 +29,6 @@ spec:
     address: '{{ host["driver_info"]["address"] }}'
     credentialsName: '{{ host["name"] }}-bmc-secret'
 
+{% endif %}
+{% set ns.counter = ns.counter + 1 %} 
 {% endfor %}


### PR DESCRIPTION
# Assisted Pull Request

## Description
This fix is useful when deploying the day2 spoke cluster. With this fix, it is now possible to only use the required extra baremetal hosts from the dev-scripts generated config file to create the required master nodes leaving the unused BMH config to create workers for the day2.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
