### PR TITLE
MGMT-7834: webhook infraenv update

### DIFF
--- a/cmd/webadmission/main.go
+++ b/cmd/webadmission/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	agentinstallvalidatingwebhooks "github.com/openshift/assisted-service/pkg/validating-webhooks/agentinstall/v1beta1"
 	hiveextvalidatingwebhooks "github.com/openshift/assisted-service/pkg/validating-webhooks/hiveextension/v1beta1"
 	admissionCmd "github.com/openshift/generic-admission-server/pkg/cmd"
 	log "github.com/sirupsen/logrus"
@@ -18,6 +19,7 @@ func main() {
 
 	admissionCmd.RunAdmissionServer(
 		hiveextvalidatingwebhooks.NewAgentClusterInstallValidatingAdmissionHook(decoder),
+		agentinstallvalidatingwebhooks.NewInfraEnvValidatingAdmissionHook(decoder),
 	)
 }
 

--- a/pkg/validating-webhooks/agentinstall/v1beta1/infraenv_admission_hook.go
+++ b/pkg/validating-webhooks/agentinstall/v1beta1/infraenv_admission_hook.go
@@ -1,0 +1,192 @@
+package v1beta1
+
+import (
+	"net/http"
+
+	"github.com/openshift/assisted-service/api/v1beta1"
+	log "github.com/sirupsen/logrus"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	infraEnvGroup    = "agent-install.openshift.io"
+	infraEnvVersion  = "v1beta1"
+	infraEnvResource = "infraenvs"
+
+	infraEnvAdmissionGroup   = "admission.agentinstall.openshift.io"
+	infraEnvAdmissionVersion = "v1"
+)
+
+// InfraEnvValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
+type InfraEnvValidatingAdmissionHook struct {
+	decoder *admission.Decoder
+}
+
+// NewInfraEnvValidatingAdmissionHook constructs a new NewInfraEnvValidatingAdmissionHook
+func NewInfraEnvValidatingAdmissionHook(decoder *admission.Decoder) *InfraEnvValidatingAdmissionHook {
+	return &InfraEnvValidatingAdmissionHook{decoder: decoder}
+}
+
+// ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
+//                    webhook is accessed by the kube apiserver.
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.agentinstall.openshift.io/v1/infraenvvalidators".
+//              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
+func (a *InfraEnvValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
+	log.WithFields(log.Fields{
+		"group":    infraEnvAdmissionGroup,
+		"version":  infraEnvAdmissionVersion,
+		"resource": "infraenvvalidator",
+	}).Info("Registering validation REST resource")
+	// NOTE: This GVR is meant to be different than the InfraEnv CRD GVR which has group "agent-install.openshift.io".
+	return schema.GroupVersionResource{
+			Group:    infraEnvAdmissionGroup,
+			Version:  infraEnvAdmissionVersion,
+			Resource: "infraenvvalidators",
+		},
+		"infraenvvalidator"
+}
+
+// Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
+func (a *InfraEnvValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	log.WithFields(log.Fields{
+		"group":    infraEnvAdmissionGroup,
+		"version":  infraEnvAdmissionVersion,
+		"resource": "infraenvvalidator",
+	}).Info("Initializing validation REST resource")
+	return nil // No initialization needed right now.
+}
+
+// Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
+// Usually it's the kube apiserver that is making the admission validation request.
+func (a *InfraEnvValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "Validate",
+	})
+
+	if !a.shouldValidate(admissionSpec) {
+		contextLogger.Info("Skipping validation for request")
+		// The request object isn't something that this validator should validate.
+		// Therefore, we say that it's allowed.
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	contextLogger.Info("Validating request")
+
+	if admissionSpec.Operation == admissionv1.Update {
+		return a.validateUpdate(admissionSpec)
+	}
+
+	// We're only validating updates at this time, so all other operations are explicitly allowed.
+	contextLogger.Info("Successful validation")
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// shouldValidate explicitly checks if the request should be validated. For example, this webhook may have accidentally been registered to check
+// the validity of some other type of object with a different GVR.
+func (a *InfraEnvValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "shouldValidate",
+	})
+
+	if admissionSpec.Resource.Group != infraEnvGroup {
+		contextLogger.Debug("Returning False, not our group")
+		return false
+	}
+
+	if admissionSpec.Resource.Version != infraEnvVersion {
+		contextLogger.Debug("Returning False, it's our group, but not the right version")
+		return false
+	}
+
+	if admissionSpec.Resource.Resource != infraEnvResource {
+		contextLogger.Debug("Returning False, it's our group and version, but not the right resource")
+		return false
+	}
+
+	// If we get here, then we're supposed to validate the object.
+	contextLogger.Debug("Returning True, passed all prerequisites.")
+	return true
+}
+
+func areClusterRefsEqual(clusterRef1 *v1beta1.ClusterReference, clusterRef2 *v1beta1.ClusterReference) bool {
+	if clusterRef1 == nil && clusterRef2 == nil {
+		return true
+	} else if clusterRef1 != nil && clusterRef2 != nil {
+		return (clusterRef1.Name == clusterRef2.Name && clusterRef1.Namespace == clusterRef2.Namespace)
+	} else {
+		return false
+	}
+}
+
+// validateUpdate specifically validates update operations for InfraEnv objects.
+func (a *InfraEnvValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateUpdate",
+	})
+
+	newObject := &v1beta1.InfraEnv{}
+	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
+
+	oldObject := &v1beta1.InfraEnv{}
+	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
+		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if !areClusterRefsEqual(oldObject.Spec.ClusterRef, newObject.Spec.ClusterRef) {
+		message := "Attempted to change Spec.ClusterRef which is immutable after InfraEnv creation."
+		contextLogger.Infof("Failed validation: %v", message)
+		contextLogger.Error(message)
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/pkg/validating-webhooks/agentinstall/v1beta1/infraenv_admission_hook_test.go
+++ b/pkg/validating-webhooks/agentinstall/v1beta1/infraenv_admission_hook_test.go
@@ -1,0 +1,258 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	apiserver "github.com/openshift/generic-admission-server/pkg/apiserver"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func createDecoder() *admission.Decoder {
+	scheme := runtime.NewScheme()
+	err := v1beta1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+	decoder, err := admission.NewDecoder(scheme)
+	Expect(err).To(BeNil())
+	return decoder
+}
+
+var _ = Describe("infraenv web hook init", func() {
+	It("ValidatingResource", func() {
+		data := NewInfraEnvValidatingAdmissionHook(createDecoder())
+		expectedPlural := schema.GroupVersionResource{
+			Group:    "admission.agentinstall.openshift.io",
+			Version:  "v1",
+			Resource: "infraenvvalidators",
+		}
+		expectedSingular := "infraenvvalidator"
+
+		plural, singular := data.ValidatingResource()
+		Expect(plural).To(Equal(expectedPlural))
+		Expect(singular).To(Equal(expectedSingular))
+
+	})
+
+	It("Initialize", func() {
+		data := NewInfraEnvValidatingAdmissionHook(createDecoder())
+		err := data.Initialize(nil, nil)
+		Expect(err).To(BeNil())
+	})
+
+	It("Check implements interface ", func() {
+		var hook interface{} = NewInfraEnvValidatingAdmissionHook(createDecoder())
+		_, ok := hook.(apiserver.ValidatingAdmissionHookV1)
+		Expect(ok).To(BeTrue())
+	})
+})
+
+var _ = Describe("infraenv web validate", func() {
+	cases := []struct {
+		name            string
+		newSpec         v1beta1.InfraEnvSpec
+		oldSpec         v1beta1.InfraEnvSpec
+		newObjectRaw    []byte
+		oldObjectRaw    []byte
+		operation       admissionv1.Operation
+		expectedAllowed bool
+		gvr             *metav1.GroupVersionResource
+	}{
+		{
+			name:            "Test unable to marshal old object during update",
+			oldObjectRaw:    []byte{0},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test doesn't validate with right version and resource, but wrong group",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "not the right group",
+				Version:  "v1beta1",
+				Resource: "infraenvs",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and resource, wrong version",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "agent-install.openshift.io",
+				Version:  "not the right version",
+				Resource: "infraenvs",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and version, wrong resource",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "agent-install.openshift.io",
+				Version:  "v1beta1",
+				Resource: "not the right resource",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test InfraEnv.Spec.ClusterRef is immutable",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "newNamespace",
+				},
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv.Spec.ClusterRef.Name is immutable",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "oldNamespace",
+				},
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv.Spec.ClusterRef.Namespace is immutable",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "newNamespace",
+				},
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv.Spec.ClusterRef can't change from nil to not nil",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: nil,
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "newNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv.Spec.ClusterRef can't change from not nil to nil",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "newNamespace",
+				},
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: nil,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv update does not fail when ClusterReference is set and remains the same",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test InfraEnv update does not fail when ClusterReference is nil and remains the same",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: nil,
+			},
+			oldSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: nil,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		It(tc.name, func() {
+			data := NewInfraEnvValidatingAdmissionHook(createDecoder())
+			newObject := &v1beta1.InfraEnv{
+				Spec: tc.newSpec,
+			}
+			oldObject := &v1beta1.InfraEnv{
+				Spec: tc.oldSpec,
+			}
+
+			if tc.newObjectRaw == nil {
+				tc.newObjectRaw, _ = json.Marshal(newObject)
+			}
+
+			if tc.oldObjectRaw == nil {
+				tc.oldObjectRaw, _ = json.Marshal(oldObject)
+			}
+
+			if tc.gvr == nil {
+				tc.gvr = &metav1.GroupVersionResource{
+					Group:    "agent-install.openshift.io",
+					Version:  "v1beta1",
+					Resource: "infraenvs",
+				}
+			}
+
+			request := &admissionv1.AdmissionRequest{
+				Operation: tc.operation,
+				Resource:  *tc.gvr,
+				Object: runtime.RawExtension{
+					Raw: tc.newObjectRaw,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: tc.oldObjectRaw,
+				},
+			}
+
+			response := data.Validate(request)
+
+			Expect(response.Allowed).To(Equal(tc.expectedAllowed))
+		})
+	}
+
+})
+
+func TestControllers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "webhooks tests")
+}

--- a/pkg/validating-webhooks/hiveextension/v1beta1/agentclusterinstall_admission_hook.go
+++ b/pkg/validating-webhooks/hiveextension/v1beta1/agentclusterinstall_admission_hook.go
@@ -42,7 +42,7 @@ func NewAgentClusterInstallValidatingAdmissionHook(decoder *admission.Decoder) *
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.agentinstall.openshift.io/v1/agentclusterinstalls".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.agentinstall.openshift.io/v1/agentclusterinstallvalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *AgentClusterInstallValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{


### PR DESCRIPTION
# Assisted Pull Request

## Description

Adding a webhook that validates that InfraEnv's clusterRef does not get updated.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
