### PR TITLE
Bug 2020928: Changing the condition that check if disk-encryption is enabled.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	reflect "reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -2690,7 +2689,7 @@ func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interfac
 
 func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncryption *models.DiskEncryption, usages map[string]models.Usage) {
 
-	if c.DiskEncryption == nil || reflect.DeepEqual(c.DiskEncryption, &models.DiskEncryption{}) {
+	if c.DiskEncryption == nil || swag.StringValue(c.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return
 	}
 

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -29,6 +29,10 @@ func GenerateTestCluster(clusterID strfmt.UUID, machineNetworks []*models.Machin
 			MachineNetworks: machineNetworks,
 			Platform:        &models.Platform{Type: models.PlatformTypeBaremetal},
 			Kind:            swag.String(models.ClusterKindCluster),
+			DiskEncryption: &models.DiskEncryption{
+				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+			},
 		},
 	}
 }

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"reflect"
 	"strings"
 	"time"
 
@@ -360,7 +359,7 @@ func isDiskEncryptionEnabledForRole(encryption models.DiskEncryption, role model
 
 func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) ValidationStatus {
 
-	if c.infraEnv != nil || reflect.DeepEqual(c.cluster.DiskEncryption, &models.DiskEncryption{}) {
+	if c.infraEnv != nil || swag.StringValue(c.cluster.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return ValidationSuccessSuppressOutput
 	}
 
@@ -1194,7 +1193,7 @@ func printIsDomainNameResolvedCorrectly(c *validationContext, status ValidationS
 		}
 		return fmt.Sprintf("Domain name resolution was successful for domain %s", domainName)
 	case ValidationFailure:
-		return fmt.Sprintf("Couldn’t resolve domain name “%s” on the host. To continue installation, create the necessary DNS entries to resolve this domain name to your %s.", domainName, destination)
+		return fmt.Sprintf("Couldn't resolve domain name %s on the host. To continue installation, create the necessary DNS entries to resolve this domain name to your %s.", domainName, destination)
 	case ValidationError:
 		return "Parse error for domain name resolutions result"
 	default:

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	reflect "reflect"
 	"text/template"
 
 	"github.com/go-openapi/swag"
@@ -298,7 +297,7 @@ func (m *ManifestsGenerator) createDiskEncryptionManifest(ctx context.Context, l
 
 func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
 
-	if reflect.DeepEqual(c.DiskEncryption, &models.DiskEncryption{}) {
+	if swag.StringValue(c.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return nil
 	}
 

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -548,7 +548,12 @@ var _ = Describe("disk encryption manifest", func() {
 			numOfManifests: 1,
 		},
 		{
-			name:           "disks encryption not set",
+			name: "disks encryption not set",
+			// This is the default values for disk_encryption
+			diskEncryption: &models.DiskEncryption{
+				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+			},
 			numOfManifests: 0,
 		},
 	} {


### PR DESCRIPTION

# Assisted Pull Request

## Description

Until now we were just checking that the disk-encryption object is
empty, but we recently added default values to disk-encryption feature
that always fill the object with data in such way that the 'enable_on'
field is set to 'none' by default, therefore, the condition for disabled
disk-encryption has changed.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
