### PR TITLE
NO-ISSUE: fix typo in overriding OVNKubernetes via install-config

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6927,7 +6927,7 @@ func init() {
           "description": "JSON-formatted string containing the user overrides for the install-config.yaml file.",
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\"",
-          "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
+          "example": "{\"networking\":{\"networkType\": \"OVNKubernetes\"},\"fips\":true}"
         },
         "install_started_at": {
           "description": "The time that this cluster started installation.",
@@ -17100,7 +17100,7 @@ func init() {
           "description": "JSON-formatted string containing the user overrides for the install-config.yaml file.",
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\"",
-          "example": "{\"networking\":{\"networkType\": \"OVN-Kubernetes\"},\"fips\":true}"
+          "example": "{\"networking\":{\"networkType\": \"OVNKubernetes\"},\"fips\":true}"
         },
         "install_started_at": {
           "description": "The time that this cluster started installation.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4224,7 +4224,7 @@ paths:
           description: Unavailable.
           schema:
             $ref: '#/definitions/error'
-  
+
   /v2/infra-envs/{infra_env_id}/hosts/{host_id}/logs-progress:
     put:
       tags:
@@ -5604,7 +5604,7 @@ definitions:
         x-go-custom-tag: gorm:"type:text"
         type: string
         description: JSON-formatted string containing the user overrides for the install-config.yaml file.
-        example: '{"networking":{"networkType": "OVN-Kubernetes"},"fips":true}'
+        example: '{"networking":{"networkType": "OVNKubernetes"},"fips":true}'
       ignition_config_overrides:
         x-go-custom-tag: gorm:"type:text"
         type: string


### PR DESCRIPTION
# Assisted Pull Request

## Description

Seems like we're offering false-advice in our examples as for how to override OVNKubernetes via install-config override mechanism.
Changing example from using ``OVN-Kubernetes`` to ``OVNKubernetes``.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @tsorya  
/cc @oshercc 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
