### PR TITLE
MGMT-7330: Make `ROOT_DIR`, `COVER_PROFILE` and `GINKGO_REPORTFILE` overridable for running unit tests in CI

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -19,4 +19,5 @@ RUN chmod g+xw -R $GOPATH && chmod g+xw -R $(go env GOROOT)
 
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin
+COPY ./data /tmp/data
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAMESPACE := $(or ${NAMESPACE},assisted-installer)
 PWD = $(shell pwd)
 BUILD_FOLDER = $(PWD)/build/$(NAMESPACE)
-ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
 CONTAINER_COMMAND := $(or ${CONTAINER_COMMAND},docker)
 TARGET := $(or ${TARGET},local)
 KUBECTL=kubectl -n $(NAMESPACE)
@@ -132,8 +132,10 @@ ifeq ($(VERBOSE), true)
 	GO_TEST_FORMAT=standard-verbose
 endif
 
-GOTEST_FLAGS = --format=$(GO_TEST_FORMAT) $(GOTEST_PUBLISH_FLAGS) -- -count=1 -cover -coverprofile=$(REPORTS)/$(TEST_SCENARIO)_coverage.out
-GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo.v -ginkgo.reportFile=./junit_$(TEST_SCENARIO)_test.xml
+COVER_PROFILE := $(or ${COVER_PROFILE}, $(REPORTS)/$(TEST_SCENARIO)_coverage.out)
+GINKGO_REPORTFILE := $(or $(GINKGO_REPORTFILE), ./junit_$(TEST_SCENARIO)_test.xml)
+GOTEST_FLAGS = --format=$(GO_TEST_FORMAT) $(GOTEST_PUBLISH_FLAGS) -- -count=1 -cover -coverprofile=$(COVER_PROFILE)
+GINKGO_FLAGS = -ginkgo.focus="$(FOCUS)" -ginkgo.v -ginkgo.skip="$(SKIP)" -ginkgo.v -ginkgo.reportFile=$(GINKGO_REPORTFILE)
 
 .EXPORT_ALL_VARIABLES:
 

--- a/Makefile
+++ b/Makefile
@@ -452,8 +452,8 @@ _test: $(REPORTS)
 	$(MAKE) _post_test
 
 _unit_test: $(REPORTS)
-	gotestsum $(GO_UNITTEST_FLAGS) $(TEST) $(GINKGO_UNITTEST_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _post_test && /bin/false)
-	$(MAKE) _post_test
+	gotestsum $(GO_UNITTEST_FLAGS) $(TEST) $(GINKGO_UNITTEST_FLAGS) -timeout $(TIMEOUT) || ($(MAKE) _post_unit_test && /bin/false)
+	$(MAKE) _post_unit_test
 
 _post_test: $(REPORTS)
 	@for name in `find '$(ROOT_DIR)' -name 'junit*.xml' -type f -not -path '$(REPORTS)/*'`; do \
@@ -461,9 +461,20 @@ _post_test: $(REPORTS)
 	done
 	$(MAKE) _coverage
 
+_post_unit_test: $(REPORTS)
+	@for name in `find '$(ROOT_DIR)' -name 'junit*.xml' -type f -not -path '$(REPORTS)/*'`; do \
+		mv -f $$name $(REPORTS)/junit_unit_$$(basename $$(dirname $$name)).xml; \
+	done
+	$(MAKE) _unit_test_coverage
+
 _coverage: $(REPORTS)
 ifeq ($(CI), true)
 	gocov convert $(REPORTS)/$(TEST_SCENARIO)_coverage.out | gocov-xml > $(REPORTS)/$(TEST_SCENARIO)_coverage.xml
+endif
+
+_unit_test_coverage: $(REPORTS)
+ifeq ($(CI), true)
+	gocov convert $(REPORTS)/unit_coverage.out | gocov-xml > $(REPORTS)/unit_coverage.xml
 endif
 
 run-db-container:


### PR DESCRIPTION
When running the unit tests in CI, the image is built as root but run as non-root.
CI isn't able to create the reports directory and results in the error
`mkdir: cannot create directory '/opt/app-root/src/reports': Permission denied`
During runtime, directories can't be added outside of `/tmp`.
To address this, `ROOT_DIR`, `COVER_PROFILE`, and `GINKGO_REPORTFILE` are made overridable. CI when running the unit tests will set these to the below values:
- TMPDIR                  "/tmp"
- COVERPROFILE   "/tmp/unit_coverage.out"
- REPORTFILE          "/tmp/junit_unit_test.xml"

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
Run `skipper shell`. Once inside the skipper environment, set the env variables. Run `make ci-unit-test`
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @lranjbar 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
