### PR TITLE
MGMT-4872: Generate Image Expirer Event

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -205,6 +205,13 @@ x-events:
     cluster_id: UUID
     failed_operators: string
 
+- name: delete_expired_image
+  message: "Deleted image from backend because it expired. It may be generated again at any time"
+  event_type: cluster
+  severity: "info"
+  properties:
+    cluster_id:  UUID
+
 - name: download_image_failed_fetch
   message: "Failed to download image: error fetching from storage backend"
   event_type: infra_env

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -1802,6 +1802,67 @@ func (e *ClusterDegradedFailedOLMOperatorsEvent) FormatMessage() string {
 }
 
 //
+// Event delete_expired_image
+//
+type DeleteExpiredImageEvent struct {
+    ClusterId strfmt.UUID
+}
+
+var DeleteExpiredImageEventName string = "delete_expired_image"
+
+func NewDeleteExpiredImageEvent(
+    clusterId strfmt.UUID,
+) *DeleteExpiredImageEvent {
+    return &DeleteExpiredImageEvent{
+        ClusterId: clusterId,
+    }
+}
+
+func SendDeleteExpiredImageEvent(
+    ctx context.Context,
+    eventsHandler events.Sender,
+    clusterId strfmt.UUID,) {
+    ev := NewDeleteExpiredImageEvent(
+        clusterId,
+    )
+    eventsHandler.SendClusterEvent(ctx, ev)
+}
+
+func SendDeleteExpiredImageEventAtTime(
+    ctx context.Context,
+    eventsHandler events.Sender,
+    clusterId strfmt.UUID,
+    eventTime time.Time) {
+    ev := NewDeleteExpiredImageEvent(
+        clusterId,
+    )
+    eventsHandler.SendClusterEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *DeleteExpiredImageEvent) GetName() string {
+    return "delete_expired_image"
+}
+
+func (e *DeleteExpiredImageEvent) GetSeverity() string {
+    return "info"
+}
+func (e *DeleteExpiredImageEvent) GetClusterId() strfmt.UUID {
+    return e.ClusterId
+}
+
+func (e *DeleteExpiredImageEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+    )
+    return r.Replace(*message)
+}
+
+func (e *DeleteExpiredImageEvent) FormatMessage() string {
+    s := "Deleted image from backend because it expired. It may be generated again at any time"
+    return e.format(&s)
+}
+
+//
 // Event download_image_failed_fetch
 //
 type DownloadImageFailedFetchEvent struct {

--- a/internal/imgexpirer/imgexpirer.go
+++ b/internal/imgexpirer/imgexpirer.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	eventgen "github.com/openshift/assisted-service/internal/common/events"
 	"github.com/openshift/assisted-service/internal/events"
-	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/leader"
 	"github.com/openshift/assisted-service/pkg/requestid"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
@@ -59,8 +59,7 @@ func (m *Manager) DeletedImageCallback(ctx context.Context, log logrus.FieldLogg
 		return
 	}
 	clusterID := strfmt.UUID(matches[1])
-	m.eventsHandler.AddEvent(ctx, clusterID, nil, models.EventSeverityInfo,
-		"Deleted image from backend because it expired. It may be generated again at any time.", time.Now())
+	eventgen.SendDeleteExpiredImageEvent(ctx, m.eventsHandler, clusterID)
 }
 
 func (m *Manager) DeletedImageNoCallback(ctx context.Context, log logrus.FieldLogger, objectName string) {

--- a/internal/imgexpirer/imgexpirer_test.go
+++ b/internal/imgexpirer/imgexpirer_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	eventgen "github.com/openshift/assisted-service/internal/common/events"
 	"github.com/openshift/assisted-service/internal/events"
-	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/internal/events/eventstest"
 	"github.com/openshift/assisted-service/pkg/leader"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
 	"github.com/sirupsen/logrus"
@@ -43,7 +43,9 @@ var _ = Describe("imgexpirer", func() {
 	})
 	It("callback_valid_objname", func() {
 		clusterId := "53116787-3eb0-4211-93ac-611d5cedaa30"
-		mockEvents.EXPECT().AddEvent(gomock.Any(), strfmt.UUID(clusterId), nil, models.EventSeverityInfo, gomock.Any(), gomock.Any())
+		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.DeleteExpiredImageEventName),
+			eventstest.WithClusterIdMatcher(clusterId)))
 		imgExp.DeletedImageCallback(ctx, log, fmt.Sprintf("%s.iso", fmt.Sprintf(s3wrapper.DiscoveryImageTemplate, clusterId)))
 	})
 	It("callback_invalid_objname", func() {


### PR DESCRIPTION
# Assisted Pull Request

## Description
The patch replaces the in-code event with a generated one for cluster
image expired.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

Signed-off-by: Moti Asayag <masayag@redhat.com>
