### PR TITLE
MGMT-7315: Allow providing machine networks for multi-node non-DHCP

### DIFF
--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -24,7 +24,7 @@
     - cluster_subnet_additional: "{{ lookup('env', 'CLUSTER_SUBNET_ADDITIONAL') }}"
     - cluster_host_prefix_additional: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_ADDITIONAL') }}"
     - external_subnet_additional: "{{ lookup('env', 'EXTERNAL_SUBNET_ADDITIONAL') }}"
-    - service_subnet_additional: "{{ lookup('env', 'SERVICE_SUBNET_ADDITIONAL_ADDITIONAL') }}"
+    - service_subnet_additional: "{{ lookup('env', 'SERVICE_SUBNET_ADDITIONAL') }}"
     - extra_baremetalhosts: "{{ lookup('file', lookup('env', 'EXTRA_BAREMETALHOSTS_FILE')) | from_json }}"
 
   tasks:

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2372,6 +2372,18 @@ func (b *bareMetalInventory) integrateWithAMSClusterUpdateName(ctx context.Conte
 func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]interface{}, cluster *common.Cluster, params installer.V2UpdateClusterParams, log logrus.FieldLogger, interactivity Interactivity) error {
 	apiVip := cluster.APIVip
 	ingressVip := cluster.IngressVip
+
+	// We are checking if the cluster is requested to be a dual-stack cluster based on the Cluster
+	// Networks provided.
+	//
+	// TODO(mko) As updateNonDhcpNetworkParams is called before updateNetworks, this check looks
+	//           at the already configured networks and not the ones inside V2UpdateClusterParams.
+	//           An extension would be to check if V2UpdateClusterParams configures any of those
+	//           and if that's the case, instead of GetConfiguredAddressFamilies(cluster) we
+	//           should call something like GetRequestedAddressFamilies(cluster).
+	reqV4, reqV6, _ := network.GetConfiguredAddressFamilies(cluster)
+	reqDualStack := reqV4 && reqV6
+
 	if params.ClusterUpdateParams.APIVip != nil {
 		updates["api_vip"] = *params.ClusterUpdateParams.APIVip
 		apiVip = *params.ClusterUpdateParams.APIVip
@@ -2381,7 +2393,8 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 		ingressVip = *params.ClusterUpdateParams.IngressVip
 	}
 	if params.ClusterUpdateParams.MachineNetworks != nil &&
-		common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) {
+		common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) &&
+		!reqDualStack {
 		err := errors.New("Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 		log.WithError(err).Warnf("Set Machine Network CIDR")
 		return common.NewApiError(http.StatusBadRequest, err)
@@ -2417,6 +2430,20 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 		if err != nil {
 			log.WithError(err).Warnf("Verify VIPs")
 			return common.NewApiError(http.StatusBadRequest, err)
+		}
+
+		if params.ClusterUpdateParams.MachineNetworks != nil {
+			err = network.VerifyMachineNetworksDualStack(params.ClusterUpdateParams.MachineNetworks, reqDualStack)
+			if err != nil {
+				log.WithError(err).Warnf("Verify dual-stack machine networks")
+				return common.NewApiError(http.StatusBadRequest, err)
+			}
+		} else {
+			err = network.VerifyMachineNetworksDualStack(cluster.MachineNetworks, reqDualStack)
+			if err != nil {
+				log.WithError(err).Warnf("Verify dual-stack machine networks")
+				return common.NewApiError(http.StatusBadRequest, err)
+			}
 		}
 	}
 

--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -3,6 +3,7 @@ package network
 import (
 	"net"
 
+	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 )
 
@@ -123,5 +124,26 @@ func VerifyNetworkHostPrefix(prefix int64) error {
 	if prefix < 1 {
 		return errors.Errorf("Host prefix, now %d, must be a positive integer", prefix)
 	}
+	return nil
+}
+
+// Verify if the constrains for dual-stack machine networks are met:
+//   * there are exactly two machine networks
+//   * the first one is IPv4 subnet
+//   * the second one is IPv6 subnet
+func VerifyMachineNetworksDualStack(networks []*models.MachineNetwork, isDualStack bool) error {
+	if !isDualStack {
+		return nil
+	}
+	if len(networks) != 2 {
+		return errors.Errorf("Expected 2 machine networks, found %d", len(networks))
+	}
+	if !IsIPV4CIDR(string(networks[0].Cidr)) {
+		return errors.Errorf("First machine network has to be IPv4 subnet")
+	}
+	if !IsIPv6CIDR(string(networks[1].Cidr)) {
+		return errors.Errorf("Second machine network has to be IPv6 subnet")
+	}
+
 	return nil
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

This commit adds an ability to manually provide machine networks in the
following scenario

* dual-stack OCP cluster
* non-DHCP mode
* VIPs manually provided

Previously whenever VIPs were provided, machine network was
automatically calculated based on them and the available networks on the
hosts. This is not a valid case anymore in case of a dual-stack cluster,
as multiple VIPs are not allowed.

In such a case we want to enable users to explicitly provide machine
networks so that the dual-stack cluster can be installed.

A sample CR presenting this scenario would look as follows

```
spec:
  apiVIP: 192.168.111.100
  ingressVIP: 192.168.111.101
  networking:
    machineNetwork:
      - cidr: "192.168.111.0/24"
      - cidr: "fd2e:6f44:5dd8:c956::/120"
    [...]
  provisionRequirements:
    controlPlaneAgents: 3
```

Contributes-to: [MGMT-7315](https://issues.redhat.com/browse/MGMT-7315)


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
