### PR TITLE
NO-ISSUE: remove '/test all' that just breaks all jobs

### DIFF
--- a/tools/ocp_version_update/update_default_release_versions_to_latest.py
+++ b/tools/ocp_version_update/update_default_release_versions_to_latest.py
@@ -432,7 +432,6 @@ def get_pr_body(updates_made):
         get_release_notes(updates_made) +
         textwrap.dedent(f"""
             /cc {" ".join(f"@{user}" for user in PR_MENTION)}
-            /test all
             /hold
         """)
     )


### PR DESCRIPTION
# Assisted Pull Request

## Description

When opening a PR for bumping OCP releases, it writes a description that holds information about the releases and it adds the following:
```
/test all
/hold
```

The first should run all tests, the second one should hold the PR until someone can take a look and approve it.
Actually ``/test all`` doesn't really run all tests, but rather runs all tests that have been triggered by default with respect to the PR's changes. Also, it seems like when including this command it breaks the run of the jobs right away for some reason.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
