### PR TITLE
MGMT-7687: Propagate Infrastructure Operator node selection and tolerations to its workloads

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -43,7 +43,6 @@ import (
 const (
 	NamespaceEnvVar string = "NAMESPACE"
 	PodNameEnvVar   string = "POD_NAME"
-	K8sSvcHost      string = "KUBERNETES_SERVICE_HOST"
 )
 
 var (
@@ -94,11 +93,6 @@ func main() {
 		setupLog.Error(fmt.Errorf("%s environment variable must be set (commonly set automatically in every Pod)", NamespaceEnvVar), "unable to get namespace")
 		os.Exit(1)
 	}
-	podName, found := os.LookupEnv(PodNameEnvVar)
-	if !found {
-		setupLog.Error(fmt.Errorf("%s environment variable must be set (commonly set automatically in every Pod)", PodNameEnvVar), "unable to get pod name")
-		os.Exit(1)
-	}
 
 	// must have openshift versions specified on the operator
 	// this prevents us from having to include the full json in source
@@ -121,8 +115,9 @@ func main() {
 	client := mgr.GetClient()
 	var nodeSelector map[string]string
 	var tolerations []corev1.Toleration
-	_, found = os.LookupEnv(K8sSvcHost)
-	if found { // Running inside a Kubelet pod
+
+	podName, found := os.LookupEnv(PodNameEnvVar)
+	if found {
 		operatorPod := &corev1.Pod{}
 		if err = client.Get(context.TODO(), types.NamespacedName{Name: podName, Namespace: ns}, operatorPod); err != nil {
 			setupLog.Error(err, "Unable to get Infrastructure Operator Pod")

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,6 +54,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -521,6 +521,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
                 image: quay.io/ocpmetal/assisted-service:latest
                 livenessProbe:
                   httpGet:

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -804,12 +804,16 @@ func (r *AgentServiceConfigReconciler) newImageServiceDeployment(ctx context.Con
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = imageServiceName
 
-		nodeSelector := make(map[string]string)
-		for key, value := range r.NodeSelector {
-			nodeSelector[key] = value
+		if r.NodeSelector != nil {
+			nodeSelector := make(map[string]string)
+			for key, value := range r.NodeSelector {
+				nodeSelector[key] = value
+			}
+			deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 		}
-		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
-		deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+		if r.Tolerations != nil {
+			deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+		}
 		return nil
 	}
 
@@ -1094,12 +1098,16 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
-		nodeSelector := make(map[string]string)
-		for key, value := range r.NodeSelector {
-			nodeSelector[key] = value
+		if r.NodeSelector != nil {
+			nodeSelector := make(map[string]string)
+			for key, value := range r.NodeSelector {
+				nodeSelector[key] = value
+			}
+			deployment.Spec.Template.Spec.NodeSelector = nodeSelector
 		}
-		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
-		deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+		if r.Tolerations != nil {
+			deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+		}
 
 		return nil
 	}

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -94,6 +94,10 @@ type AgentServiceConfigReconciler struct {
 
 	// Namespace the operator is running in
 	Namespace string
+
+	// selector and tolerations the Operator runs in and propagates to its deployments
+	NodeSelector map[string]string
+	Tolerations  []corev1.Toleration
 }
 
 type NewComponentFn func(context.Context, logrus.FieldLogger, *aiv1beta1.AgentServiceConfig) (client.Object, controllerutil.MutateFn, error)
@@ -799,6 +803,13 @@ func (r *AgentServiceConfigReconciler) newImageServiceDeployment(ctx context.Con
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{container}
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = imageServiceName
+
+		nodeSelector := make(map[string]string)
+		for key, value := range r.NodeSelector {
+			nodeSelector[key] = value
+		}
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+		deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
 		return nil
 	}
 
@@ -1082,6 +1093,13 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 		deployment.Spec.Template.Spec.Containers = []corev1.Container{serviceContainer, postgresContainer}
 		deployment.Spec.Template.Spec.Volumes = volumes
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
+
+		nodeSelector := make(map[string]string)
+		for key, value := range r.NodeSelector {
+			nodeSelector[key] = value
+		}
+		deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+		deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
 
 		return nil
 	}


### PR DESCRIPTION
# Assisted Pull Request

## Description

There is a common pattern in OpenShift to create [infrastructure machinesets](https://docs.openshift.com/container-platform/4.8/machine_management/creating-infrastructure-machinesets.html). These allow the cluster admins to have machines specialized for running the things like Hive, ACM, assisted, etc.

The upcoming Open Cluster Management 2.4 release adds support for running the operators in the infrastructure nodes. In order to satisfy the expectation that the OCM components run in the infrastructure nodes, we need to make sure that the workloads that we spawn remain in the same node selection as the Infrastructure operator does.

The way this commit seeks to achieve that, is by retrieving the node selection and the toleration that OCM set for the  infrastructure operator and set it for the image service and assisted service deployments as well.

### How to test

This PR should be tested by:
- Labeling some worker node in a specific way
- Set nodeSelector and/or tolerations in the Subscription object
- See that both the infrastructure, assisted-service and image-service all run in the selected node and that their deployments all have both the nodeSelector and the Tolerations set to what was put in Subscriptions

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @djzager 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?
