### PR TITLE
NO-ISSUE: Make setup_env user friendly

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -4,6 +4,21 @@ set -o nounset
 set -o pipefail
 set -o errexit
 set -o xtrace
+set -o verbose
+
+if [[ $(id -u) -eq 0 ]]; then
+        BINDIR="/usr/local/bin"
+elif command -v systemd-detect-virt; then
+    if systemd-detect-virt -cq; then
+        if [ -n "${TOOLBOX_PATH+x}" ]; then
+            BINDIR="$(systemd-path user-binaries)"
+        fi
+    else
+        BINDIR="$(systemd-path user-binaries)"
+    fi
+else
+    BINDIR="/usr/local/bin"
+fi
 
 function print_help() {
   ALL_FUNCS="kustomize|golang|assisted_service|hive_from_upstream|print_help"
@@ -11,38 +26,40 @@ function print_help() {
 }
 
 function kustomize() {
-  if which kustomize; then
-    return
+  if ! type -f kustomize; then
+    # We tried using "official" install_kustomize.sh script, but it used too much rate-limited APIs of GitHub
+    curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
+    tar -zx -C "$BINDIR"
   fi
-
-  # We tried using "official" install_kustomize.sh script, but it used too much rate-limited APIs of GitHub
-  curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
-    tar -zx -C /usr/bin/
 }
 
 function golang() {
   echo "Installing golang..."
-  curl -L https://storage.googleapis.com/golang/getgo/installer_linux -o /tmp/golang_installer
-  chmod u+x /tmp/golang_installer
-  /tmp/golang_installer
+  local tmpdir="$(mktemp -d)"
+  curl -L https://storage.googleapis.com/golang/getgo/installer_linux -o "${tmpdir}/golang_installer"
+  chmod u+x ${tmpdir}/golang_installer
+  "${tmpdir}/golang_installer"
   rm /tmp/golang_installer
+  rmdir "$tmpdir"
 
   echo "Activating go command on current shell..."
   set +u
-  source /root/.bash_profile
+  source "${HOME}/.bash_profile"
   set -u
 }
 
 function spectral() {
-  echo "Installing spectral..."
-  curl -L https://github.com/stoplightio/spectral/releases/download/v5.9.1/spectral-linux -o /usr/local/bin/spectral
-  chmod +x /usr/local/bin/spectral
+  if ! type -f spectral; then
+    echo "Installing spectral..."
+    curl -L https://github.com/stoplightio/spectral/releases/download/v5.9.1/spectral-linux -o "${BINDIR}/spectral"
+    chmod +x "${BINDIR}/spectral"
+  fi
 }
 
 function assisted_service() {
   latest_kubectl_version=$(curl --retry 5 -L -s https://dl.k8s.io/release/stable.txt)
   curl --retry 5 -L "https://dl.k8s.io/release/${latest_kubectl_version}/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
-    install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
+    install -o root -g root -m 0755 /tmp/kubectl "${BINDIR}/kubectl" && \
     rm -f /tmp/kubectl
   yum install -y docker podman libvirt-clients awscli python3-pip postgresql genisoimage skopeo p7zip && \
     yum clean all
@@ -59,7 +76,7 @@ function assisted_service() {
   OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.10.1
   curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
   chmod +x operator-sdk_${OS}_${ARCH}
-  install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+  install operator-sdk_${OS}_${ARCH} "${BINDIR}/operator-sdk"
 
   go get github.com/onsi/ginkgo/ginkgo@v1.16.4 \
     golang.org/x/tools/cmd/goimports@v0.1.5 \


### PR DESCRIPTION
# Assisted Pull Request

## Description

Up until now, setup_env has always tried to install things at a system
level. With this, it will install things in ~/.local/bin if:
- Running in fedora toolbox
- Running on a systemd distribution as a non-root user

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested:
Root outside of container (Fedora silverblue) -> Installs executables to /usr/local/bin
Root inside Fedora toolbox container (Fedora silverblue) -> Installs executables to /usr/local/bin
Regular user outside of container (Fedora silverblue) -> Installs executables to ${HOME}/.local/bin
Regular inside Fedora toolbox container (Fedora silverblue) -> Installs executables to ${HOME}/.local/bin

## Assignees

/cc @lranjbar 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?