### PR TITLE
MGMT-8129: Remove required attribute from current_stage in both host_progress and host_progress_info

### DIFF
--- a/models/host_progress.go
+++ b/models/host_progress.go
@@ -17,8 +17,7 @@ import (
 type HostProgress struct {
 
 	// current stage
-	// Required: true
-	CurrentStage HostStage `json:"current_stage"`
+	CurrentStage HostStage `json:"current_stage,omitempty"`
 
 	// progress info
 	ProgressInfo string `json:"progress_info,omitempty" gorm:"type:varchar(2048)"`
@@ -39,6 +38,10 @@ func (m *HostProgress) Validate(formats strfmt.Registry) error {
 }
 
 func (m *HostProgress) validateCurrentStage(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.CurrentStage) { // not required
+		return nil
+	}
 
 	if err := m.CurrentStage.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/models/host_progress_info.go
+++ b/models/host_progress_info.go
@@ -18,8 +18,7 @@ import (
 type HostProgressInfo struct {
 
 	// current stage
-	// Required: true
-	CurrentStage HostStage `json:"current_stage"`
+	CurrentStage HostStage `json:"current_stage,omitempty"`
 
 	// installation percentage
 	InstallationPercentage int64 `json:"installation_percentage,omitempty"`
@@ -59,6 +58,10 @@ func (m *HostProgressInfo) Validate(formats strfmt.Registry) error {
 }
 
 func (m *HostProgressInfo) validateCurrentStage(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.CurrentStage) { // not required
+		return nil
+	}
 
 	if err := m.CurrentStage.Validate(formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -11340,9 +11340,6 @@ func init() {
     },
     "host-progress": {
       "type": "object",
-      "required": [
-        "current_stage"
-      ],
       "properties": {
         "current_stage": {
           "type": "string",
@@ -11356,9 +11353,6 @@ func init() {
     },
     "host-progress-info": {
       "type": "object",
-      "required": [
-        "current_stage"
-      ],
       "properties": {
         "current_stage": {
           "type": "string",
@@ -24527,9 +24521,6 @@ func init() {
     },
     "host-progress": {
       "type": "object",
-      "required": [
-        "current_stage"
-      ],
       "properties": {
         "current_stage": {
           "type": "string",
@@ -24543,9 +24534,6 @@ func init() {
     },
     "host-progress-info": {
       "type": "object",
-      "required": [
-        "current_stage"
-      ],
       "properties": {
         "current_stage": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7819,8 +7819,6 @@ definitions:
 
   host-progress:
     type: object
-    required:
-      - current_stage
     properties:
       current_stage:
         type: string
@@ -7831,8 +7829,6 @@ definitions:
 
   host-progress-info:
     type: object
-    required:
-      - current_stage
     properties:
       installation_percentage:
         type: integer


### PR DESCRIPTION


# Assisted Pull Request

## Description

- This will be needed for go-swagger v0.28 since the generated code
  cases the python client to crash if this field is empty.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
