### PR TITLE
MGMT-7114: support CPUArchitecture in Cluster

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -30,6 +30,8 @@ const (
 
 	FamilyIPv4 int32 = 4
 	FamilyIPv6 int32 = 6
+
+	DefaultCPUArchitecture = "x86_64"
 )
 
 // Configuration to be injected by discovery ignition.  It will cause IPv6 DHCP client identifier to be the same

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -330,6 +330,7 @@ func CreateInfraEnvForCluster(db *gorm.DB, cluster *Cluster) error {
 		OpenshiftVersion: cluster.OpenshiftVersion,
 		PullSecretSet:    true,
 		Proxy:            &proxy,
+		CPUArchitecture:  cluster.CPUArchitecture,
 	},
 		PullSecret: cluster.PullSecret,
 	}

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -31,6 +31,7 @@ type TestConfiguration struct {
 	RhcosImage       string
 	RhcosVersion     string
 	SupportLevel     string
+	CPUArchitecture  string
 	Version          *models.OpenshiftVersion
 
 	Status            string
@@ -55,6 +56,7 @@ var (
 	RhcosImage              = "rhcos_4.6.0"
 	RhcosVersion            = "version-46.123-0"
 	SupportLevel            = "beta"
+	CPUArchitecture         = DefaultCPUArchitecture
 )
 
 // Defaults to be used by all testing modules
@@ -62,6 +64,7 @@ var TestDefaultConfig = &TestConfiguration{
 	OpenShiftVersion: OpenShiftVersion,
 	ReleaseVersion:   ReleaseVersion,
 	ReleaseImage:     ReleaseImage,
+	CPUArchitecture:  CPUArchitecture,
 	Version: &models.OpenshiftVersion{
 		DisplayName:    &OpenShiftVersion,
 		ReleaseImage:   &ReleaseImage,

--- a/internal/host/hostcommands/container_image_availability_cmd.go
+++ b/internal/host/hostcommands/container_image_availability_cmd.go
@@ -38,7 +38,7 @@ func NewImageAvailabilityCmd(log logrus.FieldLogger, db *gorm.DB, ocRelease oc.R
 func (cmd *imageAvailabilityCmd) getImages(cluster *common.Cluster) ([]string, error) {
 
 	images := make([]string, 0)
-	ocpVersion, err := cmd.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion)
+	ocpVersion, err := cmd.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion, cluster.CPUArchitecture)
 	if err != nil {
 		return images, err
 	}
@@ -50,7 +50,7 @@ func (cmd *imageAvailabilityCmd) getImages(cluster *common.Cluster) ([]string, e
 	}
 	images = append(images, mcoImage)
 
-	mustGatherImages, err := cmd.versionsHandler.GetMustGatherImages(cluster.OpenshiftVersion, cluster.PullSecret)
+	mustGatherImages, err := cmd.versionsHandler.GetMustGatherImages(cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
 	if err != nil {
 		return images, err
 	}

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -55,8 +55,8 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step", func() {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
@@ -76,7 +76,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_release_image_failure", func() {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(nil, errors.New("err")).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
 		Expect(err).To(HaveOccurred())
@@ -84,7 +84,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_mco_failure", func() {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
@@ -93,9 +93,9 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_must_gather_failure", func() {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
 		Expect(err).To(HaveOccurred())
@@ -128,9 +128,9 @@ var _ = Describe("get images", func() {
 
 	It("get_step_get_all_images", func() {
 		mco := "image-mco"
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mco, nil).Times(1)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		release := *common.TestDefaultConfig.Version.ReleaseImage
 		expected := []string{release, mco, defaultMustGatherVersion["ocp"]}
 		images, err := cmd.getImages(cluster)

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -104,7 +104,7 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		haMode = *cluster.HighAvailabilityMode
 	}
 
-	ocpVersion, err := i.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion)
+	ocpVersion, err := i.versionsHandler.GetOpenshiftVersion(cluster.OpenshiftVersion, cluster.CPUArchitecture)
 	if err != nil {
 		return "", err
 	}
@@ -114,7 +114,7 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		return "", err
 	}
 
-	mustGatherMap, err := i.versionsHandler.GetMustGatherImages(cluster.OpenshiftVersion, cluster.PullSecret)
+	mustGatherMap, err := i.versionsHandler.GetMustGatherImages(cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
 	if err != nil {
 		return "", err
 	}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -77,12 +77,12 @@ var _ = Describe("installcmd", func() {
 	})
 
 	mockGetReleaseImage := func(times int) {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(times)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(times)
 	}
 
 	mockImages := func(times int) {
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(times)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(times)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(times)
 	}
 
 	Context("negative", func() {
@@ -275,7 +275,7 @@ var _ = Describe("installcmd arguments", func() {
 
 	mockImages := func() {
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).AnyTimes()
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
 	}
 
 	BeforeSuite(func() {
@@ -289,7 +289,7 @@ var _ = Describe("installcmd arguments", func() {
 		mockEvents = events.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).AnyTimes()
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).AnyTimes()
 		mockImages()
 	})
 
@@ -383,7 +383,7 @@ var _ = Describe("installcmd arguments", func() {
 		It("verify empty value", func() {
 			mockRelease = oc.NewMockRelease(ctrl)
 			mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
-			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
+			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
 
 			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions)
 			stepReply, err := installCmd.GetSteps(ctx, &host)
@@ -396,7 +396,7 @@ var _ = Describe("installcmd arguments", func() {
 			value := "\nescaped_\n\t_value\n"
 			mockRelease = oc.NewMockRelease(ctrl)
 			mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(value, nil).AnyTimes()
-			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
+			mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).AnyTimes()
 
 			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions)
 			stepReply, err := installCmd.GetSteps(ctx, &host)

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -351,10 +351,10 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 	ExpectWithOffset(1, swag.StringValue(h.Status)).Should(Equal(state))
 	if funk.Contains(expectedStepTypes, models.StepTypeInstall) {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/disk/by-id/wwn-sda").Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
 	if funk.Contains(expectedStepTypes, models.StepTypeConnectivityCheck) {
 		mockConnectivity.EXPECT().GetHostValidInterfaces(gomock.Any()).Return([]*models.Interface{
@@ -369,8 +369,8 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 
 	if funk.Contains(expectedStepTypes, models.StepTypeContainerImageAvailability) {
-		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
-		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
+		mockVersions.EXPECT().GetOpenshiftVersion(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.Version, nil).Times(1)
+		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
 
 	stepsReply, stepsErr := instMng.GetNextSteps(ctx, &h.Host)

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -52,6 +52,21 @@ func (mr *MockHandlerMockRecorder) AddOpenshiftVersion(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOpenshiftVersion", reflect.TypeOf((*MockHandler)(nil).AddOpenshiftVersion), arg0, arg1)
 }
 
+// GetCPUArchitectures mocks base method.
+func (m *MockHandler) GetCPUArchitectures(arg0 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCPUArchitectures", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCPUArchitectures indicates an expected call of GetCPUArchitectures.
+func (mr *MockHandlerMockRecorder) GetCPUArchitectures(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPUArchitectures", reflect.TypeOf((*MockHandler)(nil).GetCPUArchitectures), arg0)
+}
+
 // GetKey mocks base method.
 func (m *MockHandler) GetKey(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
@@ -68,33 +83,33 @@ func (mr *MockHandlerMockRecorder) GetKey(arg0 interface{}) *gomock.Call {
 }
 
 // GetMustGatherImages mocks base method.
-func (m *MockHandler) GetMustGatherImages(arg0, arg1 string) (MustGatherVersion, error) {
+func (m *MockHandler) GetMustGatherImages(arg0, arg1, arg2 string) (MustGatherVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMustGatherImages", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetMustGatherImages", arg0, arg1, arg2)
 	ret0, _ := ret[0].(MustGatherVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMustGatherImages indicates an expected call of GetMustGatherImages.
-func (mr *MockHandlerMockRecorder) GetMustGatherImages(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) GetMustGatherImages(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImages", reflect.TypeOf((*MockHandler)(nil).GetMustGatherImages), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImages", reflect.TypeOf((*MockHandler)(nil).GetMustGatherImages), arg0, arg1, arg2)
 }
 
 // GetOpenshiftVersion mocks base method.
-func (m *MockHandler) GetOpenshiftVersion(arg0 string) (*models.OpenshiftVersion, error) {
+func (m *MockHandler) GetOpenshiftVersion(arg0, arg1 string) (*models.OpenshiftVersion, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOpenshiftVersion", arg0)
+	ret := m.ctrl.Call(m, "GetOpenshiftVersion", arg0, arg1)
 	ret0, _ := ret[0].(*models.OpenshiftVersion)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOpenshiftVersion indicates an expected call of GetOpenshiftVersion.
-func (mr *MockHandlerMockRecorder) GetOpenshiftVersion(arg0 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) GetOpenshiftVersion(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftVersion", reflect.TypeOf((*MockHandler)(nil).GetOpenshiftVersion), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenshiftVersion", reflect.TypeOf((*MockHandler)(nil).GetOpenshiftVersion), arg0, arg1)
 }
 
 // GetOsImage mocks base method.

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -60,6 +60,9 @@ type Cluster struct {
 	// Format: date-time
 	ControllerLogsStartedAt strfmt.DateTime `json:"controller_logs_started_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// The CPU architecture of the image (x86_64/arm64/etc).
+	CPUArchitecture string `json:"cpu_architecture,omitempty"`
+
 	// The time that this cluster was created.
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" gorm:"type:timestamp with time zone"`

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -38,6 +38,9 @@ type ClusterCreateParams struct {
 	// Cluster networks that are associated with this cluster.
 	ClusterNetworks []*ClusterNetwork `json:"cluster_networks"`
 
+	// The CPU architecture of the image (x86_64/arm64/etc).
+	CPUArchitecture string `json:"cpu_architecture,omitempty"`
+
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//

--- a/models/infra_env.go
+++ b/models/infra_env.go
@@ -26,6 +26,9 @@ type InfraEnv struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty"`
 
+	// The CPU architecture of the image (x86_64/arm64/etc).
+	CPUArchitecture string `json:"cpu_architecture,omitempty"`
+
 	// created at
 	// Format: date-time
 	CreatedAt strfmt.DateTime `json:"created_at,omitempty" gorm:"type:timestamp with time zone"`

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -26,6 +26,9 @@ type InfraEnvCreateParams struct {
 	// Format: uuid
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty"`
 
+	// The CPU architecture of the image (x86_64/arm64/etc).
+	CPUArchitecture string `json:"cpu_architecture,omitempty"`
+
 	// JSON formatted string containing the user overrides for the initial ignition config.
 	IgnitionConfigOverride string `json:"ignition_config_override,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6820,6 +6820,12 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
+        },
         "created_at": {
           "description": "The time that this cluster was created.",
           "type": "string",
@@ -7144,6 +7150,12 @@ func init() {
             "$ref": "#/definitions/cluster_network"
           },
           "x-nullable": true
+        },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
         },
         "high_availability_mode": {
           "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster\nover multiple master nodes whereas 'None' installs a full cluster over one node.\n",
@@ -8849,6 +8861,12 @@ func init() {
           "type": "string",
           "format": "uuid"
         },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
+        },
         "created_at": {
           "type": "string",
           "format": "date-time",
@@ -8952,6 +8970,12 @@ func init() {
           "type": "string",
           "format": "uuid",
           "x-nullable": true
+        },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
         },
         "ignition_config_override": {
           "description": "JSON formatted string containing the user overrides for the initial ignition config.",
@@ -17035,6 +17059,12 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
+        },
         "created_at": {
           "description": "The time that this cluster was created.",
           "type": "string",
@@ -17359,6 +17389,12 @@ func init() {
             "$ref": "#/definitions/cluster_network"
           },
           "x-nullable": true
+        },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
         },
         "high_availability_mode": {
           "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster\nover multiple master nodes whereas 'None' installs a full cluster over one node.\n",
@@ -18989,6 +19025,12 @@ func init() {
           "type": "string",
           "format": "uuid"
         },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
+        },
         "created_at": {
           "type": "string",
           "format": "date-time",
@@ -19093,6 +19135,12 @@ func init() {
           "type": "string",
           "format": "uuid",
           "x-nullable": true
+        },
+        "cpu_architecture": {
+          "description": "The CPU architecture of the image (x86_64/arm64/etc).",
+          "type": "string",
+          "default": "x86_64",
+          "x-nullable": false
         },
         "ignition_config_override": {
           "description": "JSON formatted string containing the user overrides for the initial ignition config.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5198,6 +5198,11 @@ definitions:
         type: object
         $ref: '#/definitions/platform'
         x-nullable: true
+      cpu_architecture:
+        type: string
+        x-nullable: false
+        default: 'x86_64'
+        description: The CPU architecture of the image (x86_64/arm64/etc).
 
   cluster-update-params:
     type: object
@@ -5680,6 +5685,11 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/machine_network'
+      cpu_architecture:
+        type: string
+        x-nullable: false
+        default: 'x86_64'
+        description: The CPU architecture of the image (x86_64/arm64/etc).
 
   platform:
     type: object
@@ -6829,6 +6839,11 @@ definitions:
         type: string
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"
+      cpu_architecture:
+        type: string
+        x-nullable: false
+        default: 'x86_64'
+        description: The CPU architecture of the image (x86_64/arm64/etc).
 
   proxy:
     type: object
@@ -6895,6 +6910,11 @@ definitions:
       openshift_version:
         type: string
         description: Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
+      cpu_architecture:
+        type: string
+        x-nullable: false
+        default: 'x86_64'
+        description: The CPU architecture of the image (x86_64/arm64/etc).
 
   infra-env-update-params:
     type: object


### PR DESCRIPTION
# Assisted Pull Request

## Description

As a preparation to support arm64 CPU architecture, introduced the following changes:
-  swagger: Added a 'cpu_architecture' property to the following objects:
    - cluster/cluster-create-params
    - infra-env/infra-env-create-params
-  Added cpuArchitecture to GetOpenshiftVersion func in versions:
   - Try to fetch a release image url and version from ReleaseImages list according to the requested CPU architecture.
   - An empty cpu_architecture implies the default x86_64.
- When registering a new cluster, set CPUArchitecture according to parms.
  - Validate by fetching available architectures (versions -> GetCPUArchitectures). 
- Notes:
  - Day2 flow supports only x86_64 for now.
  - Will be updated in following PRs: handle_ocp_versions.py/generate ISO flow/upload ISO flow.
  - This PR is based on changes in https://github.com/openshift/assisted-service/pull/2420

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

As this PR is adding an infrastructure for later arm64 support, no substantial impact in behaviour should occur. I.e. added tests should cover the changes.

## Assignees

/cc @YuviGold
/cc @filanov
/cc @osherdp
/cc @avishayt
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
