### PR TITLE
Bug 2010168: Fix flaky test point to a nil pointer conditions

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -362,10 +362,11 @@ func (r *BMACReconciler) addBMHDetachedAnnotationIfAgentHasStartedInstallation(c
 		return reconcileComplete{}
 	}
 
-	if agent.Status.Conditions == nil {
+	c := conditionsv1.FindStatusCondition(agent.Status.Conditions, aiv1beta1.InstalledCondition)
+	if c == nil {
 		return reconcileComplete{}
 	}
-	installConditionReason := conditionsv1.FindStatusCondition(agent.Status.Conditions, aiv1beta1.InstalledCondition).Reason
+	installConditionReason := c.Reason
 
 	// Do nothing if InstalledCondition is not in Installed, InProgress, or Failed
 	if installConditionReason != aiv1beta1.InstallationInProgressReason &&

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -896,6 +896,22 @@ var _ = Describe("bmac reconcile", func() {
 		})
 
 		Context("when Agent installation has started", func() {
+			It("conditions list doesn't contain installed condition", func() {
+				agent.Status.Conditions = []conditionsv1.Condition{
+					{},
+				}
+				Expect(c.Update(ctx, agent)).To(BeNil())
+
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				Expect(updatedHost.ObjectMeta.Annotations).NotTo(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).NotTo(Equal("assisted-service-controller"))
+			})
 			It("should set the detached annotation if agent is installed", func() {
 				agent.Status.Conditions = []conditionsv1.Condition{
 					{

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -380,7 +380,11 @@ func checkAgentCondition(ctx context.Context, hostId string, conditionType condi
 		Name:      hostId,
 	}
 	Eventually(func() string {
-		return conditionsv1.FindStatusCondition(getAgentCRD(ctx, kubeClient, hostkey).Status.Conditions, conditionType).Reason
+		condition := conditionsv1.FindStatusCondition(getAgentCRD(ctx, kubeClient, hostkey).Status.Conditions, conditionType)
+		if condition != nil {
+			return condition.Reason
+		}
+		return ""
 	}, "3m", "20s").Should(Equal(reason))
 }
 


### PR DESCRIPTION

# Assisted Pull Request

## Description

BMH controller check for empty conditions list but if because of a bug
specific conditions doesn't exdists, controller will panic
If agent reesource create and not reconciled or conditions is not found
there would be a panic in the test.

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @rollandf 
/cc @nmagnezi 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not reaquire a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
