### PR TITLE
NO-ISSUE: changing the condition that check if disk-encryption is enabled

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	reflect "reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -2660,7 +2659,7 @@ func (b *bareMetalInventory) updateDhcpNetworkParams(updates map[string]interfac
 
 func (b *bareMetalInventory) setDiskEncryptionUsage(c *models.Cluster, diskEncryption *models.DiskEncryption, usages map[string]models.Usage) {
 
-	if c.DiskEncryption == nil || reflect.DeepEqual(c.DiskEncryption, &models.DiskEncryption{}) {
+	if c.DiskEncryption == nil || swag.StringValue(c.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return
 	}
 

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -29,6 +29,10 @@ func GenerateTestCluster(clusterID strfmt.UUID, machineNetworks []*models.Machin
 			MachineNetworks: machineNetworks,
 			Platform:        &models.Platform{Type: models.PlatformTypeBaremetal},
 			Kind:            swag.String(models.ClusterKindCluster),
+			DiskEncryption: &models.DiskEncryption{
+				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+			},
 		},
 	}
 }

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"reflect"
 	"strings"
 	"time"
 
@@ -360,7 +359,7 @@ func isDiskEncryptionEnabledForRole(encryption models.DiskEncryption, role model
 
 func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) ValidationStatus {
 
-	if c.infraEnv != nil || reflect.DeepEqual(c.cluster.DiskEncryption, &models.DiskEncryption{}) {
+	if c.infraEnv != nil || swag.StringValue(c.cluster.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return ValidationSuccessSuppressOutput
 	}
 
@@ -1194,7 +1193,7 @@ func printIsDomainNameResolvedCorrectly(c *validationContext, status ValidationS
 		}
 		return fmt.Sprintf("Domain name resolution was successful for domain %s", domainName)
 	case ValidationFailure:
-		return fmt.Sprintf("Couldn’t resolve domain name “%s” on the host. To continue installation, create the necessary DNS entries to resolve this domain name to your %s.", domainName, destination)
+		return fmt.Sprintf("Couldn't resolve domain name %s on the host. To continue installation, create the necessary DNS entries to resolve this domain name to your %s.", domainName, destination)
 	case ValidationError:
 		return "Parse error for domain name resolutions result"
 	default:

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	reflect "reflect"
 	"text/template"
 
 	"github.com/go-openapi/swag"
@@ -298,7 +297,7 @@ func (m *ManifestsGenerator) createDiskEncryptionManifest(ctx context.Context, l
 
 func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log logrus.FieldLogger, c *common.Cluster) error {
 
-	if reflect.DeepEqual(c.DiskEncryption, &models.DiskEncryption{}) {
+	if swag.StringValue(c.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone {
 		return nil
 	}
 

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -548,7 +548,12 @@ var _ = Describe("disk encryption manifest", func() {
 			numOfManifests: 1,
 		},
 		{
-			name:           "disks encryption not set",
+			name: "disks encryption not set",
+			// This is the default values for disk_encryption
+			diskEncryption: &models.DiskEncryption{
+				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
+				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
+			},
 			numOfManifests: 0,
 		},
 	} {


### PR DESCRIPTION
Backported from #2887 

Until now we were just checking that the disk-encryption object is
empty, but we recently added default values to disk-encryption feature
that always fill the object with data in such a way that the 'enable_on'
field is set to 'none' by default, therefore, the condition for disabled
disk-encryption has changed.