### PR TITLE
NO-ISSUE: removed unused property from cluster-create-params

### DIFF
--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -84,9 +84,6 @@ type ClusterCreateParams struct {
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`
 
-	// OpenShift release image URI.
-	OcpReleaseImage string `json:"ocp_release_image,omitempty"`
-
 	// List of OLM operators to be installed.
 	OlmOperators []*OperatorCreateParams `json:"olm_operators"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9699,10 +9699,6 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
-        "ocp_release_image": {
-          "description": "OpenShift release image URI.",
-          "type": "string"
-        },
         "olm_operators": {
           "description": "List of OLM operators to be installed.",
           "type": "array",
@@ -22703,10 +22699,6 @@ func init() {
           "description": "An \"*\" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.",
           "type": "string",
           "x-nullable": true
-        },
-        "ocp_release_image": {
-          "description": "OpenShift release image URI.",
-          "type": "string"
         },
         "olm_operators": {
           "description": "List of OLM operators to be installed.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6721,9 +6721,6 @@ definitions:
       openshift_version:
         type: string
         description: Version of the OpenShift cluster.
-      ocp_release_image:
-        type: string
-        description: OpenShift release image URI.
       base_dns_domain:
         type: string
         description: Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.


### PR DESCRIPTION
# Assisted Pull Request

## Description

Removed unused ocp_release_image property from cluster-create-params object.
This property isn't used in cluster creation flow, so should be safe to remove.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @avishayt 
/cc @filanov 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
