### PR TITLE
MGMT-7768: Handle Host's Kind field during bind/unbind/register

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -215,6 +215,9 @@ func (m *Manager) RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB)
 		host = h
 	} else {
 		host = &dbHost.Host
+		if h != nil {
+			host.Kind = h.Kind
+		}
 	}
 
 	return m.sm.Run(TransitionTypeRegisterHost, newStateHost(host), &TransitionArgsRegisterHost{

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1597,6 +1597,7 @@ var _ = Describe("Unbind host", func() {
 			Expect(reply).To(BeNil())
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.ClusterID).To(BeNil())
+			Expect(swag.StringValue(h.Kind)).To(Equal(models.HostKindHost))
 		}
 
 		failure := func(reply error) {
@@ -1608,6 +1609,7 @@ var _ = Describe("Unbind host", func() {
 		tests := []struct {
 			name       string
 			srcState   string
+			kind       *string
 			validation func(error)
 		}{
 			{
@@ -1658,6 +1660,7 @@ var _ = Describe("Unbind host", func() {
 			{
 				name:       models.HostStatusInsufficient,
 				srcState:   models.HostStatusInsufficient,
+				kind:       swag.String(models.HostKindAddToExistingClusterHost),
 				validation: success,
 			},
 			{
@@ -1702,6 +1705,9 @@ var _ = Describe("Unbind host", func() {
 			It(t.name, func() {
 				mockEvents.EXPECT().AddEvent(gomock.Any(), infraEnvId, &hostId, models.EventSeverityInfo, gomock.Any(), gomock.Any()).Times(1)
 				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
+				if t.kind != nil {
+					host.Kind = t.kind
+				}
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				t.validation(hapi.UnbindHost(ctx, &host, db))
 			})

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -368,7 +368,7 @@ func (th *transitionHandler) PostUnbindHost(sw stateswitch.StateSwitch, args sta
 		return errors.New("PostUnbindHost invalid argument")
 	}
 
-	extra := append(resetFields[:], "cluster_id", nil)
+	extra := append(resetFields[:], "cluster_id", nil, "kind", swag.String(models.HostKindHost))
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, statusInfoUnbinding,
 		extra...)
 }

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -232,22 +232,37 @@ var _ = Describe("RegisterHost", func() {
 		tests := []struct {
 			name     string
 			srcState string
+			kind     string
 		}{
 			{
 				name:     "discovering",
 				srcState: models.HostStatusDiscovering,
+				kind:     models.HostKindHost,
 			},
 			{
 				name:     "insufficient",
 				srcState: models.HostStatusInsufficient,
+				kind:     models.HostKindHost,
 			},
 			{
 				name:     "disconnected",
 				srcState: models.HostStatusDisconnected,
+				kind:     models.HostKindHost,
 			},
 			{
 				name:     "known",
 				srcState: models.HostStatusKnown,
+				kind:     models.HostKindHost,
+			},
+			{
+				name:     "binding day1",
+				srcState: models.HostStatusBinding,
+				kind:     models.HostKindHost,
+			},
+			{
+				name:     "binding day2",
+				srcState: models.HostStatusBinding,
+				kind:     models.HostKindAddToExistingClusterHost,
 			},
 		}
 
@@ -277,6 +292,7 @@ var _ = Describe("RegisterHost", func() {
 					Inventory:  defaultHwInfo,
 					Status:     swag.String(t.srcState),
 					Bootstrap:  true,
+					Kind:       swag.String(t.kind),
 					Progress: &models.HostProgressInfo{
 						CurrentStage: common.TestDefaultConfig.HostProgressStage,
 						ProgressInfo: "some info",
@@ -298,6 +314,8 @@ var _ = Describe("RegisterHost", func() {
 					DiscoveryAgentVersion: discoveryAgentVersion,
 				},
 					db)).ShouldNot(HaveOccurred())
+				h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
+				Expect(swag.StringValue(h.Kind)).To(Equal(t.kind))
 			})
 		}
 	})


### PR DESCRIPTION
Host kind is set during Register operation. In case host already exists in DB,
the value stored in the DB is the one that is stored after register. Since host can be bound
to day2 cluster, unbound abd then bound again to day1 cluster we need to reset during unbind
operation. We also need to set the Kind based on the cluster, which is set during Register.
We must propagate this value into the host already stored on DB

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
