### PR TITLE
Update operator-index-build to use podman fixing broken Jenkins builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,4 +495,4 @@ operator-bundle-update:
 	$(CONTAINER_COMMAND) push $(BUNDLE_IMAGE)
 
 operator-index-build:
-	opm index add --bundles $(BUNDLE_IMAGE) --tag $(INDEX_IMAGE) --container-tool $(CONTAINER_COMMAND)
+	opm index add --bundles $(BUNDLE_IMAGE) --tag $(INDEX_IMAGE) --container-tool podman


### PR DESCRIPTION
# Assisted Pull Request

## Description

This is to fix the breaking changes from the PR: https://github.com/openshift/assisted-service/pull/2451
Not sure if the bundle build commands were tested with this changes.

There was an attempt to see if operator-framework worked with podman-remote: https://github.com/openshift/assisted-service/pull/2596
Operator framework doesn't to support podman-remote as we are still seeing the following error:
```
13:35:43  opm index add --bundles quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6 --tag quay.io/****/****-service-index:jenkins-****-service-master-11370 --container-tool podman-remote
13:35:43  INFO[0000] building the index                            bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:44  INFO[0000] resolved name: quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6 
13:35:44  INFO[0000] fetched                                       digest="sha256:ad882753a214dcc11aa849484bbebe15c1d7b80429064471824d92fc453d28fb"
13:35:45  INFO[0001] fetched                                       digest="sha256:b52a1630da5c446bdd8c6e63dc512a1518075e5fbbeb835e33e8d066123b175e"
13:35:45  INFO[0001] fetched                                       digest="sha256:61665692a38fdf047938c10be288ab8f1a755405748248a2e727a075ffe85f26"
13:35:45  INFO[0001] fetched                                       digest="sha256:3c1bb279c914ce58878bc815077db7732e1eac3b69aa462ac0a52ec9124ab0b3"
13:35:46  INFO[0002] unpacking layer: {application/vnd.docker.image.rootfs.diff.tar.gzip sha256:3c1bb279c914ce58878bc815077db7732e1eac3b69aa462ac0a52ec9124ab0b3 14613 [] map[] <nil>} 
13:35:46  INFO[0002] unpacking layer: {application/vnd.docker.image.rootfs.diff.tar.gzip sha256:b52a1630da5c446bdd8c6e63dc512a1518075e5fbbeb835e33e8d066123b175e 414 [] map[] <nil>} 
13:35:46  INFO[0002] Could not find optional dependencies file     dir=bundle_tmp613470183 file=bundle_tmp613470183/metadata load=annotations
13:35:46  INFO[0002] found csv, loading bundle                     dir=bundle_tmp613470183 file=bundle_tmp613470183/manifests load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=agent-install.openshift.io_agents.yaml load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=agent-install.openshift.io_agentserviceconfigs.yaml load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=agent-install.openshift.io_infraenvs.yaml load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=agent-install.openshift.io_nmstateconfigs.yaml load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=****-service-operator.clusterserviceversion.yaml load=bundle
13:35:46  INFO[0002] loading bundle file                           dir=bundle_tmp613470183/manifests file=extensions.hive.openshift.io_agentclusterinstalls.yaml load=bundle
13:35:46  INFO[0002] Generating dockerfile                         bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:46  INFO[0002] writing dockerfile: index.Dockerfile127070509  bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:46  INFO[0002] running podman build                          bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:46  INFO[0002] [podman build --format docker -f index.Dockerfile127070509 -t quay.io/****/****-service-index:jenkins-****-service-master-11370 .]  bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:46  ERRO[0002] Error: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver  bundles="[quay.io/****/****-service-operator-bundle:5600072078a351bc9bf595bb4aa10cea780d39f6]"
13:35:46  Error: error building image: Error: 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver
13:35:46  . exit status 125
13:35:46  Usage:
13:35:46    opm index add [flags]
13:35:46  
13:35:46  Examples:
13:35:46    # Create an index image from scratch with a single bundle image
13:35:46    opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus@sha256:a3ee653ffa8a0d2bbb2fabb150a94da6e878b6e9eb07defd40dc884effde11a0 --tag quay.io/operator-framework/monitoring:1.0.0
13:35:46    
13:35:46    # Add a single bundle image to an index image
13:35:46    opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus:0.15.0 --from-index quay.io/operator-framework/monitoring:1.0.0 --tag quay.io/operator-framework/monitoring:1.0.1
13:35:46    
13:35:46    # Add multiple bundles to an index and generate a Dockerfile instead of an image
13:35:46    opm index add --bundles quay.io/operator-framework/operator-bundle-prometheus:0.15.0,quay.io/operator-framework/operator-bundle-prometheus:0.22.2 --generate
13:35:46  
13:35:46  Flags:
13:35:46    -i, --binary-image opm        container image for on-image opm command
13:35:46    -u, --build-tool string       tool to build container images. One of: [docker, podman]. Defaults to podman. Overrides part of container-tool.
13:35:46    -b, --bundles strings         comma separated list of bundles to add
13:35:46    -c, --container-tool string   tool to interact with container images (save, build, etc.). One of: [docker, podman]
13:35:46    -f, --from-index string       previous index to add to
13:35:46        --generate                if enabled, just creates the dockerfile and saves it to local disk
13:35:46    -h, --help                    help for add
13:35:46        --mode string             graph update mode that defines how channel graphs are updated. One of: [replaces, semver, semver-skippatch] (default "replaces")
13:35:46    -d, --out-dockerfile string   if generating the dockerfile, this flag is used to (optionally) specify a dockerfile name
13:35:46        --permissive              allow registry load errors
13:35:46    -p, --pull-tool string        tool to pull container images. One of: [none, docker, podman]. Defaults to none. Overrides part of container-tool.
13:35:46    -t, --tag string              custom tag for container image being built
13:35:46  
13:35:46  Global Flags:
13:35:46        --skip-tls   skip TLS certificate verification for container image registries while pulling bundles or index
13:35:46  
13:35:46  make: *** [Makefile:498: operator-index-build] Error 1
13:35:46  make: *** [Makefile:217: build-publish-index] Error 2
```

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [X] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

Currently the Jenkins builds are broken which impacts everything.

## How was this code tested?
<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [X] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested locally using the command 
`skipper make operator-index-build BUNDLE_IMAGE=quay.io/ocpmetal/assisted-service-operator-bundle:latest`

Would appreciate those reviewing the PR to also run the above command. 
This type of change has to have manual tests because we do not run the publish mechanisms on PRs.

Passing output on my machine:
```
opm index add --bundles quay.io/ocpmetal/assisted-service-operator-bundle:latest --tag quay.io/ocpmetal/assisted-service-index:latest --container-tool podman
INFO[0000] building the index                            bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0000] running /usr/bin/podman pull quay.io/ocpmetal/assisted-service-operator-bundle:latest  bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0003] running podman create                         bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0003] running podman cp                             bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0004] running podman rm                             bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0004] Could not find optional dependencies file     dir=bundle_tmp357695242 file=bundle_tmp357695242/metadata load=annotations
INFO[0004] found csv, loading bundle                     dir=bundle_tmp357695242 file=bundle_tmp357695242/manifests load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=agent-install.openshift.io_agents.yaml load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=agent-install.openshift.io_agentserviceconfigs.yaml load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=agent-install.openshift.io_infraenvs.yaml load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=agent-install.openshift.io_nmstateconfigs.yaml load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=assisted-service-operator.clusterserviceversion.yaml load=bundle
INFO[0004] loading bundle file                           dir=bundle_tmp357695242/manifests file=extensions.hive.openshift.io_agentclusterinstalls.yaml load=bundle
INFO[0004] Generating dockerfile                         bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0004] writing dockerfile: index.Dockerfile486245912  bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0004] running podman build                          bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
INFO[0004] [podman build --format docker -f index.Dockerfile486245912 -t quay.io/ocpmetal/assisted-service-index:latest .]  bundles="[quay.io/ocpmetal/assisted-service-operator-bundle:latest]"
```


## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @celebdor 
/cc @YuviGold 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
