### PR TITLE
OCPBUGSM-35151: validate HA properties on register cluster

### DIFF
--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1362,7 +1362,7 @@ var _ = Describe("cluster install", func() {
 					OpenshiftVersion:     swag.String(snoVersion),
 					PullSecret:           swag.String(pullSecret),
 					SSHPublicKey:         sshPublicKey,
-					VipDhcpAllocation:    swag.Bool(true),
+					VipDhcpAllocation:    swag.Bool(false),
 					NetworkType:          swag.String("OVNKubernetes"),
 					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
 				},


### PR DESCRIPTION
# Assisted Pull Request

## Description

Validate UserManagedNetworking and VipDhcpAllocation when creating a cluster with None HighAvailabilityMode:
* User Managed Networking must be enabled on single node OpenShift:
  * If UserManagedNetworking not specified, should be set to true.
  * If false, return an API error.
* VIP DHCP Allocation cannot be enabled on single node OpenShift:
  * If VipDhcpAllocation not specified, should be set to false.
  * If true, return an API error.
 
## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eranco74 
/cc @tsorya 
/cc @avishayt 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
