### PR TITLE
MGMT-7330: remove unit-test logic from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,6 @@ pipeline {
                 }
 
                 archiveArtifacts artifacts: '*.log', fingerprint: true, allowEmptyArchive: true
-                junit '**/reports/junit*.xml'
-                cobertura coberturaReportFile: '**/reports/*coverage.xml', onlyStable: false, enableNewApi: true
 
                 sh "make clear-all"
             }

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ _update-local-k8s-image:
 
 update-local-image: $(UPDATE_LOCAL_SERVICE)
 
-build-image: validate update-minimal
+build-image: update-minimal
 
 update-service: build-in-docker
 	docker push $(SERVICE)


### PR DESCRIPTION
# Assisted Pull Request

## Description

Following openshift/release#21127, we now have unit-tests running via prow, which makes it redundant to run it also on Jenkins.
Also, it's redundant to include linting/testing before building the image, as those are non-dependent actions.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @pawanpinjarkar 
/cc @lranjbar 
/hold

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
