### PR TITLE
Bug 2007539: Pass copy-network when infraEnv.StaticNetworkConfig is set

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -265,16 +265,6 @@ func GetInfraEnvFromDB(db *gorm.DB, infraEnvID strfmt.UUID) (*InfraEnv, error) {
 	return &infraEnv, nil
 }
 
-func GetInfraEnvByClusterFromDB(db *gorm.DB, clusterId strfmt.UUID) (*InfraEnv, error) {
-	var infraEnv InfraEnv
-
-	err := db.First(&infraEnv, "cluster_id = ?", clusterId.String()).Error
-	if err != nil {
-		return nil, err
-	}
-	return &infraEnv, nil
-}
-
 func GetInfraEnvHostsFromDB(db *gorm.DB, infraEnvID strfmt.UUID) ([]*Host, error) {
 	return GetHostsFromDBWhere(db, "infra_env_id = ?", infraEnvID)
 }

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -265,6 +265,16 @@ func GetInfraEnvFromDB(db *gorm.DB, infraEnvID strfmt.UUID) (*InfraEnv, error) {
 	return &infraEnv, nil
 }
 
+func GetInfraEnvByClusterFromDB(db *gorm.DB, clusterId strfmt.UUID) (*InfraEnv, error) {
+	var infraEnv InfraEnv
+
+	err := db.First(&infraEnv, "cluster_id = ?", clusterId.String()).Error
+	if err != nil {
+		return nil, err
+	}
+	return &infraEnv, nil
+}
+
 func GetInfraEnvHostsFromDB(db *gorm.DB, infraEnvID strfmt.UUID) ([]*Host, error) {
 	return GetHostsFromDBWhere(db, "infra_env_id = ?", infraEnvID)
 }

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -82,6 +82,14 @@ var _ = Describe("instruction_manager", func() {
 					BaseDNSDomain:     "test.com",
 				}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+			infraEnv := common.InfraEnv{
+				InfraEnv: models.InfraEnv{
+					ID:        strfmt.UUID(uuid.New().String()),
+					ClusterID: clusterId,
+				},
+			}
+			Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
 			It("invalid_host_state", func() {
@@ -163,6 +171,14 @@ var _ = Describe("instruction_manager", func() {
 				BaseDNSDomain:     "test.com",
 			}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+			infraEnv := common.InfraEnv{
+				InfraEnv: models.InfraEnv{
+					ID:        strfmt.UUID(uuid.New().String()),
+					ClusterID: clusterId,
+				},
+			}
+			Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
 		})
 		Context("get_next_steps", func() {
 			It("invalid_host_state", func() {
@@ -304,6 +320,15 @@ var _ = Describe("instruction_manager", func() {
 					MachineNetworks:   common.TestIPv4Networking.MachineNetworks,
 				}}
 				Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+				infraEnv := common.InfraEnv{
+					InfraEnv: models.InfraEnv{
+						ID:        strfmt.UUID(uuid.New().String()),
+						ClusterID: clusterId,
+					},
+				}
+				Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
+
 			})
 			It("Should not filter out any step when: HostState=installing DisabledSteps=execute.", func() {
 				instMng = createInstMngWithDisabledSteps([]models.StepType{models.StepTypeExecute})

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -85,7 +85,7 @@ var _ = Describe("instruction_manager", func() {
 
 			infraEnv := common.InfraEnv{
 				InfraEnv: models.InfraEnv{
-					ID:        strfmt.UUID(uuid.New().String()),
+					ID:        infraEnvId,
 					ClusterID: clusterId,
 				},
 			}
@@ -174,7 +174,7 @@ var _ = Describe("instruction_manager", func() {
 
 			infraEnv := common.InfraEnv{
 				InfraEnv: models.InfraEnv{
-					ID:        strfmt.UUID(uuid.New().String()),
+					ID:        infraEnvId,
 					ClusterID: clusterId,
 				},
 			}
@@ -323,12 +323,11 @@ var _ = Describe("instruction_manager", func() {
 
 				infraEnv := common.InfraEnv{
 					InfraEnv: models.InfraEnv{
-						ID:        strfmt.UUID(uuid.New().String()),
+						ID:        infraEnvId,
 						ClusterID: clusterId,
 					},
 				}
 				Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
-
 			})
 			It("Should not filter out any step when: HostState=installing DisabledSteps=execute.", func() {
 				instMng = createInstMngWithDisabledSteps([]models.StepType{models.StepTypeExecute})


### PR DESCRIPTION
# Assisted Pull Request

## Description

Originally, assisted-service would add the `--copy-network` argument to
the coreos-install command when the cluster.StaticNetworkConfigured flag
was set. This flag, however, is only been set to true for cloud-managed
deployments.

The cluster.StaticNetworkConfigured flag became a cached value of data
that should be considered dynamic, which broke the abstraction and the
separation of concerns of the various objects managed internally.
Specifically, it put in the cluster data that should only belong to the
infraenv.

This commit removes the use of `cluster.StaticNetworkConfigured` when
deciding to pass the `--copy-network` flag in favor of just checking
that the `infraenv.StaticNetworkConfig` is not empty.

The field in the model is not being removed in this commit as this will
be backported and it'd be preferable to not do database migrations in
backports. A follow-up commit will take care of removing the DB column.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

(cherry picked from commit 8cf51023fecb0ef0d213b8d0d216176f903f0190)
(cherry picked from commit d3264105f8a3d6f7edfb3fbab269624e53cb7f74)

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Backport
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

See master PR for more info about tests  (#2662)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @celebdor 
/cc @djzager 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
