### PR TITLE
MGMT-8346: fix iso url when using image service

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -497,7 +497,7 @@ func (b *bareMetalInventory) generateImageDownloadURL(infraEnvID, imageType, ver
 	downloadURL := url.URL{
 		Scheme: baseURL.Scheme,
 		Host:   baseURL.Host,
-		Path:   fmt.Sprintf("/images/%s", infraEnvID),
+		Path:   fmt.Sprintf("%s/images/%s", baseURL.Path, infraEnvID),
 	}
 	queryValues := url.Values{}
 	queryValues.Set("type", imageType)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Assisted-service ignore base path when building image-service URL
if the base url contain additional path it will be ignored
url: https://api.integration.openshift.com/api/assisted-images
resutl: https://api.integration.openshift.com/images/{infa-env-id}?{params}
expected result: https://api.integration.openshift.com/api/assisted-images/images/{infa-env-id}?{params}

## List all the issues related to this PR

- [ ] New Feature
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @osherdp 
/cc @carbonin 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
