### PR TITLE
OCPBUGSM-38736: Fix 'supported-platforms' endpoint

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2048,8 +2048,8 @@ func (b *bareMetalInventory) GetClusterSupportedPlatformsInternal(
 		return nil, fmt.Errorf("error getting cluster, error: %w", err)
 	}
 	// no hosts or SNO
-	if len(cluster.Hosts) == 0 || swag.StringValue(cluster.HighAvailabilityMode) != models.ClusterHighAvailabilityModeFull {
-		return &[]models.PlatformType{models.PlatformTypeBaremetal}, nil
+	if len(cluster.Hosts) == 0 || common.IsSingleNodeCluster(cluster) {
+		return &[]models.PlatformType{models.PlatformTypeNone}, nil
 	}
 	hostSupportedPlatforms, err := b.providerRegistry.GetSupportedProvidersByHosts(cluster.Hosts)
 	if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10185,7 +10185,7 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		Expect(platformReplay).Should(BeAssignableToTypeOf(installer.NewGetClusterSupportedPlatformsOK()))
 		platforms := platformReplay.(*installer.GetClusterSupportedPlatformsOK).Payload
 		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(platforms[0]).Should(Equal(models.PlatformTypeNone))
 	})
 
 	It("single SNO vsphere host", func() {
@@ -10198,7 +10198,7 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		Expect(platformReplay).Should(BeAssignableToTypeOf(installer.NewGetClusterSupportedPlatformsOK()))
 		platforms := platformReplay.(*installer.GetClusterSupportedPlatformsOK).Payload
 		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(platforms[0]).Should(Equal(models.PlatformTypeNone))
 	})
 
 	It("HighAvailabilityMode is nil with single host", func() {
@@ -10207,11 +10207,9 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 
 		addVsphereHost(clusterID, models.HostRoleMaster)
 		validateHostsInventory(1, 0)
+		mockProviderRegistry.EXPECT().GetSupportedProvidersByHosts(gomock.Any())
 		platformReplay := bm.GetClusterSupportedPlatforms(ctx, installer.GetClusterSupportedPlatformsParams{ClusterID: clusterID})
 		Expect(platformReplay).Should(BeAssignableToTypeOf(installer.NewGetClusterSupportedPlatformsOK()))
-		platforms := platformReplay.(*installer.GetClusterSupportedPlatformsOK).Payload
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
 	})
 })
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

* Check the number of active hosts instead of
'HighAvailabilityMode' for SNO discovery.
* Return platform 'none' when it's an SNO or
there are no enabled hosts.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @romfreiman 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
