### PR TITLE
OCPBUGSM-36861: progress bar goes to 10% after pending user action on reboot

### DIFF
--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -237,63 +238,95 @@ var _ = Describe("Progress bar test", func() {
 		})
 	})
 
-	It("preparing-for-installation --> installing transition test", func() {
+	Context("update progress on transition", func() {
 
 		var clusterId strfmt.UUID
+		var hid1 strfmt.UUID
+		var none string
 		var c common.Cluster
 
-		By("Create cluster", func() {
-
+		BeforeEach(func() {
 			clusterId = strfmt.UUID(uuid.New().String())
-			hid1 := strfmt.UUID(uuid.New().String())
-			hid2 := strfmt.UUID(uuid.New().String())
-			hid3 := strfmt.UUID(uuid.New().String())
-			c = common.Cluster{
-				Cluster: models.Cluster{
-					ID:              &clusterId,
-					Status:          swag.String(models.ClusterStatusPreparingForInstallation),
-					StatusUpdatedAt: strfmt.DateTime(time.Now()),
-					Hosts: []*models.Host{
-						{
-							ID:         &hid1,
-							ClusterID:  &clusterId,
-							InfraEnvID: clusterId,
-							Status:     swag.String(models.HostStatusPreparingSuccessful),
-						},
-						{
-							ID:         &hid2,
-							ClusterID:  &clusterId,
-							InfraEnvID: clusterId,
-							Status:     swag.String(models.HostStatusPreparingSuccessful),
-						},
-						{
-							ID:         &hid3,
-							ClusterID:  &clusterId,
-							InfraEnvID: clusterId,
-							Status:     swag.String(models.HostStatusPreparingSuccessful),
-						},
-					},
-				},
-				InstallationPreparationCompletionStatus: common.InstallationPreparationSucceeded,
-			}
-			Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
-		})
+			hid1 = strfmt.UUID(uuid.New().String())
+			none = models.ClusterHighAvailabilityModeNone
 
-		By("test progress", func() {
-
-			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(3)
-			mockOperatorApi.EXPECT().ValidateCluster(ctx, gomock.Any()).Return([]api.ValidationResult{}, nil)
-			mockDnsApi.EXPECT().CreateDNSRecordSets(ctx, gomock.Any()).Return(nil)
-			mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any())
-			mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), 3, gomock.Any())
-			mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
+			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+			mockDnsApi.EXPECT().CreateDNSRecordSets(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockOperatorApi.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).Return([]api.ValidationResult{}, nil).AnyTimes()
+			mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any()).AnyTimes()
+			mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), 1, gomock.Any()).AnyTimes()
+			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
 				eventstest.WithClusterIdMatcher(clusterId.String())))
 
-			cAfterRefresh, err := clusterApi.RefreshStatus(ctx, &c, db)
-			Expect(err).NotTo(HaveOccurred())
-
-			expectProgressToBe(cAfterRefresh, 100, 0, 0)
 		})
+
+		tests := []struct {
+			name             string
+			clusterStatus    string
+			hostStatus       string
+			progress         models.ClusterProgressInfo
+			installStartTime strfmt.DateTime
+			expected         [3]int
+		}{
+			{
+				name:             "preparing-for-installation --> installing should set the progress to 10%",
+				clusterStatus:    models.ClusterStatusPreparingForInstallation,
+				hostStatus:       models.HostStatusPreparingSuccessful,
+				progress:         models.ClusterProgressInfo{},
+				installStartTime: strfmt.DateTime(time.Time{}),
+				expected:         [3]int{100, 0, 0},
+			},
+			{
+				name:             "installing-pending-user-action --> installing should not change the progress",
+				clusterStatus:    models.ClusterStatusInstallingPendingUserAction,
+				hostStatus:       models.HostStatusInstalled,
+				installStartTime: strfmt.DateTime(time.Now()),
+				progress: models.ClusterProgressInfo{PreparingForInstallationStagePercentage: 100,
+					InstallingStagePercentage: 80, FinalizingStagePercentage: 0, TotalPercentage: 66},
+				expected: [3]int{100, 80, 0},
+			},
+		}
+
+		for i := range tests {
+			t := tests[i]
+			It(t.name, func() {
+				By(fmt.Sprintf("creating cluster in state %s", t.clusterStatus))
+				c = common.Cluster{
+					Cluster: models.Cluster{
+						ID:                   &clusterId,
+						Kind:                 swag.String(models.ClusterKindCluster),
+						HighAvailabilityMode: &none,
+						MachineNetworks:      []*models.MachineNetwork{{Cidr: "1.2.3.0/24"}},
+						APIVip:               "1.2.3.5",
+						IngressVip:           "1.2.3.6",
+						Status:               swag.String(t.clusterStatus),
+						StatusUpdatedAt:      strfmt.DateTime(time.Now()),
+						InstallStartedAt:     t.installStartTime,
+						Progress:             &t.progress,
+						Hosts: []*models.Host{
+							{
+								ID:         &hid1,
+								ClusterID:  &clusterId,
+								InfraEnvID: clusterId,
+								Role:       models.HostRoleMaster,
+								Bootstrap:  true,
+								Status:     swag.String(t.hostStatus),
+								Inventory:  common.GenerateTestDefaultInventory(),
+							},
+						},
+					},
+					InstallationPreparationCompletionStatus: common.InstallationPreparationSucceeded,
+				}
+				Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
+
+				By(fmt.Sprintf("test progress from state %s to installing", t.clusterStatus))
+				cAfterRefresh, err := clusterApi.RefreshStatus(ctx, &c, db)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*cAfterRefresh.Status).To(Equal(models.ClusterStatusInstalling))
+
+				expectProgressToBe(cAfterRefresh, t.expected[0], t.expected[1], t.expected[2])
+			})
+		}
 	})
 })


### PR DESCRIPTION
# Assisted Pull Request

## Description

When reboot is stuck and the cluster moved to pending user action state
the progress bar returns to 10% after the boot error is solved and the 
installation process continues

The root cause is that a initialization code of the progress bar is called
again on transition between pending-user-action and installing

The solution is to limit the initialization to the correct transition, namely
the transition between preparing-for-installation to installing


## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
