### PR TITLE
MGMT-7507: Add feature usage for dual-stack

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3160,6 +3160,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.V2UpdateCluste
 	}
 
 	b.setUsage(vipDhcpAllocation, usage.VipDhcpAllocationUsage, nil, usages)
+	b.setUsage(network.CheckIfClusterIsDualStack(cluster), usage.DualStackUsage, nil, usages)
 	return nil
 }
 
@@ -3245,6 +3246,7 @@ func (b *bareMetalInventory) setDefaultUsage(cluster *models.Cluster) error {
 	}).([]*models.MonitoredOperator)
 	b.setOperatorsUsage(olmOperators, []*models.MonitoredOperator{}, usages)
 	b.setNetworkTypeUsage(cluster.NetworkType, usages)
+	b.setUsage(network.CheckIfClusterModelIsDualStack(cluster), usage.DualStackUsage, nil, usages)
 	b.setDiskEncryptionUsage(cluster, cluster.DiskEncryption, usages)
 	//write all the usages to the cluster object
 	err := b.providerRegistry.SetPlatformUsages(common.PlatformTypeValue(cluster.Platform.Type), cluster.Platform, usages, b.usageApi)

--- a/internal/network/dual_stack_validations.go
+++ b/internal/network/dual_stack_validations.go
@@ -97,3 +97,15 @@ func CheckIfClusterIsDualStack(c *common.Cluster) bool {
 
 	return dualStack
 }
+
+// Wrapper around CheckIfClusterIsDualStack function allowing to pass models.Cluster instead of
+// common.Cluster object.
+func CheckIfClusterModelIsDualStack(c *models.Cluster) bool {
+	cluster := common.Cluster{}
+	if c != nil {
+		cluster.MachineNetworks = c.MachineNetworks
+		cluster.ServiceNetworks = c.ServiceNetworks
+		cluster.ClusterNetworks = c.ClusterNetworks
+	}
+	return CheckIfClusterIsDualStack(&cluster)
+}

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -19,6 +19,8 @@ const (
 	OVNNetworkTypeUsage string = "OVN network type"
 	//cluster is using SDN network type
 	SDNNetworkTypeUsage string = "SDN network type"
+	//cluster is dual-stack
+	DualStackUsage string = "Dual-stack"
 	//usage of platform provider other than baremetal
 	PlatformSelectionUsage string = "Platform selection"
 	//usage of schedulable masters


### PR DESCRIPTION
# Assisted Pull Request

## Description

This commit adds a feature flag for marking clusters that use dual-stack
networking. This enables us to collect statistics about usage of this
feature so that we are able to prioritize future developments in this
area.

Contributes-to: [MGMT-7507](https://issues.redhat.com/browse/MGMT-7507)

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
