### PR TITLE
MGMT-7428: disk encryption validation for day2

### DIFF
--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -82,7 +82,7 @@ func GenerateTestHostByKind(hostID, infraEnvID strfmt.UUID, clusterID *strfmt.UU
 			StageStartedAt: now,
 			StageUpdatedAt: now,
 		},
-		APIVipConnectivity: generateTestAPIVIpConnectivity(),
+		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
 		Connectivity:       GenerateTestConnectivityReport(),
 	}
 }
@@ -98,7 +98,7 @@ func GenerateTestHostWithInfraEnv(hostID, infraEnvID strfmt.UUID, state string, 
 		Kind:               swag.String(models.HostKindHost),
 		CheckedInAt:        now,
 		StatusUpdatedAt:    now,
-		APIVipConnectivity: generateTestAPIVIpConnectivity(),
+		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
 		Connectivity:       GenerateTestConnectivityReport(),
 	}
 }
@@ -120,7 +120,7 @@ func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUI
 			StageStartedAt: now,
 			StageUpdatedAt: now,
 		},
-		APIVipConnectivity: generateTestAPIVIpConnectivity(),
+		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
 	}
 	return &h
 }
@@ -154,9 +154,10 @@ func GenerateL3ConnectivityReport(hosts []*models.Host, latency float64, packetL
 	return &con
 }
 
-func generateTestAPIVIpConnectivity() string {
+func GenerateTestAPIVIpConnectivity(ignition string) string {
 	checkAPIResponse := models.APIVipConnectivityResponse{
 		IsSuccess: true,
+		Ignition:  ignition,
 	}
 	bytes, err := json.Marshal(checkAPIResponse)
 	Expect(err).To(Not(HaveOccurred()))

--- a/models/api_vip_connectivity_response.go
+++ b/models/api_vip_connectivity_response.go
@@ -17,6 +17,9 @@ import (
 // swagger:model api_vip_connectivity_response
 type APIVipConnectivityResponse struct {
 
+	// Ignition fetched from the specified API VIP
+	Ignition string `json:"ignition,omitempty"`
+
 	// API VIP connectivity check result.
 	IsSuccess bool `json:"is_success,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9361,6 +9361,10 @@ func init() {
     "api_vip_connectivity_response": {
       "type": "object",
       "properties": {
+        "ignition": {
+          "description": "Ignition fetched from the specified API VIP",
+          "type": "string"
+        },
         "is_success": {
           "description": "API VIP connectivity check result.",
           "type": "boolean"
@@ -22878,6 +22882,10 @@ func init() {
     "api_vip_connectivity_response": {
       "type": "object",
       "properties": {
+        "ignition": {
+          "description": "Ignition fetched from the specified API VIP",
+          "type": "string"
+        },
         "is_success": {
           "description": "API VIP connectivity check result.",
           "type": "boolean"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -8374,6 +8374,9 @@ definitions:
       is_success:
         type: boolean
         description: API VIP connectivity check result.
+      ignition:
+        type: string
+        description: Ignition fetched from the specified API VIP
 
   disk_speed_check_request:
     type: object


### PR DESCRIPTION
# Assisted Pull Request

## Description

Added disk encryption validation for day2 in host validator.
Introduced the following changed to host/validator:
* Added getDiskEncryptionForDay2 func for fetching LUKS (disk encryption) from the ignition, which should be available in APIVipConnectivityResponse.
* In diskEncryptionRequirementsSatisfied:
  * Used luks info from the ignition for identifying disk encryption support for workers in the cluster.
  * If TPM2 is enabled in the cluster for workers - ensure TPM2 is available in the host. Otherwise, the disk could be encrypted only using tang.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @ybettan
/cc @nmagnezi
/cc @filanov
/cc @rollandf

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
