### PR TITLE
Monitor logs

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -529,6 +529,7 @@ func (m *Manager) ClusterMonitoring() {
 		if len(clusters) == 0 {
 			break
 		}
+		m.log.Debugf("We are going to monitor %d, query is: %+v", len(clusters), query)
 		for _, cluster := range clusters {
 			if !m.leaderElector.IsLeader() {
 				m.log.Debugf("Not a leader, exiting ClusterMonitoring")
@@ -558,6 +559,7 @@ func (m *Manager) ClusterMonitoring() {
 		}
 		offset += limit
 	}
+	m.log.Debugf("Monitored %d clusters", monitored)
 	m.metricAPI.MonitoredClusterCount(monitored)
 }
 

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -92,6 +92,9 @@ parameters:
 - name: DISABLED_HOST_VALIDATIONS
   value: ""
   required: false
+- name: LIVENESS_VALIDATION_TIMEOUT
+  value: "5m"
+  required: false
 - name: DISABLED_STEPS
   value: ""
   required: false
@@ -278,6 +281,8 @@ objects:
                 value: /etc/.aws/credentials
               - name: ADMIN_USERS
                 value: ${ADMIN_USERS}
+              - name: LIVENESS_VALIDATION_TIMEOUT
+                value: ${LIVENESS_VALIDATION_TIMEOUT}
               - name: PUBLIC_CONTAINER_REGISTRIES
                 value: ${PUBLIC_CONTAINER_REGISTRIES}
               - name: CHECK_CLUSTER_VERSION

--- a/pkg/app/middleware.go
+++ b/pkg/app/middleware.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openshift/assisted-service/pkg/thread"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
+	"github.com/sirupsen/logrus"
 )
 
 // WithMetricsResponderMiddleware Returns middleware which responds to /metrics endpoint with the prometheus metrics
@@ -21,10 +23,19 @@ func WithMetricsResponderMiddleware(next http.Handler) http.Handler {
 }
 
 // WithHealthMiddleware returns middleware which responds to the /health endpoint
-func WithHealthMiddleware(next http.Handler) http.Handler {
+func WithHealthMiddleware(next http.Handler, threads []*thread.Thread, logger logrus.FieldLogger, timeout time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
+			status := http.StatusOK
+			for _, th := range threads {
+				if time.Since(th.LastRunStartedAt()) > timeout {
+					logger.Errorf("thread %s live probe validation failed, last run timestamp "+
+						"is %v, current time %s", th.Name(), th.LastRunStartedAt(), time.Now())
+					status = http.StatusInternalServerError
+					break
+				}
+			}
+			w.WriteHeader(status)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/pkg/app/middleware_test.go
+++ b/pkg/app/middleware_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/pkg/thread"
+	"github.com/sirupsen/logrus"
+)
+
+func TestMiddleWare(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Middleware test")
+}
+
+var _ = Describe("Middleware test", func() {
+
+	l := logrus.New()
+	l.SetOutput(ioutil.Discard)
+
+	It("Healthcheck test", func() {
+		timeout := 20 * time.Millisecond
+		mHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+		failure := thread.New(l, "failed test", 10*time.Millisecond, func() {
+		})
+		failure.Start()
+		req := httptest.NewRequest("GET", "/health", nil)
+		h1 := WithHealthMiddleware(mHandler, []*thread.Thread{failure}, l, timeout)
+
+		By("Testing healthycheck success when thread is running")
+		successCounter := 0
+		Eventually(func() bool {
+			rr := httptest.NewRecorder()
+			h1.ServeHTTP(rr, req)
+			if rr.Code == http.StatusOK {
+				successCounter += 1
+			}
+			return successCounter == 3
+		}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+
+		By("Verifying healthcheck failed when thread stopped")
+
+		failure.Stop()
+		// wait more than monitored threshold
+		Eventually(func() bool {
+			rr := httptest.NewRecorder()
+			h1.ServeHTTP(rr, req)
+			return rr.Code == http.StatusInternalServerError
+		}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+	})
+})

--- a/pkg/commonutils/common_utils.go
+++ b/pkg/commonutils/common_utils.go
@@ -9,6 +9,7 @@ import (
 
 func MeasureOperation(operation string, log logrus.FieldLogger, metricsApi metrics.API) func() {
 	start := time.Now()
+	log.Debugf("%s started at: %v", operation, start)
 	return func() {
 		duration := time.Since(start)
 		log.Debugf("%s took : %v", operation, duration)


### PR DESCRIPTION
The assisted-installer cluster-monitor seems to hang for hours from time to time, whenever it hangs clusters dont' get updated by the monitor.
This cause few issues, that lead to installation failures (mainly we've seen clusters stuck in timeout while preparing for installaiton until they timeout).

Adding last run timestamp to each thread object that will run monitor.
Updated liveness probe to watch the last run timestamp with 5 minutes timeout
Adding logs around cluster monitor in order to see what takes so long.

Should this PR be tested by the reviewer? No
Is this PR relying on CI for an e2e test run? For regression
Should this PR be tested in a specific environment?
Any logs, screenshots, etc that can help with the review process?
This PR was tested using this branch in subsystem with a malformed monitor (that sleeps)
The liveness prob failed and the pod got restarted.
-->

List all the issues related to this PR
 New Feature
 Bug fix
 Tests
 Documentation
 CI/CD
What environments does this code impact?
 Automation (CI, tools, etc)
 Cloud
 Operator Managed Deployments
 None
How was this code tested?
 assisted-test-infra environment
 dev-scripts environment
 Reviewer's test appreciated
 Waiting for CI to do a full test run
 Manual (Elaborate on how it was tested)
 No tests needed
Assignees
/cc @filanov
/cc @eranco74 

Checklist
 Title and description added to both, commit and PR.
 Relevant issues have been associated (see CONTRIBUTING guide)
 Reviewers have been listed
 This change does not require a documentation update (docstring, docs, README, etc)
 Does this change include unit-tests (note that code changes require unit-tests)
Reviewers Checklist
 Are the title and description (in both PR and commit) meaningful and clear?
 Is there a bug required (and linked) for this change?
 Should this PR be backported?