### PR TITLE
NO-ISSUE: Fixing default values for disk-encryption on cluster creation.

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10372,6 +10372,9 @@ var _ = Describe("TestRegisterCluster", func() {
 		})
 
 		It("Disabling with specifying mode", func() {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					DiskEncryption: &models.DiskEncryption{
@@ -10380,10 +10383,13 @@ var _ = Describe("TestRegisterCluster", func() {
 					},
 				},
 			})
-			verifyApiErrorString(reply, http.StatusBadRequest, "Disabling encryption with specifying mode")
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
 		})
 
 		It("Specifying mode without state", func() {
+			mockClusterRegisterSuccess(bm, true)
+			mockAMSSubscription(ctx)
+
 			reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					DiskEncryption: &models.DiskEncryption{
@@ -10391,7 +10397,9 @@ var _ = Describe("TestRegisterCluster", func() {
 					},
 				},
 			})
-			verifyApiErrorString(reply, http.StatusBadRequest, "Setting encryption mode without enabling")
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+			actual := reply.(*installer.RegisterClusterCreated)
+			Expect(actual.Payload.DiskEncryption.EnableOn).To(Equal(swag.String(models.DiskEncryptionEnableOnNone)))
 		})
 
 		It("Enabling with explicit TPMv2 mode", func() {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -458,25 +458,9 @@ func ValidateDualStackIPNetworksOrder(elements ...*string) error {
 	return nil
 }
 
-// ValidateDiskEncryptionParams performs basic sanity checks for the disk encryption configuration
-// using the following set of rules
-//   * whenever a change happens, the whole DiskEncryption structure has to be provided
-//   * setting the encryption mode is allowed only when the encryption is enabled
-//   * setting the encryption mode is forbidden when the encryption is disabled
-//   * tang servers cannot be empty if tang mode is used
 func ValidateDiskEncryptionParams(diskEncryptionParams *models.DiskEncryption) error {
 	if diskEncryptionParams == nil {
 		return nil
-	}
-	// Check that mode is set only when the encryption is explicitly enabled
-	if diskEncryptionParams.Mode != nil && diskEncryptionParams.EnableOn == nil {
-		return errors.New("Setting encryption mode without enabling")
-	}
-	// Check that mode is unset if encryption is disabled
-	if (diskEncryptionParams.EnableOn == nil || diskEncryptionParams.EnableOn != nil &&
-		*diskEncryptionParams.EnableOn == models.DiskEncryptionEnableOnNone) &&
-		diskEncryptionParams.Mode != nil {
-		return errors.New("Disabling encryption with specifying mode")
 	}
 	if diskEncryptionParams.Mode != nil && *diskEncryptionParams.Mode == models.DiskEncryptionModeTang {
 		if diskEncryptionParams.TangServers == "" {


### PR DESCRIPTION

# Assisted Pull Request

## Description

Default values are already defined in swagger but when the API is used
without the clients, the default values aren't generated. This code is
aligning with the swagger's default values.

Cluster creation:

    * default values for 'enable_on':   'none'
    * default values for 'mode':        'tpmv2'

Cluster update:

    We need to allow partial updates, here is a trivial use case:

        - the user set disk encryption to work on masters
        - default values set mode to tpmv2
        - then the user changes his mind and want to encrypt all hosts
            * we should not make him choose again the encryption mode

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
