### PR TITLE
MGMT-8413: Add new condition on AgentServiceConfig Agent object

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -89,6 +89,8 @@ type AgentServiceConfigSpec struct {
 const (
 	// ConditionReconcileCompleted reports whether reconcile completed without error.
 	ConditionReconcileCompleted conditionsv1.ConditionType = "ReconcileCompleted"
+	// ConditionDeploymentsHealthy reports whether deployments are healthy.
+	ConditionDeploymentsHealthy conditionsv1.ConditionType = "DeploymentsHealthy"
 
 	// ReasonReconcileSucceeded when the reconcile completes all operations without error.
 	ReasonReconcileSucceeded string = "ReconcileSucceeded"


### PR DESCRIPTION
A new condition on the AgentServiceConfig Agent object is added to report the health status of the underlying operands (deployments) the infrastructure operator operates on. 

If all the 3 deployments `agentinstalladmission`, `assisted-image-service` and `assisted-service` have the condition status as `True` for condition type `Available` and `Progressing`, then the condition `DeploymentsHealthy` is set to `True` on the AgentServiceConfig else set to `False`
https://issues.redhat.com/browse/MGMT-8413

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
   Install assisted service/infrastructure operator using the ztp scripts. If all the 3 deployments are healthy, the AgentServiceConfig object should have a condition `DeploymentsHealthy` set to `True`. Scale down the infrastructure-operator deployment and then scale down any of the 3 deployments,e.g. `assisted-service`. Watch the condition `DeploymentsHealthy` set to `False` when the `assisted-service` deployment is not `Available` or not `Progressing`.
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
