### PR TITLE
NO-ISSUE: Change wording for the preMigration section in docs

### DIFF
--- a/docs/dev/migrations.md
+++ b/docs/dev/migrations.md
@@ -25,6 +25,5 @@ To be run, every migration function should be added to the list in `postMigratio
 
 We currently have a single migration in `preMigrations`, i.e. running before `AutoMigrate` step that is responsible for synchronizing the database schema.
 
-It is a bad decision, but given that it has already been rolled out, it would be extremely difficult to move it again to `postMigrations` with the guarantee that no deployment is going to break or end up in a state that is difficult to recover.
-
-When developing a new migration, `preMigrations` must not be used.
+The use of `preMigrations` is (currently) discouraged, as it may cause unexpected failures due to the existing usage of application code (`common.GetClustersFromDBWhere`)
+in some of the already-released migrations.


### PR DESCRIPTION


# Assisted Pull Request

## Description

This PR changes the wording in the `preMigration` docs. The documentation could be more extensive so I'm happy to incorporate suggestions from other folks.

Addresses comment from: https://github.com/openshift/assisted-service/pull/2536#discussion_r701591290

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
