### PR TITLE
Bug 2009255: Add infra-env-id to the send logs command

### DIFF
--- a/internal/host/hostcommands/logs_cmd.go
+++ b/internal/host/hostcommands/logs_cmd.go
@@ -76,7 +76,8 @@ func createUploadLogsCmd(host *models.Host, baseURL, agentImage, mastersIPs stri
 	data := map[string]string{
 		"BASE_URL":               strings.TrimSpace(baseURL),
 		"CLUSTER_ID":             host.ClusterID.String(),
-		"HOST_ID":                string(*host.ID),
+		"HOST_ID":                host.ID.String(),
+		"INFRA_ENV_ID":           host.InfraEnvID.String(),
 		"AGENT_IMAGE":            strings.TrimSpace(agentImage),
 		"SKIP_CERT_VERIFICATION": strconv.FormatBool(skipCertVerification),
 		"BOOTSTRAP":              strconv.FormatBool(host.Bootstrap),
@@ -88,7 +89,7 @@ func createUploadLogsCmd(host *models.Host, baseURL, agentImage, mastersIPs stri
 		"-v /run/systemd/journal/socket:/run/systemd/journal/socket -v /var/log:/var/log " +
 		"{{if .BOOTSTRAP}} -v /root/.ssh:/root/.ssh -v /tmp:/tmp {{end}}" +
 		"--env PULL_SECRET_TOKEN --name logs-sender --pid=host {{.AGENT_IMAGE}} logs_sender " +
-		"-url {{.BASE_URL}} -cluster-id {{.CLUSTER_ID}} -host-id {{.HOST_ID}} " +
+		"-url {{.BASE_URL}} -cluster-id {{.CLUSTER_ID}} -host-id {{.HOST_ID}} -infra-env-id {{.INFRA_ENV_ID}} " +
 		"--insecure={{.SKIP_CERT_VERIFICATION}} -bootstrap={{.BOOTSTRAP}} -with-installer-gather-logging={{.INSTALLER_GATHER}}" +
 		"{{if .MASTERS_IPS}} -masters-ips={{.MASTERS_IPS}} {{end}}" +
 		"{{if .CACERTPATH}} --cacert {{.CACERTPATH}} {{end}}"

--- a/internal/host/hostcommands/logs_cmd_test.go
+++ b/internal/host/hostcommands/logs_cmd_test.go
@@ -43,6 +43,12 @@ var _ = Describe("upload_logs", func() {
 		Expect(stepErr).ShouldNot(HaveOccurred())
 		Expect(stepReply[0].Command).Should(Equal("timeout"))
 		Expect(stepReply[0].Args).Should(ContainElement("podman"))
+		Expect(stepReply[0].Args).Should(ContainElement("-cluster-id"))
+		Expect(stepReply[0].Args).Should(ContainElement("-host-id"))
+		Expect(stepReply[0].Args).Should(ContainElement("-infra-env-id"))
+		Expect(stepReply[0].Args).Should(ContainElement(clusterId.String()))
+		Expect(stepReply[0].Args).Should(ContainElement(id.String()))
+		Expect(stepReply[0].Args).Should(ContainElement(infraEnvId.String()))
 	})
 	It("get_step without logs", func() {
 		host.LogsCollectedAt = strfmt.DateTime(time.Now())


### PR DESCRIPTION
In order for Agent to start using V2UploadLogs API, it should be able
to receive the infra-env-id of the host, in addition to the host id
and cluster-id that it already receives

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
