### PR TITLE
MGMT-8120: Change Events subsystem tests assertion

### DIFF
--- a/subsystem/events_test.go
+++ b/subsystem/events_test.go
@@ -132,7 +132,10 @@ var _ = Describe("Events tests", func() {
 
 				if test.querySucess {
 					Expect(err).Should(BeNil())
-					Expect(len(evs.GetPayload())).Should(Equal(2))
+					Expect(len(evs.GetPayload())).ShouldNot(Equal(0))
+					for idx := range evs.GetPayload() {
+						Expect(evs.GetPayload()[idx].ClusterID).Should(Equal(&clusterId))
+					}
 				} else {
 					Expect(err).ShouldNot(BeNil())
 					isExpectedAPIError(err, test.err)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Recent CI results show that some tests may expect to get
two or three cluster events.

The reason is that it might take an extra second or two
to list events for a given cluster after it got registered.
So it will always get the following events:
- Registered cluster
- Successfully registered cluster

And sometimes it will also get:
- Updated status of the cluster to pending-for-input

This PR changes the tests to:
1. expect any number of events per cluster_id filtering
2. assert that all returned events do match the given cluster_id

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @rollandf 
/cc @slaviered 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
