### PR TITLE
Allow Agent/AssistedController to authenticate for V2DownloadClusterCredentials (#2750)

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5211,6 +5211,9 @@ func init() {
           },
           {
             "urlAuth": []
+          },
+          {
+            "agentAuth": []
           }
         ],
         "description": "Downloads credentials relating to the installed/installing cluster.",
@@ -17948,6 +17951,9 @@ func init() {
           },
           {
             "urlAuth": []
+          },
+          {
+            "agentAuth": []
           }
         ],
         "description": "Downloads credentials relating to the installed/installing cluster.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4732,6 +4732,7 @@ paths:
       security:
         - userAuth: [user]
         - urlAuth: []
+        - agentAuth: []
       description: Downloads credentials relating to the installed/installing cluster.
       operationId: V2DownloadClusterCredentials
       produces:


### PR DESCRIPTION
Cherrypicked from #2750 as hotfix for v1.0.26 for fix BZ 2012901.

This PR add securiry definition agentAuth to the V2DownloadClusterCredentials in swagger
to allow this API to be used and authenticated from the agent/assisted-controller

/cc @yevgeny-shnaidman 
/hold