### PR TITLE
NO-ISSUE: fix commit message validator to allow [<tag>] at start

### DIFF
--- a/hack/check-commit-message.sh
+++ b/hack/check-commit-message.sh
@@ -4,7 +4,7 @@ set -o nounset
 
 commit_file=${1}
 commit_message="$(cat ${commit_file})"
-valid_commit_regex='^(NO-ISSUE|Merge|Revert|((Bug |[A-Z]+-|#)[0-9]+:))'
+valid_commit_regex='(NO-ISSUE|Merge|Revert|((Bug |[A-Z]+-|#)[0-9]+:))'
 
 error_msg="""Aborting commit: ${commit_message}
 ---


### PR DESCRIPTION
# Assisted Pull Request

## Description

Allow having commits like in this format (which lots of the backports are having):
```[release-ocm-2.4] Bug xxxxxxx: bla bla```

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @rollandf 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
