### PR TITLE
MGMT-6898: Fix MachineNetworks validation for multi-network setup

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2418,8 +2418,10 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(cluster.MachineNetworks[index].Cidr)))
 			}
 		}
+	}
 
-		if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, string(cluster.MachineNetworks[index].Cidr)); err != nil {
+	if len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+		if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, string(cluster.MachineNetworks[0].Cidr)); err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4832,6 +4832,38 @@ var _ = Describe("cluster", func() {
 						validateNetworkConfiguration(actual.Payload, nil, nil, &[]*models.MachineNetwork{})
 					})
 				})
+
+				Context("Dual-stack", func() {
+					var (
+						machineNetworks = []*models.MachineNetwork{{Cidr: "10.13.0.0/16"}, {Cidr: "2001:db8::/64"}}
+					)
+
+					BeforeEach(func() {
+						for _, network := range machineNetworks {
+							network.ClusterID = clusterID
+						}
+					})
+
+					It("Allow setting dual-stack machine CIDRs when VIP DHCP is true and IPv4 is the first one", func() {
+						mockSuccess(1)
+
+						Expect(db.Model(&models.MachineNetwork{}).Save(machineNetworks[0]).Error).ShouldNot(HaveOccurred())
+						Expect(db.Model(&models.MachineNetwork{}).Save(machineNetworks[1]).Error).ShouldNot(HaveOccurred())
+
+						reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.ClusterUpdateParams{
+								MachineNetworks:   machineNetworks,
+								VipDhcpAllocation: swag.Bool(true),
+							},
+						})
+						Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+						actual := reply.(*installer.UpdateClusterCreated)
+						Expect(actual.Payload.VipDhcpAllocation).NotTo(BeNil())
+						Expect(*actual.Payload.VipDhcpAllocation).To(BeTrue())
+						validateNetworkConfiguration(actual.Payload, nil, nil, &machineNetworks)
+					})
+				})
 			})
 
 			Context("NTP", func() {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR fixes the validation of VIP DHCP allocation in case multiple
Machine Networks are provided.

Given that we currently allow only single address for API and Ingress
VIPs, it does not make sense to perform a validation against all the
machine networks, but only against the first one (i.e. the one from
which the VIPs must be coming).

Contributes-to: [MGMT-6898](https://issues.redhat.com/browse/MGMT-6898)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual test

For the request
```
--data '{"machine_networks": [{"cidr":"192.168.145.0/24","cluster_id":"82b8c284-8024-4a30-9bef-4b5a8180061b"},{"cidr": "1001:db8::/120","cluster_id":"82b8c284-8024-4a30-9bef-4b5a8180061b"}]}' -H "content-type: application/json" --request PATCH
```

the cluster looks as follows
```
  "machine_network_cidr": "192.168.145.0/24",
  "machine_networks": [
    {
      "cidr": "192.168.145.0/24",
      "cluster_id": "82b8c284-8024-4a30-9bef-4b5a8180061b"
    },
    {
      "cidr": "1001:db8::/120",
      "cluster_id": "82b8c284-8024-4a30-9bef-4b5a8180061b"
    }
  ],
```

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
