### PR TITLE
MGMT-8180: day2 - fallback to default ocp version

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -810,8 +810,14 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 	// Day2 supports only x86_64 for now
 	releaseImage, err := b.versionsHandler.GetReleaseImage(inputOpenshiftVersion, common.DefaultCPUArchitecture)
 	if err != nil {
-		log.WithError(err).Errorf("Failed to get opnshift version supported by versions map from version %s", inputOpenshiftVersion)
-		return nil, common.NewApiError(http.StatusBadRequest, fmt.Errorf("failed to get opnshift version supported by versions map from version %s", inputOpenshiftVersion))
+		log.WithError(err).Warnf("Failed to get release image for version %s - fallback to default version", inputOpenshiftVersion)
+
+		// Try to get default release image as a fallback
+		releaseImage, err = b.versionsHandler.GetDefaultReleaseImage(common.DefaultCPUArchitecture)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get default release image")
+			return nil, common.NewApiError(http.StatusBadRequest, fmt.Errorf("failed to get default release image"))
+		}
 	}
 
 	if kubeKey == nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10343,6 +10343,35 @@ var _ = Describe("Register AddHostsCluster test", func() {
 		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))
 	})
+
+	It("Create AddHosts cluster - missing release image", func() {
+		defaultHostNetworks := make([]*models.HostNetwork, 0)
+		defaultHosts := make([]*models.Host, 0)
+		openshiftClusterID := strfmt.UUID(uuid.New().String())
+
+		params := installer.V2ImportClusterParams{
+			HTTPRequest: request,
+			NewImportClusterParams: &models.ImportClusterParams{
+				APIVipDnsname:      &apiVIPDnsname,
+				Name:               &clusterName,
+				OpenshiftVersion:   swag.String(common.TestDefaultConfig.OpenShiftVersion),
+				OpenshiftClusterID: &openshiftClusterID,
+			},
+		}
+		mockClusterApi.EXPECT().RegisterAddHostsCluster(ctx, gomock.Any(), common.SkipInfraEnvCreation, gomock.Any()).Return(nil).Times(1)
+		mockMetric.EXPECT().ClusterRegistered(common.TestDefaultConfig.ReleaseVersion, gomock.Any(), "Unknown").Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("missing")).Times(1)
+		mockVersions.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		res := bm.V2ImportCluster(ctx, params)
+		actual := res.(*installer.V2ImportClusterCreated)
+
+		Expect(actual.Payload.HostNetworks).To(Equal(defaultHostNetworks))
+		Expect(actual.Payload.Hosts).To(Equal(defaultHosts))
+		Expect(actual.Payload.OpenshiftVersion).To(Equal(common.TestDefaultConfig.ReleaseVersion))
+		Expect(actual.Payload.OcpReleaseImage).To(Equal(common.TestDefaultConfig.ReleaseImageUrl))
+		Expect(actual.Payload.OpenshiftClusterID).To(Equal(openshiftClusterID))
+		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2ImportClusterCreated()))
+	})
 })
 
 var _ = Describe("Reset Host test", func() {

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -67,6 +67,21 @@ func (mr *MockHandlerMockRecorder) GetCPUArchitectures(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCPUArchitectures", reflect.TypeOf((*MockHandler)(nil).GetCPUArchitectures), arg0)
 }
 
+// GetDefaultReleaseImage mocks base method.
+func (m *MockHandler) GetDefaultReleaseImage(arg0 string) (*models.ReleaseImage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultReleaseImage", arg0)
+	ret0, _ := ret[0].(*models.ReleaseImage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDefaultReleaseImage indicates an expected call of GetDefaultReleaseImage.
+func (mr *MockHandlerMockRecorder) GetDefaultReleaseImage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetDefaultReleaseImage), arg0)
+}
+
 // GetLatestOsImage mocks base method.
 func (m *MockHandler) GetLatestOsImage(arg0 string) (*models.OsImage, error) {
 	m.ctrl.T.Helper()

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -56,6 +56,7 @@ var defaultReleaseImages = models.ReleaseImages{
 		OpenshiftVersion: swag.String("4.9"),
 		URL:              swag.String("release_4.9"),
 		Version:          swag.String("4.9-candidate"),
+		Default:          true,
 	},
 	&models.ReleaseImage{
 		CPUArchitecture:  swag.String("arm64"),
@@ -295,6 +296,30 @@ var _ = Describe("list versions", func() {
 					}
 				}
 			}
+		})
+	})
+
+	Context("GetDefaultReleaseImage", func() {
+		var (
+			releaseImage *models.ReleaseImage
+		)
+
+		It("Default release image exists", func() {
+			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, defaultReleaseImages, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			releaseImage, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(releaseImage.Default).Should(Equal(true))
+			Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
+			Expect(*releaseImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+		})
+
+		It("Missing default release image", func() {
+			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{}, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			releaseImage, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(Equal("Default release image is not available"))
 		})
 	})
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

* In day2 context, when a release image for the existing cluster is missing, fallback to the the default version.
E.g. adding a host to an existing cluster based on 4.5 release image - would use 4.8 release image when installing the new added host.

* Added and helper to versions for fetching the default release image (GetDefaultReleaseImage).

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @rollandf 
/cc @filanov 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
