### PR TITLE
MGMT-4475: validations to consider effective role

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -144,7 +144,7 @@ func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, er
 
 	allowedStatuses := []string{models.HostStatusKnown, models.HostStatusPreparingForInstallation}
 	for _, host := range cluster.Hosts {
-		if host.Role == models.HostRoleMaster && funk.ContainsString(allowedStatuses, swag.StringValue(host.Status)) {
+		if common.GetEffectiveRole(host) == models.HostRoleMaster && funk.ContainsString(allowedStatuses, swag.StringValue(host.Status)) {
 			masterNodesIds = append(masterNodesIds, host.ID)
 		}
 	}
@@ -154,7 +154,7 @@ func getKnownMastersNodesIds(c *common.Cluster, db *gorm.DB) ([]*strfmt.UUID, er
 func NumberOfWorkers(c *common.Cluster) int {
 	num := 0
 	for _, host := range c.Hosts {
-		if host.Role != models.HostRoleWorker || *host.Status == models.HostStatusDisabled {
+		if common.GetEffectiveRole(host) != models.HostRoleWorker || *host.Status == models.HostStatusDisabled {
 			continue
 		}
 		num += 1
@@ -173,7 +173,7 @@ func MapWorkersHostsByStatus(c *common.Cluster) map[string][]*models.Host {
 func mapHostsByStatus(c *common.Cluster, role models.HostRole) map[string][]*models.Host {
 	hostMap := make(map[string][]*models.Host)
 	for _, host := range c.Hosts {
-		if role != "" && host.Role != role {
+		if role != "" && common.GetEffectiveRole(host) != role {
 			continue
 		}
 		if _, ok := hostMap[swag.StringValue(host.Status)]; ok {

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -380,12 +380,12 @@ func (v *clusterValidator) sufficientMastersCount(c *clusterPreprocessContext) V
 	candidates := make([]*models.Host, 0)
 
 	for _, host := range hosts {
-		switch role := host.Role; role {
+		switch role := common.GetEffectiveRole(host); role {
 		case models.HostRoleMaster:
-			//add pre-assigned master hosts to the masters list
+			//add pre-assigned/suggested master hosts to the masters list
 			masters = append(masters, host)
 		case models.HostRoleWorker:
-			//add pre-assigned worker hosts to the worker list
+			//add pre-assigned/suggested worker hosts to the worker list
 			workers = append(workers, host)
 		default:
 			//auto-assign hosts and other types go to the candidate list
@@ -397,7 +397,8 @@ func (v *clusterValidator) sufficientMastersCount(c *clusterPreprocessContext) V
 		//if allocated masters count is less than the desired count, find eligable hosts
 		//from the candidate pool to match the master count criteria, up to 3
 		if len(masters) < minMastersNeededForInstallation {
-			if isValid, err := v.hostAPI.IsValidMasterCandidate(h, c.cluster, c.db, v.log); isValid && err == nil {
+			candidate := *h
+			if isValid, err := v.hostAPI.IsValidMasterCandidate(&candidate, c.cluster, c.db, v.log); isValid && err == nil {
 				masters = append(masters, h)
 				continue
 			}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -99,6 +99,13 @@ func AreMastersSchedulable(cluster *Cluster) bool {
 	return swag.BoolValue(cluster.SchedulableMasters)
 }
 
+func GetEffectiveRole(host *models.Host) models.HostRole {
+	if host.Role == models.HostRoleAutoAssign && host.SuggestedRole != "" {
+		return host.SuggestedRole
+	}
+	return host.Role
+}
+
 func GetConsoleUrl(clusterName, baseDomain string) string {
 	return fmt.Sprintf("%s.%s.%s", consoleUrlPrefix, clusterName, baseDomain)
 }

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -168,7 +168,7 @@ func (v *validator) GetClusterHostRequirements(ctx context.Context, cluster *com
 		return nil, err
 	}
 
-	ocpRequirements, err := v.getOCPClusterHostRoleRequirementsForVersion(cluster, host.Role)
+	ocpRequirements, err := v.getOCPClusterHostRoleRequirementsForVersion(cluster, common.GetEffectiveRole(host))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -100,7 +100,7 @@ func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, su
 		*h.ID, h.InfraEnvID, srcRole).Updates(fields).Error
 }
 
-func GetHostnameAndRoleByIP(ip string, hosts []*models.Host) (string, models.HostRole, error) {
+func GetHostnameAndEffectiveRoleByIP(ip string, hosts []*models.Host) (string, models.HostRole, error) {
 	for _, h := range hosts {
 		if h.Inventory == "" {
 			continue
@@ -117,7 +117,7 @@ func GetHostnameAndRoleByIP(ip string, hosts []*models.Host) (string, models.Hos
 					return "", "", err
 				}
 				if ip == parsedIP.String() {
-					return getRealHostname(h, inv), h.Role, nil
+					return getRealHostname(h, inv), common.GetEffectiveRole(h), nil
 				}
 			}
 		}

--- a/internal/host/common_test.go
+++ b/internal/host/common_test.go
@@ -18,7 +18,7 @@ type hostNetProfile struct {
 	ip       string
 }
 
-var _ = Describe("GetHostnameAndRoleByIP", func() {
+var _ = Describe("GetHostnameAndEffectiveRoleByIP", func() {
 
 	hostRolesIpv4 := []hostNetProfile{{role: models.HostRoleMaster, hostname: "master-0", ip: "1.2.3.1"}, {role: models.HostRoleWorker, hostname: "worker-0", ip: "1.2.3.2"}}
 	hostrolesIpv6 := []hostNetProfile{{role: models.HostRoleMaster, hostname: "master-1", ip: "1001:db8::11"}, {role: models.HostRoleWorker, hostname: "worker-1", ip: "1001:db8::12"}}
@@ -80,7 +80,7 @@ var _ = Describe("GetHostnameAndRoleByIP", func() {
 					h := hostutil.GenerateTestHostWithNetworkAddress(strfmt.UUID(uuid.New().String()), infraEnvID, clusterID, v.role, models.HostStatusKnown, netAddr)
 					hosts = append(hosts, h)
 				}
-				hostname, role, err := GetHostnameAndRoleByIP(test.targetIP, hosts)
+				hostname, role, err := GetHostnameAndEffectiveRoleByIP(test.targetIP, hosts)
 				if test.expectedError != nil {
 					Expect(err).To(Equal(test.expectedError))
 				} else {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -41,6 +41,7 @@ var (
 	defaultConfig                  = &Config{
 		ResetTimeout:            3 * time.Minute,
 		EnableAutoReset:         true,
+		EnableAutoAssign:        true,
 		MonitorBatchSize:        100,
 		DisabledHostvalidations: defaultDisabledHostValidations,
 	}

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -102,7 +102,7 @@ func (i *installCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models
 }
 
 func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *models.Host, infraEnv *common.InfraEnv, bootdevice string) (string, error) {
-	role := host.Role
+	role := common.GetEffectiveRole(host)
 	if host.Bootstrap {
 		role = models.HostRoleBootstrap
 	}

--- a/internal/host/hostcommands/logs_cmd.go
+++ b/internal/host/hostcommands/logs_cmd.go
@@ -125,7 +125,7 @@ func (i *logsCmd) getNonBootstrapMastersIPsInHostCluster(ctx context.Context, ho
 func (i *logsCmd) getHostsIpsfromMachineCIDR(cluster common.Cluster) ([]string, error) {
 	var ips []string
 	for _, h := range cluster.Hosts {
-		if h.Bootstrap || h.Role == models.HostRoleWorker {
+		if h.Bootstrap || common.GetEffectiveRole(h) == models.HostRoleWorker {
 			continue
 		}
 		ip, err := network.GetPrimaryMachineCIDRIP(h, &cluster)

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -144,7 +144,7 @@ func GetDiskByInstallationPath(disks []*models.Disk, installationPath string) *m
 }
 
 func IgnitionFileName(host *models.Host) string {
-	return fmt.Sprintf("%s-%s.ign", host.Role, host.ID)
+	return fmt.Sprintf("%s-%s.ign", common.GetEffectiveRole(host), host.ID)
 }
 
 var allowedFlags = []string{"--append-karg", "--delete-karg", "-n", "--copy-network", "--network-dir", "--save-partlabel", "--save-partindex", "--image-url"}

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -295,6 +295,20 @@ func (mr *MockAPIMockRecorder) RefreshInventory(arg0, arg1, arg2, arg3 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshInventory", reflect.TypeOf((*MockAPI)(nil).RefreshInventory), arg0, arg1, arg2, arg3)
 }
 
+// RefreshRole mocks base method.
+func (m *MockAPI) RefreshRole(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshRole", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshRole indicates an expected call of RefreshRole.
+func (mr *MockAPIMockRecorder) RefreshRole(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshRole", reflect.TypeOf((*MockAPI)(nil).RefreshRole), arg0, arg1, arg2)
+}
+
 // RefreshStatus mocks base method.
 func (m *MockAPI) RefreshStatus(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
 	m.ctrl.T.Helper()

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -80,6 +80,13 @@ func (m *Manager) clusterHostMonitoring() int64 {
 					if err != nil {
 						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
 					}
+					//the refreshed role will be taken into account
+					//on the next monitor cycle. The force flag is a workaround
+					//until the feature flag is removed
+					err = m.refreshRoleInternal(ctx, host, m.db, false)
+					if err != nil {
+						log.WithError(err).Errorf("failed to refresh host %s role", *host.ID)
+					}
 				}
 			}
 		}

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2833,7 +2833,7 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected: false,
 			},
 			{
-				name:             "disconnected to insufficient (1)",
+				name:             "disconnected to insufficient - auto-assign casted as worker (1)",
 				role:             models.HostRoleAutoAssign,
 				validCheckInTime: true,
 				srcState:         models.HostStatusDisconnected,
@@ -2842,7 +2842,7 @@ var _ = Describe("Refresh Host", func() {
 					"Machine Network CIDR is undefined; the Machine Network CIDR can be defined by setting either the API or Ingress virtual IPs",
 					"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is 8.00 GiB, found only 130 bytes",
 					"Require a disk of at least 120 GB",
-					"Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes",
+					"Require at least 8.00 GiB RAM for role worker, found only 130 bytes",
 					"Host couldn't synchronize with any NTP server")),
 				inventory: insufficientHWInventory(),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
@@ -2852,8 +2852,8 @@ var _ = Describe("Refresh Host", func() {
 					HasMinMemory:                   {status: ValidationFailure, messagePattern: "The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is 8.00 GiB, found only 130 bytes"},
 					HasMinValidDisks:               {status: ValidationFailure, messagePattern: "Require a disk of at least 120 GB"},
 					IsMachineCidrDefined:           {status: ValidationFailure, messagePattern: "Machine Network CIDR is undefined"},
-					HasCPUCoresForRole:             {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role auto-assign"},
-					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes"},
+					HasCPUCoresForRole:             {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role worker, found only 130 bytes"},
 					IsHostnameUnique:               {status: ValidationSuccess, messagePattern: "Hostname  is unique in cluster"},
 					BelongsToMachineCidr:           {status: ValidationPending, messagePattern: "Missing inventory or machine network CIDR"},
 					IsPlatformNetworkSettingsValid: {status: ValidationSuccess, messagePattern: "Platform RHEL is allowed"},
@@ -2874,7 +2874,7 @@ var _ = Describe("Refresh Host", func() {
 					"Machine Network CIDR is undefined; the Machine Network CIDR can be defined by setting either the API or Ingress virtual IPs",
 					"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is 8.00 GiB, found only 130 bytes",
 					"Require a disk of at least 120 GB",
-					"Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes",
+					"Require at least 8.00 GiB RAM for role worker, found only 130 bytes",
 					"Host couldn't synchronize with any NTP server")),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
 					IsConnected:                    {status: ValidationSuccess, messagePattern: "Host is connected"},
@@ -2883,8 +2883,8 @@ var _ = Describe("Refresh Host", func() {
 					HasMinMemory:                   {status: ValidationFailure, messagePattern: "The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is 8.00 GiB, found only 130 bytes"},
 					HasMinValidDisks:               {status: ValidationFailure, messagePattern: "Require a disk of at least 120 GB"},
 					IsMachineCidrDefined:           {status: ValidationFailure, messagePattern: "Machine Network CIDR is undefined"},
-					HasCPUCoresForRole:             {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role auto-assign"},
-					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes"},
+					HasCPUCoresForRole:             {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role worker, found only 130 bytes"},
 					IsHostnameUnique:               {status: ValidationSuccess, messagePattern: "Hostname  is unique in cluster"},
 					BelongsToMachineCidr:           {status: ValidationPending, messagePattern: "Missing inventory or machine network CIDR"},
 					IsPlatformNetworkSettingsValid: {status: ValidationSuccess, messagePattern: "Platform RHEL is allowed"},
@@ -2897,7 +2897,7 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected: false,
 			},
 			{
-				name:             "discovering to insufficient (1)",
+				name:             "discovering to insufficient - auto-assign casted as worker (1)",
 				role:             models.HostRoleAutoAssign,
 				validCheckInTime: true,
 				srcState:         models.HostStatusDiscovering,
@@ -2906,7 +2906,7 @@ var _ = Describe("Refresh Host", func() {
 					"Machine Network CIDR is undefined; the Machine Network CIDR can be defined by setting either the API or Ingress virtual IPs",
 					"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for any role is 8.00 GiB, found only 130 bytes",
 					"Require a disk of at least 120 GB",
-					"Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes",
+					"Require at least 8.00 GiB RAM for role worker, found only 130 bytes",
 					"Host couldn't synchronize with any NTP server")),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
 					IsConnected:                    {status: ValidationSuccess, messagePattern: "Host is connected"},
@@ -2916,7 +2916,7 @@ var _ = Describe("Refresh Host", func() {
 					HasMinValidDisks:               {status: ValidationFailure, messagePattern: "Require a disk of at least 120 GB"},
 					IsMachineCidrDefined:           {status: ValidationFailure, messagePattern: "Machine Network CIDR is undefined"},
 					HasCPUCoresForRole:             {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role"},
-					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes"},
+					HasMemoryForRole:               {status: ValidationFailure, messagePattern: "Require at least 8.00 GiB RAM for role worker, found only 130 bytes"},
 					IsHostnameUnique:               {status: ValidationSuccess, messagePattern: "Hostname  is unique in cluster"},
 					BelongsToMachineCidr:           {status: ValidationPending, messagePattern: "Missing inventory or machine network CIDR"},
 					IsPlatformNetworkSettingsValid: {status: ValidationSuccess, messagePattern: "Platform RHEL is allowed"},
@@ -2939,7 +2939,7 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected:     true,
 			},
 			{
-				name:             "known to insufficient (1)",
+				name:             "known to insufficient - auto-assign casted as worker (1)",
 				role:             models.HostRoleAutoAssign,
 				validCheckInTime: true,
 				srcState:         models.HostStatusKnown,
@@ -2947,7 +2947,7 @@ var _ = Describe("Refresh Host", func() {
 				statusInfoChecker: makeValueChecker("Host does not meet the minimum hardware requirements: " +
 					"Host couldn't synchronize with any NTP server ; Machine Network CIDR is undefined; the Machine " +
 					"Network CIDR can be defined by setting either the API or Ingress virtual IPs ; Require a disk of at " +
-					"least 120 GB ; Require at least 8.00 GiB RAM for role auto-assign, found only 130 bytes ; " +
+					"least 120 GB ; Require at least 8.00 GiB RAM for role worker, found only 130 bytes ; " +
 					"The host is not eligible to participate in Openshift Cluster because the minimum required RAM for " +
 					"any role is 8.00 GiB, found only 130 bytes"),
 				inventory:     insufficientHWInventory(),

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -967,7 +967,7 @@ func sortHosts(hosts []*models.Host) ([]*models.Host, []*models.Host) {
 		switch {
 		case hosts[i].Status != nil && *hosts[i].Status == models.HostStatusDisabled:
 			continue
-		case hosts[i].Role == models.HostRoleMaster:
+		case common.GetEffectiveRole(hosts[i]) == models.HostRoleMaster:
 			masters = append(masters, hosts[i])
 		default:
 			workers = append(workers, hosts[i])

--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -44,7 +44,7 @@ func NewInstallConfigBuilder(
 func (i *installConfigBuilder) countHostsByRole(cluster *common.Cluster, role models.HostRole) int {
 	var count int
 	for _, host := range cluster.Hosts {
-		if swag.StringValue(host.Status) != models.HostStatusDisabled && host.Role == role {
+		if swag.StringValue(host.Status) != models.HostStatusDisabled && common.GetEffectiveRole(host) == role {
 			count += 1
 		}
 	}

--- a/internal/operators/ocs/ocs_operator.go
+++ b/internal/operators/ocs/ocs_operator.go
@@ -145,13 +145,14 @@ func (o *operator) GetHostRequirements(_ context.Context, cluster *common.Cluste
 		diskCount, _ = o.getValidDiskCount(inventory.Disks, host.InstallationDiskID)
 	}
 
+	role := common.GetEffectiveRole(host)
 	if numOfHosts <= 3 { // Compact Mode
 		var reqDisks int64 = 1
 		if diskCount > 0 {
 			reqDisks = diskCount
 		}
 		// for each disk ocs requires 2 CPUs and 5 GiB RAM
-		if host.Role == models.HostRoleMaster || host.Role == models.HostRoleAutoAssign {
+		if role == models.HostRoleMaster || role == models.HostRoleAutoAssign {
 			return &models.ClusterHostRequirementsDetails{
 				CPUCores: o.config.OCSPerHostCPUCompactMode + (reqDisks * o.config.OCSPerDiskCPUCount),
 				RAMMib:   conversions.GibToMib(o.config.OCSPerHostMemoryGiBCompactMode + (reqDisks * o.config.OCSPerDiskRAMGiB)),
@@ -165,7 +166,7 @@ func (o *operator) GetHostRequirements(_ context.Context, cluster *common.Cluste
 	}
 
 	// In standard mode, OCS does not run on master nodes so return zero
-	if host.Role == models.HostRoleMaster {
+	if role == models.HostRoleMaster {
 		return &models.ClusterHostRequirementsDetails{CPUCores: 0, RAMMib: 0}, nil
 	}
 

--- a/internal/operators/ocs/ocs_operator_test.go
+++ b/internal/operators/ocs/ocs_operator_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Ocs Operator", func() {
 					{SizeBytes: 40 * conversions.GB, DriveType: "SSD", ID: diskID2},
 					{SizeBytes: 20 * conversions.GB, DriveType: "SSD", ID: diskID2},
 				}})}
-		autoAssignHost = &models.Host{Role: models.HostRoleAutoAssign, InstallationDiskID: diskID1,
+		autoAssignHost = &models.Host{Role: models.HostRoleAutoAssign, SuggestedRole: models.HostRoleAutoAssign, InstallationDiskID: diskID1,
 			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 32 * conversions.GiB,
 				Disks: []*models.Disk{
 					{SizeBytes: 20 * conversions.GB, DriveType: "HDD", ID: diskID1},

--- a/internal/operators/ocs/validations.go
+++ b/internal/operators/ocs/validations.go
@@ -75,13 +75,14 @@ func (o *operator) computeResourcesAllNodes(cluster *models.Cluster, ocsClusterR
 		As OCS will use only worker nodes for non-compact deployments, the OCS validations cannot be performed as it cannot know which nodes will be worker nodes.
 		We ignore the role check for a cluster of 3 nodes as they will all be master nodes. OCS validations will proceed as for a compact deployment.
 		*/
+		role := common.GetEffectiveRole(host)
 		if !compactMode {
-			if host.Role == models.HostRoleAutoAssign {
+			if role == models.HostRoleAutoAssign {
 				status = "For OCS Standard Mode, all host roles must be assigned to master or worker."
 				err = errors.New("Role is set to auto-assign for host ")
 				return status, err
 			}
-			if host.Role == models.HostRoleWorker {
+			if role == models.HostRoleWorker {
 				status, err = o.computeNodeResourceUtil(host, ocsClusterResources)
 				if err != nil {
 					return status, err

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -3953,7 +3953,7 @@ var _ = Describe("disk encryption", func() {
 		waitForInstallationPreparationCompletionStatus(*c.ID, common.InstallationPreparationSucceeded)
 	})
 
-	It("host doesn't have minimal requirementes for disk-encryption, TPM mode", func() {
+	It("host doesn't have minimal requirements for disk-encryption, TPM mode", func() {
 
 		h := &registerHost(*c.ID).Host
 		nonValidTPMHwInfo := &models.Inventory{
@@ -3974,6 +3974,7 @@ var _ = Describe("disk encryption", func() {
 			TpmVersion:   models.InventoryTpmVersionNr12,
 		}
 		generateEssentialHostStepsWithInventory(ctx, h, "test-host", nonValidTPMHwInfo)
+		time.Sleep(60 * time.Second)
 		waitForHostState(ctx, *c.ID, models.HostStatusInsufficient, 60*time.Second, h)
 
 		h = getHost(*c.ID, *h.ID)


### PR DESCRIPTION
# Assisted Pull Request

## Description

  - role based validations now takes into account the
     suggested role in case of auto-assign. This results
     in timely failures in case the role to be assigned
     is incompatible with the validation's logic

  - role evaluation is now being done in its own function
    within the monitoring instead of in RefreshStatus

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
