### PR TITLE
MGMT-8532: Backport infra-env event handling for image service

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -712,3 +712,11 @@ x-events:
   properties:
     cluster_id: UUID
     message: string
+
+- name: image_info_updated
+  message: "Updated image information ({details})"
+  event_type: infra_env
+  severity: "info"
+  properties:
+    infra_env_id: UUID
+    details: string

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1445,6 +1445,9 @@ func (b *bareMetalInventory) createAndUploadNewImage(ctx context.Context, log lo
 			return err
 		}
 
+		details := b.getIgnitionConfigForLogging(ctx, infraEnv, log, imageType)
+		eventgen.SendImageInfoUpdatedEvent(ctx, b.eventsHandler, *infraEnv.ID, details)
+
 		return nil
 	} else if imageExists {
 		if err = b.updateImageInfoPostUpload(ctx, infraEnv, infraEnvProxyHash, imageType, false, v2); err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -974,6 +974,8 @@ var _ = Describe("GenerateClusterISO", func() {
 		cluster := createClusterInDB(true)
 		mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(1)
 		mockVersions.EXPECT().GetOsImage(cluster.OpenshiftVersion, cluster.CPUArchitecture).Return(common.TestDefaultConfig.OsImage, nil)
+		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(1)
+		mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName)))
 
 		generateReply := bm.GenerateClusterISO(ctx, installer.GenerateClusterISOParams{
 			ClusterID:         *cluster.ID,
@@ -1011,6 +1013,8 @@ var _ = Describe("GenerateClusterISO", func() {
 		cluster := createClusterInDB(true)
 		mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(3)
 		mockVersions.EXPECT().GetOsImage(cluster.OpenshiftVersion, cluster.CPUArchitecture).Return(common.TestDefaultConfig.OsImage, nil).Times(3)
+		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(3)
+		mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(3)
 
 		generateReply := bm.GenerateClusterISO(ctx, installer.GenerateClusterISOParams{
 			ClusterID:         *cluster.ID,
@@ -8201,8 +8205,9 @@ var _ = Describe("infraEnvs", func() {
 				})
 
 				It("sets the download url correctly with the image service", func() {
-
 					mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil)
+					mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(1)
+					mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(1)
 
 					response, err := bm.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{
 						InfraEnvID:           infraEnvID,
@@ -8235,6 +8240,8 @@ var _ = Describe("infraEnvs", func() {
 
 					It("sets a valid image_token", func() {
 						mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil)
+						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil)
+						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName)))
 
 						response, err := bm.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{
 							InfraEnvID:           infraEnvID,
@@ -8251,6 +8258,8 @@ var _ = Describe("infraEnvs", func() {
 
 					It("updates the infra-env expires_at time", func() {
 						mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil)
+						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil)
+						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName)))
 
 						response, err := bm.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{
 							InfraEnvID:           infraEnvID,
@@ -8294,6 +8303,9 @@ var _ = Describe("infraEnvs", func() {
 
 					It("does not update the image service url if nothing changed", func() {
 						mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil).Times(2)
+						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(2)
+						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(2)
+
 						params := &models.InfraEnvUpdateParams{ImageType: models.ImageTypeMinimalIso}
 						firstURL := updateInfraEnv(params)
 						newURL := updateInfraEnv(params)
@@ -8304,6 +8316,8 @@ var _ = Describe("infraEnvs", func() {
 
 					It("updates the image service url when things change", func() {
 						mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil).Times(7)
+						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(7)
+						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(7)
 
 						params := &models.InfraEnvUpdateParams{ImageType: models.ImageTypeMinimalIso}
 						prevURL := updateInfraEnv(params)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1013,8 +1013,8 @@ var _ = Describe("GenerateClusterISO", func() {
 		cluster := createClusterInDB(true)
 		mockStaticNetworkConfig.EXPECT().FormatStaticNetworkConfigForDB(gomock.Any()).Return("").Times(3)
 		mockVersions.EXPECT().GetOsImage(cluster.OpenshiftVersion, cluster.CPUArchitecture).Return(common.TestDefaultConfig.OsImage, nil).Times(3)
-		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(3)
-		mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(3)
+		mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(2)
+		mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(2)
 
 		generateReply := bm.GenerateClusterISO(ctx, installer.GenerateClusterISOParams{
 			ClusterID:         *cluster.ID,
@@ -8303,9 +8303,8 @@ var _ = Describe("infraEnvs", func() {
 
 					It("does not update the image service url if nothing changed", func() {
 						mockVersions.EXPECT().GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "").Return(common.TestDefaultConfig.OsImage, nil).Times(2)
-						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(2)
-						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(2)
-
+						mockIgnitionBuilder.EXPECT().FormatDiscoveryIgnitionFile(gomock.Any(), gomock.Any(), bm.IgnitionConfig, true, bm.authHandler.AuthType()).Return("ignitionconfigforlogging", nil).Times(1)
+						mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(eventstest.WithNameMatcher(eventgen.ImageInfoUpdatedEventName))).Times(1)
 						params := &models.InfraEnvUpdateParams{ImageType: models.ImageTypeMinimalIso}
 						firstURL := updateInfraEnv(params)
 						newURL := updateInfraEnv(params)

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -6367,3 +6367,75 @@ func (e *ClustersPermanentlyDeletedEvent) FormatMessage() string {
     return e.format(&s)
 }
 
+//
+// Event image_info_updated
+//
+type ImageInfoUpdatedEvent struct {
+    InfraEnvId strfmt.UUID
+    Details string
+}
+
+var ImageInfoUpdatedEventName string = "image_info_updated"
+
+func NewImageInfoUpdatedEvent(
+    infraEnvId strfmt.UUID,
+    details string,
+) *ImageInfoUpdatedEvent {
+    return &ImageInfoUpdatedEvent{
+        InfraEnvId: infraEnvId,
+        Details: details,
+    }
+}
+
+func SendImageInfoUpdatedEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    infraEnvId strfmt.UUID,
+    details string,) {
+    ev := NewImageInfoUpdatedEvent(
+        infraEnvId,
+        details,
+    )
+    eventsHandler.SendInfraEnvEvent(ctx, ev)
+}
+
+func SendImageInfoUpdatedEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    infraEnvId strfmt.UUID,
+    details string,
+    eventTime time.Time) {
+    ev := NewImageInfoUpdatedEvent(
+        infraEnvId,
+        details,
+    )
+    eventsHandler.SendInfraEnvEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *ImageInfoUpdatedEvent) GetName() string {
+    return "image_info_updated"
+}
+
+func (e *ImageInfoUpdatedEvent) GetSeverity() string {
+    return "info"
+}
+func (e *ImageInfoUpdatedEvent) GetClusterId() *strfmt.UUID {
+    return nil
+}
+func (e *ImageInfoUpdatedEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+func (e *ImageInfoUpdatedEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{details}", fmt.Sprint(e.Details),
+    )
+    return r.Replace(*message)
+}
+
+func (e *ImageInfoUpdatedEvent) FormatMessage() string {
+    s := "Updated image information ({details})"
+    return e.format(&s)
+}
+


### PR DESCRIPTION
## Description

This PR backports part of https://github.com/openshift/assisted-service/pull/2884 and cherry-picks https://github.com/openshift/assisted-service/pull/3049 to add an infra-env event when the image info is updated.

This is only relevant when we're using the image service (which is the case in stage currently).

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-8532
https://issues.redhat.com/browse/MGMT-7254
https://issues.redhat.com/browse/MGMT-8504

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

On the original PRs

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?
