### PR TITLE
MGMT-7484: validate UserManagedNetworking for non-default arch cluster

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2516,6 +2516,11 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.UpdateClusterP
 	}
 
 	if params.ClusterUpdateParams.UserManagedNetworking != nil && swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) != userManagedNetworking {
+		if !swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) && cluster.CPUArchitecture != common.DefaultCPUArchitecture {
+			err = errors.Errorf("disabling User Managed Networking is not allowed for clusters with non-x86_64 CPU architecture")
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
+
 		// User network mode has changed
 		userManagedNetworking = swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking)
 		updates["user_managed_networking"] = userManagedNetworking

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -185,6 +185,8 @@ func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseIm
 // extractFromRelease returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image.
 func (r *release) extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool, platformType models.PlatformType) (string, error) {
+	// Using platform type as an indication for which openshift install binary to use
+	// (e.g. as non-x86_64 clusters should use the openshift-install binary).
 	var binary string
 	if platformType == models.PlatformTypeNone {
 		binary = "openshift-install"

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/operators"
@@ -114,9 +115,8 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 }
 
 func (k *installGenerator) getClusterPlatformType(cluster common.Cluster) models.PlatformType {
-	// Using platform type as an indication for which openshift install binary to use.
-	// I.e. None x86_64 clusters should use the openshift-install binary.
-	if cluster.CPUArchitecture != common.DefaultCPUArchitecture {
+	// Enabled UserManagedNetworking implies none platfrom.
+	if swag.BoolValue(cluster.UserManagedNetworking) {
 		return models.PlatformTypeNone
 	}
 	return cluster.Platform.Type


### PR DESCRIPTION
# Assisted Pull Request

## Description

- Validate UserManagedNetworking on UpdateCluster:
  - Prohibit disabling for a cluster with non-x86 CPU architecture.
- Simplify platform type indication in installGenerator:
  - Use none platform openshift-install binary for enabled UserManagedNetworking.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eranco74 
/cc @filanov
/cc @rollandf 
/cc @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
