### PR TITLE
NO-ISSUE: there is no need to base encode an already base64 encoded CA cert

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1451,7 +1451,7 @@ func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert 
 	}
 
 	if caCert != nil {
-		ignitionParams["CACERT"] = fmt.Sprintf("data:text/plain;base64,%s", base64.StdEncoding.EncodeToString([]byte(*caCert)))
+		ignitionParams["CACERT"] = fmt.Sprintf("data:text/plain;base64,%s", *caCert)
 	}
 
 	tmpl, err := template.New("nodeIgnition").Parse(secondDayWorkerIgnitionFormat)

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1260,7 +1260,8 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 			ca := "-----BEGIN CERTIFICATE-----\nMIIDozCCAougAwIBAgIULCOqWTF" +
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &ca, nil)
+			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1268,7 +1269,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 			Expect(swag.StringValue(ignConfig.Ignition.Config.Merge[0].Source)).Should(Equal("https://url.com"))
 			Expect(ignConfig.Ignition.Config.Merge[0].HTTPHeaders).Should(HaveLen(0))
 			Expect(ignConfig.Ignition.Security.TLS.CertificateAuthorities).Should(HaveLen(1))
-			Expect(swag.StringValue(ignConfig.Ignition.Security.TLS.CertificateAuthorities[0].Source)).Should(Equal("data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte(ca))))
+			Expect(swag.StringValue(ignConfig.Ignition.Security.TLS.CertificateAuthorities[0].Source)).Should(Equal("data:text/plain;base64," + encodedCa))
 		})
 
 		It("are rendered properly with ca cert and token", func() {
@@ -1276,7 +1277,9 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 			ca := "-----BEGIN CERTIFICATE-----\nMIIDozCCAougAwIBAgIULCOqWTF" +
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &ca, &token)
+			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, &token)
+
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1286,7 +1289,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 			Expect(ignConfig.Ignition.Config.Merge[0].HTTPHeaders[0].Name).Should(Equal("Authorization"))
 			Expect(swag.StringValue(ignConfig.Ignition.Config.Merge[0].HTTPHeaders[0].Value)).Should(Equal("Bearer: " + token))
 			Expect(ignConfig.Ignition.Security.TLS.CertificateAuthorities).Should(HaveLen(1))
-			Expect(swag.StringValue(ignConfig.Ignition.Security.TLS.CertificateAuthorities[0].Source)).Should(Equal("data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte(ca))))
+			Expect(swag.StringValue(ignConfig.Ignition.Security.TLS.CertificateAuthorities[0].Source)).Should(Equal("data:text/plain;base64," + encodedCa))
 		})
 	})
 })


### PR DESCRIPTION


# Assisted Pull Request

The CA cert is already base64 encoded and there is no need to encode it again.
-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @machacekondra 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
