### PR TITLE
NO-ISSUE: downloading kustomize release directly to handle rate-limiters

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -15,9 +15,9 @@ function kustomize() {
     return
   fi
 
-  (cd /usr/bin &&
-    curl --retry 5 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
-      | bash -s -- 4.2.0)
+  # We tried using "official" install_kustomize.sh script, but it used too much rate-limited APIs of GitHub
+  curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
+    tar -zx -C /usr/bin/
 }
 
 function golang() {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Sometimes we fail on Version v4.2.0 does not exist, which actually means we hit rate-limiter of GitHub. For example:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/2510/pull-ci-openshift-assisted-service-master-lint/1432667157698711552

This will use non-limited APIs of GitHub, and will allow us to workaround this issue.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @YuviGold 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
