### PR TITLE
MGMT-7464: Pass multiple machine networks to install-config.yaml

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -391,11 +391,14 @@ func (i *installConfigBuilder) getInstallConfig(cluster *common.Cluster, addRhCa
 
 		bootstrapCidr := network.GetPrimaryMachineCidrForUserManagedNetwork(cluster, i.log)
 		if bootstrapCidr != "" {
-			i.log.Infof("None-Platform: Selected bootstrap machine network CIDR %s for cluster %s", bootstrapCidr, cluster.ID.String())
-			cfg.Networking.MachineNetwork = []MachineNetwork{{Cidr: bootstrapCidr}}
-			cluster.MachineNetworks = network.CreateMachineNetworksArray(bootstrapCidr)
+			i.log.Infof("None-Platform or SNO: Selected bootstrap machine network CIDR %s for cluster %s", bootstrapCidr, cluster.ID.String())
+			machineNetwork := []MachineNetwork{}
+			cluster.MachineNetworks = network.GetMachineNetworksFromBoostrapHost(cluster, i.log)
+			for _, net := range cluster.MachineNetworks {
+				machineNetwork = append(machineNetwork, MachineNetwork{Cidr: string(net.Cidr)})
+			}
+			cfg.Networking.MachineNetwork = machineNetwork
 			cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
-
 		} else {
 			cfg.Networking.MachineNetwork = nil
 		}


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR changes the logic of install-config.yaml generation regarding
the machine networks. Till now we have been always passing only single
IPv4 subnet (coming either from the cluster parameters or discovered
from the bootstrap host).

With this change the logic is as follows

* if cluster params contains multiple machine networks, we pass them all
  to the installcfg structure
* if cluster params do not have any machine networks, we generate them
  from the cluster's bootstrap node's inventory; we pick at most one
  IPv4 network and at most one IPv6 network

Contributes-to: [MGMT-7464](https://issues.redhat.com/browse/MGMT-7464)

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
