### PR TITLE
NO-ISSUE: Use 4.8 redhat-operators catalog on OCP 4.9

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -34,6 +34,32 @@ function install_lso() {
       "${index_image}" "${LOCAL_REGISTRY}" "${AUTHFILE}" "${catalog_source_name}"
   fi
 
+  OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
+  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.9" ]]; then
+      # LSO has not been published to the 4.9 redhat-operators catalog, so
+      # it cannot be installed on OpenShift 4.9. Until this is resolved,
+      # we explicitly install the 4.8 catalog as redhat-operators-v48
+      # and then subscribe to the LSO version from the 4.8 rather than the 4.9 catalog.
+      # TODO: Remove this once LSO is published to the 4.9 catalog.
+      catalog_source_name="redhat-operators-v48"
+      tee << EOCR >(oc apply -f -)
+kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+metadata:
+  name: redhat-operators-v48
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat Operators v48
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.8
+  priority: -100
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 10m0s
+EOCR
+  fi
+
   tee << EOCR >(oc apply -f -)
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup


### PR DESCRIPTION
# Assisted Pull Request

## Description
See the # comment in the diff for the rationale

This should solve the widespread LSO CI errors we've been seeing recently

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @YuviGold
/cc @osherdp

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md