### PR TITLE
MGMT-7654: Set cluster-id during registration only if the cluster-id in the infra-env is not empty

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5494,7 +5494,6 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		ID:                    params.NewHostParams.HostID,
 		Href:                  swag.String(url.String()),
 		Kind:                  kind,
-		ClusterID:             &infraEnv.ClusterID,
 		CheckedInAt:           strfmt.DateTime(time.Now()),
 		DiscoveryAgentVersion: params.NewHostParams.DiscoveryAgentVersion,
 		UserName:              ocm.UserNameFromContext(ctx),
@@ -5504,6 +5503,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 
 	var cluster *common.Cluster
 	if infraEnv.ClusterID != "" {
+		host.ClusterID = &infraEnv.ClusterID
 		cluster, err = common.GetClusterFromDB(tx, infraEnv.ClusterID, common.SkipEagerLoading)
 		if err != nil {
 			log.WithError(err).Errorf("Cluster get")
@@ -5525,7 +5525,6 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		if swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster {
 			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
 		}
-		host.ClusterID = &infraEnv.ClusterID
 	}
 
 	if err = b.hostApi.RegisterHost(ctx, host, tx); err != nil {


### PR DESCRIPTION

# Assisted Pull Request

## Description

- In case the cluster-id is empty (unbounded host), without this change the state machine assumes that it is bound
  and moves the host to discovering

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
