### PR TITLE
Bug 2009412: when unbound host is bounded to day2 cluster, it stays i…

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5976,7 +5976,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		return common.GenerateErrorResponder(err)
 	}
 
-	_, err = common.GetHostFromDB(tx, params.InfraEnvID.String(), params.NewHostParams.HostID.String())
+	dbHost, err := common.GetHostFromDB(tx, params.InfraEnvID.String(), params.NewHostParams.HostID.String())
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		log.WithError(err).Errorf("failed to get host %s in infra-env: %s",
 			*params.NewHostParams.HostID, params.InfraEnvID.String())
@@ -6009,12 +6009,12 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 	}
 
 	var cluster *common.Cluster
-	if infraEnv.ClusterID != "" {
-		cluster, err = common.GetClusterFromDB(tx, infraEnv.ClusterID, common.SkipEagerLoading)
-		if err != nil {
-			log.WithError(err).Errorf("Cluster get")
-			return common.NewApiError(http.StatusInternalServerError, err)
-		}
+	cluster, err = b.getBoundCluster(tx, infraEnv, dbHost)
+	if err != nil {
+		log.WithError(err).Errorf("Bound Cluster get")
+		return common.NewApiError(http.StatusInternalServerError, err)
+	}
+	if cluster != nil {
 		if newRecord {
 			if err = b.clusterApi.AcceptRegistration(cluster); err != nil {
 				log.WithError(err).Errorf("failed to register host <%s> to infra-env %s due to: %s",
@@ -6031,7 +6031,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		if swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster {
 			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
 		}
-		host.ClusterID = &infraEnv.ClusterID
+		host.ClusterID = cluster.ID
 	}
 
 	if err = b.hostApi.RegisterHost(ctx, host, tx); err != nil {
@@ -6698,4 +6698,22 @@ func (b *bareMetalInventory) refreshAfterUpdate(ctx context.Context, host *commo
 		log.WithError(err).Errorf("Failed to refresh host %s, infra env %s during update", host.ID, host.InfraEnvID)
 	}
 	return err
+}
+
+func (b *bareMetalInventory) getBoundCluster(db *gorm.DB, infraEnv *common.InfraEnv, host *common.Host) (*common.Cluster, error) {
+	var clusterID strfmt.UUID
+	if infraEnv.ClusterID != "" {
+		clusterID = infraEnv.ClusterID
+	} else if host != nil && host.Host.ClusterID != nil {
+		clusterID = *host.Host.ClusterID
+	}
+
+	if clusterID != "" {
+		cluster, err := common.GetClusterFromDB(db, clusterID, common.SkipEagerLoading)
+		if err != nil {
+			return nil, err
+		}
+		return cluster, nil
+	}
+	return nil, nil
 }

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -312,7 +312,7 @@ var _ = Describe("GenerateClusterISO", func() {
 
 	It("success - infra-env", func() {
 		infraEnvID := strfmt.UUID(uuid.New().String())
-		infraEnv := createInfraEnvWithPullSecret(db, infraEnvID)
+		infraEnv := createInfraEnvWithPullSecret(db, infraEnvID, infraEnvID)
 		mockS3Client.EXPECT().IsAwsS3().Return(false)
 		mockS3Client.EXPECT().GetObjectSizeBytes(gomock.Any(), gomock.Any()).Return(int64(100), nil).Times(1)
 		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), bm.IgnitionConfig, false, bm.authHandler.AuthType()).Return(discovery_ignition_3_1, nil).Times(1)
@@ -945,22 +945,22 @@ func createCluster(db *gorm.DB, status string) *common.Cluster {
 	return createClusterWithAvailability(db, status, models.ClusterCreateParamsHighAvailabilityModeFull)
 }
 
-func createInfraEnv(db *gorm.DB, id strfmt.UUID) *common.InfraEnv {
+func createInfraEnv(db *gorm.DB, id strfmt.UUID, clusterID strfmt.UUID) *common.InfraEnv {
 	infraEnv := &common.InfraEnv{
 		InfraEnv: models.InfraEnv{
 			ID:        id,
-			ClusterID: id,
+			ClusterID: clusterID,
 		},
 	}
 	Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
 	return infraEnv
 }
 
-func createInfraEnvWithPullSecret(db *gorm.DB, id strfmt.UUID) *common.InfraEnv {
+func createInfraEnvWithPullSecret(db *gorm.DB, id strfmt.UUID, clusterID strfmt.UUID) *common.InfraEnv {
 	infraEnv := &common.InfraEnv{
 		InfraEnv: models.InfraEnv{
 			ID:            id,
-			ClusterID:     id,
+			ClusterID:     clusterID,
 			PullSecretSet: true,
 		},
 		PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
@@ -1152,7 +1152,7 @@ var _ = Describe("RegisterHost", func() {
 	It("register host to a cluster while installation is in progress", func() {
 		By("creating the cluster")
 		cluster := createCluster(db, models.ClusterStatusInstalling)
-		_ = createInfraEnv(db, *cluster.ID)
+		_ = createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 		allowedStates := []string{
 			models.ClusterStatusInsufficient, models.ClusterStatusReady,
@@ -1196,7 +1196,7 @@ var _ = Describe("RegisterHost", func() {
 			It(fmt.Sprintf("cluster availability mode %s expected default host role %s",
 				test.availability, test.expectedRole), func() {
 				cluster := createClusterWithAvailability(db, models.ClusterStatusInsufficient, test.availability)
-				infraEnv := createInfraEnv(db, *cluster.ID)
+				infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1240,7 +1240,7 @@ var _ = Describe("RegisterHost", func() {
 
 	It("add_crd_failure", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
-		infraEnv := createInfraEnv(db, *cluster.ID)
+		infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
@@ -1272,7 +1272,7 @@ var _ = Describe("RegisterHost", func() {
 
 	It("host_api_failure", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
-		_ = createInfraEnv(db, *cluster.ID)
+		_ = createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
@@ -1331,7 +1331,7 @@ var _ = Describe("v2RegisterHost", func() {
 	It("register host to a cluster while installation is in progress", func() {
 		By("creating the cluster")
 		cluster := createCluster(db, models.ClusterStatusInstalling)
-		_ = createInfraEnv(db, *cluster.ID)
+		_ = createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 		allowedStates := []string{
 			models.ClusterStatusInsufficient, models.ClusterStatusReady,
@@ -1375,7 +1375,7 @@ var _ = Describe("v2RegisterHost", func() {
 			It(fmt.Sprintf("cluster availability mode %s expected default host role %s",
 				test.availability, test.expectedRole), func() {
 				cluster := createClusterWithAvailability(db, models.ClusterStatusInsufficient, test.availability)
-				infraEnv := createInfraEnv(db, *cluster.ID)
+				infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1419,7 +1419,7 @@ var _ = Describe("v2RegisterHost", func() {
 
 	It("add_crd_failure", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
-		infraEnv := createInfraEnv(db, *cluster.ID)
+		infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
@@ -1451,7 +1451,7 @@ var _ = Describe("v2RegisterHost", func() {
 
 	It("host_api_failure", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
-		_ = createInfraEnv(db, *cluster.ID)
+		_ = createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
@@ -1470,6 +1470,48 @@ var _ = Describe("v2RegisterHost", func() {
 		Expect(ok).Should(BeTrue())
 		Expect(err.StatusCode()).Should(Equal(int32(http.StatusBadRequest)))
 		Expect(err.Error()).Should(ContainSubstring(expectedErrMsg))
+	})
+
+	It("register day2 bound host", func() {
+		cluster := createCluster(db, models.ClusterStatusAddingHosts)
+		Expect(db.Model(&cluster).Update("kind", swag.String(models.ClusterKindAddHostsCluster)).Error).ShouldNot(HaveOccurred())
+		infraEnvId := strToUUID(uuid.New().String())
+		_ = createInfraEnv(db, *infraEnvId, "")
+
+		hostId := strToUUID(uuid.New().String())
+		host := models.Host{
+			ID:         hostId,
+			InfraEnvID: *infraEnvId,
+			ClusterID:  cluster.ID,
+			Status:     swag.String("binding"),
+			Kind:       swag.String(models.HostKindHost),
+		}
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+		mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
+				// validate that host kind was set to day2
+				Expect(swag.StringValue(h.Kind)).Should(Equal(models.HostKindAddToExistingClusterHost))
+				return nil
+			}).Times(1)
+		mockEvents.EXPECT().
+			AddEvent(gomock.Any(), *infraEnvId, hostId, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
+			Times(1)
+		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+		By("trying to register a host bound to day2 cluster")
+		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
+			InfraEnvID: *infraEnvId,
+			NewHostParams: &models.HostCreateParams{
+				DiscoveryAgentVersion: "v1",
+				HostID:                hostId,
+			},
+		})
+
+		By("verifying returned response")
+		_, ok := reply.(*installer.V2RegisterHostCreated)
+		Expect(ok).Should(BeTrue())
 	})
 })
 

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -65,8 +65,9 @@ func (th *transitionHandler) PostRegisterHost(sw stateswitch.StateSwitch, args s
 	if _, err := common.GetHostFromDB(params.db, hostParam.InfraEnvID.String(), hostParam.ID.String()); err == nil {
 		// The reason for the double register is unknown (HW might have changed) -
 		// so we reset the hw info and progress, and start the discovery process again.
-		// also log info is not current and should be resetted
-		extra := append(resetFields[:], "discovery_agent_version", params.discoveryAgentVersion, "ntp_sources", "")
+		// also log info is not current and should be resetted. In adition, due to late binding
+		// the kind should be set to the hsotParam value, because in day2 it may be changed during re-registration
+		extra := append(resetFields[:], "discovery_agent_version", params.discoveryAgentVersion, "ntp_sources", "", "kind", hostParam.Kind)
 		extra = append(extra, resetLogsField...)
 		var dbHost *common.Host
 		if dbHost, err = hostutil.UpdateHostProgress(params.ctx, log, params.db, th.eventsHandler, hostParam.InfraEnvID, *hostParam.ID, sHost.srcState,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -319,6 +319,7 @@ var _ = Describe("RegisterHost", func() {
 					InfraEnvID:            infraEnvId,
 					ClusterID:             &clusterId,
 					Status:                swag.String(t.srcState),
+					Kind:                  swag.String(t.kind),
 					DiscoveryAgentVersion: discoveryAgentVersion,
 				},
 					db)).ShouldNot(HaveOccurred())


### PR DESCRIPTION
…n insufficient state

The reason for insuffucient state is that although the cluster is day2, host kind is not set to be
day2 host.
Solution: during registration get bound cluster in case infra-env is bound or host is bound. Set
the host kind accordingly. Also, in the PostRegistration handler of transactions manager, in case host
already present in DB,update the kind field of the host based on the input host (input to the state machine).
This way we propagate the Kind change to the DB in case of re-registration (which is the flow in case of
bounded host)

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
