### PR TITLE
Make openshift-edge-bot author for OCP version bump

### DIFF
--- a/tools/ocp_version_update/Jenkinsfile.default_release_update
+++ b/tools/ocp_version_update/Jenkinsfile.default_release_update
@@ -3,7 +3,7 @@ pipeline {
     environment {
         SLACK_TOKEN = credentials('slack-token')
         JIRA_CREDS = credentials('Ronnie-jira')
-        GITHUB_CREDS = credentials('osherdp-github-creds')
+        GITHUB_CREDS = credentials('github-openshift-edge-bot-personal-access-token')
     }
 
     triggers { cron('0 0 * * *') }


### PR DESCRIPTION
# Assisted Pull Request

## Description

Use a neutral user for creating OCP version upgrades. This should be better than relying on some personal account.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @eliorerz 
/cc @romfreiman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
