### PR TITLE
MGMT-8229: All host registration events to include optional cluster_id

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -20,6 +20,7 @@ x-events:
   properties:
     host_id: UUID
     infra_env_id: UUID
+    cluster_id: UUID_PTR
 
 - name: cluster_registration_failed
   message: "Failed to register cluster. Error: {error}"
@@ -692,6 +693,7 @@ x-events:
   properties:
     host_id: UUID
     infra_env_id: UUID
+    cluster_id: UUID_PTR
     message: string
 
 - name: inactive_clusters_deregistered

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6277,13 +6277,12 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 			params.NewHostParams.HostID.String(), params.InfraEnvID.String())
 		uerr := errors.Wrap(err, fmt.Sprintf("Failed to register host %s", hostutil.GetHostnameForMsg(host)))
 
-		eventgen.SendHostRegistrationFailedEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID, params.InfraEnvID, uerr.Error())
+		eventgen.SendHostRegistrationFailedEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID, params.InfraEnvID, host.ClusterID, uerr.Error())
 		return returnRegisterHostTransitionError(http.StatusBadRequest, err)
 	}
 
 	if err = b.customizeHost(c, host); err != nil {
-		// TODO Need event for infra-env instead of cluster
-		eventgen.SendHostRegistrationSettingPropertiesFailedEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID, params.InfraEnvID)
+		eventgen.SendHostRegistrationSettingPropertiesFailedEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID, params.InfraEnvID, host.ClusterID)
 		return common.GenerateErrorResponder(err)
 	}
 

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -139,6 +139,7 @@ func (e *CancelInstallCommitFailedEvent) FormatMessage() string {
 type HostRegistrationSettingPropertiesFailedEvent struct {
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
 }
 
 var HostRegistrationSettingPropertiesFailedEventName string = "host_registration_setting_properties_failed"
@@ -146,10 +147,12 @@ var HostRegistrationSettingPropertiesFailedEventName string = "host_registration
 func NewHostRegistrationSettingPropertiesFailedEvent(
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
 ) *HostRegistrationSettingPropertiesFailedEvent {
     return &HostRegistrationSettingPropertiesFailedEvent{
         HostId: hostId,
         InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
     }
 }
 
@@ -157,10 +160,12 @@ func SendHostRegistrationSettingPropertiesFailedEvent(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
-    infraEnvId strfmt.UUID,) {
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,) {
     ev := NewHostRegistrationSettingPropertiesFailedEvent(
         hostId,
         infraEnvId,
+        clusterId,
     )
     eventsHandler.SendHostEvent(ctx, ev)
 }
@@ -170,10 +175,12 @@ func SendHostRegistrationSettingPropertiesFailedEventAtTime(
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     eventTime time.Time) {
     ev := NewHostRegistrationSettingPropertiesFailedEvent(
         hostId,
         infraEnvId,
+        clusterId,
     )
     eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
 }
@@ -186,7 +193,7 @@ func (e *HostRegistrationSettingPropertiesFailedEvent) GetSeverity() string {
     return "error"
 }
 func (e *HostRegistrationSettingPropertiesFailedEvent) GetClusterId() *strfmt.UUID {
-    return nil
+    return e.ClusterId
 }
 func (e *HostRegistrationSettingPropertiesFailedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -199,6 +206,7 @@ func (e *HostRegistrationSettingPropertiesFailedEvent) format(message *string) s
     r := strings.NewReplacer(
         "{host_id}", fmt.Sprint(e.HostId),
         "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
     )
     return r.Replace(*message)
 }
@@ -6128,6 +6136,7 @@ func (e *RegisterHostToInfraEnvFailedEvent) FormatMessage() string {
 type HostRegistrationFailedEvent struct {
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
     Message string
 }
 
@@ -6136,11 +6145,13 @@ var HostRegistrationFailedEventName string = "host_registration_failed"
 func NewHostRegistrationFailedEvent(
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     message string,
 ) *HostRegistrationFailedEvent {
     return &HostRegistrationFailedEvent{
         HostId: hostId,
         InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
         Message: message,
     }
 }
@@ -6150,10 +6161,12 @@ func SendHostRegistrationFailedEvent(
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     message string,) {
     ev := NewHostRegistrationFailedEvent(
         hostId,
         infraEnvId,
+        clusterId,
         message,
     )
     eventsHandler.SendHostEvent(ctx, ev)
@@ -6164,11 +6177,13 @@ func SendHostRegistrationFailedEventAtTime(
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     message string,
     eventTime time.Time) {
     ev := NewHostRegistrationFailedEvent(
         hostId,
         infraEnvId,
+        clusterId,
         message,
     )
     eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
@@ -6182,7 +6197,7 @@ func (e *HostRegistrationFailedEvent) GetSeverity() string {
     return "error"
 }
 func (e *HostRegistrationFailedEvent) GetClusterId() *strfmt.UUID {
-    return nil
+    return e.ClusterId
 }
 func (e *HostRegistrationFailedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -6195,6 +6210,7 @@ func (e *HostRegistrationFailedEvent) format(message *string) string {
     r := strings.NewReplacer(
         "{host_id}", fmt.Sprint(e.HostId),
         "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{message}", fmt.Sprint(e.Message),
     )
     return r.Replace(*message)


### PR DESCRIPTION
# Assisted Pull Request

## Description

As a follow up to MGMT-8198, there are two additional host registration
events that may include a cluster_id:

host_registration_failed
host_registration_setting_properties_failed

We should add cluster_id as an optional parameter to make those
consistent with: host_registration_succeeded

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @arielireni 
/cc @masayag 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
