### PR TITLE
OCPBUGSM-31544: Set the BMH's hostname to the desired value

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -469,7 +469,12 @@ func (r *BMACReconciler) reconcileAgentInventory(bmh *bmh_v1alpha1.BareMetalHost
 	}
 
 	// Add hostname
-	hardwareDetails.Hostname = agent.Status.Inventory.Hostname
+	annotations := bmh.ObjectMeta.GetAnnotations()
+	if val, ok := annotations[BMH_AGENT_HOSTNAME]; ok {
+		hardwareDetails.Hostname = val
+	} else {
+		hardwareDetails.Hostname = agent.Status.Inventory.Hostname
+	}
 
 	bytes, err := json.Marshal(hardwareDetails)
 	if err != nil {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -623,6 +623,7 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(hDetails.RAMMebibytes).To(BeEquivalentTo(agent.Status.Inventory.Memory.PhysicalBytes / (1024 * 1024)))
 				Expect(hDetails.CPU.Arch).To(Equal(agent.Status.Inventory.Cpu.Architecture))
 				Expect(hDetails.CPU.Model).To(Equal(agent.Status.Inventory.Cpu.ModelName))
+				Expect(hDetails.Hostname).To(Equal(agent.Spec.Hostname))
 			})
 		})
 	})


### PR DESCRIPTION
# Assisted Pull Request

## Description

BMAC currently sets the BMH's hostname to the value inspected by the agent. However, this is not necessarily
the final desired valueas the bmac.agent-install.openshift.io/hostname annotation could've been set.

Use the value from the annotation if present. Otherwise, use the one from the agent's inventory

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I also manually set the `hardwaredetails` for an BMH in an existing cluster. Doing this resulted in the `Machine` resource getting the right hostname in the status, and eventually the CSR being approved:

Machine:

![image](https://user-images.githubusercontent.com/13816/129183858-0fcbc777-3ba2-4a75-a823-c381268a9d85.png)

CSR:

![image](https://user-images.githubusercontent.com/13816/129183702-8ad6f13d-a3b5-491d-970d-19675f0cb614.png)


Note that the above also depends on #2325

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pawanpinjarkar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
