### PR TITLE
MGMT-7497: Remove KubeAPI EnableDay2Cluster flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ deploy-service-requirements: | deploy-namespace deploy-inventory-service-file
 		--public-registries "$(PUBLIC_CONTAINER_REGISTRIES)" \
 		--check-cvo $(CHECK_CLUSTER_VERSION) --apply-manifest $(APPLY_MANIFEST) $(ENABLE_KUBE_API_CMD) $(E2E_TESTS_CONFIG) \
 		--storage $(STORAGE) --ipv6-support $(IPV6_SUPPORT) --enable-sno-dnsmasq $(ENABLE_SINGLE_NODE_DNSMASQ) \
-		--hw-requirements '$(subst ",\",$(HW_REQUIREMENTS))' --kubeapi-day2 "$(ENABLE_KUBE_API_DAY2)" \
+		--hw-requirements '$(subst ",\",$(HW_REQUIREMENTS))' \
 		--disabled-host-validations "$(DISABLED_HOST_VALIDATIONS)" --disabled-steps "$(DISABLED_STEPS)"
 ifeq ($(MIRROR_REGISTRY_SUPPORT), True)
 	python3 ./tools/deploy_assisted_installer_configmap_registry_ca.py  --target "$(TARGET)" \
@@ -396,7 +396,7 @@ _run_subsystem_test:
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=120m TEST="$(or $(TEST),./subsystem/...)"
 
 enable-kube-api-for-subsystem: $(BUILD_FOLDER)
-	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true ENABLE_KUBE_API_DAY2=true
+	$(MAKE) deploy-service-requirements AUTH_TYPE=local ENABLE_KUBE_API=true
 	$(call restart_service_pods)
 	$(MAKE) wait-for-service
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,6 @@ var Options struct {
 	AssistedServiceISOConfig    assistedserviceiso.Config
 	ManifestsGeneratorConfig    network.Config
 	EnableKubeAPI               bool `envconfig:"ENABLE_KUBE_API" default:"false"`
-	EnableKubeAPIDay2Cluster    bool `envconfig:"ENABLE_KUBE_API_DAY2" default:"false"`
 	InfraEnvConfig              controllers.InfraEnvConfig
 	ISOEditorConfig             isoeditor.Config
 	CheckClusterVersion         bool          `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
@@ -495,18 +494,17 @@ func main() {
 			}).SetupWithManager(ctrlMgr), "unable to create controller InfraEnv")
 
 			failOnError((&controllers.ClusterDeploymentsReconciler{
-				Client:            ctrlMgr.GetClient(),
-				APIReader:         ctrlMgr.GetAPIReader(),
-				Log:               log,
-				Scheme:            ctrlMgr.GetScheme(),
-				Installer:         bm,
-				ClusterApi:        clusterApi,
-				HostApi:           hostApi,
-				CRDEventsHandler:  crdEventsHandler,
-				Manifests:         manifestsApi,
-				ServiceBaseURL:    Options.BMConfig.ServiceBaseURL,
-				AuthType:          Options.Auth.AuthType,
-				EnableDay2Cluster: Options.EnableKubeAPIDay2Cluster,
+				Client:           ctrlMgr.GetClient(),
+				APIReader:        ctrlMgr.GetAPIReader(),
+				Log:              log,
+				Scheme:           ctrlMgr.GetScheme(),
+				Installer:        bm,
+				ClusterApi:       clusterApi,
+				HostApi:          hostApi,
+				CRDEventsHandler: crdEventsHandler,
+				Manifests:        manifestsApi,
+				ServiceBaseURL:   Options.BMConfig.ServiceBaseURL,
+				AuthType:         Options.Auth.AuthType,
 			}).SetupWithManager(ctrlMgr), "unable to create controller ClusterDeployment")
 
 			failOnError((&controllers.AgentReconciler{

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -419,7 +419,6 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(log logrus.FieldLogger, ins
 			"CHECK_CLUSTER_VERSION":       "True",
 			"CREATE_S3_BUCKET":            "False",
 			"ENABLE_KUBE_API":             "True",
-			"ENABLE_KUBE_API_DAY2":        "True",
 			"ENABLE_SINGLE_NODE_DNSMASQ":  "True",
 			"IPV6_SUPPORT":                "True",
 			"JWKS_URL":                    "https://api.openshift.com/.well-known/jwks.json",

--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -27,7 +27,6 @@ def handle_arguments():
     parser.add_argument("--ipv6-support", default="True")
     parser.add_argument("--enable-sno-dnsmasq", default="True")
     parser.add_argument("--hw-requirements")
-    parser.add_argument("--kubeapi-day2", default="False")
     parser.add_argument("--disabled-host-validations", default="")
     parser.add_argument("--disabled-steps", default="")
 
@@ -120,9 +119,6 @@ def main():
 
             if deploy_options.enable_kube_api:
                 y['data']['ENABLE_KUBE_API'] = 'true'
-
-            if deploy_options.kubeapi_day2:
-                y['data']['ENABLE_KUBE_API_DAY2'] = deploy_options.kubeapi_day2
 
             data = yaml.dump(y)
             dst.write(data)


### PR DESCRIPTION
# Assisted Pull Request

## Description

This feature should always be enabled.
Once a day1 cluster finished the installation process successfully,
The clusterDeployments controller will invoke an internal API to transform
that cluster into a day2 cluster.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
