### PR TITLE
OCPBUGSM-35242: Set x86_64 as the default architecture for OsImages and ReleaseImages

### DIFF
--- a/models/os_image.go
+++ b/models/os_image.go
@@ -19,7 +19,7 @@ type OsImage struct {
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
-	CPUArchitecture *string `json:"cpu_architecture"`
+	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// Version of the OpenShift cluster.
 	// Required: true

--- a/models/release_image.go
+++ b/models/release_image.go
@@ -19,7 +19,7 @@ type ReleaseImage struct {
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
-	CPUArchitecture *string `json:"cpu_architecture"`
+	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// Version of the OpenShift cluster.
 	// Required: true

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -11383,7 +11383,9 @@ func init() {
       "properties": {
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
-          "type": "string"
+          "type": "string",
+          "default": "x86_64",
+          "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
@@ -11493,7 +11495,9 @@ func init() {
       "properties": {
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
-          "type": "string"
+          "type": "string",
+          "default": "x86_64",
+          "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
@@ -23419,7 +23423,9 @@ func init() {
       "properties": {
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
-          "type": "string"
+          "type": "string",
+          "default": "x86_64",
+          "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
@@ -23529,7 +23535,9 @@ func init() {
       "properties": {
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
-          "type": "string"
+          "type": "string",
+          "default": "x86_64",
+          "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7944,7 +7944,9 @@ definitions:
         description: Version of the OpenShift cluster.
       cpu_architecture:
         type: string
+        default: "x86_64"
         description: The CPU architecture of the image (x86_64/arm64/etc).
+        x-go-custom-tag: gorm:"default:'x86_64'"
       url:
         type: string
         description: The base OS image used for the discovery iso.
@@ -7973,7 +7975,9 @@ definitions:
         description: Version of the OpenShift cluster.
       cpu_architecture:
         type: string
+        default: "x86_64"
         description: The CPU architecture of the image (x86_64/arm64/etc).
+        x-go-custom-tag: gorm:"default:'x86_64'"
       url:
         type: string
         description: The installation image of the OpenShift cluster.


### PR DESCRIPTION
# Assisted Pull Request

## Description

This commit aligns the definition of OsImages and ReleaseImages to what was discussed in the enhancement
proposal[0]. The default architecture should be x86_64.

[0] https://github.com/openshift/assisted-service/blob/34c986435c1e85776b2bcb0544eab2e6e77a2c2b/docs/enhancements/arm64-cpu-architecture.md\#cluster-creation-and-iso-generation

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @djzager 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
