### PR TITLE
MGMT-7568: ocp_version_update - clone repo before updates

### DIFF
--- a/tools/ocp_version_update/update_default_release_versions_to_latest.py
+++ b/tools/ocp_version_update/update_default_release_versions_to_latest.py
@@ -21,7 +21,7 @@ logging.getLogger("__main__").setLevel(logging.INFO)
 
 # Users / branch names / messages
 BRANCH_NAME = "{prefix}_update_assisted_service_versions"
-DEFAULT_ASSIGN = "lgamliel"
+DEFAULT_ASSIGN = "oscohen"
 DEFAULT_WATCHERS = ["lgamliel", "yuvalgoldberg"]
 PR_MENTION = ["gamli75", "YuviGold"]
 PR_MESSAGE = "{task}: Bump OCP versions {versions_string}"
@@ -232,8 +232,8 @@ def get_latest_release_from_minor(minor_release, cpu_architecture: str):
     release_data = get_release_data(minor_release, cpu_architecture)
     return release_data['version']
 
-def get_release_note_url(minor_release, cpu_architecture: str):
-    release_data = get_release_data(minor_release, cpu_architecture)
+def get_release_note_url(minor_release):
+    release_data = get_release_data(minor_release, CPU_ARCHITECTURE_AMD64)
     try:
         release_url = release_data['metadata']["url"]
     except KeyError:
@@ -312,6 +312,10 @@ def main(args):
 
     updates_made = set()
     updates_made_str = set()
+
+    if not dry_run:
+        user, password = get_login(args.github_user_password)
+        clone_assisted_service(user, password)
 
     update_release_images_json(default_release_images_json, updates_made, updates_made_str, dry_run)
     update_os_images_json(default_os_images_json, updates_made, updates_made_str, dry_run)
@@ -477,9 +481,6 @@ def create_jira_task(updates_made_str, dry_run, args):
 
     title = PR_MESSAGE.format(task=task, versions_string=versions_str)
     logger.info(f"PR title will be {title}")
-
-    user, password = get_login(args.github_user_password)
-    clone_assisted_service(user, password)
 
     return title, task
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Clone the assisted-service repo before making changes to the json files.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @oshercc 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
