### PR TITLE
MGMT-7384: add usage to schedulable masters feature

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2177,7 +2177,9 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 		}
 	}
 	if params.ClusterUpdateParams.SchedulableMasters != nil {
-		updates["schedulable_masters"] = swag.BoolValue(params.ClusterUpdateParams.SchedulableMasters)
+		value := swag.BoolValue(params.ClusterUpdateParams.SchedulableMasters)
+		updates["schedulable_masters"] = value
+		b.setUsage(value, usage.SchedulableMasters, nil, usages)
 	}
 	if len(updates) > 0 {
 		updates["trigger_monitor_timestamp"] = time.Now()

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -19,4 +19,6 @@ const (
 	NetworkTypeSelectionUsage string = "NetworkType"
 	//usage of platform provider other than baremetal
 	PlatformSelectionUsage string = "Platform selection"
+	//ussage of schedulable masters
+	SchedulableMasters string = "Schedulable masters"
 )


### PR DESCRIPTION
# Assisted Pull Request

## Description
Add usage report to the feature schedulable masters. The usage is reported when a non-default value is selected
(i.e. true)

## List all the issues related to this PR
- [X] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [  ] No tests needed

## Assignees
/assign @gamli75 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
