### PR TITLE
MGMT-8300: Allow configuring dual-stack networking in single step

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6768,8 +6768,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						"Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 				})
 				It("Machine network CIDR in non dhcp for dual-stack", func() {
-					mockSuccess(2)
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockSuccess(1)
 
 					apiVip := "10.11.12.15"
 					ingressVip := "10.11.12.16"
@@ -6779,15 +6778,6 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
-						},
-					})
-					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-
-					reply = bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-						ClusterID: clusterID,
-						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							APIVip:          &apiVip,
-							IngressVip:      &ingressVip,
 							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
@@ -6806,6 +6796,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR changes the logic of updateNonDhcpNetworkParams so that changing
cluster state between single- and dual-stack is possible in a single API
call.

Previously, because the check of the "stackness" of the cluster was
happening without taking the updated params into consideration, at least
2 API calls were needed to change the status of the cluster. With this
change in order to check what is the "stackness" of the cluster we are
using a merge of 2 states

* current cluster network configuration
* updated configuration passed as an update parameter

Because of this, we no longer use the stale state.

Contributes-to: [MGMT-8300](https://issues.redhat.com/browse/MGMT-8300)
## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @osherdp 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
