### PR TITLE
MGMT-7643: update ocp to 4.9 in operator/common

### DIFF
--- a/deploy/operator/common.sh
+++ b/deploy/operator/common.sh
@@ -31,10 +31,10 @@ if [ -z "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-}" ]; then
     export ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE=$(echo ${OPENSHIFT_VERSIONS} | jq -rc '[.[].release_image]|max')
 fi
 
-export ASSISTED_OPENSHIFT_VERSION="${ASSISTED_OPENSHIFT_VERSION:-openshift-v4.8.0}"
+export ASSISTED_OPENSHIFT_VERSION="${ASSISTED_OPENSHIFT_VERSION:-openshift-v4.9.0}"
 
 OPENSHIFT_VERSIONS=$(echo ${OPENSHIFT_VERSIONS} |
-    jq -rc 'with_entries(.key = "4.8") | with_entries(
+    jq -rc 'with_entries(select(.key != "4.6" and .key != "4.7")) | with_entries(
     {
         key: .key,
         value: {rhcos_image:   .value.rhcos_image,


### PR DESCRIPTION
# Assisted Pull Request

## Description

Updating '4.8' key since ocp 4.9 has been recently added to default_ocp_versions and we use 'max' release image in [common.sh](https://github.com/openshift/assisted-service/blob/7bc89fcbdb3cd412e40df1dc74a520f1a5bd5399/deploy/operator/common.sh#L31).

Note: the script should be refactored to use OS_IMAGES/RELEASE_IMAGES - will be handled as part of MGMT-7705.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @YuviGold 
/cc @osherdp
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
