### PR TITLE
Revert "MGMT-2391: Deprecate host stage_started_at and stage_updated_at fields"

### DIFF
--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -337,12 +337,12 @@ var _ = Describe("update_progress", func() {
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
-				updatedAt := hostFromDB.Progress.StageUpdatedAt.String()
+				updatedAt := hostFromDB.StageUpdatedAt.String()
 
 				Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*hostFromDB.ID, host.InfraEnvID, db)
 				Expect(*hostFromDB.Status).Should(Equal(models.HostStatusInstallingInProgress))
-				Expect(hostFromDB.Progress.StageUpdatedAt.String()).Should(Equal(updatedAt))
+				Expect(hostFromDB.StageUpdatedAt.String()).Should(Equal(updatedAt))
 			})
 
 			It("writing to disk", func() {

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1444,6 +1444,8 @@ var _ = Describe("Unbind", func() {
 		Expect(h.LogsInfo).Should(BeEmpty())
 		Expect(h.LogsStartedAt).Should(Equal(strfmt.DateTime(time.Time{})))
 		Expect(h.LogsCollectedAt).Should(Equal(strfmt.DateTime(time.Time{})))
+		Expect(h.StageStartedAt).Should(Equal(strfmt.DateTime(time.Time{})))
+		Expect(h.StageUpdatedAt).Should(Equal(strfmt.DateTime(time.Time{})))
 	}
 
 	failure := func(reply error, srcState string) {
@@ -1548,6 +1550,8 @@ var _ = Describe("Unbind", func() {
 			host.LogsInfo = models.LogsStateRequested
 			host.LogsStartedAt = strfmt.DateTime(time.Now())
 			host.LogsCollectedAt = strfmt.DateTime(time.Now())
+			host.StageStartedAt = strfmt.DateTime(time.Now())
+			host.StageUpdatedAt = strfmt.DateTime(time.Now())
 
 			dstState := models.HostStatusUnbinding
 

--- a/models/host.go
+++ b/models/host.go
@@ -127,6 +127,14 @@ type Host struct {
 	// role
 	Role HostRole `json:"role,omitempty"`
 
+	// Time at which the current progress stage started.
+	// Format: date-time
+	StageStartedAt strfmt.DateTime `json:"stage_started_at,omitempty" gorm:"type:timestamp with time zone"`
+
+	// Time at which the current progress stage was last updated.
+	// Format: date-time
+	StageUpdatedAt strfmt.DateTime `json:"stage_updated_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// status
 	// Required: true
 	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound]
@@ -211,6 +219,14 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateRole(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStageStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStageUpdatedAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -460,6 +476,32 @@ func (m *Host) validateRole(formats strfmt.Registry) error {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("role")
 		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *Host) validateStageStartedAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StageStartedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("stage_started_at", "body", "date-time", m.StageStartedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Host) validateStageUpdatedAt(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StageUpdatedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("stage_updated_at", "body", "date-time", m.StageUpdatedAt.String(), formats); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10911,6 +10911,18 @@ func init() {
         "role": {
           "$ref": "#/definitions/host-role"
         },
+        "stage_started_at": {
+          "description": "Time at which the current progress stage started.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
+        "stage_updated_at": {
+          "description": "Time at which the current progress stage was last updated.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
         "status": {
           "type": "string",
           "enum": [
@@ -23699,6 +23711,18 @@ func init() {
         },
         "role": {
           "$ref": "#/definitions/host-role"
+        },
+        "stage_started_at": {
+          "description": "Time at which the current progress stage started.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
+        "stage_updated_at": {
+          "description": "Time at which the current progress stage was last updated.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
         "status": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6412,6 +6412,16 @@ definitions:
       progress:
         $ref: '#/definitions/host-progress-info'
         x-go-custom-tag: gorm:"embedded;embedded_prefix:progress_"
+      stage_started_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone"
+        description: Time at which the current progress stage started.
+      stage_updated_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone"
+        description: Time at which the current progress stage was last updated.
       progress_stages:
         type: array
         items:


### PR DESCRIPTION
Reverts openshift/assisted-service#2681

QE test environments always work with the same latest client version.
It means that when the `master` changes and the client got updated accordingly, the staging still uses the old protocol.

Since this change is just nice-to-have and isn't mandatory, it would be much faster to revert this PR and adjust the QE pipeline later on.

cc @lalon4 @filanov @gamli75 