### PR TITLE
MGMT-8029: Gorm creates wrong field name for https_proxy field in infra-env

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1270,7 +1270,7 @@ func (b *bareMetalInventory) GenerateClusterISOInternal(ctx context.Context, par
 	updates["image_expires_at"] = strfmt.DateTime(now.Add(b.Config.ImageExpirationTime))
 	updates["static_network_config"] = staticNetworkConfig
 	updates["proxy_http_proxy"] = cluster.HTTPProxy
-	updates["proxy_http_s_proxy"] = cluster.HTTPSProxy
+	updates["proxy_https_proxy"] = cluster.HTTPSProxy
 	updates["proxy_no_proxy"] = cluster.NoProxy
 	//[TODO] - remove this code once we update ignition config override in InfraEnv via UpdateDiscoveryIgnitionInternal
 	updates["ignition_config_override"] = cluster.IgnitionConfigOverrides

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -7760,6 +7760,77 @@ var _ = Describe("infraEnvs", func() {
 				Expect(i.Type).To(Equal(models.ImageTypeFullIso))
 			})
 
+			It("Update proxy", func() {
+				var err error
+				mockInfraEnvUpdateSuccess()
+				proxyURL := "http://[1001:db9::1]:3129"
+				noProxy := ".test-infra-cluster-b0cea5e8.redhat.com,1001:db9::/120,2002:db8::/53,2003:db8::/112"
+				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
+					InfraEnvID: *i.ID,
+					InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+						Proxy: &models.Proxy{
+							HTTPProxy:  swag.String(proxyURL),
+							HTTPSProxy: swag.String(proxyURL),
+							NoProxy:    swag.String(noProxy),
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
+				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(i.Proxy).ToNot(BeNil())
+				Expect(swag.StringValue(i.Proxy.HTTPProxy)).To(Equal(proxyURL))
+				Expect(swag.StringValue(i.Proxy.HTTPSProxy)).To(Equal(proxyURL))
+				Expect(swag.StringValue(i.Proxy.NoProxy)).To(Equal(noProxy))
+			})
+			It("Update proxy - יhttps missing", func() {
+				var err error
+				mockInfraEnvUpdateSuccess()
+				proxyURL := "http://[1001:db9::1]:3129"
+				noProxy := ".test-infra-cluster-b0cea5e8.redhat.com,1001:db9::/120,2002:db8::/53,2003:db8::/112"
+				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
+					InfraEnvID: *i.ID,
+					InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+						Proxy: &models.Proxy{
+							HTTPProxy: swag.String(proxyURL),
+							NoProxy:   swag.String(noProxy),
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
+				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(i.Proxy).ToNot(BeNil())
+				Expect(swag.StringValue(i.Proxy.HTTPProxy)).To(Equal(proxyURL))
+				Expect(swag.StringValue(i.Proxy.HTTPSProxy)).To(Equal(proxyURL))
+				Expect(swag.StringValue(i.Proxy.NoProxy)).To(Equal(noProxy))
+			})
+
+			It("Update proxy - יhttps different", func() {
+				var err error
+				mockInfraEnvUpdateSuccess()
+				proxyURL1 := "http://[1001:db9::1]:3129"
+				proxyURL2 := "http://[1001:db9::1]:3130"
+				noProxy := ".test-infra-cluster-b0cea5e8.redhat.com,1001:db9::/120,2002:db8::/53,2003:db8::/112"
+				reply := bm.UpdateInfraEnv(ctx, installer.UpdateInfraEnvParams{
+					InfraEnvID: *i.ID,
+					InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+						Proxy: &models.Proxy{
+							HTTPProxy:  swag.String(proxyURL1),
+							HTTPSProxy: swag.String(proxyURL2),
+							NoProxy:    swag.String(noProxy),
+						},
+					},
+				})
+				Expect(reply).To(BeAssignableToTypeOf(installer.NewUpdateInfraEnvCreated()))
+				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(i.Proxy).ToNot(BeNil())
+				Expect(swag.StringValue(i.Proxy.HTTPProxy)).To(Equal(proxyURL1))
+				Expect(swag.StringValue(i.Proxy.HTTPSProxy)).To(Equal(proxyURL2))
+				Expect(swag.StringValue(i.Proxy.NoProxy)).To(Equal(noProxy))
+			})
+
 			It("Update StaticNetwork", func() {
 				mockInfraEnvUpdateSuccess()
 				staticNetworkFormatRes := "static network format result"

--- a/models/proxy.go
+++ b/models/proxy.go
@@ -23,7 +23,7 @@ type Proxy struct {
 	// A proxy URL to use for creating HTTPS connections outside the cluster.
 	// http://\<username\>:\<pswd\>@\<ip\>:\<port\>
 	//
-	HTTPSProxy *string `json:"https_proxy,omitempty"`
+	HTTPSProxy *string `json:"https_proxy,omitempty" gorm:"column:https_proxy"`
 
 	// An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.
 	NoProxy *string `json:"no_proxy,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -12423,6 +12423,7 @@ func init() {
         "https_proxy": {
           "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
+          "x-go-custom-tag": "gorm:\"column:https_proxy\"",
           "x-nullable": true
         },
         "no_proxy": {
@@ -25431,6 +25432,7 @@ func init() {
         "https_proxy": {
           "description": "A proxy URL to use for creating HTTPS connections outside the cluster.\nhttp://\\\u003cusername\\\u003e:\\\u003cpswd\\\u003e@\\\u003cip\\\u003e:\\\u003cport\\\u003e\n",
           "type": "string",
+          "x-go-custom-tag": "gorm:\"column:https_proxy\"",
           "x-nullable": true
         },
         "no_proxy": {

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Infra_Env", func() {
 		updateInfraEnv := res.Payload
 		Expect(updateInfraEnv.SSHAuthorizedKey).To(Equal(newSshKey))
 		Expect(swag.StringValue(updateInfraEnv.Proxy.HTTPProxy)).To(Equal("http://proxy.proxy"))
-		Expect(swag.StringValue(updateInfraEnv.Proxy.HTTPSProxy)).To(Equal(""))
+		Expect(swag.StringValue(updateInfraEnv.Proxy.HTTPSProxy)).To(Equal("http://proxy.proxy"))
 		Expect(swag.StringValue(updateInfraEnv.Proxy.NoProxy)).To(Equal("proxy.proxy"))
 		Expect(updateInfraEnv.Type).To(Equal(models.ImageTypeMinimalIso))
 	})

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8758,6 +8758,7 @@ definitions:
           A proxy URL to use for creating HTTPS connections outside the cluster.
           http://\<username\>:\<pswd\>@\<ip\>:\<port\>
         x-nullable: true
+        x-go-custom-tag: gorm:"column:https_proxy"
       no_proxy:
         type: string
         description: An "*" or a comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude from proxying.


### PR DESCRIPTION



# Assisted Pull Request

## Description

Instead of htps_proxy it creates a field http_s_proxy.
To solve, create a tag to set the column name

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
