### PR TITLE
MGMT-7330: Create a job in prow CI to run assisted-service unit tests

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,10 +1,21 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM quay.io/edge-infrastructure/postgresql-12-centos7:latest
 
-ENV GO111MODULE=on
-ENV GOFLAGS=""
+ENV GOPATH=/go
+ENV GOROOT=/usr/local/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+USER 0
+
+RUN yum install -y epel-release && yum install -y gcc genisoimage jq
+
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.16 /usr/bin/git /usr/bin/gotestsum /usr/bin/make /usr/bin/
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.16 /usr/local/go /usr/local/go
+
 
 COPY ./hack/setup_env.sh ./dev-requirements.txt ./
 RUN ./setup_env.sh assisted_service
+
+RUN chmod g+xw -R $GOPATH && chmod g+xw -R $(go env GOROOT)
 
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -44,7 +44,7 @@ function assisted_service() {
   curl --retry 5 -L "https://dl.k8s.io/release/${latest_kubectl_version}/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
     install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
     rm -f /tmp/kubectl
-  yum install -y docker podman libvirt-clients awscli python3-pip postgresql genisoimage skopeo p7zip && \
+  yum install -y docker podman libvirt-clients awscli python3-pip genisoimage skopeo p7zip && \
     yum clean all
 
   kustomize

--- a/hack/start_db.sh
+++ b/hack/start_db.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -euo pipefail
+set -o errexit
+
+mkdir -p /tmp/postgres/data
+mkdir -p /tmp/postgres/sockets
+
+/usr/bin/initdb -D /tmp/postgres/data -U postgres
+/opt/rh/rh-postgresql12/root/usr/bin/pg_ctl -D /tmp/postgres/data -l /tmp/postgres/logfile -o'-k /tmp/postgres/sockets' start

--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -47,7 +47,7 @@ func InitializeDBTest() {
 		oldResource.Close()
 	}
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-		Repository: "postgresql-12-centos7",
+		Repository: "quay.io/edge-infrastructure/postgresql-12-centos7",
 		Tag:        "latest",
 		Env:        []string{"POSTGRESQL_ADMIN_PASSWORD=admin"},
 		Name:       dbDockerName,


### PR DESCRIPTION
# Assisted Pull Request

## Description
Instead of the current `unit-test` target which does multiple things in one target -  create a docker DB, run unit tests and clean/kill docker db container, create separate targets for each task. 
- `run-db-container` only creates a container database
- `run-unit-test` runs the unit tests
- `kill-db-container` kills the DB container

The current `unit-test` target functionality remains as-is for local development - `unit-test` calls `run-db-container`, ` run-unit-test` and `kill-db-container`.

For running unit tests in CI, the assisted-service-build dockerfile is updated to use `quay.io/edge-infrastructure/postgresql-12-centos7:latest` as the base image and installs required dependencies. When running unit tests in CI job, invoke `make ci-unit-test` which will first start the database, and then invoke `run-unit-test` which will run the unit tests.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
The current `unit-test` target functionality remains as-is for local development - unit-test calls run-db-container, run-unit-test, and kill-db-container. When running unit tests in CI job, invoke make ci-unit-test which will first start the database, and then invoke just-unit-test which will run the unit tests. Run `skipper make ci-unit-test` to test running the unit tests in CI.
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
