### PR TITLE
MGMT-7567 Check cluster owner for file downloads only with rhsso auth

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3543,7 +3543,8 @@ func (b *bareMetalInventory) DownloadClusterFiles(ctx context.Context, params in
 		return filemiddleware.NewResponder(installer.NewDownloadClusterFilesOK().WithPayload(ioutil.NopCloser(strings.NewReader(cfg))), params.FileName, int64(len(cfg)))
 	}
 
-	if funk.Contains(clusterPkg.ClusterOwnerFileNames, params.FileName) {
+	// the OCM payload is only set in the cloud environment when the auth type is RHSSO
+	if funk.Contains(clusterPkg.ClusterOwnerFileNames, params.FileName) && b.authHandler.AuthType() == auth.TypeRHSSO {
 		authPayload := ocm.PayloadFromContext(ctx)
 		if ocm.UserRole != authPayload.Role {
 			errMsg := fmt.Sprintf("File '%v' is accessible only for cluster owners", params.FileName)


### PR DESCRIPTION
## Description

Previously it was impossible to download sensitive cluster files when
using "none" auth type because we were unconditionally checking the user
name in the context, but that is only being set when we use rhsso auth.

https://issues.redhat.com/browse/MGMT-7567

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?
Unit tests

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @sagidayan 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
