### PR TITLE
Bug 2007106: Extend dual-stack network subnet validations

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6545,7 +6545,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{Cidr: "fd2e:6f44:5dd8:c956::/120"}, {Cidr: "10.12.0.0/16"}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "IPv6 network provided before IPv4")
+					verifyApiErrorString(reply, http.StatusBadRequest, "First machine network has to be IPv4 subnet")
 				})
 			})
 			Context("Advanced networking validations", func() {
@@ -12476,19 +12476,26 @@ var _ = Describe("[V2UpdateCluster] IPv6 support disabled", func() {
 var _ = Describe("Dual-stack cluster", func() {
 
 	var (
-		bm  *bareMetalInventory
-		cfg Config
-		db  *gorm.DB
-		ctx = context.Background()
+		bm                                *bareMetalInventory
+		cfg                               Config
+		db                                *gorm.DB
+		ctx                               = context.Background()
+		TestDualStackNetworkingWrongOrder = common.TestNetworking{
+			ClusterNetworks: append(common.TestIPv4Networking.ClusterNetworks, common.TestIPv6Networking.ClusterNetworks...),
+			ServiceNetworks: append(common.TestIPv4Networking.ServiceNetworks, common.TestIPv6Networking.ServiceNetworks...),
+			MachineNetworks: append(common.TestIPv4Networking.MachineNetworks, common.TestIPv6Networking.MachineNetworks...),
+			APIVip:          common.TestIPv4Networking.APIVip,
+			IngressVip:      common.TestIPv4Networking.IngressVip,
+		}
 	)
 
-	clusterNetworksWrongOrder := common.TestDualStackNetworking.ClusterNetworks
+	clusterNetworksWrongOrder := TestDualStackNetworkingWrongOrder.ClusterNetworks
 	clusterNetworksWrongOrder[0], clusterNetworksWrongOrder[1] = clusterNetworksWrongOrder[1], clusterNetworksWrongOrder[0]
 
-	serviceNetworksWrongOrder := common.TestDualStackNetworking.ServiceNetworks
+	serviceNetworksWrongOrder := TestDualStackNetworkingWrongOrder.ServiceNetworks
 	serviceNetworksWrongOrder[0], serviceNetworksWrongOrder[1] = serviceNetworksWrongOrder[1], serviceNetworksWrongOrder[0]
 
-	machineNetworksWrongOrder := common.TestDualStackNetworking.MachineNetworks
+	machineNetworksWrongOrder := TestDualStackNetworkingWrongOrder.MachineNetworks
 	machineNetworksWrongOrder[0], machineNetworksWrongOrder[1] = machineNetworksWrongOrder[1], machineNetworksWrongOrder[0]
 
 	BeforeEach(func() {
@@ -12502,7 +12509,6 @@ var _ = Describe("Dual-stack cluster", func() {
 	})
 
 	Context("Register cluster", func() {
-
 		var params installer.RegisterClusterParams
 
 		BeforeEach(func() {
@@ -12512,31 +12518,46 @@ var _ = Describe("Dual-stack cluster", func() {
 		})
 
 		Context("Cluster with wrong network order", func() {
-
-			const errorMsg = "IPv6 network provided before IPv4"
-
 			It("v6-first in cluster networks rejected", func() {
-				params.NewClusterParams.ClusterNetworks = clusterNetworksWrongOrder
+				params.NewClusterParams.ClusterNetworks = TestDualStackNetworkingWrongOrder.ClusterNetworks
 				reply := bm.RegisterCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First cluster network has to be IPv4 subnet")
 			})
-
 			It("v6-first in service networks rejected", func() {
-				params.NewClusterParams.ServiceNetworks = serviceNetworksWrongOrder
+				params.NewClusterParams.ServiceNetworks = TestDualStackNetworkingWrongOrder.ServiceNetworks
 				reply := bm.RegisterCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First service network has to be IPv4 subnet")
 			})
-
 			It("v6-first in machine networks rejected", func() {
-				params.NewClusterParams.MachineNetworks = machineNetworksWrongOrder
+				params.NewClusterParams.MachineNetworks = TestDualStackNetworkingWrongOrder.MachineNetworks
 				reply := bm.RegisterCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First machine network has to be IPv4 subnet")
+			})
+		})
+
+		Context("Cluster with single network when two required", func() {
+			It("Single service network", func() {
+				params.NewClusterParams.ClusterNetworks = common.TestDualStackNetworking.ClusterNetworks
+				params.NewClusterParams.ServiceNetworks = common.TestIPv4Networking.ServiceNetworks
+				reply := bm.RegisterCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 service networks, found 1")
+			})
+			It("Single cluster network", func() {
+				params.NewClusterParams.ClusterNetworks = common.TestIPv4Networking.ClusterNetworks
+				params.NewClusterParams.ServiceNetworks = common.TestDualStackNetworking.ServiceNetworks
+				reply := bm.RegisterCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 cluster networks, found 1")
+			})
+			It("Single machine network", func() {
+				params.NewClusterParams.ServiceNetworks = common.TestDualStackNetworking.ServiceNetworks
+				params.NewClusterParams.MachineNetworks = common.TestIPv4Networking.MachineNetworks
+				reply := bm.RegisterCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 machine networks, found 1")
 			})
 		})
 	})
 
 	Context("Update cluster", func() {
-
 		var params installer.UpdateClusterParams
 
 		BeforeEach(func() {
@@ -12547,31 +12568,46 @@ var _ = Describe("Dual-stack cluster", func() {
 		})
 
 		Context("Cluster with wrong network order", func() {
-
-			const errorMsg = "IPv6 network provided before IPv4"
-
 			It("v6-first in cluster networks rejected", func() {
-				params.ClusterUpdateParams.ClusterNetworks = clusterNetworksWrongOrder
+				params.ClusterUpdateParams.ClusterNetworks = TestDualStackNetworkingWrongOrder.ClusterNetworks
 				reply := bm.UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First cluster network has to be IPv4 subnet")
 			})
-
 			It("v6-first in service networks rejected", func() {
-				params.ClusterUpdateParams.ServiceNetworks = serviceNetworksWrongOrder
+				params.ClusterUpdateParams.ServiceNetworks = TestDualStackNetworkingWrongOrder.ServiceNetworks
 				reply := bm.UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First service network has to be IPv4 subnet")
 			})
-
 			It("v6-first in machine networks rejected", func() {
-				params.ClusterUpdateParams.MachineNetworks = machineNetworksWrongOrder
+				params.ClusterUpdateParams.MachineNetworks = TestDualStackNetworkingWrongOrder.MachineNetworks
 				reply := bm.UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First machine network has to be IPv4 subnet")
+			})
+		})
+
+		Context("Cluster with single network when two required", func() {
+			It("Single service network", func() {
+				params.ClusterUpdateParams.ClusterNetworks = common.TestDualStackNetworking.ClusterNetworks
+				params.ClusterUpdateParams.ServiceNetworks = common.TestIPv4Networking.ServiceNetworks
+				reply := bm.UpdateCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 service networks, found 1")
+			})
+			It("Single cluster network", func() {
+				params.ClusterUpdateParams.ClusterNetworks = common.TestIPv4Networking.ClusterNetworks
+				params.ClusterUpdateParams.ServiceNetworks = common.TestDualStackNetworking.ServiceNetworks
+				reply := bm.UpdateCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 cluster networks, found 1")
+			})
+			It("Single machine network", func() {
+				params.ClusterUpdateParams.ServiceNetworks = common.TestDualStackNetworking.ServiceNetworks
+				params.ClusterUpdateParams.MachineNetworks = common.TestIPv4Networking.MachineNetworks
+				reply := bm.UpdateCluster(ctx, params)
+				verifyApiErrorString(reply, http.StatusBadRequest, "Expected 2 machine networks, found 1")
 			})
 		})
 	})
 
 	Context("[V2] Update cluster", func() {
-
 		var params installer.V2UpdateClusterParams
 
 		BeforeEach(func() {
@@ -12582,25 +12618,20 @@ var _ = Describe("Dual-stack cluster", func() {
 		})
 
 		Context("Cluster with wrong network order", func() {
-
-			const errorMsg = "IPv6 network provided before IPv4"
-
 			It("v6-first in cluster networks rejected", func() {
-				params.ClusterUpdateParams.ClusterNetworks = clusterNetworksWrongOrder
+				params.ClusterUpdateParams.ClusterNetworks = TestDualStackNetworkingWrongOrder.ClusterNetworks
 				reply := bm.V2UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First cluster network has to be IPv4 subnet")
 			})
-
 			It("v6-first in service networks rejected", func() {
-				params.ClusterUpdateParams.ServiceNetworks = serviceNetworksWrongOrder
+				params.ClusterUpdateParams.ServiceNetworks = TestDualStackNetworkingWrongOrder.ServiceNetworks
 				reply := bm.V2UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First service network has to be IPv4 subnet")
 			})
-
 			It("v6-first in machine networks rejected", func() {
-				params.ClusterUpdateParams.MachineNetworks = machineNetworksWrongOrder
+				params.ClusterUpdateParams.MachineNetworks = TestDualStackNetworkingWrongOrder.MachineNetworks
 				reply := bm.V2UpdateCluster(ctx, params)
-				verifyApiErrorString(reply, http.StatusBadRequest, errorMsg)
+				verifyApiErrorString(reply, http.StatusBadRequest, "First machine network has to be IPv4 subnet")
 			})
 		})
 	})

--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -3,7 +3,6 @@ package network
 import (
 	"net"
 
-	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 )
 
@@ -124,26 +123,5 @@ func VerifyNetworkHostPrefix(prefix int64) error {
 	if prefix < 1 {
 		return errors.Errorf("Host prefix, now %d, must be a positive integer", prefix)
 	}
-	return nil
-}
-
-// Verify if the constrains for dual-stack machine networks are met:
-//   * there are exactly two machine networks
-//   * the first one is IPv4 subnet
-//   * the second one is IPv6 subnet
-func VerifyMachineNetworksDualStack(networks []*models.MachineNetwork, isDualStack bool) error {
-	if !isDualStack {
-		return nil
-	}
-	if len(networks) != 2 {
-		return errors.Errorf("Expected 2 machine networks, found %d", len(networks))
-	}
-	if !IsIPV4CIDR(string(networks[0].Cidr)) {
-		return errors.Errorf("First machine network has to be IPv4 subnet")
-	}
-	if !IsIPv6CIDR(string(networks[1].Cidr)) {
-		return errors.Errorf("Second machine network has to be IPv6 subnet")
-	}
-
 	return nil
 }

--- a/internal/network/dual_stack_validations.go
+++ b/internal/network/dual_stack_validations.go
@@ -1,0 +1,61 @@
+package network
+
+import (
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+)
+
+// Verify if the constrains for dual-stack machine networks are met:
+//   * there are exactly two machine networks
+//   * the first one is IPv4 subnet
+//   * the second one is IPv6 subnet
+func VerifyMachineNetworksDualStack(networks []*models.MachineNetwork, isDualStack bool) error {
+	if !isDualStack {
+		return nil
+	}
+	if len(networks) != 2 {
+		return errors.Errorf("Expected 2 machine networks, found %d", len(networks))
+	}
+	if !IsIPV4CIDR(string(networks[0].Cidr)) {
+		return errors.Errorf("First machine network has to be IPv4 subnet")
+	}
+	if !IsIPv6CIDR(string(networks[1].Cidr)) {
+		return errors.Errorf("Second machine network has to be IPv6 subnet")
+	}
+
+	return nil
+}
+
+func VerifyServiceNetworksDualStack(networks []*models.ServiceNetwork, isDualStack bool) error {
+	if !isDualStack {
+		return nil
+	}
+	if len(networks) != 2 {
+		return errors.Errorf("Expected 2 service networks, found %d", len(networks))
+	}
+	if !IsIPV4CIDR(string(networks[0].Cidr)) {
+		return errors.Errorf("First service network has to be IPv4 subnet")
+	}
+	if !IsIPv6CIDR(string(networks[1].Cidr)) {
+		return errors.Errorf("Second service network has to be IPv6 subnet")
+	}
+
+	return nil
+}
+
+func VerifyClusterNetworksDualStack(networks []*models.ClusterNetwork, isDualStack bool) error {
+	if !isDualStack {
+		return nil
+	}
+	if len(networks) != 2 {
+		return errors.Errorf("Expected 2 cluster networks, found %d", len(networks))
+	}
+	if !IsIPV4CIDR(string(networks[0].Cidr)) {
+		return errors.Errorf("First cluster network has to be IPv4 subnet")
+	}
+	if !IsIPv6CIDR(string(networks[1].Cidr)) {
+		return errors.Errorf("Second cluster network has to be IPv6 subnet")
+	}
+
+	return nil
+}

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -66,10 +66,70 @@ func GetConfiguredAddressFamilies(cluster *common.Cluster) (ipv4 bool, ipv6 bool
 	return
 }
 
+func GetAddressFamilies(networks interface{}) (ipv4 bool, ipv6 bool, err error) {
+	addresses := make([]models.Subnet, 0)
+	ipv4 = false
+	ipv6 = false
+
+	switch v := networks.(type) {
+	case []*models.ClusterNetwork:
+		for _, net := range v {
+			addresses = append(addresses, net.Cidr)
+		}
+	case []*models.ServiceNetwork:
+		for _, net := range v {
+			addresses = append(addresses, net.Cidr)
+		}
+	case []*models.MachineNetwork:
+		for _, net := range v {
+			addresses = append(addresses, net.Cidr)
+		}
+	default:
+		return false, false, errors.New("Provided invalid network list")
+	}
+
+	for _, cidr := range addresses {
+		if IsIPV4CIDR(string(cidr)) {
+			ipv4 = true
+		} else {
+			ipv6 = true
+		}
+	}
+
+	return ipv4, ipv6, nil
+}
+
 func IsMachineCidrAvailable(cluster *common.Cluster) bool {
 	return common.IsSliceNonEmpty(cluster.MachineNetworks)
 }
 
 func GetMachineCidrById(cluster *common.Cluster, index int) string {
 	return string(cluster.MachineNetworks[index].Cidr)
+}
+
+func DerefMachineNetworks(obj interface{}) []*models.MachineNetwork {
+	switch v := obj.(type) {
+	case []*models.MachineNetwork:
+		return v
+	default:
+		return nil
+	}
+}
+
+func DerefServiceNetworks(obj interface{}) []*models.ServiceNetwork {
+	switch v := obj.(type) {
+	case []*models.ServiceNetwork:
+		return v
+	default:
+		return nil
+	}
+}
+
+func DerefClusterNetworks(obj interface{}) []*models.ClusterNetwork {
+	switch v := obj.(type) {
+	case []*models.ClusterNetwork:
+		return v
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description

This commit extends the validations performed for dual-stack OCP
clusters by making sure the following requirements are met if a cluster
is dual-stack

* exactly 2 machine networks are provided (if any)
* exactly 2 service networks are provided
* exactly 2 cluster networks are provided
* for every list containing 2 networks, the first one has to be IPv4 and
  the second one IPv6

Closes-bug: #2007106
Contributes-to: #2005440
Closes: [OCPBUGSM-35447](https://issues.redhat.com/browse/OCPBUGSM-35447)
Contributes-to: [OCPBUGSM-35273](https://issues.redhat.com/browse/OCPBUGSM-35273)

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual test for single service network

#### KubeAPI

```
time="2021-09-28T11:38:22Z" level=error msg="Failed to registered cluster test-infra-cluster-assisted-installer-debug with id c89e1293-7b2e-4959-bc1a-b6934a20a6f3" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).RegisterClusterInternal.func1" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:419" cluster_id=c89e1293-7b2e-4959-bc1a-b6934a20a6f3 error="Expected 2 service networks, found 1" go-id=661 pkg=Inventory request_id=98aee5cf-5531-440d-bbe4-8e986964c42b
```

```
status:
  conditions:
  - lastProbeTime: "2021-09-28T11:38:17Z"
    lastTransitionTime: "2021-09-28T11:38:17Z"
    message: 'The Spec could not be synced due to an input error: Expected 2 service
      networks, found 1'
    reason: InputError
    status: "False"
    type: SpecSynced
```

#### Rest API

```
[root@edge-14 ~]# export PAYLOAD='{"vip_dhcp_allocation":true,"network_type":"OVNKubernetes","user_managed_networking":false,"cluster_networks":[{"cidr":"10.128.0.0/14","host_prefix":23},{"cidr":"fd01::/48","host_prefix":64}],"service_networks":[{"cidr":"172.30.0.0/16"}],"machine_networks":[{"cidr":"192.168.127.0/24"},{"cidr":"1001:db8::/120"}]}'
[root@edge-14 ~]# curl --data $PAYLOAD -H "content-type: application/json" --request PATCH http://chocobomb.lab/api/assisted-install/v1/clusters/$CLUSTER
{"code":"400","href":"","id":400,"kind":"Error","reason":"Expected 2 service networks, found 1"}
```

The service is not crashing. Test succeeded.

### Manual test for single machine network

#### KubeAPI

Does not throw an error yet, that's why only `Contributes-to: #2005440` and not `Closes-bug: #2005440`

#### Rest API

```
[root@edge-14 ~]# export PAYLOAD='{"vip_dhcp_allocation":true,"network_type":"OVNKubernetes","user_managed_networking":false,"cluster_networks":[{"cidr":"10.128.0.0/14","host_prefix":23},{"cidr":"fd01::/48","host_prefix":64}],"service_networks":[{"cidr":"172.30.0.0/16"},{"cidr":"fd02::/112"}],"machine_networks":[{"cidr":"192.168.127.0/24"}]}' 
[root@edge-14 ~]# curl --data $PAYLOAD -H "content-type: application/json" --request PATCH http://chocobomb.lab/api/assisted-install/v1/clusters/$CLUSTER
{"code":"400","href":"","id":400,"kind":"Error","reason":"Expected 2 machine networks, found 1"}
```

## Assignees

/cc @flaper87 
/cc @YuviGold 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
