### PR TITLE
NO-ISSUE: clear host's log timestamp when deleting the logs

### DIFF
--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -400,6 +400,7 @@ func (th *transitionHandler) PostPreparingForInstallationHost(sw stateswitch.Sta
 	if validationFailed(params, string(models.HostValidationIDContainerImagesAvailable)) {
 		extra = append(extra, "images_status", "")
 	}
+	extra = append(extra, resetLogsField...)
 
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, statusInfoHostPreparationSuccessful,
 		extra...)


### PR DESCRIPTION
Timestamps for logs were not clear even though the logs themselves
were deleted

This has cause errors in e2e tests

# Assisted Pull Request

## Description
Timestamps for logs were not clear even though the logs themselves
were deleted

This has cause errors in e2e tests

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees
/cc @tsorya 
/cc @gamli75 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
