### PR TITLE
MGMT-4475: add operators host criteria to canBeMaster

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1098,10 +1098,11 @@ func (m *Manager) IsValidMasterCandidate(h *models.Host, c *common.Cluster, db *
 }
 
 func (m *Manager) canBeMaster(conditions map[string]bool) bool {
-	if conditions[HasCPUCoresForRole.String()] && conditions[HasMemoryForRole.String()] {
-		return true
-	}
-	return false
+	return conditions[HasCPUCoresForRole.String()] &&
+		conditions[HasMemoryForRole.String()] &&
+		conditions[AreLsoRequirementsSatisfied.String()] &&
+		conditions[AreOcsRequirementsSatisfied.String()] &&
+		conditions[AreCnvRequirementsSatisfied.String()]
 }
 
 func (m *Manager) GetHostValidDisks(host *models.Host) ([]*models.Disk, error) {


### PR DESCRIPTION
# Assisted Pull Request

## Description

add operators host criteria to canBeMaster. Now it also takes into account the operator's ValidateHost() results
## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
