### PR TITLE
MGMT-7710: Adding TPM requirements for preflight requirements API.

### DIFF
--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -893,6 +893,108 @@ var _ = Describe("Preflight host requirements", func() {
 		Expect(result.Operators).To(ConsistOf(operatorRequirements))
 	})
 
+	Context("disk-encryption TPM requirements", func() {
+
+		It("TPM - all roles", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeTrue())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeTrue())
+		})
+
+		It("TPM - masters only", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					EnableOn: swag.String(models.DiskEncryptionEnableOnMasters),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeTrue())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeFalse())
+		})
+
+		It("TPM - workers only", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					EnableOn: swag.String(models.DiskEncryptionEnableOnWorkers),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeFalse())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeTrue())
+		})
+
+		It("TPM - none", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+					Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeFalse())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeFalse())
+		})
+
+		It("Tang - all roles", func() {
+
+			diskEncryptionClusterID := strfmt.UUID(uuid.New().String())
+			diskEncryptionCluster := &common.Cluster{Cluster: models.Cluster{
+				ID:               &diskEncryptionClusterID,
+				OpenshiftVersion: openShiftVersionNotInConfig,
+				DiskEncryption: &models.DiskEncryption{
+					EnableOn: swag.String(models.DiskEncryptionEnableOnAll),
+					Mode:     swag.String(models.DiskEncryptionModeTang),
+				},
+			}}
+
+			operatorsMock.EXPECT().GetPreflightRequirementsBreakdownForCluster(gomock.Any(), gomock.Eq(diskEncryptionCluster)).Return(operatorRequirements, nil)
+
+			result, err := hwvalidator.GetPreflightHardwareRequirements(context.TODO(), diskEncryptionCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Ocp.Master.Quantitative.TpmEnabledInBios).To(BeFalse())
+			Expect(result.Ocp.Worker.Quantitative.TpmEnabledInBios).To(BeFalse())
+		})
+	})
 })
 
 func isBlockDeviceNameInlist(disks []*models.Disk, name string) bool {

--- a/models/cluster_host_requirements_details.go
+++ b/models/cluster_host_requirements_details.go
@@ -32,6 +32,9 @@ type ClusterHostRequirementsDetails struct {
 
 	// Required number of RAM in MiB
 	RAMMib int64 `json:"ram_mib,omitempty"`
+
+	// Whether TPM module should be enabled in host's BIOS.
+	TpmEnabledInBios bool `json:"tpm_enabled_in_bios,omitempty"`
 }
 
 // Validate validates this cluster host requirements details

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9813,6 +9813,10 @@ func init() {
         "ram_mib": {
           "description": "Required number of RAM in MiB",
           "type": "integer"
+        },
+        "tpm_enabled_in_bios": {
+          "description": "Whether TPM module should be enabled in host's BIOS.",
+          "type": "boolean"
         }
       }
     },
@@ -22809,6 +22813,10 @@ func init() {
         "ram_mib": {
           "description": "Required number of RAM in MiB",
           "type": "integer"
+        },
+        "tpm_enabled_in_bios": {
+          "description": "Whether TPM module should be enabled in host's BIOS.",
+          "type": "boolean"
         }
       }
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6271,6 +6271,10 @@ definitions:
         format: double
         x-nullable: true
         description: Maximum packet loss allowed at L3 for role.
+      tpm_enabled_in_bios:
+        type: boolean
+        description: Whether TPM module should be enabled in host's BIOS.
+
 
   versioned-host-requirements:
     type: object


### PR DESCRIPTION
# Assisted Pull Request

## Description

In case the user has requested for disk-encryption using TPM mode for a
cluster, the API will return a new requirement requiring to enable TPM
in the host BIOS according to the roles selected by the user to apply the
encryption on.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

Here how it looks like from the API POV when enabled on all hosts:
```
{
  "ocp": {
    "master": {
      "quantitative": {
        "cpu_cores": 4,
...
        "tpm_enabled_in_bios": true
      }
    },
    "worker": {
      "quantitative": {
        "cpu_cores": 2,
...
        "tpm_enabled_in_bios": true
      }
    }
  },
...
}
```

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
