### PR TITLE
Bug 1992138: Handle possible NULLs in user data migration

### DIFF
--- a/internal/migrations/20210825135341_copy_cluster_user_info_to_infra_env.go
+++ b/internal/migrations/20210825135341_copy_cluster_user_info_to_infra_env.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	"database/sql"
 	"strings"
 
 	"github.com/go-openapi/strfmt"
@@ -28,12 +29,12 @@ func copyClusterUserInfoToInfraEnv() *gormigrate.Migration {
 		for rows.Next() {
 			var (
 				infraEnvID          strfmt.UUID
-				infraEnvUserName    string
-				infraEnvEmailDomain string
-				infraEnvOrgID       string
-				clusterUserName     string
-				clusterEmailDomain  string
-				clusterOrgID        string
+				infraEnvUserName    sql.NullString
+				infraEnvEmailDomain sql.NullString
+				infraEnvOrgID       sql.NullString
+				clusterUserName     sql.NullString
+				clusterEmailDomain  sql.NullString
+				clusterOrgID        sql.NullString
 			)
 
 			if err = rows.Scan(&infraEnvID, &infraEnvUserName, &infraEnvEmailDomain, &infraEnvOrgID, &clusterUserName, &clusterEmailDomain, &clusterOrgID); err != nil {
@@ -46,18 +47,18 @@ func copyClusterUserInfoToInfraEnv() *gormigrate.Migration {
 			updates := make(map[string]interface{})
 			var changed bool
 
-			if infraEnvUserName == "" && clusterUserName != "" {
-				updates["user_name"] = clusterUserName
+			if infraEnvUserName.String == "" && clusterUserName.Valid {
+				updates["user_name"] = clusterUserName.String
 				changed = true
 			}
 
-			if infraEnvEmailDomain == "" && clusterEmailDomain != "" {
-				updates["email_domain"] = clusterEmailDomain
+			if infraEnvEmailDomain.String == "" && clusterEmailDomain.Valid {
+				updates["email_domain"] = clusterEmailDomain.String
 				changed = true
 			}
 
-			if infraEnvOrgID == "" && clusterOrgID != "" {
-				updates["org_id"] = clusterOrgID
+			if infraEnvOrgID.String == "" && clusterOrgID.Valid {
+				updates["org_id"] = clusterOrgID.String
 				changed = true
 			}
 


### PR DESCRIPTION
## Description

There are cases where the user data in either the cluster or infra env
could be NULL in the database. This fails the migration with the
following error:

`sql: Scan error on column index 1, name \"user_name\": converting NULL
to string is unsupported`

This commit handles these cases by using the sql.NullString type in the
Scan call which is specifically made to handle a value from a database
that can either be NULL or a valid string.

https://bugzilla.redhat.com/show_bug.cgi?id=1992138

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
