### PR TITLE
Bug 2007515: Fix regression introduced by copy-network bugfix

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -265,16 +265,6 @@ func GetInfraEnvFromDB(db *gorm.DB, infraEnvID strfmt.UUID) (*InfraEnv, error) {
 	return &infraEnv, nil
 }
 
-func GetInfraEnvByClusterFromDB(db *gorm.DB, clusterId strfmt.UUID) (*InfraEnv, error) {
-	var infraEnv InfraEnv
-
-	err := db.First(&infraEnv, "cluster_id = ?", clusterId.String()).Error
-	if err != nil {
-		return nil, err
-	}
-	return &infraEnv, nil
-}
-
 func GetInfraEnvHostsFromDB(db *gorm.DB, infraEnvID strfmt.UUID) ([]*Host, error) {
 	return GetHostsFromDBWhere(db, "infra_env_id = ?", infraEnvID)
 }

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -85,7 +85,7 @@ var _ = Describe("instruction_manager", func() {
 
 			infraEnv := common.InfraEnv{
 				InfraEnv: models.InfraEnv{
-					ID:        strfmt.UUID(uuid.New().String()),
+					ID:        infraEnvId,
 					ClusterID: clusterId,
 				},
 			}
@@ -174,7 +174,7 @@ var _ = Describe("instruction_manager", func() {
 
 			infraEnv := common.InfraEnv{
 				InfraEnv: models.InfraEnv{
-					ID:        strfmt.UUID(uuid.New().String()),
+					ID:        infraEnvId,
 					ClusterID: clusterId,
 				},
 			}
@@ -323,12 +323,11 @@ var _ = Describe("instruction_manager", func() {
 
 				infraEnv := common.InfraEnv{
 					InfraEnv: models.InfraEnv{
-						ID:        strfmt.UUID(uuid.New().String()),
+						ID:        infraEnvId,
 						ClusterID: clusterId,
 					},
 				}
 				Expect(db.Create(&infraEnv).Error).ShouldNot(HaveOccurred())
-
 			})
 			It("Should not filter out any step when: HostState=installing DisabledSteps=execute.", func() {
 				instMng = createInstMngWithDisabledSteps([]models.StepType{models.StepTypeExecute})


### PR DESCRIPTION
# Assisted Pull Request

## Description
Commit 8cf51023fecb0ef0d213b8d0d216176f903f0190 (#2662) introduced a bug
which broke late binding.

The `GetInfraEnvByClusterFromDB` function introduced by that commit
wrongly assumed that every infra env must have a corresponding cluster
ID. This is not the case for late-binding infra-envs where infra envs
can have no cluster ID.

This commit gets rid of the `GetInfraEnvByClusterFromDB` function and instead fetches
the infra-env database object during install command creation by taking the infraenv
ID from the host and using the existing `GetInfraEnvFromDB` function.

All "modern" hosts are guaranteed to have an infra env ID.

Older hosts in the database might not have an infra env ID, but we
do not expect any user to actually try to go through with "installation"
of these old hosts. In any case, the `constructHostInstallerArgs` has
been modified to handle a `nil` `*InfraEnv`.

Unit tests have been adjusted to use the correct infra env ID which is
actually set in the host, rather then re-generating a new infra env ID
when creating test-specific infra env objects.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?
- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

(Currently there are no E2E tests for late binding, which is the reason this
 regression was missed in the first place)

This PR is being tested manually by attempting to install a late-binding cluster locally.
Proper late-binding tests are in the works and should be merged in the upcoming days.

## Assignees

/cc @flaper87
/cc @carbonin

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md