### PR TITLE
MGMT-8302 Ignition endpoint token should not be returned

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -81,6 +81,9 @@ type Host struct {
 
 	// Timestamp to trigger monitor. Monitor will be triggered if timestamp is recent
 	TriggerMonitorTimestamp time.Time
+
+	// A string which will be used as Authorization Bearer token to fetch the ignition from ignition_endpoint_url.
+	IgnitionEndpointToken string `json:"ignition_endpoint_token" gorm:"type:TEXT"`
 }
 
 type InfraEnv struct {

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -884,7 +884,7 @@ func (r *AgentReconciler) updateIfNeeded(ctx context.Context, log logrus.FieldLo
 		}
 	}
 
-	if spec.IgnitionEndpointToken != "" && spec.IgnitionEndpointToken != swag.StringValue(internalHost.IgnitionEndpointToken) {
+	if spec.IgnitionEndpointToken != "" && spec.IgnitionEndpointToken != internalHost.IgnitionEndpointToken {
 		hostUpdate = true
 		params.HostUpdateParams.IgnitionEndpointToken = &spec.IgnitionEndpointToken
 	}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2252,7 +2252,8 @@ var _ = Describe("UpdateIgnitionEndpointToken", func() {
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 
 			h := hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db)
-			Expect(h.IgnitionEndpointToken).Should(BeNil())
+			Expect(h.IgnitionEndpointToken).Should(BeEquivalentTo(""))
+			Expect(h.IgnitionEndpointTokenSet).Should(BeEquivalentTo(false))
 
 			// Test
 			err := hapi.UpdateIgnitionEndpointToken(ctx, db, &host, t.name)
@@ -2260,11 +2261,12 @@ var _ = Describe("UpdateIgnitionEndpointToken", func() {
 
 			if t.isValid {
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(h.IgnitionEndpointToken).ShouldNot(BeNil())
-				Expect(*h.IgnitionEndpointToken).Should(Equal(t.name))
+				Expect(h.IgnitionEndpointToken).Should(Equal(t.name))
+				Expect(h.IgnitionEndpointTokenSet).Should(BeEquivalentTo(true))
 			} else {
 				Expect(err).Should(HaveOccurred())
-				Expect(h.IgnitionEndpointToken).Should(BeNil())
+				Expect(h.IgnitionEndpointToken).Should(BeEquivalentTo(""))
+				Expect(h.IgnitionEndpointTokenSet).Should(BeEquivalentTo(false))
 			}
 
 		})

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -329,7 +329,7 @@ type Generator interface {
 //go:generate mockgen -source=ignition.go -package=ignition -destination=mock_ignition.go
 type IgnitionBuilder interface {
 	FormatDiscoveryIgnitionFile(ctx context.Context, infraEnv *common.InfraEnv, cfg IgnitionConfig, safeForLogs bool, authType auth.AuthType) (string, error)
-	FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken *string) ([]byte, error)
+	FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error)
 }
 
 type installerGenerator struct {
@@ -1439,15 +1439,15 @@ func (ib *ignitionBuilder) prepareStaticNetworkConfigForIgnition(ctx context.Con
 	return filesList, nil
 }
 
-func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken *string) ([]byte, error) {
+func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error) {
 	var ignitionParams = map[string]interface{}{
 		// https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigServer.md#endpoint
 		"SOURCE":  url,
 		"HEADERS": map[string]string{},
 		"CACERT":  "",
 	}
-	if bearerToken != nil {
-		ignitionParams["HEADERS"].(map[string]string)["Authorization"] = fmt.Sprintf("Bearer %s", *bearerToken)
+	if bearerToken != "" {
+		ignitionParams["HEADERS"].(map[string]string)["Authorization"] = fmt.Sprintf("Bearer %s", bearerToken)
 	}
 
 	if caCert != nil {

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1232,7 +1232,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 	Context("test custom ignition endpoint", func() {
 
 		It("are rendered properly without ca cert and token", func() {
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, nil)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1244,7 +1244,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 
 		It("are rendered properly with token", func() {
 			token := "xyzabc123"
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, &token)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, token)
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1261,7 +1261,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
 			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, nil)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1278,7 +1278,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
 			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, &token)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, token)
 
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/ignition/mock_ignition.go
+++ b/internal/ignition/mock_ignition.go
@@ -118,7 +118,7 @@ func (mr *MockIgnitionBuilderMockRecorder) FormatDiscoveryIgnitionFile(ctx, infr
 }
 
 // FormatSecondDayWorkerIgnitionFile mocks base method.
-func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert, bearerToken *string) ([]byte, error) {
+func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FormatSecondDayWorkerIgnitionFile", url, caCert, bearerToken)
 	ret0, _ := ret[0].([]byte)

--- a/models/host.go
+++ b/models/host.go
@@ -72,8 +72,8 @@ type Host struct {
 	// Example: {\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}
 	IgnitionConfigOverrides string `json:"ignition_config_overrides,omitempty" gorm:"type:text"`
 
-	// A string which will be used as Authorization Bearer token to fetch the ignition from ignition_endpoint_url.
-	IgnitionEndpointToken *string `json:"ignition_endpoint_token,omitempty"`
+	// True if the token to fetch the ignition from ignition_endpoint_url is set.
+	IgnitionEndpointTokenSet bool `json:"ignition_endpoint_token_set,omitempty"`
 
 	// Array of image statuses.
 	ImagesStatus string `json:"images_status,omitempty" gorm:"type:text"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -11393,10 +11393,9 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}"
         },
-        "ignition_endpoint_token": {
-          "description": "A string which will be used as Authorization Bearer token to fetch the ignition from ignition_endpoint_url.",
-          "type": "string",
-          "x-nullable": true
+        "ignition_endpoint_token_set": {
+          "description": "True if the token to fetch the ignition from ignition_endpoint_url is set.",
+          "type": "boolean"
         },
         "images_status": {
           "description": "Array of image statuses.",
@@ -24957,10 +24956,9 @@ func init() {
           "x-go-custom-tag": "gorm:\"type:text\"",
           "example": "{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/tmp/example\", \"contents\": {\"source\": \"data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj\"}}]}}"
         },
-        "ignition_endpoint_token": {
-          "description": "A string which will be used as Authorization Bearer token to fetch the ignition from ignition_endpoint_url.",
-          "type": "string",
-          "x-nullable": true
+        "ignition_endpoint_token_set": {
+          "description": "True if the token to fetch the ignition from ignition_endpoint_url is set.",
+          "type": "boolean"
         },
         "images_status": {
           "description": "Array of image statuses.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6921,10 +6921,9 @@ definitions:
         x-go-custom-tag: gorm:"type:text"
         type: string
         description: The domain name resolution result.
-      ignition_endpoint_token:
-        x-nullable: true
-        type: string
-        description: A string which will be used as Authorization Bearer token to fetch the ignition from ignition_endpoint_url.
+      ignition_endpoint_token_set:
+        type: boolean
+        description: True if the token to fetch the ignition from ignition_endpoint_url is set.
 
 
   installer-args-params:


### PR DESCRIPTION
# Assisted Pull Request

## Description

The ignition endpoint token is sensitive information and should not be
returned to users once it is set. Instead, we have a boolean flag
showing that it has been set.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/assign @eranco74 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
