### PR TITLE
MGMT-7498: Add backwards compatibility for network configuration

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -513,6 +513,18 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		TriggerMonitorTimestamp: time.Now(),
 	}
 
+	// TODO MGMT-7365: Deprecate single network
+	if len(params.NewClusterParams.ClusterNetworks) > 0 {
+		cluster.ClusterNetworkCidr = string(params.NewClusterParams.ClusterNetworks[0].Cidr)
+		cluster.ClusterNetworkHostPrefix = params.NewClusterParams.ClusterNetworks[0].HostPrefix
+	}
+	if len(params.NewClusterParams.ServiceNetworks) > 0 {
+		cluster.ServiceNetworkCidr = string(params.NewClusterParams.ServiceNetworks[0].Cidr)
+	}
+	if len(params.NewClusterParams.MachineNetworks) > 0 {
+		cluster.MachineNetworkCidr = string(params.NewClusterParams.MachineNetworks[0].Cidr)
+	}
+
 	pullSecret := swag.StringValue(params.NewClusterParams.PullSecret)
 	err = b.secretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), b.authHandler)
 	if err != nil {
@@ -2153,6 +2165,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 			} else {
 				cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: models.Subnet(primaryMachineNetworkCidr)}}
 			}
+			updates["machine_network_cidr"] = primaryMachineNetworkCidr
 		}
 		err = network.VerifyVips(cluster.Hosts, primaryMachineNetworkCidr, apiVip, ingressVip, false, log)
 		if err != nil {
@@ -2283,8 +2296,8 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 	return nil
 }
 
-func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.UpdateClusterParams, cluster *common.Cluster,
-	userManagedNetworking, vipDhcpAllocation bool) error {
+func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.UpdateClusterParams, updates map[string]interface{},
+	cluster *common.Cluster, userManagedNetworking, vipDhcpAllocation bool) error {
 	var err error
 
 	if params.ClusterUpdateParams.ClusterNetworks != nil {
@@ -2303,6 +2316,15 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 			}
 		}
 		cluster.ClusterNetworks = params.ClusterUpdateParams.ClusterNetworks
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(params.ClusterUpdateParams.ClusterNetworks) > 0 {
+			updates["cluster_network_cidr"] = string(params.ClusterUpdateParams.ClusterNetworks[0].Cidr)
+			updates["cluster_network_host_prefix"] = params.ClusterUpdateParams.ClusterNetworks[0].HostPrefix
+		} else {
+			updates["cluster_network_cidr"] = ""
+			updates["cluster_network_host_prefix"] = 0
+		}
 	}
 
 	if params.ClusterUpdateParams.ServiceNetworks != nil {
@@ -2312,10 +2334,24 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 			}
 		}
 		cluster.ServiceNetworks = params.ClusterUpdateParams.ServiceNetworks
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(params.ClusterUpdateParams.ServiceNetworks) > 0 {
+			updates["service_network_cidr"] = string(params.ClusterUpdateParams.ServiceNetworks[0].Cidr)
+		} else {
+			updates["service_network_cidr"] = ""
+		}
 	}
 
 	if params.ClusterUpdateParams.MachineNetworks != nil {
 		cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+			updates["machine_network_cidr"] = string(params.ClusterUpdateParams.MachineNetworks[0].Cidr)
+		} else {
+			updates["machine_network_cidr"] = ""
+		}
 	}
 
 	for index := range cluster.MachineNetworks {
@@ -2448,7 +2484,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 		}
 	}
 
-	if err = b.updateNetworks(db, params, cluster, userManagedNetworking, vipDhcpAllocation); err != nil {
+	if err = b.updateNetworks(db, params, updates, cluster, userManagedNetworking, vipDhcpAllocation); err != nil {
 		return err
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2958,11 +2958,12 @@ var _ = Describe("cluster", func() {
 		BeforeEach(func() {
 			clusterID = strfmt.UUID(uuid.New().String())
 			err := db.Create(&common.Cluster{Cluster: models.Cluster{
-				ID:               &clusterID,
-				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
-				APIVip:           "10.11.12.13",
-				IngressVip:       "10.11.12.14",
-				MachineNetworks:  []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}},
+				ID:                 &clusterID,
+				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
+				APIVip:             "10.11.12.13",
+				IngressVip:         "10.11.12.14",
+				MachineNetworks:    []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}},
+				MachineNetworkCidr: "10.11.0.0/16", // TODO MGMT-7365: Deprecate single network
 			}}).Error
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -4822,6 +4823,14 @@ var _ = Describe("cluster", func() {
 						network.ClusterID = clusterID
 						Expect(db.Model(&models.MachineNetwork{}).Save(network).Error).ShouldNot(HaveOccurred())
 					}
+
+					// TODO MGMT-7365: Deprecate single network
+					Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterID).Updates(map[string]interface{}{
+						"cluster_network_cidr":        clusterNetworks[0].Cidr,
+						"cluster_network_host_prefix": clusterNetworks[0].HostPrefix,
+						"machine_network_cidr":        machineNetworks[0].Cidr,
+						"service_network_cidr":        serviceNetworks[0].Cidr,
+					}).Error).ShouldNot(HaveOccurred())
 
 					cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
 					Expect(err).ToNot(HaveOccurred())
@@ -9866,6 +9875,15 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 			Expect(cluster.ClusterNetworks[index].Cidr).To(Equal((*clusterNetworks)[index].Cidr))
 			Expect(cluster.ClusterNetworks[index].HostPrefix).To(Equal((*clusterNetworks)[index].HostPrefix))
 		}
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(*clusterNetworks) > 0 {
+			Expect(cluster.ClusterNetworkCidr).To(Equal(string((*clusterNetworks)[0].Cidr)))
+			Expect(cluster.ClusterNetworkHostPrefix).To(Equal((*clusterNetworks)[0].HostPrefix))
+		} else {
+			Expect(cluster.ClusterNetworkCidr).To(Equal(""))
+			Expect(cluster.ClusterNetworkHostPrefix).To(Equal(""))
+		}
 	}
 	if serviceNetworks != nil {
 		Expect(cluster.ServiceNetworks).To(HaveLen(len(*serviceNetworks)))
@@ -9873,12 +9891,26 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 			Expect(cluster.ServiceNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.ServiceNetworks[index].Cidr).To(Equal((*serviceNetworks)[index].Cidr))
 		}
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(*serviceNetworks) > 0 {
+			Expect(cluster.ServiceNetworkCidr).To(Equal(string((*serviceNetworks)[0].Cidr)))
+		} else {
+			Expect(cluster.ServiceNetworkCidr).To(Equal(""))
+		}
 	}
 	if machineNetworks != nil {
 		Expect(cluster.MachineNetworks).To(HaveLen(len(*machineNetworks)))
 		for index := range *machineNetworks {
 			Expect(cluster.MachineNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.MachineNetworks[index].Cidr).To(Equal((*machineNetworks)[index].Cidr))
+		}
+
+		// TODO MGMT-7365: Deprecate single network
+		if len(*machineNetworks) > 0 {
+			Expect(cluster.MachineNetworkCidr).To(Equal(string((*machineNetworks)[0].Cidr)))
+		} else {
+			Expect(cluster.MachineNetworkCidr).To(Equal(""))
 		}
 	}
 }

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1119,6 +1119,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				ClusterNetworks:       common.TestIPv4Networking.ClusterNetworks,
 				ServiceNetworks:       common.TestIPv4Networking.ServiceNetworks,
 				MachineNetworks:       network.CreateMachineNetworksArray(t.machineNetworkCIDR),
+				MachineNetworkCidr:    t.machineNetworkCIDR, // TODO MGMT-7365: Deprecate single network
 				VipDhcpAllocation:     swag.Bool(t.dhcpEnabled),
 				UserManagedNetworking: swag.Bool(t.userManagedNetworking),
 			}}
@@ -1143,10 +1144,13 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			cluster := getClusterFromDB(id, db)
 			if t.expectedMachineCIDR == "" {
 				Expect(cluster.MachineNetworks).To(BeEmpty())
+				Expect(cluster.MachineNetworkCidr).To(Equal("")) // TODO MGMT-7365: Deprecate single network
 			} else {
 				Expect(cluster.MachineNetworks).NotTo(BeEmpty())
 				Expect(network.GetMachineCidrById(&cluster, 0)).To(Equal(t.expectedMachineCIDR))
+				Expect(cluster.MachineNetworkCidr).To(Equal(t.expectedMachineCIDR)) // TODO MGMT-7365: Deprecate single network
 			}
+
 			ctrl.Finish()
 		})
 	}

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -222,7 +222,9 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 		}
 	}
 
-	return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(&common.Cluster{
-		MachineNetworkCidrUpdatedAt: time.Now(),
-	}).Error
+	// TODO MGMT-7365: Deprecate single network
+	return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(
+		"machine_network_cidr", machineCidr,
+		"machine_network_cidr_updated_at", time.Now(),
+	).Error
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR adds a backwards compatibility for retrieving network
configuration using the old data structures

* MachineNetworkCidr
* ClusterNetworkCidr
* ServiceNetworkCidr

This works in a way that whenever the new structures are assigned, their
respective values are replicated to the old ones.

Please note, it is not possible to write using old structures as they
are not forward-synchronized.

Contributes-to: [MGMT-7498](https://issues.redhat.com/browse/MGMT-7498)

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
