### PR TITLE
NO-ISSUE: Fixing disk-encryption definition in swagger.yaml.

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -8577,8 +8577,8 @@ var _ = Describe("TestRegisterCluster", func() {
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					DiskEncryption: &models.DiskEncryption{
-						EnableOn: models.DiskEncryptionEnableOnAll,
-						Mode:     models.DiskEncryptionModeTang,
+						EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+						Mode:     swag.String(models.DiskEncryptionModeTang),
 					},
 				},
 			})
@@ -8591,8 +8591,8 @@ var _ = Describe("TestRegisterCluster", func() {
 				reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 					NewClusterParams: &models.ClusterCreateParams{
 						DiskEncryption: &models.DiskEncryption{
-							EnableOn:    models.DiskEncryptionEnableOnAll,
-							Mode:        models.DiskEncryptionModeTang,
+							EnableOn:    swag.String(models.DiskEncryptionEnableOnAll),
+							Mode:        swag.String(models.DiskEncryptionModeTang),
 							TangServers: `[{"URL":"","Thumbprint":""}]`,
 						},
 					},
@@ -8604,8 +8604,8 @@ var _ = Describe("TestRegisterCluster", func() {
 				reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 					NewClusterParams: &models.ClusterCreateParams{
 						DiskEncryption: &models.DiskEncryption{
-							EnableOn:    models.DiskEncryptionEnableOnAll,
-							Mode:        models.DiskEncryptionModeTang,
+							EnableOn:    swag.String(models.DiskEncryptionEnableOnAll),
+							Mode:        swag.String(models.DiskEncryptionModeTang),
 							TangServers: `[{"URL":"invalidUrl","Thumbprint":""}]`,
 						},
 					},
@@ -8618,8 +8618,8 @@ var _ = Describe("TestRegisterCluster", func() {
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					DiskEncryption: &models.DiskEncryption{
-						EnableOn:    models.DiskEncryptionEnableOnAll,
-						Mode:        models.DiskEncryptionModeTang,
+						EnableOn:    swag.String(models.DiskEncryptionEnableOnAll),
+						Mode:        swag.String(models.DiskEncryptionModeTang),
 						TangServers: `[{"URL":"http://tang.example.com:7500","Thumbprint":""}]`,
 					},
 				},

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -400,7 +400,7 @@ func ValidateDiskEncryptionParams(diskEncryptionParams *models.DiskEncryption) e
 	if diskEncryptionParams == nil {
 		return nil
 	}
-	if diskEncryptionParams.Mode == models.DiskEncryptionModeTang {
+	if *diskEncryptionParams.Mode == models.DiskEncryptionModeTang {
 		if diskEncryptionParams.TangServers == "" {
 			return errors.New("Setting Tang mode but tang_servers isn't set")
 		}

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -304,7 +304,7 @@ func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log 
 
 	manifestParams := map[string]interface{}{}
 
-	switch c.DiskEncryption.Mode {
+	switch *c.DiskEncryption.Mode {
 
 	case models.DiskEncryptionModeTpmv2:
 
@@ -320,13 +320,9 @@ func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log 
 
 		manifestParams["MODE"] = "tang"
 		manifestParams["TANG_SERVERS"] = tangServers
-
-	default:
-
-		return errors.New("None of the encryption modes were specified")
 	}
 
-	switch c.DiskEncryption.EnableOn {
+	switch *c.DiskEncryption.EnableOn {
 
 	case models.DiskEncryptionEnableOnAll:
 
@@ -353,14 +349,6 @@ func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log 
 		if err := m.createDiskEncryptionManifest(ctx, log, c, manifestParams); err != nil {
 			return err
 		}
-
-	case models.DiskEncryptionEnableOnNone:
-
-		return nil
-
-	default:
-
-		return errors.New("Not specified to which role encryption should be applied")
 	}
 
 	return nil

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -474,21 +474,20 @@ var _ = Describe("disk encryption manifest", func() {
 		name           string
 		diskEncryption *models.DiskEncryption
 		numOfManifests int
-		shouldErr      bool
 	}{
 		{
 			name: "masters and workers, tpmv2",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn: models.DiskEncryptionEnableOnAll,
-				Mode:     models.DiskEncryptionModeTpmv2,
+				EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 			},
 			numOfManifests: 2,
 		},
 		{
 			name: "masters and workers, tang",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn:    models.DiskEncryptionEnableOnAll,
-				Mode:        models.DiskEncryptionModeTang,
+				EnableOn:    swag.String(models.DiskEncryptionEnableOnAll),
+				Mode:        swag.String(models.DiskEncryptionModeTang),
 				TangServers: `[{"url":"http://tang.invalid","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"}]`,
 			},
 			numOfManifests: 2,
@@ -496,16 +495,16 @@ var _ = Describe("disk encryption manifest", func() {
 		{
 			name: "masters only, tpmv2",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn: models.DiskEncryptionEnableOnMasters,
-				Mode:     models.DiskEncryptionModeTpmv2,
+				EnableOn: swag.String(models.DiskEncryptionEnableOnMasters),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 			},
 			numOfManifests: 1,
 		},
 		{
 			name: "masters only, tang",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn:    models.DiskEncryptionEnableOnMasters,
-				Mode:        models.DiskEncryptionModeTang,
+				EnableOn:    swag.String(models.DiskEncryptionEnableOnMasters),
+				Mode:        swag.String(models.DiskEncryptionModeTang),
 				TangServers: `[{"url":"http://tang.invalid","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"}]`,
 			},
 			numOfManifests: 1,
@@ -513,36 +512,22 @@ var _ = Describe("disk encryption manifest", func() {
 		{
 			name: "workers only, tpmv2",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn: models.DiskEncryptionEnableOnWorkers,
-				Mode:     models.DiskEncryptionModeTpmv2,
+				EnableOn: swag.String(models.DiskEncryptionEnableOnWorkers),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 			},
 			numOfManifests: 1,
 		},
 		{
 			name: "workers only, tang",
 			diskEncryption: &models.DiskEncryption{
-				EnableOn:    models.DiskEncryptionEnableOnWorkers,
-				Mode:        models.DiskEncryptionModeTang,
+				EnableOn:    swag.String(models.DiskEncryptionEnableOnWorkers),
+				Mode:        swag.String(models.DiskEncryptionModeTang),
 				TangServers: `[{"url":"http://tang.invalid","thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"}]`,
 			},
 			numOfManifests: 1,
 		},
 		{
 			name: "disks encryption not set",
-		},
-		{
-			name: "non of the roles were specified",
-			diskEncryption: &models.DiskEncryption{
-				Mode: models.DiskEncryptionModeTpmv2,
-			},
-			shouldErr: true,
-		},
-		{
-			name: "non of the encryption modes were specified",
-			diskEncryption: &models.DiskEncryption{
-				EnableOn: models.DiskEncryptionEnableOnAll,
-			},
-			shouldErr: true,
 		},
 	} {
 		t := t
@@ -554,11 +539,7 @@ var _ = Describe("disk encryption manifest", func() {
 
 			mockManifestsApi.EXPECT().CreateClusterManifest(ctx, gomock.Any()).Return(operations.NewCreateClusterManifestCreated()).Times(t.numOfManifests)
 			err := manifestsGeneratorApi.AddDiskEncryptionManifest(ctx, log, &c)
-			if t.shouldErr == false {
-				Expect(err).ToNot(HaveOccurred())
-			} else {
-				Expect(err).To(HaveOccurred())
-			}
+			Expect(err).ToNot(HaveOccurred())
 		})
 	}
 })

--- a/models/disk_encryption.go
+++ b/models/disk_encryption.go
@@ -21,11 +21,11 @@ type DiskEncryption struct {
 
 	// Enable/disable disk encryption on master nodes, worker nodes, or all nodes.
 	// Enum: [none all masters workers]
-	EnableOn string `json:"enable_on,omitempty"`
+	EnableOn *string `json:"enable_on,omitempty"`
 
 	// The disk encryption mode to use.
 	// Enum: [tpmv2 tang]
-	Mode string `json:"mode,omitempty"`
+	Mode *string `json:"mode,omitempty"`
 
 	// JSON-formatted string containing additional information regarding tang's configuration
 	TangServers string `json:"tang_servers,omitempty" gorm:"type:text"`
@@ -91,7 +91,7 @@ func (m *DiskEncryption) validateEnableOn(formats strfmt.Registry) error {
 	}
 
 	// value enum
-	if err := m.validateEnableOnEnum("enable_on", "body", m.EnableOn); err != nil {
+	if err := m.validateEnableOnEnum("enable_on", "body", *m.EnableOn); err != nil {
 		return err
 	}
 
@@ -134,7 +134,7 @@ func (m *DiskEncryption) validateMode(formats strfmt.Registry) error {
 	}
 
 	// value enum
-	if err := m.validateModeEnum("mode", "body", m.Mode); err != nil {
+	if err := m.validateModeEnum("mode", "body", *m.Mode); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8393,6 +8393,7 @@ func init() {
         "enable_on": {
           "description": "Enable/disable disk encryption on master nodes, worker nodes, or all nodes.",
           "type": "string",
+          "default": "none",
           "enum": [
             "none",
             "all",
@@ -8403,6 +8404,7 @@ func init() {
         "mode": {
           "description": "The disk encryption mode to use.",
           "type": "string",
+          "default": "tpmv2",
           "enum": [
             "tpmv2",
             "tang"
@@ -18997,6 +18999,7 @@ func init() {
         "enable_on": {
           "description": "Enable/disable disk encryption on master nodes, worker nodes, or all nodes.",
           "type": "string",
+          "default": "none",
           "enum": [
             "none",
             "all",
@@ -19007,6 +19010,7 @@ func init() {
         "mode": {
           "description": "The disk encryption mode to use.",
           "type": "string",
+          "default": "tpmv2",
           "enum": [
             "tpmv2",
             "tang"

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -202,16 +202,16 @@ var _ = Describe("disk encryption", func() {
 					SSHPublicKey:     sshPublicKey,
 					BaseDNSDomain:    "example.com",
 					DiskEncryption: &models.DiskEncryption{
-						EnableOn: models.DiskEncryptionEnableOnAll,
-						Mode:     models.DiskEncryptionModeTpmv2,
+						EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+						Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			c := registerClusterReply.GetPayload()
-			Expect(c.DiskEncryption.EnableOn).To(Equal(models.DiskEncryptionEnableOnAll))
-			Expect(c.DiskEncryption.Mode).To(Equal(models.DiskEncryptionModeTpmv2))
+			Expect(*c.DiskEncryption.EnableOn).To(Equal(models.DiskEncryptionEnableOnAll))
+			Expect(*c.DiskEncryption.Mode).To(Equal(models.DiskEncryptionModeTpmv2))
 
 			clusterID = *c.ID
 		})
@@ -221,8 +221,8 @@ var _ = Describe("disk encryption", func() {
 			updateClusterReply, err := userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
 				ClusterUpdateParams: &models.ClusterUpdateParams{
 					DiskEncryption: &models.DiskEncryption{
-						EnableOn:    models.DiskEncryptionEnableOnMasters,
-						Mode:        models.DiskEncryptionModeTang,
+						EnableOn:    swag.String(models.DiskEncryptionEnableOnMasters),
+						Mode:        swag.String(models.DiskEncryptionModeTang),
 						TangServers: defaultTangServers,
 					},
 				},
@@ -231,8 +231,8 @@ var _ = Describe("disk encryption", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			c := updateClusterReply.GetPayload()
-			Expect(c.DiskEncryption.EnableOn).To(Equal(models.DiskEncryptionEnableOnMasters))
-			Expect(c.DiskEncryption.Mode).To(Equal(models.DiskEncryptionModeTang))
+			Expect(*c.DiskEncryption.EnableOn).To(Equal(models.DiskEncryptionEnableOnMasters))
+			Expect(*c.DiskEncryption.Mode).To(Equal(models.DiskEncryptionModeTang))
 		})
 	})
 
@@ -330,8 +330,8 @@ spec:
 			{
 				name: "all nodes, tpm2",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn: models.DiskEncryptionEnableOnAll,
-					Mode:     models.DiskEncryptionModeTpmv2,
+					EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 				},
 				expectedManifestsNames: []string{
 					"99-openshift-master-tpm-encryption.yaml",
@@ -345,8 +345,8 @@ spec:
 			{
 				name: "all nodes, tang",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn:    models.DiskEncryptionEnableOnAll,
-					Mode:        models.DiskEncryptionModeTang,
+					EnableOn:    swag.String(models.DiskEncryptionEnableOnAll),
+					Mode:        swag.String(models.DiskEncryptionModeTang),
 					TangServers: defaultTangServers,
 				},
 				expectedManifestsNames: []string{
@@ -361,8 +361,8 @@ spec:
 			{
 				name: "masters only, tpmv2",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn: models.DiskEncryptionEnableOnMasters,
-					Mode:     models.DiskEncryptionModeTpmv2,
+					EnableOn: swag.String(models.DiskEncryptionEnableOnMasters),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 				},
 				expectedManifestsNames: []string{
 					"99-openshift-master-tpm-encryption.yaml",
@@ -374,8 +374,8 @@ spec:
 			{
 				name: "masters only, tang",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn:    models.DiskEncryptionEnableOnMasters,
-					Mode:        models.DiskEncryptionModeTang,
+					EnableOn:    swag.String(models.DiskEncryptionEnableOnMasters),
+					Mode:        swag.String(models.DiskEncryptionModeTang),
 					TangServers: defaultTangServers,
 				},
 				expectedManifestsNames: []string{
@@ -388,8 +388,8 @@ spec:
 			{
 				name: "workers only, tpmv2",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn: models.DiskEncryptionEnableOnWorkers,
-					Mode:     models.DiskEncryptionModeTpmv2,
+					EnableOn: swag.String(models.DiskEncryptionEnableOnWorkers),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 				},
 				expectedManifestsNames: []string{
 					"99-openshift-worker-tpm-encryption.yaml",
@@ -401,8 +401,8 @@ spec:
 			{
 				name: "workers only, tang",
 				diskEncryption: &models.DiskEncryption{
-					EnableOn:    models.DiskEncryptionEnableOnWorkers,
-					Mode:        models.DiskEncryptionModeTang,
+					EnableOn:    swag.String(models.DiskEncryptionEnableOnWorkers),
+					Mode:        swag.String(models.DiskEncryptionModeTang),
 					TangServers: defaultTangServers,
 				},
 				expectedManifestsNames: []string{

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6160,10 +6160,12 @@ definitions:
         type: string
         description: Enable/disable disk encryption on master nodes, worker nodes, or all nodes.
         enum: ['none', 'all', 'masters', 'workers']
+        default: none
       mode:
         type: string
         description: The disk encryption mode to use.
         enum: ['tpmv2', 'tang']
+        default: tpmv2
       tang_servers:
         type: string
         description: JSON-formatted string containing additional information regarding tang's configuration


### PR DESCRIPTION
# Assisted Pull Request

Added default values to 'mode' and 'enable_on' properties in
disk-encryption.

This makes the code simpler as we can always assume that the values of
those properties are always one of the enum possibilities (and not empty).

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
