### PR TITLE
MGMT-7728: Add NTP configuration to ISO

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5407,13 +5407,15 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 		}
 	}
 
-	if params.InfraenvCreateParams.AdditionalNtpSources != &b.Config.DefaultNTPSource {
+	if params.InfraenvCreateParams.AdditionalNtpSources != nil && swag.StringValue(params.InfraenvCreateParams.AdditionalNtpSources) != b.Config.DefaultNTPSource {
 		ntpSource := swag.StringValue(params.InfraenvCreateParams.AdditionalNtpSources)
 
 		if ntpSource != "" && !validations.ValidateAdditionalNTPSource(ntpSource) {
 			err = errors.Errorf("Invalid NTP source: %s", ntpSource)
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}
+	} else {
+		params.InfraenvCreateParams.AdditionalNtpSources = swag.String(b.Config.DefaultNTPSource)
 	}
 
 	osImage, err := b.getOsImageOrLatest(params.InfraenvCreateParams.OpenshiftVersion, params.InfraenvCreateParams.CPUArchitecture)

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -113,11 +113,11 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusCancelled:            {[]CommandGetter{stopCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 		},
 		poolHostToSteps: stateToStepsMap{
-			models.HostStatusDiscoveringUnbound:  {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
+			models.HostStatusDiscoveringUnbound:  {[]CommandGetter{inventoryCmd, ntpSynchronizerCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusDisconnectedUnbound: {[]CommandGetter{inventoryCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusDisabledUnbound:     {[]CommandGetter{}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
-			models.HostStatusInsufficientUnbound: {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
-			models.HostStatusKnownUnbound:        {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
+			models.HostStatusInsufficientUnbound: {[]CommandGetter{inventoryCmd, ntpSynchronizerCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
+			models.HostStatusKnownUnbound:        {[]CommandGetter{inventoryCmd, ntpSynchronizerCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusUnbinding:           {[]CommandGetter{noopCmd}, 0, models.StepsPostStepActionExit},
 		},
 	}

--- a/internal/host/pool_host_statemachine.go
+++ b/internal/host/pool_host_statemachine.go
@@ -99,6 +99,7 @@ func NewPoolHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler)
 	})
 
 	var hasMinRequiredHardware = stateswitch.And(If(HasMinValidDisks), If(HasMinCPUCores), If(HasMinMemory))
+	sufficientToBeBound := stateswitch.And(hasMinRequiredHardware, If(IsNTPSynced))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles
@@ -111,7 +112,7 @@ func NewPoolHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler)
 			stateswitch.State(models.HostStatusKnownUnbound),
 		},
 		Condition: stateswitch.And(If(IsConnected), If(HasInventory),
-			stateswitch.Not(hasMinRequiredHardware)),
+			stateswitch.Not(sufficientToBeBound)),
 		DestinationState: stateswitch.State(models.HostStatusInsufficientUnbound),
 		PostTransition:   th.PostRefreshHost(statusInfoInsufficientHardware),
 	})
@@ -138,7 +139,7 @@ func NewPoolHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler)
 			stateswitch.State(models.HostStatusKnownUnbound),
 		},
 		Condition: stateswitch.And(If(IsConnected), If(HasInventory),
-			hasMinRequiredHardware),
+			sufficientToBeBound),
 		DestinationState: stateswitch.State(models.HostStatusKnownUnbound),
 		PostTransition:   th.PostRefreshHost(statusInfoHostReadyToBeMoved),
 	})

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -4936,6 +4936,7 @@ var _ = Describe("Refresh Host", func() {
 			inventory         string
 			eventRaised       bool
 			statusInfoChecker statusInfoChecker
+			sourceState       models.SourceState
 		}{
 			{
 				name:              "discovering-unbound to disconnected-unbound",
@@ -5075,6 +5076,7 @@ var _ = Describe("Refresh Host", func() {
 				hostname:          "test-hostname",
 				eventRaised:       true,
 				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+				sourceState:       models.SourceStateSynced,
 			},
 			{
 				name:              "discovering-unbound to known-unbound",
@@ -5085,6 +5087,7 @@ var _ = Describe("Refresh Host", func() {
 				hostname:          "test-hostname",
 				eventRaised:       true,
 				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+				sourceState:       models.SourceStateSynced,
 			},
 			{
 				name:              "insufficient-unbound to known-unbound",
@@ -5095,6 +5098,7 @@ var _ = Describe("Refresh Host", func() {
 				hostname:          "test-hostname",
 				eventRaised:       true,
 				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+				sourceState:       models.SourceStateSynced,
 			},
 			{
 				name:              "known-unbound to known-unbound",
@@ -5104,6 +5108,94 @@ var _ = Describe("Refresh Host", func() {
 				inventory:         hostutil.GenerateMasterInventory(),
 				eventRaised:       false,
 				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+				sourceState:       models.SourceStateSynced,
+			},
+			{
+				name:              "disconnected-unbound to known-unbound - no NTP",
+				srcState:          models.HostStatusDisconnectedUnbound,
+				dstState:          models.HostStatusKnownUnbound,
+				validCheckInTime:  true,
+				inventory:         hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:          "test-hostname",
+				eventRaised:       true,
+				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+			},
+			{
+				name:              "discovering-unbound to known-unbound - no NTP",
+				srcState:          models.HostStatusDiscoveringUnbound,
+				dstState:          models.HostStatusKnownUnbound,
+				validCheckInTime:  true,
+				inventory:         hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:          "test-hostname",
+				eventRaised:       true,
+				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+			},
+			{
+				name:              "insufficient-unbound to known-unbound - no NTP",
+				srcState:          models.HostStatusInsufficientUnbound,
+				dstState:          models.HostStatusKnownUnbound,
+				validCheckInTime:  true,
+				inventory:         hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:          "test-hostname",
+				eventRaised:       true,
+				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+			},
+			{
+				name:              "known-unbound to known-unbound - no NTP",
+				srcState:          models.HostStatusKnownUnbound,
+				dstState:          models.HostStatusKnownUnbound,
+				validCheckInTime:  true,
+				inventory:         hostutil.GenerateMasterInventory(),
+				eventRaised:       false,
+				statusInfoChecker: makeValueChecker(statusInfoHostReadyToBeMoved),
+			},
+			{
+				name:             "disconnected-unbound to insufficient-unbound un-synced NTP",
+				srcState:         models.HostStatusDisconnectedUnbound,
+				dstState:         models.HostStatusInsufficientUnbound,
+				validCheckInTime: true,
+				inventory:        hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:         "test-hostname",
+				eventRaised:      true,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoInsufficientHardware,
+					"Host couldn't synchronize with any NTP server")),
+				sourceState: models.SourceStateUnreachable,
+			},
+			{
+				name:             "discovering-unbound to insufficient-unbound un-synced NTP",
+				srcState:         models.HostStatusDiscoveringUnbound,
+				dstState:         models.HostStatusInsufficientUnbound,
+				validCheckInTime: true,
+				inventory:        hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:         "test-hostname",
+				eventRaised:      true,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoInsufficientHardware,
+					"Host couldn't synchronize with any NTP server")),
+				sourceState: models.SourceStateUnreachable,
+			},
+			{
+				name:             "insufficient-unbound to insufficient-unbound un-synced NTP",
+				srcState:         models.HostStatusInsufficientUnbound,
+				dstState:         models.HostStatusInsufficientUnbound,
+				validCheckInTime: true,
+				inventory:        hostutil.GenerateMasterInventoryWithHostname("test-hostname"),
+				hostname:         "test-hostname",
+				eventRaised:      false,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoInsufficientHardware,
+					"Host couldn't synchronize with any NTP server")),
+				sourceState: models.SourceStateUnreachable,
+			},
+			{
+				name:             "known-unbound to insufficient-unbound un-synced NTP",
+				srcState:         models.HostStatusKnownUnbound,
+				dstState:         models.HostStatusInsufficientUnbound,
+				validCheckInTime: true,
+				hostname:         "master-hostname",
+				inventory:        hostutil.GenerateMasterInventory(),
+				eventRaised:      true,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoInsufficientHardware,
+					"Host couldn't synchronize with any NTP server")),
+				sourceState: models.SourceStateUnreachable,
 			},
 		}
 
@@ -5119,6 +5211,17 @@ var _ = Describe("Refresh Host", func() {
 					hostCheckInAt = strfmt.DateTime(time.Now().Add(-4 * time.Minute))
 				}
 				host.CheckedInAt = hostCheckInAt
+				if t.sourceState != "" {
+					b, err := json.Marshal(&[]*models.NtpSource{
+						{
+							SourceName:  "source",
+							SourceState: t.sourceState,
+						},
+					})
+					Expect(err).ToNot(HaveOccurred())
+					host.NtpSources = string(b)
+					Expect(db.Model(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: infraEnvId}}).Update("additional_ntp_sources", "source").Error).ToNot(HaveOccurred())
+				}
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
 				mockDefaultInfraEnvHostRequirements(mockHwValidator)


### PR DESCRIPTION
# Assisted Pull Request

## Description

- Make NTP sources be extracted from AdditionalNtpSources in ifra-env for NtpSynchronizer step if such sources fo not exist for cluster.
  This applies also to unbound states.
- Extract NTP sources from all infra-envs of cluster, if the cluster does not have its own NTP sources.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] Unit tests

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 


## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
