### PR TITLE
OCPBUGSM-35987: Adding default value for disk_encryption in cluster registration.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	reflect "reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -391,6 +392,13 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 	if params.NewClusterParams.HTTPProxy != nil &&
 		(params.NewClusterParams.HTTPSProxy == nil || *params.NewClusterParams.HTTPSProxy == "") {
 		params.NewClusterParams.HTTPSProxy = params.NewClusterParams.HTTPProxy
+	}
+
+	if params.NewClusterParams.DiskEncryption == nil {
+		params.NewClusterParams.DiskEncryption = &models.DiskEncryption{
+			EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+			Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+		}
 	}
 
 	return params
@@ -2289,6 +2297,7 @@ func (b *bareMetalInventory) updateClusterInternal(ctx context.Context, v1Params
 	}
 
 	if err = validations.ValidateDiskEncryptionParams(v2Params.ClusterUpdateParams.DiskEncryption); err != nil {
+		log.WithError(err).Errorf("failed to validate disk-encryption params: %v", *v2Params.ClusterUpdateParams.DiskEncryption)
 		return nil, err
 	}
 
@@ -2602,16 +2611,19 @@ func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interfac
 
 func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncryption *models.DiskEncryption, usages map[string]models.Usage) {
 
-	if c.DiskEncryption == nil {
+	if c.DiskEncryption == nil || reflect.DeepEqual(c.DiskEncryption, &models.DiskEncryption{}) {
 		return
 	}
 
-	props := map[string]interface{}{
-		"enable_on":    *diskEncryption.EnableOn,
-		"mode":         *diskEncryption.Mode,
-		"tang_servers": diskEncryption.TangServers,
+	props := map[string]interface{}{}
+	if diskEncryption.EnableOn != nil {
+		props["enable_on"] = swag.StringValue(diskEncryption.EnableOn)
 	}
-	b.setUsage(*c.DiskEncryption.EnableOn != models.DiskEncryptionEnableOnNone, usage.DiskEncryption, &props, usages)
+	if diskEncryption.Mode != nil {
+		props["mode"] = swag.StringValue(diskEncryption.Mode)
+		props["tang_servers"] = diskEncryption.TangServers
+	}
+	b.setUsage(swag.StringValue(c.DiskEncryption.EnableOn) != models.DiskEncryptionEnableOnNone, usage.DiskEncryption, &props, usages)
 }
 
 func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *common.Cluster, params installer.V2UpdateClusterParams, usages map[string]models.Usage, db *gorm.DB, log logrus.FieldLogger, interactivity Interactivity) error {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10699,6 +10699,82 @@ var _ = Describe("TestRegisterCluster", func() {
 			Expect(actual.Payload.DiskEncryption.EnableOn).To(Equal(swag.String(models.DiskEncryptionEnableOnNone)))
 		})
 
+		It("updating cluster with disk encryption", func() {
+
+			var c *models.Cluster
+			diskEncryptionBm := createInventory(db, cfg)
+			diskEncryptionBm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
+				db, mockEvents, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil)
+
+			By("Register cluster", func() {
+
+				mockClusterRegisterSuccess(diskEncryptionBm, true)
+				mockUsageReports()
+				mockAMSSubscription(ctx)
+
+				reply := diskEncryptionBm.RegisterCluster(ctx, installer.RegisterClusterParams{
+					NewClusterParams: &models.ClusterCreateParams{},
+				})
+				Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
+				c = reply.(*installer.RegisterClusterCreated).Payload
+				Expect(swag.StringValue(c.DiskEncryption.EnableOn)).To(Equal(models.DiskEncryptionEnableOnNone))
+				Expect(swag.StringValue(c.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTpmv2))
+			})
+
+			By("Update cluster with full object", func() {
+
+				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+				mockEvents.EXPECT().SendClusterEvent(ctx, gomock.Any())
+
+				reply := diskEncryptionBm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: *c.ID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						DiskEncryption: &models.DiskEncryption{
+							EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+							Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+				c = reply.(*installer.UpdateClusterCreated).Payload
+				Expect(swag.StringValue(c.DiskEncryption.EnableOn)).To(Equal(models.DiskEncryptionEnableOnAll))
+				Expect(swag.StringValue(c.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTpmv2))
+			})
+
+			By("Update cluster with partial object", func() {
+
+				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+
+				reply := diskEncryptionBm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: *c.ID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						DiskEncryption: &models.DiskEncryption{
+							EnableOn: swag.String(models.DiskEncryptionEnableOnMasters),
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+				c = reply.(*installer.UpdateClusterCreated).Payload
+				Expect(swag.StringValue(c.DiskEncryption.EnableOn)).To(Equal(models.DiskEncryptionEnableOnMasters))
+				Expect(swag.StringValue(c.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTpmv2))
+			})
+
+			By("Update cluster with emtpy object", func() {
+
+				mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+
+				reply := diskEncryptionBm.UpdateCluster(ctx, installer.UpdateClusterParams{
+					ClusterID: *c.ID,
+					ClusterUpdateParams: &models.ClusterUpdateParams{
+						DiskEncryption: &models.DiskEncryption{},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateClusterCreated()))
+				c = reply.(*installer.UpdateClusterCreated).Payload
+				Expect(swag.StringValue(c.DiskEncryption.EnableOn)).To(Equal(models.DiskEncryptionEnableOnMasters))
+				Expect(swag.StringValue(c.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTpmv2))
+			})
+		})
 	})
 
 	Context("NTPSource", func() {


### PR DESCRIPTION


# Assisted Pull Request

## Description

The default value is '{"enable_on":"none","mode":"tpmv2"}'.

By setting default value in swagger, when updating a cluster without
disk-encryption, the default values will be used to override the current
value, therefore the default value is used in cluster's registration and
not in cluster's updates

Signed-off-by: Yoni Bettan <ybettan@redhat.com>


## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
