### PR TITLE
Only inspect netrc file in case file exists

### DIFF
--- a/tools/ocp_version_update/update_default_release_versions_to_latest.py
+++ b/tools/ocp_version_update/update_default_release_versions_to_latest.py
@@ -363,6 +363,9 @@ def get_release_notes(updates_made):
 
 
 def get_github_credentials_from_netrc():
+    if not os.path.isfile(os.path.join(os.path.expanduser("~"), ".netrc")):
+        return None
+
     credentials = netrc.netrc().authenticators("github.com")
     if credentials is None:
         return None


### PR DESCRIPTION
# Assisted Pull Request

## Description

When an environment has no ``~/.netrc`` file on the host, docker will create this path on the host as a directory.
This should make sure we only take this path into account if it's a file. 

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
