### PR TITLE
MGMT-7443: skip removable disks format

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -252,7 +252,8 @@ func (i *installCmd) getDiskUnbootableCmd(ctx context.Context, host models.Host)
 	formatCmds := ""
 	for _, disk := range inventory.Disks {
 		isFcIscsi := strings.Contains(disk.ByPath, "-fc-") || strings.Contains(disk.ByPath, "-iscsi-")
-		if disk.Bootable && !isFcIscsi && !disk.IsInstallationMedia {
+		isMmcblk := strings.Contains(disk.ByPath, "mmcblk") //mmc devices should be treated as removable
+		if disk.Bootable && !disk.Removable && !isMmcblk && !isFcIscsi && !disk.IsInstallationMedia {
 			formatCmds += fmt.Sprintf("dd if=/dev/zero of=%s bs=512 count=1 ; ", hostutil.GetDeviceIdentifier(disk))
 			i.eventsHandler.AddEvent(
 				ctx,

--- a/models/disk.go
+++ b/models/disk.go
@@ -52,6 +52,9 @@ type Disk struct {
 	// path
 	Path string `json:"path,omitempty"`
 
+	// removable
+	Removable bool `json:"removable,omitempty"`
+
 	// serial
 	Serial string `json:"serial,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7335,6 +7335,9 @@ func init() {
         "path": {
           "type": "string"
         },
+        "removable": {
+          "type": "boolean"
+        },
         "serial": {
           "type": "string"
         },
@@ -16760,6 +16763,9 @@ func init() {
         },
         "path": {
           "type": "string"
+        },
+        "removable": {
+          "type": "boolean"
         },
         "serial": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5606,6 +5606,8 @@ definitions:
         type: integer
       bootable:
         type: boolean
+      removable:
+        type: boolean
       is_installation_media:
         type: boolean
         description: Whether the disk appears to be an installation media or not


### PR DESCRIPTION
Avoid formatting of USB and SD cards that suppose to belong
to the users and should be controlled by them

Avoid formatting mmblk devices (NVIDIA servers case where such
a device was part of the server infrastructure

# Assisted Pull Request

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees
/assign @avishayt 
/assign @omertuc 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
