### PR TITLE
MGMT-7569: remove release getters from Versions

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -447,7 +447,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		}
 	}
 
-	openshiftVersion, err := b.versionsHandler.GetVersion(swag.StringValue(params.NewClusterParams.OpenshiftVersion))
+	openshiftVersion, err := b.versionsHandler.GetOpenshiftVersion(swag.StringValue(params.NewClusterParams.OpenshiftVersion))
 	if err != nil {
 		err = errors.Errorf("Openshift version %s is not supported",
 			swag.StringValue(params.NewClusterParams.OpenshiftVersion))
@@ -645,7 +645,7 @@ func (b *bareMetalInventory) RegisterAddHostsClusterInternal(ctx context.Context
 		return nil, common.NewApiError(http.StatusBadRequest, fmt.Errorf("AddHostsCluster for AI cluster %s already exists", id))
 	}
 
-	openshiftVersion, err := b.versionsHandler.GetVersion(inputOpenshiftVersion)
+	openshiftVersion, err := b.versionsHandler.GetOpenshiftVersion(inputOpenshiftVersion)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get opnshift version supported by versions map from version %s", inputOpenshiftVersion)
 		return nil, common.NewApiError(http.StatusBadRequest, fmt.Errorf("failed to get opnshift version supported by versions map from version %s", inputOpenshiftVersion))
@@ -1740,14 +1740,14 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 		return errors.Wrapf(err, "failed to get install config for cluster %s", cluster.ID)
 	}
 
-	releaseImage, err := b.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion)
-
+	ocpVersion, err := b.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion)
 	if err != nil {
-		log.WithError(err).Errorf("failed to get release image for cluster %s with openshift version %s", cluster.ID, cluster.OpenshiftVersion)
-		return errors.Wrapf(err, "failed to get release image for cluster %s with openshift version %s", cluster.ID, cluster.OpenshiftVersion)
+		msg := fmt.Sprintf("failed to get OpenshiftVersion for cluster %s with openshift version %s", cluster.ID, cluster.OpenshiftVersion)
+		log.WithError(err).Errorf(msg)
+		return errors.Wrapf(err, msg)
 	}
 
-	if err := b.generator.GenerateInstallConfig(ctx, cluster, cfg, releaseImage); err != nil {
+	if err := b.generator.GenerateInstallConfig(ctx, cluster, cfg, *ocpVersion.ReleaseImage); err != nil {
 		msg := fmt.Sprintf("failed generating install config for cluster %s", cluster.ID)
 		log.WithError(err).Error(msg)
 		return errors.Wrap(err, msg)
@@ -4895,7 +4895,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 		}
 	}
 
-	openshiftVersion, err := b.versionsHandler.GetVersion(swag.StringValue(params.InfraenvCreateParams.OpenshiftVersion))
+	openshiftVersion, err := b.versionsHandler.GetOpenshiftVersion(swag.StringValue(params.InfraenvCreateParams.OpenshiftVersion))
 	if err != nil {
 		err = errors.Errorf("Openshift version %s is not supported",
 			swag.StringValue(params.InfraenvCreateParams.OpenshiftVersion))

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -112,7 +112,7 @@ var (
 
 func mockClusterRegisterSteps() {
 	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	mockVersions.EXPECT().GetVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+	mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 }
 
@@ -126,7 +126,7 @@ func mockClusterRegisterSuccess(bm *bareMetalInventory, withEvents bool) {
 }
 
 func mockInfraEnvRegisterSuccess() {
-	mockVersions.EXPECT().GetVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+	mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 	mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(1)
 	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(2)
@@ -178,7 +178,7 @@ func strToUUID(s string) *strfmt.UUID {
 
 func mockGenerateInstallConfigSuccess(mockGenerator *generator.MockISOInstallConfigGenerator, mockVersions *versions.MockHandler) {
 	if mockGenerator != nil {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return("releaseImage", nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockGenerator.EXPECT().GenerateInstallConfig(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	}
 }
@@ -3485,7 +3485,7 @@ var _ = Describe("cluster", func() {
 				It("OLM invalid name", func() {
 					newOperatorName := "invalid-name"
 
-					mockVersions.EXPECT().GetVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+					mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().GetOperatorByName(newOperatorName).Return(nil, errors.Errorf("error")).Times(1)
 
@@ -7057,7 +7057,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 		}
 		mockClusterApi.EXPECT().RegisterAddHostsCluster(ctx, gomock.Any(), true).Return(nil).Times(1)
 		mockMetric.EXPECT().ClusterRegistered(common.TestDefaultConfig.ReleaseVersion, clusterID, "Unknown").Times(1)
-		mockVersions.EXPECT().GetVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		res := bm.RegisterAddHostsCluster(ctx, params)
 		actual := res.(*installer.RegisterAddHostsClusterCreated)
 
@@ -7665,7 +7665,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
-		mockVersions.EXPECT().GetVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
@@ -7678,7 +7678,7 @@ var _ = Describe("TestRegisterCluster", func() {
 	})
 
 	It("openshift version not supported", func() {
-		mockVersions.EXPECT().GetVersion(gomock.Any()).Return(nil, errors.Errorf("OpenShift VVersion is not supported")).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(nil, errors.Errorf("OpenShift VVersion is not supported")).Times(1)
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{

--- a/internal/host/hostcommands/container_image_availability_cmd.go
+++ b/internal/host/hostcommands/container_image_availability_cmd.go
@@ -38,13 +38,13 @@ func NewImageAvailabilityCmd(log logrus.FieldLogger, db *gorm.DB, ocRelease oc.R
 func (cmd *imageAvailabilityCmd) getImages(cluster *common.Cluster) ([]string, error) {
 
 	images := make([]string, 0)
-	releaseImage, err := cmd.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion)
+	ocpVersion, err := cmd.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion)
 	if err != nil {
 		return images, err
 	}
-	images = append(images, releaseImage)
+	images = append(images, *ocpVersion.ReleaseImage)
 
-	mcoImage, err := cmd.ocRelease.GetMCOImage(cmd.log, releaseImage, cmd.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
+	mcoImage, err := cmd.ocRelease.GetMCOImage(cmd.log, *ocpVersion.ReleaseImage, cmd.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
 	if err != nil {
 		return images, err
 	}

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -55,7 +55,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 
@@ -63,6 +63,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(step).NotTo(BeNil())
 
+		defaultReleaseImage := *common.TestDefaultConfig.Version.ReleaseImage
 		request := &models.ContainerImageAvailabilityRequest{
 			Images:  []string{defaultReleaseImage, defaultMCOImage, ocpMustGatherImage, cmd.instructionConfig.InstallerImage},
 			Timeout: defaultImageAvailabilityTimeoutSeconds,
@@ -75,7 +76,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_release_image_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return("", errors.New("err")).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
 		Expect(err).To(HaveOccurred())
@@ -83,7 +84,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_mco_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
@@ -92,7 +93,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_must_gather_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
@@ -126,11 +127,11 @@ var _ = Describe("get images", func() {
 	})
 
 	It("get_step_get_all_images", func() {
-		release := "image-rel"
 		mco := "image-mco"
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(release, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mco, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
+		release := *common.TestDefaultConfig.Version.ReleaseImage
 		expected := []string{release, mco, defaultMustGatherVersion["ocp"]}
 		images, err := cmd.getImages(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -104,12 +104,12 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		haMode = *cluster.HighAvailabilityMode
 	}
 
-	releaseImage, err := i.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion)
+	ocpVersion, err := i.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion)
 	if err != nil {
 		return "", err
 	}
 
-	mcoImage, err := i.ocRelease.GetMCOImage(i.log, releaseImage, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
+	mcoImage, err := i.ocRelease.GetMCOImage(i.log, *ocpVersion.ReleaseImage, i.instructionConfig.ReleaseImageMirror, cluster.PullSecret)
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +123,7 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		return "", err
 	}
 
-	i.log.Infof("Install command releaseImage: %s, mcoImage: %s", releaseImage, mcoImage)
+	i.log.Infof("Install command releaseImage: %s, mcoImage: %s", *ocpVersion.ReleaseImage, mcoImage)
 
 	podmanCmd := podmanBaseCmd[:]
 	installerCmd := []string{

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	defaultReleaseImage = "releaseImage"
-	defaultMCOImage     = "mcoImage"
-	ocpMustGatherImage  = "mustGatherImage"
+	defaultMCOImage    = "mcoImage"
+	ocpMustGatherImage = "mustGatherImage"
 )
 
 var defaultMustGatherVersion = versions.MustGatherVersion{
@@ -78,7 +77,7 @@ var _ = Describe("installcmd", func() {
 	})
 
 	mockGetReleaseImage := func(times int) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(times)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(times)
 	}
 
 	mockImages := func(times int) {
@@ -290,7 +289,7 @@ var _ = Describe("installcmd arguments", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).AnyTimes()
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).AnyTimes()
 		mockImages()
 	})
 

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -334,7 +334,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 	ExpectWithOffset(1, swag.StringValue(h.Status)).Should(Equal(state))
 	if funk.Contains(expectedStepTypes, models.StepTypeInstall) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/disk/by-id/wwn-sda").Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
@@ -352,7 +352,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 
 	if funk.Contains(expectedStepTypes, models.StepTypeContainerImageAvailability) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any()).Return(defaultReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
 

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -81,6 +81,21 @@ func (mr *MockHandlerMockRecorder) GetMustGatherImages(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImages", reflect.TypeOf((*MockHandler)(nil).GetMustGatherImages), arg0, arg1)
 }
 
+// GetOpenshiftVersion mocks base method
+func (m *MockHandler) GetOpenshiftVersion(arg0 string) (*models.OpenshiftVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOpenshiftVersion", arg0)
+	ret0, _ := ret[0].(*models.OpenshiftVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOpenshiftVersion indicates an expected call of GetOpenshiftVersion
+func (mr *MockHandlerMockRecorder) GetOpenshiftVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftVersion", reflect.TypeOf((*MockHandler)(nil).GetOpenshiftVersion), arg0)
+}
+
 // GetOsImage mocks base method
 func (m *MockHandler) GetOsImage(arg0 string) (*models.OsImage, error) {
 	m.ctrl.T.Helper()
@@ -94,51 +109,6 @@ func (m *MockHandler) GetOsImage(arg0 string) (*models.OsImage, error) {
 func (mr *MockHandlerMockRecorder) GetOsImage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOsImage", reflect.TypeOf((*MockHandler)(nil).GetOsImage), arg0)
-}
-
-// GetReleaseImage mocks base method
-func (m *MockHandler) GetReleaseImage(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReleaseImage", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReleaseImage indicates an expected call of GetReleaseImage
-func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0)
-}
-
-// GetReleaseVersion mocks base method
-func (m *MockHandler) GetReleaseVersion(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReleaseVersion", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReleaseVersion indicates an expected call of GetReleaseVersion
-func (mr *MockHandlerMockRecorder) GetReleaseVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseVersion", reflect.TypeOf((*MockHandler)(nil).GetReleaseVersion), arg0)
-}
-
-// GetVersion mocks base method
-func (m *MockHandler) GetVersion(arg0 string) (*models.OpenshiftVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVersion", arg0)
-	ret0, _ := ret[0].(*models.OpenshiftVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVersion indicates an expected call of GetVersion
-func (mr *MockHandlerMockRecorder) GetVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockHandler)(nil).GetVersion), arg0)
 }
 
 // IsOpenshiftVersionSupported mocks base method


### PR DESCRIPTION
# Assisted Pull Request

## Description

In order to simplify the Versions API and avoid code duplication, removed the GetReleaseImage and GetReleaseVersion functions. Instead, a single func (GetOpenshiftVersion) that returns the entire OpenshiftVersion struct should be used.
That way, extending the struct with additional fields should be easier, as the validation code is encapsulated in one place.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

Just an internal code-change.

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

Added relevant unit-tests.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @filanov 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
