### PR TITLE
MGMT-8298: MCP can’t be set until the host is day2

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -680,12 +680,6 @@ func (m *Manager) UpdateRole(ctx context.Context, h *models.Host, role models.Ho
 }
 
 func (m *Manager) UpdateMachineConfigPoolName(ctx context.Context, db *gorm.DB, h *models.Host, machineConfigPoolName string) error {
-	if !hostutil.IsDay2Host(h) {
-		return common.NewApiError(http.StatusBadRequest,
-			errors.Errorf("Host %s must be in day2 to update its machine config pool name to %s",
-				h.ID.String(), machineConfigPoolName))
-	}
-
 	hostStatus := swag.StringValue(h.Status)
 	if !funk.ContainsString(hostStatusesBeforeInstallation[:], hostStatus) {
 		return common.NewApiError(http.StatusBadRequest,

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2117,7 +2117,7 @@ var _ = Describe("UpdateMachineConfigPoolName", func() {
 			name:    "day1",
 			status:  models.HostStatusDiscovering,
 			day2:    false,
-			isValid: false,
+			isValid: true,
 		},
 		{
 			name:    "day2_before_installation",


### PR DESCRIPTION
## Description
MCP can't be set unless the host is day2 (Error: "Host %s must be in day2 to update its machine config pool name to %s"). This makes sense in the REST API, but in the k8s API once the host is day2 the installation already starts and it's too late. Consider moving the check to apply only to the REST API.

This change allows unbound hosts to set the machineConfigPool
Note that unbound hosts have the same kind as day-1 hosts hence this change
allow changing the machineConfigPool of day-1 hosts as well.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes for regression
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) created an agent CR with machineConfigPool and check the assisted-service log for the above-mentioned error.
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
