### PR TITLE
Backwards backport of backward compatibility work

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -528,6 +528,8 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		TriggerMonitorTimestamp: time.Now(),
 	}
 
+	createNetworkParamsCompatibilityPropagation(params)
+
 	// TODO MGMT-7365: Deprecate single network
 	if len(params.NewClusterParams.ClusterNetworks) > 0 {
 		cluster.ClusterNetworkCidr = string(params.NewClusterParams.ClusterNetworks[0].Cidr)
@@ -2312,6 +2314,9 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 
 	b.updatePlatformSources(params, updates, usages)
 
+	if err = updateNetworkParamsCompatiblityPropagation(params, cluster); err != nil {
+		return err
+	}
 	if err = b.updateNetworkParams(params, cluster, updates, usages, db, log, interactivity); err != nil {
 		return err
 	}
@@ -2442,9 +2447,14 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 				machineNetworkCidr = string(cluster.MachineNetworks[index].Cidr)
 			}
 
+			serviceNetworkCidr := ""
+			if len(cluster.ServiceNetworks) > index {
+				serviceNetworkCidr = string(cluster.ServiceNetworks[index].Cidr)
+			}
+
 			if err = network.VerifyClusterCIDRsNotOverlap(machineNetworkCidr,
 				string(cluster.ClusterNetworks[index].Cidr),
-				string(cluster.ServiceNetworks[index].Cidr),
+				serviceNetworkCidr,
 				userManagedNetworking); err != nil {
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
@@ -2496,6 +2506,100 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 			err = errors.Wrapf(err, "failed to update machine network %v of cluster %s", *machineNetwork, params.ClusterID)
 			return common.NewApiError(http.StatusInternalServerError, err)
 		}
+	}
+
+	return nil
+}
+
+// createNetworkParamsCompatibilityPropagation is a backwards compatibility adapter adding ability
+// to configure clutster networking using the following structures
+//
+//   * MachineNetworkCidr
+//   * ClusterNetworkCidr
+//   * ClusterNetworkHostPrefix
+//   * ServiceNetworkCidr
+//
+// Please note those will take precedence over the more complex introduced as part of dual-stack
+// and multi-network support, i.e.
+//
+//   * MachineNetworks
+//   * ClusterNetworks
+//   * ServiceNetworks
+func createNetworkParamsCompatibilityPropagation(params installer.V2RegisterClusterParams) {
+	if params.NewClusterParams.ServiceNetworkCidr != nil {
+		serviceNetwork := []*models.ServiceNetwork{}
+		if *params.NewClusterParams.ServiceNetworkCidr != "" {
+			serviceNetwork = []*models.ServiceNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.NewClusterParams.ServiceNetworkCidr)),
+			}}
+		}
+		params.NewClusterParams.ServiceNetworks = serviceNetwork
+	}
+
+	if params.NewClusterParams.ClusterNetworkCidr != nil || params.NewClusterParams.ClusterNetworkHostPrefix != 0 {
+		net := []*models.ClusterNetwork{}
+		var netCidr models.Subnet
+		var netHostPrefix int64
+
+		if params.NewClusterParams.ClusterNetworkCidr != nil {
+			netCidr = models.Subnet(*params.NewClusterParams.ClusterNetworkCidr)
+		}
+		if params.NewClusterParams.ClusterNetworkHostPrefix != 0 {
+			netHostPrefix = params.NewClusterParams.ClusterNetworkHostPrefix
+		}
+		if netCidr != "" || netHostPrefix != 0 {
+			net = []*models.ClusterNetwork{{Cidr: netCidr, HostPrefix: netHostPrefix}}
+		}
+
+		params.NewClusterParams.ClusterNetworks = net
+	}
+}
+
+// updateNetworkParamsCompatiblityPropagation is an adapter equivalent to the one above, i.e.
+// createNetworkParamsCompatibilityPropagation but responsible for handling cluster updates. It
+// exists as a separate function because creation and update of the cluster use different data
+// structures, i.e. installer.V2RegisterClusterParams and installer.UpdateClusterParams
+func updateNetworkParamsCompatiblityPropagation(params installer.UpdateClusterParams, cluster *common.Cluster) error {
+	if params.ClusterUpdateParams.ServiceNetworkCidr != nil {
+		serviceNetwork := []*models.ServiceNetwork{}
+		if *params.ClusterUpdateParams.ServiceNetworkCidr != "" {
+			serviceNetwork = []*models.ServiceNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.ClusterUpdateParams.ServiceNetworkCidr)),
+			}}
+		}
+		params.ClusterUpdateParams.ServiceNetworks = serviceNetwork
+	}
+	if params.ClusterUpdateParams.MachineNetworkCidr != nil {
+		machineNetwork := []*models.MachineNetwork{}
+		if *params.ClusterUpdateParams.MachineNetworkCidr != "" {
+			machineNetwork = []*models.MachineNetwork{{
+				Cidr: models.Subnet(swag.StringValue(params.ClusterUpdateParams.MachineNetworkCidr)),
+			}}
+		}
+		params.ClusterUpdateParams.MachineNetworks = machineNetwork
+	}
+
+	if params.ClusterUpdateParams.ClusterNetworkCidr != nil || params.ClusterUpdateParams.ClusterNetworkHostPrefix != nil {
+		clusterNetwork := []*models.ClusterNetwork{}
+		var netCidr models.Subnet
+		var netHostPrefix int64
+
+		if cluster.ClusterNetworks[0] != nil {
+			netCidr = cluster.ClusterNetworks[0].Cidr
+			netHostPrefix = cluster.ClusterNetworks[0].HostPrefix
+		}
+
+		if params.ClusterUpdateParams.ClusterNetworkCidr != nil {
+			netCidr = models.Subnet(*params.ClusterUpdateParams.ClusterNetworkCidr)
+		}
+		if params.ClusterUpdateParams.ClusterNetworkHostPrefix != nil {
+			netHostPrefix = *params.ClusterUpdateParams.ClusterNetworkHostPrefix
+		}
+		if netCidr != "" || netHostPrefix != 0 {
+			clusterNetwork = []*models.ClusterNetwork{{Cidr: netCidr, HostPrefix: netHostPrefix}}
+		}
+
+		params.ClusterUpdateParams.ClusterNetworks = clusterNetwork
 	}
 
 	return nil

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -531,14 +531,14 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	createNetworkParamsCompatibilityPropagation(params)
 
 	// TODO MGMT-7365: Deprecate single network
-	if len(params.NewClusterParams.ClusterNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.ClusterNetworks) {
 		cluster.ClusterNetworkCidr = string(params.NewClusterParams.ClusterNetworks[0].Cidr)
 		cluster.ClusterNetworkHostPrefix = params.NewClusterParams.ClusterNetworks[0].HostPrefix
 	}
-	if len(params.NewClusterParams.ServiceNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.ServiceNetworks) {
 		cluster.ServiceNetworkCidr = string(params.NewClusterParams.ServiceNetworks[0].Cidr)
 	}
-	if len(params.NewClusterParams.MachineNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.NewClusterParams.MachineNetworks) {
 		cluster.MachineNetworkCidr = string(params.NewClusterParams.MachineNetworks[0].Cidr)
 	}
 
@@ -2189,7 +2189,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 		ingressVip = *params.ClusterUpdateParams.IngressVip
 	}
 	if params.ClusterUpdateParams.MachineNetworks != nil &&
-		len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+		common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
 		err := errors.New("Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 		log.WithError(err).Warnf("Set Machine Network CIDR")
 		return common.NewApiError(http.StatusBadRequest, err)
@@ -2389,7 +2389,7 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 		cluster.ClusterNetworks = params.ClusterUpdateParams.ClusterNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.ClusterNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.ClusterNetworks) {
 			updates["cluster_network_cidr"] = string(params.ClusterUpdateParams.ClusterNetworks[0].Cidr)
 			updates["cluster_network_host_prefix"] = params.ClusterUpdateParams.ClusterNetworks[0].HostPrefix
 		} else {
@@ -2407,7 +2407,7 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 		cluster.ServiceNetworks = params.ClusterUpdateParams.ServiceNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.ServiceNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.ServiceNetworks) {
 			updates["service_network_cidr"] = string(params.ClusterUpdateParams.ServiceNetworks[0].Cidr)
 		} else {
 			updates["service_network_cidr"] = ""
@@ -2415,24 +2415,23 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.Update
 	}
 
 	if params.ClusterUpdateParams.MachineNetworks != nil {
+		for _, machineNetwork := range params.ClusterUpdateParams.MachineNetworks {
+			if err = network.VerifyMachineCIDR(string(machineNetwork.Cidr)); err != nil {
+				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(machineNetwork.Cidr)))
+			}
+		}
 		cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks
 
 		// TODO MGMT-7365: Deprecate single network
-		if len(params.ClusterUpdateParams.MachineNetworks) > 0 {
+		if common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
 			updates["machine_network_cidr"] = string(params.ClusterUpdateParams.MachineNetworks[0].Cidr)
 		} else {
 			updates["machine_network_cidr"] = ""
 		}
 	}
 
-	for index := range cluster.MachineNetworks {
-		if string(cluster.MachineNetworks[index].Cidr) != "" {
-			if err = network.VerifyMachineCIDR(string(cluster.MachineNetworks[index].Cidr)); err != nil {
-				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(cluster.MachineNetworks[index].Cidr)))
-			}
-		}
-
-		if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, string(cluster.MachineNetworks[index].Cidr)); err != nil {
+	if common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
+		if err = validations.ValidateVipDHCPAllocationWithIPv6(vipDhcpAllocation, string(cluster.MachineNetworks[0].Cidr)); err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
 	}
@@ -2525,7 +2524,7 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 //   * MachineNetworks
 //   * ClusterNetworks
 //   * ServiceNetworks
-func createNetworkParamsCompatibilityPropagation(params installer.V2RegisterClusterParams) {
+func createNetworkParamsCompatibilityPropagation(params installer.RegisterClusterParams) {
 	if params.NewClusterParams.ServiceNetworkCidr != nil {
 		serviceNetwork := []*models.ServiceNetwork{}
 		if *params.NewClusterParams.ServiceNetworkCidr != "" {
@@ -2724,7 +2723,7 @@ func validateUserManagedNetworkConflicts(params *models.ClusterUpdateParams, sin
 		log.WithError(err)
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
-	if params.MachineNetworks != nil && len(params.MachineNetworks) > 0 && !singleNodeCluster {
+	if common.IsSliceNonEmpty(params.MachineNetworks) && !singleNodeCluster {
 		err := errors.Errorf("Machine Network CIDR cannot be set with User Managed Networking")
 		log.WithError(err)
 		return common.NewApiError(http.StatusBadRequest, err)

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -237,5 +237,9 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 		}).Error
 	}
 
-	return nil
+	// TODO MGMT-7365: Deprecate single network
+	return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Update(
+		"machine_network_cidr", machineCidr,
+		"machine_network_cidr_updated_at", time.Now(),
+	).Error
 }

--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -384,7 +384,7 @@ var _ = Describe("UpdateMachineCidr", func() {
 		It(test.name, func() {
 			// TODO MGMT-7365: Deprecate single network
 			primaryMachineCidr := ""
-			if len(test.clusterMachineNetworks) > 0 {
+			if common.IsSliceNonEmpty(test.clusterMachineNetworks) {
 				primaryMachineCidr = string(test.clusterMachineNetworks[0].Cidr)
 			}
 

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -122,7 +122,7 @@ func (v *clusterValidator) printIsMachineCidrDefined(context *clusterPreprocessC
 }
 
 func (v *clusterValidator) isClusterCidrDefined(c *clusterPreprocessContext) ValidationStatus {
-	return boolToValidationStatus(len(c.cluster.ClusterNetworks) > 0 && c.cluster.ClusterNetworks[0].Cidr != "")
+	return boolToValidationStatus(common.IsSliceNonEmpty(c.cluster.ClusterNetworks))
 }
 
 func (v *clusterValidator) printIsClusterCidrDefined(context *clusterPreprocessContext, status ValidationStatus) string {
@@ -137,7 +137,7 @@ func (v *clusterValidator) printIsClusterCidrDefined(context *clusterPreprocessC
 }
 
 func (v *clusterValidator) isServiceCidrDefined(c *clusterPreprocessContext) ValidationStatus {
-	return boolToValidationStatus(len(c.cluster.ServiceNetworks) > 0 && c.cluster.ServiceNetworks[0].Cidr != "")
+	return boolToValidationStatus(common.IsSliceNonEmpty(c.cluster.ServiceNetworks))
 }
 
 func (v *clusterValidator) printIsServiceCidrDefined(context *clusterPreprocessContext, status ValidationStatus) string {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
@@ -150,8 +151,42 @@ func GetNetworkCidrAttr(obj interface{}, fieldName string) []*string {
 	}
 
 	funk.ForEach(field, func(elem interface{}) {
-		addresses = append(addresses, swag.String(string(funk.Get(elem, "Cidr").(models.Subnet))))
+		address := funk.Get(elem, "Cidr")
+		if address != nil {
+			addresses = append(addresses, swag.String(string(address.(models.Subnet))))
+		}
 	})
 
 	return addresses
+}
+
+// IsSliceNonEmpty checks whether the provided slice is non-empty. The slice is assumed to be
+// non-empty if at least one of its elements contains a non-zero value for its respective type.
+// Examples:
+// - `[]*models.MachineNetwork{{Cidr: "5.5.0.0/24"}, {Cidr: "6.6.0.0/24"}}` - valid, as we are
+//   configuring two machine networks
+// - `[]*models.ClusterNetwork{}` - valid, as it means we are removing all the cluster networks
+//   that may have been currently configured
+// - `[]*models.MachineNetwork{{}}` - invalid, as it means that we are trying to configure
+//    a single machine network that is empty; a valid network contains at least a CIDR which is
+//    missing in this case
+// - `[]*models.MachineNetwork{{Cidr: ""}}` - invalid, as it means we are trying to configure
+//   a single machine network that has empty CIDR; a valid network should contain a non-empty
+//   CIDR
+// - `[]*models.ClusterNetwork{{HostPrefix: 0}}` - invalid, as it means we are trying to configure
+//   a single cluster network with host prefix with a value 0; this is not a valid subnet lenght
+func IsSliceNonEmpty(arg interface{}) bool {
+	res := false
+	if reflect.ValueOf(arg).Kind() == reflect.Slice {
+		funk.ForEach(arg, func(elem interface{}) {
+			v := reflect.ValueOf(elem)
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				res = res || !v.Field(i).IsZero()
+			}
+		})
+	}
+	return res
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -761,13 +761,13 @@ func selectClusterNetworkType(params *models.ClusterUpdateParams, cluster *commo
 		},
 	}
 
-	if len(params.ClusterNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.ClusterNetworks) {
 		clusterWithNewNetworks.ClusterNetworks = params.ClusterNetworks
 	}
-	if len(params.ServiceNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.ServiceNetworks) {
 		clusterWithNewNetworks.ServiceNetworks = params.ServiceNetworks
 	}
-	if len(params.MachineNetworks) > 0 {
+	if common.IsSliceNonEmpty(params.MachineNetworks) {
 		clusterWithNewNetworks.MachineNetworks = params.MachineNetworks
 	}
 

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -67,7 +67,7 @@ func GetConfiguredAddressFamilies(cluster *common.Cluster) (ipv4 bool, ipv6 bool
 }
 
 func IsMachineCidrAvailable(cluster *common.Cluster) bool {
-	return len(cluster.MachineNetworks) > 0
+	return common.IsSliceNonEmpty(cluster.MachineNetworks)
 }
 
 func GetMachineCidrById(cluster *common.Cluster, index int) string {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Rebased on top of https://github.com/openshift/assisted-service/pull/2553.

This PR adds backwards compatibility for the network configuration. Specifically, it cherry-picks 3 PRs:

* https://github.com/openshift/assisted-service/pull/2455
* https://github.com/openshift/assisted-service/pull/2485
* https://github.com/openshift/assisted-service/pull/2512

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Waiting for CI to do a full test run

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @mkowalski 
/cc @gamli75 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
