### PR TITLE
MGMT-8127: Webhook block unbind if Agent is installing

### DIFF
--- a/cmd/webadmission/main.go
+++ b/cmd/webadmission/main.go
@@ -20,6 +20,7 @@ func main() {
 	admissionCmd.RunAdmissionServer(
 		hiveextvalidatingwebhooks.NewAgentClusterInstallValidatingAdmissionHook(decoder),
 		agentinstallvalidatingwebhooks.NewInfraEnvValidatingAdmissionHook(decoder),
+		agentinstallvalidatingwebhooks.NewAgentValidatingAdmissionHook(decoder),
 	)
 }
 

--- a/pkg/validating-webhooks/agentinstall/v1beta1/agent_admission_hook.go
+++ b/pkg/validating-webhooks/agentinstall/v1beta1/agent_admission_hook.go
@@ -1,0 +1,192 @@
+package v1beta1
+
+import (
+	"net/http"
+
+	"github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/models"
+	log "github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	agentResource = "agents"
+
+	agentAdmissionGroup   = "admission.agentinstall.openshift.io"
+	agentAdmissionVersion = "v1"
+)
+
+// AgentValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
+type AgentValidatingAdmissionHook struct {
+	decoder *admission.Decoder
+}
+
+// NewAgentValidatingAdmissionHook constructs a new NewAgentValidatingAdmissionHook
+func NewAgentValidatingAdmissionHook(decoder *admission.Decoder) *AgentValidatingAdmissionHook {
+	return &AgentValidatingAdmissionHook{decoder: decoder}
+}
+
+// ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
+//                    webhook is accessed by the kube apiserver.
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.agentinstall.openshift.io/v1/agentvalidators".
+//              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
+func (a *AgentValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
+	log.WithFields(log.Fields{
+		"group":    agentAdmissionGroup,
+		"version":  agentAdmissionVersion,
+		"resource": "agentvalidator",
+	}).Info("Registering validation REST resource")
+	// NOTE: This GVR is meant to be different than the Agent CRD GVR which has group "agent-install.openshift.io".
+	return schema.GroupVersionResource{
+			Group:    agentAdmissionGroup,
+			Version:  agentAdmissionVersion,
+			Resource: "agentvalidators",
+		},
+		"agentvalidator"
+}
+
+// Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
+func (a *AgentValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	log.WithFields(log.Fields{
+		"group":    agentAdmissionGroup,
+		"version":  agentAdmissionVersion,
+		"resource": "agentvalidator",
+	}).Info("Initializing validation REST resource")
+	return nil // No initialization needed right now.
+}
+
+// Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
+// Usually it's the kube apiserver that is making the admission validation request.
+func (a *AgentValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "Validate",
+	})
+
+	if !a.shouldValidate(admissionSpec) {
+		contextLogger.Info("Skipping validation for request")
+		// The request object isn't something that this validator should validate.
+		// Therefore, we say that it's allowed.
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	contextLogger.Info("Validating request")
+
+	if admissionSpec.Operation == admissionv1.Update {
+		return a.validateUpdate(admissionSpec)
+	}
+
+	// We're only validating updates at this time, so all other operations are explicitly allowed.
+	contextLogger.Info("Successful validation")
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// shouldValidate explicitly checks if the request should be validated. For example, this webhook may have accidentally been registered to check
+// the validity of some other type of object with a different GVR.
+func (a *AgentValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "shouldValidate",
+	})
+
+	if admissionSpec.Resource.Group != v1beta1.Group {
+		contextLogger.Debug("Returning False, not our group")
+		return false
+	}
+
+	if admissionSpec.Resource.Version != v1beta1.Version {
+		contextLogger.Debug("Returning False, it's our group, but not the right version")
+		return false
+	}
+
+	if admissionSpec.Resource.Resource != agentResource {
+		contextLogger.Debug("Returning False, it's our group and version, but not the right resource")
+		return false
+	}
+
+	// If we get here, then we're supposed to validate the object.
+	contextLogger.Debug("Returning True, passed all prerequisites.")
+	return true
+}
+
+// validateUpdate specifically validates update operations for Agent objects.
+func (a *AgentValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateUpdate",
+	})
+
+	newObject := &v1beta1.Agent{}
+	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
+
+	oldObject := &v1beta1.Agent{}
+	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
+		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
+		return &admissionv1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if !areClusterRefsEqual(oldObject.Spec.ClusterDeploymentName, newObject.Spec.ClusterDeploymentName) {
+		installingStatuses := []string{
+			models.HostStatusPreparingForInstallation,
+			models.HostStatusPreparingFailed,
+			models.HostStatusPreparingSuccessful,
+			models.HostStatusInstalling,
+			models.HostStatusInstallingInProgress,
+			models.HostStatusInstallingPendingUserAction,
+		}
+		if funk.ContainsString(installingStatuses, newObject.Status.DebugInfo.State) {
+			message := "Attempted to change Spec.ClusterDeploymentName which is immutable during Agent installation."
+			contextLogger.Infof("Failed validation: %v", message)
+			contextLogger.Error(message)
+			return &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+					Message: message,
+				},
+			}
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/pkg/validating-webhooks/agentinstall/v1beta1/agent_admission_hook_test.go
+++ b/pkg/validating-webhooks/agentinstall/v1beta1/agent_admission_hook_test.go
@@ -1,0 +1,221 @@
+package v1beta1
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/models"
+	apiserver "github.com/openshift/generic-admission-server/pkg/apiserver"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("agent web hook init", func() {
+	It("ValidatingResource", func() {
+		data := NewAgentValidatingAdmissionHook(createDecoder())
+		expectedPlural := schema.GroupVersionResource{
+			Group:    "admission.agentinstall.openshift.io",
+			Version:  "v1",
+			Resource: "agentvalidators",
+		}
+		expectedSingular := "agentvalidator"
+
+		plural, singular := data.ValidatingResource()
+		Expect(plural).To(Equal(expectedPlural))
+		Expect(singular).To(Equal(expectedSingular))
+
+	})
+
+	It("Initialize", func() {
+		data := NewAgentValidatingAdmissionHook(createDecoder())
+		err := data.Initialize(nil, nil)
+		Expect(err).To(BeNil())
+	})
+
+	It("Check implements interface ", func() {
+		var hook interface{} = NewAgentValidatingAdmissionHook(createDecoder())
+		_, ok := hook.(apiserver.ValidatingAdmissionHookV1)
+		Expect(ok).To(BeTrue())
+	})
+})
+
+var _ = Describe("agent web validate", func() {
+	cases := []struct {
+		name            string
+		newSpec         v1beta1.AgentSpec
+		oldSpec         v1beta1.AgentSpec
+		newObjectRaw    []byte
+		oldObjectRaw    []byte
+		operation       admissionv1.Operation
+		expectedAllowed bool
+		gvr             *metav1.GroupVersionResource
+		newState        string
+	}{
+		{
+			name:            "Test unable to marshal old object during update",
+			oldObjectRaw:    []byte{0},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test doesn't validate with right version and resource, but wrong group",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "not the right group",
+				Version:  "v1beta1",
+				Resource: "agents",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and resource, wrong version",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "agent-install.openshift.io",
+				Version:  "not the right version",
+				Resource: "agents",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and version, wrong resource",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "agent-install.openshift.io",
+				Version:  "v1beta1",
+				Resource: "not the right resource",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test Agent.Spec.ClusterDeploymentName is mutable, no State",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "oldNamespace",
+				},
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test Agent.Spec.ClusterDeploymentName.Namespace is immutable, state installing",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "newNamespace",
+				},
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+			newState:        models.HostStatusInstalling,
+		},
+		{
+			name: "Test Agent.Spec.ClusterDeploymentName.Namespace is mutable, state known",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "newNamespace",
+				},
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+			newState:        models.HostStatusKnown,
+		},
+		{
+			name: "Test Agent update does not fail when ClusterReference is set and remains the same",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: &v1beta1.ClusterReference{
+					Name:      "oldName",
+					Namespace: "oldNamespace",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test Agent update does not fail when ClusterReference is nil and remains the same",
+			newSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: nil,
+			},
+			oldSpec: v1beta1.AgentSpec{
+				ClusterDeploymentName: nil,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		It(tc.name, func() {
+			data := NewAgentValidatingAdmissionHook(createDecoder())
+			newObject := &v1beta1.Agent{
+				Spec: tc.newSpec,
+			}
+			if tc.newState != "" {
+				newObject.Status = v1beta1.AgentStatus{DebugInfo: v1beta1.DebugInfo{State: tc.newState}}
+			}
+			oldObject := &v1beta1.Agent{
+				Spec: tc.oldSpec,
+			}
+
+			if tc.newObjectRaw == nil {
+				tc.newObjectRaw, _ = json.Marshal(newObject)
+			}
+
+			if tc.oldObjectRaw == nil {
+				tc.oldObjectRaw, _ = json.Marshal(oldObject)
+			}
+
+			if tc.gvr == nil {
+				tc.gvr = &metav1.GroupVersionResource{
+					Group:    "agent-install.openshift.io",
+					Version:  "v1beta1",
+					Resource: "agents",
+				}
+			}
+
+			request := &admissionv1.AdmissionRequest{
+				Operation: tc.operation,
+				Resource:  *tc.gvr,
+				Object: runtime.RawExtension{
+					Raw: tc.newObjectRaw,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: tc.oldObjectRaw,
+				},
+			}
+
+			response := data.Validate(request)
+
+			Expect(response.Allowed).To(Equal(tc.expectedAllowed))
+		})
+	}
+
+})


### PR DESCRIPTION
# Assisted Pull Request

## Description
Reject change in ClusterDeploymentName in Agent CR if Agent is currently installing.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @isaacdorfman 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
