### PR TITLE
Bug 2007515: Pass copy-network when infraEnv.StaticNetworkConfig is set

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -265,6 +265,16 @@ func GetInfraEnvFromDB(db *gorm.DB, infraEnvID strfmt.UUID) (*InfraEnv, error) {
 	return &infraEnv, nil
 }
 
+func GetInfraEnvByClusterFromDB(db *gorm.DB, clusterId strfmt.UUID) (*InfraEnv, error) {
+	var infraEnv InfraEnv
+
+	err := db.First(&infraEnv, "cluster_id = ?", clusterId.String()).Error
+	if err != nil {
+		return nil, err
+	}
+	return &infraEnv, nil
+}
+
 func GetInfraEnvHostsFromDB(db *gorm.DB, infraEnvID strfmt.UUID) ([]*Host, error) {
 	return GetHostsFromDBWhere(db, "infra_env_id = ?", infraEnvID)
 }

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -82,6 +82,14 @@ var _ = Describe("instruction_manager", func() {
 					BaseDNSDomain:     "test.com",
 				}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+			infraEnv := common.InfraEnv{
+				InfraEnv: models.InfraEnv{
+					ID:        strfmt.UUID(uuid.New().String()),
+					ClusterID: clusterId,
+				},
+			}
+			Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
 			It("invalid_host_state", func() {
@@ -163,6 +171,14 @@ var _ = Describe("instruction_manager", func() {
 				BaseDNSDomain:     "test.com",
 			}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+			infraEnv := common.InfraEnv{
+				InfraEnv: models.InfraEnv{
+					ID:        strfmt.UUID(uuid.New().String()),
+					ClusterID: clusterId,
+				},
+			}
+			Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
 			It("invalid_host_state", func() {
@@ -304,6 +320,15 @@ var _ = Describe("instruction_manager", func() {
 					MachineNetworks:   common.TestIPv4Networking.MachineNetworks,
 				}}
 				Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+				infraEnv := common.InfraEnv{
+					InfraEnv: models.InfraEnv{
+						ID:        strfmt.UUID(uuid.New().String()),
+						ClusterID: clusterId,
+					},
+				}
+				Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
+
 			})
 			It("Should not filter out any step when: HostState=installing DisabledSteps=execute.", func() {
 				instMng = createInstMngWithDisabledSteps([]models.StepType{models.StepTypeExecute})


### PR DESCRIPTION
# Assisted Pull Request

## Description

Originally, assisted-service would add the `--copy-network` argument to
the coreos-install command when the cluster.StaticNetworkConfigured flag
was set. This flag, however, is only been set to true for cloud-managed
deployments.

The cluster.StaticNetworkConfigured flag became a cached value of data
that should be considered dynamic, which broke the abstraction and the
separation of concerns of the various objects managed internally.
Specifically, it put in the cluster data that should only belong to the
infraenv.

This commit removes the use of `cluster.StaticNetworkConfigured` when
deciding to pass the `--copy-network` flag in favor of just checking
that the `infraenv.StaticNetworkConfig` is not empty.

The field in the model is not being removed in this commit as this will
be backported and it'd be preferable to not do database migrations in
backports. A follow-up commit will take care of removing the DB column.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Did a deployment with static IP addresses, here's the result:

```
Sep 24 05:50:43 localhost installer[5731]: time="2021-09-24T05:50:43Z" level=info msg="Assisted installer started. Configuration is:\n struct Config {\n\tRole: \"master\",\n\tClusterID: \"064958fa-e558-4775-95c6-6f92ae0e088c\",\n\tInfraEnvID: \"6c7ea4bb-6709-4234-8004-8e5772b7c497\",\n\tHostID: \"4d462bd1-91a2-de92-a9
72-35f424de682c\",\n\tDevice: \"/dev/disk/by-id/wwn-0x5707c181006c0d1e\",\n\tURL: \"https://assisted-service-assisted-installer.apps.hub-sno.kubeframe.com\",\n\tVerbose: false,\n\tOpenshiftVersion: \"4.9.0-rc.0\",\n\tMCOImage: \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b71a7fb195da48e20c057dfb0d2f462d0495
d8be5026de7674f5442acdb74d36\",\n\tControllerImage: \"quay.io/ocpmetal/assisted-installer-controller:latest\",\n\tAgentImage: \"quay.io/ocpmetal/assisted-installer-agent:latest\",\n\tPullSecretToken: <SECRET>,\n\tSkipCertVerification: false,\n\tCACertPath: \"/etc/assisted-service/service-ca-cert.crt\",\n\tHTTPProxy: \
"\",\n\tHTTPSProxy: \"\",\n\tNoProxy: \"\",\n\tServiceIPs: \"\",\n\tInstallerArgs: []string{\"--append-karg\", \"ip=eno1:dhcp\", \"--copy-network\"},\n\tHighAvailabilityMode: \"Full\",\n\tCheckClusterVersion: true,\n\tMustGatherImage: \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b1e3786295a42239f1dbe998020f
fba5716875e4ef6772eb3e4b13cf22f54a07\",\n}"
...
Sep 24 05:51:46 localhost kernel:  sda: sda1 sda2 sda3 sda4
Sep 24 05:51:46 localhost systemd[2258]: Starting Cleanup of User's Temporary Files and Directories...
Sep 24 05:51:46 localhost systemd[2258]: systemd-tmpfiles-clean.service: Succeeded.
Sep 24 05:51:46 localhost systemd[2258]: Started Cleanup of User's Temporary Files and Directories.
Sep 24 05:51:46 localhost kernel: EXT4-fs (sda3): mounted filesystem with ordered data mode. Opts: (null)
Sep 24 05:51:46 localhost installer[5731]: time="2021-09-24T05:51:46Z" level=info msg="Writing Ignition config\n"
Sep 24 05:51:46 localhost installer[5731]: time="2021-09-24T05:51:46Z" level=info msg="Modifying kernel arguments\n"
Sep 24 05:51:46 localhost installer[5731]: time="2021-09-24T05:51:46Z" level=info msg="Copying networking configuration from /etc/NetworkManager/system-connections/\n"
Sep 24 05:51:46 localhost installer[5731]: time="2021-09-24T05:51:46Z" level=info msg="Copying /etc/NetworkManager/system-connections/eno1.nmconnection to installed system\n"
```


First boot:

```
[root@kubeframe-master-0 ~]# cat /etc/NetworkManager/system-connections/eno1.nmconnection
[connection]
id=eno1
uuid=05c67f57-6086-4e6b-8f11-5fccadb20b06
type=ethernet
interface-name=eno1
permissions=
autoconnect=true
autoconnect-priority=1

[ethernet]
auto-negotiate=true
cloned-mac-address=00:FD:45:FF:2B:75
mac-address-blacklist=
mtu=1500

[ipv4]
address1=192.168.7.10/24
dhcp-client-id=mac
dns=192.168.7.8;192.168.7.1;
dns-priority=40
dns-search=
method=manual
route1=0.0.0.0/0,192.168.7.1
route1_options=table=254

[ipv6]
addr-gen-mode=eui64
dhcp-duid=ll
dhcp-iaid=mac
dns-search=
method=disabled

[proxy]
```

```
[root@kubeframe-master-0 ~]# ls /etc/NetworkManager/system-connections/
eno1.nmconnection
```

Get Nodes:

```
➜ KUBECONFIG=/home/flaper87/workspace/assisted-service/spoke-kubeconfig oc get nodes -owide
NAME                 STATUS     ROLES    AGE   VERSION                INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
kubeframe-master-0   NotReady   master   32s   v1.22.0-rc.0+75ee307   192.168.7.10   <none>        Red Hat Enterprise Linux CoreOS 49.84.202109041651-0 (Ootpa)   4.18.0-305.12.1.el8_4.x86_64   cri-o://1.22.0-68.rhaos4.9.git011c10a.el8
```

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @trewest 
/cc @celebdor 
/cc @yevgeny-shnaidman 
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
