### PR TITLE
Bug 2005651 Add maintenance to release-image support levels

### DIFF
--- a/models/release_image.go
+++ b/models/release_image.go
@@ -31,7 +31,7 @@ type ReleaseImage struct {
 	OpenshiftVersion *string `json:"openshift_version"`
 
 	// Level of support of the version.
-	// Enum: [beta production]
+	// Enum: [beta production maintenance]
 	SupportLevel string `json:"support_level,omitempty"`
 
 	// The installation image of the OpenShift cluster.
@@ -95,7 +95,7 @@ var releaseImageTypeSupportLevelPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["beta","production"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["beta","production","maintenance"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -110,6 +110,9 @@ const (
 
 	// ReleaseImageSupportLevelProduction captures enum value "production"
 	ReleaseImageSupportLevelProduction string = "production"
+
+	// ReleaseImageSupportLevelMaintenance captures enum value "maintenance"
+	ReleaseImageSupportLevelMaintenance string = "maintenance"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -12372,7 +12372,8 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production"
+            "production",
+            "maintenance"
           ]
         },
         "url": {
@@ -25284,7 +25285,8 @@ func init() {
           "type": "string",
           "enum": [
             "beta",
-            "production"
+            "production",
+            "maintenance"
           ]
         },
         "url": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8549,7 +8549,7 @@ definitions:
         description: Indication that the version is the recommended one.
       support_level:
         type: string
-        enum: [beta, production]
+        enum: [beta, production, maintenance]
         description: Level of support of the version.
 
   release-images:


### PR DESCRIPTION
## Description
Add maintenance to release-image support levels, this should allow the UI to filter out versions with maintenance support_level from the cluster create options.


- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
