### PR TITLE
MGMT-7498: Migrate multiple networks

### DIFF
--- a/internal/migrations/20210713123129_populate_infra_env.go
+++ b/internal/migrations/20210713123129_populate_infra_env.go
@@ -31,7 +31,7 @@ func populateInfraEnv() *gormigrate.Migration {
 				return err
 			}
 
-			dbClusters, err := getClustersFromDB(tx)
+			dbClusters, err := common.GetClustersFromDBWhere(tx, common.UseEagerLoading, common.IncludeDeletedRecords)
 			if err != nil {
 				return err
 			}
@@ -87,14 +87,4 @@ func populateInfraEnv() *gormigrate.Migration {
 		Migrate:  gormigrate.MigrateFunc(migrate),
 		Rollback: gormigrate.RollbackFunc(rollback),
 	}
-}
-
-func getClustersFromDB(db *gorm.DB) ([]*common.Cluster, error) {
-	var clusters []*common.Cluster
-
-	db = db.Unscoped()
-	if err := db.Find(&clusters).Error; err != nil {
-		return nil, err
-	}
-	return clusters, nil
 }

--- a/internal/migrations/20210822134659_multiple_networks.go
+++ b/internal/migrations/20210822134659_multiple_networks.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+func multipleNetworks() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		dbClusters, err := common.GetClustersFromDBWhere(tx, common.UseEagerLoading, common.IncludeDeletedRecords)
+		if err != nil {
+			return err
+		}
+		for _, cluster := range dbClusters {
+			if cluster.ClusterNetworkCidr != "" {
+				clusterNetwork := &models.ClusterNetwork{
+					ClusterID:  *cluster.ID,
+					Cidr:       models.Subnet(cluster.ClusterNetworkCidr),
+					HostPrefix: cluster.ClusterNetworkHostPrefix,
+				}
+				if err = tx.Save(clusterNetwork).Error; err != nil {
+					return err
+				}
+			}
+
+			if cluster.ServiceNetworkCidr != "" {
+				serviceNetwork := &models.ServiceNetwork{
+					ClusterID: *cluster.ID,
+					Cidr:      models.Subnet(cluster.ServiceNetworkCidr),
+				}
+				if err = tx.Save(serviceNetwork).Error; err != nil {
+					return err
+				}
+			}
+
+			if cluster.MachineNetworkCidr != "" {
+				machineNetwork := &models.MachineNetwork{Cidr: models.Subnet(cluster.MachineNetworkCidr), ClusterID: *cluster.ID}
+				if err = tx.Save(machineNetwork).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		for _, model := range []interface{}{
+			&models.ClusterNetwork{},
+			&models.ServiceNetwork{},
+			&models.MachineNetwork{},
+		} {
+			if err := tx.Unscoped().Delete(model).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20210822134659",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/20210822134659_multiple_networks_test.go
+++ b/internal/migrations/20210822134659_multiple_networks_test.go
@@ -1,0 +1,80 @@
+package migrations
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	gormigrate "gopkg.in/gormigrate.v1"
+)
+
+var _ = Describe("multipleNetworks", func() {
+	var (
+		db            *gorm.DB
+		dbName        string
+		clusterID     strfmt.UUID
+		cluster       *common.Cluster
+		clusterFromDb *common.Cluster
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster = &common.Cluster{
+			Cluster: models.Cluster{
+				ID:                       &clusterID,
+				ClusterNetworkCidr:       string(common.TestIPv4Networking.ClusterNetworks[0].Cidr),
+				ClusterNetworkHostPrefix: common.TestIPv4Networking.ClusterNetworks[0].HostPrefix,
+				ServiceNetworkCidr:       string(common.TestIPv4Networking.ServiceNetworks[0].Cidr),
+				MachineNetworkCidr:       string(common.TestIPv4Networking.MachineNetworks[0].Cidr),
+			},
+		}
+		Expect(db.Save(cluster).Error).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Migrates up", func() {
+		// setup
+
+		err := migrateTo(db, "20210822134659")
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		clusterFromDb, err = common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clusterFromDb.ClusterNetworks).To(HaveLen(1))
+		Expect(string(clusterFromDb.ClusterNetworks[0].Cidr)).To(Equal(cluster.ClusterNetworkCidr))
+		Expect(clusterFromDb.ClusterNetworks[0].HostPrefix).To(Equal(cluster.ClusterNetworkHostPrefix))
+		Expect(clusterFromDb.ClusterNetworks[0].ClusterID).To(Equal(*cluster.ID))
+		Expect(clusterFromDb.ServiceNetworks).To(HaveLen(1))
+		Expect(string(clusterFromDb.ServiceNetworks[0].Cidr)).To(Equal(cluster.ServiceNetworkCidr))
+		Expect(clusterFromDb.ServiceNetworks[0].ClusterID).To(Equal(*cluster.ID))
+		Expect(clusterFromDb.MachineNetworks).To(HaveLen(1))
+		Expect(string(clusterFromDb.MachineNetworks[0].Cidr)).To(Equal(cluster.MachineNetworkCidr))
+		Expect(clusterFromDb.MachineNetworks[0].ClusterID).To(Equal(*cluster.ID))
+	})
+
+	It("Migrates down", func() {
+		err := migrateTo(db, "20210822134659")
+		Expect(err).NotTo(HaveOccurred())
+
+		// setup
+
+		err = gormigrate.New(db, gormigrate.DefaultOptions, post()).RollbackMigration(multipleNetworks())
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		clusterFromDb, err = common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(clusterFromDb.ClusterNetworks).To(HaveLen(0))
+		Expect(clusterFromDb.ServiceNetworks).To(HaveLen(0))
+		Expect(clusterFromDb.MachineNetworks).To(HaveLen(0))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -31,6 +31,7 @@ func post() []*gormigrate.Migration {
 		changeImageSSHKeyToText(),
 		changeClusterValidationsInfoToText(),
 		changeHostValidationsInfoToText(),
+		multipleNetworks(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })

--- a/tools/migration_generator/migration_generator.go
+++ b/tools/migration_generator/migration_generator.go
@@ -132,7 +132,7 @@ var _ = Describe("{{.FuncName}}", func() {
 
 		// setup
 
-		err = gormigrate.New(db, gormigrate.DefaultOptions, all()).RollbackMigration({{.FuncName}}())
+		err = gormigrate.New(db, gormigrate.DefaultOptions, post()).RollbackMigration({{.FuncName}}())
 		Expect(err).NotTo(HaveOccurred())
 
 		// test


### PR DESCRIPTION
# Assisted Pull Request

## Description

Add a migration to switch from a single CIDR values to multiple subnets arrays.
Only in case there are values for `ClusterNetworkCIDR`,
`ServiceNetworkCidr`, and `MachineNetworkCIDR` - The `ClusterNetworks`,
`ServiceNetworks`, and `MachineNetworks` arrays would create accordingly.


## List all the issues related to this PR

- [x] New Feature

## What environments does this code impact?

- [x] Cloud

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Waiting for CI to do a full test run

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @filanov 
/cc @gamli75 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
