### PR TITLE
MGMT-7929: Host status update events to include optional cluster ID

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -248,6 +248,7 @@ x-events:
   properties:
     host_id: UUID
     infra_env_id: UUID
+    cluster_id: UUID_PTR
     severity: string
     host_name: string
     src_status: string

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1866,8 +1866,8 @@ var _ = Describe("PostStepReply", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
-
 			params := installer.V2PostStepReplyParams{
 				InfraEnvID: *clusterId,
 				HostID:     *hostId,
@@ -2385,7 +2385,8 @@ var _ = Describe("v2PostStepReply", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 
 			params := installer.V2PostStepReplyParams{
 				InfraEnvID: *clusterId,

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -2130,6 +2130,7 @@ func (e *HostBootstrapSetEvent) FormatMessage() string {
 type HostStatusUpdatedEvent struct {
     HostId strfmt.UUID
     InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
     Severity string
     HostName string
     SrcStatus string
@@ -2142,6 +2143,7 @@ var HostStatusUpdatedEventName string = "host_status_updated"
 func NewHostStatusUpdatedEvent(
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     severity string,
     hostName string,
     srcStatus string,
@@ -2151,6 +2153,7 @@ func NewHostStatusUpdatedEvent(
     return &HostStatusUpdatedEvent{
         HostId: hostId,
         InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
         Severity: severity,
         HostName: hostName,
         SrcStatus: srcStatus,
@@ -2164,6 +2167,7 @@ func SendHostStatusUpdatedEvent(
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     severity string,
     hostName string,
     srcStatus string,
@@ -2172,6 +2176,7 @@ func SendHostStatusUpdatedEvent(
     ev := NewHostStatusUpdatedEvent(
         hostId,
         infraEnvId,
+        clusterId,
         severity,
         hostName,
         srcStatus,
@@ -2186,6 +2191,7 @@ func SendHostStatusUpdatedEventAtTime(
     eventsHandler eventsapi.Sender,
     hostId strfmt.UUID,
     infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
     severity string,
     hostName string,
     srcStatus string,
@@ -2195,6 +2201,7 @@ func SendHostStatusUpdatedEventAtTime(
     ev := NewHostStatusUpdatedEvent(
         hostId,
         infraEnvId,
+        clusterId,
         severity,
         hostName,
         srcStatus,
@@ -2212,7 +2219,7 @@ func (e *HostStatusUpdatedEvent) GetSeverity() string {
     return e.Severity
 }
 func (e *HostStatusUpdatedEvent) GetClusterId() *strfmt.UUID {
-    return nil
+    return e.ClusterId
 }
 func (e *HostStatusUpdatedEvent) GetHostId() strfmt.UUID {
     return e.HostId
@@ -2225,6 +2232,7 @@ func (e *HostStatusUpdatedEvent) format(message *string) string {
     r := strings.NewReplacer(
         "{host_id}", fmt.Sprint(e.HostId),
         "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{severity}", fmt.Sprint(e.Severity),
         "{host_name}", fmt.Sprint(e.HostName),
         "{src_status}", fmt.Sprint(e.SrcStatus),

--- a/internal/events/eventstest/events_test_utils.go
+++ b/internal/events/eventstest/events_test_utils.go
@@ -42,7 +42,8 @@ func WithClusterIdMatcher(expected string) eventPartMatcher {
 			return e.GetClusterId().String() == expected
 		case eventsapi.HostEvent:
 			if e.GetClusterId() == nil {
-				return false
+				// cluster_id is an optional parameter for host events
+				return expected == ""
 			}
 			return e.GetClusterId().String() == expected
 		default:

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -323,6 +323,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -335,6 +336,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -354,6 +356,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -367,6 +370,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -389,6 +393,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityError)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -404,6 +409,7 @@ var _ = Describe("update_progress", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(host.ID.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityError)))
 				Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 				hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -419,6 +425,7 @@ var _ = Describe("update_progress", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 					Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -438,6 +445,7 @@ var _ = Describe("update_progress", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityError)))
 					Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &newProgress)).ShouldNot(HaveOccurred())
 					hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -469,6 +477,7 @@ var _ = Describe("update_progress", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 					Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 					verifyDb()
@@ -482,6 +491,7 @@ var _ = Describe("update_progress", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 					Expect(state.UpdateInstallProgress(ctx, &hostFromDB.Host, &newProgress)).Should(HaveOccurred())
 					verifyDb()
@@ -574,6 +584,7 @@ var _ = Describe("update progress special cases", func() {
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -596,6 +607,7 @@ var _ = Describe("update progress special cases", func() {
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -615,6 +627,7 @@ var _ = Describe("update progress special cases", func() {
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 			Expect(state.UpdateInstallProgress(ctx, &host, &progress)).ShouldNot(HaveOccurred())
 			hostFromDB = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
@@ -1641,6 +1654,7 @@ var _ = Describe("Bind host", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(hostId.String()),
 					eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+					eventstest.WithClusterIdMatcher(clusterId.String()),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 				host = hostutil.GenerateTestHost(hostId, infraEnvId, "", t.srcState)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
@@ -1792,6 +1806,7 @@ var _ = Describe("Unbind host", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(hostId.String()),
 					eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+					eventstest.WithClusterIdMatcher(swag.StringValue(nil)),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, t.srcState)
 				if t.kind != nil {

--- a/internal/host/hostutil/update_host.go
+++ b/internal/host/hostutil/update_host.go
@@ -72,8 +72,7 @@ func UpdateHostStatus(ctx context.Context, log logrus.FieldLogger, db *gorm.DB, 
 		if statusInfo != "" {
 			statusInfo += fmt.Sprintf("(%s)", statusInfo)
 		}
-		// TODO Need event for infra-env instead of cluster
-		eventgen.SendHostStatusUpdatedEvent(ctx, eventsHandler, hostId, infraEnvId, GetEventSeverityFromHostStatus(newStatus),
+		eventgen.SendHostStatusUpdatedEvent(ctx, eventsHandler, hostId, infraEnvId, host.ClusterID, GetEventSeverityFromHostStatus(newStatus),
 			GetHostnameForMsg(&host.Host), srcStatus, newStatus, statusInfo)
 		log.Infof("host %s from infra env %s has been updated with the following updates %+v", hostId, infraEnvId, extra)
 	}

--- a/internal/host/hostutil/update_host_test.go
+++ b/internal/host/hostutil/update_host_test.go
@@ -51,7 +51,8 @@ var _ = Describe("update_host_state", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 			returnedHost, err = UpdateHostStatus(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, common.TestDefaultConfig.Status,
 				newStatus, newStatusInfo)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -132,7 +133,8 @@ var _ = Describe("update_host_state", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 			returnedHost, err = UpdateHostProgress(ctx, common.GetTestLog(), db, mockEvents, host.InfraEnvID, *host.ID, *host.Status, newStatus, newStatusInfo,
 				host.Progress.CurrentStage, common.TestDefaultConfig.HostProgressStage, "")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -112,7 +112,8 @@ var _ = Describe("monitor_disconnection", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 			state.HostMonitoring()
 			db.First(&host, "id = ? and cluster_id = ?", host.ID, host.ClusterID)
 			Expect(*host.Status).Should(Equal(models.HostStatusDisconnected))
@@ -131,7 +132,8 @@ var _ = Describe("monitor_disconnection", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 			state.HostMonitoring()
 			db.First(&host, "id = ? and cluster_id = ?", host.ID, host.ClusterID)
 			Expect(*host.Status).Should(Equal(models.HostStatusDiscovering))

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -163,6 +163,7 @@ var _ = Describe("RegisterHost", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(clusterId.String()),
 						eventstest.WithSeverityMatcher(t.expectedEventStatus)))
 				}
 
@@ -311,6 +312,7 @@ var _ = Describe("RegisterHost", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(clusterId.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				}
 
@@ -465,6 +467,7 @@ var _ = Describe("RegisterHost", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(clusterId.String()),
 						eventstest.WithSeverityMatcher(t.eventSeverity)))
 				}
 
@@ -575,6 +578,7 @@ var _ = Describe("RegisterHost", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(swag.StringValue(nil)),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(t.dstState))))
 				}
 
@@ -631,6 +635,7 @@ var _ = Describe("HostInstallationFailed", func() {
 			eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 			eventstest.WithHostIdMatcher(hostId.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+			eventstest.WithClusterIdMatcher(clusterId.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockMetric.EXPECT().ReportHostInstallationMetrics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 		Expect(hapi.HandleInstallationFailure(ctx, &host)).ShouldNot(HaveOccurred())
@@ -987,6 +992,7 @@ var _ = Describe("Install", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(hostId.String()),
 					eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+					eventstest.WithClusterIdMatcher(clusterId.String()),
 					eventstest.WithMessageMatcher(fmt.Sprintf("Host %s: updated status from \"%s\" to \"installing\" (Installation is in progress)",
 						host.ID.String(), t.srcState)),
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -1023,7 +1029,9 @@ var _ = Describe("Install", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String())))
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
+			))
 			Expect(hapi.RefreshStatus(ctx, &host, tx)).ShouldNot(HaveOccurred())
 			Expect(tx.Commit().Error).ShouldNot(HaveOccurred())
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
@@ -1038,6 +1046,7 @@ var _ = Describe("Install", func() {
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 			Expect(hapi.RefreshStatus(ctx, &host, tx)).ShouldNot(HaveOccurred())
 			Expect(tx.Rollback().Error).ShouldNot(HaveOccurred())
@@ -1092,10 +1101,15 @@ var _ = Describe("Disable", func() {
 		}
 
 		mockEventsUpdateStatus := func(srcState, dstState string) {
+			cId := ""
+			if host.ClusterID != nil {
+				cId = host.ClusterID.String()
+			}
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(host.ID.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(cId),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo))).Times(1)
 		}
 
@@ -1377,10 +1391,15 @@ var _ = Describe("Enable", func() {
 
 				// Test definition
 				if t.sendEvent {
+					cId := ""
+					if host.ClusterID != nil {
+						cId = host.ClusterID.String()
+					}
 					mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(cId),
 						eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 				}
 				t.validation(hapi.EnableHost(ctx, &host, db), dstState)
@@ -1782,6 +1801,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusError))))
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -1844,6 +1864,7 @@ var _ = Describe("Refresh Host", func() {
 					eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 					eventstest.WithHostIdMatcher(hostId.String()),
 					eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+					eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 					eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusError))))
 				err := hapi.RefreshStatus(ctx, &host, db)
 
@@ -1935,6 +1956,7 @@ var _ = Describe("Refresh Host", func() {
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(hostId.String()),
 				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 				eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusDisconnected))))
 			err := hapi.RefreshStatus(ctx, &host, db)
 
@@ -1981,6 +2003,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusError))))
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -2055,12 +2078,14 @@ var _ = Describe("Refresh Host", func() {
 									eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 									eventstest.WithHostIdMatcher(hostId.String()),
 									eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+									eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 									eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusInstallingPendingUserAction))))
 							} else {
 								mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 									eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 									eventstest.WithHostIdMatcher(hostId.String()),
 									eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+									eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 									eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(models.HostStatusError))))
 							}
 						}
@@ -2586,6 +2611,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(t.dstState))))
 				}
 				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
@@ -2668,6 +2694,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(t.dstState))))
 				}
 				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
@@ -4005,6 +4032,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(t.dstState))))
 				}
 				Expect(getHost(infraEnvId, hostId).ValidationsInfo).To(BeEmpty())
@@ -4064,6 +4092,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(hostutil.GetEventSeverityFromHostStatus(t.dstState))))
 				}
 				err := hapi.RefreshStatus(ctx, &host, db)
@@ -4514,6 +4543,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(host.ID.String()),
 						eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String()),
 						eventstest.WithSeverityMatcher(expectedSeverity)))
 				}
 
@@ -4590,6 +4620,7 @@ var _ = Describe("Refresh Host", func() {
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
 						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(clusterId.String()),
 						eventstest.WithSeverityMatcher(models.EventSeverityError)))
 
 					err := hapi.RefreshStatus(ctx, &h, db)
@@ -4626,7 +4657,8 @@ var _ = Describe("Refresh Host", func() {
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 				eventstest.WithHostIdMatcher(hostId.String()),
-				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()))).AnyTimes()
+				eventstest.WithInfraEnvIdMatcher(host.InfraEnvID.String()),
+				eventstest.WithClusterIdMatcher(host.ClusterID.String()))).AnyTimes()
 		})
 
 		tests := []struct {
@@ -4679,7 +4711,8 @@ var _ = Describe("Refresh Host", func() {
 			mockDefaultClusterHostRequirements(mockHwValidator)
 			mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
-				eventstest.WithHostIdMatcher(hostId.String()))).AnyTimes()
+				eventstest.WithHostIdMatcher(hostId.String()),
+				eventstest.WithClusterIdMatcher(clusterId.String()))).AnyTimes()
 		})
 
 		tests := []struct {
@@ -5115,7 +5148,8 @@ var _ = Describe("Refresh Host", func() {
 					mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
-						eventstest.WithInfraEnvIdMatcher(infraEnvId.String())))
+						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(host.ClusterID.String())))
 				}
 				Expect(hapi.RefreshStatus(ctx, &host, db)).NotTo(HaveOccurred())
 				var resultHost models.Host
@@ -5449,7 +5483,8 @@ var _ = Describe("Refresh Host", func() {
 					mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 						eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 						eventstest.WithHostIdMatcher(hostId.String()),
-						eventstest.WithInfraEnvIdMatcher(infraEnvId.String())))
+						eventstest.WithInfraEnvIdMatcher(infraEnvId.String()),
+						eventstest.WithClusterIdMatcher(swag.StringValue(nil))))
 				}
 
 				Expect(hapi.RefreshStatus(ctx, &host, db)).NotTo(HaveOccurred())

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Validations test", func() {
 			eventstest.WithNameMatcher(eventgen.HostStatusUpdatedEventName),
 			eventstest.WithHostIdMatcher(h.ID.String()),
 			eventstest.WithInfraEnvIdMatcher(h.InfraEnvID.String()),
+			eventstest.WithClusterIdMatcher(h.ClusterID.String()),
 		))
 		mockAndRefreshStatusWithoutEvents(h)
 	}


### PR DESCRIPTION
# Assisted Pull Request

## Description

Host status update events currently only include InfraEnv.
Example:
"Host test-infra-cluster-assisted-installer-master-0: updated status
from discovering to pending-for-input Waiting for user input"

When a host is bound to a cluster, the cluster-ID should also be included.
Adding cluster-ID will allow a view of those events when queries are filtered by a cluster-Id.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @masayag 
/cc @arielireni 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
