### PR TITLE
MGMT-7475: allow only cluster owners to download sensitive files.

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -55,6 +55,12 @@ var S3FileNames = []string{
 	"custom_manifests.yaml",
 }
 
+var ClusterOwnerFileNames = []string{
+	constants.Kubeconfig,
+	"kubeadmin-password",
+	"kubeconfig-noingress",
+}
+
 //go:generate mockgen -source=cluster.go -package=cluster -destination=mock_cluster_api.go
 
 type RegistrationAPI interface {

--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -361,7 +361,7 @@ var _ = Describe("authz", func() {
 		},
 		{
 			name:         "download cluster kubeconfig",
-			allowedRoles: []ocm.RoleType{ocm.AdminRole, ocm.ReadOnlyAdminRole, ocm.UserRole},
+			allowedRoles: []ocm.RoleType{ocm.UserRole},
 			apiCall:      downloadClusterKubeconfig,
 		},
 		{

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1691,8 +1691,6 @@ func init() {
         "security": [
           {
             "userAuth": [
-              "admin",
-              "read-only-admin",
               "user"
             ]
           },
@@ -11014,8 +11012,6 @@ func init() {
         "security": [
           {
             "userAuth": [
-              "admin",
-              "read-only-admin",
               "user"
             ]
           },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -677,7 +677,7 @@ paths:
       tags:
         - installer
       security:
-        - userAuth: [admin, read-only-admin, user]
+        - userAuth: [user]
         - urlAuth: []
       description: Downloads the kubeconfig file for this cluster.
       operationId: DownloadClusterKubeconfig


### PR DESCRIPTION
# Assisted Pull Request

## Description

Files that only cluster owners can download:
 - kubeconfig
 - kubeconfig-noingress
 - kubeadmin-password

---
- Updated swagger security for endpoint `/v1/clusters/{cluster_id}/downloads/kubeconfig`
- Added logic in `/v1/clusters/{cluster_id}/downloads/files` handler
- Added subsystem tests to check file accessibility

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @YuviGold 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
