### PR TITLE
MGMT-7282: Stop cluster installation after agent discovery

### DIFF
--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -16,6 +16,7 @@ export EXTRA_BAREMETALHOSTS_FILE="${EXTRA_BAREMETALHOSTS_FILE:-/home/test/dev-sc
 export SPOKE_CONTROLPLANE_AGENTS="${SPOKE_CONTROLPLANE_AGENTS:-1}"
 export SPOKE_API_VIP="${SPOKE_API_VIP:-}"
 export SPOKE_INGRESS_VIP="${SPOKE_INGRESS_VIP:-}"
+export ASSISTED_STOP_AFTER_AGENT_DISCOVERY="${ASSISTED_STOP_AFTER_AGENT_DISCOVERY:-False}"
 
 if [[ "${IP_STACK}" == "v4" ]]; then
     export CLUSTER_SUBNET="${CLUSTER_SUBNET_V4}"
@@ -66,6 +67,12 @@ echo "Waiting until at least ${SPOKE_CONTROLPLANE_AGENTS} agents are available..
 export -f wait_for_object_amount
 timeout 20m bash -c "wait_for_object_amount agent ${SPOKE_CONTROLPLANE_AGENTS} 30 ${SPOKE_NAMESPACE}"
 echo "All ${SPOKE_CONTROLPLANE_AGENTS} agents have been discovered!"
+
+# Only set by CI. Should not be used for local deployment/testing.
+if [[ "${ASSISTED_STOP_AFTER_AGENT_DISCOVERY}" == "True" ]]; then
+    echo "Agents have been discovered, do not wait for the cluster installtion to finish."
+    exit
+fi
 
 wait_for_condition "agentclusterinstall/${ASSISTED_AGENT_CLUSTER_INSTALL_NAME}" "Stopped" "90m" "${SPOKE_NAMESPACE}"
 echo "Cluster installation has been stopped (either for good or bad reasons)"


### PR DESCRIPTION

# Assisted Pull Request

## Description
When CI executes a periodic operator upgrade job, we let the cluster to completely
get installed before the upgrade. When deploying a cluster after the upgrade, when the agents
are discovered for the second cluster, we can skip the second cluster installation.
This is done for the CI job to complete sooner.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [X] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
