### PR TITLE
MGMT-7708: Generate openshift_versions API from RELEASE_IMAGES

### DIFF
--- a/client/versions/list_supported_openshift_versions_responses.go
+++ b/client/versions/list_supported_openshift_versions_responses.go
@@ -29,6 +29,12 @@ func (o *ListSupportedOpenshiftVersionsReader) ReadResponse(response runtime.Cli
 			return nil, err
 		}
 		return result, nil
+	case 500:
+		result := NewListSupportedOpenshiftVersionsInternalServerError()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 503:
 		result := NewListSupportedOpenshiftVersionsServiceUnavailable()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -66,6 +72,39 @@ func (o *ListSupportedOpenshiftVersionsOK) readResponse(response runtime.ClientR
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewListSupportedOpenshiftVersionsInternalServerError creates a ListSupportedOpenshiftVersionsInternalServerError with default headers values
+func NewListSupportedOpenshiftVersionsInternalServerError() *ListSupportedOpenshiftVersionsInternalServerError {
+	return &ListSupportedOpenshiftVersionsInternalServerError{}
+}
+
+/*ListSupportedOpenshiftVersionsInternalServerError handles this case with default header values.
+
+Error.
+*/
+type ListSupportedOpenshiftVersionsInternalServerError struct {
+	Payload *models.Error
+}
+
+func (o *ListSupportedOpenshiftVersionsInternalServerError) Error() string {
+	return fmt.Sprintf("[GET /v1/openshift_versions][%d] listSupportedOpenshiftVersionsInternalServerError  %+v", 500, o.Payload)
+}
+
+func (o *ListSupportedOpenshiftVersionsInternalServerError) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *ListSupportedOpenshiftVersionsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,8 +306,8 @@ func main() {
 	for _, ocpVersion := range openshiftVersionsMap {
 		// ReleaseImage is not necessarily specified when using the operator
 		// (fetched from ClusterImageSet instead)
-		if ocpVersion.ReleaseImage != nil {
-			images = append(images, *ocpVersion.ReleaseImage)
+		if ocpVersion.ReleaseImage != "" {
+			images = append(images, ocpVersion.ReleaseImage)
 		}
 	}
 

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -68,12 +68,12 @@ var TestDefaultConfig = &TestConfiguration{
 	ReleaseImageUrl:  ReleaseImage,
 	CPUArchitecture:  CPUArchitecture,
 	Version: &models.OpenshiftVersion{
-		DisplayName:    &OpenShiftVersion,
-		ReleaseImage:   &ReleaseImage,
-		ReleaseVersion: &ReleaseVersion,
-		RhcosImage:     &RhcosImage,
-		RhcosVersion:   &RhcosVersion,
-		SupportLevel:   &SupportLevel,
+		DisplayName:    OpenShiftVersion,
+		ReleaseImage:   ReleaseImage,
+		ReleaseVersion: ReleaseVersion,
+		RhcosImage:     RhcosImage,
+		RhcosVersion:   RhcosVersion,
+		SupportLevel:   SupportLevel,
 	},
 	ReleaseImage: &models.ReleaseImage{
 		CPUArchitecture:  &CPUArchitecture,

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1250,10 +1250,10 @@ func (r *AgentServiceConfigReconciler) getOpenshiftVersions(log logrus.FieldLogg
 		}
 
 		openshiftVersion := models.OpenshiftVersion{
-			DisplayName:  &key,
-			RhcosVersion: &instance.Spec.OSImages[i].Version,
-			RhcosImage:   &instance.Spec.OSImages[i].Url,
-			RhcosRootfs:  &instance.Spec.OSImages[i].RootFSUrl,
+			DisplayName:  key,
+			RhcosVersion: instance.Spec.OSImages[i].Version,
+			RhcosImage:   instance.Spec.OSImages[i].Url,
+			RhcosRootfs:  instance.Spec.OSImages[i].RootFSUrl,
 		}
 
 		// the last entry for a particular OpenShift version takes precedence.

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1111,19 +1111,18 @@ func newASCWithOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, string) {
 		},
 	}
 
-	s := func(s string) *string { return &s }
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.8": {
-			DisplayName:  s("4.8"),
-			RhcosVersion: s("48"),
-			RhcosImage:   s("4.8.iso"),
-			RhcosRootfs:  s("4.8.img"),
+			DisplayName:  "4.8",
+			RhcosVersion: "48",
+			RhcosImage:   "4.8.iso",
+			RhcosRootfs:  "4.8.img",
 		},
 		"4.9": {
-			DisplayName:  s("4.9"),
-			RhcosVersion: s("49"),
-			RhcosImage:   s("4.9.iso"),
-			RhcosRootfs:  s("4.9.img"),
+			DisplayName:  "4.9",
+			RhcosVersion: "49",
+			RhcosImage:   "4.9.iso",
+			RhcosRootfs:  "4.9.img",
 		},
 	})
 
@@ -1147,19 +1146,18 @@ func newASCWithMultipleOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, strin
 		},
 	}
 
-	s := func(s string) *string { return &s }
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.7": {
-			DisplayName:  s("4.7"),
-			RhcosVersion: s("47"),
-			RhcosImage:   s("4.7.iso"),
-			RhcosRootfs:  s("4.7.img"),
+			DisplayName:  "4.7",
+			RhcosVersion: "47",
+			RhcosImage:   "4.7.iso",
+			RhcosRootfs:  "4.7.img",
 		},
 		"4.8": {
-			DisplayName:  s("4.8"),
-			RhcosVersion: s("48"),
-			RhcosImage:   s("4.8.iso"),
-			RhcosRootfs:  s("4.8.img"),
+			DisplayName:  "4.8",
+			RhcosVersion: "48",
+			RhcosImage:   "4.8.iso",
+			RhcosRootfs:  "4.8.img",
 		},
 	})
 
@@ -1189,19 +1187,18 @@ func newASCWithDuplicateOpenshiftVersions() (*aiv1beta1.AgentServiceConfig, stri
 		},
 	}
 
-	s := func(s string) *string { return &s }
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.7": {
-			DisplayName:  s("4.7"),
-			RhcosVersion: s("47"),
-			RhcosImage:   s("4.7.iso"),
-			RhcosRootfs:  s("4.7.img"),
+			DisplayName:  "4.7",
+			RhcosVersion: "47",
+			RhcosImage:   "4.7.iso",
+			RhcosRootfs:  "4.7.img",
 		},
 		"4.8": {
-			DisplayName:  s("4.8"),
-			RhcosVersion: s("48"),
-			RhcosImage:   s("4.8.iso"),
-			RhcosRootfs:  s("4.8.img"),
+			DisplayName:  "4.8",
+			RhcosVersion: "48",
+			RhcosImage:   "4.8.iso",
+			RhcosRootfs:  "4.8.img",
 		},
 	})
 
@@ -1235,13 +1232,12 @@ func newASCWithLongOpenshiftVersion() (*aiv1beta1.AgentServiceConfig, string) {
 		},
 	}
 
-	s := func(s string) *string { return &s }
 	encodedVersions, _ := json.Marshal(map[string]models.OpenshiftVersion{
 		"4.8": {
-			DisplayName:  s("4.8"),
-			RhcosVersion: s("48"),
-			RhcosImage:   s("4.8.iso"),
-			RhcosRootfs:  s("4.8.img"),
+			DisplayName:  "4.8",
+			RhcosVersion: "48",
+			RhcosImage:   "4.8.iso",
+			RhcosRootfs:  "4.8.img",
 		},
 	})
 

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -63,7 +63,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(step).NotTo(BeNil())
 
-		defaultReleaseImage := *common.TestDefaultConfig.Version.ReleaseImage
+		defaultReleaseImage := common.TestDefaultConfig.Version.ReleaseImage
 		request := &models.ContainerImageAvailabilityRequest{
 			Images:  []string{defaultReleaseImage, defaultMCOImage, ocpMustGatherImage, cmd.instructionConfig.InstallerImage},
 			Timeout: defaultImageAvailabilityTimeoutSeconds,
@@ -131,7 +131,7 @@ var _ = Describe("get images", func() {
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mco, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
-		release := *common.TestDefaultConfig.Version.ReleaseImage
+		release := common.TestDefaultConfig.Version.ReleaseImage
 		expected := []string{release, mco, defaultMustGatherVersion["ocp"]}
 		images, err := cmd.getImages(cluster)
 		Expect(err).NotTo(HaveOccurred())

--- a/models/openshift_version.go
+++ b/models/openshift_version.go
@@ -19,66 +19,38 @@ import (
 // swagger:model openshift-version
 type OpenshiftVersion struct {
 
+	// Available CPU architectures.
+	CPUArchitectures []string `json:"cpu_architectures"`
+
 	// Indication that the version is the recommended one.
 	Default bool `json:"default,omitempty"`
 
 	// Name of the version to be presented to the user.
-	// Required: true
-	DisplayName *string `json:"display_name"`
+	DisplayName string `json:"display_name,omitempty"`
 
 	// The installation image of the OpenShift cluster.
-	// Required: true
-	ReleaseImage *string `json:"release_image"`
+	ReleaseImage string `json:"release_image,omitempty"`
 
 	// OCP version from the release metadata.
-	// Required: true
-	ReleaseVersion *string `json:"release_version"`
+	ReleaseVersion string `json:"release_version,omitempty"`
 
 	// The base RHCOS image used for the discovery iso.
-	// Required: true
-	RhcosImage *string `json:"rhcos_image"`
+	RhcosImage string `json:"rhcos_image,omitempty"`
 
 	// The RHCOS rootfs url.
-	// Required: true
-	RhcosRootfs *string `json:"rhcos_rootfs"`
+	RhcosRootfs string `json:"rhcos_rootfs,omitempty"`
 
 	// Build ID of the RHCOS image.
-	// Required: true
-	RhcosVersion *string `json:"rhcos_version"`
+	RhcosVersion string `json:"rhcos_version,omitempty"`
 
 	// Level of support of the version.
-	// Required: true
-	// Enum: [beta production custom]
-	SupportLevel *string `json:"support_level"`
+	// Enum: [beta production]
+	SupportLevel string `json:"support_level,omitempty"`
 }
 
 // Validate validates this openshift version
 func (m *OpenshiftVersion) Validate(formats strfmt.Registry) error {
 	var res []error
-
-	if err := m.validateDisplayName(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReleaseImage(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateReleaseVersion(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateRhcosImage(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateRhcosRootfs(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateRhcosVersion(formats); err != nil {
-		res = append(res, err)
-	}
 
 	if err := m.validateSupportLevel(formats); err != nil {
 		res = append(res, err)
@@ -90,65 +62,11 @@ func (m *OpenshiftVersion) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *OpenshiftVersion) validateDisplayName(formats strfmt.Registry) error {
-
-	if err := validate.Required("display_name", "body", m.DisplayName); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *OpenshiftVersion) validateReleaseImage(formats strfmt.Registry) error {
-
-	if err := validate.Required("release_image", "body", m.ReleaseImage); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *OpenshiftVersion) validateReleaseVersion(formats strfmt.Registry) error {
-
-	if err := validate.Required("release_version", "body", m.ReleaseVersion); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *OpenshiftVersion) validateRhcosImage(formats strfmt.Registry) error {
-
-	if err := validate.Required("rhcos_image", "body", m.RhcosImage); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *OpenshiftVersion) validateRhcosRootfs(formats strfmt.Registry) error {
-
-	if err := validate.Required("rhcos_rootfs", "body", m.RhcosRootfs); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *OpenshiftVersion) validateRhcosVersion(formats strfmt.Registry) error {
-
-	if err := validate.Required("rhcos_version", "body", m.RhcosVersion); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 var openshiftVersionTypeSupportLevelPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["beta","production","custom"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["beta","production"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -163,9 +81,6 @@ const (
 
 	// OpenshiftVersionSupportLevelProduction captures enum value "production"
 	OpenshiftVersionSupportLevelProduction string = "production"
-
-	// OpenshiftVersionSupportLevelCustom captures enum value "custom"
-	OpenshiftVersionSupportLevelCustom string = "custom"
 )
 
 // prop value enum
@@ -178,12 +93,12 @@ func (m *OpenshiftVersion) validateSupportLevelEnum(path, location string, value
 
 func (m *OpenshiftVersion) validateSupportLevel(formats strfmt.Registry) error {
 
-	if err := validate.Required("support_level", "body", m.SupportLevel); err != nil {
-		return err
+	if swag.IsZero(m.SupportLevel) { // not required
+		return nil
 	}
 
 	// value enum
-	if err := m.validateSupportLevelEnum("support_level", "body", *m.SupportLevel); err != nil {
+	if err := m.validateSupportLevelEnum("support_level", "body", m.SupportLevel); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -4330,6 +4330,12 @@ func init() {
               "$ref": "#/definitions/openshift-versions"
             }
           },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          },
           "503": {
             "description": "Unavailable.",
             "schema": {
@@ -11946,16 +11952,14 @@ func init() {
     },
     "openshift-version": {
       "type": "object",
-      "required": [
-        "display_name",
-        "release_image",
-        "release_version",
-        "rhcos_image",
-        "rhcos_rootfs",
-        "rhcos_version",
-        "support_level"
-      ],
       "properties": {
+        "cpu_architectures": {
+          "description": "Available CPU architectures.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "default": {
           "description": "Indication that the version is the recommended one.",
           "type": "boolean"
@@ -11989,8 +11993,7 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production",
-            "custom"
+            "production"
           ]
         }
       }
@@ -17065,6 +17068,12 @@ func init() {
             "description": "Success.",
             "schema": {
               "$ref": "#/definitions/openshift-versions"
+            }
+          },
+          "500": {
+            "description": "Error.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "503": {
@@ -24742,16 +24751,14 @@ func init() {
     },
     "openshift-version": {
       "type": "object",
-      "required": [
-        "display_name",
-        "release_image",
-        "release_version",
-        "rhcos_image",
-        "rhcos_rootfs",
-        "rhcos_version",
-        "support_level"
-      ],
       "properties": {
+        "cpu_architectures": {
+          "description": "Available CPU architectures.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "default": {
           "description": "Indication that the version is the recommended one.",
           "type": "boolean"
@@ -24785,8 +24792,7 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production",
-            "custom"
+            "production"
           ]
         }
       }

--- a/restapi/operations/versions/list_supported_openshift_versions_responses.go
+++ b/restapi/operations/versions/list_supported_openshift_versions_responses.go
@@ -60,6 +60,50 @@ func (o *ListSupportedOpenshiftVersionsOK) WriteResponse(rw http.ResponseWriter,
 	}
 }
 
+// ListSupportedOpenshiftVersionsInternalServerErrorCode is the HTTP code returned for type ListSupportedOpenshiftVersionsInternalServerError
+const ListSupportedOpenshiftVersionsInternalServerErrorCode int = 500
+
+/*ListSupportedOpenshiftVersionsInternalServerError Error.
+
+swagger:response listSupportedOpenshiftVersionsInternalServerError
+*/
+type ListSupportedOpenshiftVersionsInternalServerError struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewListSupportedOpenshiftVersionsInternalServerError creates ListSupportedOpenshiftVersionsInternalServerError with default headers values
+func NewListSupportedOpenshiftVersionsInternalServerError() *ListSupportedOpenshiftVersionsInternalServerError {
+
+	return &ListSupportedOpenshiftVersionsInternalServerError{}
+}
+
+// WithPayload adds the payload to the list supported openshift versions internal server error response
+func (o *ListSupportedOpenshiftVersionsInternalServerError) WithPayload(payload *models.Error) *ListSupportedOpenshiftVersionsInternalServerError {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the list supported openshift versions internal server error response
+func (o *ListSupportedOpenshiftVersionsInternalServerError) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ListSupportedOpenshiftVersionsInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(500)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ListSupportedOpenshiftVersionsServiceUnavailableCode is the HTTP code returned for type ListSupportedOpenshiftVersionsServiceUnavailable
 const ListSupportedOpenshiftVersionsServiceUnavailableCode int = 503
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3029,6 +3029,10 @@ paths:
           description: Success.
           schema:
             $ref: '#/definitions/openshift-versions'
+        "500":
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         "503":
           description: Unavailable.
           schema:
@@ -8389,14 +8393,6 @@ definitions:
 
   openshift-version:
     type: object
-    required:
-      - display_name
-      - release_image
-      - release_version
-      - rhcos_image
-      - rhcos_rootfs
-      - rhcos_version
-      - support_level
     properties:
       display_name:
         type: string
@@ -8418,11 +8414,16 @@ definitions:
         description: Build ID of the RHCOS image.
       support_level:
         type: string
-        enum: [beta, production, custom]
+        enum: [beta, production]
         description: Level of support of the version.
       default:
         type: boolean
         description: Indication that the version is the recommended one.
+      cpu_architectures:
+        type: array
+        items:
+          type: string
+        description: Available CPU architectures.
 
   os-image:
     type: object


### PR DESCRIPTION
# Assisted Pull Request

## Description

As OPENSHIFT_VERSIONS env var should be deprecated, the openshift_versions API
(used by the UI to display versions list) is now generated according to RELEASE_IMAGES env var.

* Added 'default' property to 'release-image' object.
  * Should be manually specified in release_images instead of in openshift_versions.
* Added 'cpu_architectures' array to openshift-version:
  * Generated according to available architectures in release_images.
* Since openshift-versions is now optional, the 'openshift-version' model is used
as a simple struct without required properties.
* SupportLevel is detected according to the release image version.
  I.e. rc/fc/nightly are considered as beta.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @YuviGold  

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
