### PR TITLE
Bug 2014262: No cache no client cause hub gotta speak to spoke when retrying

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -206,6 +206,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if result.Stop(ctx) {
+		log.Debugf("Stopping BMAC reconcile after reconcileBMH")
 		return result.Result()
 	}
 
@@ -219,6 +220,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	// handle multiple agents matching the
 	// same BMH's Mac Address
 	if agent == nil {
+		log.Debugf("Stopping BMAC reconcile after findAgent")
 		return result.Result()
 	}
 
@@ -236,6 +238,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if result.Stop(ctx) {
+		log.Debugf("Stopping BMAC reconcile after reconcileAgentSpec")
 		return result.Result()
 	}
 
@@ -249,6 +252,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if result.Stop(ctx) {
+		log.Debugf("Stopping BMAC reconcile after reconcileAgentInventory")
 		return result.Result()
 	}
 
@@ -262,6 +266,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if result.Stop(ctx) {
+		log.Debugf("Stopping BMAC reconcile after ensureMCSCert")
 		return result.Result()
 	}
 
@@ -277,6 +282,7 @@ func (r *BMACReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (c
 	}
 
 	if result.Stop(ctx) {
+		log.Debugf("Stopping BMAC reconcile after add detached annotation")
 		return result.Result()
 	}
 
@@ -408,12 +414,14 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 
 	bmhAnnotations := bmh.ObjectMeta.GetAnnotations()
 	if _, ok := bmhAnnotations[BMH_HARDWARE_DETAILS_ANNOTATION]; ok {
+		log.Debugf("%s annotation exists", BMH_HARDWARE_DETAILS_ANNOTATION)
 		return reconcileComplete{}
 	}
 
 	// Check whether HardwareDetails has been set already. This annotation
 	// status should only be set through this Reconcile in this scenario.
 	if bmh.Status.HardwareDetails != nil && bmh.Status.HardwareDetails.Hostname != "" {
+		log.Debugf("HardwareDetails or Hostname already present in the BMH")
 		return reconcileComplete{}
 	}
 
@@ -1028,6 +1036,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 
 	secret, err := getSecret(ctx, r.Client, r.APIReader, key)
 	if err != nil {
+		log.WithError(err).Errorf("failed to get secret %s", key)
 		return reconcileError{err}
 	}
 
@@ -1039,6 +1048,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 
 	MCSCert, ignitionWithMCSCert, err := r.createIgnitionWithMCSCert(ctx, log, spokeClient)
 	if err != nil {
+		log.WithError(err).Errorf("failed to create ignition with mcs cert")
 		return reconcileError{err}
 	}
 	if bmh.ObjectMeta.Annotations == nil {

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1232,11 +1232,14 @@ func (r *BMACReconciler) newSpokeMachine(bmh *bmh_v1alpha1.BareMetalHost, cluste
 
 func (r *BMACReconciler) getSpokeClient(secret *corev1.Secret) (client.Client, error) {
 	var err error
+	// We only set `spokeClient` during tests. Do not
+	// set it as it would cache the client, which would
+	// make the reconcile useless to manage multiple spoke
+	// clusters.
 	if r.spokeClient != nil {
 		return r.spokeClient, err
 	}
-	r.spokeClient, err = getSpokeClient(secret)
-	return r.spokeClient, err
+	return getSpokeClient(secret)
 }
 
 // Returns a list of BMH ReconcileRequests for a given Agent


### PR DESCRIPTION
# Assisted Pull Request

## Description

BMAC currently caches the spokeClient instance. This was originally done as an optimization
to avoid creating client instances on very loop. Unfortunatelly, this causes issues as the spokeClient
instance being cached is able to speak to just one spoke cluster, whereas BMAC should be able to speak
to many spoke clusters when adding day2 workers.

Ultimately, the caching was not really needed as BMAC stops reconciling BMH CRs that have been detached, which
reduces the number of times it has to talk to the spoke cluster

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tests were done in a QE environment /cc @trewest 

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pawanpinjarkar 
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
