### PR TITLE
Bug 2012901: Allow Agent/AssistedController to authenticate for V2Dow…

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5217,6 +5217,9 @@ func init() {
           },
           {
             "urlAuth": []
+          },
+          {
+            "agentAuth": []
           }
         ],
         "description": "Downloads credentials relating to the installed/installing cluster.",
@@ -18070,6 +18073,9 @@ func init() {
           },
           {
             "urlAuth": []
+          },
+          {
+            "agentAuth": []
           }
         ],
         "description": "Downloads credentials relating to the installed/installing cluster.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4736,6 +4736,7 @@ paths:
       security:
         - userAuth: [user]
         - urlAuth: []
+        - agentAuth: []
       description: Downloads credentials relating to the installed/installing cluster.
       operationId: V2DownloadClusterCredentials
       produces:


### PR DESCRIPTION
…nloadClusterCredentials

This PR add securiry definition agentAuth to the V2DownloadClusterCredentials in swagger
to allow this API to be used and authenticated from the agent/assisted-controller

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
