### PR TITLE
MGMT-8477: invoke cluster validations when updating host

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6790,12 +6790,8 @@ func (b *bareMetalInventory) V2UpdateHostLogsProgress(ctx context.Context, param
 
 func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params installer.V2UpdateHostParams) (*common.Host, error) {
 	log := logutil.FromContext(ctx, b.log)
-
-	host, err := common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())
-	if err != nil {
-		log.WithError(err).Errorf("failed to find host <%s>, infra env <%s>", params.HostID, params.InfraEnvID)
-		return nil, common.NewApiError(http.StatusNotFound, err)
-	}
+	var c *models.Cluster
+	var cluster *common.Cluster
 
 	txSuccess := false
 	tx := b.db.Begin()
@@ -6810,6 +6806,12 @@ func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params in
 			tx.Rollback()
 		}
 	}()
+
+	host, err := common.GetHostFromDB(transaction.AddForUpdateQueryOption(tx), params.InfraEnvID.String(), params.HostID.String())
+	if err != nil {
+		log.WithError(err).Errorf("failed to find host <%s>, infra env <%s>", params.HostID, params.InfraEnvID)
+		return nil, common.NewApiError(http.StatusNotFound, err)
+	}
 
 	err = b.updateHostRole(ctx, host, params.HostUpdateParams.HostRole, tx)
 	if err != nil {
@@ -6832,7 +6834,17 @@ func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params in
 		return nil, err
 	}
 
-	err = b.refreshAfterUpdate(ctx, host, tx)
+	//get bound cluster
+	if host.ClusterID != nil {
+		cluster, err = common.GetClusterFromDBForUpdate(tx, *host.ClusterID, common.SkipEagerLoading)
+		if err != nil {
+			err = fmt.Errorf("can not find a cluster for host %s", params.HostID.String())
+			return nil, common.NewApiError(http.StatusInternalServerError, err)
+		}
+		c = &cluster.Cluster
+	}
+
+	err = b.refreshAfterUpdate(ctx, cluster, host, tx)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to refresh host %s, infra env %s during update", host.ID, host.InfraEnvID)
 		return nil, err
@@ -6849,18 +6861,6 @@ func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params in
 	if err != nil {
 		log.WithError(err).Errorf("failed to get host <%s>, infra env <%s> after update", params.HostID, params.InfraEnvID)
 		return nil, common.NewApiError(http.StatusNotFound, err)
-	}
-
-	//get bound cluster
-	var c *models.Cluster
-	var cluster *common.Cluster
-	if host.ClusterID != nil {
-		cluster, err = common.GetClusterFromDB(b.db, *host.ClusterID, common.SkipEagerLoading)
-		if err != nil {
-			err = fmt.Errorf("can not find a cluster for host %s", params.HostID.String())
-			return nil, common.NewApiError(http.StatusInternalServerError, err)
-		}
-		c = &cluster.Cluster
 	}
 
 	err = b.customizeHost(c, &host.Host)
@@ -6968,7 +6968,7 @@ func (b *bareMetalInventory) updateHostIgnitionEndpointToken(ctx context.Context
 	return nil
 }
 
-func (b *bareMetalInventory) refreshAfterUpdate(ctx context.Context, host *common.Host, db *gorm.DB) error {
+func (b *bareMetalInventory) refreshAfterUpdate(ctx context.Context, cluster *common.Cluster, host *common.Host, db *gorm.DB) error {
 	log := logutil.FromContext(ctx, b.log)
 	if host.ClusterID != nil {
 		if host.Inventory != "" {
@@ -6982,6 +6982,15 @@ func (b *bareMetalInventory) refreshAfterUpdate(ctx context.Context, host *commo
 	err := b.hostApi.RefreshStatus(ctx, &host.Host, db)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to refresh host %s, infra env %s during update", host.ID, host.InfraEnvID)
+		return err
+	}
+
+	if host.ClusterID != nil {
+		_, err = b.clusterApi.RefreshStatus(ctx, cluster, db)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to refresh cluster %s, infra env %s during host update", host.ID, host.InfraEnvID)
+			return err
+		}
 	}
 	return err
 }

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -8559,6 +8559,7 @@ var _ = Describe("infraEnvs host", func() {
 			mockHostApi.EXPECT().UpdateMachineConfigPoolName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().UpdateIgnitionEndpointToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			resp := bm.V2UpdateHost(ctx, installer.V2UpdateHostParams{
 				InfraEnvID: infraEnvID,
@@ -8594,6 +8595,7 @@ var _ = Describe("infraEnvs host", func() {
 			mockHostApi.EXPECT().UpdateMachineConfigPoolName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().UpdateIgnitionEndpointToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			resp := bm.V2UpdateHost(ctx, installer.V2UpdateHostParams{
 				InfraEnvID: infraEnvID,
@@ -8646,6 +8648,7 @@ var _ = Describe("infraEnvs host", func() {
 			mockHostApi.EXPECT().UpdateMachineConfigPoolName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().UpdateIgnitionEndpointToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			resp := bm.V2UpdateHost(ctx, installer.V2UpdateHostParams{
 				InfraEnvID: infraEnvID,
@@ -8687,6 +8690,7 @@ var _ = Describe("infraEnvs host", func() {
 			mockHostApi.EXPECT().UpdateMachineConfigPoolName(gomock.Any(), gomock.Any(), gomock.Any(), "machinepool").Return(nil).Times(1)
 			mockHostApi.EXPECT().UpdateIgnitionEndpointToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			resp := bm.V2UpdateHost(ctx, installer.V2UpdateHostParams{
 				InfraEnvID: infraEnvID,
@@ -8722,6 +8726,7 @@ var _ = Describe("infraEnvs host", func() {
 			mockHostApi.EXPECT().UpdateMachineConfigPoolName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			mockHostApi.EXPECT().UpdateIgnitionEndpointToken(gomock.Any(), gomock.Any(), gomock.Any(), "mytoken").Return(nil).Times(1)
 			mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 			mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			resp := bm.V2UpdateHost(ctx, installer.V2UpdateHostParams{
 				InfraEnvID: infraEnvID,

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -239,6 +239,27 @@ var _ = Describe("[V2ClusterTests]", func() {
 		waitForHostStateV2(ctx, models.HostStatusKnownUnbound, defaultWaitForHostStateTimeout, h1)
 	})
 
+	It("Cluster validations are run after host update", func() {
+		By("register 3 nodes and check that the cluster is ready")
+		h1 = registerNode(ctx, boundInfraEnv, "h1", ips[0])
+		generateFullMeshConnectivity(ctx, ips[0], h1, h2, h3)
+		waitForClusterState(ctx, clusterID, models.ClusterStatusReady, defaultWaitForClusterStateTimeout,
+			IgnoreStateInfo)
+
+		By("update the host's role to worker and check validation")
+		hostReq := &installer.V2UpdateHostParams{
+			InfraEnvID: boundInfraEnv,
+			HostID:     *h1.ID,
+			HostUpdateParams: &models.HostUpdateParams{
+				HostRole: swag.String(string(models.HostRoleWorker)),
+			},
+		}
+		h1 = updateHostV2(ctx, hostReq)
+		c := getCluster(clusterID)
+		log.Info(c.ValidationsInfo)
+		Expect(*c.Status).To(Equal(models.ClusterStatusInsufficient))
+	})
+
 	It("Verify garbage collector inactive cluster and infraenv deregistration", func() {
 		By("Update cluster's updated_at attribute to become eligible for deregistration due to inactivity")
 		cluster := getCluster(clusterID)


### PR DESCRIPTION
# Assisted Pull Request

## Description
When updating a host the cluster level validation may be affected. For example, when
changing a role of a host from master to worker the sufficient count validation may fail.
If the installation is confirmed quickly using the UI, it may fail with out a warning because
the monitor has no time to run again and execute the validations

This code make sure that the cluster validation runs when the host parameters are updated
without having to wait for the monitor

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
