### PR TITLE
NO-ISSUE: set PlatformType on ImportCluster

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -828,6 +828,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		HostNetworks:       []*models.HostNetwork{},
 		Hosts:              []*models.Host{},
 		CPUArchitecture:    common.DefaultCPUArchitecture,
+		Platform:           &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 	},
 		KubeKeyName:      kubeKey.Name,
 		KubeKeyNamespace: kubeKey.Namespace,

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10208,6 +10208,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
 		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.ReleaseVersion))
 		Expect(actual.Payload.OcpReleaseImage).To(Equal(common.TestDefaultConfig.ReleaseImageUrl))
+		Expect(actual.Payload.Platform).To(Equal(&models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)}))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewRegisterAddHostsClusterCreated()))
 	})
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

Set explicitly the PlatformType on V2ImportClusterInternal as the property has been changed to a pointer as part of go-swagger upgrade[1]. I.e. currently, upon day2 cluster creation, assisted-service python client fails with ValueError on PlatformType model deserialize[2] as type in the response is null[3].

[1]
https://github.com/openshift/assisted-service/pull/2872/files#diff-3657f5d7ebd63c86fef223229378261d08b79e7d363b6f297cd6595e74683697R27

[2]
:type: PlatformType
"""
if self._configuration.client_side_validation and type is None:
    raise ValueError("Invalid value for `type`, must not be `None`")  # noqa: E501
    ValueError: Invalid value for `type`, must not be `None`

[3]
day2 cluster repsonse:
...
"platform": {
       "ovirt": {},
       "type": null,
       "vsphere": {}
   },

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @eliorerz 
/cc @yevgeny-shnaidman 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
