### PR TITLE
MGMT-8088 validate hostname before transition to known-unbound

### DIFF
--- a/internal/host/pool_host_statemachine.go
+++ b/internal/host/pool_host_statemachine.go
@@ -100,7 +100,7 @@ func NewPoolHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler)
 	})
 
 	var hasMinRequiredHardware = stateswitch.And(If(HasMinValidDisks), If(HasMinCPUCores), If(HasMinMemory))
-	sufficientToBeBound := stateswitch.And(hasMinRequiredHardware, If(IsNTPSynced))
+	sufficientToBeBound := stateswitch.And(hasMinRequiredHardware, If(IsHostnameValid), If(IsNTPSynced))
 
 	// In order for this transition to be fired at least one of the validations in minRequiredHardwareValidations must fail.
 	// This transition handles the case that a host does not pass minimum hardware requirements for any of the roles

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -5222,6 +5222,16 @@ var _ = Describe("Refresh Host", func() {
 					"Host couldn't synchronize with any NTP server")),
 			},
 			{
+				name:             "discovering-unbound to insufficient-unbound (invalid hostname)",
+				srcState:         models.HostStatusDiscoveringUnbound,
+				dstState:         models.HostStatusInsufficientUnbound,
+				validCheckInTime: true,
+				inventory:        hostutil.GenerateMasterInventoryWithHostname("localhost"),
+				eventRaised:      true,
+				statusInfoChecker: makeValueChecker(formatStatusInfoFailedValidation(statusInfoInsufficientHardware,
+					"Hostname localhost is forbidden")),
+			},
+			{
 				name:             "discovering-unbound to insufficient-unbound",
 				srcState:         models.HostStatusDiscoveringUnbound,
 				dstState:         models.HostStatusInsufficientUnbound,


### PR DESCRIPTION
# Assisted Pull Request

## Description
validate hostname (should not be localhost) before transition to known-unbound in the InfraEnv state machine.

localhost is the hostname assigned by the NetworkManager in case there was no configuration either via NM config, RHEL config or DHCP. so any node that does not have hostname defined by either of those methods will be named localhost. This means that we might end up with at least 2 nodes with the same name, which is illegal for Kuberentes cluster, since it identifies nodes by the hostname


## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
