### PR TITLE
MGMT-8237: incorrect api responses for cluster managed networking with vms (#2936)

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3338,11 +3338,11 @@ func (b *bareMetalInventory) updateClusterNetworkVMUsage(cluster *common.Cluster
 	if updateParams != nil && updateParams.UserManagedNetworking != nil {
 		userManagedNetwork = *updateParams.UserManagedNetworking
 	}
-	if userManagedNetwork {
+	if !userManagedNetwork {
 		for _, host := range cluster.Hosts {
 			hostInventory, err := common.UnmarshalInventory(host.Inventory)
 			if err != nil {
-				err = errors.Wrap(err, "Failed to update usage flag for 'User managed network with VMs'.")
+				err = errors.Wrap(err, "Failed to update usage flag for 'Cluster managed network with VMs'.")
 				log.Error(err)
 				return
 			}
@@ -3352,7 +3352,7 @@ func (b *bareMetalInventory) updateClusterNetworkVMUsage(cluster *common.Cluster
 			}
 		}
 	}
-	b.setUsage(len(vmHosts) > 0, usage.UserManagedNetworkWithVMs, &map[string]interface{}{"VM Hosts": vmHosts}, usages)
+	b.setUsage(len(vmHosts) > 0, usage.ClusterManagedNetworkWithVMs, &map[string]interface{}{"VM Hosts": vmHosts}, usages)
 }
 
 func (b *bareMetalInventory) updateClusterCPUFeatureUsage(cluster *common.Cluster, usages map[string]models.Usage) {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13493,61 +13493,67 @@ var _ = Describe("Update cluster - feature usage flags", func() {
 	})
 
 	Context("Cluster managed network with VMs", func() {
-		It("Should Not add usage when network is not user managed", func() {
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(0)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(1)
-			bm.updateClusterNetworkVMUsage(cluster, nil, usages, common.GetTestLog())
-		})
-		It("Should not add usage when network is user managed but no VM hosts", func() {
+		It("Should Not add usage when network is not cluster managed", func() {
 			userManagedNetwork := true
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(0)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(1)
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(1)
 			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
 				UserManagedNetworking: &userManagedNetwork,
 			}, usages, common.GetTestLog())
 		})
-		It("Should not add usage when network is not user managed and contains VMs", func() {
-			addVMToCluster(cluster, db)
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(0)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(1)
-			bm.updateClusterNetworkVMUsage(cluster, nil, usages, common.GetTestLog())
-		})
-		It("Should add usage when updating cluster userManagedNetworking nil->true", func() {
-			addVMToCluster(cluster, db)
-			userManagedNetwork := true
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(1)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(0)
+		It("Should not add usage when network is cluster managed but no VM hosts", func() {
+			userManagedNetwork := false
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(1)
 			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
 				UserManagedNetworking: &userManagedNetwork,
 			}, usages, common.GetTestLog())
 		})
-		It("Should add usage when updating cluster userManagedNetworking true->(no update value)", func() {
+		It("Should not add usage when network is user managed and contains VMs", func() {
+			userManagedNetwork := true
+			addVMToCluster(cluster, db)
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(1)
+			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
+				UserManagedNetworking: &userManagedNetwork,
+			}, usages, common.GetTestLog())
+		})
+		It("Should not add usage when updating cluster userManagedNetworking nil->true", func() {
 			addVMToCluster(cluster, db)
 			userManagedNetwork := true
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(1)
+			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
+				UserManagedNetworking: &userManagedNetwork,
+			}, usages, common.GetTestLog())
+		})
+		It("Should add usage when updating cluster userManagedNetworking false->(no update value)", func() {
+			addVMToCluster(cluster, db)
+			userManagedNetwork := false
 			cluster.UserManagedNetworking = &userManagedNetwork
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(1)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(0)
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(1)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(0)
 			bm.updateClusterNetworkVMUsage(cluster, nil, usages, common.GetTestLog())
 		})
-		It("Should add usage when updating userManagedNetworking false -> true", func() {
+		It("Should remove usage when updating userManagedNetworking false -> true", func() {
 			addVMToCluster(cluster, db)
 			userManagedNetwork := false
 			updateTo := true
 			cluster.UserManagedNetworking = &userManagedNetwork
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(1)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(0)
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(1)
 			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
 				UserManagedNetworking: &updateTo,
 			}, usages, common.GetTestLog())
 		})
 
-		It("Should remove usage when updating userManagedNetworking true -> false", func() {
+		It("Should add usage when updating userManagedNetworking true -> false", func() {
 			addVMToCluster(cluster, db)
-			userManagedNetwork := false
-			updateTo := true
+			userManagedNetwork := true
+			updateTo := false
 			cluster.UserManagedNetworking = &userManagedNetwork
-			mockUsage.EXPECT().Add(usages, usage.UserManagedNetworkWithVMs, gomock.Any()).Times(1)
-			mockUsage.EXPECT().Remove(usages, usage.UserManagedNetworkWithVMs).Times(1)
+			mockUsage.EXPECT().Add(usages, usage.ClusterManagedNetworkWithVMs, gomock.Any()).Times(1)
+			mockUsage.EXPECT().Remove(usages, usage.ClusterManagedNetworkWithVMs).Times(0)
 			bm.updateClusterNetworkVMUsage(cluster, &models.V2ClusterUpdateParams{
 				UserManagedNetworking: &updateTo,
 			}, usages, common.GetTestLog())

--- a/internal/featuresupport/support_levels_list.go
+++ b/internal/featuresupport/support_levels_list.go
@@ -28,7 +28,7 @@ var SupportLevelsList = models.FeatureSupportLevels{
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 			{
-				FeatureID:    usageNameToID(usage.UserManagedNetworkWithVMs),
+				FeatureID:    usageNameToID(usage.ClusterManagedNetworkWithVMs),
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 		},
@@ -53,7 +53,7 @@ var SupportLevelsList = models.FeatureSupportLevels{
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 			{
-				FeatureID:    usageNameToID(usage.UserManagedNetworkWithVMs),
+				FeatureID:    usageNameToID(usage.ClusterManagedNetworkWithVMs),
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 		},
@@ -77,7 +77,7 @@ var SupportLevelsList = models.FeatureSupportLevels{
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 			{
-				FeatureID:    usageNameToID(usage.UserManagedNetworkWithVMs),
+				FeatureID:    usageNameToID(usage.ClusterManagedNetworkWithVMs),
 				SupportLevel: models.FeatureSupportLevelFeaturesItems0SupportLevelUnsupported,
 			},
 		},

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -29,8 +29,8 @@ const (
 	CustomManifest string = "Custom manifest"
 	// usage of disk encryption
 	DiskEncryption string = "Disk encryption"
-	// User managed networking with VMs
-	UserManagedNetworkWithVMs string = "User managed networking with VMs"
+	// Cluster managed networking with VMs
+	ClusterManagedNetworkWithVMs string = "Cluster managed networking with VMs"
 	// ARM64 Architecture usage
 	CPUArchitectureARM64 string = "arm64 architecture"
 )

--- a/models/feature_support_level.go
+++ b/models/feature_support_level.go
@@ -90,6 +90,7 @@ func (m *FeatureSupportLevel) UnmarshalBinary(b []byte) error {
 type FeatureSupportLevelFeaturesItems0 struct {
 
 	// The ID of the feature
+	// Enum: [ADDITIONAL_NTP_SOURCE REQUESTED_HOSTNAME PROXY SNO DAY2_HOSTS VIP_AUTO_ALLOC DISK_SELECTION OVN_NETWORK_TYPE SDN_NETWORK_TYPE PLATFORM_SELECTION SCHEDULABLE_MASTERS AUTO_ASSIGN_ROLE CUSTOM_MANIFEST DISK_ENCRYPTION CLUSTER_MANAGED_NETWORKING_WITH_VMS ARM64_ARCHITECTURE]
 	FeatureID string `json:"feature_id,omitempty"`
 
 	// support level
@@ -101,6 +102,10 @@ type FeatureSupportLevelFeaturesItems0 struct {
 func (m *FeatureSupportLevelFeaturesItems0) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateFeatureID(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateSupportLevel(formats); err != nil {
 		res = append(res, err)
 	}
@@ -108,6 +113,91 @@ func (m *FeatureSupportLevelFeaturesItems0) Validate(formats strfmt.Registry) er
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var featureSupportLevelFeaturesItems0TypeFeatureIDPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["ADDITIONAL_NTP_SOURCE","REQUESTED_HOSTNAME","PROXY","SNO","DAY2_HOSTS","VIP_AUTO_ALLOC","DISK_SELECTION","OVN_NETWORK_TYPE","SDN_NETWORK_TYPE","PLATFORM_SELECTION","SCHEDULABLE_MASTERS","AUTO_ASSIGN_ROLE","CUSTOM_MANIFEST","DISK_ENCRYPTION","CLUSTER_MANAGED_NETWORKING_WITH_VMS","ARM64_ARCHITECTURE"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		featureSupportLevelFeaturesItems0TypeFeatureIDPropEnum = append(featureSupportLevelFeaturesItems0TypeFeatureIDPropEnum, v)
+	}
+}
+
+const (
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDADDITIONALNTPSOURCE captures enum value "ADDITIONAL_NTP_SOURCE"
+	FeatureSupportLevelFeaturesItems0FeatureIDADDITIONALNTPSOURCE string = "ADDITIONAL_NTP_SOURCE"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDREQUESTEDHOSTNAME captures enum value "REQUESTED_HOSTNAME"
+	FeatureSupportLevelFeaturesItems0FeatureIDREQUESTEDHOSTNAME string = "REQUESTED_HOSTNAME"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDPROXY captures enum value "PROXY"
+	FeatureSupportLevelFeaturesItems0FeatureIDPROXY string = "PROXY"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDSNO captures enum value "SNO"
+	FeatureSupportLevelFeaturesItems0FeatureIDSNO string = "SNO"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDDAY2HOSTS captures enum value "DAY2_HOSTS"
+	FeatureSupportLevelFeaturesItems0FeatureIDDAY2HOSTS string = "DAY2_HOSTS"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDVIPAUTOALLOC captures enum value "VIP_AUTO_ALLOC"
+	FeatureSupportLevelFeaturesItems0FeatureIDVIPAUTOALLOC string = "VIP_AUTO_ALLOC"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDDISKSELECTION captures enum value "DISK_SELECTION"
+	FeatureSupportLevelFeaturesItems0FeatureIDDISKSELECTION string = "DISK_SELECTION"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDOVNNETWORKTYPE captures enum value "OVN_NETWORK_TYPE"
+	FeatureSupportLevelFeaturesItems0FeatureIDOVNNETWORKTYPE string = "OVN_NETWORK_TYPE"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDSDNNETWORKTYPE captures enum value "SDN_NETWORK_TYPE"
+	FeatureSupportLevelFeaturesItems0FeatureIDSDNNETWORKTYPE string = "SDN_NETWORK_TYPE"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDPLATFORMSELECTION captures enum value "PLATFORM_SELECTION"
+	FeatureSupportLevelFeaturesItems0FeatureIDPLATFORMSELECTION string = "PLATFORM_SELECTION"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDSCHEDULABLEMASTERS captures enum value "SCHEDULABLE_MASTERS"
+	FeatureSupportLevelFeaturesItems0FeatureIDSCHEDULABLEMASTERS string = "SCHEDULABLE_MASTERS"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDAUTOASSIGNROLE captures enum value "AUTO_ASSIGN_ROLE"
+	FeatureSupportLevelFeaturesItems0FeatureIDAUTOASSIGNROLE string = "AUTO_ASSIGN_ROLE"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDCUSTOMMANIFEST captures enum value "CUSTOM_MANIFEST"
+	FeatureSupportLevelFeaturesItems0FeatureIDCUSTOMMANIFEST string = "CUSTOM_MANIFEST"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDDISKENCRYPTION captures enum value "DISK_ENCRYPTION"
+	FeatureSupportLevelFeaturesItems0FeatureIDDISKENCRYPTION string = "DISK_ENCRYPTION"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDCLUSTERMANAGEDNETWORKINGWITHVMS captures enum value "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
+	FeatureSupportLevelFeaturesItems0FeatureIDCLUSTERMANAGEDNETWORKINGWITHVMS string = "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
+
+	// FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTURE captures enum value "ARM64_ARCHITECTURE"
+	FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTURE string = "ARM64_ARCHITECTURE"
+)
+
+// prop value enum
+func (m *FeatureSupportLevelFeaturesItems0) validateFeatureIDEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, featureSupportLevelFeaturesItems0TypeFeatureIDPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FeatureSupportLevelFeaturesItems0) validateFeatureID(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.FeatureID) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateFeatureIDEnum("feature_id", "body", m.FeatureID); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10901,12 +10901,34 @@ func init() {
       "properties": {
         "features": {
           "type": "array",
+          "required": [
+            "feature_id",
+            "support_level"
+          ],
           "items": {
             "type": "object",
             "properties": {
               "feature_id": {
                 "description": "The ID of the feature",
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "ADDITIONAL_NTP_SOURCE",
+                  "REQUESTED_HOSTNAME",
+                  "PROXY",
+                  "SNO",
+                  "DAY2_HOSTS",
+                  "VIP_AUTO_ALLOC",
+                  "DISK_SELECTION",
+                  "OVN_NETWORK_TYPE",
+                  "SDN_NETWORK_TYPE",
+                  "PLATFORM_SELECTION",
+                  "SCHEDULABLE_MASTERS",
+                  "AUTO_ASSIGN_ROLE",
+                  "CUSTOM_MANIFEST",
+                  "DISK_ENCRYPTION",
+                  "CLUSTER_MANAGED_NETWORKING_WITH_VMS",
+                  "ARM64_ARCHITECTURE"
+                ]
               },
               "support_level": {
                 "type": "string",
@@ -22365,7 +22387,25 @@ func init() {
       "properties": {
         "feature_id": {
           "description": "The ID of the feature",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "ADDITIONAL_NTP_SOURCE",
+            "REQUESTED_HOSTNAME",
+            "PROXY",
+            "SNO",
+            "DAY2_HOSTS",
+            "VIP_AUTO_ALLOC",
+            "DISK_SELECTION",
+            "OVN_NETWORK_TYPE",
+            "SDN_NETWORK_TYPE",
+            "PLATFORM_SELECTION",
+            "SCHEDULABLE_MASTERS",
+            "AUTO_ASSIGN_ROLE",
+            "CUSTOM_MANIFEST",
+            "DISK_ENCRYPTION",
+            "CLUSTER_MANAGED_NETWORKING_WITH_VMS",
+            "ARM64_ARCHITECTURE"
+          ]
         },
         "support_level": {
           "type": "string",
@@ -24014,6 +24054,10 @@ func init() {
       "properties": {
         "features": {
           "type": "array",
+          "required": [
+            "feature_id",
+            "support_level"
+          ],
           "items": {
             "$ref": "#/definitions/FeatureSupportLevelFeaturesItems0"
           }

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1401,7 +1401,7 @@ var _ = Describe("cluster install", func() {
 					HostsNames: []*models.ClusterUpdateParamsHostsNamesItems0{
 						{ID: *h.ID, Hostname: "h1"},
 					},
-					UserManagedNetworking: swag.Bool(true),
+					UserManagedNetworking: swag.Bool(false),
 				},
 				ClusterID: clusterID,
 			})
@@ -1412,7 +1412,7 @@ var _ = Describe("cluster install", func() {
 			verifyUsageSet(getReply.Payload.FeatureUsage,
 				models.Usage{Name: usage.OVNNetworkTypeUsage},
 				models.Usage{
-					Name: usage.UserManagedNetworkWithVMs,
+					Name: usage.ClusterManagedNetworkWithVMs,
 					Data: map[string]interface{}{
 						"VM Hosts": []interface{}{
 							h.ID.String(),

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6239,12 +6239,32 @@ definitions:
         description: Version of the OpenShift cluster.
       features:
         type: array
+        required:
+        - feature_id
+        - support_level
         items:
           type: object
           properties:
             feature_id:
               type: string
               description: The ID of the feature
+              enum:
+              - 'ADDITIONAL_NTP_SOURCE'
+              - 'REQUESTED_HOSTNAME'
+              - 'PROXY'
+              - 'SNO'
+              - 'DAY2_HOSTS'
+              - 'VIP_AUTO_ALLOC'
+              - 'DISK_SELECTION'
+              - 'OVN_NETWORK_TYPE'
+              - 'SDN_NETWORK_TYPE'
+              - 'PLATFORM_SELECTION'
+              - 'SCHEDULABLE_MASTERS'
+              - 'AUTO_ASSIGN_ROLE'
+              - 'CUSTOM_MANIFEST'
+              - 'DISK_ENCRYPTION'
+              - 'CLUSTER_MANAGED_NETWORKING_WITH_VMS'
+              - 'ARM64_ARCHITECTURE'
             support_level:
               type: string
               enum: [supported, unsupported, tech-preview, dev-preview]


### PR DESCRIPTION
# Assisted Pull Request

## Description

The feature usage of cluster managed newtorking with VMs support was returning wrong data.

Now marking `CLUSTER_MANAGED_NETWORKING_WITH_VMS` when cluster `userManagedNetworking` is false and there is at least one VM host in cluster.

Note: Changed featureID `USER_MANAGED_NETWORKING_WITH_VMS` -> `CLUSTER_MANAGED_NETWORKING_WITH_VMS`

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @sagidayan 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
