### PR TITLE
NO-ISSUE: report OVN and SDN nw types separately

### DIFF
--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -15,8 +15,10 @@ const (
 	VipDhcpAllocationUsage string = "VIP auto alloc."
 	//usage of disk selection
 	DiskSelectionUsage string = "Disk Selection"
-	//user networkType selection
-	NetworkTypeSelectionUsage string = "NetworkType"
+	//cluster is using OVN network type
+	OVNNetworkTypeUsage string = "OVN network type"
+	//cluster is using SDN network type
+	SDNNetworkTypeUsage string = "SDN network type"
 	//usage of platform provider other than baremetal
 	PlatformSelectionUsage string = "Platform selection"
 	//usage of schedulable masters

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1186,6 +1186,7 @@ var _ = Describe("cluster install", func() {
 					PullSecret:           swag.String(pullSecret),
 					SSHPublicKey:         sshPublicKey,
 					VipDhcpAllocation:    swag.Bool(true),
+					NetworkType:          swag.String("OVNKubernetes"),
 					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
 				},
 			})
@@ -1196,6 +1197,7 @@ var _ = Describe("cluster install", func() {
 			log.Infof("usage after create: %s\n", getReply.Payload.FeatureUsage)
 			verifyUsageSet(getReply.Payload.FeatureUsage,
 				models.Usage{Name: usage.HighAvailabilityModeUsage})
+			verifyUsageSet(getReply.Payload.FeatureUsage, models.Usage{Name: usage.OVNNetworkTypeUsage})
 			verifyUsageNotSet(getReply.Payload.FeatureUsage, strings.ToUpper("console"), usage.VipDhcpAllocationUsage)
 		})
 
@@ -1205,6 +1207,7 @@ var _ = Describe("cluster install", func() {
 			ntpSources := "1.1.1.1,2.2.2.2"
 			proxy := "http://1.1.1.1:8080"
 			no_proxy := "a.redhat.com"
+			ovn := "OVNKubernetes"
 			_, err := userBMClient.Installer.UpdateCluster(ctx, &installer.UpdateClusterParams{
 				ClusterUpdateParams: &models.ClusterUpdateParams{
 					VipDhcpAllocation:   swag.Bool(true),
@@ -1212,6 +1215,7 @@ var _ = Describe("cluster install", func() {
 					HTTPProxy:           &proxy,
 					HTTPSProxy:          &proxy,
 					NoProxy:             &no_proxy,
+					NetworkType:         &ovn,
 					HostsNames: []*models.ClusterUpdateParamsHostsNamesItems0{
 						{ID: *h.ID, Hostname: "h1"},
 					},
@@ -1223,6 +1227,7 @@ var _ = Describe("cluster install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			verifyUsageSet(getReply.Payload.FeatureUsage,
 				models.Usage{Name: usage.VipDhcpAllocationUsage},
+				models.Usage{Name: usage.OVNNetworkTypeUsage},
 				models.Usage{
 					Name: usage.AdditionalNtpSourceUsage,
 					Data: map[string]interface{}{


### PR DESCRIPTION
# Assisted Pull Request

## Description
Have a separate line in feature usage table for OVN-based clusters vs. SDN


## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
