### PR TITLE
NO-ISSUE: update default versions - support new stable

### DIFF
--- a/tools/ocp_version_update/update_default_release_versions_to_latest.py
+++ b/tools/ocp_version_update/update_default_release_versions_to_latest.py
@@ -379,8 +379,16 @@ def update_ocp_versions_json(default_version_json, updates_made, updates_made_st
 
             logger.info(f"New latest rhcos release available, {rhcos_default_release} -> {rhcos_latest_release}")
 
-            updated_version_json[release]["rhcos_image"] = updated_version_json[release]["rhcos_image"].replace(rhcos_default_release, rhcos_latest_release)
-            updated_version_json[release]["rhcos_rootfs"] = updated_version_json[release]["rhcos_rootfs"].replace(rhcos_default_release, rhcos_latest_release)
+            # Update rhcos image/rootfs with latest version
+            rhcos_image = updated_version_json[release]["rhcos_image"].replace(rhcos_default_release, rhcos_latest_release)
+            rhcos_rootfs = updated_version_json[release]["rhcos_rootfs"].replace(rhcos_default_release, rhcos_latest_release)
+            if not pre_release:
+                # Replace 'pre-release' with minor version
+                rhcos_image = rhcos_image.replace(RHCOS_PRE_RELEASE, release)
+                rhcos_rootfs = rhcos_rootfs.replace(RHCOS_PRE_RELEASE, release)
+            # Update json
+            updated_version_json[release]["rhcos_image"] = rhcos_image
+            updated_version_json[release]["rhcos_rootfs"] = rhcos_rootfs
 
             if dry_run:
                 rhcos_version_from_iso = "8888888"
@@ -455,8 +463,16 @@ def update_os_images_json(default_os_images_json, updates_made, updates_made_str
             updates_made_str.add(f"rhcos {rhcos_default_release} -> {rhcos_latest_release}")
 
             logger.info(f"New latest rhcos release available, {rhcos_default_release} -> {rhcos_latest_release}")
-            updated_version_json[index]["url"] = updated_version_json[index]["url"].replace(rhcos_default_release, rhcos_latest_release)
-            updated_version_json[index]["rootfs_url"] = updated_version_json[index]["rootfs_url"].replace(rhcos_default_release, rhcos_latest_release)
+            # Update rhcos image/rootfs with latest version
+            rhcos_image = updated_version_json[index]["url"].replace(rhcos_default_release, rhcos_latest_release)
+            rhcos_rootfs = updated_version_json[index]["rootfs_url"].replace(rhcos_default_release, rhcos_latest_release)
+            if not pre_release:
+                # Replace 'pre-release' with minor version
+                rhcos_image = rhcos_image.replace(RHCOS_PRE_RELEASE, openshift_version)
+                rhcos_rootfs = rhcos_rootfs.replace(RHCOS_PRE_RELEASE, openshift_version)
+            # Update json
+            updated_version_json[index]["url"] = rhcos_image
+            updated_version_json[index]["rootfs_url"] = rhcos_rootfs
 
             if dry_run:
                 rhcos_version_from_iso = "8888888"


### PR DESCRIPTION
# Assisted Pull Request

## Description

update_default_release_versions_to_latest:
When a new stable rhcos version is introduced to an existing pre-release, the image/rootfs URLs should be updated to stable format.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @osherdp 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
