### PR TITLE
MGMT-7181: CNV operator cpu architecture validation

### DIFF
--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -69,10 +69,19 @@ func (o *operator) GetHostValidationID() string {
 	return string(models.HostValidationIDCnvRequirementsSatisfied)
 }
 
-// ValidateCluster always return "valid" result
-func (o *operator) ValidateCluster(_ context.Context, _ *common.Cluster) (api.ValidationResult, error) {
-	// No need to validate cluster because it will be validate on per host basis
-	return api.ValidationResult{Status: api.Success, ValidationId: o.GetClusterValidationID()}, nil
+// ValidateCluster verifies whether this operator is valid for given cluster
+func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+	status, message := o.validateRequirements(&cluster.Cluster)
+	return api.ValidationResult{Status: status, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+}
+
+func (o *operator) validateRequirements(cluster *models.Cluster) (api.ValidationStatus, string) {
+	if cluster.CPUArchitecture != common.DefaultCPUArchitecture {
+		return api.Failure, fmt.Sprintf(
+			"OpenShift Virtualization is supported only for %s CPU architecture.",
+			common.DefaultCPUArchitecture)
+	}
+	return api.Success, ""
 }
 
 // ValidateHost returns validationResult based on node type requirements such as memory and cpu

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -234,6 +234,24 @@ var _ = Describe("CNV operator", func() {
 			Expect(requirements.Requirements.Master.Qualitative).To(BeEquivalentTo(requirements.Requirements.Worker.Qualitative))
 		})
 	})
+
+	Context("cluster requirements", func() {
+		It("only x86_64 is supported for CNV operator", func() {
+			cluster := common.Cluster{}
+
+			cluster.CPUArchitecture = common.DefaultCPUArchitecture
+			validation, err := operator.ValidateCluster(context.TODO(), &cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(validation.Status).To(Equal(api.Success))
+
+			cluster.CPUArchitecture = "arm64"
+			validation, err = operator.ValidateCluster(context.TODO(), &cluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(validation.Status).To(Equal(api.Failure))
+			Expect(validation.Reasons).To(ContainElements(
+				"OpenShift Virtualization is supported only for x86_64 CPU architecture."))
+		})
+	})
 })
 
 func getInventoryWithGPUs(gpus []*models.Gpu) string {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added a validation to cnv_operator to ensure that "OpenShift Virtualization" is enabled only for clusters with x86_64 CPU architecture.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @avishayt 
/cc @pkliczewski 
/cc @jakub-dzon 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
