### PR TITLE
MGMT-7258: Use image service in assisted service

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -86,6 +86,7 @@ type Config struct {
 	ignition.IgnitionConfig
 	AgentDockerImg                  string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/ocpmetal/assisted-installer-agent:latest"`
 	ServiceBaseURL                  string            `envconfig:"SERVICE_BASE_URL"`
+	ImageServiceBaseURL             string            `envconfig:"IMAGE_SERVICE_BASE_URL"`
 	ServiceCACertPath               string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
 	S3EndpointURL                   string            `envconfig:"S3_ENDPOINT_URL" default:"http://10.35.59.36:30925"`
 	S3Bucket                        string            `envconfig:"S3_BUCKET" default:"test"`
@@ -955,7 +956,6 @@ func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, infr
 				return errors.New("Failed to generate image: error generating URL")
 			}
 		} else {
-			// TODO(djzager): Needs to be updated with image-service work, MGMT-3934
 			var builder uriBuilder
 			if v2 {
 				builder = &installer.DownloadInfraEnvDiscoveryImageURL{InfraEnvID: infraEnv.ID}
@@ -991,6 +991,86 @@ func (b *bareMetalInventory) updateImageInfoPostUpload(ctx context.Context, infr
 	dbReply := b.db.Model(&common.InfraEnv{}).Where("id = ?", infraEnv.ID.String()).Updates(updates)
 	if dbReply.Error != nil {
 		return errors.New("Failed to generate image: error updating image record")
+	}
+
+	return nil
+}
+
+func (b *bareMetalInventory) updateExternalImageInfo(infraEnv *common.InfraEnv, infraEnvProxyHash string, imageType models.ImageType) error {
+	updates := map[string]interface{}{}
+
+	// this is updated before now for the v2 (infraEnv) case, but not in the cluster ISO case so we need to check if we should save it here
+	if infraEnv.ProxyHash != infraEnvProxyHash {
+		updates["proxy_hash"] = infraEnvProxyHash
+		infraEnv.ProxyHash = infraEnvProxyHash
+	}
+
+	var (
+		prevType    string
+		prevVersion string
+		prevArch    string
+	)
+	if infraEnv.DownloadURL != "" {
+		currentURL, err := url.Parse(infraEnv.DownloadURL)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse current download URL")
+		}
+		vals := currentURL.Query()
+		prevType = vals.Get("type")
+		prevVersion = vals.Get("version")
+		prevArch = vals.Get("arch")
+	}
+
+	updates["type"] = imageType
+	infraEnv.Type = imageType
+
+	osImage, err := b.getOsImageOrLatest(&infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+	if err != nil {
+		return err
+	}
+
+	var version string
+	if osImage.Version != nil {
+		version = *osImage.OpenshiftVersion
+	} else {
+		return errors.Errorf("OS image entry '%+v' missing OpenshiftVersion field", osImage)
+	}
+
+	var arch string
+	if osImage.CPUArchitecture != nil {
+		arch = *osImage.CPUArchitecture
+	}
+
+	// only update download url if type or version have changed
+	if string(imageType) != prevType || version != prevVersion || arch != prevArch {
+		baseURL, urlErr := url.Parse(b.ImageServiceBaseURL)
+		if urlErr != nil {
+			return errors.Wrap(err, "failed to parse image service base URL")
+		}
+		downloadURL := url.URL{
+			Scheme: baseURL.Scheme,
+			Host:   baseURL.Host,
+			Path:   fmt.Sprintf("/images/%s", infraEnv.ID),
+		}
+		queryValues := url.Values{}
+		queryValues.Set("type", string(imageType))
+		queryValues.Set("version", version)
+		queryValues.Set("arch", arch)
+		downloadURL.RawQuery = queryValues.Encode()
+		infraEnv.DownloadURL = downloadURL.String()
+
+		if b.authHandler.AuthType() == auth.TypeLocal {
+			infraEnv.DownloadURL, err = gencrypto.SignURL(downloadURL.String(), infraEnv.ID.String(), gencrypto.InfraEnvKey)
+			if err != nil {
+				return errors.Wrap(err, "failed to sign image URL")
+			}
+		}
+		updates["download_url"] = infraEnv.DownloadURL
+	}
+
+	err = b.db.Model(&common.InfraEnv{}).Where("id = ?", infraEnv.ID.String()).Updates(updates).Error
+	if err != nil {
+		return errors.Wrap(err, "failed to update infraenv")
 	}
 
 	return nil
@@ -1077,10 +1157,13 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	/* We need to ensure that the metadata in the DB matches the image that will be uploaded to S3,
 	so we check that at least 10 seconds have past since the previous request to reduce the chance
 	of a race between two consecutive requests.
+
+	This is not relevant if we're using the image service as the image is never uploaded to s3, so skip the check
+	if the image service URL is set
 	*/
 	now := time.Now()
 	previousCreatedAt := time.Time(infraEnv.GeneratedAt)
-	if previousCreatedAt.Add(WindowBetweenRequestsInSeconds).After(now) {
+	if b.ImageServiceBaseURL == "" && previousCreatedAt.Add(WindowBetweenRequestsInSeconds).After(now) {
 		log.Error("request came too soon after previous request")
 		return nil, common.NewApiError(
 			http.StatusConflict,
@@ -1126,7 +1209,7 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	updates["proxy_no_proxy"] = cluster.NoProxy
 	//[TODO] - remove this code once we update ignition config override in InfraEnv via UpdateDiscoveryIgnitionInternal
 	updates["ignition_config_override"] = cluster.IgnitionConfigOverrides
-	if !imageExists {
+	if b.ImageServiceBaseURL == "" && !imageExists {
 		// set image-generated indicator to false before the attempt to genearate the image in order to have an explicit
 		// state of the image creation based on the cluster parameters which will be committed to the DB
 		updates["generated"] = false
@@ -1158,27 +1241,8 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 		return nil, common.NewApiError(http.StatusInternalServerError, errors.New(msg))
 	}
 	txSuccess = true
-	if infraEnv, err = common.GetInfraEnvFromDB(b.db, params.ClusterID); err != nil {
-		log.WithError(err).Errorf("failed to get infra env %s after update", params.ClusterID)
-		msg := "Failed to generate image: error fetching updated infra env metadata"
-		b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityError, msg, time.Now())
-		return nil, err
-	}
 
-	if imageExists {
-		if err = b.updateImageInfoPostUpload(ctx, infraEnv, infraEnvProxyHash, params.ImageCreateParams.ImageType, false, false); err != nil {
-			return nil, common.NewApiError(http.StatusInternalServerError, err)
-		}
-
-		log.Infof("Re-used existing cluster <%s> image", params.ClusterID)
-		b.eventsHandler.AddEvent(ctx, params.ClusterID, nil, models.EventSeverityInfo,
-			fmt.Sprintf(`Re-used existing image rather than generating a new one (image type is "%s")`,
-				params.ImageCreateParams.ImageType),
-			time.Now())
-		return b.GetClusterInternal(ctx, installer.V2GetClusterParams{ClusterID: params.ClusterID})
-	}
-
-	err = b.createAndUploadNewImage(ctx, log, infraEnvProxyHash, infraEnv, params.ImageCreateParams.ImageType, false)
+	err = b.createAndUploadNewImage(ctx, log, infraEnvProxyHash, params.ClusterID, params.ImageCreateParams.ImageType, false, imageExists)
 	if err != nil {
 		return nil, err
 	}
@@ -1199,10 +1263,13 @@ func (b *bareMetalInventory) GenerateInfraEnvISOInternal(ctx context.Context, in
 	/* We need to ensure that the metadata in the DB matches the image that will be uploaded to S3,
 	so we check that at least 10 seconds have past since the previous request to reduce the chance
 	of a race between two consecutive requests.
+
+	This is not relevant if we're using the image service as the image is never uploaded to s3, so skip the check
+	if the image service URL is set
 	*/
 	now := time.Now()
 	previousCreatedAt := time.Time(infraEnv.GeneratedAt)
-	if previousCreatedAt.Add(WindowBetweenRequestsInSeconds).After(now) {
+	if b.ImageServiceBaseURL == "" && previousCreatedAt.Add(WindowBetweenRequestsInSeconds).After(now) {
 		log.Error("request came too soon after previous request")
 		return common.NewApiError(
 			http.StatusConflict,
@@ -1226,7 +1293,7 @@ func (b *bareMetalInventory) GenerateInfraEnvISOInternal(ctx context.Context, in
 	updates := map[string]interface{}{}
 	updates["generated_at"] = strfmt.DateTime(now)
 	updates["image_expires_at"] = strfmt.DateTime(now.Add(b.Config.ImageExpirationTime))
-	if !imageExists {
+	if b.ImageServiceBaseURL == "" && !imageExists {
 		// set image-generated indicator to false before the attempt to genearate the image in order to have an explicit
 		// state of the image creation based on the cluster parameters which will be committed to the DB
 		updates["generated"] = false
@@ -1239,21 +1306,7 @@ func (b *bareMetalInventory) GenerateInfraEnvISOInternal(ctx context.Context, in
 		return common.NewApiError(http.StatusInternalServerError, errors.New(msg))
 	}
 
-	if infraEnv, err = common.GetInfraEnvFromDB(b.db, infraEnv.ID); err != nil {
-		log.WithError(err).Errorf("failed to get infra env %s after update", infraEnv.ID)
-		return common.NewApiError(http.StatusInternalServerError, err)
-	}
-
-	if imageExists {
-		if err = b.updateImageInfoPostUpload(ctx, infraEnv, infraEnv.ProxyHash, infraEnv.Type, false, true); err != nil {
-			return common.NewApiError(http.StatusInternalServerError, err)
-		}
-
-		log.Infof("Re-used existing InfraEnv <%s> image", infraEnv.ID)
-		return nil
-	}
-
-	err = b.createAndUploadNewImage(ctx, log, infraEnv.ProxyHash, infraEnv, infraEnv.Type, true)
+	err = b.createAndUploadNewImage(ctx, log, infraEnv.ProxyHash, infraEnv.ID, infraEnv.Type, true, imageExists)
 	if err != nil {
 		return err
 	}
@@ -1262,7 +1315,35 @@ func (b *bareMetalInventory) GenerateInfraEnvISOInternal(ctx context.Context, in
 }
 
 func (b *bareMetalInventory) createAndUploadNewImage(ctx context.Context, log logrus.FieldLogger, infraEnvProxyHash string,
-	infraEnv *common.InfraEnv, imageType models.ImageType, v2 bool) error {
+	infraEnvID strfmt.UUID, imageType models.ImageType, v2 bool, imageExists bool) error {
+
+	infraEnv, err := common.GetInfraEnvFromDB(b.db, infraEnvID)
+	if err != nil {
+		log.WithError(err).Errorf("failed to get infra env %s after update", infraEnv.ID)
+		msg := "Failed to generate image: error fetching updated infra env metadata"
+		b.eventsHandler.AddEvent(ctx, infraEnvID, nil, models.EventSeverityError, msg, time.Now())
+		return err
+	}
+
+	// return without generating the image if we're using the image service or if the image has already been generated
+	if b.ImageServiceBaseURL != "" {
+		if err = b.updateExternalImageInfo(infraEnv, infraEnvProxyHash, imageType); err != nil {
+			return err
+		}
+
+		return nil
+	} else if imageExists {
+		if err = b.updateImageInfoPostUpload(ctx, infraEnv, infraEnvProxyHash, imageType, false, v2); err != nil {
+			return err
+		}
+
+		log.Infof("Re-used existing image <%s>", infraEnv.ID)
+		b.eventsHandler.AddEvent(ctx, infraEnvID, nil, models.EventSeverityInfo,
+			fmt.Sprintf(`Re-used existing image rather than generating a new one (image type is "%s")`, imageType),
+			time.Now())
+		return nil
+	}
+
 	// Setting ImageInfo.Type at this point in order to pass it to FormatDiscoveryIgnitionFile without saving it to the DB.
 	// Saving it to the DB will be done after a successful image generation by updateImageInfoPostUpload
 	infraEnv.Type = imageType


### PR DESCRIPTION
## Description

This PR has two parts:
1. Make assisted service set the infra env download URL to the image service when the image service base url is provided
    - This also adds a new environment variable to assisted service `IMAGE_SERVICE_BASE_URL`.
    - The presence of this string changes the behavior of assisted service (images will not be generated internally and the template images will not be downloaded/created)
2. Provide `IMAGE_SERVICE_BASE_URL` to assisted service using the agent service config operator.
    - Specifically we pass in the route host with https as this will be used to build a link for users which should be accessible from outside the cluster we're running on.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-7258

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Deployed the operator on a local CRC cluster, created agent service config to deploy assisted service, created an infra-env and validated that the URL in the infra env both points to the image service, and responds with a valid discovery image.

I did specifically update the assisted service configmap to fill in the release image info into openshift versions to get this to work.
Otherwise I was running into a problem where the infra env controller couldn't find a valid openshift version in the cluster record.

Some logs from assisted service, note that the entire infraenv reconcile took <1 second as the image didn't need to be generated.
```
time="2021-09-16T20:34:36Z" level=info msg="InfraEnv Reconcile started" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).Reconcile" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:81" go-id=591 infra_env=test-infra-env infra_env_namespace=spoke-cluster request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
time="2021-09-16T20:34:36Z" level=info msg="Register infraenv: test-infra-env with id ce271ba7-d37d-4b9e-a4ca-b680e60d6659" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).RegisterInfraEnvInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:5469" cluster_id=ce271ba7-d37d-4b9e-a4ca-b680e60d6659 go-id=591 pkg=Inventory request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
time="2021-09-16T20:34:36Z" level=info msg="prepare image for infraEnv ce271ba7-d37d-4b9e-a4ca-b680e60d6659" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).GenerateInfraEnvISOInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:1256" go-id=591 pkg=Inventory request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
time="2021-09-16T20:34:36Z" level=info msg="Successfully registered InfraEnv test-infra-env with id ce271ba7-d37d-4b9e-a4ca-b680e60d6659" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).RegisterInfraEnvInternal.func1" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:5476" cluster_id=ce271ba7-d37d-4b9e-a4ca-b680e60d6659 go-id=591 pkg=Inventory request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
time="2021-09-16T20:34:36Z" level=info msg="ISODownloadURL changed from  to https://assisted-image-service-assisted-installer.apps-crc.testing/images/ce271ba7-d37d-4b9e-a4ca-b680e60d6659?api_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbmZyYV9lbnZfaWQiOiJjZTI3MWJhNy1kMzdkLTRiOWUtYTRjYS1iNjgwZTYwZDY2NTkifQ.c17RItpYMURmUv8XkupZ5XfxpUAW8TlUZZqFVuuyFjh6GdPbbcNjnwynxztqmSSNA_eoMJoQeaOue8ZrvokPfA&arch=x86_64&type=minimal-iso&version=4.9" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).updateEnsureISOSuccess" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:374" go-id=591 infra_env=test-infra-env infra_env_namespace=spoke-cluster request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
time="2021-09-16T20:34:36Z" level=info msg="InfraEnv Reconcile ended" func="github.com/openshift/assisted-service/internal/controller/controllers.(*InfraEnvReconciler).Reconcile.func1" file="/go/src/github.com/openshift/origin/internal/controller/controllers/infraenv_controller.go:78" go-id=591 infra_env=test-infra-env infra_env_namespace=spoke-cluster request_id=f63576cc-91e1-437f-b5d1-5c556cb7613e
```

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @djzager 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?
