### PR TITLE
MGMT-6670: Create a getter for Machine Network CIDR

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3220,7 +3220,7 @@ func (b *bareMetalInventory) processDhcpAllocationResponse(ctx context.Context, 
 	ingressVip := dhcpAllocationReponse.IngressVipAddress.String()
 	primaryMachineCIDR := ""
 	if network.IsMachineCidrAvailable(cluster) {
-		primaryMachineCIDR = string(cluster.MachineNetworks[0].Cidr)
+		primaryMachineCIDR = network.GetMachineCidrById(cluster, 0)
 	}
 
 	isApiVipInMachineCIDR, err := network.IpInCidr(apiVip, primaryMachineCIDR)

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -428,7 +428,7 @@ func (m *Manager) tryAssignMachineCidrNonDHCPMode(cluster *common.Cluster) error
 
 	if err != nil {
 		return err
-	} else if network.IsMachineCidrAvailable(cluster) && machineCidr == string(cluster.MachineNetworks[0].Cidr) {
+	} else if network.IsMachineCidrAvailable(cluster) && machineCidr == network.GetMachineCidrById(cluster, 0) {
 		return nil
 	}
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1145,7 +1145,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				Expect(cluster.MachineNetworks).To(BeEmpty())
 			} else {
 				Expect(cluster.MachineNetworks).NotTo(BeEmpty())
-				Expect(string(cluster.MachineNetworks[0].Cidr)).To(Equal(t.expectedMachineCIDR))
+				Expect(network.GetMachineCidrById(&cluster, 0)).To(Equal(t.expectedMachineCIDR))
 			}
 			ctrl.Finish()
 		})

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -208,7 +208,7 @@ func GetCluster(ctx context.Context, logger logrus.FieldLogger, db *gorm.DB, clu
 func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string) error {
 	// Delete previous primary machine CIDR
 	if network.IsMachineCidrAvailable(cluster) {
-		if err := common.DeleteRecordsByClusterID(db, *cluster.ID, []interface{}{&models.MachineNetwork{}}, "cidr = ?", cluster.MachineNetworks[0].Cidr); err != nil {
+		if err := common.DeleteRecordsByClusterID(db, *cluster.ID, []interface{}{&models.MachineNetwork{}}, "cidr = ?", network.GetMachineCidrById(cluster, 0)); err != nil {
 			return err
 		}
 	}

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -162,7 +162,7 @@ func (v *clusterValidator) isMachineCidrEqualsToCalculatedCidr(c *clusterPreproc
 	c.calculateCidr = cidr
 	return boolToValidationStatus(err == nil &&
 		network.IsMachineCidrAvailable(c.cluster) &&
-		string(c.cluster.MachineNetworks[0].Cidr) == cidr)
+		network.GetMachineCidrById(c.cluster, 0) == cidr)
 }
 
 func (v *clusterValidator) printIsMachineCidrEqualsToCalculatedCidr(context *clusterPreprocessContext, status ValidationStatus) string {
@@ -180,7 +180,7 @@ func (v *clusterValidator) printIsMachineCidrEqualsToCalculatedCidr(context *clu
 	case ValidationFailure:
 		clusterMachineCidr := ""
 		if network.IsMachineCidrAvailable(context.cluster) {
-			clusterMachineCidr = string(context.cluster.MachineNetworks[0].Cidr)
+			clusterMachineCidr = network.GetMachineCidrById(context.cluster, 0)
 		}
 		return fmt.Sprintf("The Cluster Machine CIDR %s is different than the calculated CIDR %s.", clusterMachineCidr, context.calculateCidr)
 	default:
@@ -229,7 +229,7 @@ func (v *clusterValidator) isApiVipValid(c *clusterPreprocessContext) Validation
 	if c.cluster.APIVip == "" || !c.hasHostsWithInventories || !validationStatusToBool(v.isMachineCidrDefined(c)) {
 		return ValidationPending
 	}
-	err := network.VerifyVip(c.cluster.Hosts, string(c.cluster.MachineNetworks[0].Cidr), c.cluster.APIVip, ApiVipName,
+	err := network.VerifyVip(c.cluster.Hosts, network.GetMachineCidrById(c.cluster, 0), c.cluster.APIVip, ApiVipName,
 		true, v.log)
 	return boolToValidationStatus(err == nil)
 }
@@ -333,7 +333,7 @@ func (v *clusterValidator) isIngressVipValid(c *clusterPreprocessContext) Valida
 	if c.cluster.IngressVip == "" || !c.hasHostsWithInventories || !validationStatusToBool(v.isMachineCidrDefined(c)) {
 		return ValidationPending
 	}
-	err := network.VerifyVip(c.cluster.Hosts, string(c.cluster.MachineNetworks[0].Cidr), c.cluster.IngressVip, IngressVipName,
+	err := network.VerifyVip(c.cluster.Hosts, network.GetMachineCidrById(c.cluster, 0), c.cluster.IngressVip, IngressVipName,
 		true, v.log)
 	return boolToValidationStatus(err == nil)
 }

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -497,14 +497,14 @@ func (v *validator) printBelongsToMachineCidr(c *validationContext, status Valid
 			return "No machine network CIDR validation needed: User Managed Networking"
 		}
 		if network.IsMachineCidrAvailable(c.cluster) {
-			return fmt.Sprintf("Host belongs to machine network CIDR %s", c.cluster.MachineNetworks[0].Cidr)
+			return fmt.Sprintf("Host belongs to machine network CIDR %s", network.GetMachineCidrById(c.cluster, 0))
 		}
 
 		// TODO MGMT-7566: Fix day2 message
 		return "Host belongs to machine network CIDR"
 	case ValidationFailure:
 		if network.IsMachineCidrAvailable(c.cluster) {
-			return fmt.Sprintf("Host does not belong to machine network CIDR %s", c.cluster.MachineNetworks[0].Cidr)
+			return fmt.Sprintf("Host does not belong to machine network CIDR %s", network.GetMachineCidrById(c.cluster, 0))
 		}
 		return "Host does not belong to machine network CIDR"
 	case ValidationPending:
@@ -626,7 +626,7 @@ func (v *validator) belongsToL2MajorityGroup(c *validationContext, majorityGroup
 	}
 
 	// TODO: Handle multple machine networks
-	return boolValue(funk.Contains(majorityGroups[string(c.cluster.MachineNetworks[0].Cidr)], *c.host.ID))
+	return boolValue(funk.Contains(majorityGroups[network.GetMachineCidrById(c.cluster, 0)], *c.host.ID))
 }
 
 func (v *validator) belongsToL3MajorityGroup(c *validationContext, majorityGroups map[string][]strfmt.UUID) ValidationStatus {

--- a/internal/installcfg/installcfg_test.go
+++ b/internal/installcfg/installcfg_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"gopkg.in/yaml.v2"
@@ -142,7 +143,7 @@ var _ = Describe("installcfg", func() {
 		Expect(result.Proxy.HTTPSProxy).Should(Equal(proxyURL))
 		splitNoProxy := strings.Split(result.Proxy.NoProxy, ",")
 		Expect(splitNoProxy).To(HaveLen(4))
-		Expect(splitNoProxy).To(ContainElement(string(cluster.MachineNetworks[0].Cidr)))
+		Expect(splitNoProxy).To(ContainElement(network.GetMachineCidrById(&cluster, 0)))
 		Expect(splitNoProxy).To(ContainElement(string(cluster.ServiceNetworks[0].Cidr)))
 		Expect(splitNoProxy).To(ContainElement(string(cluster.ClusterNetworks[0].Cidr)))
 		domainName := "." + cluster.Name + "." + cluster.BaseDNSDomain
@@ -365,7 +366,7 @@ var _ = Describe("installcfg", func() {
 		Expect(result.Platform.Baremetal).Should(BeNil())
 		Expect(*result.Platform.None).Should(Equal(platformNone{}))
 		Expect(result.BootstrapInPlace.InstallationDisk).Should(Equal("/dev/test"))
-		Expect(result.Networking.MachineNetwork[0].Cidr).Should(Equal(string(cluster.MachineNetworks[0].Cidr)))
+		Expect(result.Networking.MachineNetwork[0].Cidr).Should(Equal(network.GetMachineCidrById(&cluster, 0)))
 		Expect(result.Networking.NetworkType).To(Equal(models.ClusterNetworkTypeOpenShiftSDN))
 	})
 
@@ -384,7 +385,7 @@ var _ = Describe("installcfg", func() {
 		Expect(result.Platform.Baremetal).Should(BeNil())
 		var none = platformNone{}
 		Expect(*result.Platform.None).Should(Equal(none))
-		Expect(result.Networking.MachineNetwork[0].Cidr).Should(Equal(string(cluster.MachineNetworks[0].Cidr)))
+		Expect(result.Networking.MachineNetwork[0].Cidr).Should(Equal(network.GetMachineCidrById(&cluster, 0)))
 	})
 
 	It("Hyperthreading config", func() {
@@ -569,13 +570,13 @@ var _ = Describe("Generate NoProxy", func() {
 	It("Default NoProxy", func() {
 		noProxy := installConfig.generateNoProxy(cluster)
 		Expect(noProxy).Should(Equal(fmt.Sprintf(".proxycluster.myproxy.com,%s,%s,%s",
-			cluster.ClusterNetworks[0].Cidr, cluster.ServiceNetworks[0].Cidr, cluster.MachineNetworks[0].Cidr)))
+			cluster.ClusterNetworks[0].Cidr, cluster.ServiceNetworks[0].Cidr, network.GetMachineCidrById(cluster, 0))))
 	})
 	It("Update NoProxy", func() {
 		cluster.NoProxy = "domain.org,127.0.0.2"
 		noProxy := installConfig.generateNoProxy(cluster)
 		Expect(noProxy).Should(Equal(fmt.Sprintf("domain.org,127.0.0.2,.proxycluster.myproxy.com,%s,%s,%s",
-			cluster.ClusterNetworks[0].Cidr, cluster.ServiceNetworks[0].Cidr, cluster.MachineNetworks[0].Cidr)))
+			cluster.ClusterNetworks[0].Cidr, cluster.ServiceNetworks[0].Cidr, network.GetMachineCidrById(cluster, 0))))
 	})
 	It("All-excluded NoProxy", func() {
 		cluster.NoProxy = "*"

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -170,7 +170,7 @@ func getMachineCIDRObj(host *models.Host, machineNetworkCidr string, obj string)
 func GetPrimaryMachineCIDRInterface(host *models.Host, cluster *common.Cluster) (string, error) {
 	primaryMachineCidr := ""
 	if IsMachineCidrAvailable(cluster) {
-		primaryMachineCidr = string(cluster.MachineNetworks[0].Cidr)
+		primaryMachineCidr = GetMachineCidrById(cluster, 0)
 	}
 	return getMachineCIDRObj(host, primaryMachineCidr, "interface")
 }
@@ -178,7 +178,7 @@ func GetPrimaryMachineCIDRInterface(host *models.Host, cluster *common.Cluster) 
 func GetPrimaryMachineCIDRIP(host *models.Host, cluster *common.Cluster) (string, error) {
 	primaryMachineCidr := ""
 	if IsMachineCidrAvailable(cluster) {
-		primaryMachineCidr = string(cluster.MachineNetworks[0].Cidr)
+		primaryMachineCidr = GetMachineCidrById(cluster, 0)
 	}
 	return getMachineCIDRObj(host, primaryMachineCidr, "ip")
 }
@@ -215,7 +215,7 @@ func GetPrimaryMachineCIDRHosts(log logrus.FieldLogger, cluster *common.Cluster)
 	if !IsMachineCidrAvailable(cluster) {
 		return nil, errors.New("Machine network CIDR was not set in cluster")
 	}
-	_, machineIpnet, err := net.ParseCIDR(string(cluster.MachineNetworks[0].Cidr))
+	_, machineIpnet, err := net.ParseCIDR(GetMachineCidrById(cluster, 0))
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func GetPrimaryMachineCIDRHosts(log logrus.FieldLogger, cluster *common.Cluster)
 // GetPrimaryMachineCidrForUserManagedNetwork used to get the primary machine cidr in case of none platform and sno
 func GetPrimaryMachineCidrForUserManagedNetwork(cluster *common.Cluster, log logrus.FieldLogger) string {
 	if IsMachineCidrAvailable(cluster) {
-		return string(cluster.MachineNetworks[0].Cidr)
+		return GetMachineCidrById(cluster, 0)
 	}
 
 	bootstrap := common.GetBootstrapHost(cluster)

--- a/internal/network/machine_network_cidr_test.go
+++ b/internal/network/machine_network_cidr_test.go
@@ -362,7 +362,7 @@ var _ = Describe("inventory", func() {
 				createInventory(createInterface("127.0.0.1/17")))
 			cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "1.2.5.0/23"}}
 			machineCidr := GetPrimaryMachineCidrForUserManagedNetwork(cluster, log)
-			Expect(machineCidr).To(Equal(string(cluster.MachineNetworks[0].Cidr)))
+			Expect(machineCidr).To(Equal(GetMachineCidrById(cluster, 0)))
 		})
 
 	})

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -69,3 +69,7 @@ func GetConfiguredAddressFamilies(cluster *common.Cluster) (ipv4 bool, ipv6 bool
 func IsMachineCidrAvailable(cluster *common.Cluster) bool {
 	return len(cluster.MachineNetworks) > 0
 }
+
+func GetMachineCidrById(cluster *common.Cluster, index int) string {
+	return string(cluster.MachineNetworks[index].Cidr)
+}


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR creates a getter function that returns a CIDR for respective
Machine Network based on its id.

Contributes-to: [MGMT-6670](https://issues.redhat.com/browse/MGMT-6670)

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
