### PR TITLE
MGMT-8295: reconcile fail in case agent spec.IgnitionEndpointToken isn't empty due to null pointer dereference

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -884,7 +884,7 @@ func (r *AgentReconciler) updateIfNeeded(ctx context.Context, log logrus.FieldLo
 		}
 	}
 
-	if spec.IgnitionEndpointToken != "" && spec.IgnitionEndpointToken != *internalHost.IgnitionEndpointToken {
+	if spec.IgnitionEndpointToken != "" && spec.IgnitionEndpointToken != swag.StringValue(internalHost.IgnitionEndpointToken) {
 		hostUpdate = true
 		params.HostUpdateParams.IgnitionEndpointToken = &spec.IgnitionEndpointToken
 	}


### PR DESCRIPTION
use swag.StringValue when checking the value of string pointer

# Assisted Pull Request

## Description
We get panic in case the ignition endpoint token is set:
```
│ panic: runtime error: invalid memory address or nil pointer dereference                                                                                               │
│ [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2935398]                                                                                               │
│ goroutine 883 [running]:                                                                                                                                              │
│ github.com/openshift/assisted-service/internal/controller/controllers.(*AgentReconciler).updateIfNeeded(0xc00027a8c0, 0x380a370, 0xc0012ca330, 0x3851b70, 0xc0000ba0e │
│     /go/src/github.com/openshift/origin/internal/controller/controllers/agent_controller.go:885 +0x5f8                                                                │
│ github.com/openshift/assisted-service/internal/controller/controllers.(*AgentReconciler).Reconcile(0xc00027a8c0, 0x380a370, 0xc0012ca300, 0xc001047500, 0xf, 0xc0013d │
│     /go/src/github.com/openshift/origin/internal/controller/controllers/agent_controller.go:188 +0x75d                                                                │
│ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0001bed20, 0x380a2c8, 0xc001cce180, 0x2eebe40, 0xc00209a140)                 │
│     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298 +0x30d                                                                │
│ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0001bed20, 0x380a2c8, 0xc001cce180, 0x3473d00)                            │
│     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253 +0x205                                                                │
│ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc0023f10a0, 0xc0001bed20, 0x380a2c8, 0xc001cce180)                               │
│     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214 +0x6b                                                                 │
│ created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2                                                                           │
│     /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:210 +0x425 
```

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) creating an agent with ignition endpoint token and checking the service isn't crashing
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @machacekondra 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
