### PR TITLE
MGMT-8308: Fix vsphere provider db fields.

### DIFF
--- a/internal/provider/vsphere/consts.go
+++ b/internal/provider/vsphere/consts.go
@@ -13,10 +13,10 @@ const (
 	DbFieldUsername         = "platform_vsphere_username"
 	DbFieldPassword         = "platform_vsphere_password"
 	DbFieldDatacenter       = "platform_vsphere_datacenter"
-	DbFieldDefaultDatastore = "platform_vsphere_defaultDatastore"
+	DbFieldDefaultDatastore = "platform_vsphere_default_datastore"
 	DbFieldCluster          = "platform_vsphere_cluster"
 	DbFieldNetwork          = "platform_vsphere_network"
-	DbFieldVCenter          = "platform_vsphere_vCenter"
+	DbFieldVCenter          = "platform_vsphere_v_center"
 	DbFieldFolder           = "platform_vsphere_folder"
 
 	VmwareManufacturer string = "VMware, Inc."


### PR DESCRIPTION
# Assisted Pull Request

## Description

Fix wrong vsphere provider db consts to match
database column names.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @avishayt 
/cc @eliorerz 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

