### PR TITLE
MGMT-8196: Use postgresql-12-centos7:latest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,8 +447,8 @@ endif
 
 unit-test:
 	docker ps -q --filter "name=postgres" | xargs -r docker kill && sleep 3
-	docker run -d  --rm --tmpfs /var/lib/postgresql/data --name postgres -e POSTGRES_PASSWORD=admin -e POSTGRES_USER=admin -p 127.0.0.1:5432:5432 \
-		quay.io/ocpmetal/postgres:12.3-alpine -c 'max_connections=10000'
+	docker run -d  --rm --tmpfs /var/lib/postgresql/data --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 -p 127.0.0.1:5432:5432 \
+	quay.io/edge-infrastructure/postgresql-12-centos7:latest
 	timeout 5m ./hack/wait_for_postgres.sh
 	SKIP_UT_DB=1 $(MAKE) _test TEST_SCENARIO=unit TIMEOUT=30m TEST="$(or $(TEST),$(shell go list ./... | grep -v subsystem))" || (docker kill postgres && /bin/false)
 	docker kill postgres

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -4,6 +4,7 @@ The assisted-installer tests are divided into 3 categories:
 
 * **Unit tests** - Focused on a module/function level while other modules are mocked.
 Unit tests are located in the package, where the code they are testing resides, using the pattern `<module_name>_test.go`.
+Unit tests needs a postgresql db container. The image for db container `quay.io/edge-infrastructure/postgresql-12-centos7:latest` is built from `https://github.com/sclorg/postgresql-container`
 
 * **Subsystem tests** - Focused on the component while mocking other component.
 For example, assisted-service subsystem tests mock the agent responses.

--- a/hack/wait_for_postgres.sh
+++ b/hack/wait_for_postgres.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-PG_USER=admin
+PG_USER=postgres
 PG_DATABASE=postgres
 PG_HOST=127.0.0.1
 PG_PORT=5432

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -47,9 +47,9 @@ func InitializeDBTest() {
 		oldResource.Close()
 	}
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "postgres",
-		Tag:        "12.3-alpine",
-		Env:        []string{"POSTGRES_PASSWORD=admin", "POSTGRES_USER=admin"},
+		Repository: "postgresql-12-centos7",
+		Tag:        "latest",
+		Env:        []string{"POSTGRESQL_ADMIN_PASSWORD=admin"},
 		Name:       dbDockerName,
 	})
 	Expect(err).ShouldNot(HaveOccurred())
@@ -61,7 +61,7 @@ func InitializeDBTest() {
 	err = gDbCtx.pool.Retry(func() error {
 		var er error
 
-		dbTemp, er = gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+		dbTemp, er = gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=admin sslmode=disable", gDbCtx.GetPort()))
 		return er
 	})
 	Expect(err).ShouldNot(HaveOccurred())
@@ -87,7 +87,7 @@ func randomDBName() string {
 
 func PrepareTestDB(extrasSchemas ...interface{}) (*gorm.DB, string) {
 	dbName := randomDBName()
-	dbTemp, err := gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+	dbTemp, err := gorm.Open("postgres", fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=admin sslmode=disable", gDbCtx.GetPort()))
 	Expect(err).ShouldNot(HaveOccurred())
 	defer dbTemp.Close()
 
@@ -95,7 +95,7 @@ func PrepareTestDB(extrasSchemas ...interface{}) (*gorm.DB, string) {
 	Expect(dbTemp.Error).ShouldNot(HaveOccurred())
 
 	db, err := gorm.Open("postgres",
-		fmt.Sprintf("host=127.0.0.1 port=%s dbname=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort(), dbName))
+		fmt.Sprintf("host=127.0.0.1 port=%s dbname=%s user=postgres password=admin sslmode=disable", gDbCtx.GetPort(), dbName))
 	Expect(err).ShouldNot(HaveOccurred())
 	// db = db.Debug()
 	err = AutoMigrate(db)
@@ -114,7 +114,7 @@ func DeleteTestDB(db *gorm.DB, dbName string) {
 	db.Close()
 
 	db, err := gorm.Open("postgres",
-		fmt.Sprintf("host=127.0.0.1 port=%s user=admin password=admin sslmode=disable", gDbCtx.GetPort()))
+		fmt.Sprintf("host=127.0.0.1 port=%s user=postgres password=admin sslmode=disable", gDbCtx.GetPort()))
 	Expect(err).ShouldNot(HaveOccurred())
 	defer db.Close()
 	db = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s;", dbName))


### PR DESCRIPTION
# Assisted Pull Request

## Description
Use `quay.io/edge-infrastructure/postgresql-12-centos7:latest` image. Use only one consistent Postgres image in the existing code. Currently, we have 2 different images in the code - `quay.io/ocpmetal/postgres:12.3-alpine` and `quay.io/ocpmetal/postgresql-12-centos7` which is now the same as `quay.io/edge-infrastructure/postgresql-12-centos7:latest`. 

Some additional changes such as the use of `postgres` user for test cases are added to address the `pq: permission denied` error while creating a database. Also, the password for the admin account `postgres` is added using POSTGRESQL_ADMIN_PASSWORD env var.

Ref: https://issues.redhat.com/browse/MGMT-8196
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
` skipper make unit-test`
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
