### PR TITLE
Bug 2001973: Fix handling nil value when setting disk encryption

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2602,8 +2602,7 @@ func (b *bareMetalInventory) updatePlatformParams(params installer.V2UpdateClust
 }
 
 func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncryption *models.DiskEncryption, usages map[string]models.Usage) {
-
-	if c.DiskEncryption == nil {
+	if diskEncryption == nil || diskEncryption.EnableOn == nil {
 		return
 	}
 
@@ -2612,7 +2611,7 @@ func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncry
 		"mode":         *diskEncryption.Mode,
 		"tang_servers": diskEncryption.TangServers,
 	}
-	b.setUsage(*c.DiskEncryption.EnableOn != models.DiskEncryptionEnableOnNone, usage.DiskEncryption, &props, usages)
+	b.setUsage(*diskEncryption.EnableOn != models.DiskEncryptionEnableOnNone, usage.DiskEncryption, &props, usages)
 }
 
 func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *common.Cluster, params installer.V2UpdateClusterParams, usages map[string]models.Usage, db *gorm.DB, log logrus.FieldLogger, interactivity Interactivity) error {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This commit fixes handling of nil values when setting a feature usage
for disk encryption.

Currently it happens that when sending an update payload with
`disk_encryption: {}` we were trying to access fields inside the
payload, what was causing null pointer exceptions.

This commit also changes the way of determining the status of the
feature from looking at the cluster object into looking into the cluster
update object. Previously the check for nil values was taking into
account the current state of the cluster and not the desired state. With
this change, we are always comparing against the requested state from
the update payload.

Closes-bug: #2001973

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ybettan 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
