### PR TITLE
Bug 2011976: operator should handle rm nodeSelector

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -818,14 +818,15 @@ func (r *AgentServiceConfigReconciler) newImageServiceDeployment(ctx context.Con
 		deployment.Spec.Template.Spec.ServiceAccountName = imageServiceName
 
 		if r.NodeSelector != nil {
-			nodeSelector := make(map[string]string)
-			for key, value := range r.NodeSelector {
-				nodeSelector[key] = value
-			}
-			deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+			deployment.Spec.Template.Spec.NodeSelector = r.NodeSelector
+		} else {
+			deployment.Spec.Template.Spec.NodeSelector = map[string]string{}
 		}
+
 		if r.Tolerations != nil {
-			deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+			deployment.Spec.Template.Spec.Tolerations = r.Tolerations
+		} else {
+			deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 		}
 		return nil
 	}
@@ -1111,14 +1112,15 @@ func (r *AgentServiceConfigReconciler) newAssistedServiceDeployment(ctx context.
 		deployment.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
 		if r.NodeSelector != nil {
-			nodeSelector := make(map[string]string)
-			for key, value := range r.NodeSelector {
-				nodeSelector[key] = value
-			}
-			deployment.Spec.Template.Spec.NodeSelector = nodeSelector
+			deployment.Spec.Template.Spec.NodeSelector = r.NodeSelector
+		} else {
+			deployment.Spec.Template.Spec.NodeSelector = map[string]string{}
 		}
+
 		if r.Tolerations != nil {
-			deployment.Spec.Template.Spec.Tolerations = append([]corev1.Toleration{}, r.Tolerations...)
+			deployment.Spec.Template.Spec.Tolerations = r.Tolerations
+		} else {
+			deployment.Spec.Template.Spec.Tolerations = []corev1.Toleration{}
 		}
 
 		return nil


### PR DESCRIPTION
# Assisted Pull Request

## Description

nodeSelectors and tolerations on the infrastructure-operator's operands
should always match those of the operator itself. This change makes it
so the operator will always make the operands match the operator's
current running configuration.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @celebdor 
/cc @pawanpinjarkar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
