### PR TITLE
NO-ISSUE - Increase operator deployment wait-for-service-pod-ready timeout

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -35,7 +35,7 @@ function wait_for_pod() {
     namespace="${2:-}"
     selector="${3:-}"
 
-    wait_for_condition "pod" "Ready" "22m" "${namespace}" "${selector}"
+    wait_for_condition "pod" "Ready" "30m" "${namespace}" "${selector}"
 }
 
 function hash() {


### PR DESCRIPTION
# Assisted Pull Request

## Description
When deploying the operator, we wait 22m for the service pods to become ready,
and if they don't become ready, we give up and exit with an error.

I've had a run fail due to this timeout being too short, where the pod did eventually
became ready - if the timeout were to be higher, it would've probably worked just fine.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yuvigold
/cc @carbonin

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md