### PR TITLE
OCPBUGSM-34323: Use the hostname in the Spec if present

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -474,7 +474,11 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 	}
 
 	// Add hostname
-	hardwareDetails.Hostname = inventory.Hostname
+	if agent.Spec.Hostname != "" {
+		hardwareDetails.Hostname = agent.Spec.Hostname
+	} else {
+		hardwareDetails.Hostname = inventory.Hostname
+	}
 
 	bytes, err := json.Marshal(hardwareDetails)
 	if err != nil {


### PR DESCRIPTION
# Assisted Pull Request

## Description

The agent has two fields for the Hostname: Spec.Hostname and
Status.Inventory.Hostname.

The former is the one provided to the agent, the desired hostname. The
latter is the hostname discovered. The discovered hostname is sent
*before* the node's hostname is set. Relying solely on the discovered
hostname may cause inconsistencies when the desired hostname is
different from the discovered one.

Use the desired hostname (assuming the agent will succeed when setting
it) if present, otherwise rely on the discovered one.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Test based on unit-test and in @alknopfler environment

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pawanpinjarkar 
/cc @djzager 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [x] Are the title and description (in both PR and commit) meaningful and clear?
- [x] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
