### PR TITLE
OCPBUGSM-35037: Fix osImages refenrece passing

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1158,13 +1158,13 @@ func (r *AgentServiceConfigReconciler) getOSImages(log logrus.FieldLogger, insta
 	}
 
 	osImages := make(models.OsImages, 0)
-	for _, image := range instance.Spec.OSImages {
+	for i := range instance.Spec.OSImages {
 		osImage := models.OsImage{
-			OpenshiftVersion: &image.OpenshiftVersion,
-			URL:              &image.Url,
-			RootfsURL:        &image.RootFSUrl,
-			Version:          &image.Version,
-			CPUArchitecture:  &image.CPUArchitecture,
+			OpenshiftVersion: &instance.Spec.OSImages[i].OpenshiftVersion,
+			URL:              &instance.Spec.OSImages[i].Url,
+			RootfsURL:        &instance.Spec.OSImages[i].RootFSUrl,
+			Version:          &instance.Spec.OSImages[i].Version,
+			CPUArchitecture:  &instance.Spec.OSImages[i].CPUArchitecture,
 		}
 		osImages = append(osImages, &osImage)
 	}

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -822,6 +822,13 @@ var _ = Describe("getOSImages", func() {
 			Version:          "version-49.123-0",
 			CPUArchitecture:  "x86_64",
 		},
+		{
+			OpenshiftVersion: "4.9",
+			Url:              "rhcos_4.9",
+			RootFSUrl:        "rhcos_rootfs_4.9",
+			Version:          "version-49.123-0",
+			CPUArchitecture:  "arm",
+		},
 	}
 	var defaultEnvOsImages = models.OsImages{
 		&models.OsImage{
@@ -835,6 +842,13 @@ var _ = Describe("getOSImages", func() {
 	var outSpecOsImages = models.OsImages{
 		&models.OsImage{
 			CPUArchitecture:  swag.String("x86_64"),
+			OpenshiftVersion: swag.String("4.9"),
+			RootfsURL:        swag.String("rhcos_rootfs_4.9"),
+			URL:              swag.String("rhcos_4.9"),
+			Version:          swag.String("version-49.123-0"),
+		},
+		&models.OsImage{
+			CPUArchitecture:  swag.String("arm"),
 			OpenshiftVersion: swag.String("4.9"),
 			RootfsURL:        swag.String("rhcos_rootfs_4.9"),
 			URL:              swag.String("rhcos_4.9"),
@@ -1064,6 +1078,12 @@ func newASCWithOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, string) {
 			Url:              "4.8.iso",
 			RootFSUrl:        "4.8.img",
 		},
+		{
+			OpenshiftVersion: "4.9",
+			Version:          "49",
+			Url:              "4.9.iso",
+			RootFSUrl:        "4.9.img",
+		},
 	}
 
 	s := func(s string) *string { return &s }
@@ -1073,6 +1093,12 @@ func newASCWithOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, string) {
 			RhcosVersion: s("48"),
 			RhcosImage:   s("4.8.iso"),
 			RhcosRootfs:  s("4.8.img"),
+		},
+		"4.9": {
+			DisplayName:  s("4.9"),
+			RhcosVersion: s("49"),
+			RhcosImage:   s("4.9.iso"),
+			RhcosRootfs:  s("4.9.img"),
 		},
 	})
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Reference the object in the array rather than the reference in the loop. Golang's gotcha's strike back

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
