### PR TITLE
MGMT-2391: Deprecate host stage_started_at and stage_updated_at fields

### DIFF
--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -337,12 +337,12 @@ var _ = Describe("update_progress", func() {
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
-				updatedAt := hostFromDB.StageUpdatedAt.String()
+				updatedAt := hostFromDB.Progress.StageUpdatedAt.String()
 
 				Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*hostFromDB.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
-				Expect(hostFromDB.StageUpdatedAt.String()).Should(Equal(updatedAt))
+				Expect(hostFromDB.Progress.StageUpdatedAt.String()).Should(Equal(updatedAt))
 			})
 
 			It("writing to disk", func() {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1441,8 +1441,6 @@ var _ = Describe("Unbind", func() {
 		Expect(h.LogsInfo).Should(BeEmpty())
 		Expect(h.LogsStartedAt).Should(Equal(strfmt.DateTime(time.Time{})))
 		Expect(h.LogsCollectedAt).Should(Equal(strfmt.DateTime(time.Time{})))
-		Expect(h.StageStartedAt).Should(Equal(strfmt.DateTime(time.Time{})))
-		Expect(h.StageUpdatedAt).Should(Equal(strfmt.DateTime(time.Time{})))
 	}
 
 	failure := func(reply error, srcState string) {
@@ -1547,8 +1545,6 @@ var _ = Describe("Unbind", func() {
 			host.LogsInfo = models.LogsStateRequested
 			host.LogsStartedAt = strfmt.DateTime(time.Now())
 			host.LogsCollectedAt = strfmt.DateTime(time.Now())
-			host.StageStartedAt = strfmt.DateTime(time.Now())
-			host.StageUpdatedAt = strfmt.DateTime(time.Now())
 
 			dstState := models.HostStatusUnbinding
 

--- a/models/host.go
+++ b/models/host.go
@@ -127,14 +127,6 @@ type Host struct {
 	// role
 	Role HostRole `json:"role,omitempty"`
 
-	// Time at which the current progress stage started.
-	// Format: date-time
-	StageStartedAt strfmt.DateTime `json:"stage_started_at,omitempty" gorm:"type:timestamp with time zone"`
-
-	// Time at which the current progress stage was last updated.
-	// Format: date-time
-	StageUpdatedAt strfmt.DateTime `json:"stage_updated_at,omitempty" gorm:"type:timestamp with time zone"`
-
 	// status
 	// Required: true
 	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound]
@@ -219,14 +211,6 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRole(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStageStartedAt(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStageUpdatedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -476,32 +460,6 @@ func (m *Host) validateRole(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("role")
 		}
-		return err
-	}
-
-	return nil
-}
-
-func (m *Host) validateStageStartedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.StageStartedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("stage_started_at", "body", "date-time", m.StageStartedAt.String(), formats); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Host) validateStageUpdatedAt(formats strfmt.Registry) error {
-
-	if swag.IsZero(m.StageUpdatedAt) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("stage_updated_at", "body", "date-time", m.StageUpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10911,18 +10911,6 @@ func init() {
         "role": {
           "$ref": "#/definitions/host-role"
         },
-        "stage_started_at": {
-          "description": "Time at which the current progress stage started.",
-          "type": "string",
-          "format": "date-time",
-          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
-        },
-        "stage_updated_at": {
-          "description": "Time at which the current progress stage was last updated.",
-          "type": "string",
-          "format": "date-time",
-          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
-        },
         "status": {
           "type": "string",
           "enum": [
@@ -23711,18 +23699,6 @@ func init() {
         },
         "role": {
           "$ref": "#/definitions/host-role"
-        },
-        "stage_started_at": {
-          "description": "Time at which the current progress stage started.",
-          "type": "string",
-          "format": "date-time",
-          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
-        },
-        "stage_updated_at": {
-          "description": "Time at which the current progress stage was last updated.",
-          "type": "string",
-          "format": "date-time",
-          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
         "status": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6412,16 +6412,6 @@ definitions:
       progress:
         $ref: '#/definitions/host-progress-info'
         x-go-custom-tag: gorm:"embedded;embedded_prefix:progress_"
-      stage_started_at:
-        type: string
-        format: date-time
-        x-go-custom-tag: gorm:"type:timestamp with time zone"
-        description: Time at which the current progress stage started.
-      stage_updated_at:
-        type: string
-        format: date-time
-        x-go-custom-tag: gorm:"type:timestamp with time zone"
-        description: Time at which the current progress stage was last updated.
       progress_stages:
         type: array
         items:


### PR DESCRIPTION
# Assisted Pull Request

## Description

These old fields are irrelevant anymore because they exist under `progress` field.

* stage_started_at
* stage_updated_at

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
