### PR TITLE
MGMT-4321: Bugfix flaky auto assign DHCP machine cidr

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -206,15 +206,26 @@ func GetCluster(ctx context.Context, logger logrus.FieldLogger, db *gorm.DB, clu
 }
 
 func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string) error {
+	txSuccess := false
+	tx := db.Begin()
+	defer func() {
+		if !txSuccess {
+			tx.Rollback()
+		}
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
 	// Delete previous primary machine CIDR
 	if network.IsMachineCidrAvailable(cluster) {
-		if err := common.DeleteRecordsByClusterID(db, *cluster.ID, []interface{}{&models.MachineNetwork{}}, "cidr = ?", network.GetMachineCidrById(cluster, 0)); err != nil {
+		if err := common.DeleteRecordsByClusterID(tx, *cluster.ID, []interface{}{&models.MachineNetwork{}}, "cidr = ?", network.GetMachineCidrById(cluster, 0)); err != nil {
 			return err
 		}
 	}
 
 	if machineCidr != "" {
-		if err := db.Model(&models.MachineNetwork{}).Save(&models.MachineNetwork{
+		if err := tx.Model(&models.MachineNetwork{}).Save(&models.MachineNetwork{
 			ClusterID: *cluster.ID,
 			Cidr:      models.Subnet(machineCidr),
 		}).Error; err != nil {
@@ -223,8 +234,17 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 	}
 
 	// TODO MGMT-7365: Deprecate single network
-	return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(
+	if err := tx.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(
 		"machine_network_cidr", machineCidr,
 		"machine_network_cidr_updated_at", time.Now(),
-	).Error
+	).Error; err != nil {
+		return err
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return err
+	}
+
+	txSuccess = true
+	return nil
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

In parallel we run the monitoring loop.
The loop tries to auto-assign the machine cidr  every interval.
The functionality is on `UpdateMachineCidr`.

Previously, when you changed from X value to X value you couldn't sense any change.
But now, we delete previous machine networks records.
So we fail on the gap between the deletion and the insertion of the new auto-assigned value.

The solution for that would be to make it all as a transaction.
Then, the DB would get locked until the deletion and the insertion is finished,
and any other process won't be able to fail on the gap between them.

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Cloud

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
