### PR TITLE
MGMT-8074: Make the assisted-service more dry run friendly

### DIFF
--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -139,8 +139,6 @@ var _ = Describe("installcmd", func() {
 	It("invalid_inventory", func() {
 		host.Inventory = "blah"
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return(common.TestDiskId).Times(1)
-		mockGetReleaseImage(1)
-		mockImages(1)
 		stepReply, stepErr = installCmd.GetSteps(ctx, &host)
 		postvalidation(true, true, nil, stepErr, "")
 	})
@@ -978,7 +976,7 @@ func verifyArgInCommand(command, key, value string, count int) {
 }
 
 func verifyDiskFormatCommand(command string, value string, exists bool) {
-	r := regexp.MustCompile(`dd if=\/dev\/zero of=([^\s]+) bs=512 count=1 ; `)
+	r := regexp.MustCompile(`--format-disk ([^\s]+)`)
 	matches := r.FindAllStringSubmatch(command, -1)
 	matchValue := func() bool {
 		if matches == nil {

--- a/internal/host/hostcommands/next_step_runner_cmd.go
+++ b/internal/host/hostcommands/next_step_runner_cmd.go
@@ -31,6 +31,8 @@ func GetNextStepRunnerCommand(config *NextStepRunnerConfig) (string, *[]string) 
 
 	arguments = append(arguments,
 		"--env", "PULL_SECRET_TOKEN",
+		"--env", "CONTAINERS_CONF",
+		"--env", "CONTAINERS_STORAGE_CONF",
 		"--env", "HTTP_PROXY", "--env", "HTTPS_PROXY", "--env", "NO_PROXY",
 		"--env", "http_proxy", "--env", "https_proxy", "--env", "no_proxy",
 		"--name", "next-step-runner", config.NextStepRunnerImage, "next_step_runner",


### PR DESCRIPTION
# Assisted Pull Request

## Description

Dry run modes have been introduced to the agent/installer (and in the
future also to the controller):

https://github.com/openshift/assisted-installer-agent/pull/250
https://github.com/openshift/assisted-installer/pull/371

To make these dry run modes work more easily, the service required some
minor modifcations, implemented by this commit.

The changes are as follows -
1) Propagate host agent environment to next-step-runner and inventory
This commit makes it so the `CONTAINERS_CONF` and `CONTAINERS_STORAGE_CONF` environment
variables from the host agent also propagate to the the next_step_runner container.

This allows the assisted-swarm to freely control how other environment variables
propagate to the step containers, and also how podman storage is
managed for those containers.

Currently CONTAINERS_CONF is used to tell podman to automatically relay
certain environment variables to the step containers (with the
.containers.env containers.conf TOML configuration).

CONTAINERS_STORAGE_CONF is used to configure podman storage in such a
way that swarm agents don't share the same container storage, but do
share image storage and overlayfs layers. This helps with performance.

2) mtab copy file path - when launching the inventory command, we tell
the agent to copy the `/etc/mtab` file to `/root/mtab`. This caused an
issue when running multiple agents on the same host (using the dry run
mode), because they were fighting over the `/root/mtab` host path. This
commit appends the host ID to the `/root/mtab` path to make sure that
each swarm host will work with a different file and the will not
fight over the same path.

3) Use the new installer `--format-disk` flag rather than use plain `dd`
commands directly. This gives the installer more flexibility in deciding
whether to format the disks or just to pretend to format them as it does
in dry mode.

This commit should NOT be merged before
https://github.com/openshift/assisted-installer/pull/371 is merged,
because only in that PR the `--format-disk` commandline flags are
implemented.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    - Tested that `--format-disk` flags get passed correctly to the installer
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov
/cc @rollandf


## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md