### PR TITLE
MGMT-8200: Fix controller crash when import installed cluster 

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -819,7 +819,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		Kind:               swag.String(models.ClusterKindAddHostsCluster),
 		Name:               clusterName,
 		OpenshiftVersion:   *releaseImage.Version,
-		OpenshiftClusterID: *params.NewImportClusterParams.OpenshiftClusterID,
+		OpenshiftClusterID: common.StrFmtUUIDVal(params.NewImportClusterParams.OpenshiftClusterID),
 		OcpReleaseImage:    *releaseImage.URL,
 		UserName:           ocm.UserNameFromContext(ctx),
 		OrgID:              ocm.OrgIDFromContext(ctx),

--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -1,6 +1,9 @@
 package common
 
-import "github.com/openshift/assisted-service/models"
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/openshift/assisted-service/models"
+)
 
 func PlatformTypePtr(p models.PlatformType) *models.PlatformType {
 	return &p
@@ -33,4 +36,11 @@ func LogStateValue(l *models.LogsState) models.LogsState {
 		return ""
 	}
 	return *l
+}
+
+func StrFmtUUIDVal(u *strfmt.UUID) strfmt.UUID {
+	if u == nil {
+		return ""
+	}
+	return *u
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1059,6 +1059,12 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 		OpenshiftVersion: swag.String(*releaseImage.Version),
 	}
 
+	// add optional parameter
+	if clusterInstall.Spec.ClusterMetadata != nil {
+		cid := strfmt.UUID(clusterInstall.Spec.ClusterMetadata.ClusterID)
+		clusterParams.OpenshiftClusterID = &cid
+	}
+
 	c, err := r.Installer.V2ImportClusterInternal(ctx, &key, &id, installer.V2ImportClusterParams{
 		NewImportClusterParams: clusterParams,
 	}, true)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3277,6 +3277,26 @@ spec:
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterSyncedOkReason)
 		checkAgentClusterInstallConditionConsistency(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterSyncedOkReason)
 	})
+
+	It("import installed cluster", func() {
+		By("deploy installed cluster deployment")
+		clusterDeploymentSpec.Installed = true
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		By("deploy agent cluster install")
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+
+		By("check ACI conditions")
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterSyncedOkReason)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterCompletedCondition, hiveext.ClusterStoppedCompletedReason)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterAlreadyInstallingReason)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterValidatedCondition, hiveext.ClusterValidationsPassingReason)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterFailedCondition, hiveext.ClusterNotFailedReason)
+	})
+
 })
 
 var _ = Describe("bmac reconcile flow", func() {


### PR DESCRIPTION
# Assisted Pull Request

## Description

* Reset API require OpenshiftClusterID in V2ImportClusterInternal but because it is in internal function it can be called without OpenshiftClusterID, for example by controller packages, because this parameter is not required for the ACM we can skip it in the controller.
* Importing cluster can add optional parameter OpenshiftClusterID when creating day2 clsuter without having day1 (import cluster) OpenshiftClusterID is added by setting ACI.spec.clusterMetadata.clusterID
* Add subsystem test that create installed CD and ACI to check that cluster can be imported without being installed by AI controller.

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @nmagnezi 
/cc @rollandf 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
