### PR TITLE
MGMT-7180: Add support_level to release-image

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -119,7 +119,7 @@ func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params o
 			CPUArchitectures: availableArchitectures,
 			Default:          releaseImage.Default,
 			DisplayName:      *releaseImage.Version,
-			SupportLevel:     h.getSupportLevel(*releaseImage.Version),
+			SupportLevel:     h.getSupportLevel(*releaseImage),
 		}
 		openshiftVersions[key] = openshiftVersion
 	}
@@ -374,10 +374,14 @@ func (h *handler) isOpenshiftVersionSupported(openshiftVersion string) bool {
 	return true
 }
 
-func (h *handler) getSupportLevel(openshiftVersion string) string {
+func (h *handler) getSupportLevel(releaseImage models.ReleaseImage) string {
+	if releaseImage.SupportLevel != "" {
+		return releaseImage.SupportLevel
+	}
+
 	preReleases := []string{"-fc", "-rc", "nightly"}
 	for _, preRelease := range preReleases {
-		if strings.Contains(openshiftVersion, preRelease) {
+		if strings.Contains(*releaseImage.Version, preRelease) {
 			return models.OpenshiftVersionSupportLevelBeta
 		}
 	}

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -213,8 +213,32 @@ var _ = Describe("list versions", func() {
 				Expect(version.CPUArchitectures).Should(Equal(architectures))
 				Expect(version.Default).Should(Equal(releaseImage.Default))
 				Expect(version.DisplayName).Should(Equal(*releaseImage.Version))
-				Expect(version.SupportLevel).Should(Equal(h.getSupportLevel(*releaseImage.Version)))
+				Expect(version.SupportLevel).Should(Equal(h.getSupportLevel(*releaseImage)))
 			}
+		})
+
+		It("getSupportLevel", func() {
+			h, err = NewHandler(logger, mockRelease, versions, *openshiftVersions, *osImages, *releaseImages, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			releaseImage := models.ReleaseImage{
+				CPUArchitecture:  &cpuArchitecture,
+				OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
+				URL:              &common.TestDefaultConfig.ReleaseImageUrl,
+				Version:          &common.TestDefaultConfig.ReleaseVersion,
+			}
+
+			// Production release version
+			releaseImage.Version = swag.String("4.8.12")
+			Expect(h.getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
+
+			// Beta release version
+			releaseImage.Version = swag.String("4.9.0-rc.4")
+			Expect(h.getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelBeta))
+
+			// Support level specified in release image
+			releaseImage.SupportLevel = models.OpenshiftVersionSupportLevelProduction
+			Expect(h.getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
 		})
 	})
 

--- a/models/release_image.go
+++ b/models/release_image.go
@@ -6,6 +6,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -28,6 +30,10 @@ type ReleaseImage struct {
 	// Required: true
 	OpenshiftVersion *string `json:"openshift_version"`
 
+	// Level of support of the version.
+	// Enum: [beta production]
+	SupportLevel string `json:"support_level,omitempty"`
+
 	// The installation image of the OpenShift cluster.
 	// Required: true
 	URL *string `json:"url"`
@@ -46,6 +52,10 @@ func (m *ReleaseImage) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateOpenshiftVersion(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSupportLevel(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -75,6 +85,49 @@ func (m *ReleaseImage) validateCPUArchitecture(formats strfmt.Registry) error {
 func (m *ReleaseImage) validateOpenshiftVersion(formats strfmt.Registry) error {
 
 	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var releaseImageTypeSupportLevelPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["beta","production"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		releaseImageTypeSupportLevelPropEnum = append(releaseImageTypeSupportLevelPropEnum, v)
+	}
+}
+
+const (
+
+	// ReleaseImageSupportLevelBeta captures enum value "beta"
+	ReleaseImageSupportLevelBeta string = "beta"
+
+	// ReleaseImageSupportLevelProduction captures enum value "production"
+	ReleaseImageSupportLevelProduction string = "production"
+)
+
+// prop value enum
+func (m *ReleaseImage) validateSupportLevelEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, releaseImageTypeSupportLevelPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ReleaseImage) validateSupportLevel(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.SupportLevel) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateSupportLevelEnum("support_level", "body", m.SupportLevel); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -12262,6 +12262,14 @@ func init() {
           "description": "Version of the OpenShift cluster.",
           "type": "string"
         },
+        "support_level": {
+          "description": "Level of support of the version.",
+          "type": "string",
+          "enum": [
+            "beta",
+            "production"
+          ]
+        },
         "url": {
           "description": "The installation image of the OpenShift cluster.",
           "type": "string"
@@ -25060,6 +25068,14 @@ func init() {
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
           "type": "string"
+        },
+        "support_level": {
+          "description": "Level of support of the version.",
+          "type": "string",
+          "enum": [
+            "beta",
+            "production"
+          ]
         },
         "url": {
           "description": "The installation image of the OpenShift cluster.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8482,6 +8482,10 @@ definitions:
       default:
         type: boolean
         description: Indication that the version is the recommended one.
+      support_level:
+        type: string
+        enum: [beta, production]
+        description: Level of support of the version.
 
   release-images:
     type: array


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added support_level to ReleaseImage model to allow overriding the property in openshift_versions API.
I.e. return if specified in release image; otherwise, search pre-release string in version.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eranco74 
/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
