### PR TITLE
OCPBUGSM-35978: Add cluster_id and infra_env_id to logs in more flows

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -60,7 +60,6 @@ import (
 	"github.com/openshift/assisted-service/pkg/leader"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/pkg/ocm"
-	"github.com/openshift/assisted-service/pkg/requestid"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
 	"github.com/openshift/assisted-service/pkg/staticnetworkconfig"
 	"github.com/openshift/assisted-service/pkg/transaction"
@@ -1648,7 +1647,7 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 
 	go func() {
 		var err error
-		asyncCtx := requestid.ToContext(context.Background(), requestid.FromContext(ctx))
+		asyncCtx := ctxparams.Copy(ctx)
 
 		defer func() {
 			if err != nil {

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -2,8 +2,6 @@ package log
 
 import (
 	"context"
-	"runtime"
-	"strings"
 
 	params "github.com/openshift/assisted-service/pkg/context"
 	"github.com/openshift/assisted-service/pkg/requestid"
@@ -24,38 +22,10 @@ type Config struct {
 // FromContext equip a given logger with values from the given context
 func FromContext(ctx context.Context, inner logrus.FieldLogger) logrus.FieldLogger {
 	requestID := requestid.FromContext(ctx)
-	return requestid.RequestIDLogger(inner, requestID).WithFields(getFields(ctx))
+	return requestid.RequestIDLogger(inner, requestID).WithFields(params.GetContextParams(ctx))
 }
 
 func EntryFromContext(ctx context.Context, inner logrus.FieldLogger) *logrus.Entry {
 	requestID := requestid.FromContext(ctx)
-	return requestid.RequestIDLogger(inner, requestID).WithFields(getFields(ctx))
-}
-
-//values to be added to the decorated log
-func getFields(ctx context.Context) logrus.Fields {
-	var fields = make(map[string]interface{})
-	fields["go-id"] = goid()
-
-	cluster_id := params.GetParam(ctx, params.ClusterId)
-	if cluster_id != "" {
-		fields[params.ClusterId] = cluster_id
-	}
-
-	host_id := params.GetParam(ctx, params.HostId)
-	if host_id != "" {
-		fields[params.HostId] = host_id
-	}
-	return fields
-}
-
-// get the low-level gorouting id
-// This has been taken from:
-// https://groups.google.com/d/msg/golang-nuts/Nt0hVV_nqHE/bwndAYvxAAAJ
-// This is hacky and should not be used for anything but logging
-func goid() string {
-	var buf [64]byte
-	n := runtime.Stack(buf[:], false)
-	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
-	return idField
+	return requestid.RequestIDLogger(inner, requestID).WithFields(params.GetContextParams(ctx))
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description
- propogate the route params to asyn contexts
- add infra_env_id to logs fields

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
