### PR TITLE
MGMT-7796: reset host data, set by the cluster on unbind operation

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -306,7 +306,6 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler) sta
 			stateswitch.State(models.HostStatusDisabled),
 			stateswitch.State(models.HostStatusPendingForInput),
 			stateswitch.State(models.HostStatusError),
-			stateswitch.State(models.HostStatusAddedToExistingCluster),
 			stateswitch.State(models.HostStatusCancelled),
 		},
 		DestinationState: stateswitch.State(models.HostStatusUnbinding),

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -31,6 +31,11 @@ type transitionHandler struct {
 
 var resetFields = [...]interface{}{"inventory", "", "bootstrap", false}
 var resetLogsField = []interface{}{"logs_info", "", "logs_started_at", strfmt.DateTime(time.Time{}), "logs_collected_at", strfmt.DateTime(time.Time{})}
+var restFieldsOnUnbind = []interface{}{"cluster_id", nil, "kind", swag.String(models.HostKindHost), "connectivity", "", "domain_name_resolutions", "",
+	"free_addresses", "", "images_status", "", "installation_disk_id", "", "installation_disk_path", "", "machine_config_pool_name", "",
+	"role", "auto-assign", "api_vip_connectivity", "", "suggested_role", "", "progress_current_stage", "", "progress_installation_percentage", 0,
+	"progress_progress_info", "", "progress_stage_started_at", strfmt.DateTime(time.Time{}), "progress_stage_updated_at", strfmt.DateTime(time.Time{}),
+	"progress_stages", nil, "stage_started_at", strfmt.DateTime(time.Time{}), "stage_updated_at", strfmt.DateTime(time.Time{})}
 
 ////////////////////////////////////////////////////////////////////////////
 // RegisterHost
@@ -368,7 +373,8 @@ func (th *transitionHandler) PostUnbindHost(sw stateswitch.StateSwitch, args sta
 		return errors.New("PostUnbindHost invalid argument")
 	}
 
-	extra := append(resetFields[:], "cluster_id", nil, "kind", swag.String(models.HostKindHost))
+	extra := append(resetFields[:], resetLogsField...)
+	extra = append(extra, restFieldsOnUnbind...)
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, statusInfoUnbinding,
 		extra...)
 }


### PR DESCRIPTION
The following fields will be resetted upon unbinding:
cluster_id, kind, connectivity, domain_name_resolutions,
free_addresses, images_status, installation_disk_id,
installation_disk_path, machine_config_pool_name,
role, api_vip_connectivity, suggested_role

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
