### PR TITLE
MGMT-7754: Support iso creation with EFI boot only

### DIFF
--- a/internal/isoutil/isoutil.go
+++ b/internal/isoutil/isoutil.go
@@ -189,6 +189,24 @@ func (h *installerHandler) Create(outPath string, volumeLabel string) error {
 				},
 			},
 		}
+	} else if exists, _ := h.fileExists("images/efiboot.img"); exists {
+		// Creating an ISO with EFI boot only
+		efiSectors, err := h.efiLoadSectors()
+		if err != nil {
+			return err
+		}
+		options.ElTorito = &iso9660.ElTorito{
+			BootCatalog:     "boot.catalog",
+			HideBootCatalog: true,
+			Entries: []*iso9660.ElToritoEntry{
+				{
+					Platform:  iso9660.EFI,
+					Emulation: iso9660.NoEmulation,
+					BootFile:  "images/efiboot.img",
+					LoadSize:  efiSectors,
+				},
+			},
+		}
 	}
 
 	return iso.Finalize(options)


### PR DESCRIPTION
# Assisted Pull Request

## Description

As the aarch64 rhcos image[*] contains a single boot image (efiboot.img),
added a proper support to isoutil for creating an ISO with only that boot platform.
This should facilitate the creation of a minimal ISO template for arm64 CPU architecture.

Note: the logic should later be cherry-picked to assisted-image-service:
https://github.com/openshift/assisted-image-service/blob/main/pkg/isoeditor/isoutil.go

[*] https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/pre-release/4.9.0-fc.1/rhcos-4.9.0-fc.1-aarch64-live.aarch64.iso

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @carbonin 
/cc @omertuc 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
