### PR TITLE
MGMT-6670: Fix handling of empty network in various network params

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -536,14 +536,14 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	}
 
 	// TODO MGMT-7365: Deprecate single network
-	if len(params.NewClusterParams.ClusterNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.ClusterNetworks) {
 		cluster.ClusterNetworkCidr = string(params.NewClusterParams.ClusterNetworks[0].Cidr)
 		cluster.ClusterNetworkHostPrefix = params.NewClusterParams.ClusterNetworks[0].HostPrefix
 	}
-	if len(params.NewClusterParams.ServiceNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.ServiceNetworks) {
 		cluster.ServiceNetworkCidr = string(params.NewClusterParams.ServiceNetworks[0].Cidr)
 	}
-	if len(params.NewClusterParams.MachineNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.MachineNetworks) {
 		cluster.MachineNetworkCidr = string(params.NewClusterParams.MachineNetworks[0].Cidr)
 	}
 
@@ -2200,7 +2200,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 		ingressVip = *params.ClusterUpdateParams.IngressVip
 	}
 	if params.ClusterUpdateParams.MachineNetworks != nil &&
-		len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+		common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
 		err := errors.New("Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 		log.WithError(err).Warnf("Set Machine Network CIDR")
 		return common.NewApiError(http.StatusBadRequest, err)
@@ -2389,7 +2389,7 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 		cluster.ClusterNetworks = params.ClusterUpdateParams.ClusterNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.ClusterNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.ClusterNetworks) {
 			updates["cluster_network_cidr"] = string(params.ClusterUpdateParams.ClusterNetworks[0].Cidr)
 			updates["cluster_network_host_prefix"] = params.ClusterUpdateParams.ClusterNetworks[0].HostPrefix
 		} else {
@@ -2407,7 +2407,7 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 		cluster.ServiceNetworks = params.ClusterUpdateParams.ServiceNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.ServiceNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.ServiceNetworks) {
 			updates["service_network_cidr"] = string(params.ClusterUpdateParams.ServiceNetworks[0].Cidr)
 		} else {
 			updates["service_network_cidr"] = ""
@@ -2415,25 +2415,22 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 	}
 
 	if params.ClusterUpdateParams.MachineNetworks != nil {
+		for _, machineNetwork := range params.ClusterUpdateParams.MachineNetworks {
+			if err = network.VerifyMachineCIDR(string(machineNetwork.Cidr)); err != nil {
+				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(machineNetwork.Cidr)))
+			}
+		}
 		cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
 			updates["machine_network_cidr"] = string(params.ClusterUpdateParams.MachineNetworks[0].Cidr)
 		} else {
 			updates["machine_network_cidr"] = ""
 		}
 	}
 
-	for index := range cluster.MachineNetworks {
-		if string(cluster.MachineNetworks[index].Cidr) != "" {
-			if err = network.VerifyMachineCIDR(string(cluster.MachineNetworks[index].Cidr)); err != nil {
-				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(cluster.MachineNetworks[index].Cidr)))
-			}
-		}
-	}
-
-	if len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
 		if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, string(cluster.MachineNetworks[0].Cidr)); err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
@@ -2628,7 +2625,7 @@ func validateUserManagedNetworkConflicts(params *models.ClusterUpdateParams, sin
 		log.WithError(err)
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
-	if params.MachineNetworks != nil && len(params.MachineNetworks) > 0 && !singleNodeCluster {
+	if common.IsSliceNonEmpty(params.MachineNetworks) && !singleNodeCluster {
 		err := errors.Errorf("Machine Network CIDR cannot be set with User Managed Networking")
 		log.WithError(err)
 		return common.NewApiError(http.StatusBadRequest, err)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5020,7 +5020,7 @@ var _ = Describe("cluster", func() {
 					validateNetworkConfiguration(actual.Payload, &clusterNetworks, &serviceNetworks, &machineNetworks)
 				})
 
-				It("Empty networks", func() {
+				It("Empty networks - valid", func() {
 					mockSuccess(1)
 					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
 						ClusterID: clusterID,
@@ -5036,6 +5036,90 @@ var _ = Describe("cluster", func() {
 					Expect(actual.Payload.ClusterNetworks).To(BeEmpty())
 					Expect(actual.Payload.ServiceNetworks).To(BeEmpty())
 					Expect(actual.Payload.MachineNetworks).To(BeEmpty())
+				})
+
+				It("Empty networks - invalid empty ClusterNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{{}},
+							ServiceNetworks: []*models.ServiceNetwork{},
+							MachineNetworks: []*models.MachineNetwork{},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid CIDR, ClusterNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{{Cidr: ""}},
+							ServiceNetworks: []*models.ServiceNetwork{},
+							MachineNetworks: []*models.MachineNetwork{},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid HostPrefix, ClusterNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{{HostPrefix: 0}},
+							ServiceNetworks: []*models.ServiceNetwork{},
+							MachineNetworks: []*models.MachineNetwork{},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid empty ServiceNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{},
+							ServiceNetworks: []*models.ServiceNetwork{{}},
+							MachineNetworks: []*models.MachineNetwork{},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid CIDR, ServiceNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{},
+							ServiceNetworks: []*models.ServiceNetwork{{Cidr: ""}},
+							MachineNetworks: []*models.MachineNetwork{},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid empty MachineNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{},
+							ServiceNetworks: []*models.ServiceNetwork{},
+							MachineNetworks: []*models.MachineNetwork{{}},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
+				})
+
+				It("Empty networks - invalid CIDR, MachineNetwork", func() {
+					reply := bm.UpdateCluster(ctx, installer.UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.ClusterUpdateParams{
+							ClusterNetworks: []*models.ClusterNetwork{},
+							ServiceNetworks: []*models.ServiceNetwork{},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: ""}},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
 				})
 
 				It("Override networks", func() {

--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -384,7 +384,7 @@ var _ = Describe("UpdateMachineCidr", func() {
 		It(test.name, func() {
 			// TODO MGMT-7365: Deprecate single network
 			primaryMachineCidr := ""
-			if len(test.clusterMachineNetworks) > 0 {
+			if common.IsSliceNonEmpty(test.clusterMachineNetworks) {
 				primaryMachineCidr = string(test.clusterMachineNetworks[0].Cidr)
 			}
 

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -122,7 +122,7 @@ func (v *clusterValidator) printIsMachineCidrDefined(context *clusterPreprocessC
 }
 
 func (v *clusterValidator) isClusterCidrDefined(c *clusterPreprocessContext) ValidationStatus {
-	return boolToValidationStatus(len(c.cluster.ClusterNetworks) > 0 && c.cluster.ClusterNetworks[0].Cidr != "")
+	return boolToValidationStatus(common.IsSliceNonEmpty(c.cluster.ClusterNetworks))
 }
 
 func (v *clusterValidator) printIsClusterCidrDefined(context *clusterPreprocessContext, status ValidationStatus) string {
@@ -137,7 +137,7 @@ func (v *clusterValidator) printIsClusterCidrDefined(context *clusterPreprocessC
 }
 
 func (v *clusterValidator) isServiceCidrDefined(c *clusterPreprocessContext) ValidationStatus {
-	return boolToValidationStatus(len(c.cluster.ServiceNetworks) > 0 && c.cluster.ServiceNetworks[0].Cidr != "")
+	return boolToValidationStatus(common.IsSliceNonEmpty(c.cluster.ServiceNetworks))
 }
 
 func (v *clusterValidator) printIsServiceCidrDefined(context *clusterPreprocessContext, status ValidationStatus) string {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
@@ -150,8 +151,42 @@ func GetNetworkCidrAttr(obj interface{}, fieldName string) []*string {
 	}
 
 	funk.ForEach(field, func(elem interface{}) {
-		addresses = append(addresses, swag.String(string(funk.Get(elem, "Cidr").(models.Subnet))))
+		address := funk.Get(elem, "Cidr")
+		if address != nil {
+			addresses = append(addresses, swag.String(string(address.(models.Subnet))))
+		}
 	})
 
 	return addresses
+}
+
+// IsSliceNonEmpty checks whether the provided slice is non-empty. The slice is assumed to be
+// non-empty if at least one of its elements contains a non-zero value for its respective type.
+// Examples:
+// - `[]*models.MachineNetwork{{Cidr: "5.5.0.0/24"}, {Cidr: "6.6.0.0/24"}}` - valid, as we are
+//   configuring two machine networks
+// - `[]*models.ClusterNetwork{}` - valid, as it means we are removing all the cluster networks
+//   that may have been currently configured
+// - `[]*models.MachineNetwork{{}}` - invalid, as it means that we are trying to configure
+//    a single machine network that is empty; a valid network contains at least a CIDR which is
+//    missing in this case
+// - `[]*models.MachineNetwork{{Cidr: ""}}` - invalid, as it means we are trying to configure
+//   a single machine network that has empty CIDR; a valid network should contain a non-empty
+//   CIDR
+// - `[]*models.ClusterNetwork{{HostPrefix: 0}}` - invalid, as it means we are trying to configure
+//   a single cluster network with host prefix with a value 0; this is not a valid subnet lenght
+func IsSliceNonEmpty(arg interface{}) bool {
+	res := false
+	if reflect.ValueOf(arg).Kind() == reflect.Slice {
+		funk.ForEach(arg, func(elem interface{}) {
+			v := reflect.ValueOf(elem)
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				res = res || !v.Field(i).IsZero()
+			}
+		})
+	}
+	return res
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -761,13 +761,13 @@ func selectClusterNetworkType(params *models.ClusterUpdateParams, cluster *commo
 		},
 	}
 
-	if len(params.ClusterNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.ClusterNetworks) {
 		clusterWithNewNetworks.ClusterNetworks = params.ClusterNetworks
 	}
-	if len(params.ServiceNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.ServiceNetworks) {
 		clusterWithNewNetworks.ServiceNetworks = params.ServiceNetworks
 	}
-	if len(params.MachineNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.MachineNetworks) {
 		clusterWithNewNetworks.MachineNetworks = params.MachineNetworks
 	}
 

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -67,7 +67,7 @@ func GetConfiguredAddressFamilies(cluster *common.Cluster) (ipv4 bool, ipv6 bool
 }
 
 func IsMachineCidrAvailable(cluster *common.Cluster) bool {
-	return len(cluster.MachineNetworks) > 0
+	return common.IsSliceNonEmpty(cluster.MachineNetworks)
 }
 
 func GetMachineCidrById(cluster *common.Cluster, index int) string {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR fixes handling of Machine, Cluster and Service Networks when
the value passed is a non-empty array with empty objects.

The current assumption that the MachineNetworks (or other) variable is
either empty or contains a valid set of CIDRs is incorrect, as it has
been discovered that the following requests arrive to the service

```
--data '{"machine_networks": [{}]}'
```

Those should be rather arriving as

```
--data '{"machine_networks": []}'
```

but in order to handle all the possibilities, we add a scenario for the
former in this change.

Contributes-to: [MGMT-6670](https://issues.redhat.com/browse/MGMT-6670)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
