### PR TITLE
Bug 2001973: Add more validations for Disk Encryption settings

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -8825,6 +8825,80 @@ var _ = Describe("TestRegisterCluster", func() {
 			verifyApiErrorString(reply, http.StatusBadRequest, "Tang thumbprint isn't set")
 		})
 
+		It("Disabling with specifying mode", func() {
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					DiskEncryption: &models.DiskEncryption{
+						EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+						Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+					},
+				},
+			})
+			verifyApiErrorString(reply, http.StatusBadRequest, "Disabling encryption with specifying mode")
+		})
+
+		It("Specifying mode without state", func() {
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					DiskEncryption: &models.DiskEncryption{
+						Mode: swag.String(models.DiskEncryptionModeTpmv2),
+					},
+				},
+			})
+			verifyApiErrorString(reply, http.StatusBadRequest, "Setting encryption mode without enabling")
+		})
+
+		It("Enabling with explicit TPMv2 mode", func() {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					DiskEncryption: &models.DiskEncryption{
+						EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+						Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+					},
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.DiskEncryption.EnableOn).To(Equal(swag.String(models.DiskEncryptionEnableOnAll)))
+			Expect(actual.Payload.DiskEncryption.Mode).To(Equal(swag.String(models.DiskEncryptionModeTpmv2)))
+		})
+
+		It("Enabling with default TPMv2 mode", func() {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					DiskEncryption: &models.DiskEncryption{
+						EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+					},
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.DiskEncryption.EnableOn).To(Equal(swag.String(models.DiskEncryptionEnableOnAll)))
+			Expect(actual.Payload.DiskEncryption.Mode).To(Equal(swag.String(models.DiskEncryptionModeTpmv2)))
+		})
+
+		It("Disabling", func() {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
+			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					DiskEncryption: &models.DiskEncryption{
+						EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+					},
+				},
+			})
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.DiskEncryption.EnableOn).To(Equal(swag.String(models.DiskEncryptionEnableOnNone)))
+		})
+
 	})
 
 	Context("NTPSource", func() {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -396,11 +396,27 @@ func ValidateIPAddressFamily(ipV6Supported bool, elements ...*string) error {
 	return nil
 }
 
+// ValidateDiskEncryptionParams performs basic sanity checks for the disk encryption configuration
+// using the following set of rules
+//   * whenever a change happens, the whole DiskEncryption structure has to be provided
+//   * setting the encryption mode is allowed only when the encryption is enabled
+//   * setting the encryption mode is forbidden when the encryption is disabled
+//   * tang servers cannot be empty if tang mode is used
 func ValidateDiskEncryptionParams(diskEncryptionParams *models.DiskEncryption) error {
 	if diskEncryptionParams == nil {
 		return nil
 	}
-	if *diskEncryptionParams.Mode == models.DiskEncryptionModeTang {
+	// Check that mode is set only when the encryption is explicitly enabled
+	if diskEncryptionParams.Mode != nil && diskEncryptionParams.EnableOn == nil {
+		return errors.New("Setting encryption mode without enabling")
+	}
+	// Check that mode is unset if encryption is disabled
+	if (diskEncryptionParams.EnableOn == nil || diskEncryptionParams.EnableOn != nil &&
+		*diskEncryptionParams.EnableOn == models.DiskEncryptionEnableOnNone) &&
+		diskEncryptionParams.Mode != nil {
+		return errors.New("Disabling encryption with specifying mode")
+	}
+	if diskEncryptionParams.Mode != nil && *diskEncryptionParams.Mode == models.DiskEncryptionModeTang {
 		if diskEncryptionParams.TangServers == "" {
 			return errors.New("Setting Tang mode but tang_servers isn't set")
 		}


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR adds more validations when setting parameters configuring disk
encryption. It ensures that whenever the user enables encryption the
mode is also being set, as well as ensures that disabling the encryption
must not contain an encryption mode in the payload.

Closes: [OCPBUGSM-34496](https://issues.redhat.com/browse/OCPBUGSM-34496)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
