### PR TITLE
MGMT-8128 - Fix wait_for_assisted_service failing on multiple tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ jira==3.0.1
 PyGithub>=1.54
 python-gitlab>=2.6.0
 ruamel.yaml>=0.16.12
+retry==0.9.2

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -70,11 +70,7 @@ def check_output(command, raise_on_error=True):
     err = process.stderr.strip()
 
     if raise_on_error and process.returncode != 0:
-        raise RuntimeError(
-            f'command={command} exited with an '
-            f'error={err if err else out} '
-            f'code={process.returncode}'
-        )
+        raise RuntimeError(f'command={command} exited with an error={err if err else out} code={process.returncode}')
 
     return out if out else err
 
@@ -100,11 +96,7 @@ def get_service_host(
     return host.strip()
 
 
-def get_service_port(
-        service,
-        target=None,
-        namespace='assisted-installer',
-        ):
+def get_service_port(service, target=None, namespace='assisted-installer'):
     kubectl_cmd = get_kubectl_command(target, namespace)
     cmd = f'{kubectl_cmd} get service {service} | grep {service}'
     reply = check_output(cmd)[:-1].split()

--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -7,6 +7,7 @@ import requests
 import utils
 import deployment_options
 from urllib.parse import urlunsplit, urlsplit
+from retry import retry
 
 SERVICE = "assisted-service"
 TIMEOUT = 60 * 30
@@ -25,7 +26,9 @@ def wait_for_request(url: str) -> bool:
     return res.status_code == 200
 
 
+@retry(exceptions=RuntimeError, tries=2, delay=3)
 def is_assisted_service_ready(target, domain, namespace, disable_tls) -> bool:
+    print(f"DEBUG - is_assisted_service_ready({target} {domain} {namespace} {disable_tls})")
     service_url = utils.get_service_url(
         service=SERVICE, target=target, domain=domain,
         namespace=namespace, disable_tls=disable_tls)


### PR DESCRIPTION
Currently there are multiple CI failures due to `RuntimeError` raised while running `kubectl --namespace assisted-installer get service assisted-service` command

The error is: `Error from server: etcdserver: request timed out code=1`

/cc @osherdp 