### PR TITLE
NO-ISSUE: Backport OCP versions bump to match 4.8 as the default version

### DIFF
--- a/data/default_ocp_versions.json
+++ b/data/default_ocp_versions.json
@@ -9,22 +9,22 @@
         "support_level": "production"
     },
     "4.7": {
-        "display_name": "4.7.9",
-        "release_version": "4.7.9",
-        "release_image": "quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64",
-        "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso",
-        "rhcos_rootfs": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img",
-        "rhcos_version": "47.83.202103251640-0",
-        "support_level": "production",
-        "default": true
+        "display_name": "4.7.23",
+        "release_version": "4.7.23",
+        "release_image": "quay.io/openshift-release-dev/ocp-release:4.7.23-x86_64",
+        "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-4.7.13-x86_64-live.x86_64.iso",
+        "rhcos_rootfs": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.13/rhcos-live-rootfs.x86_64.img",
+        "rhcos_version": "47.83.202105220305-0",
+        "support_level": "production"
     },
     "4.8": {
-        "display_name": "4.8.0-fc.3",
-        "release_version": "4.8.0-fc.3",
-        "release_image": "quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64",
-        "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-4.8.0-fc.3-x86_64-live.x86_64.iso",
-        "rhcos_rootfs": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-live-rootfs.x86_64.img",
-        "rhcos_version": "48.84.202105062123-0",
-        "support_level": "beta"
+        "display_name": "4.8.4",
+        "release_version": "4.8.4",
+        "release_image": "quay.io/openshift-release-dev/ocp-release:4.8.4-x86_64",
+        "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-4.8.2-x86_64-live.x86_64.iso",
+        "rhcos_rootfs": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img",
+        "rhcos_version": "48.84.202107202156-0",
+        "support_level": "production",
+        "default": true
     }
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

Backport OCP versions bump to match 4.8 as the default version
Mostly for CI jobs to follow the default one as would be used on https://github.com/openshift/release/pull/21225

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @celebdor 
/cc @gamli75 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
