### PR TITLE
MGMT-8198: Rename host_cluster_registered to host_registration_succeeded

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -615,13 +615,14 @@ x-events:
     host_name: string
     approved_value: bool
 
-- name: host_cluster_registered
-  message: "Host {host_name}: registered to cluster"
+- name: host_registration_succeeded
+  message: "Host {host_name}: Successfully registered"
   event_type: host
   severity: "info"
   properties:
     host_id: UUID
     infra_env_id: UUID
+    cluster_id: UUID_PTR
     host_name: string
 
 - name: generate_image_format_failed

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6270,9 +6270,8 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		return common.GenerateErrorResponder(err)
 	}
 
-	// TODO Need event for infra-env instead of cluster
-	eventgen.SendHostClusterRegisteredEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID,
-		params.InfraEnvID, hostutil.GetHostnameForMsg(host))
+	eventgen.SendHostRegistrationSucceededEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID,
+		params.InfraEnvID, host.ClusterID, hostutil.GetHostnameForMsg(host))
 
 	hostRegistration := models.HostRegistrationResponse{
 		Host:                  *host,

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1348,7 +1348,7 @@ var _ = Describe("RegisterHost", func() {
 				mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-					eventstest.WithNameMatcher(eventgen.HostClusterRegisteredEventName),
+					eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
 					eventstest.WithHostIdMatcher(hostID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 
@@ -1393,7 +1393,7 @@ var _ = Describe("RegisterHost", func() {
 			}).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostClusterRegisteredEventName),
+			eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
 			eventstest.WithHostIdMatcher(hostID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 		mockHostApi.EXPECT().UnRegisterHost(ctx, hostID.String(), infraEnv.ID.String()).Return(nil).Times(1)
@@ -1531,7 +1531,7 @@ var _ = Describe("v2RegisterHost", func() {
 				mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-					eventstest.WithNameMatcher(eventgen.HostClusterRegisteredEventName),
+					eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
 					eventstest.WithHostIdMatcher(hostID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 
@@ -1578,7 +1578,7 @@ var _ = Describe("v2RegisterHost", func() {
 		mockHostApi.EXPECT().UnRegisterHost(ctx, hostID.String(), infraEnv.ID.String()).Return(nil).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostClusterRegisteredEventName),
+			eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
 			eventstest.WithHostIdMatcher(hostID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
@@ -1643,7 +1643,7 @@ var _ = Describe("v2RegisterHost", func() {
 				return nil
 			}).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostClusterRegisteredEventName),
+			eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
 			eventstest.WithHostIdMatcher(hostId.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvId.String()))).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -5490,85 +5490,93 @@ func (e *HostApprovedUpdatedEvent) FormatMessage() string {
 }
 
 //
-// Event host_cluster_registered
+// Event host_registration_succeeded
 //
-type HostClusterRegisteredEvent struct {
+type HostRegistrationSucceededEvent struct {
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
     HostName string
 }
 
-var HostClusterRegisteredEventName string = "host_cluster_registered"
+var HostRegistrationSucceededEventName string = "host_registration_succeeded"
 
-func NewHostClusterRegisteredEvent(
+func NewHostRegistrationSucceededEvent(
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostName string,
-) *HostClusterRegisteredEvent {
-    return &HostClusterRegisteredEvent{
+) *HostRegistrationSucceededEvent {
+    return &HostRegistrationSucceededEvent{
         HostId: hostId,
         InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
         HostName: hostName,
     }
 }
 
-func SendHostClusterRegisteredEvent(
+func SendHostRegistrationSucceededEvent(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostName string,) {
-    ev := NewHostClusterRegisteredEvent(
+    ev := NewHostRegistrationSucceededEvent(
         hostId,
         infraEnvId,
+        clusterId,
         hostName,
     )
     eventsHandler.SendHostEvent(ctx, ev)
 }
 
-func SendHostClusterRegisteredEventAtTime(
+func SendHostRegistrationSucceededEventAtTime(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     hostName string,
     eventTime time.Time) {
-    ev := NewHostClusterRegisteredEvent(
+    ev := NewHostRegistrationSucceededEvent(
         hostId,
         infraEnvId,
+        clusterId,
         hostName,
     )
     eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
 }
 
-func (e *HostClusterRegisteredEvent) GetName() string {
-    return "host_cluster_registered"
+func (e *HostRegistrationSucceededEvent) GetName() string {
+    return "host_registration_succeeded"
 }
 
-func (e *HostClusterRegisteredEvent) GetSeverity() string {
+func (e *HostRegistrationSucceededEvent) GetSeverity() string {
     return "info"
 }
-func (e *HostClusterRegisteredEvent) GetClusterId() *strfmt.UUID {
-    return nil
+func (e *HostRegistrationSucceededEvent) GetClusterId() *strfmt.UUID {
+    return e.ClusterId
 }
-func (e *HostClusterRegisteredEvent) GetHostId() strfmt.UUID {
+func (e *HostRegistrationSucceededEvent) GetHostId() strfmt.UUID {
     return e.HostId
 }
-func (e *HostClusterRegisteredEvent) GetInfraEnvId() strfmt.UUID {
+func (e *HostRegistrationSucceededEvent) GetInfraEnvId() strfmt.UUID {
     return e.InfraEnvId
 }
 
-func (e *HostClusterRegisteredEvent) format(message *string) string {
+func (e *HostRegistrationSucceededEvent) format(message *string) string {
     r := strings.NewReplacer(
         "{host_id}", fmt.Sprint(e.HostId),
         "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{host_name}", fmt.Sprint(e.HostName),
     )
     return r.Replace(*message)
 }
 
-func (e *HostClusterRegisteredEvent) FormatMessage() string {
-    s := "Host {host_name}: registered to cluster"
+func (e *HostRegistrationSucceededEvent) FormatMessage() string {
+    s := "Host {host_name}: Successfully registered"
     return e.format(&s)
 }
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

This event is only used once in V2RegisterHost with InfraEnv[1].
The rationale for renaming is:
1. Event name should be on par with the respective cluster
   event: cluster_registration_succeeded
2. host_registration_succeeded is on par with host_registration_failed.
3. The event does not include a cluster id.

[1] https://github.com/openshift/assisted-service/blob/c48bcdf24e33c114545089df0ae90fa27b926e24/internal/bminventory/inventory.go#L6273-L6275

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @masayag 
/cc @arielireni  
/cc @avishayt  
## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
