### PR TITLE
NO-ISSUE: Graduate hive CRDs to apiextensions.k8s.io/v1

### DIFF
--- a/hack/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/hack/crds/hive.openshift.io_clusterdeployments.yaml
@@ -1,34 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterdeployments.hive.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-platform
-    name: Platform
-    type: string
-  - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-region
-    name: Region
-    type: string
-  - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-type
-    name: ClusterType
-    type: string
-  - JSONPath: .spec.installed
-    name: Installed
-    type: boolean
-  - JSONPath: .spec.clusterMetadata.infraID
-    name: InfraID
-    type: string
-  - JSONPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
-    name: Version
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Hibernating')].reason
-    name: PowerState
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: hive.openshift.io
   names:
     kind: ClusterDeployment
@@ -38,369 +15,265 @@ spec:
     - cd
     singular: clusterdeployment
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterDeployment is the Schema for the clusterdeployments API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterDeploymentSpec defines the desired state of ClusterDeployment
-          properties:
-            baseDomain:
-              description: BaseDomain is the base domain to which the cluster should
-                belong.
-              type: string
-            boundServiceAccountSigningKeySecretRef:
-              description: BoundServiceAccountSignkingKeySecretRef refers to a Secret
-                that contains a 'bound-service-account-signing-key.key' data key pointing
-                to the private key that will be used to sign ServiceAccount objects.
-                Primarily used to provision AWS clusters to use Amazon's Security
-                Token Service.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            certificateBundles:
-              description: CertificateBundles is a list of certificate bundles associated
-                with this cluster
-              items:
-                description: CertificateBundleSpec specifies a certificate bundle
-                  associated with a cluster deployment
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clusterMetadata.infraID
+      name: InfraID
+      type: string
+    - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-platform
+      name: Platform
+      type: string
+    - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-region
+      name: Region
+      type: string
+    - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
+      name: Version
+      type: string
+    - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-type
+      name: ClusterType
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
+      name: ProvisionStatus
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
+      name: PowerState
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterDeployment is the Schema for the clusterdeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterDeploymentSpec defines the desired state of ClusterDeployment
+            properties:
+              baseDomain:
+                description: BaseDomain is the base domain to which the cluster should
+                  belong.
+                type: string
+              boundServiceAccountSigningKeySecretRef:
+                description: BoundServiceAccountSignkingKeySecretRef refers to a Secret
+                  that contains a 'bound-service-account-signing-key.key' data key
+                  pointing to the private key that will be used to sign ServiceAccount
+                  objects. Primarily used to provision AWS clusters to use Amazon's
+                  Security Token Service.
                 properties:
-                  certificateSecretRef:
-                    description: CertificateSecretRef is the reference to the secret
-                      that contains the certificate bundle. If the certificate bundle
-                      is to be generated, it will be generated with the name in this
-                      reference. Otherwise, it is expected that the secret should
-                      exist in the same namespace as the ClusterDeployment
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              certificateBundles:
+                description: CertificateBundles is a list of certificate bundles associated
+                  with this cluster
+                items:
+                  description: CertificateBundleSpec specifies a certificate bundle
+                    associated with a cluster deployment
+                  properties:
+                    certificateSecretRef:
+                      description: CertificateSecretRef is the reference to the secret
+                        that contains the certificate bundle. If the certificate bundle
+                        is to be generated, it will be generated with the name in
+                        this reference. Otherwise, it is expected that the secret
+                        should exist in the same namespace as the ClusterDeployment
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    generate:
+                      description: Generate indicates whether this bundle should have
+                        real certificates generated for it.
+                      type: boolean
+                    name:
+                      description: Name is an identifier that must be unique within
+                        the bundle and must be referenced by an ingress or by the
+                        control plane serving certs
+                      type: string
+                  required:
+                  - certificateSecretRef
+                  - name
+                  type: object
+                type: array
+              clusterInstallRef:
+                description: ClusterInstallLocalReference provides reference to an
+                  object that implements the hivecontract ClusterInstall. The namespace
+                  of the object is same as the ClusterDeployment. This cannot be set
+                  when Provisioning is also set.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                - version
+                type: object
+              clusterMetadata:
+                description: ClusterMetadata contains metadata information about the
+                  installed cluster.
+                properties:
+                  adminKubeconfigSecretRef:
+                    description: AdminKubeconfigSecretRef references the secret containing
+                      the admin kubeconfig for this cluster.
                     properties:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
-                  generate:
-                    description: Generate indicates whether this bundle should have
-                      real certificates generated for it.
-                    type: boolean
-                  name:
-                    description: Name is an identifier that must be unique within
-                      the bundle and must be referenced by an ingress or by the control
-                      plane serving certs
+                  adminPasswordSecretRef:
+                    description: AdminPasswordSecretRef references the secret containing
+                      the admin username/password which can be used to login to this
+                      cluster.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  clusterID:
+                    description: ClusterID is a globally unique identifier for this
+                      cluster generated during installation. Used for reporting metrics
+                      among other places.
+                    type: string
+                  infraID:
+                    description: InfraID is an identifier for this cluster generated
+                      during installation and used for tagging/naming resources in
+                      cloud providers.
                     type: string
                 required:
-                - certificateSecretRef
-                - name
+                - adminKubeconfigSecretRef
+                - clusterID
+                - infraID
                 type: object
-              type: array
-            clusterInstallRef:
-              description: ClusterInstallLocalReference provides reference to an object
-                that implements the hivecontract ClusterInstall. The namespace of
-                the object is same as the ClusterDeployment. This cannot be set when
-                Provisioning is also set.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-                version:
-                  type: string
-              required:
-              - group
-              - kind
-              - name
-              - version
-              type: object
-            clusterMetadata:
-              description: ClusterMetadata contains metadata information about the
-                installed cluster.
-              properties:
-                adminKubeconfigSecretRef:
-                  description: AdminKubeconfigSecretRef references the secret containing
-                    the admin kubeconfig for this cluster.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                adminPasswordSecretRef:
-                  description: AdminPasswordSecretRef references the secret containing
-                    the admin username/password which can be used to login to this
-                    cluster.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                clusterID:
-                  description: ClusterID is a globally unique identifier for this
-                    cluster generated during installation. Used for reporting metrics
-                    among other places.
-                  type: string
-                infraID:
-                  description: InfraID is an identifier for this cluster generated
-                    during installation and used for tagging/naming resources in cloud
-                    providers.
-                  type: string
-              required:
-              - adminKubeconfigSecretRef
-              - adminPasswordSecretRef
-              - clusterID
-              - infraID
-              type: object
-            clusterName:
-              description: ClusterName is the friendly name of the cluster. It is
-                used for subdomains, some resource tagging, and other instances where
-                a friendly name for the cluster is useful.
-              type: string
-            clusterPoolRef:
-              description: ClusterPoolRef is a reference to the ClusterPool that this
-                ClusterDeployment originated from.
-              properties:
-                claimName:
-                  description: ClaimName is the name of the ClusterClaim that claimed
-                    the cluster from the pool.
-                  type: string
-                namespace:
-                  description: Namespace is the namespace where the ClusterPool resides.
-                  type: string
-                poolName:
-                  description: PoolName is the name of the ClusterPool for which the
-                    cluster was created.
-                  type: string
-              required:
-              - namespace
-              - poolName
-              type: object
-            controlPlaneConfig:
-              description: ControlPlaneConfig contains additional configuration for
-                the target cluster's control plane
-              properties:
-                apiURLOverride:
-                  description: APIURLOverride is the optional URL override to which
-                    Hive will transition for communication with the API server of
-                    the remote cluster. When a remote cluster is created, Hive will
-                    initially communicate using the API URL established during installation.
-                    If an API URL Override is specified, Hive will periodically attempt
-                    to connect to the remote cluster using the override URL. Once
-                    Hive has determined that the override URL is active, Hive will
-                    use the override URL for further communications with the API server
-                    of the remote cluster.
-                  type: string
-                servingCertificates:
-                  description: ServingCertificates specifies serving certificates
-                    for the control plane
-                  properties:
-                    additional:
-                      description: Additional is a list of additional domains and
-                        certificates that are also associated with the control plane's
-                        api endpoint.
-                      items:
-                        description: ControlPlaneAdditionalCertificate defines an
-                          additional serving certificate for a control plane
-                        properties:
-                          domain:
-                            description: Domain is the domain of the additional control
-                              plane certificate
-                            type: string
-                          name:
-                            description: Name references a CertificateBundle in the
-                              ClusterDeployment.Spec that should be used for this
-                              additional certificate.
-                            type: string
-                        required:
-                        - domain
-                        - name
-                        type: object
-                      type: array
-                    default:
-                      description: Default references the name of a CertificateBundle
-                        in the ClusterDeployment that should be used for the control
-                        plane's default endpoint.
-                      type: string
-                  type: object
-              type: object
-            hibernateAfter:
-              description: HibernateAfter will transition a cluster to hibernating
-                power state after it has been running for the given duration. The
-                time that a cluster has been running is the time since the cluster
-                was installed or the time since the cluster last came out of hibernation.
-              type: string
-            ingress:
-              description: Ingress allows defining desired clusteringress/shards to
-                be configured on the cluster.
-              items:
-                description: ClusterIngress contains the configurable pieces for any
-                  ClusterIngress objects that should exist on the cluster.
+              clusterName:
+                description: ClusterName is the friendly name of the cluster. It is
+                  used for subdomains, some resource tagging, and other instances
+                  where a friendly name for the cluster is useful.
+                type: string
+              clusterPoolRef:
+                description: ClusterPoolRef is a reference to the ClusterPool that
+                  this ClusterDeployment originated from.
                 properties:
-                  domain:
-                    description: Domain (sometimes referred to as shard) is the full
-                      DNS suffix that the resulting IngressController object will
-                      service (eg abcd.mycluster.mydomain.com).
+                  claimName:
+                    description: ClaimName is the name of the ClusterClaim that claimed
+                      the cluster from the pool.
                     type: string
-                  name:
-                    description: Name of the ClusterIngress object to create.
+                  claimedTimestamp:
+                    description: ClaimedTimestamp is the time this cluster was assigned
+                      to a ClusterClaim. This is only used for ClusterDeployments
+                      belonging to ClusterPools.
+                    format: date-time
                     type: string
-                  namespaceSelector:
-                    description: NamespaceSelector allows filtering the list of namespaces
-                      serviced by the ingress controller.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  routeSelector:
-                    description: RouteSelector allows filtering the set of Routes
-                      serviced by the ingress controller
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  servingCertificate:
-                    description: ServingCertificate references a CertificateBundle
-                      in the ClusterDeployment.Spec that should be used for this Ingress
+                  namespace:
+                    description: Namespace is the namespace where the ClusterPool
+                      resides.
+                    type: string
+                  poolName:
+                    description: PoolName is the name of the ClusterPool for which
+                      the cluster was created.
                     type: string
                 required:
-                - domain
-                - name
+                - namespace
+                - poolName
                 type: object
-              type: array
-            installAttemptsLimit:
-              description: InstallAttemptsLimit is the maximum number of times Hive
-                will attempt to install the cluster.
-              format: int32
-              type: integer
-            installed:
-              description: Installed is true if the cluster has been installed
-              type: boolean
-            machineManagement:
-              description: MachineManagement contains machine management settings
-                including the strategy that will be used when provisioning worker
-                machines.
-              properties:
-                central:
-                  description: Central contains settings for central machine management.
-                    If set Central indicates that central machine management will
-                    be used as opposed to management on the spoke cluster.
-                  type: object
-                targetNamespace:
-                  description: TargetNamespace is the namespace in which we will create
-                    worker machineset resources. Resources required to create machines
-                    will be copied to the TargetNamespace. TargetNamespace is created
-                    for you and cannot be set during creation. TargetNamespace is
-                    also immutable once set.
-                  type: string
-              type: object
-            manageDNS:
-              description: ManageDNS specifies whether a DNSZone should be created
-                and managed automatically for this ClusterDeployment
-              type: boolean
-            platform:
-              description: Platform is the configuration for the specific platform
-                upon which to perform the installation.
-              properties:
-                agentBareMetal:
-                  description: AgentBareMetal is the configuration used when performing
-                    an Assisted Agent based installation to bare metal.
+              controlPlaneConfig:
+                description: ControlPlaneConfig contains additional configuration
+                  for the target cluster's control plane
+                properties:
+                  apiURLOverride:
+                    description: APIURLOverride is the optional URL override to which
+                      Hive will transition for communication with the API server of
+                      the remote cluster. When a remote cluster is created, Hive will
+                      initially communicate using the API URL established during installation.
+                      If an API URL Override is specified, Hive will periodically
+                      attempt to connect to the remote cluster using the override
+                      URL. Once Hive has determined that the override URL is active,
+                      Hive will use the override URL for further communications with
+                      the API server of the remote cluster.
+                    type: string
+                  servingCertificates:
+                    description: ServingCertificates specifies serving certificates
+                      for the control plane
+                    properties:
+                      additional:
+                        description: Additional is a list of additional domains and
+                          certificates that are also associated with the control plane's
+                          api endpoint.
+                        items:
+                          description: ControlPlaneAdditionalCertificate defines an
+                            additional serving certificate for a control plane
+                          properties:
+                            domain:
+                              description: Domain is the domain of the additional
+                                control plane certificate
+                              type: string
+                            name:
+                              description: Name references a CertificateBundle in
+                                the ClusterDeployment.Spec that should be used for
+                                this additional certificate.
+                              type: string
+                          required:
+                          - domain
+                          - name
+                          type: object
+                        type: array
+                      default:
+                        description: Default references the name of a CertificateBundle
+                          in the ClusterDeployment that should be used for the control
+                          plane's default endpoint.
+                        type: string
+                    type: object
+                type: object
+              hibernateAfter:
+                description: HibernateAfter will transition a cluster to hibernating
+                  power state after it has been running for the given duration. The
+                  time that a cluster has been running is the time since the cluster
+                  was installed or the time since the cluster last came out of hibernation.
+                  This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                  for accepted formats.
+                format: duration
+                type: string
+              ingress:
+                description: Ingress allows defining desired clusteringress/shards
+                  to be configured on the cluster.
+                items:
+                  description: ClusterIngress contains the configurable pieces for
+                    any ClusterIngress objects that should exist on the cluster.
                   properties:
-                    agentSelector:
-                      description: AgentSelector is a label selector used for associating
-                        relevant custom resources with this cluster. (Agent, BareMetalHost,
-                        etc)
+                    domain:
+                      description: Domain (sometimes referred to as shard) is the
+                        full DNS suffix that the resulting IngressController object
+                        will service (eg abcd.mycluster.mydomain.com).
+                      type: string
+                    name:
+                      description: Name of the ClusterIngress object to create.
+                      type: string
+                    namespaceSelector:
+                      description: NamespaceSelector allows filtering the list of
+                        namespaces serviced by the ingress controller.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
@@ -443,597 +316,759 @@ spec:
                             only "value". The requirements are ANDed.
                           type: object
                       type: object
-                  required:
-                  - agentSelector
-                  type: object
-                aws:
-                  description: AWS is the configuration used when installing on AWS.
-                  properties:
-                    credentialsAssumeRole:
-                      description: CredentialsAssumeRole refers to the IAM role that
-                        must be assumed to obtain AWS account access for the cluster
-                        operations.
+                    routeSelector:
+                      description: RouteSelector allows filtering the set of Routes
+                        serviced by the ingress controller
                       properties:
-                        externalID:
-                          description: 'ExternalID is random string generated by platform
-                            so that assume role is protected from confused deputy
-                            problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
-                          type: string
-                        roleARN:
-                          type: string
-                      required:
-                      - roleARN
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
                       type: object
-                    credentialsSecretRef:
-                      description: CredentialsSecretRef refers to a secret that contains
-                        the AWS account access credentials.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    privateLink:
-                      description: PrivateLink allows uses to enable access to the
-                        cluster's API server using AWS PrivateLink. AWS PrivateLink
-                        includes a pair of VPC Endpoint Service and VPC Endpoint accross
-                        AWS accounts and allows clients to connect to services using
-                        AWS's internal networking instead of the Internet.
-                      properties:
-                        enabled:
-                          type: boolean
-                      required:
-                      - enabled
-                      type: object
-                    region:
-                      description: Region specifies the AWS region where the cluster
-                        will be created.
-                      type: string
-                    userTags:
-                      additionalProperties:
-                        type: string
-                      description: UserTags specifies additional tags for AWS resources
-                        created for the cluster.
-                      type: object
-                  required:
-                  - region
-                  type: object
-                azure:
-                  description: Azure is the configuration used when installing on
-                    Azure.
-                  properties:
-                    baseDomainResourceGroupName:
-                      description: BaseDomainResourceGroupName specifies the resource
-                        group where the azure DNS zone for the base domain is found
-                      type: string
-                    credentialsSecretRef:
-                      description: CredentialsSecretRef refers to a secret that contains
-                        the Azure account access credentials.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    region:
-                      description: Region specifies the Azure region where the cluster
-                        will be created.
+                    servingCertificate:
+                      description: ServingCertificate references a CertificateBundle
+                        in the ClusterDeployment.Spec that should be used for this
+                        Ingress
                       type: string
                   required:
-                  - credentialsSecretRef
-                  - region
-                  type: object
-                baremetal:
-                  description: BareMetal is the configuration used when installing
-                    on bare metal.
-                  properties:
-                    libvirtSSHPrivateKeySecretRef:
-                      description: LibvirtSSHPrivateKeySecretRef is the reference
-                        to the secret that contains the private SSH key to use for
-                        access to the libvirt provisioning host. The SSH private key
-                        is expected to be in the secret data under the "ssh-privatekey"
-                        key.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                  required:
-                  - libvirtSSHPrivateKeySecretRef
-                  type: object
-                gcp:
-                  description: GCP is the configuration used when installing on Google
-                    Cloud Platform.
-                  properties:
-                    credentialsSecretRef:
-                      description: CredentialsSecretRef refers to a secret that contains
-                        the GCP account access credentials.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    region:
-                      description: Region specifies the GCP region where the cluster
-                        will be created.
-                      type: string
-                  required:
-                  - credentialsSecretRef
-                  - region
-                  type: object
-                openstack:
-                  description: OpenStack is the configuration used when installing
-                    on OpenStack
-                  properties:
-                    certificatesSecretRef:
-                      description: "CertificatesSecretRef refers to a secret that
-                        contains CA certificates necessary for communicating with
-                        the OpenStack. There is additional configuration required
-                        for the OpenShift cluster to trust the certificates provided
-                        in this secret. The \"clouds.yaml\" file included in the credentialsSecretRef
-                        Secret must also include a reference to the certificate bundle
-                        file for the OpenShift cluster being created to trust the
-                        OpenStack endpoints. The \"clouds.yaml\" file must set the
-                        \"cacert\" field to either \"/etc/openstack-ca/<key name containing
-                        the trust bundle in credentialsSecretRef Secret>\" or \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\".
-                        \n For example, \"\"\"clouds.yaml clouds:   shiftstack:     auth:
-                        ...     cacert: \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\"
-                        \"\"\""
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    cloud:
-                      description: Cloud will be used to indicate the OS_CLOUD value
-                        to use the right section from the clouds.yaml in the CredentialsSecretRef.
-                      type: string
-                    credentialsSecretRef:
-                      description: CredentialsSecretRef refers to a secret that contains
-                        the OpenStack account access credentials.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    trunkSupport:
-                      description: TrunkSupport indicates whether or not to use trunk
-                        ports in your OpenShift cluster.
-                      type: boolean
-                  required:
-                  - cloud
-                  - credentialsSecretRef
-                  type: object
-                ovirt:
-                  description: Ovirt is the configuration used when installing on
-                    oVirt
-                  properties:
-                    certificatesSecretRef:
-                      description: CertificatesSecretRef refers to a secret that contains
-                        the oVirt CA certificates necessary for communicating with
-                        oVirt.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    credentialsSecretRef:
-                      description: 'CredentialsSecretRef refers to a secret that contains
-                        the oVirt account access credentials with fields: ovirt_url,
-                        ovirt_username, ovirt_password, ovirt_ca_bundle'
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    ovirt_cluster_id:
-                      description: The target cluster under which all VMs will run
-                      type: string
-                    ovirt_network_name:
-                      description: The target network of all the network interfaces
-                        of the nodes. Omitting defaults to ovirtmgmt network which
-                        is a default network for evert ovirt cluster.
-                      type: string
-                    storage_domain_id:
-                      description: The target storage domain under which all VM disk
-                        would be created.
-                      type: string
-                  required:
-                  - certificatesSecretRef
-                  - credentialsSecretRef
-                  - ovirt_cluster_id
-                  - storage_domain_id
-                  type: object
-                vsphere:
-                  description: VSphere is the configuration used when installing on
-                    vSphere
-                  properties:
-                    certificatesSecretRef:
-                      description: CertificatesSecretRef refers to a secret that contains
-                        the vSphere CA certificates necessary for communicating with
-                        the VCenter.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    cluster:
-                      description: Cluster is the name of the cluster virtual machines
-                        will be cloned into.
-                      type: string
-                    credentialsSecretRef:
-                      description: 'CredentialsSecretRef refers to a secret that contains
-                        the vSphere account access credentials: GOVC_USERNAME, GOVC_PASSWORD
-                        fields.'
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    datacenter:
-                      description: Datacenter is the name of the datacenter to use
-                        in the vCenter.
-                      type: string
-                    defaultDatastore:
-                      description: DefaultDatastore is the default datastore to use
-                        for provisioning volumes.
-                      type: string
-                    folder:
-                      description: Folder is the name of the folder that will be used
-                        and/or created for virtual machines.
-                      type: string
-                    network:
-                      description: Network specifies the name of the network to be
-                        used by the cluster.
-                      type: string
-                    vCenter:
-                      description: VCenter is the domain name or IP address of the
-                        vCenter.
-                      type: string
-                  required:
-                  - certificatesSecretRef
-                  - credentialsSecretRef
-                  - datacenter
-                  - defaultDatastore
-                  - vCenter
-                  type: object
-              type: object
-            powerState:
-              description: PowerState indicates whether a cluster should be running
-                or hibernating. When omitted, PowerState defaults to the Running state.
-              enum:
-              - ""
-              - Running
-              - Hibernating
-              type: string
-            preserveOnDelete:
-              description: PreserveOnDelete allows the user to disconnect a cluster
-                from Hive without deprovisioning it
-              type: boolean
-            provisioning:
-              description: Provisioning contains settings used only for initial cluster
-                provisioning. May be unset in the case of adopted clusters.
-              properties:
-                imageSetRef:
-                  description: ImageSetRef is a reference to a ClusterImageSet. If
-                    a value is specified for ReleaseImage, that will take precedence
-                    over the one from the ClusterImageSet.
-                  properties:
-                    name:
-                      description: Name is the name of the ClusterImageSet that this
-                        refers to
-                      type: string
-                  required:
+                  - domain
                   - name
                   type: object
-                installConfigSecretRef:
-                  description: InstallConfigSecretRef is the reference to a secret
-                    that contains an openshift-install InstallConfig. This file will
-                    be passed through directly to the installer. Any version of InstallConfig
-                    can be used, provided it can be parsed by the openshift-install
-                    version for the release you are provisioning.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                installerEnv:
-                  description: InstallerEnv are extra environment variables to pass
-                    through to the installer. This may be used to enable additional
-                    features of the installer.
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
+                type: array
+              installAttemptsLimit:
+                description: InstallAttemptsLimit is the maximum number of times Hive
+                  will attempt to install the cluster.
+                format: int32
+                type: integer
+              installed:
+                description: Installed is true if the cluster has been installed
+                type: boolean
+              machineManagement:
+                description: MachineManagement contains machine management settings
+                  including the strategy that will be used when provisioning worker
+                  machines.
+                properties:
+                  central:
+                    description: Central contains settings for central machine management.
+                      If set Central indicates that central machine management will
+                      be used as opposed to management on the spoke cluster.
+                    type: object
+                  targetNamespace:
+                    description: TargetNamespace is the namespace in which we will
+                      create worker machineset resources. Resources required to create
+                      machines will be copied to the TargetNamespace. TargetNamespace
+                      is created for you and cannot be set during creation. TargetNamespace
+                      is also immutable once set.
+                    type: string
+                type: object
+              manageDNS:
+                description: ManageDNS specifies whether a DNSZone should be created
+                  and managed automatically for this ClusterDeployment
+                type: boolean
+              platform:
+                description: Platform is the configuration for the specific platform
+                  upon which to perform the installation.
+                properties:
+                  agentBareMetal:
+                    description: AgentBareMetal is the configuration used when performing
+                      an Assisted Agent based installation to bare metal.
                     properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
+                      agentSelector:
+                        description: AgentSelector is a label selector used for associating
+                          relevant custom resources with this cluster. (Agent, BareMetalHost,
+                          etc)
                         properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                            - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
-                                type: string
-                            required:
-                            - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
-                                type: string
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                            - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                            - key
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
                             type: object
                         type: object
                     required:
+                    - agentSelector
+                    type: object
+                  aws:
+                    description: AWS is the configuration used when installing on
+                      AWS.
+                    properties:
+                      credentialsAssumeRole:
+                        description: CredentialsAssumeRole refers to the IAM role
+                          that must be assumed to obtain AWS account access for the
+                          cluster operations.
+                        properties:
+                          externalID:
+                            description: 'ExternalID is random string generated by
+                              platform so that assume role is protected from confused
+                              deputy problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
+                            type: string
+                          roleARN:
+                            type: string
+                        required:
+                        - roleARN
+                        type: object
+                      credentialsSecretRef:
+                        description: CredentialsSecretRef refers to a secret that
+                          contains the AWS account access credentials.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      privateLink:
+                        description: PrivateLink allows uses to enable access to the
+                          cluster's API server using AWS PrivateLink. AWS PrivateLink
+                          includes a pair of VPC Endpoint Service and VPC Endpoint
+                          accross AWS accounts and allows clients to connect to services
+                          using AWS's internal networking instead of the Internet.
+                        properties:
+                          enabled:
+                            type: boolean
+                        required:
+                        - enabled
+                        type: object
+                      region:
+                        description: Region specifies the AWS region where the cluster
+                          will be created.
+                        type: string
+                      userTags:
+                        additionalProperties:
+                          type: string
+                        description: UserTags specifies additional tags for AWS resources
+                          created for the cluster.
+                        type: object
+                    required:
+                    - region
+                    type: object
+                  azure:
+                    description: Azure is the configuration used when installing on
+                      Azure.
+                    properties:
+                      baseDomainResourceGroupName:
+                        description: BaseDomainResourceGroupName specifies the resource
+                          group where the azure DNS zone for the base domain is found
+                        type: string
+                      cloudName:
+                        description: cloudName is the name of the Azure cloud environment
+                          which can be used to configure the Azure SDK with the appropriate
+                          Azure API endpoints. If empty, the value is equal to "AzurePublicCloud".
+                        enum:
+                        - ""
+                        - AzurePublicCloud
+                        - AzureUSGovernmentCloud
+                        - AzureChinaCloud
+                        - AzureGermanCloud
+                        type: string
+                      credentialsSecretRef:
+                        description: CredentialsSecretRef refers to a secret that
+                          contains the Azure account access credentials.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      region:
+                        description: Region specifies the Azure region where the cluster
+                          will be created.
+                        type: string
+                    required:
+                    - credentialsSecretRef
+                    - region
+                    type: object
+                  baremetal:
+                    description: BareMetal is the configuration used when installing
+                      on bare metal.
+                    properties:
+                      libvirtSSHPrivateKeySecretRef:
+                        description: LibvirtSSHPrivateKeySecretRef is the reference
+                          to the secret that contains the private SSH key to use for
+                          access to the libvirt provisioning host. The SSH private
+                          key is expected to be in the secret data under the "ssh-privatekey"
+                          key.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                    required:
+                    - libvirtSSHPrivateKeySecretRef
+                    type: object
+                  gcp:
+                    description: GCP is the configuration used when installing on
+                      Google Cloud Platform.
+                    properties:
+                      credentialsSecretRef:
+                        description: CredentialsSecretRef refers to a secret that
+                          contains the GCP account access credentials.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      region:
+                        description: Region specifies the GCP region where the cluster
+                          will be created.
+                        type: string
+                    required:
+                    - credentialsSecretRef
+                    - region
+                    type: object
+                  openstack:
+                    description: OpenStack is the configuration used when installing
+                      on OpenStack
+                    properties:
+                      certificatesSecretRef:
+                        description: "CertificatesSecretRef refers to a secret that
+                          contains CA certificates necessary for communicating with
+                          the OpenStack. There is additional configuration required
+                          for the OpenShift cluster to trust the certificates provided
+                          in this secret. The \"clouds.yaml\" file included in the
+                          credentialsSecretRef Secret must also include a reference
+                          to the certificate bundle file for the OpenShift cluster
+                          being created to trust the OpenStack endpoints. The \"clouds.yaml\"
+                          file must set the \"cacert\" field to either \"/etc/openstack-ca/<key
+                          name containing the trust bundle in credentialsSecretRef
+                          Secret>\" or \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\".
+                          \n For example, \"\"\"clouds.yaml clouds:   shiftstack:
+                          \    auth: ...     cacert: \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\"
+                          \"\"\""
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      cloud:
+                        description: Cloud will be used to indicate the OS_CLOUD value
+                          to use the right section from the clouds.yaml in the CredentialsSecretRef.
+                        type: string
+                      credentialsSecretRef:
+                        description: CredentialsSecretRef refers to a secret that
+                          contains the OpenStack account access credentials.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      trunkSupport:
+                        description: TrunkSupport indicates whether or not to use
+                          trunk ports in your OpenShift cluster.
+                        type: boolean
+                    required:
+                    - cloud
+                    - credentialsSecretRef
+                    type: object
+                  ovirt:
+                    description: Ovirt is the configuration used when installing on
+                      oVirt
+                    properties:
+                      certificatesSecretRef:
+                        description: CertificatesSecretRef refers to a secret that
+                          contains the oVirt CA certificates necessary for communicating
+                          with oVirt.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      credentialsSecretRef:
+                        description: 'CredentialsSecretRef refers to a secret that
+                          contains the oVirt account access credentials with fields:
+                          ovirt_url, ovirt_username, ovirt_password, ovirt_ca_bundle'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      ovirt_cluster_id:
+                        description: The target cluster under which all VMs will run
+                        type: string
+                      ovirt_network_name:
+                        description: The target network of all the network interfaces
+                          of the nodes. Omitting defaults to ovirtmgmt network which
+                          is a default network for evert ovirt cluster.
+                        type: string
+                      storage_domain_id:
+                        description: The target storage domain under which all VM
+                          disk would be created.
+                        type: string
+                    required:
+                    - certificatesSecretRef
+                    - credentialsSecretRef
+                    - ovirt_cluster_id
+                    - storage_domain_id
+                    type: object
+                  vsphere:
+                    description: VSphere is the configuration used when installing
+                      on vSphere
+                    properties:
+                      certificatesSecretRef:
+                        description: CertificatesSecretRef refers to a secret that
+                          contains the vSphere CA certificates necessary for communicating
+                          with the VCenter.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      cluster:
+                        description: Cluster is the name of the cluster virtual machines
+                          will be cloned into.
+                        type: string
+                      credentialsSecretRef:
+                        description: 'CredentialsSecretRef refers to a secret that
+                          contains the vSphere account access credentials: GOVC_USERNAME,
+                          GOVC_PASSWORD fields.'
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      datacenter:
+                        description: Datacenter is the name of the datacenter to use
+                          in the vCenter.
+                        type: string
+                      defaultDatastore:
+                        description: DefaultDatastore is the default datastore to
+                          use for provisioning volumes.
+                        type: string
+                      folder:
+                        description: Folder is the name of the folder that will be
+                          used and/or created for virtual machines.
+                        type: string
+                      network:
+                        description: Network specifies the name of the network to
+                          be used by the cluster.
+                        type: string
+                      vCenter:
+                        description: VCenter is the domain name or IP address of the
+                          vCenter.
+                        type: string
+                    required:
+                    - certificatesSecretRef
+                    - credentialsSecretRef
+                    - datacenter
+                    - defaultDatastore
+                    - vCenter
+                    type: object
+                type: object
+              powerState:
+                description: PowerState indicates whether a cluster should be running
+                  or hibernating. When omitted, PowerState defaults to the Running
+                  state.
+                enum:
+                - ""
+                - Running
+                - Hibernating
+                type: string
+              preserveOnDelete:
+                description: PreserveOnDelete allows the user to disconnect a cluster
+                  from Hive without deprovisioning it. This can also be used to abandon
+                  ongoing cluster deprovision.
+                type: boolean
+              provisioning:
+                description: Provisioning contains settings used only for initial
+                  cluster provisioning. May be unset in the case of adopted clusters.
+                properties:
+                  imageSetRef:
+                    description: ImageSetRef is a reference to a ClusterImageSet.
+                      If a value is specified for ReleaseImage, that will take precedence
+                      over the one from the ClusterImageSet.
+                    properties:
+                      name:
+                        description: Name is the name of the ClusterImageSet that
+                          this refers to
+                        type: string
+                    required:
                     - name
                     type: object
-                  type: array
-                manifestsConfigMapRef:
-                  description: ManifestsConfigMapRef is a reference to user-provided
-                    manifests to add to or replace manifests that are generated by
-                    the installer.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                releaseImage:
-                  description: ReleaseImage is the image containing metadata for all
-                    components that run in the cluster, and is the primary and best
-                    way to specify what specific version of OpenShift you wish to
-                    install.
-                  type: string
-                sshKnownHosts:
-                  description: SSHKnownHosts are known hosts to be configured in the
-                    hive install manager pod to avoid ssh prompts. Use of ssh in the
-                    install pod is somewhat limited today (failure log gathering from
-                    cluster, some bare metal provisioning scenarios), so this setting
-                    is often not needed.
-                  items:
-                    type: string
-                  type: array
-                sshPrivateKeySecretRef:
-                  description: SSHPrivateKeySecretRef is the reference to the secret
-                    that contains the private SSH key to use for access to compute
-                    instances. This private key should correspond to the public key
-                    included in the InstallConfig. The private key is used by Hive
-                    to gather logs on the target cluster if there are install failures.
-                    The SSH private key is expected to be in the secret data under
-                    the "ssh-privatekey" key.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-              type: object
-            pullSecretRef:
-              description: PullSecretRef is the reference to the secret to use when
-                pulling images.
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-          required:
-          - baseDomain
-          - clusterName
-          - platform
-          type: object
-        status:
-          description: ClusterDeploymentStatus defines the observed state of ClusterDeployment
-          properties:
-            apiURL:
-              description: APIURL is the URL where the cluster's API can be accessed.
-              type: string
-            certificateBundles:
-              description: CertificateBundles contains of the status of the certificate
-                bundles associated with this cluster deployment.
-              items:
-                description: CertificateBundleStatus specifies whether a certificate
-                  bundle was generated for this cluster deployment.
-                properties:
-                  generated:
-                    description: Generated indicates whether the certificate bundle
-                      was generated
-                    type: boolean
-                  name:
-                    description: Name of the certificate bundle
-                    type: string
-                required:
-                - generated
-                - name
-                type: object
-              type: array
-            cliImage:
-              description: CLIImage is the name of the oc cli image to use when installing
-                the target cluster
-              type: string
-            conditions:
-              description: Conditions includes more detailed status for the cluster
-                deployment
-              items:
-                description: ClusterDeploymentCondition contains details for the current
-                  condition of a cluster deployment
-                properties:
-                  lastProbeTime:
-                    description: LastProbeTime is the last time we probed the condition.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about last transition.
-                    type: string
-                  reason:
-                    description: Reason is a unique, one-word, CamelCase reason for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status is the status of the condition.
-                    type: string
-                  type:
-                    description: Type is the type of the condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            installRestarts:
-              description: InstallRestarts is the total count of container restarts
-                on the clusters install job.
-              type: integer
-            installStartedTimestamp:
-              description: InstallStartedTimestamp is the time when all pre-requisites
-                were met and cluster installation was launched.
-              format: date-time
-              type: string
-            installVersion:
-              description: InstallVersion is the version of OpenShift as reported
-                by the release image resolved for the installation.
-              type: string
-            installedTimestamp:
-              description: InstalledTimestamp is the time we first detected that the
-                cluster has been successfully installed.
-              format: date-time
-              type: string
-            installerImage:
-              description: InstallerImage is the name of the installer image to use
-                when installing the target cluster
-              type: string
-            platformStatus:
-              description: Platform contains the observed state for the specific platform
-                upon which to perform the installation.
-              properties:
-                aws:
-                  description: AWS is the observed state on AWS.
-                  properties:
-                    privateLink:
-                      description: PrivateLinkAccessStatus contains the observed state
-                        for PrivateLinkAccess resources.
+                  installConfigSecretRef:
+                    description: InstallConfigSecretRef is the reference to a secret
+                      that contains an openshift-install InstallConfig. This file
+                      will be passed through directly to the installer. Any version
+                      of InstallConfig can be used, provided it can be parsed by the
+                      openshift-install version for the release you are provisioning.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  installerEnv:
+                    description: InstallerEnv are extra environment variables to pass
+                      through to the installer. This may be used to enable additional
+                      features of the installer.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
-                        hostedZoneID:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
                           type: string
-                        vpcEndpointID:
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                           type: string
-                        vpcEndpointService:
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
-                            id:
-                              type: string
-                            name:
-                              type: string
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
                           type: object
+                      required:
+                      - name
                       type: object
+                    type: array
+                  manifestsConfigMapRef:
+                    description: ManifestsConfigMapRef is a reference to user-provided
+                      manifests to add to or replace manifests that are generated
+                      by the installer.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  releaseImage:
+                    description: ReleaseImage is the image containing metadata for
+                      all components that run in the cluster, and is the primary and
+                      best way to specify what specific version of OpenShift you wish
+                      to install.
+                    type: string
+                  sshKnownHosts:
+                    description: SSHKnownHosts are known hosts to be configured in
+                      the hive install manager pod to avoid ssh prompts. Use of ssh
+                      in the install pod is somewhat limited today (failure log gathering
+                      from cluster, some bare metal provisioning scenarios), so this
+                      setting is often not needed.
+                    items:
+                      type: string
+                    type: array
+                  sshPrivateKeySecretRef:
+                    description: SSHPrivateKeySecretRef is the reference to the secret
+                      that contains the private SSH key to use for access to compute
+                      instances. This private key should correspond to the public
+                      key included in the InstallConfig. The private key is used by
+                      Hive to gather logs on the target cluster if there are install
+                      failures. The SSH private key is expected to be in the secret
+                      data under the "ssh-privatekey" key.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                type: object
+              pullSecretRef:
+                description: PullSecretRef is the reference to the secret to use when
+                  pulling images.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+            required:
+            - baseDomain
+            - clusterName
+            - platform
+            type: object
+          status:
+            description: ClusterDeploymentStatus defines the observed state of ClusterDeployment
+            properties:
+              apiURL:
+                description: APIURL is the URL where the cluster's API can be accessed.
+                type: string
+              certificateBundles:
+                description: CertificateBundles contains of the status of the certificate
+                  bundles associated with this cluster deployment.
+                items:
+                  description: CertificateBundleStatus specifies whether a certificate
+                    bundle was generated for this cluster deployment.
+                  properties:
+                    generated:
+                      description: Generated indicates whether the certificate bundle
+                        was generated
+                      type: boolean
+                    name:
+                      description: Name of the certificate bundle
+                      type: string
+                  required:
+                  - generated
+                  - name
                   type: object
-              type: object
-            provisionRef:
-              description: ProvisionRef is a reference to the last ClusterProvision
-                created for the deployment
-              properties:
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    TODO: Add other useful fields. apiVersion, kind, uid?'
-                  type: string
-              type: object
-            webConsoleURL:
-              description: WebConsoleURL is the URL for the cluster's web console
-                UI.
-              type: string
-          type: object
-  version: v1
-  versions:
-  - name: v1
+                type: array
+              cliImage:
+                description: CLIImage is the name of the oc cli image to use when
+                  installing the target cluster
+                type: string
+              conditions:
+                description: Conditions includes more detailed status for the cluster
+                  deployment
+                items:
+                  description: ClusterDeploymentCondition contains details for the
+                    current condition of a cluster deployment
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about last transition.
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              installRestarts:
+                description: InstallRestarts is the total count of container restarts
+                  on the clusters install job.
+                type: integer
+              installStartedTimestamp:
+                description: InstallStartedTimestamp is the time when all pre-requisites
+                  were met and cluster installation was launched.
+                format: date-time
+                type: string
+              installVersion:
+                description: InstallVersion is the version of OpenShift as reported
+                  by the release image resolved for the installation.
+                type: string
+              installedTimestamp:
+                description: InstalledTimestamp is the time we first detected that
+                  the cluster has been successfully installed.
+                format: date-time
+                type: string
+              installerImage:
+                description: InstallerImage is the name of the installer image to
+                  use when installing the target cluster
+                type: string
+              platformStatus:
+                description: Platform contains the observed state for the specific
+                  platform upon which to perform the installation.
+                properties:
+                  aws:
+                    description: AWS is the observed state on AWS.
+                    properties:
+                      privateLink:
+                        description: PrivateLinkAccessStatus contains the observed
+                          state for PrivateLinkAccess resources.
+                        properties:
+                          hostedZoneID:
+                            type: string
+                          vpcEndpointID:
+                            type: string
+                          vpcEndpointService:
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              provisionRef:
+                description: ProvisionRef is a reference to the last ClusterProvision
+                  created for the deployment
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+              webConsoleURL:
+                description: WebConsoleURL is the URL for the cluster's web console
+                  UI.
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/hack/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/hack/crds/hive.openshift.io_clusterimagesets.yaml
@@ -1,13 +1,11 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterimagesets.hive.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.releaseImage
-    name: Release
-    type: string
   group: hive.openshift.io
   names:
     kind: ClusterImageSet
@@ -17,42 +15,46 @@ spec:
     - imgset
     singular: clusterimageset
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterImageSet is the Schema for the clusterimagesets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterImageSetSpec defines the desired state of ClusterImageSet
-          properties:
-            releaseImage:
-              description: ReleaseImage is the image that contains the payload to
-                use when installing a cluster.
-              type: string
-          required:
-          - releaseImage
-          type: object
-        status:
-          description: ClusterImageSetStatus defines the observed state of ClusterImageSet
-          type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.releaseImage
+      name: Release
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ClusterImageSet is the Schema for the clusterimagesets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterImageSetSpec defines the desired state of ClusterImageSet
+            properties:
+              releaseImage:
+                description: ReleaseImage is the image that contains the payload to
+                  use when installing a cluster.
+                type: string
+            required:
+            - releaseImage
+            type: object
+          status:
+            description: ClusterImageSetStatus defines the observed state of ClusterImageSet
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
# Assisted Pull Request

## Description

Kubernetes 1.22 [no longer supports](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122) CRDS with version `apiextensions.k8s.io/v1beta1`. This [impacts](https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/1196/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-kube-api/1455153244295663616/build-log.txt) using minikube version v.1.22.0 and above when creating a cluster with the `assisted-test-infra`.

```
RuntimeError: command=kubectl --namespace assisted-installer apply -f /home/assisted/assisted-service/hack/crds//hive.openshift.io_clusterdeployments.yaml exited with an error=error: unable to recognize "/home/assisted/assisted-service/hack/crds//hive.openshift.io_clusterdeployments.yaml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1" code=1
```

The new manifests contain the latest values of the [hive.openshift.io_clusterdeployments.yaml](https://github.com/openshift/hive/blob/2bbebf5983eecf3e539241cecd2c46a1681b472e/config/crds/hive.openshift.io_clusterdeployments.yaml) and [hive.openshift.io_clusterimagesets.yaml](https://github.com/openshift/hive/blob/2bbebf5983eecf3e539241cecd2c46a1681b472e/config/crds/hive.openshift.io_clusterimagesets.yaml) as defined in the hive project.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @osherdp 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
