### PR TITLE
Bug 2025280: Add ClusterOSImage to Baremetal platform (#2862)

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -33,6 +33,7 @@ type baremetal struct {
 	APIVIP              string `yaml:"apiVIP"`
 	IngressVIP          string `yaml:"ingressVIP"`
 	Hosts               []host `yaml:"hosts"`
+	ClusterOSImage      string `json:"clusterOSImage,omitempty"`
 }
 
 type platform struct {


### PR DESCRIPTION
This is a manual cherry-pick of #2862 
