### PR TITLE
MGMT-7897: Add sub claim to image service cloud auth enhancement

### DIFF
--- a/docs/enhancements/image-service-cloud-authentication.md
+++ b/docs/enhancements/image-service-cloud-authentication.md
@@ -3,7 +3,7 @@ title: image-service-cloud-authentication
 authors:
   - "@carbonin"
 creation-date: 2021-10-07
-last-updated: 2021-10-18
+last-updated: 2021-10-20
 ---
 
 # Image Service Cloud Authentication
@@ -43,9 +43,10 @@ which will be included directly in a download URL
 
 The new authentication mechanism will be a JWT signed by the assisted service
 using a randomly generated key stored with the infraEnv. The JWT will include
-an `exp` claim as defined in RFC7519. A token will be included as a parameter
-in the image download URL and assisted service authentication will pass if the
-token in the URL is not expired and validates using the key in the infraEnv record.
+an `exp` claim as defined in RFC7519 and a `sub` claim containing the infraEnv
+ID. A token will be included as a parameter in the image download URL and
+assisted service authentication will pass if the token in the URL is not expired
+and validates using the key in the infraEnv record.
 
 Managing the signed URL and key will require a few API changes. The REST API will no
 longer return a `download_url` as a part of an infraEnv as the token in the URL could
@@ -105,6 +106,15 @@ These new endpoints and will be protected by SSO user credential authentication 
 
 The image service will accept a new URL parameter, `image_token`, which will
 then be forwarded to assisted service in the `Image-Token` header key.
+
+#### Assisted Service Authentication and Authorization Flow
+
+1. Request arrives to one of the infraEnv download endpoints with an `Image-Token` header
+2. Assisted service middleware stores infraEnv ID from the request path in the request context
+3. Authentication validates the token using the key associated with the infraEnv for the id in the token `sub` claim
+4. If a token is valid, authentication stores the `sub` claim in the request context
+5. Authorization ensures the infraEnv ID from the `sub` claim in the request context matches the infraEnv ID in the request path (also from the context)
+6. Request is processed
 
 ### Risks and Mitigations
 


### PR DESCRIPTION
## Description

This will be required because the authentication implementation doesn't
have access to the request parameters when validating a token. It only
has the token itself.

This means we need the infraEnv id in the token to fetch the correct
encryption key.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mhrivnak 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?