### PR TITLE
OCPBUGSM-35727: Fix calling 'supported-platforms' just after the cluster creation causes a panic

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1964,7 +1964,7 @@ func (b *bareMetalInventory) GetClusterSupportedPlatformsInternal(
 		return nil, fmt.Errorf("error getting cluster, error: %w", err)
 	}
 	// no hosts or SNO
-	if len(cluster.Hosts) == 0 || *cluster.HighAvailabilityMode != models.ClusterHighAvailabilityModeFull {
+	if len(cluster.Hosts) == 0 || swag.StringValue(cluster.HighAvailabilityMode) != models.ClusterHighAvailabilityModeFull {
 		return &[]models.PlatformType{models.PlatformTypeBaremetal}, nil
 	}
 	hostSupportedPlatforms, err := b.providerRegistry.GetSupportedProvidersByHosts(cluster.Hosts)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -9774,6 +9774,19 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		Expect(len(platforms)).Should(Equal(1))
 		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
 	})
+
+	It("HighAvailabilityMode is nil with single host", func() {
+		c.HighAvailabilityMode = nil
+		db.Save(c)
+
+		addVsphereHost(clusterID, models.HostRoleMaster)
+		validateHostsInventory(1, 0)
+		platformReplay := bm.GetClusterSupportedPlatforms(ctx, installer.GetClusterSupportedPlatformsParams{ClusterID: clusterID})
+		Expect(platformReplay).Should(BeAssignableToTypeOf(installer.NewGetClusterSupportedPlatformsOK()))
+		platforms := platformReplay.(*installer.GetClusterSupportedPlatformsOK).Payload
+		Expect(len(platforms)).Should(Equal(1))
+		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+	})
 })
 
 func verifyApiError(responder middleware.Responder, expectedHttpStatus int32) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2009670

Fix assisted service can panics after creating a cluster with registered hosts and call the 'supported-platforms' endpoint.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @rollandf 
