### PR TITLE
MGMT-4505 Fixes RWN creation when no hostname annotation is passed

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -420,7 +420,7 @@ func installed(agent *aiv1beta1.Agent, status, statusInfo string) {
 	var reason string
 	var msg string
 	switch status {
-	case models.HostStatusInstalled:
+	case models.HostStatusInstalled, models.HostStatusAddedToExistingCluster:
 		condStatus = corev1.ConditionTrue
 		reason = aiv1beta1.InstalledReason
 		msg = fmt.Sprintf("%s %s", aiv1beta1.InstalledMsg, statusInfo)


### PR DESCRIPTION
# Assisted Pull Request

## Description

commit 6da57ff459b363fcf052db5cef93a77d9949fe84:

    Bug 2000612: Use the agent's inventory hostname as the source for BMH's hostname

    The hostname was not being set in the BMH's hardware details when the
    hostname annotation was not used. This is because the reconcile step was
    using agent.Spec.Hostname as the source of hostname rather than the
    inventory. The former is latter set (after inspection) while the former
    is only set when the annotation is set

    Signed-off-by: Flavio Percoco <flavio@redhat.com>

commit 3e5e0331c0409ca6f444f9629153f6dbee07ea23

    Bug 2000614: Handle HostStatusAddedToHost status when reconciling agent

    This will set the agent condition as Installed for the Agent CR when the agent resource reaches
    the added-to-host status

    Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @nmagnezi 
/cc @pawanpinjarkar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
