### PR TITLE
MGMT-4475: add suggested-role

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1446,10 +1446,21 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 	}
 	// auto select hosts roles if not selected yet.
 	err = b.db.Transaction(func(tx *gorm.DB) error {
+		var autoAssigned bool
+		var selected bool
 		for i := range cluster.Hosts {
-			if err = b.hostApi.AutoAssignRole(ctx, cluster.Hosts[i], tx); err != nil {
+			if selected, err = b.hostApi.AutoAssignRole(ctx, cluster.Hosts[i], tx); err != nil {
 				return err
+			} else {
+				autoAssigned = autoAssigned || selected
 			}
+		}
+		//usage for auto role selection is measured only for day1 clusters with more than
+		//3 hosts (which would automatically be assigned as masters if the hw is sufficient)
+		if usages, uerr := usage.Unmarshal(cluster.Cluster.FeatureUsage); uerr == nil {
+			report := cluster.Cluster.EnabledHostCount > common.MinMasterHostsNeededForInstallation && selected
+			b.setUsage(report, usage.AutoAssignRoleUsage, nil, usages)
+			b.usageApi.Save(tx, *cluster.ID, usages)
 		}
 		return nil
 	})
@@ -1554,7 +1565,7 @@ func (b *bareMetalInventory) InstallSingleDay2HostInternal(ctx context.Context, 
 	}
 	// auto select host roles if not selected yet.
 	err = b.db.Transaction(func(tx *gorm.DB) error {
-		if err = b.hostApi.AutoAssignRole(ctx, &h.Host, tx); err != nil {
+		if _, err = b.hostApi.AutoAssignRole(ctx, &h.Host, tx); err != nil {
 			return err
 		}
 		return nil
@@ -1641,7 +1652,7 @@ func (b *bareMetalInventory) V2InstallHost(ctx context.Context, params installer
 		return common.NewApiError(http.StatusConflict, fmt.Errorf("cannot install host in state %s", swag.StringValue(h.Status)))
 	}
 
-	err = b.hostApi.AutoAssignRole(ctx, h, b.db)
+	_, err = b.hostApi.AutoAssignRole(ctx, h, b.db)
 	if err != nil {
 		log.Errorf("Failed to update role for host %s", params.HostID)
 		return common.GenerateErrorResponder(err)
@@ -1689,7 +1700,7 @@ func (b *bareMetalInventory) InstallHosts(ctx context.Context, params installer.
 			if swag.StringValue(cluster.Hosts[i].Status) != models.HostStatusKnown {
 				continue
 			}
-			if err = b.hostApi.AutoAssignRole(ctx, cluster.Hosts[i], tx); err != nil {
+			if _, err = b.hostApi.AutoAssignRole(ctx, cluster.Hosts[i], tx); err != nil {
 				return err
 			}
 		}
@@ -4459,7 +4470,7 @@ func (b *bareMetalInventory) InstallHost(ctx context.Context, params installer.I
 		return common.NewApiError(http.StatusConflict, fmt.Errorf("cannot install host in state %s", swag.StringValue(h.Status)))
 	}
 
-	err = b.hostApi.AutoAssignRole(ctx, h, b.db)
+	_, err = b.hostApi.AutoAssignRole(ctx, h, b.db)
 	if err != nil {
 		log.Errorf("Failed to update role for host %s", params.HostID)
 		return common.GenerateErrorResponder(err)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3040,10 +3040,10 @@ var _ = Describe("cluster", func() {
 	}
 	mockAutoAssignFailed := func() {
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(errors.Errorf("")).Times(1)
+			Return(false, errors.Errorf("")).Times(1)
 	}
 	mockAutoAssignSuccess := func(times int) {
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(times)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(times)
 	}
 	mockClusterRefreshStatusSuccess := func() {
 		mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -8080,7 +8080,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -8096,7 +8096,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -8178,7 +8178,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(0)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ign failure")).Times(1)
@@ -8193,7 +8193,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(0)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ign failure")).Times(1)
@@ -8208,7 +8208,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
@@ -8223,7 +8223,7 @@ var _ = Describe("Install Host test", func() {
 			HostID:      hostID,
 		}
 		addHost(hostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
@@ -8266,7 +8266,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 	It("Install Single Day2 Host", func() {
 		hostId := strfmt.UUID(uuid.New().String())
 		addHost(hostId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -8279,7 +8279,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		expectedErrMsg := "some-internal-error"
 		hostId := strfmt.UUID(uuid.New().String())
 		addHost(hostId, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -8374,7 +8374,7 @@ var _ = Describe("Install Hosts test", func() {
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname1", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname2", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
@@ -8394,7 +8394,7 @@ var _ = Describe("Install Hosts test", func() {
 		addHost(knownHostID, models.HostRoleWorker, models.HostStatusKnown, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname2", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusInstalled, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname3", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusAddedToExistingCluster, models.HostKindAddToExistingClusterHost, clusterID, clusterID, getInventoryStr("hostname4", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(5)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		fileName := fmt.Sprintf("%s/worker-%s.ign", clusterID, knownHostID)
@@ -8412,7 +8412,7 @@ var _ = Describe("Install Hosts test", func() {
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusInstalling, models.HostKindAddToExistingClusterHost, clusterID, clusterID, "", db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusInsufficient, models.HostKindAddToExistingClusterHost, clusterID, clusterID, "", db)
 		addHost(strfmt.UUID(uuid.New().String()), models.HostRoleWorker, models.HostStatusDisconnected, models.HostKindAddToExistingClusterHost, clusterID, clusterID, "", db)
-		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
+		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(0)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
 		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(0)
 		res := bm.InstallHosts(ctx, params)

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -76,7 +76,7 @@ func refreshHostStageUpdateTime(
 }
 
 // update host role with an option to update only if the current role is srcRole to prevent races
-func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, db *gorm.DB, srcRole *string) error {
+func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, suggestedRole models.HostRole, db *gorm.DB, srcRole *string) error {
 	hostStatus := swag.StringValue(h.Status)
 	allowedStatuses := append(hostStatusesBeforeInstallation[:], hostStatusesInInfraEnv[:]...)
 	if !funk.ContainsString(allowedStatuses, hostStatus) {
@@ -85,7 +85,7 @@ func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, db
 				hostStatus, hostStatusesBeforeInstallation[:]))
 	}
 
-	extras := append(make([]interface{}, 0), "role", role)
+	extras := append(make([]interface{}, 0), "role", role, "suggested_role", suggestedRole)
 
 	if hostutil.IsDay2Host(h) && (h.MachineConfigPoolName == "" || h.MachineConfigPoolName == *srcRole) {
 		extras = append(extras, "machine_config_pool_name", role)

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -41,11 +41,12 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 }
 
 // AutoAssignRole mocks base method.
-func (m *MockAPI) AutoAssignRole(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
+func (m *MockAPI) AutoAssignRole(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AutoAssignRole", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AutoAssignRole indicates an expected call of AutoAssignRole.

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -19,6 +19,8 @@ const (
 	NetworkTypeSelectionUsage string = "NetworkType"
 	//usage of platform provider other than baremetal
 	PlatformSelectionUsage string = "Platform selection"
-	//ussage of schedulable masters
+	//usage of schedulable masters
 	SchedulableMasters string = "Schedulable masters"
+	//usage of auto assign role
+	AutoAssignRoleUsage string = "auto assign role"
 )

--- a/models/host.go
+++ b/models/host.go
@@ -148,6 +148,9 @@ type Host struct {
 	// Format: date-time
 	StatusUpdatedAt strfmt.DateTime `json:"status_updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// suggested role
+	SuggestedRole HostRole `json:"suggested_role,omitempty"`
+
 	// updated at
 	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
@@ -236,6 +239,10 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateStatusUpdatedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSuggestedRole(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -626,6 +633,22 @@ func (m *Host) validateStatusUpdatedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("status_updated_at", "body", "date-time", m.StatusUpdatedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Host) validateSuggestedRole(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SuggestedRole) { // not required
+		return nil
+	}
+
+	if err := m.SuggestedRole.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("suggested_role")
+		}
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8767,6 +8767,9 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "suggested_role": {
+          "$ref": "#/definitions/host-role"
+        },
         "updated_at": {
           "type": "string",
           "format": "date-time",
@@ -19189,6 +19192,9 @@ func init() {
           "type": "string",
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
+        "suggested_role": {
+          "$ref": "#/definitions/host-role"
         },
         "updated_at": {
           "type": "string",

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1124,6 +1124,10 @@ var _ = Describe("cluster install", func() {
 		}
 		Expect(mastersCount).Should(Equal(3))
 		Expect(workersCount).Should(Equal(3))
+
+		By("check auto-assign usage report")
+		verifyUsageSet(getReply.Payload.FeatureUsage,
+			models.Usage{Name: usage.AutoAssignRoleUsage})
 	})
 
 	It("Schedulable masters", func() {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5012,6 +5012,8 @@ definitions:
         description: Additional information about disks, formatted as JSON.
       role:
         $ref: '#/definitions/host-role'
+      suggested_role:
+        $ref: '#/definitions/host-role'
       bootstrap:
         type: boolean
       logs_collected_at:


### PR DESCRIPTION
 Assisted Pull Request

## Description
First phase of early auto assign implementation:
1. add suggested-role field to host
2. whenever AutoAssignRole is called, first fill the suggested role
   for hosts in auto-assign and then assign the host role from the
   suggested field
3. report usage when auto selection is done and there is a real
   choice (i.e. more than 3 nodes are involved)

In the next phases the suggested-role will be calculated in the
monitor and AutoAssignRole would just use that recommendation
without calling it directly


## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
