### PR TITLE
MGMT-7633: Update CD controller to use V2 API

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -124,7 +124,7 @@ type OCPClusterAPI interface {
 type InstallerInternals interface {
 	RegisterClusterInternal(ctx context.Context, kubeKey *types.NamespacedName, params installer.V2RegisterClusterParams, v1Flag bool) (*common.Cluster, error)
 	GetClusterInternal(ctx context.Context, params installer.V2GetClusterParams) (*common.Cluster, error)
-	UpdateClusterNonInteractive(ctx context.Context, params installer.UpdateClusterParams) (*common.Cluster, error)
+	UpdateClusterNonInteractive(ctx context.Context, params installer.V2UpdateClusterParams) (*common.Cluster, error)
 	GenerateClusterISOInternal(ctx context.Context, params installer.GenerateClusterISOParams) (*common.Cluster, error)
 	UpdateDiscoveryIgnitionInternal(ctx context.Context, params installer.UpdateDiscoveryIgnitionParams) error
 	GetClusterByKubeKey(key types.NamespacedName) (*common.Cluster, error)
@@ -2079,8 +2079,8 @@ func (b *bareMetalInventory) V2UpdateCluster(ctx context.Context, params install
 	return installer.NewV2UpdateClusterCreated().WithPayload(&c.Cluster)
 }
 
-func (b *bareMetalInventory) UpdateClusterNonInteractive(ctx context.Context, params installer.UpdateClusterParams) (*common.Cluster, error) {
-	return b.updateClusterInternal(ctx, params, NonInteractive)
+func (b *bareMetalInventory) UpdateClusterNonInteractive(ctx context.Context, params installer.V2UpdateClusterParams) (*common.Cluster, error) {
+	return b.v2UpdateClusterInternal(ctx, params, NonInteractive)
 }
 
 func (b *bareMetalInventory) updateClusterInternal(ctx context.Context, v1Params installer.UpdateClusterParams, interactivity Interactivity) (*common.Cluster, error) {

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -383,7 +383,7 @@ func (mr *MockInstallerInternalsMockRecorder) UpdateClusterInstallConfigInternal
 }
 
 // UpdateClusterNonInteractive mocks base method.
-func (m *MockInstallerInternals) UpdateClusterNonInteractive(arg0 context.Context, arg1 installer.UpdateClusterParams) (*common.Cluster, error) {
+func (m *MockInstallerInternals) UpdateClusterNonInteractive(arg0 context.Context, arg1 installer.V2UpdateClusterParams) (*common.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateClusterNonInteractive", arg0, arg1)
 	ret0, _ := ret[0].(*common.Cluster)

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -457,7 +457,7 @@ func (r *ClusterDeploymentsReconciler) updateKubeConfigSecret(ctx context.Contex
 		return nil, getErr
 	}
 
-	respBody, _, err := r.Installer.DownloadClusterFilesInternal(ctx, installer.DownloadClusterFilesParams{
+	respBody, _, err := r.Installer.V2DownloadClusterCredentialsInternal(ctx, installer.V2DownloadClusterCredentialsParams{
 		ClusterID: *c.ID,
 		FileName:  constants.Kubeconfig,
 	})
@@ -485,7 +485,7 @@ func (r *ClusterDeploymentsReconciler) ensureKubeConfigNoIngressSecret(ctx conte
 	if getErr == nil || !k8serrors.IsNotFound(getErr) {
 		return s, getErr
 	}
-	respBody, _, err := r.Installer.DownloadClusterFilesInternal(ctx, installer.DownloadClusterFilesParams{
+	respBody, _, err := r.Installer.V2DownloadClusterCredentialsInternal(ctx, installer.V2DownloadClusterCredentialsParams{
 		ClusterID: *c.ID,
 		FileName:  constants.KubeconfigNoIngress,
 	})
@@ -622,7 +622,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	cluster *common.Cluster) (*common.Cluster, error) {
 
 	update := false
-	params := &models.ClusterUpdateParams{}
+	params := &models.V2ClusterUpdateParams{}
 
 	spec := clusterDeployment.Spec
 	updateString := func(new, old string, target **string) {
@@ -727,7 +727,8 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	}
 
 	var clusterAfterUpdate *common.Cluster
-	clusterAfterUpdate, err = r.Installer.UpdateClusterNonInteractive(ctx, installer.UpdateClusterParams{
+
+	clusterAfterUpdate, err = r.Installer.UpdateClusterNonInteractive(ctx, installer.V2UpdateClusterParams{
 		ClusterUpdateParams: params,
 		ClusterID:           *cluster.ID,
 	})
@@ -740,7 +741,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	return clusterAfterUpdate, nil
 }
 
-func selectClusterNetworkType(params *models.ClusterUpdateParams, cluster *common.Cluster) string {
+func selectClusterNetworkType(params *models.V2ClusterUpdateParams, cluster *common.Cluster) string {
 	clusterWithNewNetworks := &common.Cluster{
 		Cluster: models.Cluster{
 			ClusterNetworks: cluster.ClusterNetworks,

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1055,7 +1055,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 			kubeconfig := "kubeconfig content"
 			mockInstallerInternal.EXPECT().GetCredentialsInternal(gomock.Any(), gomock.Any()).Return(&models.Credentials{Password: "foo", Username: "bar"}, nil).Times(1)
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
@@ -1101,7 +1101,7 @@ var _ = Describe("cluster reconcile", func() {
 				Username: username,
 			}
 			mockInstallerInternal.EXPECT().GetCredentialsInternal(gomock.Any(), gomock.Any()).Return(cred, nil).Times(1)
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfigNoIngress)), int64(len(kubeconfigNoIngress)), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfigNoIngress)), int64(len(kubeconfigNoIngress)), nil).Times(1)
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
@@ -1116,7 +1116,7 @@ var _ = Describe("cluster reconcile", func() {
 			By("Call reconcile again to test update of Kubeconfig secret")
 			backEndCluster.Status = swag.String(models.ClusterStatusInstalled)
 			kubeconfigIngress := "kubeconfig content WITHINGRESS"
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfigIngress)), int64(len(kubeconfigIngress)), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfigIngress)), int64(len(kubeconfigIngress)), nil).Times(1)
 			result, err = cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -1144,7 +1144,7 @@ var _ = Describe("cluster reconcile", func() {
 				Username: username,
 			}
 			mockInstallerInternal.EXPECT().GetCredentialsInternal(gomock.Any(), gomock.Any()).Return(cred, nil).Times(1)
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader(kubeconfig)), int64(len(kubeconfig)), nil).Times(1)
 			aci.Spec.ProvisionRequirements.WorkerAgents = 0
 			aci.Spec.ProvisionRequirements.ControlPlaneAgents = 1
 			cluster.Spec.BaseDomain = "hive.example.com"
@@ -1245,7 +1245,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetCredentialsInternal(gomock.Any(), gomock.Any()).Return(cred, nil).Times(1)
 			expectedErr := "internal error"
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(nil, int64(0), errors.New(expectedErr)).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(nil, int64(0), errors.New(expectedErr)).Times(1)
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
 			Expect(err).To(BeNil())
@@ -1788,7 +1788,7 @@ var _ = Describe("cluster reconcile", func() {
 				PullSecret: testPullSecretVal,
 			}
 			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, param installer.UpdateClusterParams) {
+				Do(func(ctx context.Context, param installer.V2UpdateClusterParams) {
 					Expect(swag.StringValue(param.ClusterUpdateParams.PullSecret)).To(Equal(testPullSecretVal))
 					Expect(swag.StringValue(param.ClusterUpdateParams.Name)).To(Equal(defaultClusterSpec.ClusterName))
 					Expect(string(param.ClusterUpdateParams.ClusterNetworks[0].Cidr)).
@@ -1874,7 +1874,7 @@ var _ = Describe("cluster reconcile", func() {
 						updateReply.MachineNetworks = machineNetworksEntriesToArray(test.expectedMachineNetworks)
 
 						mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
-							Do(func(ctx context.Context, param installer.UpdateClusterParams) {
+							Do(func(ctx context.Context, param installer.V2UpdateClusterParams) {
 								Expect(param.ClusterUpdateParams.MachineNetworks).Should(
 									Equal(machineNetworksEntriesToArray(test.expectedMachineNetworks)))
 							}).Return(updateReply, nil)
@@ -2202,7 +2202,7 @@ var _ = Describe("cluster reconcile", func() {
 				PullSecret: testPullSecretVal,
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader("kubeconfig")), int64(len("kubeconfig")), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader("kubeconfig")), int64(len("kubeconfig")), nil).Times(1)
 
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
@@ -2241,7 +2241,7 @@ var _ = Describe("cluster reconcile", func() {
 				PullSecret: testPullSecretVal,
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-			mockInstallerInternal.EXPECT().DownloadClusterFilesInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader("kubeconfig")), int64(len("kubeconfig")), nil).Times(1)
+			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(ioutil.NopCloser(strings.NewReader("kubeconfig")), int64(len("kubeconfig")), nil).Times(1)
 
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
@@ -2648,7 +2648,7 @@ var _ = Describe("selectClusterNetworkType", func() {
 	for i := range tests {
 		t := tests[i]
 		It("getNetworkType", func() {
-			ClusterUpdateParams := &models.ClusterUpdateParams{
+			ClusterUpdateParams := &models.V2ClusterUpdateParams{
 				ServiceNetworks: t.paramServiceNetworks,
 			}
 


### PR DESCRIPTION

# Assisted Pull Request

## Description

Updates:
- UpdateClusterNonInteractive
- DownloadClusterFilesInternal to V2DownloadClusterCredentials. Not using v2DownloadClusterFilesInternal
  since the controller used the v1 DownloadClusterFilesInternal for kubeconfig.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @yevgeny-shnaidman 
/cc @filanov 
/cc @rollandf 
 
## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
