### PR TITLE
Pipe arguments to configmap creation script via env-vars

### DIFF
--- a/tools/deploy_assisted_installer_configmap.py
+++ b/tools/deploy_assisted_installer_configmap.py
@@ -17,9 +17,9 @@ def handle_arguments():
     parser.add_argument("--jwks-url", default="https://api.openshift.com/.well-known/jwks.json")
     parser.add_argument("--ocm-url", default="https://api-integration.6943.hive-integration.openshiftapps.com")
     parser.add_argument("--ocp-versions")
-    parser.add_argument("--os-images")
-    parser.add_argument("--release-images")
-    parser.add_argument("--must-gather-images")
+    parser.add_argument("--os-images", default=os.environ.get("OS_IMAGES"))
+    parser.add_argument("--release-images", default=os.environ.get("RELEASE_IMAGES"))
+    parser.add_argument("--must-gather-images", default=os.environ.get("MUST_GATHER_IMAGES"))
     parser.add_argument("--installation-timeout", type=int)
     parser.add_argument("--public-registries", default="")
     parser.add_argument("--img-expr-time", default="")
@@ -27,7 +27,7 @@ def handle_arguments():
     parser.add_argument("--check-cvo", default="False")
     parser.add_argument("--ipv6-support", default="True")
     parser.add_argument("--enable-sno-dnsmasq", default="True")
-    parser.add_argument("--hw-requirements")
+    parser.add_argument("--hw-requirements", default=os.environ.get("HW_REQUIREMENTS"))
     parser.add_argument("--disabled-host-validations", default="")
     parser.add_argument("--disabled-steps", default="")
     parser.add_argument("--disk-encryption-support", default="True")
@@ -52,7 +52,7 @@ def get_deployment_tag(args):
 
 def main():
     utils.verify_build_directory(deploy_options.namespace)
-    verify_images(release_images=json.loads(json.loads('"{}"'.format(deploy_options.release_images))))
+    verify_images(release_images=json.loads(deploy_options.release_images))
     with open(SRC_FILE, "r") as src:
         with open(DST_FILE, "w+") as dst:
             data = src.read()


### PR DESCRIPTION
# Assisted Pull Request

## Description

Refactor our code to deliver arguments via environment variables, instead of "serializing" them on the CLI.

## List all the issues related to this PR

- [ ] New Feature
- [x] Refactor
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @osherdp
<TBD>

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
