### PR TITLE
NO-ISSUE: align spelling of infra-env in swagger descriptions

### DIFF
--- a/client/events/v2_list_events_parameters.go
+++ b/client/events/v2_list_events_parameters.go
@@ -84,7 +84,7 @@ type V2ListEventsParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env to return events for.
+	   The infra-env to return events for.
 
 	   Format: uuid
 	*/

--- a/client/installer/bind_host_parameters.go
+++ b/client/installer/bind_host_parameters.go
@@ -77,7 +77,7 @@ type BindHostParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that is being bound.
+	   The infra-env of the host that is being bound.
 
 	   Format: uuid
 	*/

--- a/client/installer/deregister_infra_env_parameters.go
+++ b/client/installer/deregister_infra_env_parameters.go
@@ -61,7 +61,7 @@ type DeregisterInfraEnvParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv to be deleted.
+	   The infra-env to be deleted.
 
 	   Format: uuid
 	*/

--- a/client/installer/download_infra_env_discovery_image_headers_parameters.go
+++ b/client/installer/download_infra_env_discovery_image_headers_parameters.go
@@ -61,7 +61,7 @@ type DownloadInfraEnvDiscoveryImageHeadersParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv whose image headers should be retrieved.
+	   The infra-env whose image headers should be retrieved.
 
 	   Format: uuid
 	*/

--- a/client/installer/download_infra_env_discovery_image_parameters.go
+++ b/client/installer/download_infra_env_discovery_image_parameters.go
@@ -61,7 +61,7 @@ type DownloadInfraEnvDiscoveryImageParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv whose image should be downloaded.
+	   The infra-env whose image should be downloaded.
 
 	   Format: uuid
 	*/

--- a/client/installer/download_minimal_initrd_parameters.go
+++ b/client/installer/download_minimal_initrd_parameters.go
@@ -61,7 +61,7 @@ type DownloadMinimalInitrdParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that should be retrieved.
+	   The infra-env of the host that should be retrieved.
 
 	   Format: uuid
 	*/

--- a/client/installer/get_infra_env_parameters.go
+++ b/client/installer/get_infra_env_parameters.go
@@ -61,7 +61,7 @@ type GetInfraEnvParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv to be retrieved.
+	   The infra-env to be retrieved.
 
 	   Format: uuid
 	*/

--- a/client/installer/installer_client.go
+++ b/client/installer/installer_client.go
@@ -34,7 +34,7 @@ type API interface {
 	   DeregisterHost Deregisters an OpenShift host.*/
 	DeregisterHost(ctx context.Context, params *DeregisterHostParams) (*DeregisterHostNoContent, error)
 	/*
-	   DeregisterInfraEnv Deletes an InfraEnv.*/
+	   DeregisterInfraEnv Deletes an infra-env.*/
 	DeregisterInfraEnv(ctx context.Context, params *DeregisterInfraEnvParams) (*DeregisterInfraEnvNoContent, error)
 	/*
 	   DisableHost Disables a host for inclusion in the cluster.*/
@@ -110,7 +110,7 @@ type API interface {
 	   GetHostIgnition Get the customized ignition file for this host as a string*/
 	GetHostIgnition(ctx context.Context, params *GetHostIgnitionParams) (*GetHostIgnitionOK, error)
 	/*
-	   GetInfraEnv Retrieves the details of the InfraEnv.*/
+	   GetInfraEnv Retrieves the details of the infra-env.*/
 	GetInfraEnv(ctx context.Context, params *GetInfraEnvParams) (*GetInfraEnvOK, error)
 	/*
 	   GetPreflightRequirements Get preflight requirements for a cluster.*/
@@ -134,7 +134,7 @@ type API interface {
 	   ListHosts Retrieves the list of OpenShift hosts.*/
 	ListHosts(ctx context.Context, params *ListHostsParams) (*ListHostsOK, error)
 	/*
-	   ListInfraEnvs Retrieves the list of InfraEnvs.*/
+	   ListInfraEnvs Retrieves the list of infra-envs.*/
 	ListInfraEnvs(ctx context.Context, params *ListInfraEnvsParams) (*ListInfraEnvsOK, error)
 	/*
 	   RegenerateInfraEnvSigningKey Regenerate InfraEnv token signing key.*/
@@ -187,7 +187,7 @@ type API interface {
 	   UpdateHostLogsProgress Update log collection state and progress.*/
 	UpdateHostLogsProgress(ctx context.Context, params *UpdateHostLogsProgressParams) (*UpdateHostLogsProgressNoContent, error)
 	/*
-	   UpdateInfraEnv Updates an InfraEnv.*/
+	   UpdateInfraEnv Updates an infra-env.*/
 	UpdateInfraEnv(ctx context.Context, params *UpdateInfraEnvParams) (*UpdateInfraEnvCreated, error)
 	/*
 	   UploadClusterIngressCert Transfer the ingress certificate for the cluster.*/
@@ -277,7 +277,7 @@ type API interface {
 	   V2ListFeatureSupportLevels Retrieves the support levels for features for each OpenShift version.*/
 	V2ListFeatureSupportLevels(ctx context.Context, params *V2ListFeatureSupportLevelsParams) (*V2ListFeatureSupportLevelsOK, error)
 	/*
-	   V2ListHosts Retrieves the list of OpenShift hosts that belong to infra-env.*/
+	   V2ListHosts Retrieves the list of OpenShift hosts that belong the infra-env.*/
 	V2ListHosts(ctx context.Context, params *V2ListHostsParams) (*V2ListHostsOK, error)
 	/*
 	   V2PostStepReply Posts the result of the operations from the host agent.*/
@@ -469,7 +469,7 @@ func (a *Client) DeregisterHost(ctx context.Context, params *DeregisterHostParam
 }
 
 /*
-DeregisterInfraEnv Deletes an InfraEnv.
+DeregisterInfraEnv Deletes an infra-env.
 */
 func (a *Client) DeregisterInfraEnv(ctx context.Context, params *DeregisterInfraEnvParams) (*DeregisterInfraEnvNoContent, error) {
 
@@ -1079,7 +1079,7 @@ func (a *Client) GetHostIgnition(ctx context.Context, params *GetHostIgnitionPar
 }
 
 /*
-GetInfraEnv Retrieves the details of the InfraEnv.
+GetInfraEnv Retrieves the details of the infra-env.
 */
 func (a *Client) GetInfraEnv(ctx context.Context, params *GetInfraEnvParams) (*GetInfraEnvOK, error) {
 
@@ -1279,7 +1279,7 @@ func (a *Client) ListHosts(ctx context.Context, params *ListHostsParams) (*ListH
 }
 
 /*
-ListInfraEnvs Retrieves the list of InfraEnvs.
+ListInfraEnvs Retrieves the list of infra-envs.
 */
 func (a *Client) ListInfraEnvs(ctx context.Context, params *ListInfraEnvsParams) (*ListInfraEnvsOK, error) {
 
@@ -1706,7 +1706,7 @@ func (a *Client) UpdateHostLogsProgress(ctx context.Context, params *UpdateHostL
 }
 
 /*
-UpdateInfraEnv Updates an InfraEnv.
+UpdateInfraEnv Updates an infra-env.
 */
 func (a *Client) UpdateInfraEnv(ctx context.Context, params *UpdateInfraEnvParams) (*UpdateInfraEnvCreated, error) {
 
@@ -2456,7 +2456,7 @@ func (a *Client) V2ListFeatureSupportLevels(ctx context.Context, params *V2ListF
 }
 
 /*
-V2ListHosts Retrieves the list of OpenShift hosts that belong to infra-env.
+V2ListHosts Retrieves the list of OpenShift hosts that belong the infra-env.
 */
 func (a *Client) V2ListHosts(ctx context.Context, params *V2ListHostsParams) (*V2ListHostsOK, error) {
 

--- a/client/installer/unbind_host_parameters.go
+++ b/client/installer/unbind_host_parameters.go
@@ -69,7 +69,7 @@ type UnbindHostParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that is being bound.
+	   The infra-env of the host that is being bound.
 
 	   Format: uuid
 	*/

--- a/client/installer/update_infra_env_parameters.go
+++ b/client/installer/update_infra_env_parameters.go
@@ -69,7 +69,7 @@ type UpdateInfraEnvParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv to be updated.
+	   The infra-env to be updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_deregister_host_parameters.go
+++ b/client/installer/v2_deregister_host_parameters.go
@@ -69,7 +69,7 @@ type V2DeregisterHostParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that should be deregistered.
+	   The infra-env of the host that should be deregistered.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_download_infra_env_files_parameters.go
+++ b/client/installer/v2_download_infra_env_files_parameters.go
@@ -67,7 +67,7 @@ type V2DownloadInfraEnvFilesParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv whose file should be downloaded.
+	   The infra-env whose file should be downloaded.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_get_host_ignition_parameters.go
+++ b/client/installer/v2_get_host_ignition_parameters.go
@@ -69,7 +69,7 @@ type V2GetHostIgnitionParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host whose ignition file should be obtained.
+	   The infra-env of the host whose ignition file should be obtained.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_get_host_parameters.go
+++ b/client/installer/v2_get_host_parameters.go
@@ -69,7 +69,7 @@ type V2GetHostParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that should be retrieved.
+	   The infra-env of the host that should be retrieved.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_get_next_steps_parameters.go
+++ b/client/installer/v2_get_next_steps_parameters.go
@@ -75,7 +75,7 @@ type V2GetNextStepsParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that is retrieving instructions.
+	   The infra-env of the host that is retrieving instructions.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_install_host_parameters.go
+++ b/client/installer/v2_install_host_parameters.go
@@ -69,7 +69,7 @@ type V2InstallHostParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host that is being installed.
+	   The infra-env of the host that is being installed.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_list_hosts_parameters.go
+++ b/client/installer/v2_list_hosts_parameters.go
@@ -61,7 +61,7 @@ type V2ListHostsParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv that the hosts are asociated with.
+	   The infra-env that the hosts are asociated with.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_post_step_reply_parameters.go
+++ b/client/installer/v2_post_step_reply_parameters.go
@@ -77,7 +77,7 @@ type V2PostStepReplyParams struct {
 
 	/* InfraEnvID.
 
-	   The infra env of the host that is posting results.
+	   The infra-env of the host that is posting results.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_register_host_parameters.go
+++ b/client/installer/v2_register_host_parameters.go
@@ -69,7 +69,7 @@ type V2RegisterHostParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv that the agent is associated with.
+	   The infra-env that the agent is associated with.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_reset_host_parameters.go
+++ b/client/installer/v2_reset_host_parameters.go
@@ -69,7 +69,7 @@ type V2ResetHostParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host that is being reset.
+	   The infra-env of the host that is being reset.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_reset_host_validation_parameters.go
+++ b/client/installer/v2_reset_host_validation_parameters.go
@@ -69,7 +69,7 @@ type V2ResetHostValidationParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host that its validation is being reset.
+	   The infra-env of the host that its validation is being reset.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_update_host_ignition_parameters.go
+++ b/client/installer/v2_update_host_ignition_parameters.go
@@ -77,7 +77,7 @@ type V2UpdateHostIgnitionParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host whose ignition file should be updated.
+	   The infra-env of the host whose ignition file should be updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_update_host_install_progress_parameters.go
+++ b/client/installer/v2_update_host_install_progress_parameters.go
@@ -83,7 +83,7 @@ type V2UpdateHostInstallProgressParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host being updated.
+	   The infra-env of the host being updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_update_host_installer_args_parameters.go
+++ b/client/installer/v2_update_host_installer_args_parameters.go
@@ -71,7 +71,7 @@ type V2UpdateHostInstallerArgsParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv of the host whose installer arguments should be updated.
+	   The infra-env of the host whose installer arguments should be updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_update_host_logs_progress_parameters.go
+++ b/client/installer/v2_update_host_logs_progress_parameters.go
@@ -71,7 +71,7 @@ type V2UpdateHostLogsProgressParams struct {
 
 	/* InfraEnvID.
 
-	   The InfraEnv whose log progress is being updated.
+	   The infra-env whose log progress is being updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_update_host_parameters.go
+++ b/client/installer/v2_update_host_parameters.go
@@ -77,7 +77,7 @@ type V2UpdateHostParams struct {
 
 	/* InfraEnvID.
 
-	   The infra_env_id of the host to be updated.
+	   The infra-env ID of the host to be updated.
 
 	   Format: uuid
 	*/

--- a/client/installer/v2_upload_logs_parameters.go
+++ b/client/installer/v2_upload_logs_parameters.go
@@ -77,7 +77,7 @@ type V2UploadLogsParams struct {
 
 	/* InfraEnvID.
 
-	   The infra_env_id of the host.
+	   The infra-env ID of the host.
 
 	   Format: uuid
 	*/

--- a/models/event.go
+++ b/models/event.go
@@ -37,7 +37,7 @@ type Event struct {
 	// Format: uuid
 	HostID *strfmt.UUID `json:"host_id,omitempty" gorm:"index"`
 
-	// Unique identifier of the infra env this event relates to.
+	// Unique identifier of the infra-env this event relates to.
 	// Format: uuid
 	InfraEnvID *strfmt.UUID `json:"infra_env_id,omitempty" gorm:"index"`
 

--- a/models/host.go
+++ b/models/host.go
@@ -78,7 +78,7 @@ type Host struct {
 	// Array of image statuses.
 	ImagesStatus string `json:"images_status,omitempty" gorm:"type:text"`
 
-	// The InfraEnv that this host is associated with.
+	// The infra-env that this host is associated with.
 	// Format: uuid
 	InfraEnvID strfmt.UUID `json:"infra_env_id,omitempty" gorm:"primary_key;foreignkey:InfraEnvID"`
 

--- a/models/infra_env.go
+++ b/models/infra_env.go
@@ -66,7 +66,7 @@ type InfraEnv struct {
 	// Enum: [InfraEnv]
 	Kind *string `json:"kind"`
 
-	// Name of the InfraEnv.
+	// Name of the infra-env.
 	// Required: true
 	Name *string `json:"name"`
 
@@ -96,7 +96,7 @@ type InfraEnv struct {
 	// Required: true
 	Type *ImageType `json:"type"`
 
-	// The last time that this infraenv was updated.
+	// The last time that this infra-env was updated.
 	// Required: true
 	// Format: date-time
 	UpdatedAt *timeext.Time `json:"updated_at" gorm:"type:timestamp with time zone"`

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -36,7 +36,7 @@ type InfraEnvCreateParams struct {
 	// image type
 	ImageType ImageType `json:"image_type,omitempty"`
 
-	// Name of the InfraEnv.
+	// Name of the infra-env.
 	// Required: true
 	Name *string `json:"name"`
 

--- a/restapi/configure_assisted_install.go
+++ b/restapi/configure_assisted_install.go
@@ -72,7 +72,7 @@ type InstallerAPI interface {
 	/* DeregisterHost Deregisters an OpenShift host. */
 	DeregisterHost(ctx context.Context, params installer.DeregisterHostParams) middleware.Responder
 
-	/* DeregisterInfraEnv Deletes an InfraEnv. */
+	/* DeregisterInfraEnv Deletes an infra-env. */
 	DeregisterInfraEnv(ctx context.Context, params installer.DeregisterInfraEnvParams) middleware.Responder
 
 	/* DisableHost Disables a host for inclusion in the cluster. */
@@ -148,7 +148,7 @@ type InstallerAPI interface {
 	/* GetHostIgnition Get the customized ignition file for this host as a string */
 	GetHostIgnition(ctx context.Context, params installer.GetHostIgnitionParams) middleware.Responder
 
-	/* GetInfraEnv Retrieves the details of the InfraEnv. */
+	/* GetInfraEnv Retrieves the details of the infra-env. */
 	GetInfraEnv(ctx context.Context, params installer.GetInfraEnvParams) middleware.Responder
 
 	/* GetPreflightRequirements Get preflight requirements for a cluster. */
@@ -172,7 +172,7 @@ type InstallerAPI interface {
 	/* ListHosts Retrieves the list of OpenShift hosts. */
 	ListHosts(ctx context.Context, params installer.ListHostsParams) middleware.Responder
 
-	/* ListInfraEnvs Retrieves the list of InfraEnvs. */
+	/* ListInfraEnvs Retrieves the list of infra-envs. */
 	ListInfraEnvs(ctx context.Context, params installer.ListInfraEnvsParams) middleware.Responder
 
 	/* RegenerateInfraEnvSigningKey Regenerate InfraEnv token signing key. */
@@ -223,7 +223,7 @@ type InstallerAPI interface {
 	/* UpdateHostLogsProgress Update log collection state and progress. */
 	UpdateHostLogsProgress(ctx context.Context, params installer.UpdateHostLogsProgressParams) middleware.Responder
 
-	/* UpdateInfraEnv Updates an InfraEnv. */
+	/* UpdateInfraEnv Updates an infra-env. */
 	UpdateInfraEnv(ctx context.Context, params installer.UpdateInfraEnvParams) middleware.Responder
 
 	/* UploadClusterIngressCert Transfer the ingress certificate for the cluster. */
@@ -313,7 +313,7 @@ type InstallerAPI interface {
 	/* V2ListFeatureSupportLevels Retrieves the support levels for features for each OpenShift version. */
 	V2ListFeatureSupportLevels(ctx context.Context, params installer.V2ListFeatureSupportLevelsParams) middleware.Responder
 
-	/* V2ListHosts Retrieves the list of OpenShift hosts that belong to infra-env. */
+	/* V2ListHosts Retrieves the list of OpenShift hosts that belong the infra-env. */
 	V2ListHosts(ctx context.Context, params installer.V2ListHostsParams) middleware.Responder
 
 	/* V2PostStepReply Posts the result of the operations from the host agent. */

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5962,7 +5962,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra_env_id of the host.",
+            "description": "The infra-env ID of the host.",
             "name": "infra_env_id",
             "in": "query"
           },
@@ -6881,7 +6881,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env to return events for.",
+            "description": "The infra-env to return events for.",
             "name": "infra_env_id",
             "in": "query"
           },
@@ -7082,7 +7082,7 @@ func init() {
             ]
           }
         ],
-        "description": "Retrieves the list of InfraEnvs.",
+        "description": "Retrieves the list of infra-envs.",
         "tags": [
           "installer"
         ],
@@ -7221,7 +7221,7 @@ func init() {
             "agentAuth": []
           }
         ],
-        "description": "Retrieves the details of the InfraEnv.",
+        "description": "Retrieves the details of the infra-env.",
         "tags": [
           "installer"
         ],
@@ -7230,7 +7230,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be retrieved.",
+            "description": "The infra-env to be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7288,7 +7288,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Deletes an InfraEnv.",
+        "description": "Deletes an infra-env.",
         "tags": [
           "installer"
         ],
@@ -7297,7 +7297,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be deleted.",
+            "description": "The infra-env to be deleted.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7352,7 +7352,7 @@ func init() {
         }
       },
       "patch": {
-        "description": "Updates an InfraEnv.",
+        "description": "Updates an infra-env.",
         "tags": [
           "installer"
         ],
@@ -7361,7 +7361,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be updated.",
+            "description": "The infra-env to be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7466,7 +7466,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose file should be downloaded.",
+            "description": "The infra-env whose file should be downloaded.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7566,7 +7566,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose image should be downloaded.",
+            "description": "The infra-env whose image should be downloaded.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7649,7 +7649,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose image headers should be retrieved.",
+            "description": "The infra-env whose image headers should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7742,7 +7742,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be retrieved.",
+            "description": "The infra-env of the host that should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7812,7 +7812,7 @@ func init() {
             "agentAuth": []
           }
         ],
-        "description": "Retrieves the list of OpenShift hosts that belong to infra-env.",
+        "description": "Retrieves the list of OpenShift hosts that belong the infra-env.",
         "tags": [
           "installer"
         ],
@@ -7821,7 +7821,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv that the hosts are asociated with.",
+            "description": "The infra-env that the hosts are asociated with.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7887,7 +7887,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv that the agent is associated with.",
+            "description": "The infra-env that the agent is associated with.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -7992,7 +7992,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be retrieved.",
+            "description": "The infra-env of the host that should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8061,7 +8061,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be deregistered.",
+            "description": "The infra-env of the host that should be deregistered.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8127,7 +8127,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra_env_id of the host to be updated.",
+            "description": "The infra-env ID of the host to be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8213,7 +8213,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is being bound.",
+            "description": "The infra-env of the host that is being bound.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8305,7 +8305,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that is being installed.",
+            "description": "The infra-env of the host that is being installed.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8370,7 +8370,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that is being reset.",
+            "description": "The infra-env of the host that is being reset.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8436,7 +8436,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that its validation is being reset.",
+            "description": "The infra-env of the host that its validation is being reset.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8514,7 +8514,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is being bound.",
+            "description": "The infra-env of the host that is being bound.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8603,7 +8603,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host whose ignition file should be obtained.",
+            "description": "The infra-env of the host whose ignition file should be obtained.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8678,7 +8678,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host whose ignition file should be updated.",
+            "description": "The infra-env of the host whose ignition file should be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8761,7 +8761,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host whose installer arguments should be updated.",
+            "description": "The infra-env of the host whose installer arguments should be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8858,7 +8858,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is retrieving instructions.",
+            "description": "The infra-env of the host that is retrieving instructions.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -8950,7 +8950,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is posting results.",
+            "description": "The infra-env of the host that is posting results.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -9043,7 +9043,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose log progress is being updated.",
+            "description": "The infra-env whose log progress is being updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -9143,7 +9143,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host being updated.",
+            "description": "The infra-env of the host being updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -11060,7 +11060,7 @@ func init() {
           "x-nullable": true
         },
         "infra_env_id": {
-          "description": "Unique identifier of the infra env this event relates to.",
+          "description": "Unique identifier of the infra-env this event relates to.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"index\"",
@@ -11311,7 +11311,7 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:text\""
         },
         "infra_env_id": {
-          "description": "The InfraEnv that this host is associated with.",
+          "description": "The infra-env that this host is associated with.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primary_key;foreignkey:InfraEnvID\""
@@ -11914,7 +11914,7 @@ func init() {
           ]
         },
         "name": {
-          "description": "Name of the InfraEnv.",
+          "description": "Name of the infra-env.",
           "type": "string"
         },
         "openshift_version": {
@@ -11946,7 +11946,7 @@ func init() {
           "$ref": "#/definitions/image_type"
         },
         "updated_at": {
-          "description": "The last time that this infraenv was updated.",
+          "description": "The last time that this infra-env was updated.",
           "type": "string",
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\"",
@@ -11998,7 +11998,7 @@ func init() {
           "$ref": "#/definitions/image_type"
         },
         "name": {
-          "description": "Name of the InfraEnv.",
+          "description": "Name of the infra-env.",
           "type": "string"
         },
         "openshift_version": {
@@ -19348,7 +19348,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra_env_id of the host.",
+            "description": "The infra-env ID of the host.",
             "name": "infra_env_id",
             "in": "query"
           },
@@ -20267,7 +20267,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env to return events for.",
+            "description": "The infra-env to return events for.",
             "name": "infra_env_id",
             "in": "query"
           },
@@ -20468,7 +20468,7 @@ func init() {
             ]
           }
         ],
-        "description": "Retrieves the list of InfraEnvs.",
+        "description": "Retrieves the list of infra-envs.",
         "tags": [
           "installer"
         ],
@@ -20607,7 +20607,7 @@ func init() {
             "agentAuth": []
           }
         ],
-        "description": "Retrieves the details of the InfraEnv.",
+        "description": "Retrieves the details of the infra-env.",
         "tags": [
           "installer"
         ],
@@ -20616,7 +20616,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be retrieved.",
+            "description": "The infra-env to be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -20674,7 +20674,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Deletes an InfraEnv.",
+        "description": "Deletes an infra-env.",
         "tags": [
           "installer"
         ],
@@ -20683,7 +20683,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be deleted.",
+            "description": "The infra-env to be deleted.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -20738,7 +20738,7 @@ func init() {
         }
       },
       "patch": {
-        "description": "Updates an InfraEnv.",
+        "description": "Updates an infra-env.",
         "tags": [
           "installer"
         ],
@@ -20747,7 +20747,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv to be updated.",
+            "description": "The infra-env to be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -20852,7 +20852,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose file should be downloaded.",
+            "description": "The infra-env whose file should be downloaded.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -20952,7 +20952,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose image should be downloaded.",
+            "description": "The infra-env whose image should be downloaded.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21035,7 +21035,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose image headers should be retrieved.",
+            "description": "The infra-env whose image headers should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21128,7 +21128,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be retrieved.",
+            "description": "The infra-env of the host that should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21198,7 +21198,7 @@ func init() {
             "agentAuth": []
           }
         ],
-        "description": "Retrieves the list of OpenShift hosts that belong to infra-env.",
+        "description": "Retrieves the list of OpenShift hosts that belong the infra-env.",
         "tags": [
           "installer"
         ],
@@ -21207,7 +21207,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv that the hosts are asociated with.",
+            "description": "The infra-env that the hosts are asociated with.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21273,7 +21273,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv that the agent is associated with.",
+            "description": "The infra-env that the agent is associated with.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21378,7 +21378,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be retrieved.",
+            "description": "The infra-env of the host that should be retrieved.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21447,7 +21447,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that should be deregistered.",
+            "description": "The infra-env of the host that should be deregistered.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21513,7 +21513,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra_env_id of the host to be updated.",
+            "description": "The infra-env ID of the host to be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21599,7 +21599,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is being bound.",
+            "description": "The infra-env of the host that is being bound.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21691,7 +21691,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that is being installed.",
+            "description": "The infra-env of the host that is being installed.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21756,7 +21756,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that is being reset.",
+            "description": "The infra-env of the host that is being reset.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21822,7 +21822,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host that its validation is being reset.",
+            "description": "The infra-env of the host that its validation is being reset.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21900,7 +21900,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is being bound.",
+            "description": "The infra-env of the host that is being bound.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -21989,7 +21989,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host whose ignition file should be obtained.",
+            "description": "The infra-env of the host whose ignition file should be obtained.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22064,7 +22064,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host whose ignition file should be updated.",
+            "description": "The infra-env of the host whose ignition file should be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22147,7 +22147,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host whose installer arguments should be updated.",
+            "description": "The infra-env of the host whose installer arguments should be updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22244,7 +22244,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is retrieving instructions.",
+            "description": "The infra-env of the host that is retrieving instructions.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22336,7 +22336,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The infra env of the host that is posting results.",
+            "description": "The infra-env of the host that is posting results.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22429,7 +22429,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv whose log progress is being updated.",
+            "description": "The infra-env whose log progress is being updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -22529,7 +22529,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The InfraEnv of the host being updated.",
+            "description": "The infra-env of the host being updated.",
             "name": "infra_env_id",
             "in": "path",
             "required": true
@@ -24550,7 +24550,7 @@ func init() {
           "x-nullable": true
         },
         "infra_env_id": {
-          "description": "Unique identifier of the infra env this event relates to.",
+          "description": "Unique identifier of the infra-env this event relates to.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"index\"",
@@ -24768,7 +24768,7 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:text\""
         },
         "infra_env_id": {
-          "description": "The InfraEnv that this host is associated with.",
+          "description": "The infra-env that this host is associated with.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primary_key;foreignkey:InfraEnvID\""
@@ -25372,7 +25372,7 @@ func init() {
           ]
         },
         "name": {
-          "description": "Name of the InfraEnv.",
+          "description": "Name of the infra-env.",
           "type": "string"
         },
         "openshift_version": {
@@ -25405,7 +25405,7 @@ func init() {
           "$ref": "#/definitions/image_type"
         },
         "updated_at": {
-          "description": "The last time that this infraenv was updated.",
+          "description": "The last time that this infra-env was updated.",
           "type": "string",
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\"",
@@ -25457,7 +25457,7 @@ func init() {
           "$ref": "#/definitions/image_type"
         },
         "name": {
-          "description": "Name of the InfraEnv.",
+          "description": "Name of the infra-env.",
           "type": "string"
         },
         "openshift_version": {

--- a/restapi/operations/events/v2_list_events_parameters.go
+++ b/restapi/operations/events/v2_list_events_parameters.go
@@ -45,7 +45,7 @@ type V2ListEventsParams struct {
 	  In: query
 	*/
 	HostID *strfmt.UUID
-	/*The infra env to return events for.
+	/*The infra-env to return events for.
 	  In: query
 	*/
 	InfraEnvID *strfmt.UUID

--- a/restapi/operations/installer/bind_host_parameters.go
+++ b/restapi/operations/installer/bind_host_parameters.go
@@ -46,7 +46,7 @@ type BindHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that is being bound.
+	/*The infra-env of the host that is being bound.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/deregister_infra_env.go
+++ b/restapi/operations/installer/deregister_infra_env.go
@@ -31,7 +31,7 @@ func NewDeregisterInfraEnv(ctx *middleware.Context, handler DeregisterInfraEnvHa
 
 /* DeregisterInfraEnv swagger:route DELETE /v2/infra-envs/{infra_env_id} installer deregisterInfraEnv
 
-Deletes an InfraEnv.
+Deletes an infra-env.
 
 */
 type DeregisterInfraEnv struct {

--- a/restapi/operations/installer/deregister_infra_env_parameters.go
+++ b/restapi/operations/installer/deregister_infra_env_parameters.go
@@ -31,7 +31,7 @@ type DeregisterInfraEnvParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The InfraEnv to be deleted.
+	/*The infra-env to be deleted.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/download_infra_env_discovery_image_headers_parameters.go
+++ b/restapi/operations/installer/download_infra_env_discovery_image_headers_parameters.go
@@ -31,7 +31,7 @@ type DownloadInfraEnvDiscoveryImageHeadersParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The InfraEnv whose image headers should be retrieved.
+	/*The infra-env whose image headers should be retrieved.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/download_infra_env_discovery_image_parameters.go
+++ b/restapi/operations/installer/download_infra_env_discovery_image_parameters.go
@@ -31,7 +31,7 @@ type DownloadInfraEnvDiscoveryImageParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The InfraEnv whose image should be downloaded.
+	/*The infra-env whose image should be downloaded.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/download_minimal_initrd_parameters.go
+++ b/restapi/operations/installer/download_minimal_initrd_parameters.go
@@ -31,7 +31,7 @@ type DownloadMinimalInitrdParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The infra env of the host that should be retrieved.
+	/*The infra-env of the host that should be retrieved.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/get_infra_env.go
+++ b/restapi/operations/installer/get_infra_env.go
@@ -31,7 +31,7 @@ func NewGetInfraEnv(ctx *middleware.Context, handler GetInfraEnvHandler) *GetInf
 
 /* GetInfraEnv swagger:route GET /v2/infra-envs/{infra_env_id} installer getInfraEnv
 
-Retrieves the details of the InfraEnv.
+Retrieves the details of the infra-env.
 
 */
 type GetInfraEnv struct {

--- a/restapi/operations/installer/get_infra_env_parameters.go
+++ b/restapi/operations/installer/get_infra_env_parameters.go
@@ -31,7 +31,7 @@ type GetInfraEnvParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The InfraEnv to be retrieved.
+	/*The infra-env to be retrieved.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/list_infra_envs.go
+++ b/restapi/operations/installer/list_infra_envs.go
@@ -31,7 +31,7 @@ func NewListInfraEnvs(ctx *middleware.Context, handler ListInfraEnvsHandler) *Li
 
 /* ListInfraEnvs swagger:route GET /v2/infra-envs installer listInfraEnvs
 
-Retrieves the list of InfraEnvs.
+Retrieves the list of infra-envs.
 
 */
 type ListInfraEnvs struct {

--- a/restapi/operations/installer/unbind_host_parameters.go
+++ b/restapi/operations/installer/unbind_host_parameters.go
@@ -36,7 +36,7 @@ type UnbindHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that is being bound.
+	/*The infra-env of the host that is being bound.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/update_infra_env.go
+++ b/restapi/operations/installer/update_infra_env.go
@@ -31,7 +31,7 @@ func NewUpdateInfraEnv(ctx *middleware.Context, handler UpdateInfraEnvHandler) *
 
 /* UpdateInfraEnv swagger:route PATCH /v2/infra-envs/{infra_env_id} installer updateInfraEnv
 
-Updates an InfraEnv.
+Updates an infra-env.
 
 */
 type UpdateInfraEnv struct {

--- a/restapi/operations/installer/update_infra_env_parameters.go
+++ b/restapi/operations/installer/update_infra_env_parameters.go
@@ -41,7 +41,7 @@ type UpdateInfraEnvParams struct {
 	  In: body
 	*/
 	InfraEnvUpdateParams *models.InfraEnvUpdateParams
-	/*The InfraEnv to be updated.
+	/*The infra-env to be updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_deregister_host_parameters.go
+++ b/restapi/operations/installer/v2_deregister_host_parameters.go
@@ -36,7 +36,7 @@ type V2DeregisterHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that should be deregistered.
+	/*The infra-env of the host that should be deregistered.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_download_infra_env_files_parameters.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_parameters.go
@@ -37,7 +37,7 @@ type V2DownloadInfraEnvFilesParams struct {
 	  In: query
 	*/
 	FileName string
-	/*The InfraEnv whose file should be downloaded.
+	/*The infra-env whose file should be downloaded.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_get_host_ignition_parameters.go
+++ b/restapi/operations/installer/v2_get_host_ignition_parameters.go
@@ -36,7 +36,7 @@ type V2GetHostIgnitionParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host whose ignition file should be obtained.
+	/*The infra-env of the host whose ignition file should be obtained.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_get_host_parameters.go
+++ b/restapi/operations/installer/v2_get_host_parameters.go
@@ -36,7 +36,7 @@ type V2GetHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that should be retrieved.
+	/*The infra-env of the host that should be retrieved.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_get_next_steps_parameters.go
+++ b/restapi/operations/installer/v2_get_next_steps_parameters.go
@@ -40,7 +40,7 @@ type V2GetNextStepsParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that is retrieving instructions.
+	/*The infra-env of the host that is retrieving instructions.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_install_host_parameters.go
+++ b/restapi/operations/installer/v2_install_host_parameters.go
@@ -36,7 +36,7 @@ type V2InstallHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host that is being installed.
+	/*The infra-env of the host that is being installed.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_list_hosts.go
+++ b/restapi/operations/installer/v2_list_hosts.go
@@ -31,7 +31,7 @@ func NewV2ListHosts(ctx *middleware.Context, handler V2ListHostsHandler) *V2List
 
 /* V2ListHosts swagger:route GET /v2/infra-envs/{infra_env_id}/hosts installer v2ListHosts
 
-Retrieves the list of OpenShift hosts that belong to infra-env.
+Retrieves the list of OpenShift hosts that belong the infra-env.
 
 */
 type V2ListHosts struct {

--- a/restapi/operations/installer/v2_list_hosts_parameters.go
+++ b/restapi/operations/installer/v2_list_hosts_parameters.go
@@ -31,7 +31,7 @@ type V2ListHostsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The InfraEnv that the hosts are asociated with.
+	/*The infra-env that the hosts are asociated with.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_post_step_reply_parameters.go
+++ b/restapi/operations/installer/v2_post_step_reply_parameters.go
@@ -44,7 +44,7 @@ type V2PostStepReplyParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra env of the host that is posting results.
+	/*The infra-env of the host that is posting results.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_register_host_parameters.go
+++ b/restapi/operations/installer/v2_register_host_parameters.go
@@ -40,7 +40,7 @@ type V2RegisterHostParams struct {
 	  In: header
 	*/
 	DiscoveryAgentVersion *string
-	/*The InfraEnv that the agent is associated with.
+	/*The infra-env that the agent is associated with.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_reset_host_parameters.go
+++ b/restapi/operations/installer/v2_reset_host_parameters.go
@@ -36,7 +36,7 @@ type V2ResetHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host that is being reset.
+	/*The infra-env of the host that is being reset.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_reset_host_validation_parameters.go
+++ b/restapi/operations/installer/v2_reset_host_validation_parameters.go
@@ -36,7 +36,7 @@ type V2ResetHostValidationParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host that its validation is being reset.
+	/*The infra-env of the host that its validation is being reset.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_update_host_ignition_parameters.go
+++ b/restapi/operations/installer/v2_update_host_ignition_parameters.go
@@ -46,7 +46,7 @@ type V2UpdateHostIgnitionParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host whose ignition file should be updated.
+	/*The infra-env of the host whose ignition file should be updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_update_host_install_progress_parameters.go
+++ b/restapi/operations/installer/v2_update_host_install_progress_parameters.go
@@ -50,7 +50,7 @@ type V2UpdateHostInstallProgressParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host being updated.
+	/*The infra-env of the host being updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_update_host_installer_args_parameters.go
+++ b/restapi/operations/installer/v2_update_host_installer_args_parameters.go
@@ -41,7 +41,7 @@ type V2UpdateHostInstallerArgsParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv of the host whose installer arguments should be updated.
+	/*The infra-env of the host whose installer arguments should be updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_update_host_logs_progress_parameters.go
+++ b/restapi/operations/installer/v2_update_host_logs_progress_parameters.go
@@ -41,7 +41,7 @@ type V2UpdateHostLogsProgressParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The InfraEnv whose log progress is being updated.
+	/*The infra-env whose log progress is being updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_update_host_parameters.go
+++ b/restapi/operations/installer/v2_update_host_parameters.go
@@ -46,7 +46,7 @@ type V2UpdateHostParams struct {
 	  In: path
 	*/
 	HostID strfmt.UUID
-	/*The infra_env_id of the host to be updated.
+	/*The infra-env ID of the host to be updated.
 	  Required: true
 	  In: path
 	*/

--- a/restapi/operations/installer/v2_upload_logs_parameters.go
+++ b/restapi/operations/installer/v2_upload_logs_parameters.go
@@ -50,7 +50,7 @@ type V2UploadLogsParams struct {
 	  In: query
 	*/
 	HostID *strfmt.UUID
-	/*The infra_env_id of the host.
+	/*The infra-env ID of the host.
 	  In: query
 	*/
 	InfraEnvID *strfmt.UUID

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3304,7 +3304,7 @@ paths:
         - installer
       security:
         - userAuth: [admin, read-only-admin, user]
-      description: Retrieves the list of InfraEnvs.
+      description: Retrieves the list of infra-envs.
       operationId: ListInfraEnvs
       responses:
         "200":
@@ -3343,12 +3343,12 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
-      description: Retrieves the details of the InfraEnv.
+      description: Retrieves the details of the infra-env.
       operationId: GetInfraEnv
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv to be retrieved.
+          description: The infra-env to be retrieved.
           type: string
           format: uuid
           required: true
@@ -3389,12 +3389,12 @@ paths:
     patch:
       tags:
         - installer
-      description: Updates an InfraEnv.
+      description: Updates an infra-env.
       operationId: UpdateInfraEnv
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv to be updated.
+          description: The infra-env to be updated.
           type: string
           format: uuid
           required: true
@@ -3445,12 +3445,12 @@ paths:
     delete:
       tags:
         - installer
-      description: Deletes an InfraEnv.
+      description: Deletes an infra-env.
       operationId: DeregisterInfraEnv
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv to be deleted.
+          description: The infra-env to be deleted.
           format: uuid
           type: string
           required: true
@@ -3501,7 +3501,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv whose image should be downloaded.
+          description: The infra-env whose image should be downloaded.
           type: string
           format: uuid
           required: true
@@ -3553,7 +3553,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv whose image headers should be retrieved.
+          description: The infra-env whose image headers should be retrieved.
           type: string
           format: uuid
           required: true
@@ -3607,7 +3607,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv that the agent is associated with.
+          description: The infra-env that the agent is associated with.
           type: string
           format: uuid
           required: true
@@ -3669,12 +3669,12 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
-      description: Retrieves the list of OpenShift hosts that belong to infra-env.
+      description: Retrieves the list of OpenShift hosts that belong the infra-env.
       operationId: v2ListHosts
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv that the hosts are asociated with.
+          description: The infra-env that the hosts are asociated with.
           type: string
           format: uuid
           required: true
@@ -3719,7 +3719,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that should be retrieved.
+          description: The infra-env of the host that should be retrieved.
           type: string
           format: uuid
           required: true
@@ -3766,7 +3766,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra_env_id of the host to be updated.
+          description: The infra-env ID of the host to be updated.
           type: string
           format: uuid
           required: true
@@ -3823,7 +3823,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that should be deregistered.
+          description: The infra-env of the host that should be deregistered.
           type: string
           format: uuid
           required: true
@@ -3873,7 +3873,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that is retrieving instructions.
+          description: The infra-env of the host that is retrieving instructions.
           type: string
           format: uuid
           required: true
@@ -3937,7 +3937,7 @@ paths:
           required: false
         - in: path
           name: infra_env_id
-          description: The infra env of the host that is posting results.
+          description: The infra-env of the host that is posting results.
           type: string
           format: uuid
           required: true
@@ -4004,7 +4004,7 @@ paths:
           required: false
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host being updated.
+          description: The infra-env of the host being updated.
           type: string
           format: uuid
           required: true
@@ -4057,7 +4057,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that is being bound.
+          description: The infra-env of the host that is being bound.
           type: string
           format: uuid
           required: true
@@ -4120,7 +4120,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that is being bound.
+          description: The infra-env of the host that is being bound.
           type: string
           format: uuid
           required: true
@@ -4182,7 +4182,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host that its validation is being reset.
+          description: The infra-env of the host that its validation is being reset.
           type: string
           format: uuid
           required: true
@@ -4236,7 +4236,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host that is being reset.
+          description: The infra-env of the host that is being reset.
           type: string
           format: uuid
           required: true
@@ -4281,7 +4281,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host that is being installed.
+          description: The infra-env of the host that is being installed.
           type: string
           format: uuid
           required: true
@@ -4326,7 +4326,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host whose installer arguments should be updated.
+          description: The infra-env of the host whose installer arguments should be updated.
           type: string
           format: uuid
           required: true
@@ -4389,7 +4389,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host whose ignition file should be obtained.
+          description: The infra-env of the host whose ignition file should be obtained.
           type: string
           format: uuid
           required: true
@@ -4440,7 +4440,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv of the host whose ignition file should be updated.
+          description: The infra-env of the host whose ignition file should be updated.
           type: string
           format: uuid
           required: true
@@ -4504,7 +4504,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv whose file should be downloaded.
+          description: The infra-env whose file should be downloaded.
           type: string
           format: uuid
           required: true
@@ -4563,7 +4563,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The InfraEnv whose log progress is being updated.
+          description: The infra-env whose log progress is being updated.
           type: string
           format: uuid
           required: true
@@ -4987,7 +4987,7 @@ paths:
       parameters:
         - in: path
           name: infra_env_id
-          description: The infra env of the host that should be retrieved.
+          description: The infra-env of the host that should be retrieved.
           type: string
           format: uuid
           required: true
@@ -5867,7 +5867,7 @@ paths:
           required: true
         - in: query
           name: infra_env_id
-          description: The infra_env_id of the host.
+          description: The infra-env ID of the host.
           type: string
           format: uuid
           required: false
@@ -6096,7 +6096,7 @@ paths:
           required: false
         - in: query
           name: infra_env_id
-          description: The infra env to return events for.
+          description: The infra-env to return events for.
           type: string
           format: uuid
           required: false
@@ -6588,7 +6588,7 @@ definitions:
       infra_env_id:
         type: string
         format: uuid
-        description: Unique identifier of the infra env this event relates to.
+        description: Unique identifier of the infra-env this event relates to.
         x-go-custom-tag: gorm:"index"
         x-nullable: true
       severity:
@@ -6703,7 +6703,7 @@ definitions:
         type: string
         format: uuid
         x-go-custom-tag: gorm:"primary_key;foreignkey:InfraEnvID"
-        description: The InfraEnv that this host is associated with.
+        description: The infra-env that this host is associated with.
       status:
         type: string
         enum:
@@ -8986,7 +8986,7 @@ definitions:
         description: Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
       name:
         type: string
-        description: Name of the InfraEnv.
+        description: Name of the infra-env.
       user_name:
         type: string
       org_id:
@@ -9034,7 +9034,7 @@ definitions:
           hints:
             noValidation: true
         x-go-custom-tag: gorm:"type:timestamp with time zone"
-        description: The last time that this infraenv was updated.
+        description: The last time that this infra-env was updated.
       created_at:
         type: string
         format: date-time
@@ -9091,7 +9091,7 @@ definitions:
     properties:
       name:
         type: string
-        description: Name of the InfraEnv.
+        description: Name of the infra-env.
       proxy:
         $ref: "#/definitions/proxy"
       additional_ntp_sources:


### PR DESCRIPTION
# Assisted Pull Request

## Description

Align spelling of infra-env in the swagger descriptions.

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
