### PR TITLE
MGMT-7925: Remove a redundant cluster registration event

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -37,13 +37,6 @@ x-events:
   severity: "info"
   properties:
     cluster_id: UUID
-
-- name: cluster_registered
-  message: "Registered cluster"
-  event_type: cluster
-  severity: "info"
-  properties:
-    cluster_id: UUID
     cluster_kind: string
 
 - name: cluster_deregister_failed

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -481,14 +481,17 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			msg := fmt.Sprintf("Successfully registered cluster %s with id %s",
 				swag.StringValue(params.NewClusterParams.Name), id)
 			log.Info(msg)
-			eventgen.SendClusterRegistrationSucceededEvent(ctx, b.eventsHandler, id)
+			eventgen.SendClusterRegistrationSucceededEvent(ctx, b.eventsHandler, id, models.ClusterKindCluster)
 		} else {
 			errWrapperLog := log
+			errStr := fmt.Sprintf("Failed to registered cluster %s with id %s", swag.StringValue(params.NewClusterParams.Name), id)
 			if err != nil {
 				errWrapperLog = log.WithError(err)
+				eventgen.SendClusterRegistrationFailedEvent(ctx, b.eventsHandler, id, err.Error(), models.ClusterKindCluster)
+			} else {
+				eventgen.SendClusterRegistrationFailedEvent(ctx, b.eventsHandler, id, errStr, models.ClusterKindCluster)
 			}
-			errWrapperLog.Errorf("Failed to registered cluster %s with id %s",
-				swag.StringValue(params.NewClusterParams.Name), id)
+			errWrapperLog.Errorf(errStr)
 		}
 	}()
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -188,14 +188,7 @@ func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, eventsHandler e
 }
 
 func (m *Manager) RegisterCluster(ctx context.Context, c *common.Cluster, v1Flag common.InfraEnvCreateFlag, v1ISOType models.ImageType) error {
-	err := m.registrationAPI.RegisterCluster(ctx, c, v1Flag, v1ISOType)
-	if err != nil {
-		eventgen.SendClusterRegistrationFailedEvent(ctx, m.eventsHandler, *c.ID, err.Error(), models.ClusterKindCluster)
-
-	} else {
-		eventgen.SendClusterRegisteredEvent(ctx, m.eventsHandler, *c.ID, models.ClusterKindCluster)
-	}
-	return err
+	return m.registrationAPI.RegisterCluster(ctx, c, v1Flag, v1ISOType)
 }
 
 func (m *Manager) RegisterAddHostsCluster(ctx context.Context, c *common.Cluster, v1Flag common.InfraEnvCreateFlag, v1ISOType models.ImageType) error {
@@ -203,7 +196,7 @@ func (m *Manager) RegisterAddHostsCluster(ctx context.Context, c *common.Cluster
 	if err != nil {
 		eventgen.SendClusterRegistrationFailedEvent(ctx, m.eventsHandler, *c.ID, err.Error(), models.ClusterKindAddHostsCluster)
 	} else {
-		eventgen.SendClusterRegisteredEvent(ctx, m.eventsHandler, *c.ID, models.ClusterKindAddHostsCluster)
+		eventgen.SendClusterRegistrationSucceededEvent(ctx, m.eventsHandler, *c.ID, models.ClusterKindAddHostsCluster)
 	}
 	return err
 }

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2158,7 +2158,7 @@ var _ = Describe("insufficient_state", func() {
 			PullSecretSet:   true,
 		}}
 		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.ClusterRegisteredEventName),
+			eventstest.WithNameMatcher(eventgen.ClusterRegistrationSucceededEventName),
 			eventstest.WithClusterIdMatcher(id.String()))).AnyTimes()
 	})
 
@@ -2916,9 +2916,6 @@ var _ = Describe("Validation metrics and events", func() {
 	registerTestClusterWithValidationsAndHost := func() *common.Cluster {
 
 		clusterID := strfmt.UUID(uuid.New().String())
-		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.ClusterRegisteredEventName),
-			eventstest.WithClusterIdMatcher(clusterID.String())))
 		c := common.Cluster{
 			Cluster: models.Cluster{
 				ID:               &clusterID,

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -298,24 +298,29 @@ func (e *ClusterRegistrationFailedEvent) FormatMessage() string {
 //
 type ClusterRegistrationSucceededEvent struct {
     ClusterId strfmt.UUID
+    ClusterKind string
 }
 
 var ClusterRegistrationSucceededEventName string = "cluster_registration_succeeded"
 
 func NewClusterRegistrationSucceededEvent(
     clusterId strfmt.UUID,
+    clusterKind string,
 ) *ClusterRegistrationSucceededEvent {
     return &ClusterRegistrationSucceededEvent{
         ClusterId: clusterId,
+        ClusterKind: clusterKind,
     }
 }
 
 func SendClusterRegistrationSucceededEvent(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
-    clusterId strfmt.UUID,) {
+    clusterId strfmt.UUID,
+    clusterKind string,) {
     ev := NewClusterRegistrationSucceededEvent(
         clusterId,
+        clusterKind,
     )
     eventsHandler.SendClusterEvent(ctx, ev)
 }
@@ -324,9 +329,11 @@ func SendClusterRegistrationSucceededEventAtTime(
     ctx context.Context,
     eventsHandler eventsapi.Sender,
     clusterId strfmt.UUID,
+    clusterKind string,
     eventTime time.Time) {
     ev := NewClusterRegistrationSucceededEvent(
         clusterId,
+        clusterKind,
     )
     eventsHandler.SendClusterEventAtTime(ctx, ev, eventTime)
 }
@@ -345,81 +352,13 @@ func (e *ClusterRegistrationSucceededEvent) GetClusterId() strfmt.UUID {
 func (e *ClusterRegistrationSucceededEvent) format(message *string) string {
     r := strings.NewReplacer(
         "{cluster_id}", fmt.Sprint(e.ClusterId),
+        "{cluster_kind}", fmt.Sprint(e.ClusterKind),
     )
     return r.Replace(*message)
 }
 
 func (e *ClusterRegistrationSucceededEvent) FormatMessage() string {
     s := "Successfully registered cluster"
-    return e.format(&s)
-}
-
-//
-// Event cluster_registered
-//
-type ClusterRegisteredEvent struct {
-    ClusterId strfmt.UUID
-    ClusterKind string
-}
-
-var ClusterRegisteredEventName string = "cluster_registered"
-
-func NewClusterRegisteredEvent(
-    clusterId strfmt.UUID,
-    clusterKind string,
-) *ClusterRegisteredEvent {
-    return &ClusterRegisteredEvent{
-        ClusterId: clusterId,
-        ClusterKind: clusterKind,
-    }
-}
-
-func SendClusterRegisteredEvent(
-    ctx context.Context,
-    eventsHandler eventsapi.Sender,
-    clusterId strfmt.UUID,
-    clusterKind string,) {
-    ev := NewClusterRegisteredEvent(
-        clusterId,
-        clusterKind,
-    )
-    eventsHandler.SendClusterEvent(ctx, ev)
-}
-
-func SendClusterRegisteredEventAtTime(
-    ctx context.Context,
-    eventsHandler eventsapi.Sender,
-    clusterId strfmt.UUID,
-    clusterKind string,
-    eventTime time.Time) {
-    ev := NewClusterRegisteredEvent(
-        clusterId,
-        clusterKind,
-    )
-    eventsHandler.SendClusterEventAtTime(ctx, ev, eventTime)
-}
-
-func (e *ClusterRegisteredEvent) GetName() string {
-    return "cluster_registered"
-}
-
-func (e *ClusterRegisteredEvent) GetSeverity() string {
-    return "info"
-}
-func (e *ClusterRegisteredEvent) GetClusterId() strfmt.UUID {
-    return e.ClusterId
-}
-
-func (e *ClusterRegisteredEvent) format(message *string) string {
-    r := strings.NewReplacer(
-        "{cluster_id}", fmt.Sprint(e.ClusterId),
-        "{cluster_kind}", fmt.Sprint(e.ClusterKind),
-    )
-    return r.Replace(*message)
-}
-
-func (e *ClusterRegisteredEvent) FormatMessage() string {
-    s := "Registered cluster"
     return e.format(&s)
 }
 

--- a/internal/events/eventstest/events_test_utils.go
+++ b/internal/events/eventstest/events_test_utils.go
@@ -80,7 +80,7 @@ func WithInfraEnvIdMatcher(expected string) eventPartMatcher {
 
 func WithSeverityMatcher(expected string) eventPartMatcher {
 	return func(event interface{}) bool {
-		e, ok := event.(eventsapi.HostEvent)
+		e, ok := event.(eventsapi.BaseEvent)
 		if !ok {
 			return false
 		}

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -109,7 +109,7 @@ var _ = Describe("system-test image tests", func() {
 				downloadClusterIsoHeaders(ctx, clusterID)
 
 				By("Verify events")
-				verifyEventExistence(clusterID, "Registered cluster")
+				verifyEventExistence(clusterID, "Successfully registered cluster")
 				verifyEventExistence(clusterID, fmt.Sprintf("Image type is \"%s\"", imageType))
 			}
 		})


### PR DESCRIPTION
# Assisted Pull Request

## Description

Upon cluster registration two events were produced:
- Registered cluster
- Successfully registered cluster

To match with host events, the 'Registered cluster' was removed.

Additionally, some registration failures did not produce any event.
This change addresses that problem as well.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
