### PR TITLE
MGMT-7498: Add backwards compatibility for network configuration

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -528,6 +528,8 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		TriggerMonitorTimestamp: time.Now(),
 	}
 
+	createNetworkParamsCompatibilityPropagation(params)
+
 	// TODO MGMT-7365: Deprecate single network
 	if len(params.NewClusterParams.ClusterNetworks) > 0 {
 		cluster.ClusterNetworkCidr = string(params.NewClusterParams.ClusterNetworks[0].Cidr)
@@ -2312,6 +2314,9 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 
 	b.updatePlatformSources(params, updates, usages)
 
+	if err = updateNetworkParamsCompatiblityPropagation(params, cluster); err != nil {
+		return err
+	}
 	if err = b.updateNetworkParams(params, cluster, updates, usages, db, log, interactivity); err != nil {
 		return err
 	}
@@ -2442,9 +2447,14 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 				machineNetworkCidr = string(cluster.MachineNetworks[index].Cidr)
 			}
 
+			serviceNetworkCidr := ""
+			if len(cluster.ServiceNetworks) > index {
+				serviceNetworkCidr = string(cluster.ServiceNetworks[index].Cidr)
+			}
+
 			if err = network.VerifyClusterCIDRsNotOverlap(machineNetworkCidr,
 				string(cluster.ClusterNetworks[index].Cidr),
-				string(cluster.ServiceNetworks[index].Cidr),
+				serviceNetworkCidr,
 				userManagedNetworking); err != nil {
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
@@ -2496,6 +2506,100 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 			err = errors.Wrapf(err, "failed to update machine network %v of cluster %s", *machineNetwork, params.ClusterID)
 			return common.NewApiError(http.StatusInternalServerError, err)
 		}
+	}
+
+	return nil
+}
+
+// createNetworkParamsCompatibilityPropagation is a backwards compatibility adapter adding ability
+// to configure clutster networking using the following structures
+//
+//   * MachineNetworkCidr
+//   * ClusterNetworkCidr
+//   * ClusterNetworkHostPrefix
+//   * ServiceNetworkCidr
+//
+// Please note those will take precedence over the more complex introduced as part of dual-stack
+// and multi-network support, i.e.
+//
+//   * MachineNetworks
+//   * ClusterNetworks
+//   * ServiceNetworks
+func createNetworkParamsCompatibilityPropagation(params installer.V2RegisterClusterParams) {
+	if params.NewClusterParams.ServiceNetworkCidr != nil {
+		serviceNetwork := []*models.ServiceNetwork{}
+		if *params.NewClusterParams.ServiceNetworkCidr != "" {
+			serviceNetwork = []*models.ServiceNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.NewClusterParams.ServiceNetworkCidr)),
+			}}
+		}
+		params.NewClusterParams.ServiceNetworks = serviceNetwork
+	}
+
+	if params.NewClusterParams.ClusterNetworkCidr != nil || params.NewClusterParams.ClusterNetworkHostPrefix != 0 {
+		net := []*models.ClusterNetwork{}
+		var netCidr models.Subnet
+		var netHostPrefix int64
+
+		if params.NewClusterParams.ClusterNetworkCidr != nil {
+			netCidr = models.Subnet(*params.NewClusterParams.ClusterNetworkCidr)
+		}
+		if params.NewClusterParams.ClusterNetworkHostPrefix != 0 {
+			netHostPrefix = params.NewClusterParams.ClusterNetworkHostPrefix
+		}
+		if netCidr != "" || netHostPrefix != 0 {
+			net = []*models.ClusterNetwork{{Cidr: netCidr, HostPrefix: netHostPrefix}}
+		}
+
+		params.NewClusterParams.ClusterNetworks = net
+	}
+}
+
+// updateNetworkParamsCompatiblityPropagation is an adapter equivalent to the one above, i.e.
+// createNetworkParamsCompatibilityPropagation but responsible for handling cluster updates. It
+// exists as a separate function because creation and update of the cluster use different data
+// structures, i.e. installer.V2RegisterClusterParams and installer.UpdateClusterParams
+func updateNetworkParamsCompatiblityPropagation(params installer.UpdateClusterParams, cluster *common.Cluster) error {
+	if params.ClusterUpdateParams.ServiceNetworkCidr != nil {
+		serviceNetwork := []*models.ServiceNetwork{}
+		if *params.ClusterUpdateParams.ServiceNetworkCidr != "" {
+			serviceNetwork = []*models.ServiceNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.ClusterUpdateParams.ServiceNetworkCidr)),
+			}}
+		}
+		params.ClusterUpdateParams.ServiceNetworks = serviceNetwork
+	}
+	if params.ClusterUpdateParams.MachineNetworkCidr != nil {
+		machineNetwork := []*models.MachineNetwork{}
+		if *params.ClusterUpdateParams.MachineNetworkCidr != "" {
+			machineNetwork = []*models.MachineNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.ClusterUpdateParams.MachineNetworkCidr)),
+			}}
+		}
+		params.ClusterUpdateParams.MachineNetworks = machineNetwork
+	}
+
+	if params.ClusterUpdateParams.ClusterNetworkCidr != nil || params.ClusterUpdateParams.ClusterNetworkHostPrefix != nil {
+		clusterNetwork := []*models.ClusterNetwork{}
+		var netCidr models.Subnet
+		var netHostPrefix int64
+
+		if cluster.ClusterNetworks[0] != nil {
+			netCidr = cluster.ClusterNetworks[0].Cidr
+			netHostPrefix = cluster.ClusterNetworks[0].HostPrefix
+		}
+
+		if params.ClusterUpdateParams.ClusterNetworkCidr != nil {
+			netCidr = models.Subnet(*params.ClusterUpdateParams.ClusterNetworkCidr)
+		}
+		if params.ClusterUpdateParams.ClusterNetworkHostPrefix != nil {
+			netHostPrefix = *params.ClusterUpdateParams.ClusterNetworkHostPrefix
+		}
+		if netCidr != "" || netHostPrefix != 0 {
+			clusterNetwork = []*models.ClusterNetwork{{Cidr: netCidr, HostPrefix: netHostPrefix}}
+		}
+
+		params.ClusterUpdateParams.ClusterNetworks = clusterNetwork
 	}
 
 	return nil

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -237,5 +237,9 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 		}).Error
 	}
 
-	return nil
+	// TODO MGMT-7365: Deprecate single network
+	return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(
+		"machine_network_cidr", machineCidr,
+		"machine_network_cidr_updated_at", time.Now(),
+	).Error
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR adds backwards compatibility for the network configuration. Specifically, it cherry-picks 2 PRs:

* https://github.com/openshift/assisted-service/pull/2455
* https://github.com/openshift/assisted-service/pull/2485

I had to manually modify this PR to remove code that depends on a commit that doesn't exist in this branch:

https://github.com/openshift/assisted-service/pull/2553/commits/c71ea0ff0e469dfcc98c9e69d58632340f902b20

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Manual test done in the original PR: https://github.com/openshift/assisted-service/pull/2485

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @gamli75 
/cc @YuviGold 
/cc @celebdor 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
