### PR TITLE
NO-ISSUE: Use .Equal to compare time objects

### DIFF
--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -64,7 +64,7 @@ var _ = Describe("update_cluster_state", func() {
 				Expect(db.First(&cluster, "id = ?", cluster.ID).Error).ShouldNot(HaveOccurred())
 				Expect(*cluster.Status).ShouldNot(Equal(newStatus))
 				Expect(*cluster.StatusInfo).ShouldNot(Equal(newStatusInfo))
-				Expect(cluster.StatusUpdatedAt.String()).Should(Equal(lastUpdatedTime.String()))
+				Expect(cluster.StatusUpdatedAt.Equal(lastUpdatedTime)).Should(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
## Description

Before this change this test was failing locally because the string
representation of the time didn't match even though it was actually the
same time.

Example failure:
```
• Failure in Spec Teardown (AfterEach) [0.520 seconds]
update_cluster_state
/home/ncarboni/Source/assisted-service/internal/cluster/common_test.go:19
  UpdateCluster
  /home/ncarboni/Source/assisted-service/internal/cluster/common_test.go:42
    negative
    /home/ncarboni/Source/assisted-service/internal/cluster/common_test.go:50
      no_matching_rows [AfterEach]
      /home/ncarboni/Source/assisted-service/internal/cluster/common_test.go:58

      Expected
          <string>: 0000-12-31T19:03:58.000-04:56
      to equal
          <string>: 0001-01-01T00:00:00.000Z

      /home/ncarboni/Source/assisted-service/internal/cluster/common_test.go:67
```

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ori-amizur 
/cc @jordigilh 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?