### PR TITLE
OCPBUGSM-36598: clean progress on reset

### DIFF
--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -30,6 +30,10 @@ import (
 )
 
 var resetLogsField = []interface{}{"logs_info", "", "controller_logs_started_at", strfmt.DateTime(time.Time{}), "controller_logs_collected_at", strfmt.DateTime(time.Time{})}
+var resetProgressFields = []interface{}{"progress_finalizing_stage_percentage", 0, "progress_installing_stage_percentage", 0,
+	"progress_preparing_for_installation_stage_percentage", 0, "progress_total_percentage", 0}
+
+var resetFields = append(append(resetProgressFields, resetLogsField...), "openshift_cluster_id", "")
 
 type transitionHandler struct {
 	log                 logrus.FieldLogger
@@ -84,8 +88,7 @@ func (th *transitionHandler) PostResetCluster(sw stateswitch.StateSwitch, args s
 		return errors.New("PostResetCluster invalid argument")
 	}
 
-	//reset log fields and Openshift ClusterID when resetting the cluster
-	extra := append(append(make([]interface{}, 0), "OpenshiftClusterID", ""), resetLogsField...)
+	extra := resetFields[:]
 	// reset api_vip and ingress_vip in case of resetting the SNO cluster
 	if common.IsSingleNodeCluster(sCluster.cluster) {
 		extra = append(extra, "api_vip", "", "ingress_vip", "")

--- a/internal/host/hostutil/update_host.go
+++ b/internal/host/hostutil/update_host.go
@@ -16,8 +16,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ResetLogsField = []interface{}{"logs_info", "", "logs_started_at", strfmt.DateTime(time.Time{}), "logs_collected_at", strfmt.DateTime(time.Time{})}
-
 func UpdateHostProgress(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, eventsHandler eventsapi.Handler, infraEnvId strfmt.UUID, hostId strfmt.UUID,
 	srcStatus string, newStatus string, statusInfo string,
 	srcStage models.HostStage, newStage models.HostStage, progressInfo string, extra ...interface{}) (*common.Host, error) {

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -29,13 +29,15 @@ type transitionHandler struct {
 	eventsHandler eventsapi.Handler
 }
 
-var resetFields = [...]interface{}{"inventory", "", "bootstrap", false}
 var resetLogsField = []interface{}{"logs_info", "", "logs_started_at", strfmt.DateTime(time.Time{}), "logs_collected_at", strfmt.DateTime(time.Time{})}
-var restFieldsOnUnbind = []interface{}{"cluster_id", nil, "kind", swag.String(models.HostKindHost), "connectivity", "", "domain_name_resolutions", "",
+var resetProgressFields = []interface{}{"progress_current_stage", "", "progress_installation_percentage", 0,
+	"progress_progress_info", "", "progress_stage_started_at", strfmt.DateTime(time.Time{}), "progress_stage_updated_at", strfmt.DateTime(time.Time{})}
+
+var resetFields = append(resetProgressFields, "inventory", "", "bootstrap", false)
+var restFieldsOnUnbind = append(append(resetProgressFields, resetLogsField...), "cluster_id", nil, "kind", swag.String(models.HostKindHost), "connectivity", "", "domain_name_resolutions", "",
 	"free_addresses", "", "images_status", "", "installation_disk_id", "", "installation_disk_path", "", "machine_config_pool_name", "",
-	"role", "auto-assign", "api_vip_connectivity", "", "suggested_role", "", "progress_current_stage", "", "progress_installation_percentage", 0,
-	"progress_progress_info", "", "progress_stage_started_at", strfmt.DateTime(time.Time{}), "progress_stage_updated_at", strfmt.DateTime(time.Time{}),
-	"progress_stages", nil, "stage_started_at", strfmt.DateTime(time.Time{}), "stage_updated_at", strfmt.DateTime(time.Time{})}
+	"role", "auto-assign", "api_vip_connectivity", "", "suggested_role", "",
+	"progress_stages", nil, "stage_started_at", strfmt.DateTime(time.Time{}), "stage_updated_at", strfmt.DateTime(time.Time{}))
 
 ////////////////////////////////////////////////////////////////////////////
 // RegisterHost


### PR DESCRIPTION
# Assisted Pull Request

## Description
After reset the progress is not going back to zero
The solution is to reset the progress fields on reset so the calculation can start anew - the same as in first time installation

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
