### PR TITLE
MGMT-8300: Improve behaviour of dual-stack via REST API

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2647,36 +2647,47 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 	if interactivity == Interactive && (params.ClusterUpdateParams.APIVip != nil || params.ClusterUpdateParams.IngressVip != nil) {
 		var primaryMachineNetworkCidr string
 		matchRequired := apiVip != "" || ingressVip != ""
-		primaryMachineNetworkCidr, err = network.CalculateMachineNetworkCIDR(apiVip, ingressVip, cluster.Hosts, matchRequired)
-		if err != nil {
-			return common.NewApiError(http.StatusBadRequest, errors.Wrap(err, "Calculate machine network CIDR"))
-		}
-		if primaryMachineNetworkCidr != "" {
-			if network.IsMachineCidrAvailable(cluster) {
-				cluster.MachineNetworks[0].Cidr = models.Subnet(primaryMachineNetworkCidr)
-			} else {
-				cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: models.Subnet(primaryMachineNetworkCidr)}}
-			}
-			updates["machine_network_cidr"] = primaryMachineNetworkCidr
-		}
-		err = network.VerifyVips(cluster.Hosts, primaryMachineNetworkCidr, apiVip, ingressVip, false, log)
-		if err != nil {
-			log.WithError(err).Warnf("Verify VIPs")
-			return common.NewApiError(http.StatusBadRequest, err)
-		}
 
-		if params.ClusterUpdateParams.MachineNetworks != nil {
-			err = network.VerifyMachineNetworksDualStack(params.ClusterUpdateParams.MachineNetworks, reqDualStack)
+		// We want to calculate Machine Network based on the API/Ingress VIPs only in case of the
+		// single-stack cluster. Autocalculation is not supported for dual-stack in which we
+		// require that user explictly provides all the Machine Networks.
+		if reqDualStack {
+			if params.ClusterUpdateParams.MachineNetworks != nil {
+				cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks
+				primaryMachineNetworkCidr = string(params.ClusterUpdateParams.MachineNetworks[0].Cidr)
+			} else {
+				primaryMachineNetworkCidr = network.GetPrimaryMachineCidrForUserManagedNetwork(cluster, log)
+			}
+
+			err = network.VerifyMachineNetworksDualStack(targetConfiguration.MachineNetworks, reqDualStack)
 			if err != nil {
 				log.WithError(err).Warnf("Verify dual-stack machine networks")
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
 		} else {
-			err = network.VerifyMachineNetworksDualStack(cluster.MachineNetworks, reqDualStack)
+			primaryMachineNetworkCidr, err = network.CalculateMachineNetworkCIDR(apiVip, ingressVip, cluster.Hosts, matchRequired)
 			if err != nil {
-				log.WithError(err).Warnf("Verify dual-stack machine networks")
-				return common.NewApiError(http.StatusBadRequest, err)
+				return common.NewApiError(http.StatusBadRequest, errors.Wrap(err, "Calculate machine network CIDR"))
 			}
+			if primaryMachineNetworkCidr != "" {
+				if network.IsMachineCidrAvailable(cluster) {
+					cluster.MachineNetworks[0].Cidr = models.Subnet(primaryMachineNetworkCidr)
+				} else {
+					cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: models.Subnet(primaryMachineNetworkCidr)}}
+				}
+				// In case we calculated Machine Network automatically (because conditions for
+				// doing so were met), we update the `params` payload so that from the
+				// perspective of the DB write/delete actions it looks like a valid update
+				// operation. Without that we don't have other way to mark this field of the
+				// cluster as dirty.
+				params.ClusterUpdateParams.MachineNetworks = []*models.MachineNetwork{{Cidr: models.Subnet(primaryMachineNetworkCidr)}}
+			}
+		}
+
+		err = network.VerifyVips(cluster.Hosts, primaryMachineNetworkCidr, apiVip, ingressVip, false, log)
+		if err != nil {
+			log.WithError(err).Warnf("Verify VIPs")
+			return common.NewApiError(http.StatusBadRequest, err)
 		}
 	}
 
@@ -2950,17 +2961,26 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 		}
 	}
 
-	// TODO: Update machine CIDR only if necessary
-	// The machine cidr can be resetted, calculated and provided by the user
-	if err = db.Where("cluster_id = ?", *cluster.ID).Delete(&models.MachineNetwork{}).Error; err != nil {
-		err = errors.Wrapf(err, "failed to delete machine networks of cluster %s", *cluster.ID)
-		return common.NewApiError(http.StatusInternalServerError, err)
-	}
-	for _, machineNetwork := range cluster.MachineNetworks {
-		machineNetwork.ClusterID = *cluster.ID
-		if err = db.Save(machineNetwork).Error; err != nil {
-			err = errors.Wrapf(err, "failed to update machine network %v of cluster %s", *machineNetwork, params.ClusterID)
+	// Updating Machine CIDR can happen only in the following scenarios
+	// * explicitly provided as a payload
+	// * autocalculation based on the API/Ingress VIP and Host subnet
+	// * reset because change of the state of UserManagedNetworking or VipDhcpAllocation
+	//
+	// In case of autocalculation, the new value is injected into ClusterUpdateParams therefore
+	// no additional detection of this scenario is required.
+	if params.ClusterUpdateParams.MachineNetworks != nil ||
+		params.ClusterUpdateParams.UserManagedNetworking != cluster.UserManagedNetworking ||
+		params.ClusterUpdateParams.VipDhcpAllocation != cluster.VipDhcpAllocation {
+		if err = db.Where("cluster_id = ?", *cluster.ID).Delete(&models.MachineNetwork{}).Error; err != nil {
+			err = errors.Wrapf(err, "failed to delete machine networks of cluster %s", *cluster.ID)
 			return common.NewApiError(http.StatusInternalServerError, err)
+		}
+		for _, machineNetwork := range cluster.MachineNetworks {
+			machineNetwork.ClusterID = *cluster.ID
+			if err = db.Save(machineNetwork).Error; err != nil {
+				err = errors.Wrapf(err, "failed to update machine network %v of cluster %s", *machineNetwork, params.ClusterID)
+				return common.NewApiError(http.StatusInternalServerError, err)
+			}
 		}
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6768,8 +6768,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						"Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 				})
 				It("Machine network CIDR in non dhcp for dual-stack", func() {
-					mockSuccess(2)
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockSuccess(1)
 
 					apiVip := "10.11.12.15"
 					ingressVip := "10.11.12.16"
@@ -6779,15 +6778,6 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
-						},
-					})
-					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-
-					reply = bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-						ClusterID: clusterID,
-						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							APIVip:          &apiVip,
-							IngressVip:      &ingressVip,
 							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
@@ -6806,6 +6796,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6778,7 +6778,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
-							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
@@ -6796,7 +6796,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							APIVip:          &apiVip,
 							IngressVip:      &ingressVip,
 							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
-							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
@@ -6810,6 +6810,20 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						},
 					})
 					verifyApiErrorString(reply, http.StatusBadRequest, "First machine network has to be IPv4 subnet")
+				})
+				It("API VIP in wrong subnet for dual-stack", func() {
+					apiVip := "10.11.12.15"
+					ingressVip := "10.11.12.16"
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							APIVip:          &apiVip,
+							IngressVip:      &ingressVip,
+							ClusterNetworks: []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}, {Cidr: "fd01::/48", HostPrefix: 64}},
+							MachineNetworks: []*models.MachineNetwork{{Cidr: "10.12.0.0/16"}, {Cidr: "fd2e:6f44:5dd8:c956::/120"}},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "api-vip <10.11.12.15> does not belong to machine-network-cidr <10.12.0.0/16>")
 				})
 			})
 			Context("Advanced networking validations", func() {

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -219,7 +219,13 @@ func GetCluster(ctx context.Context, logger logrus.FieldLogger, db *gorm.DB, clu
 }
 
 func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string) error {
-	// TODO MGMT-7678: Support dual-stack. It requires to indicate primary by a new flag field / ordinal numbering
+	// In case of dual-stack clusters the autocalculation feature is not supported. That means
+	// as soon as we detect that current Machine Network configuration indicates we have such
+	// a cluster, the function stops its execution.
+	reqDualStack := network.CheckIfClusterIsDualStack(cluster)
+	if reqDualStack {
+		return nil
+	}
 
 	previousPrimaryMachineCidr := ""
 	if network.IsMachineCidrAvailable(cluster) {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR consists of 2 commits - enabling to convert single-stack cluster to dual-stack in one API call and disabling autogeneration of machine networks for dual-stack clusters. A combination of those 2 allows at the end to create a complete dual-stack cluster with only a single API call.

Previously, because the check of the "stackness" of the cluster was happening without taking the updated params into consideration, at least 2 API calls were needed to change the status of the cluster. With this change in order to check what is the "stackness" of the cluster we are using a merge of 2 states

* current cluster network configuration
* updated configuration passed as an update parameter

Because of this, we no longer use the stale state.

The logic behind automatic calculation of Machine Network changes so that it does not apply for dual-stack clusters. For those we require user to explicitly provide machine networks according to requirements of the OCP as well as OVN-K8s.

As a side effect this PR fixes a bug which made it impossible to configure Machine Networks before cluster had Agents registered, effectively requiring multiple API calls to form a correct dual-stack cluster.

This PR contributes to the following issues
* https://issues.redhat.com/browse/MGMT-8300
* https://issues.redhat.com/browse/MGMT-8332

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual test

The following POST payload has been used to create a new cluster

```
{
    "additional_ntp_source": "clock.redhat.com,clock2.redhat.com",
    "api_vip": "192.168.123.102",
    "base_dns_domain": "chocobomb.lab.redhat.com",
    "cluster_networks": [
        {
            "cidr": "10.128.0.0/14",
            "host_prefix": 23
        },
        {
            "cidr": "fd01::/48",
            "host_prefix": 64
        }
    ],
    "ingress_vip": "192.168.123.124",
    "machine_networks": [
        {
            "cidr": "192.168.123.0/24"
        },
        {
            "cidr": "2001:db8:dead:beef:fe::/96"
        }
    ],
    "name": "ocp-cluster-chocobomb-0",
    "network_type": "OVNKubernetes",
    "openshift_version": "4.8",
    
    "service_networks": [
        {
            "cidr": "172.30.0.0/16"
        },
        {
            "cidr": "fd02::/112"
        }
    ],
    "ssh_public_key": "[...]",
    "vip_dhcp_allocation": false,
    "pull_secret": "[...]"
}
```

A subsequent GET request returned the following cluster object

```
{
  "additional_ntp_source": "clock.redhat.com,clock2.redhat.com",
  "base_dns_domain": "chocobomb.lab.redhat.com",
  "cluster_network_cidr": "10.128.0.0/14",
  "cluster_network_host_prefix": 23,
  "cluster_networks": [
    {
      "cidr": "10.128.0.0/14",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372",
      "host_prefix": 23
    },
    {
      "cidr": "fd01::/48",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372",
      "host_prefix": 64
    }
  ],
  "connectivity_majority_groups": "{\"IPv4\":[],\"IPv6\":[]}",
  "controller_logs_collected_at": "0001-01-01T00:00:00.000Z",
  "controller_logs_started_at": "0001-01-01T00:00:00.000Z",
  "cpu_architecture": "x86_64",
  "created_at": "2021-12-10T22:48:05.292391Z",
  "deleted_at": null,
  "disk_encryption": {
    "enable_on": "none",
    "mode": "tpmv2"
  },
  "email_domain": "Unknown",
  "feature_usage": "{\"Additional NTP Source\":{\"data\":{\"source_count\":2},\"id\":\"ADDITIONAL_NTP_SOURCE\",\"name\":\"Additional NTP Source\"},\"OVN network type\":{\"id\":\"OVN_NETWORK_TYPE\",\"name\":\"OVN network type\"}}",
  "host_networks": [],
  "hosts": [],
  "href": "/api/assisted-install/v1/clusters/fb8e9685-84f4-4071-9831-f4fc94238372",
  "hyperthreading": "all",
  "id": "fb8e9685-84f4-4071-9831-f4fc94238372",
  "ignition_endpoint": {},
  "image_info": {
    "created_at": "0001-01-01T00:00:00Z",
    "expires_at": "0001-01-01T00:00:00.000Z"
  },
  "ingress_vip": "192.168.123.124",
  "install_completed_at": "2000-01-01T00:00:00.000Z",
  "install_started_at": "2000-01-01T00:00:00.000Z",
  "kind": "Cluster",
  "machine_network_cidr": "192.168.123.0/24",
  "machine_networks": [
    {
      "cidr": "192.168.123.0/24",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372"
    },
    {
      "cidr": "2001:db8:dead:beef:fe::/96",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372"
    }
  ],
  "monitored_operators": [
    {
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372",
      "name": "console",
      "operator_type": "builtin",
      "status_updated_at": "0001-01-01T00:00:00.000Z",
      "timeout_seconds": 3600
    }
  ],
  "name": "ocp-cluster-chocobomb-0",
  "network_type": "OVNKubernetes",
  "ocp_release_image": "quay.io/openshift-release-dev/ocp-release:4.8.23-x86_64",
  "openshift_version": "4.8.23",
  "platform": {
    "ovirt": {},
    "type": "baremetal",
    "vsphere": {}
  },
  "progress": {},
  "pull_secret_set": true,
  "schedulable_masters": false,
  "service_network_cidr": "172.30.0.0/16",
  "service_networks": [
    {
      "cidr": "172.30.0.0/16",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372"
    },
    {
      "cidr": "fd02::/112",
      "cluster_id": "fb8e9685-84f4-4071-9831-f4fc94238372"
    }
  ],
  "ssh_public_key": "[...]",
  "status": "pending-for-input",
  "status_info": "User input required",
  "status_updated_at": "2021-12-10T22:48:11.796Z",
  "updated_at": "2021-12-10T22:48:11.79651Z",
  "user_managed_networking": false,
  "user_name": "admin",
  "validations_info": "{\"configuration\":[{\"id\":\"pull-secret-set\",\"status\":\"success\",\"message\":\"The pull secret is set.\"}],\"hosts-data\":[{\"id\":\"all-hosts-are-ready-to-install\",\"status\":\"success\",\"message\":\"All hosts in the cluster are ready to install.\"},{\"id\":\"sufficient-masters-count\",\"status\":\"failure\",\"message\":\"Clusters must have exactly 3 dedicated masters and if workers are added, there should be at least 2 workers. Please check your configuration and add or remove hosts as to meet the above requirement.\"}],\"network\":[{\"id\":\"api-vip-defined\",\"status\":\"failure\",\"message\":\"The API virtual IP is undefined and must be provided.\"},{\"id\":\"api-vip-valid\",\"status\":\"pending\",\"message\":\"The API virtual IP is undefined.\"},{\"id\":\"cluster-cidr-defined\",\"status\":\"success\",\"message\":\"The Cluster Network CIDR is defined.\"},{\"id\":\"dns-domain-defined\",\"status\":\"success\",\"message\":\"The base domain is defined.\"},{\"id\":\"ingress-vip-defined\",\"status\":\"success\",\"message\":\"The Ingress virtual IP is defined.\"},{\"id\":\"ingress-vip-valid\",\"status\":\"pending\",\"message\":\"Hosts have not been discovered yet\"},{\"id\":\"machine-cidr-defined\",\"status\":\"success\",\"message\":\"The Machine Network CIDR is defined.\"},{\"id\":\"machine-cidr-equals-to-calculated-cidr\",\"status\":\"pending\",\"message\":\"Hosts have not been discovered yet\"},{\"id\":\"network-prefix-valid\",\"status\":\"success\",\"message\":\"The Cluster Network prefix is valid.\"},{\"id\":\"network-type-valid\",\"status\":\"success\",\"message\":\"The cluster has a valid network type\"},{\"id\":\"no-cidrs-overlapping\",\"status\":\"success\",\"message\":\"No CIDRS are overlapping.\"},{\"id\":\"ntp-server-configured\",\"status\":\"success\",\"message\":\"No ntp problems found\"},{\"id\":\"service-cidr-defined\",\"status\":\"success\",\"message\":\"The Service Network CIDR is defined.\"}],\"operators\":[{\"id\":\"cnv-requirements-satisfied\",\"status\":\"success\",\"message\":\"cnv is disabled\"},{\"id\":\"lso-requirements-satisfied\",\"status\":\"success\",\"message\":\"lso is disabled\"},{\"id\":\"ocs-requirements-satisfied\",\"status\":\"success\",\"message\":\"ocs is disabled\"}]}",
  "vip_dhcp_allocation": false
}
```

As can be observed, all the networks (cluster, service and machine) preserved their initial state and the object represents a correct dual-stack cluster.

## Assignees

/cc @osherdp 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
