### PR TITLE
MGMT-7755: Remove infraEnvUpdates Channel

### DIFF
--- a/internal/controller/controllers/crd_events_handler.go
+++ b/internal/controller/controllers/crd_events_handler.go
@@ -10,23 +10,19 @@ const EventsChannelSize = 200
 //go:generate mockgen -package controllers -destination mock_crd_events_handler.go . CRDEventsHandler
 type CRDEventsHandler interface {
 	NotifyClusterDeploymentUpdates(clusterDeploymentName string, clusterDeploymentNamespace string)
-	NotifyInfraEnvUpdates(infraEnvName string, infraEnvNamespace string)
 	NotifyAgentUpdates(agentName string, agentNamespace string)
-	GetInfraEnvUpdates() chan event.GenericEvent
 	GetClusterDeploymentUpdates() chan event.GenericEvent
 	GetAgentUpdates() chan event.GenericEvent
 }
 
 type CRDEventsHandlerChannels struct {
 	clusterDeploymentUpdates chan event.GenericEvent
-	infraEnvUpdates          chan event.GenericEvent
 	agentUpdates             chan event.GenericEvent
 }
 
 func NewCRDEventsHandler() CRDEventsHandler {
 	return &CRDEventsHandlerChannels{
 		clusterDeploymentUpdates: make(chan event.GenericEvent, EventsChannelSize),
-		infraEnvUpdates:          make(chan event.GenericEvent, EventsChannelSize),
 		agentUpdates:             make(chan event.GenericEvent, EventsChannelSize),
 	}
 }
@@ -48,14 +44,6 @@ func (h *CRDEventsHandlerChannels) NotifyClusterDeploymentUpdates(clusterDeploym
 
 func (h *CRDEventsHandlerChannels) NotifyAgentUpdates(agentName string, agentNamespace string) {
 	h.NotifyUpdates(h.agentUpdates, agentName, agentNamespace)
-}
-
-func (h *CRDEventsHandlerChannels) NotifyInfraEnvUpdates(infraEnvName string, infraEnvNamespace string) {
-	h.NotifyUpdates(h.infraEnvUpdates, infraEnvName, infraEnvNamespace)
-}
-
-func (h *CRDEventsHandlerChannels) GetInfraEnvUpdates() chan event.GenericEvent {
-	return h.infraEnvUpdates
 }
 
 func (h *CRDEventsHandlerChannels) GetClusterDeploymentUpdates() chan event.GenericEvent {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -502,11 +502,9 @@ func (r *InfraEnvReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return reply
 	}
 
-	infraEnvUpdates := r.CRDEventsHandler.GetInfraEnvUpdates()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&aiv1beta1.InfraEnv{}).
 		Watches(&source.Kind{Type: &aiv1beta1.NMStateConfig{}}, handler.EnqueueRequestsFromMapFunc(mapNMStateConfigToInfraEnv)).
 		Watches(&source.Kind{Type: &hivev1.ClusterDeployment{}}, handler.EnqueueRequestsFromMapFunc(mapClusterDeploymentToInfraEnv)).
-		Watches(&source.Channel{Source: infraEnvUpdates}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

The infraEnvUpdates channel is no longer in use after
https://github.com/openshift/assisted-service/pull/2532 got merged.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @rollandf 
/cc @danielerez 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
