### PR TITLE
OCPBUGSM-34158: Transition day2 hosts to Done

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -545,7 +545,7 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 		if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost {
 			_, err = hostutil.UpdateHostProgress(ctx, logutil.FromContext(ctx, m.log), m.db, m.eventsHandler, h.InfraEnvID, *h.ID,
 				swag.StringValue(h.Status), models.HostStatusAddedToExistingCluster, statusInfo,
-				h.Progress.CurrentStage, progress.CurrentStage, progress.ProgressInfo, extra...)
+				h.Progress.CurrentStage, models.HostStageDone, progress.ProgressInfo, extra...)
 			break
 		}
 		fallthrough

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -83,7 +83,7 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler) sta
 	// Register host after reboot
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeRegisterHost,
-		Condition:      th.IsHostInReboot,
+		Condition:      stateswitch.Or(th.IsHostInReboot, stateswitch.And(th.IsDay2Host, th.IsHostInDone)),
 		SourceStates: []stateswitch.State{
 			stateswitch.State(models.HostStatusInstallingInProgress),
 			stateswitch.State(models.HostStatusInstallingPendingUserAction),

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -105,6 +105,15 @@ func (th *transitionHandler) IsHostInReboot(sw stateswitch.StateSwitch, _ states
 	return sHost.host.Progress.CurrentStage == models.HostStageRebooting, nil
 }
 
+func (th *transitionHandler) IsHostInDone(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error) {
+	sHost, ok := sw.(*stateHost)
+	if !ok {
+		return false, errors.New("IsInDone incompatible type of StateSwitch")
+	}
+
+	return sHost.host.Progress.CurrentStage == models.HostStageDone, nil
+}
+
 func (th *transitionHandler) PostRegisterDuringReboot(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 	sHost, ok := sw.(*stateHost)
 	if !ok {


### PR DESCRIPTION
# Assisted Pull Request

## Description

The progress stage for day2 hosts was kept as Rebooting, even after it had been
added to the host. Let's make sure the stage transitions to Done so that it reflects
the actual phase of the installation and the progress of the agent

With the current code, this is what the host record in the DB looks like after a successful deployment of a day2 host:

```
installer=# select id, cluster_id, status, status_info, progress_current_stage, progress_progress_info from hosts where id='068e58b1-5f2d-4392-b800-271023b31f26';
                  id                  |              cluster_id              |          status           | status_info | progress_current_stage | progress_progress_info
--------------------------------------+--------------------------------------+---------------------------+-------------+------------------------+------------------------
 068e58b1-5f2d-4392-b800-271023b31f26 | afe73292-f2c2-478b-9ea3-560b478fa2c3 | added-to-existing-cluster | Rebooting   | Rebooting              |
(1 row)
```

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
