### PR TITLE
MGMT-7428: added ignition to apivip check response in swagger

### DIFF
--- a/models/api_vip_connectivity_response.go
+++ b/models/api_vip_connectivity_response.go
@@ -17,6 +17,9 @@ import (
 // swagger:model api_vip_connectivity_response
 type APIVipConnectivityResponse struct {
 
+	// Ignition fetched from the specified API VIP
+	Ignition string `json:"ignition,omitempty"`
+
 	// API VIP connectivity check result.
 	IsSuccess bool `json:"is_success,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9361,6 +9361,10 @@ func init() {
     "api_vip_connectivity_response": {
       "type": "object",
       "properties": {
+        "ignition": {
+          "description": "Ignition fetched from the specified API VIP",
+          "type": "string"
+        },
         "is_success": {
           "description": "API VIP connectivity check result.",
           "type": "boolean"
@@ -22878,6 +22882,10 @@ func init() {
     "api_vip_connectivity_response": {
       "type": "object",
       "properties": {
+        "ignition": {
+          "description": "Ignition fetched from the specified API VIP",
+          "type": "string"
+        },
         "is_success": {
           "description": "API VIP connectivity check result.",
           "type": "boolean"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8374,6 +8374,9 @@ definitions:
       is_success:
         type: boolean
         description: API VIP connectivity check result.
+      ignition:
+        type: string
+        description: Ignition fetched from the specified API VIP
 
   disk_speed_check_request:
     type: object


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added ignition property to api_vip_connectivity_response for populating when invoking apivip_check cmd in agent.
The ignition is required to fetch disk LUKS (disk encryption) information for workers in the cluster.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @ybettan 
/cc @nmagnezi 
/cc @filanov 
/cc @rollandf 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
