### PR TITLE
MGMT-6670: Create sample ACI manifests for dual-stack OCP

### DIFF
--- a/docs/hive-integration/crds/agentClusterInstall-dualstack-SNO.yaml
+++ b/docs/hive-integration/crds/agentClusterInstall-dualstack-SNO.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  name: test-agent-cluster-install
+  namespace: spoke-cluster
+spec:
+  clusterDeploymentRef:
+    name: single-node
+  imageSetRef:
+    name: openshift-v4.8.0
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    - cidr: fd01::/48
+      hostPrefix: 64
+    machineNetwork:
+    - cidr: 192.168.126.0/24
+    - cidr: 1001:db8::/120
+    serviceNetwork:
+    - 172.30.0.0/16
+    - fd02::/112
+  provisionRequirements:
+    controlPlaneAgents: 1
+ #sshPublicKey: ssh-rsa your-public-key-here (optional)

--- a/docs/hive-integration/crds/agentClusterInstall-dualstack.yaml
+++ b/docs/hive-integration/crds/agentClusterInstall-dualstack.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  name: test-agent-cluster-install
+  namespace: spoke-cluster
+spec:
+  apiVIP: 1.2.3.8
+  clusterDeploymentRef:
+    name: test-cluster
+  imageSetRef:
+    name: openshift-v4.8.0
+  ingressVIP: 1.2.3.9
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    - cidr: fd01::/48
+      hostPrefix: 64
+    serviceNetwork:
+    - 172.30.0.0/16
+    - fd02::/112
+  provisionRequirements:
+    controlPlaneAgents: 3
+ #sshPublicKey: ssh-rsa your-public-key-here (optional)
+  # By default, SMT (or hyperthreading) is enabled to increase the performance of your machines' cores.
+  # Therefore, you can omit this section unless you wish to disable hyperthreading.
+  # You can disable SMT by setting the parameter value to 'Disabled'. Then, you must disable it in all cluster machines;
+  # this includes both control plane and compute machines.
+  compute:
+  - hyperthreading: Enabled
+    name: worker
+  controlPlane:
+    hyperthreading: Enabled
+    name: master


### PR DESCRIPTION


# Assisted Pull Request

## Description

This PR creates a sample AgentClusterInstall manifests for OCP
installation using dual-stack. ACI for SNO cluster provides
required clusterNetwork, machineNetwork and serviceNetwork whereas the
ACI for the multi-node cluster provides clusterNetwork and
serviceNetwork, as machineNetwork values are calculated automatically by
the assisted-service.

Contributes-to: [MGMT-6670](https://issues.redhat.com/browse/MGMT-6670)

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
