### PR TITLE
MGMT-7600 log ignition generator user request id from the api

### DIFF
--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 			},
 		}
 		g := NewGenerator(workDir, installerCacheDir, cluster, "", "", "", "", mockS3Client, log, mockOperatorManager).(*installerGenerator)
-		err = g.updateBootstrap(examplePath)
+		err = g.updateBootstrap(context.Background(), examplePath)
 
 		bootstrapBytes, _ := ioutil.ReadFile(examplePath)
 		config, _, err1 = config_32.Parse(bootstrapBytes)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Add context to internal functions in order to log everything with the
same request id, it will be used to search the logs and see the output
of the failure.
Installer output can be long so we will not return it in the api.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @osherdp 
/cc @tsorya 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
