### PR TITLE
NO-ISSUE: Set machine network only in case of SNO. Remove unused VIPs from cluster deployment.

### DIFF
--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -14,8 +14,10 @@ spec:
     clusterNetwork:
     - cidr: {{ cluster_subnet }}
       hostPrefix: {{ cluster_host_prefix }}
+{% if spoke_controlplane_agents|int == 1 %}
     machineNetwork:
     - cidr: {{ external_subnet }}
+{% endif %}
     serviceNetwork:
     - {{ service_subnet }}
   provisionRequirements:

--- a/deploy/operator/ztp/clusterDeployment.j2
+++ b/deploy/operator/ztp/clusterDeployment.j2
@@ -13,8 +13,6 @@ spec:
     version: v1beta1
   platform:
     agentBareMetal:
-      apiVIP: ""
-      ingressVIP: ""
       agentSelector: {}
   pullSecretRef:
     name: '{{ pull_secret_name }}'


### PR DESCRIPTION
# Assisted Pull Request

## Description
Set machine network only in case of SNO. Remove unused VIPs from cluster deployment. Setting machine network when deploying multi-node cluster results in the below error- 



> [root@hardprov-fx2-21 ~]# oc get aci assisted-agent-cluster-install -n assisted-spoke-cluster  -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'

SpecSynced	False	InputError	The Spec could not be synced due to an input error: Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode
RequirementsMet	False	ClusterNotReady	The cluster is not ready to begin the installation
Validated	False	ValidationsUserPending	The cluster's validations are pending for user: The API virtual IP is undefined and must be provided.,The API virtual IP is undefined.
Completed	False	InstallationNotStarted	The installation has not yet started
Failed	False	InstallationNotFailed	The installation has not failed
Stopped	False	InstallationNotStopped	The installation is waiting to start or in progress


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
