### PR TITLE
MGMT-7583: AddEvent function should be used with InfraEnvID

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3140,7 +3140,7 @@ func (b *bareMetalInventory) processDiskSpeedCheckResponse(ctx context.Context, 
 			msg := fmt.Sprintf("Host's disk %s is slower than the supported speed, and may cause degraded cluster performance (fdatasync duration: %d ms)",
 				diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
 			log.Warnf(msg)
-			b.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityWarning, msg, time.Now())
+			b.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, models.EventSeverityWarning, msg, time.Now())
 		}
 	}
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -562,7 +562,7 @@ func (m *Manager) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap 
 		if err != nil {
 			return errors.Wrapf(err, "failed to set bootstrap to host %s", h.ID.String())
 		}
-		m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo,
+		m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, models.EventSeverityInfo,
 			fmt.Sprintf("Host %s: set as bootstrap", hostutil.GetHostnameForMsg(h)), time.Now())
 	}
 	return nil
@@ -694,7 +694,7 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 				newImageStatus.Time, newImageStatus.SizeBytes, newImageStatus.DownloadRate)
 		}
 
-		m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, eventInfo, time.Now())
+		m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, models.EventSeverityInfo, eventInfo, time.Now())
 	}
 	marshalledStatuses, err := common.MarshalImageStatuses(hostImageStatuses)
 	if err != nil {
@@ -763,7 +763,7 @@ func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
-			m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, eventSeverity, eventInfo, time.Now())
+			m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, eventSeverity, eventInfo, time.Now())
 		}
 	}()
 
@@ -805,7 +805,7 @@ func (m *Manager) ResetHost(ctx context.Context, h *models.Host, reason string, 
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
-			m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, eventSeverity, eventInfo, time.Now())
+			m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, eventSeverity, eventInfo, time.Now())
 		}
 	}()
 
@@ -843,7 +843,7 @@ func (m *Manager) ResetPendingUserAction(ctx context.Context, h *models.Host, db
 	shouldAddEvent := true
 	defer func() {
 		if shouldAddEvent {
-			m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, eventSeverity, eventInfo, time.Now())
+			m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, eventSeverity, eventInfo, time.Now())
 		}
 	}()
 
@@ -930,11 +930,11 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
 					m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
 					eventMsg := fmt.Sprintf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)
-					m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityWarning, eventMsg, time.Now())
+					m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, models.EventSeverityWarning, eventMsg, time.Now())
 				}
 				if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
 					eventMsg := fmt.Sprintf("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
-					m.eventsHandler.AddEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, eventMsg, time.Now())
+					m.eventsHandler.AddEvent(ctx, h.InfraEnvID, h.ID, models.EventSeverityInfo, eventMsg, time.Now())
 				}
 			}
 		}


### PR DESCRIPTION
In case the event being raised is a host event (hostID != nil )
then the clusterID param should contain InfraEnvID of the host.
This is a temp solution until we have a complete solution for
event generation with late-binding

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
