### PR TITLE
MGMT 4321: delete networks records on deletion

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4805,7 +4805,11 @@ var _ = Describe("cluster", func() {
 					machineNetworks = []*models.MachineNetwork{{Cidr: "5.5.0.0/24"}, {Cidr: "6.6.0.0/24"}}
 				)
 
-				BeforeEach(func() {
+				setNetworksClusterID := func(clusterID strfmt.UUID,
+					clusterNetworks []*models.ClusterNetwork,
+					serviceNetworks []*models.ServiceNetwork,
+					machineNetworks []*models.MachineNetwork,
+				) {
 					for _, network := range clusterNetworks {
 						network.ClusterID = clusterID
 						Expect(db.Model(&models.ClusterNetwork{}).Save(network).Error).ShouldNot(HaveOccurred())
@@ -4818,6 +4822,14 @@ var _ = Describe("cluster", func() {
 						network.ClusterID = clusterID
 						Expect(db.Model(&models.MachineNetwork{}).Save(network).Error).ShouldNot(HaveOccurred())
 					}
+
+					cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+					Expect(err).ToNot(HaveOccurred())
+					validateNetworkConfiguration(&cluster.Cluster, &clusterNetworks, &serviceNetworks, &machineNetworks)
+				}
+
+				BeforeEach(func() {
+					setNetworksClusterID(clusterID, clusterNetworks, serviceNetworks, machineNetworks)
 				})
 
 				It("No new networks data", func() {
@@ -4829,9 +4841,7 @@ var _ = Describe("cluster", func() {
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
 					actual := reply.(*installer.UpdateClusterCreated)
 
-					Expect(actual.Payload.ClusterNetworks).To(HaveLen(len(clusterNetworks)))
-					Expect(actual.Payload.ServiceNetworks).To(HaveLen(len(serviceNetworks)))
-					Expect(actual.Payload.MachineNetworks).To(HaveLen(len(machineNetworks)))
+					validateNetworkConfiguration(actual.Payload, &clusterNetworks, &serviceNetworks, &machineNetworks)
 				})
 
 				It("Empty networks", func() {
@@ -4870,24 +4880,35 @@ var _ = Describe("cluster", func() {
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
 					actual := reply.(*installer.UpdateClusterCreated)
 
-					Expect(actual.Payload.ClusterNetworks).To(HaveLen(len(clusterNetworks)))
-					for index := range clusterNetworks {
-						Expect(actual.Payload.ClusterNetworks[index].Cidr).To(Equal(clusterNetworks[index].Cidr))
-						Expect(actual.Payload.ClusterNetworks[index].HostPrefix).To(Equal(clusterNetworks[index].HostPrefix))
-						Expect(actual.Payload.ClusterNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-					}
+					validateNetworkConfiguration(actual.Payload, &clusterNetworks, &serviceNetworks, &machineNetworks)
+				})
 
-					Expect(actual.Payload.ServiceNetworks).To(HaveLen(len(serviceNetworks)))
-					for index := range serviceNetworks {
-						Expect(actual.Payload.ServiceNetworks[index].Cidr).To(Equal(serviceNetworks[index].Cidr))
-						Expect(actual.Payload.ServiceNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-					}
+				It("Multiple clusters", func() {
+					secondClusterID := strfmt.UUID(uuid.New().String())
+					Expect(db.Create(&common.Cluster{Cluster: models.Cluster{ID: &secondClusterID}}).Error).ShouldNot(HaveOccurred())
+					setNetworksClusterID(secondClusterID, clusterNetworks, serviceNetworks, machineNetworks)
 
-					Expect(actual.Payload.MachineNetworks).To(HaveLen(len(machineNetworks)))
-					for index := range machineNetworks {
-						Expect(actual.Payload.MachineNetworks[index].Cidr).To(Equal(machineNetworks[index].Cidr))
-						Expect(actual.Payload.MachineNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-					}
+					mockSuccess(1)
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks:   clusterNetworks,
+							ServiceNetworks:   serviceNetworks,
+							MachineNetworks:   machineNetworks,
+							VipDhcpAllocation: swag.Bool(true),
+						},
+					})
+					Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+					actual := reply.(*installer.UpdateClusterCreated)
+					validateNetworkConfiguration(actual.Payload, &clusterNetworks, &serviceNetworks, &machineNetworks)
+
+					cluster, err := common.GetClusterFromDB(db, secondClusterID, common.UseEagerLoading)
+					Expect(err).ToNot(HaveOccurred())
+					validateNetworkConfiguration(&cluster.Cluster, &clusterNetworks, &serviceNetworks, &machineNetworks)
+
+					var dbMachineNetworks []*models.MachineNetwork
+					Expect(db.Find(&dbMachineNetworks).Error).ShouldNot(HaveOccurred())
+					Expect(dbMachineNetworks).To(HaveLen(len(machineNetworks) * 2))
 				})
 			})
 		})
@@ -7957,6 +7978,29 @@ var _ = Describe("TestRegisterCluster", func() {
 	})
 
 	Context("Networking", func() {
+		var (
+			clusterNetworks = []*models.ClusterNetwork{{Cidr: "1.1.1.0/24", HostPrefix: 24}, {Cidr: "2.2.2.0/24", HostPrefix: 24}}
+			serviceNetworks = []*models.ServiceNetwork{{Cidr: "3.3.3.0/24"}, {Cidr: "4.4.4.0/24"}}
+			machineNetworks = []*models.MachineNetwork{{Cidr: "5.5.5.0/24"}, {Cidr: "6.6.6.0/24"}}
+		)
+
+		registerCluster := func() *models.Cluster {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String("some-cluster-name"),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+					ClusterNetworks:  clusterNetworks,
+					ServiceNetworks:  serviceNetworks,
+					MachineNetworks:  machineNetworks,
+				},
+			})
+			Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterCreated())))
+			return reply.(*installer.RegisterClusterCreated).Payload
+		}
+
 		It("Networking defaults", func() {
 			defaultClusterNetwork := "1.2.3.4/14"
 			bm.Config.DefaultClusterNetworkCidr = defaultClusterNetwork
@@ -7980,43 +8024,26 @@ var _ = Describe("TestRegisterCluster", func() {
 			Expect(string(actual.Payload.ServiceNetworks[0].Cidr)).To(Equal(defultServiceNetwork))
 		})
 
-		It("Multiple Networks", func() {
-			clusterNetworks := []*models.ClusterNetwork{{Cidr: "1.1.1.0/24", HostPrefix: 24}, {Cidr: "2.2.2.0/24", HostPrefix: 24}}
-			serviceNetworks := []*models.ServiceNetwork{{Cidr: "3.3.3.0/24"}, {Cidr: "4.4.4.0/24"}}
-			machineNetworks := []*models.MachineNetwork{{Cidr: "5.5.5.0/24"}, {Cidr: "6.6.6.0/24"}}
-			mockClusterRegisterSuccess(bm, true)
-			mockAMSSubscription(ctx)
-			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
-				NewClusterParams: &models.ClusterCreateParams{
-					Name:             swag.String("some-cluster-name"),
-					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
-					OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
-					ClusterNetworks:  clusterNetworks,
-					ServiceNetworks:  serviceNetworks,
-					MachineNetworks:  machineNetworks,
-				},
-			})
-			Expect(reflect.TypeOf(reply)).Should(Equal(reflect.TypeOf(installer.NewRegisterClusterCreated())))
-			actual := reply.(*installer.RegisterClusterCreated)
+		It("Multiple networks single cluster", func() {
+			c := registerCluster()
+			validateNetworkConfiguration(c, &clusterNetworks, &serviceNetworks, &machineNetworks)
+		})
 
-			Expect(actual.Payload.ClusterNetworks).To(HaveLen(len(clusterNetworks)))
-			for index := range clusterNetworks {
-				Expect(actual.Payload.ClusterNetworks[index].Cidr).To(Equal(clusterNetworks[index].Cidr))
-				Expect(actual.Payload.ClusterNetworks[index].HostPrefix).To(Equal(clusterNetworks[index].HostPrefix))
-				Expect(actual.Payload.ClusterNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-			}
+		It("Multiple networks multiple clusters", func() {
+			By("Register")
+			c1 := registerCluster()
+			c2 := registerCluster()
+			validateNetworkConfiguration(c1, &clusterNetworks, &serviceNetworks, &machineNetworks)
+			validateNetworkConfiguration(c2, &clusterNetworks, &serviceNetworks, &machineNetworks)
 
-			Expect(actual.Payload.ServiceNetworks).To(HaveLen(len(serviceNetworks)))
-			for index := range serviceNetworks {
-				Expect(actual.Payload.ServiceNetworks[index].Cidr).To(Equal(serviceNetworks[index].Cidr))
-				Expect(actual.Payload.ServiceNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-			}
+			By("Check DB")
+			cluster, err := common.GetClusterFromDB(db, *c1.ID, common.UseEagerLoading)
+			Expect(err).ToNot(HaveOccurred())
+			validateNetworkConfiguration(&cluster.Cluster, &clusterNetworks, &serviceNetworks, &machineNetworks)
 
-			Expect(actual.Payload.MachineNetworks).To(HaveLen(len(machineNetworks)))
-			for index := range machineNetworks {
-				Expect(actual.Payload.MachineNetworks[index].Cidr).To(Equal(machineNetworks[index].Cidr))
-				Expect(actual.Payload.MachineNetworks[index].ClusterID).To(Equal(*actual.Payload.ID))
-			}
+			cluster, err = common.GetClusterFromDB(db, *c2.ID, common.UseEagerLoading)
+			Expect(err).ToNot(HaveOccurred())
+			validateNetworkConfiguration(&cluster.Cluster, &clusterNetworks, &serviceNetworks, &machineNetworks)
 		})
 	})
 })
@@ -9753,6 +9780,7 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 	if clusterNetworks != nil {
 		Expect(cluster.ClusterNetworks).To(HaveLen(len(*clusterNetworks)))
 		for index := range *clusterNetworks {
+			Expect(cluster.ClusterNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.ClusterNetworks[index].Cidr).To(Equal((*clusterNetworks)[index].Cidr))
 			Expect(cluster.ClusterNetworks[index].HostPrefix).To(Equal((*clusterNetworks)[index].HostPrefix))
 		}
@@ -9760,12 +9788,14 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 	if serviceNetworks != nil {
 		Expect(cluster.ServiceNetworks).To(HaveLen(len(*serviceNetworks)))
 		for index := range *serviceNetworks {
+			Expect(cluster.ServiceNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.ServiceNetworks[index].Cidr).To(Equal((*serviceNetworks)[index].Cidr))
 		}
 	}
 	if machineNetworks != nil {
 		Expect(cluster.MachineNetworks).To(HaveLen(len(*machineNetworks)))
 		for index := range *machineNetworks {
+			Expect(cluster.MachineNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.MachineNetworks[index].Cidr).To(Equal((*machineNetworks)[index].Cidr))
 		}
 	}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1099,12 +1099,14 @@ func (m Manager) PermanentClustersDeletion(ctx context.Context, olderThan strfmt
 			m.log.Debugf("Deleted %s cluster from db", reply.RowsAffected)
 		}
 
-		if err := common.DeleteRecordsByClusterID(db, *c.ID, models.Event{}); err != nil {
-			m.log.WithError(err).Warnf("Failed deleting events from db for cluster %s", c.ID.String())
-		}
-
-		if err := common.DeleteRecordsByClusterID(db, *c.ID, models.MonitoredOperator{}); err != nil {
-			m.log.WithError(err).Warnf("Failed deleting operators from db for cluster %s", c.ID.String())
+		if err := common.DeleteRecordsByClusterID(db, *c.ID, []interface{}{
+			&models.Event{},
+			&models.MonitoredOperator{},
+			&models.ClusterNetwork{},
+			&models.ServiceNetwork{},
+			&models.MachineNetwork{},
+		}); err != nil {
+			m.log.WithError(err).Warnf("Failed deleting cluster records from db for cluster %s", c.ID.String())
 		}
 	}
 	return nil

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -208,7 +208,7 @@ func GetCluster(ctx context.Context, logger logrus.FieldLogger, db *gorm.DB, clu
 func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string) error {
 	// Delete previous primary machine CIDR
 	if network.IsMachineCidrAvailable(cluster) {
-		if err := common.DeleteRecordsByClusterID(db, *cluster.ID, models.MachineNetwork{}, "cidr = ?", cluster.MachineNetworks[0].Cidr); err != nil {
+		if err := common.DeleteRecordsByClusterID(db, *cluster.ID, []interface{}{&models.MachineNetwork{}}, "cidr = ?", cluster.MachineNetworks[0].Cidr); err != nil {
 			return err
 		}
 	}

--- a/internal/cluster/registrar_test.go
+++ b/internal/cluster/registrar_test.go
@@ -22,7 +22,6 @@ var _ = Describe("registrar", func() {
 		updateErr       error
 		cluster         common.Cluster
 		infraEnv        *common.InfraEnv
-		host            models.Host
 		dbName          string
 	)
 
@@ -31,22 +30,24 @@ var _ = Describe("registrar", func() {
 		registerManager = NewRegistrar(common.GetTestLog(), db)
 
 		id = strfmt.UUID(uuid.New().String())
-		cluster = common.Cluster{Cluster: models.Cluster{
-			ID:     &id,
-			Status: swag.String(models.ClusterStatusInsufficient),
-		}}
-
-		//register cluster
-		updateErr = registerManager.RegisterCluster(ctx, &cluster, true)
-		Expect(updateErr).Should(BeNil())
-		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
-		cluster = getClusterFromDB(*cluster.ID, db)
-		Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
-		infraEnv, updateErr = common.GetInfraEnvFromDB(db, id)
-		Expect(updateErr).Should(BeNil())
 	})
 
 	Context("register cluster", func() {
+		BeforeEach(func() {
+			cluster = common.Cluster{Cluster: models.Cluster{
+				ID:     &id,
+				Status: swag.String(models.ClusterStatusInsufficient),
+			}}
+
+			updateErr = registerManager.RegisterCluster(ctx, &cluster, true)
+			Expect(updateErr).Should(BeNil())
+			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
+			cluster = getClusterFromDB(*cluster.ID, db)
+			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInsufficient))
+			infraEnv, updateErr = common.GetInfraEnvFromDB(db, id)
+			Expect(updateErr).Should(BeNil())
+		})
+
 		It("register a registered cluster", func() {
 			updateErr = registerManager.RegisterCluster(ctx, &cluster, true)
 			Expect(updateErr).Should(HaveOccurred())
@@ -79,6 +80,23 @@ var _ = Describe("registrar", func() {
 	})
 
 	Context("deregister", func() {
+		BeforeEach(func() {
+			cluster = common.Cluster{Cluster: models.Cluster{
+				ID:                 &id,
+				MonitoredOperators: []*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator},
+				ClusterNetworks:    common.TestIPv4Networking.ClusterNetworks,
+				ServiceNetworks:    common.TestIPv4Networking.ServiceNetworks,
+				MachineNetworks:    common.TestIPv4Networking.MachineNetworks,
+			}}
+
+			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+			dbCluster := getClusterFromDB(*cluster.ID, db)
+			Expect(dbCluster.MonitoredOperators).ToNot(BeEmpty())
+			Expect(dbCluster.ClusterNetworks).ToNot(BeEmpty())
+			Expect(dbCluster.ServiceNetworks).ToNot(BeEmpty())
+			Expect(dbCluster.MachineNetworks).ToNot(BeEmpty())
+		})
+
 		It("unregister a registered cluster", func() {
 			updateErr = registerManager.DeregisterCluster(ctx, &cluster)
 			Expect(updateErr).Should(BeNil())
@@ -87,9 +105,13 @@ var _ = Describe("registrar", func() {
 			Expect(err).Should(HaveOccurred())
 
 			Expect(db.First(&common.Cluster{}, "id = ?", cluster.ID).Error).Should(HaveOccurred())
-			Expect(db.First(&host, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
-
+			Expect(db.First(&models.Host{}, "cluster_id = ?", *cluster.ID).Error).Should(HaveOccurred())
+			Expect(db.First(&models.MonitoredOperator{}, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
+			Expect(db.First(&models.ClusterNetwork{}, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
+			Expect(db.First(&models.ServiceNetwork{}, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
+			Expect(db.First(&models.MachineNetwork{}, "cluster_id = ?", cluster.ID).Error).Should(HaveOccurred())
 		})
+
 		It("unregister a cluster in installing state", func() {
 			// cluster state to installing
 			cluster.Status = swag.String("installing")
@@ -101,7 +123,6 @@ var _ = Describe("registrar", func() {
 			db.First(&cluster, "id = ?", cluster.ID)
 			Expect(db.First(&cluster, "id = ?", cluster.ID).Error).NotTo(HaveOccurred())
 			Expect(swag.StringValue(cluster.Status)).Should(Equal(models.ClusterStatusInstalling))
-
 		})
 	})
 

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -279,8 +279,14 @@ func GetInfraEnvsFromDBWhere(db *gorm.DB, where ...interface{}) ([]*InfraEnv, er
 	return infraEnvs, nil
 }
 
-func DeleteRecordsByClusterID(db *gorm.DB, clusterID strfmt.UUID, value interface{}, where ...interface{}) error {
-	return db.Where("cluster_id = ?", clusterID).Delete(value, where...).Error
+func DeleteRecordsByClusterID(db *gorm.DB, clusterID strfmt.UUID, values []interface{}, where ...interface{}) error {
+	for _, value := range values {
+		if err := db.Where("cluster_id = ?", clusterID).Delete(value, where...).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func ToModelsHosts(hosts []*Host) []*models.Host {

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -40,8 +40,17 @@ func clearDB() {
 	}
 
 	// Clean the DB to make sure we start tests from scratch
-	db.Delete(&models.Host{})
-	db.Delete(&models.Cluster{})
+	for _, model := range []interface{}{
+		&models.Host{},
+		&models.Cluster{},
+		&models.Event{},
+		&models.MonitoredOperator{},
+		&models.ClusterNetwork{},
+		&models.ServiceNetwork{},
+		&models.MachineNetwork{},
+	} {
+		db.Delete(model)
+	}
 }
 
 func strToUUID(s string) *strfmt.UUID {

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -49,7 +49,7 @@ func clearDB() {
 		&models.ServiceNetwork{},
 		&models.MachineNetwork{},
 	} {
-		db.Delete(model)
+		db.Unscoped().Delete(model)
 	}
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description


Delete `ClusterNetwork`, `ServiceNetwork`, and `MachineNetwork` models on
cluster deletion.
    
- `DeregisterCluster` - Triggered by the user owner when he deletes the cluster.
- `PermanentClustersDeletion` - Triggered by a cron job deleting idle clusters.
- `clearDB` - Subsystem teardown utility to start tests from scratch.

## List all the issues related to this PR

- [x] Bug fix
- [x] Tests

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
