### PR TITLE
Bug 1990659: Disconnected spoke cluster install fails with pull secret must contain auth for "registry.redhat.io"

### DIFF
--- a/internal/assistedserviceiso/assistedserviceiso_api.go
+++ b/internal/assistedserviceiso/assistedserviceiso_api.go
@@ -29,6 +29,7 @@ import (
 type Config struct {
 	ImageExpirationTime        time.Duration `envconfig:"IMAGE_EXPIRATION_TIME" default:"4h"`
 	IgnitionConfigBaseFilename string        `envconfig:"IGNITION_CONFIG_BASE_FILENAME" default:"/data/onprem-iso-config.ign"`
+	IPv6Support                bool          `envconfig:"IPV6_SUPPORT" default:"true"`
 }
 
 var _ restapi.AssistedServiceIsoAPI = &assistedServiceISOApi{}
@@ -65,7 +66,7 @@ func (a *assistedServiceISOApi) CreateISOAndUploadToS3(ctx context.Context, para
 
 	pullSecret := params.AssistedServiceIsoCreateParams.PullSecret
 	if pullSecret != "" {
-		err := a.pullSecretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), a.authHandler)
+		err := a.pullSecretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), a.authHandler, a.config.IPv6Support)
 		if err != nil {
 			log.WithError(err).Errorf("Pull-secret for Assisted Service ISO has invalid format")
 			return assisted_service_iso.NewCreateISOAndUploadToS3BadRequest().

--- a/internal/assistedserviceiso/assistedserviceiso_api_test.go
+++ b/internal/assistedserviceiso/assistedserviceiso_api_test.go
@@ -57,7 +57,7 @@ var _ = Describe("AssistedServiceISO", func() {
 		})
 
 		It("success", func() {
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			ignitionParams := models.AssistedServiceIsoCreateParams{
 				SSHPublicKey:     sshPublicKey,
 				PullSecret:       pullSecret,
@@ -70,7 +70,7 @@ var _ = Describe("AssistedServiceISO", func() {
 		})
 
 		It("failure when pull-secret is missing", func() {
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			ignitionParams := models.AssistedServiceIsoCreateParams{
 				SSHPublicKey: sshPublicKey,
 				PullSecret:   "",
@@ -82,7 +82,7 @@ var _ = Describe("AssistedServiceISO", func() {
 		})
 
 		It("failure when pull-secret is wrong format", func() {
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("bad pull secret")).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.Errorf("bad pull secret")).Times(1)
 			ignitionParams := models.AssistedServiceIsoCreateParams{
 				SSHPublicKey: sshPublicKey,
 				PullSecret:   "not-correct-format",
@@ -94,7 +94,7 @@ var _ = Describe("AssistedServiceISO", func() {
 		})
 
 		It("ssh public key is not required and request should be successful if it is missing", func() {
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			ignitionParams := models.AssistedServiceIsoCreateParams{
 				SSHPublicKey:     "",
 				PullSecret:       pullSecret,
@@ -107,7 +107,7 @@ var _ = Describe("AssistedServiceISO", func() {
 		})
 
 		It("multiple creates", func() {
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			ignitionParams := models.AssistedServiceIsoCreateParams{
 				SSHPublicKey:     sshPublicKey,
 				PullSecret:       pullSecret,
@@ -120,7 +120,7 @@ var _ = Describe("AssistedServiceISO", func() {
 			Expect(generateReply).Should(BeAssignableToTypeOf(assisted_service_iso.NewCreateISOAndUploadToS3Created()))
 			// second
 			uploadIsoSuccess()
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			generateReply = api.CreateISOAndUploadToS3(ctx, assisted_service_iso.CreateISOAndUploadToS3Params{
 				AssistedServiceIsoCreateParams: &ignitionParams,
 			})

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -564,7 +564,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	}
 
 	pullSecret := swag.StringValue(params.NewClusterParams.PullSecret)
-	err = b.secretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), b.authHandler)
+	err = b.secretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), b.authHandler, b.IPv6Support)
 	if err != nil {
 		err = errors.Wrap(secretValidationToUserError(err), "pull secret for new cluster is invalid")
 		return nil, common.NewApiError(http.StatusBadRequest, err)
@@ -2129,7 +2129,7 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 	log := logutil.FromContext(ctx, b.log)
 
 	if swag.StringValue(params.ClusterUpdateParams.PullSecret) != "" {
-		if err := b.secretValidator.ValidatePullSecret(*params.ClusterUpdateParams.PullSecret, ocm.UserNameFromContext(ctx), b.authHandler); err != nil {
+		if err := b.secretValidator.ValidatePullSecret(*params.ClusterUpdateParams.PullSecret, ocm.UserNameFromContext(ctx), b.authHandler, b.IPv6Support); err != nil {
 			log.WithError(err).Errorf("Pull secret for cluster %s is invalid", params.ClusterID)
 			return installer.V2UpdateClusterParams{}, err
 		}
@@ -5665,7 +5665,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 	}
 
 	pullSecret := swag.StringValue(params.InfraenvCreateParams.PullSecret)
-	err = b.secretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), b.authHandler)
+	err = b.secretValidator.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx), b.authHandler, b.IPv6Support)
 	if err != nil {
 		err = errors.Wrap(secretValidationToUserError(err), "pull secret for new infraEnv is invalid")
 		return nil, common.NewApiError(http.StatusBadRequest, err)
@@ -5897,7 +5897,7 @@ func (b *bareMetalInventory) validateAndUpdateInfraEnvParams(ctx context.Context
 	log := logutil.FromContext(ctx, b.log)
 
 	if params.InfraEnvUpdateParams.PullSecret != "" {
-		if err := b.secretValidator.ValidatePullSecret(params.InfraEnvUpdateParams.PullSecret, ocm.UserNameFromContext(ctx), b.authHandler); err != nil {
+		if err := b.secretValidator.ValidatePullSecret(params.InfraEnvUpdateParams.PullSecret, ocm.UserNameFromContext(ctx), b.authHandler, b.IPv6Support); err != nil {
 			log.WithError(err).Errorf("Pull secret for infraEnv %s is invalid", params.InfraEnvID)
 			return installer.UpdateInfraEnvParams{}, err
 		}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -118,7 +118,7 @@ var (
 )
 
 func mockClusterRegisterSteps() {
-	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 	mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -139,7 +139,7 @@ func mockClusterRegisterSuccess(bm *bareMetalInventory, withEvents bool) {
 func mockInfraEnvRegisterSuccess() {
 	mockVersions.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 	mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(1)
-	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(2)
 	mockS3Client.EXPECT().GetBaseIsoObject(gomock.Any(), gomock.Any()).Return("rhcos", nil).Times(1)
 	mockS3Client.EXPECT().UploadISO(gomock.Any(), gomock.Any(), "rhcos", gomock.Any()).Return(nil).Times(1)
@@ -7531,7 +7531,7 @@ var _ = Describe("infraEnvs", func() {
 		It("No version specified", func() {
 			mockVersions.EXPECT().GetLatestOsImage(gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(1)
-			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(discovery_ignition_3_1, nil).Times(2)
 			mockS3Client.EXPECT().GetBaseIsoObject(gomock.Any(), gomock.Any()).Return("rhcos", nil).Times(1)
 			mockS3Client.EXPECT().UploadISO(gomock.Any(), gomock.Any(), "rhcos", gomock.Any()).Return(nil).Times(1)
@@ -8078,7 +8078,7 @@ var _ = Describe("infraEnvs", func() {
 						prevURL = newURL
 
 						By("updating pull secret")
-						mockSecretValidator.EXPECT().ValidatePullSecret("mypullsecret", gomock.Any(), gomock.Any()).Return(nil)
+						mockSecretValidator.EXPECT().ValidatePullSecret("mypullsecret", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 						params.PullSecret = "mypullsecret"
 						newURL = updateInfraEnv(params)
 						Expect(newURL).ToNot(Equal(prevURL))
@@ -10759,7 +10759,7 @@ var _ = Describe("TestRegisterCluster", func() {
 	})
 
 	It("cluster api failed to register with invalid pull secret", func() {
-		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).
+		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
@@ -12896,6 +12896,15 @@ var _ = Describe("Platform tests", func() {
 			Expect(cluster.Platform).ShouldNot(BeNil())
 			Expect(cluster.Platform.Type).Should(BeEquivalentTo(models.PlatformTypeVsphere))
 			Expect(cluster.Platform.Vsphere).ShouldNot(BeNil())
+		})
+
+		It("Skip registry.redhat.io auth validation for IPv6 cluster", func() {
+			var params installer.RegisterClusterParams = installer.RegisterClusterParams{
+				NewClusterParams: getDefaultClusterCreateParams(),
+			}
+			params.NewClusterParams.PullSecret = swag.String("abcd")
+			reply := bm.RegisterCluster(ctx, params)
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewRegisterClusterCreated()))
 		})
 	})
 })

--- a/internal/cluster/validations/mock_validations.go
+++ b/internal/cluster/validations/mock_validations.go
@@ -35,15 +35,15 @@ func (m *MockPullSecretValidator) EXPECT() *MockPullSecretValidatorMockRecorder 
 }
 
 // ValidatePullSecret mocks base method.
-func (m *MockPullSecretValidator) ValidatePullSecret(secret, username string, authHandler auth.Authenticator) error {
+func (m *MockPullSecretValidator) ValidatePullSecret(secret, username string, authHandler auth.Authenticator, IPv6Support bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidatePullSecret", secret, username, authHandler)
+	ret := m.ctrl.Call(m, "ValidatePullSecret", secret, username, authHandler, IPv6Support)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidatePullSecret indicates an expected call of ValidatePullSecret.
-func (mr *MockPullSecretValidatorMockRecorder) ValidatePullSecret(secret, username, authHandler interface{}) *gomock.Call {
+func (mr *MockPullSecretValidatorMockRecorder) ValidatePullSecret(secret, username, authHandler, IPv6Support interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePullSecret", reflect.TypeOf((*MockPullSecretValidator)(nil).ValidatePullSecret), secret, username, authHandler)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatePullSecret", reflect.TypeOf((*MockPullSecretValidator)(nil).ValidatePullSecret), secret, username, authHandler, IPv6Support)
 }

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -20,16 +20,17 @@ import (
 
 // #nosec
 const (
-	validSecretFormat        = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}"
-	invalidAuthFormat        = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"afsdfasf==\",\"email\":\"r@r.com\"}}}"
-	invalidSecretFormat      = "{\"auths\":{\"cloud.openshift.com\":{\"key\":\"abcdef=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"adasfsdf=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"tatastata==\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"afsdfasf==\",\"email\":\"r@r.com\"}}}"
-	validSSHPublicKey        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain"
-	validSSHPublicKeys       = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain"
-	invalidSSHPublicKeyA     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDI2PBP9RuAHCJ1JvxS0gkK7cm1sMHtdqCYuHzK7fmoMSPeAu+GEPVlBmes825gabO7vUK/pVmcsP9mQLXB0KZ8m/QEBXSO9vmF8dEt5OqtpRLcRzxmcnU1iUs50VSQyEeSxdSV4KA9JuWa+q0f3o3VO+CF6s4kQvQ4lumyCyNSFIBnFCX16+O8syah/UpHUWVqJeHaXCV8qzYKyRvy6nMI5lqCgxe+ENqHkgfkQkgEKHZ8gEnzHtJgewZ3E6fbjQ59eEEvF0zb7WKKWA0YzWOMVGGybj4cFMPQ4Jt7iJ0OZKPBQZMHBcPNrej5lasgcKR7nH5XS0UjHhX5vZJ7e7zONHK4XZj6OjEOXilg3/4rxSn0+QQtT1v0RDXRQhHS6sCyRFV12MqEP8XjPIdBMbE26lRwk3tBwWx7plj3UCVamQid3nY5kslD4X7+cqE8n3bNF922rhCy5STycfEFN3XTs73yKvVPjpro4aQw4BVi4P7B7m7F1d/DqRBuYwWuQ6cLLLLLLLLLLL= root@xxxxxx.xx.xxx.xxx.redhat.com"
-	invalidSSHPublicKeyB     = "test!!! ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDi8KHZYGyPQjECHwytquI3rmpgoUn6M+lkeOD2nEKvYElLE5mPIeqF0izJIl56uar2wda+3z107M9QkatE+dP4S9/Ltrlm+/ktAf4O6UoxNLUzv/TGHasb9g3Xkt8JTkohVzVK36622Sd8kLzEc61v1AonLWIADtpwq6/GvHMAuPK2R/H0rdKhTokylKZLDdTqQ+KUFelI6RNIaUBjtVrwkx1j0htxN11DjBVuUyPT2O1ejWegtrM0T+4vXGEA3g3YfbT2k0YnEzjXXqngqbXCYEJCZidp3pJLH/ilo4Y4BId/bx/bhzcbkZPeKlLwjR8g9sydce39bzPIQj+b7nlFv1Vot/77VNwkjXjYPUdUPu0d1PkFD9jKDOdB3fAC61aG2a/8PFS08iBrKiMa48kn+hKXC4G4D5gj/QzIAgzWSl2tEzGQSoIVTucwOAL/jox2dmAa0RyKsnsHORppanuW4qD7KAcmas1GHrAqIfNyDiU2JR50r1jCxj5H76QxIuM= root@ocp-edge34.lab.eng.tlv2.redhat.com"
-	userName                 = "jdoe123@example.com"
-	validSecretFormatUpdated = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.stage.redhat.io\":{\"auth\":\"c29tZW9uZUBleGFtcGxlLmNvbTp0aGlzaXNhc2VjcmV0\"}}}"
-	regCred                  = "someone@example.com:thisisasecret"
+	validSecretFormat                        = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}"
+	invalidAuthFormat                        = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"afsdfasf==\",\"email\":\"r@r.com\"}}}"
+	invalidSecretFormat                      = "{\"auths\":{\"cloud.openshift.com\":{\"key\":\"abcdef=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"adasfsdf=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"tatastata==\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"afsdfasf==\",\"email\":\"r@r.com\"}}}"
+	validSSHPublicKey                        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain"
+	validSSHPublicKeys                       = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain\nssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQD14Gv4V1111yr7O6/44laYx52VYLe8yrEA3fOieWDmojRs3scqLnfeLHJWsfYA4QMjTuraLKhT8dhETSYiSR88RMM56+isLbcLshE6GkNkz3MBZE2hcdakqMDm6vucP3dJD6snuh5Hfpq7OWDaTcC0zCAzNECJv8F7LcWVa8TLpyRgpek4U022T5otE1ZVbNFqN9OrGHgyzVQLtC4xN1yT83ezo3r+OEdlSVDRQfsq73Zg26d4dyagb6lmrryUUA111mn/HalJTHB73LyjilKiPvJ+x2bG7Aeiq111wtQSpt02FCdQGptmsSqqWF/b9botOO38e111PNppMn7LT5wzDZdDlfwTCBWkpqijPcdo/LTD9dJlNHjwXZtHETtiid6N3ZZWpA0/VKjqUeQdSnHqLEzTidswsnOjCIoIhmJFqczeP5kOty/MWdq1II/FX/EpYCJxoSWkT/hVwD6VOamGwJbLVw9LkEb0VVWFRJB5suT/T8DtPdPl+A0qUGiN4KM= xxxxxx@localhost.localdomain"
+	invalidSSHPublicKeyA                     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDI2PBP9RuAHCJ1JvxS0gkK7cm1sMHtdqCYuHzK7fmoMSPeAu+GEPVlBmes825gabO7vUK/pVmcsP9mQLXB0KZ8m/QEBXSO9vmF8dEt5OqtpRLcRzxmcnU1iUs50VSQyEeSxdSV4KA9JuWa+q0f3o3VO+CF6s4kQvQ4lumyCyNSFIBnFCX16+O8syah/UpHUWVqJeHaXCV8qzYKyRvy6nMI5lqCgxe+ENqHkgfkQkgEKHZ8gEnzHtJgewZ3E6fbjQ59eEEvF0zb7WKKWA0YzWOMVGGybj4cFMPQ4Jt7iJ0OZKPBQZMHBcPNrej5lasgcKR7nH5XS0UjHhX5vZJ7e7zONHK4XZj6OjEOXilg3/4rxSn0+QQtT1v0RDXRQhHS6sCyRFV12MqEP8XjPIdBMbE26lRwk3tBwWx7plj3UCVamQid3nY5kslD4X7+cqE8n3bNF922rhCy5STycfEFN3XTs73yKvVPjpro4aQw4BVi4P7B7m7F1d/DqRBuYwWuQ6cLLLLLLLLLLL= root@xxxxxx.xx.xxx.xxx.redhat.com"
+	invalidSSHPublicKeyB                     = "test!!! ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDi8KHZYGyPQjECHwytquI3rmpgoUn6M+lkeOD2nEKvYElLE5mPIeqF0izJIl56uar2wda+3z107M9QkatE+dP4S9/Ltrlm+/ktAf4O6UoxNLUzv/TGHasb9g3Xkt8JTkohVzVK36622Sd8kLzEc61v1AonLWIADtpwq6/GvHMAuPK2R/H0rdKhTokylKZLDdTqQ+KUFelI6RNIaUBjtVrwkx1j0htxN11DjBVuUyPT2O1ejWegtrM0T+4vXGEA3g3YfbT2k0YnEzjXXqngqbXCYEJCZidp3pJLH/ilo4Y4BId/bx/bhzcbkZPeKlLwjR8g9sydce39bzPIQj+b7nlFv1Vot/77VNwkjXjYPUdUPu0d1PkFD9jKDOdB3fAC61aG2a/8PFS08iBrKiMa48kn+hKXC4G4D5gj/QzIAgzWSl2tEzGQSoIVTucwOAL/jox2dmAa0RyKsnsHORppanuW4qD7KAcmas1GHrAqIfNyDiU2JR50r1jCxj5H76QxIuM= root@ocp-edge34.lab.eng.tlv2.redhat.com"
+	userName                                 = "jdoe123@example.com"
+	validSecretFormatUpdated                 = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.redhat.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.stage.redhat.io\":{\"auth\":\"c29tZW9uZUBleGFtcGxlLmNvbTp0aGlzaXNhc2VjcmV0\"}}}"
+	validSecretFormatUpdatedIPV6Disconnected = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"quay.io\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.connect.redhat.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"},\"registry.stage.redhat.io\":{\"auth\":\"c29tZW9uZUBleGFtcGxlLmNvbTp0aGlzaXNhc2VjcmV0\"}}}"
+	regCred                                  = "someone@example.com:thisisasecret"
 )
 
 var _ = Describe("Pull secret validation", func() {
@@ -56,30 +57,30 @@ var _ = Describe("Pull secret validation", func() {
 		})
 
 		It("valid format", func() {
-			err := secretValidator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled)
+			err := secretValidator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("empty secret", func() {
-			err := secretValidator.ValidatePullSecret("", "", authHandlerDisabled)
+			err := secretValidator.ValidatePullSecret("", "", authHandlerDisabled, true)
 			Expect(err).Should(HaveOccurred())
 		})
 		It("invalid format for the auth", func() {
-			err := secretValidator.ValidatePullSecret(invalidAuthFormat, "", authHandlerDisabled)
+			err := secretValidator.ValidatePullSecret(invalidAuthFormat, "", authHandlerDisabled, true)
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(BeAssignableToTypeOf(&PullSecretError{}))
 		})
 		It("invalid format", func() {
-			err := secretValidator.ValidatePullSecret(invalidSecretFormat, "", authHandlerDisabled)
+			err := secretValidator.ValidatePullSecret(invalidSecretFormat, "", authHandlerDisabled, true)
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(BeAssignableToTypeOf(&PullSecretError{}))
 		})
 		It("valid format - Invalid user", func() {
-			err := secretValidator.ValidatePullSecret(validSecretFormat, "NotSameUser@example.com", authHandler)
+			err := secretValidator.ValidatePullSecret(validSecretFormat, "NotSameUser@example.com", authHandler, true)
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(BeAssignableToTypeOf(&PullSecretError{}))
 		})
 		It("valid format - Valid user", func() {
-			err := secretValidator.ValidatePullSecret(validSecretFormat, userName, authHandler)
+			err := secretValidator.ValidatePullSecret(validSecretFormat, userName, authHandler, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("Add RH Reg PullSecret ", func() {
@@ -101,14 +102,14 @@ var _ = Describe("Pull secret validation", func() {
 		It("pull secret accepted when it contains all required registries", func() {
 			validator, err := NewPullSecretValidator(Config{}, "quay.io/testing:latest", "registry.redhat.io/image:v1")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("pull secret accepted even if it does not contain registry.stage.redhat.io", func() {
 			validator, err := NewPullSecretValidator(Config{}, "quay.io/testing:latest", "registry.stage.redhat.io/special:v1")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -118,44 +119,50 @@ var _ = Describe("Pull secret validation", func() {
 			}
 			validator, err := NewPullSecretValidator(config, "quay.io/testing:latest", "ignore.com/image:v1", "something.com/container:X")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("docker.io auth is accepted when there is an image from docker.io", func() {
 			validator, err := NewPullSecretValidator(Config{}, "docker.io/testing:latest")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(pullSecDocker, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(pullSecDocker, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("legacy DockerHub auth is accepted when there is an image from docker.io", func() {
 			validator, err := NewPullSecretValidator(Config{}, "docker.io/testing:latest")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(pullSecLegacyDocker, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(pullSecLegacyDocker, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("docker.io auth is accepted when there is an image with default registry", func() {
 			validator, err := NewPullSecretValidator(Config{}, "local:v1")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(pullSecDocker, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(pullSecDocker, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("legacy DockerHub auth is accepted when there is an image with default registry", func() {
 			validator, err := NewPullSecretValidator(Config{}, "local:v2")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(pullSecLegacyDocker, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(pullSecLegacyDocker, "", authHandlerDisabled, true)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("error when pull secret does not contain required registry", func() {
 			validator, err := NewPullSecretValidator(Config{}, "quay.io/testing:latest", "required.com/image:v1")
 			Expect(err).ShouldNot(HaveOccurred())
-			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled)
+			err = validator.ValidatePullSecret(validSecretFormat, "", authHandlerDisabled, false)
 			Expect(err).Should(HaveOccurred())
 			Expect(err).Should(BeAssignableToTypeOf(&PullSecretError{}))
+		})
+		It("Skip registry.redhat.io auth validation in case of IPV6 disconnected cluster", func() {
+			validator, err := NewPullSecretValidator(Config{}, "quay.io/testing:latest", "registry.redhat.io/image:v1")
+			Expect(err).ShouldNot(HaveOccurred())
+			err = validator.ValidatePullSecret(validSecretFormatUpdatedIPV6Disconnected, "", authHandlerDisabled, true)
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -50,7 +50,7 @@ func init() {
 // it verifies the format of the pull secrete and access to required image registries
 //go:generate mockgen -source=validations.go -package=validations -destination=mock_validations.go
 type PullSecretValidator interface {
-	ValidatePullSecret(secret string, username string, authHandler auth.Authenticator) error
+	ValidatePullSecret(secret string, username string, authHandler auth.Authenticator, IPv6Support bool) error
 }
 
 type registryPullSecretValidator struct {
@@ -156,7 +156,7 @@ func NewPullSecretValidator(config Config, images ...string) (PullSecretValidato
 }
 
 // ValidatePullSecret validates that a pull secret is well formed and contains all required data
-func (v *registryPullSecretValidator) ValidatePullSecret(secret string, username string, authHandler auth.Authenticator) error {
+func (v *registryPullSecretValidator) ValidatePullSecret(secret string, username string, authHandler auth.Authenticator, IPv6Support bool) error {
 	creds, err := ParsePullSecret(secret)
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func (v *registryPullSecretValidator) ValidatePullSecret(secret string, username
 			continue
 		}
 
-		if _, ok := creds[registry]; !ok {
+		if _, ok := creds[registry]; !ok && !IPv6Support {
 			return &PullSecretError{Msg: fmt.Sprintf("pull secret must contain auth for %q", registry)}
 		}
 	}


### PR DESCRIPTION


# Assisted Pull Request

## Description
Disconnected ipv6 Spoke cluster deployment fails with below status in AgentClusterInstall CR.
'The Spec could not be synced due to an input error: pull secret for new cluster is invalid:
pull secret must contain auth for "registry.redhat.io"'

This fix skips the pull secret validation for auth in case of IPV6
as with IPV6 spoke cluster should NOT need a pull secret entry for "registry.redhat.io"
as that registry is being mapped to the local disconnected mirror registry via the mirror-registry-ca configmap.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
