### PR TITLE
Bug 2013791: Delete host from DB if Agent creation fails

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5490,7 +5490,7 @@ func (b *bareMetalInventory) DeregisterInfraEnvInternal(ctx context.Context, par
 		return err
 	}
 	if len(hosts) > 0 {
-		msg := fmt.Sprintf("failed to deregister infraEnv %s, hosts are still associated", params.InfraEnvID)
+		msg := fmt.Sprintf("failed to deregister infraEnv %s, %d hosts are still associated", params.InfraEnvID, len(hosts))
 		log.Error(msg)
 		return common.NewApiError(http.StatusBadRequest, fmt.Errorf(msg))
 	}
@@ -6128,8 +6128,13 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
+	// Create AgentCR if needed, after commit in DB as KubeKey will be updated.
 	if err := b.crdUtils.CreateAgentCR(ctx, log, params.NewHostParams.HostID.String(), infraEnv, cluster); err != nil {
-		log.WithError(err).Errorf("Fail to create Agent CR. Namespace: %s, InfraEnv: %s, HostID: %s", infraEnv.KubeKeyNamespace, swag.StringValue(infraEnv.Name), params.NewHostParams.HostID.String())
+		log.WithError(err).Errorf("Fail to create Agent CR, deleting host. Namespace: %s, InfraEnv: %s, HostID: %s", infraEnv.KubeKeyNamespace, swag.StringValue(infraEnv.Name), params.NewHostParams.HostID.String())
+		if err2 := b.hostApi.UnRegisterHost(ctx, params.NewHostParams.HostID.String(), params.InfraEnvID.String()); err2 != nil {
+			return installer.NewV2RegisterHostInternalServerError().
+				WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+		}
 		return installer.NewV2RegisterHostInternalServerError().
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1279,7 +1279,6 @@ var _ = Describe("RegisterHost", func() {
 		cluster := createCluster(db, models.ClusterStatusInsufficient)
 		infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
-
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1293,6 +1292,7 @@ var _ = Describe("RegisterHost", func() {
 		mockEvents.EXPECT().
 			AddEvent(gomock.Any(), *cluster.ID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).
 			Times(1)
+		mockHostApi.EXPECT().UnRegisterHost(ctx, hostID.String(), infraEnv.ID.String()).Return(nil).Times(1)
 		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
 			InfraEnvID: *cluster.ID,
 			NewHostParams: &models.HostCreateParams{
@@ -1468,6 +1468,7 @@ var _ = Describe("v2RegisterHost", func() {
 				Expect(h.InfraEnvID).Should(Equal(*infraEnv.ID))
 				return nil
 			}).Times(1)
+		mockHostApi.EXPECT().UnRegisterHost(ctx, hostID.String(), infraEnv.ID.String()).Return(nil).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEvents.EXPECT().
 			AddEvent(gomock.Any(), *cluster.ID, &hostID, models.EventSeverityInfo, gomock.Any(), gomock.Any()).


### PR DESCRIPTION
# Assisted Pull Request

## Description

In Kube API flow, when an host registers a corresponding Agent CR is
created.
Before this patch, in case that the Agent CR creation fails, the host was still created
in the DB. That would lead to a state where the InfraEnv cannot be
deleted as it still has hosts connected.

To fix this issue,  the host is deleted from DB if the creation of the Agent CR fails.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @omertuc 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
