### PR TITLE
MGMT-7806: Change host events API in order to solve segmentation fault

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -217,7 +217,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
 
@@ -226,7 +226,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -236,7 +236,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -259,7 +259,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -272,7 +272,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -282,7 +282,7 @@ x-events:
   event_type: host
   severity: "error"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -293,7 +293,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -303,7 +303,7 @@ x-events:
   event_type: host
   severity: "error"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -314,7 +314,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -324,7 +324,7 @@ x-events:
   event_type: host
   severity: "error"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -335,7 +335,7 @@ x-events:
   event_type: host
   severity: "warning"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string
@@ -346,7 +346,7 @@ x-events:
   event_type: host
   severity: "info"
   properties:
-    cluster_id: UUID
+    cluster_id: UUID_PTR
     host_id: UUID
     infra_env_id: UUID
     host_name: string

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3457,7 +3457,7 @@ func (b *bareMetalInventory) V2DeregisterHostInternal(ctx context.Context, param
 		return err
 	}
 	clusterID = infraEnv.ClusterID
-	eventgen.SendHostDeregisteredClusterEvent(ctx, b.eventsHandler, clusterID, params.HostID, params.InfraEnvID)
+	eventgen.SendHostDeregisteredClusterEvent(ctx, b.eventsHandler, &clusterID, params.HostID, params.InfraEnvID)
 	return nil
 }
 
@@ -3524,7 +3524,7 @@ func (b *bareMetalInventory) UpdateHostInstallerArgsInternal(ctx context.Context
 	}
 
 	// TODO: pass InfraEnvID instead of ClusterID
-	eventgen.SendHostInstallerArgsAppliedEvent(ctx, b.eventsHandler, params.ClusterID, params.HostID, params.ClusterID, hostutil.GetHostnameForMsg(&h.Host))
+	eventgen.SendHostInstallerArgsAppliedEvent(ctx, b.eventsHandler, &params.ClusterID, params.HostID, params.ClusterID, hostutil.GetHostnameForMsg(&h.Host))
 	log.Infof("Custom installer arguments were applied to host %s in cluster %s", params.HostID, params.ClusterID)
 
 	h, err = b.getHost(ctx, params.ClusterID.String(), params.HostID.String())

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -1869,7 +1869,7 @@ func (e *DownloadImageFailedFetchEvent) FormatMessage() string {
 // Event host_deregistered_cluster
 //
 type HostDeregisteredClusterEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
 }
@@ -1877,7 +1877,7 @@ type HostDeregisteredClusterEvent struct {
 var HostDeregisteredClusterEventName string = "host_deregistered_cluster"
 
 func NewHostDeregisteredClusterEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
 ) *HostDeregisteredClusterEvent {
@@ -1891,7 +1891,7 @@ func NewHostDeregisteredClusterEvent(
 func SendHostDeregisteredClusterEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,) {
     ev := NewHostDeregisteredClusterEvent(
@@ -1905,7 +1905,7 @@ func SendHostDeregisteredClusterEvent(
 func SendHostDeregisteredClusterEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     eventTime time.Time) {
@@ -1925,7 +1925,7 @@ func (e *HostDeregisteredClusterEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostDeregisteredClusterEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostDeregisteredClusterEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -1952,7 +1952,7 @@ func (e *HostDeregisteredClusterEvent) FormatMessage() string {
 // Event host_installer_args_applied
 //
 type HostInstallerArgsAppliedEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -1961,7 +1961,7 @@ type HostInstallerArgsAppliedEvent struct {
 var HostInstallerArgsAppliedEventName string = "host_installer_args_applied"
 
 func NewHostInstallerArgsAppliedEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -1977,7 +1977,7 @@ func NewHostInstallerArgsAppliedEvent(
 func SendHostInstallerArgsAppliedEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,) {
@@ -1993,7 +1993,7 @@ func SendHostInstallerArgsAppliedEvent(
 func SendHostInstallerArgsAppliedEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2015,7 +2015,7 @@ func (e *HostInstallerArgsAppliedEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostInstallerArgsAppliedEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostInstallerArgsAppliedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2043,7 +2043,7 @@ func (e *HostInstallerArgsAppliedEvent) FormatMessage() string {
 // Event host_set_bootstrap
 //
 type HostSetBootstrapEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2052,7 +2052,7 @@ type HostSetBootstrapEvent struct {
 var HostSetBootstrapEventName string = "host_set_bootstrap"
 
 func NewHostSetBootstrapEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2068,7 +2068,7 @@ func NewHostSetBootstrapEvent(
 func SendHostSetBootstrapEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,) {
@@ -2084,7 +2084,7 @@ func SendHostSetBootstrapEvent(
 func SendHostSetBootstrapEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2106,7 +2106,7 @@ func (e *HostSetBootstrapEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostSetBootstrapEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostSetBootstrapEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2249,7 +2249,7 @@ func (e *HostStatusUpdatedEvent) FormatMessage() string {
 // Event update_image_status
 //
 type UpdateImageStatusEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2261,7 +2261,7 @@ type UpdateImageStatusEvent struct {
 var UpdateImageStatusEventName string = "update_image_status"
 
 func NewUpdateImageStatusEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2283,7 +2283,7 @@ func NewUpdateImageStatusEvent(
 func SendUpdateImageStatusEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2305,7 +2305,7 @@ func SendUpdateImageStatusEvent(
 func SendUpdateImageStatusEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2333,7 +2333,7 @@ func (e *UpdateImageStatusEvent) GetSeverity() string {
     return "info"
 }
 func (e *UpdateImageStatusEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *UpdateImageStatusEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2364,7 +2364,7 @@ func (e *UpdateImageStatusEvent) FormatMessage() string {
 // Event host_installation_cancelled
 //
 type HostInstallationCancelledEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2373,7 +2373,7 @@ type HostInstallationCancelledEvent struct {
 var HostInstallationCancelledEventName string = "host_installation_cancelled"
 
 func NewHostInstallationCancelledEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2389,7 +2389,7 @@ func NewHostInstallationCancelledEvent(
 func SendHostInstallationCancelledEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,) {
@@ -2405,7 +2405,7 @@ func SendHostInstallationCancelledEvent(
 func SendHostInstallationCancelledEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2427,7 +2427,7 @@ func (e *HostInstallationCancelledEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostInstallationCancelledEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostInstallationCancelledEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2455,7 +2455,7 @@ func (e *HostInstallationCancelledEvent) FormatMessage() string {
 // Event host_cancel_installation_failed
 //
 type HostCancelInstallationFailedEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2465,7 +2465,7 @@ type HostCancelInstallationFailedEvent struct {
 var HostCancelInstallationFailedEventName string = "host_cancel_installation_failed"
 
 func NewHostCancelInstallationFailedEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2483,7 +2483,7 @@ func NewHostCancelInstallationFailedEvent(
 func SendHostCancelInstallationFailedEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2501,7 +2501,7 @@ func SendHostCancelInstallationFailedEvent(
 func SendHostCancelInstallationFailedEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2525,7 +2525,7 @@ func (e *HostCancelInstallationFailedEvent) GetSeverity() string {
     return "error"
 }
 func (e *HostCancelInstallationFailedEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostCancelInstallationFailedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2554,7 +2554,7 @@ func (e *HostCancelInstallationFailedEvent) FormatMessage() string {
 // Event host_reset_installation
 //
 type HostResetInstallationEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2563,7 +2563,7 @@ type HostResetInstallationEvent struct {
 var HostResetInstallationEventName string = "host_reset_installation"
 
 func NewHostResetInstallationEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2579,7 +2579,7 @@ func NewHostResetInstallationEvent(
 func SendHostResetInstallationEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,) {
@@ -2595,7 +2595,7 @@ func SendHostResetInstallationEvent(
 func SendHostResetInstallationEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2617,7 +2617,7 @@ func (e *HostResetInstallationEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostResetInstallationEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostResetInstallationEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2645,7 +2645,7 @@ func (e *HostResetInstallationEvent) FormatMessage() string {
 // Event host_reset_installation_failed
 //
 type HostResetInstallationFailedEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2655,7 +2655,7 @@ type HostResetInstallationFailedEvent struct {
 var HostResetInstallationFailedEventName string = "host_reset_installation_failed"
 
 func NewHostResetInstallationFailedEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2673,7 +2673,7 @@ func NewHostResetInstallationFailedEvent(
 func SendHostResetInstallationFailedEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2691,7 +2691,7 @@ func SendHostResetInstallationFailedEvent(
 func SendHostResetInstallationFailedEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2715,7 +2715,7 @@ func (e *HostResetInstallationFailedEvent) GetSeverity() string {
     return "error"
 }
 func (e *HostResetInstallationFailedEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostResetInstallationFailedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2744,7 +2744,7 @@ func (e *HostResetInstallationFailedEvent) FormatMessage() string {
 // Event user_required_complete_installation_reset
 //
 type UserRequiredCompleteInstallationResetEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2753,7 +2753,7 @@ type UserRequiredCompleteInstallationResetEvent struct {
 var UserRequiredCompleteInstallationResetEventName string = "user_required_complete_installation_reset"
 
 func NewUserRequiredCompleteInstallationResetEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2769,7 +2769,7 @@ func NewUserRequiredCompleteInstallationResetEvent(
 func SendUserRequiredCompleteInstallationResetEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,) {
@@ -2785,7 +2785,7 @@ func SendUserRequiredCompleteInstallationResetEvent(
 func SendUserRequiredCompleteInstallationResetEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2807,7 +2807,7 @@ func (e *UserRequiredCompleteInstallationResetEvent) GetSeverity() string {
     return "info"
 }
 func (e *UserRequiredCompleteInstallationResetEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *UserRequiredCompleteInstallationResetEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2835,7 +2835,7 @@ func (e *UserRequiredCompleteInstallationResetEvent) FormatMessage() string {
 // Event host_set_status_failed
 //
 type HostSetStatusFailedEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2845,7 +2845,7 @@ type HostSetStatusFailedEvent struct {
 var HostSetStatusFailedEventName string = "host_set_status_failed"
 
 func NewHostSetStatusFailedEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2863,7 +2863,7 @@ func NewHostSetStatusFailedEvent(
 func SendHostSetStatusFailedEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2881,7 +2881,7 @@ func SendHostSetStatusFailedEvent(
 func SendHostSetStatusFailedEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2905,7 +2905,7 @@ func (e *HostSetStatusFailedEvent) GetSeverity() string {
     return "error"
 }
 func (e *HostSetStatusFailedEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostSetStatusFailedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2934,7 +2934,7 @@ func (e *HostSetStatusFailedEvent) FormatMessage() string {
 // Event host_validation_falling
 //
 type HostValidationFallingEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -2944,7 +2944,7 @@ type HostValidationFallingEvent struct {
 var HostValidationFallingEventName string = "host_validation_falling"
 
 func NewHostValidationFallingEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2962,7 +2962,7 @@ func NewHostValidationFallingEvent(
 func SendHostValidationFallingEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -2980,7 +2980,7 @@ func SendHostValidationFallingEvent(
 func SendHostValidationFallingEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -3004,7 +3004,7 @@ func (e *HostValidationFallingEvent) GetSeverity() string {
     return "warning"
 }
 func (e *HostValidationFallingEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostValidationFallingEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -3033,7 +3033,7 @@ func (e *HostValidationFallingEvent) FormatMessage() string {
 // Event host_validation_fixed
 //
 type HostValidationFixedEvent struct {
-    ClusterId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
     HostName string
@@ -3043,7 +3043,7 @@ type HostValidationFixedEvent struct {
 var HostValidationFixedEventName string = "host_validation_fixed"
 
 func NewHostValidationFixedEvent(
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -3061,7 +3061,7 @@ func NewHostValidationFixedEvent(
 func SendHostValidationFixedEvent(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -3079,7 +3079,7 @@ func SendHostValidationFixedEvent(
 func SendHostValidationFixedEventAtTime(
     ctx context.Context,
     eventsHandler events.Sender,
-    clusterId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
     hostName string,
@@ -3103,7 +3103,7 @@ func (e *HostValidationFixedEvent) GetSeverity() string {
     return "info"
 }
 func (e *HostValidationFixedEvent) GetClusterId() *strfmt.UUID {
-    return &e.ClusterId
+    return e.ClusterId
 }
 func (e *HostValidationFixedEvent) GetHostId() strfmt.UUID {
     return e.HostId

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -114,7 +114,7 @@ func (e *Events) SendHostEvent(ctx context.Context, event HostEvent) {
 
 func (e *Events) SendHostEventAtTime(ctx context.Context, event HostEvent, eventTime time.Time) {
 	hostID := event.GetHostId()
-	if event.GetClusterId() == nil || len(*event.GetClusterId()) == 0 {
+	if event.GetClusterId() == nil {
 		e.AddEvent(ctx, event.GetInfraEnvId(), &hostID, event.GetSeverity(), event.FormatMessage(), eventTime)
 	} else {
 		e.AddEvent(ctx, *event.GetClusterId(), &hostID, event.GetSeverity(), event.FormatMessage(), eventTime)

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -582,7 +582,7 @@ func (m *Manager) SetBootstrap(ctx context.Context, h *models.Host, isbootstrap 
 		if err != nil {
 			return errors.Wrapf(err, "failed to set bootstrap to host %s", h.ID.String())
 		}
-		eventgen.SendHostSetBootstrapEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID, h.InfraEnvID, hostutil.GetHostnameForMsg(h))
+		eventgen.SendHostSetBootstrapEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID, h.InfraEnvID, hostutil.GetHostnameForMsg(h))
 	}
 	return nil
 }
@@ -710,7 +710,7 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 				newImageStatus.Time, newImageStatus.SizeBytes, newImageStatus.DownloadRate)
 		}
 
-		eventgen.SendUpdateImageStatusEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID, h.InfraEnvID,
+		eventgen.SendUpdateImageStatusEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID, h.InfraEnvID,
 			hostutil.GetHostnameForMsg(h), newImageStatus.Name, string(newImageStatus.Result), eventInfo)
 	}
 	marshalledStatuses, err := common.MarshalImageStatuses(hostImageStatuses)
@@ -783,10 +783,10 @@ func (m *Manager) CancelInstallation(ctx context.Context, h *models.Host, reason
 	defer func() {
 		if shouldAddEvent {
 			if isFailed {
-				eventgen.SendHostCancelInstallationFailedEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID,
+				eventgen.SendHostCancelInstallationFailedEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h), err.Error())
 			} else {
-				eventgen.SendHostInstallationCancelledEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID,
+				eventgen.SendHostInstallationCancelledEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h))
 			}
 		}
@@ -830,10 +830,10 @@ func (m *Manager) ResetHost(ctx context.Context, h *models.Host, reason string, 
 	defer func() {
 		if shouldAddEvent {
 			if isFailed {
-				eventgen.SendHostResetInstallationFailedEvent(ctx, m.eventsHandler, h.InfraEnvID, *h.ID,
+				eventgen.SendHostResetInstallationFailedEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h), err.Error())
 			} else {
-				eventgen.SendHostResetInstallationEvent(ctx, m.eventsHandler, h.InfraEnvID, *h.ID,
+				eventgen.SendHostResetInstallationEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h))
 			}
 		}
@@ -873,10 +873,10 @@ func (m *Manager) ResetPendingUserAction(ctx context.Context, h *models.Host, db
 	defer func() {
 		if shouldAddEvent {
 			if isFailed {
-				eventgen.SendHostSetStatusFailedEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID,
+				eventgen.SendHostSetStatusFailedEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h), err.Error())
 			} else {
-				eventgen.SendUserRequiredCompleteInstallationResetEvent(ctx, m.eventsHandler, *h.ClusterID, *h.ID,
+				eventgen.SendUserRequiredCompleteInstallationResetEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 					h.InfraEnvID, hostutil.GetHostnameForMsg(h))
 			}
 		}
@@ -956,13 +956,6 @@ func (m *Manager) ReportValidationFailedMetrics(ctx context.Context, h *models.H
 	return nil
 }
 
-func getClusterIDForEvent(h *models.Host) strfmt.UUID {
-	if h.ClusterID != nil {
-		return *h.ClusterID
-	}
-	return h.InfraEnvID
-}
-
 func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validationContext, h *models.Host,
 	newValidationRes, currentValidationRes ValidationsStatus) {
 	for vCategory, vRes := range newValidationRes {
@@ -974,11 +967,11 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 					} else if vc.infraEnv != nil {
 						m.metricApi.HostValidationChanged(vc.infraEnv.OpenshiftVersion, vc.infraEnv.EmailDomain, models.HostValidationID(v.ID))
 					}
-					eventgen.SendHostValidationFallingEvent(ctx, m.eventsHandler, getClusterIDForEvent(h), *h.ID,
+					eventgen.SendHostValidationFallingEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 						h.InfraEnvID, hostutil.GetHostnameForMsg(h), v.ID.String())
 				}
 				if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
-					eventgen.SendHostValidationFixedEvent(ctx, m.eventsHandler, getClusterIDForEvent(h), *h.ID,
+					eventgen.SendHostValidationFixedEvent(ctx, m.eventsHandler, h.ClusterID, *h.ID,
 						h.InfraEnvID, hostutil.GetHostnameForMsg(h), v.ID.String())
 				}
 			}

--- a/tools/generate_events.py
+++ b/tools/generate_events.py
@@ -96,7 +96,7 @@ func (e *{{eventName}}) GetClusterId() strfmt.UUID {
 }
 {%- else %}
 func (e *{{eventName}}) GetClusterId() *strfmt.UUID {
-    {% if event.properties.cluster_id -%}     return &e.ClusterId
+    {% if event.properties.cluster_id -%}     return e.ClusterId
     {%- else -%}      return nil
     {%- endif %}
 }
@@ -130,6 +130,7 @@ func (e *{{eventName}}) FormatMessage() string {
 
 class EventGenerator(object):
     VALID_PROPS_TYPES = {"UUID":dict(go_type="strfmt.UUID", go_import="github.com/go-openapi/strfmt"),
+                         "UUID_PTR":dict(go_type="*strfmt.UUID", go_import="github.com/go-openapi/strfmt"),
                          "integer":dict(go_type="int", go_import=None),
                          "int64":dict(go_type="int64", go_import=None),
                          "string":dict(go_type="string", go_import=None),


### PR DESCRIPTION
Currently host/cluster events store ClusterID as strfmt.UUID. As a result, APIs
that create events also expect clusterId parameter as strfmt.UUID. In case of
unbound host this may cause issues, since ClusterID will be nil.
We change the host event to store ClusterID as pointer, and propagate it as is
to SendHostEvent* APIs, which already handle the case where it is nil

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
