### PR TITLE
OCPBUGSM-35272: empty cpu architecture implies default

### DIFF
--- a/config/samples/agent-install.openshift.io_v1beta1_agentserviceconfig.yaml
+++ b/config/samples/agent-install.openshift.io_v1beta1_agentserviceconfig.yaml
@@ -26,15 +26,18 @@ spec:
     openshiftVersion: '4.8'
     url: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel8
   osImages:
-  - openshiftVersion: '4.8'
+  - cpuArchitecture: x86_64
+    openshiftVersion: '4.8'
     rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img
     url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-4.8.2-x86_64-live.x86_64.iso
     version: 48.84.202107202156-0
-  - openshiftVersion: '4.9'
+  - cpuArchitecture: x86_64
+    openshiftVersion: '4.9'
     rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-live-rootfs.x86_64.img
     url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-x86_64-live.x86_64.iso
     version: 49.84.202109241334-0
-  - openshiftVersion: '4.9'
+  - cpuArchitecture: arm64
+    openshiftVersion: '4.9'
     rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-aarch64-live-rootfs.aarch64.img
     url: https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-aarch64-live.aarch64.iso
     version: 49.84.202109210947-0

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -50,18 +50,21 @@ metadata:
             ],
             "osImages": [
               {
+                "cpuArchitecture": "x86_64",
                 "openshiftVersion": "4.8",
                 "rootFSUrl": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img",
                 "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-4.8.2-x86_64-live.x86_64.iso",
                 "version": "48.84.202107202156-0"
               },
               {
+                "cpuArchitecture": "x86_64",
                 "openshiftVersion": "4.9",
                 "rootFSUrl": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-live-rootfs.x86_64.img",
                 "url": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-x86_64-live.x86_64.iso",
                 "version": "49.84.202109241334-0"
               },
               {
+                "cpuArchitecture": "arm64",
                 "openshiftVersion": "4.9",
                 "rootFSUrl": "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-aarch64-live-rootfs.aarch64.img",
                 "url": "https://mirror.openshift.com/pub/openshift-v4/arm64/dependencies/rhcos/pre-release/4.9.0-rc.4/rhcos-4.9.0-rc.4-aarch64-live.aarch64.iso",

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -108,6 +108,7 @@ with open("'${__root}/config/samples/agent-install.openshift.io_v1beta1_agentser
     doc = yaml.load(f, Loader=yaml.FullLoader)
     doc["spec"]["osImages"] = [
         {
+            "cpuArchitecture": v["cpu_architecture"],
             "openshiftVersion": v["openshift_version"],
             "version": v["version"],
             "url": v["url"],

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -313,10 +313,14 @@ func (h *handler) GetCPUArchitectures(openshiftVersion string) ([]string, error)
 			if release.OpenshiftVersion == nil {
 				return nil, errors.Errorf("Missing openshift_version in OsImage")
 			}
-			if release.CPUArchitecture == nil {
-				return nil, errors.Errorf("Missing cpu_architecture in OsImage")
+			if swag.StringValue(release.CPUArchitecture) == "" {
+				// Empty or missing property implies default CPU architecture
+				defaultArch := common.DefaultCPUArchitecture
+				release.CPUArchitecture = &defaultArch
 			}
-			cpuArchitectures = append(cpuArchitectures, *release.CPUArchitecture)
+			if !funk.Contains(cpuArchitectures, *release.CPUArchitecture) {
+				cpuArchitectures = append(cpuArchitectures, *release.CPUArchitecture)
+			}
 		}
 	}
 

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -710,6 +710,7 @@ var _ = Describe("list versions", func() {
 		BeforeEach(func() {
 			h, err = NewHandler(logger, mockRelease, versions, defaultOpenShiftVersions, *osImages, *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
+			osImages = &defaultOsImages
 		})
 
 		It("releaseImages not defined", func() {
@@ -732,6 +733,21 @@ var _ = Describe("list versions", func() {
 				architectures, err = h.GetCPUArchitectures(key)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(architectures).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture, "arm64"}))
+			}
+		})
+
+		It("empty architecture fallback to default", func() {
+			empty := ""
+			osImages = &defaultOsImages
+			(*osImages)[0].CPUArchitecture = &empty
+			(*osImages)[1].CPUArchitecture = nil
+			h, err = NewHandler(logger, mockRelease, versions, models.OpenshiftVersions{}, *osImages, models.ReleaseImages{}, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			for key := range newOpenShiftVersions {
+				architectures, err = h.GetCPUArchitectures(key)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(architectures).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture}))
 			}
 		})
 	})


### PR DESCRIPTION
# Assisted Pull Request

## Description

If 'cpuArchitecture' is not specified under osImages in AgentServiceConfig,
an empty string is specified in OS_IMAGES[*].
Hance, handling an empty string as missing property - default to x86_64.

Also added the property to the CRD sample to make it explicit.

[*]
https://github.com/openshift/assisted-service/blob/824eef89ac58cf89a474d9272e9d54b4b353c911/internal/controller/controllers/agentserviceconfig_controller.go#L1206

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @flaper87 
/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
