### PR TITLE
MGMT-8278: Allow updating agent properties before binding

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6845,11 +6845,6 @@ func (b *bareMetalInventory) updateHostRole(ctx context.Context, host *common.Ho
 		log.Infof("No request for role update for host %s", host.ID)
 		return nil
 	}
-	if host.ClusterID == nil {
-		msg := fmt.Sprintf("Update role of the host %s is not allowed, does not belongs to a cluster ", host.ID)
-		log.Errorf(msg)
-		return common.NewApiError(http.StatusBadRequest, fmt.Errorf(msg))
-	}
 	err := b.hostApi.UpdateRole(ctx, &host.Host, models.HostRole(*hostRole), db)
 	if err != nil {
 		log.WithError(err).Errorf("failed to set role <%s> host <%s>, infra env <%s>",
@@ -6885,11 +6880,6 @@ func (b *bareMetalInventory) updateHostDisksSelectionConfig(ctx context.Context,
 		log.Infof("No request for disk selection config update for host %s", host.ID)
 		return nil
 	}
-	if host.ClusterID == nil {
-		msg := fmt.Sprintf("Update disks selection config of the host %s is not allowed, does not belongs to a cluster ", host.ID)
-		log.Errorf(msg)
-		return common.NewApiError(http.StatusBadRequest, fmt.Errorf(msg))
-	}
 	disksToInstallOn := funk.Filter(disksSelectedConfig, func(diskConfigParams *models.DiskConfigParams) bool {
 		return models.DiskRoleInstall == diskConfigParams.Role
 	}).([]*models.DiskConfigParams)
@@ -6919,11 +6909,6 @@ func (b *bareMetalInventory) updateHostMachineConfigPoolName(ctx context.Context
 	if machineConfigPoolName == nil {
 		log.Infof("No request for machine config pool name update for host %s", host.ID)
 		return nil
-	}
-	if host.ClusterID == nil {
-		msg := fmt.Sprintf("Update machine config pool of the host %s is not allowed, does not belongs to a cluster ", host.ID)
-		log.Errorf(msg)
-		return common.NewApiError(http.StatusBadRequest, fmt.Errorf(msg))
 	}
 	err := b.hostApi.UpdateMachineConfigPoolName(ctx, db, &host.Host, *machineConfigPoolName)
 	if err != nil {

--- a/subsystem/host_v2_test.go
+++ b/subsystem/host_v2_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Host tests v2", func() {
 		Expect(updatedHost.RequestedHostname).To(Equal("new-host-name"))
 	})
 
-	It("update infra-env host installation disk id failure", func() {
+	It("update infra-env host installation disk id success", func() {
 		host := &registerHost(infraEnvID).Host
 		host = getHostV2(infraEnvID, *host.ID)
 		Expect(host).NotTo(BeNil())
@@ -147,7 +147,7 @@ var _ = Describe("Host tests v2", func() {
 		}
 
 		_, error = userBMClient.Installer.V2UpdateHost(ctx, diskSelectionRequest)
-		Expect(error).Should(HaveOccurred())
+		Expect(error).ToNot(HaveOccurred())
 	})
 
 	It("register_same_host_id", func() {


### PR DESCRIPTION
# Assisted Pull Request

## Description
Allow updating agent properties before binding to a cluster

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/assign @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
