### PR TITLE
MGMT-8461: Avoid panic in case nil is passed to GenerateError

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2806,8 +2806,8 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 
 	if len(updates) > 0 {
 		updates["trigger_monitor_timestamp"] = time.Now()
-		dbReply := db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates)
-		if dbReply.Error != nil {
+		err = db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates).Error
+		if err != nil {
 			return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "failed to update cluster: %s", params.ClusterID))
 		}
 	}

--- a/internal/common/error_utils.go
+++ b/internal/common/error_utils.go
@@ -21,23 +21,23 @@ func (f NotFound) Error() string {
 }
 
 func GenerateError(id int32, err error) *models.Error {
+	var reason string
+	if err != nil {
+		reason = err.Error()
+	} else {
+		reason = "error is nil"
+	}
 	return &models.Error{
 		Code:   swag.String(strconv.Itoa(int(id))),
 		Href:   swag.String(""),
 		ID:     swag.Int32(id),
 		Kind:   swag.String("Error"),
-		Reason: swag.String(err.Error()),
+		Reason: swag.String(reason),
 	}
 }
 
 func GenerateInternalFromError(err error) *models.Error {
-	return &models.Error{
-		Code:   swag.String(strconv.Itoa(http.StatusInternalServerError)),
-		Href:   swag.String(""),
-		ID:     swag.Int32(http.StatusInternalServerError),
-		Kind:   swag.String("Error"),
-		Reason: swag.String(err.Error()),
-	}
+	return GenerateError(http.StatusInternalServerError, err)
 }
 
 func GenerateInfraError(id int32, err error) *models.InfraError {


### PR DESCRIPTION
# Assisted Pull Request

## Description
- Instead set error string "error is nil"
- In addition, fix a potential location that nil error was sent to  NewApiError
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
