### PR TITLE
Bug 2016178: Add ClusterOSImage to Baremetal platform

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -26,6 +26,7 @@ type BareMetalInstallConfigPlatform struct {
 	APIVIP              string `yaml:"apiVIP"`
 	IngressVIP          string `yaml:"ingressVIP"`
 	Hosts               []Host `yaml:"hosts"`
+	ClusterOSImage      string `json:"clusterOSImage,omitempty"`
 }
 
 type VsphereInstallConfigPlatform struct {


### PR DESCRIPTION

# Assisted Pull Request

## Description

This should allow users to specify clusterOSImage in the install-config-overrides

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no, it was tested by qe
- Should this PR be tested in a specific environment? OCM-2.4 + ignition override for clusterOSImage
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
