### PR TITLE
MGMT-7742: Fixing host getting stuck in "binding" state

### DIFF
--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -97,6 +97,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusResetting:                {[]CommandGetter{resetCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusError:                    {[]CommandGetter{logsCmd, stopCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusCancelled:                {[]CommandGetter{logsCmd, stopCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
+			models.HostStatusBinding:                  {[]CommandGetter{noopCmd}, 0, models.StepsPostStepActionExit},
 		},
 		addHostsClusterToSteps: stateToStepsMap{
 			models.HostStatusKnown:                {[]CommandGetter{connectivityCmd, apivipConnectivityCmd, inventoryCmd, ntpSynchronizerCmd, domainNameResolutionCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
@@ -117,7 +118,6 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusDisabledUnbound:     {[]CommandGetter{}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusInsufficientUnbound: {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusKnownUnbound:        {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
-			models.HostStatusBinding:             {[]CommandGetter{noopCmd}, 0, models.StepsPostStepActionExit},
 			models.HostStatusUnbinding:           {[]CommandGetter{noopCmd}, 0, models.StepsPostStepActionExit},
 		},
 	}

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -142,6 +142,9 @@ var _ = Describe("instruction_manager", func() {
 					models.StepTypeResetInstallation,
 				})
 			})
+			It("binding", func() {
+				checkStep(models.HostStatusBinding, nil)
+			})
 		})
 	})
 
@@ -173,6 +176,9 @@ var _ = Describe("instruction_manager", func() {
 					models.StepTypeDhcpLeaseAllocate, models.StepTypeInventory,
 					models.StepTypeNtpSynchronizer, models.StepTypeDomainResolution,
 				})
+			})
+			It("binding", func() {
+				checkStep(models.HostStatusBinding, nil)
 			})
 			It("disconnected", func() {
 				checkStep(models.HostStatusDisconnected, []models.StepType{
@@ -223,8 +229,6 @@ var _ = Describe("instruction_manager", func() {
 
 	Context("Unbound host steps", func() {
 		BeforeEach(func() {
-			//host_updates := map[string]interface{}{}
-			//host_updates["cluster_id"] = nil
 			Expect(db.Model(&common.Host{}).Select("cluster_id").Updates(map[string]interface{}{"cluster_id": nil}).Error).ShouldNot(HaveOccurred())
 		})
 
@@ -250,10 +254,6 @@ var _ = Describe("instruction_manager", func() {
 			checkStep(models.HostStatusKnownUnbound, []models.StepType{
 				models.StepTypeInventory,
 			})
-		})
-
-		It("binding", func() {
-			checkStep(models.HostStatusBinding, nil)
 		})
 
 		It("unbinding", func() {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6319,11 +6319,6 @@ func init() {
     },
     "/v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/bind": {
       "post": {
-        "security": [
-          {
-            "agentAuth": []
-          }
-        ],
         "description": "Bind host to a cluster",
         "tags": [
           "installer"
@@ -6625,11 +6620,6 @@ func init() {
     },
     "/v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/unbind": {
       "post": {
-        "security": [
-          {
-            "agentAuth": []
-          }
-        ],
         "description": "Unbind host to a cluster",
         "tags": [
           "installer"
@@ -17171,11 +17161,6 @@ func init() {
     },
     "/v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/bind": {
       "post": {
-        "security": [
-          {
-            "agentAuth": []
-          }
-        ],
         "description": "Bind host to a cluster",
         "tags": [
           "installer"
@@ -17477,11 +17462,6 @@ func init() {
     },
     "/v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/unbind": {
       "post": {
-        "security": [
-          {
-            "agentAuth": []
-          }
-        ],
         "description": "Unbind host to a cluster",
         "tags": [
           "installer"

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -87,6 +87,18 @@ func registerHostByUUID(infraEnvID, hostID strfmt.UUID) *models.HostRegistration
 	return host.GetPayload()
 }
 
+func bindHost(infraEnvID, hostID, clusterID strfmt.UUID) *models.Host {
+	host, err := userBMClient.Installer.BindHost(context.Background(), &installer.BindHostParams{
+		HostID:     hostID,
+		InfraEnvID: infraEnvID,
+		BindHostParams: &models.BindHostParams{
+			ClusterID: &clusterID,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return host.GetPayload()
+}
+
 func getHost(clusterID, hostID strfmt.UUID) *models.Host {
 	host, err := userBMClient.Installer.GetHost(context.Background(), &installer.GetHostParams{
 		ClusterID: clusterID,
@@ -162,9 +174,9 @@ func getStepInList(steps models.Steps, sType models.StepType) (*models.Step, boo
 	return nil, false
 }
 
-func getNextSteps(clusterID, hostID strfmt.UUID) models.Steps {
+func getNextSteps(infraEnvID, hostID strfmt.UUID) models.Steps {
 	steps, err := agentBMClient.Installer.V2GetNextSteps(context.Background(), &installer.V2GetNextStepsParams{
-		InfraEnvID: clusterID,
+		InfraEnvID: infraEnvID,
 		HostID:     hostID,
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3980,8 +3980,6 @@ paths:
     post:
       tags:
         - installer
-      security:
-        - agentAuth: [ ]
       description: Bind host to a cluster
       operationId: BindHost
       parameters:
@@ -4045,8 +4043,6 @@ paths:
     post:
       tags:
         - installer
-      security:
-        - agentAuth: [ ]
       description: Unbind host to a cluster
       operationId: UnbindHost
       parameters:


### PR DESCRIPTION
Once Bind command isssued, the host moves to Binding state and its ClusterID is set
to the target cluster. So, from instruction manager POV this host is now bound host and
not unbound host. The fix is to move binding instuction from unboind host instruction manager
commands set, to the bound host instruction manager command set.
In addition fixing the security definitions for Bind (adn unbind) command. It should be user
auth, and not agent auth

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
