### PR TITLE
MGMT-8677: use "edge-infrastructure" organization for all images

### DIFF
--- a/tools/deploy_ui.py
+++ b/tools/deploy_ui.py
@@ -18,8 +18,7 @@ def main():
     dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'deploy_ui.yaml')
     image_fqdn = deployment_options.get_image_override(deploy_options,
                                                        "assisted-installer-ui",
-                                                       "UI_IMAGE",
-                                                       org="edge-infrastructure")
+                                                       "UI_IMAGE")
 
     tag = deployment_options.get_tag(image_fqdn)
     clone_directory = os.path.join(os.getcwd(), "build/assisted-installer-ui")

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -89,7 +89,7 @@ def get_manifest_from_url(tag):
 
 
 def get_image_revision_from_manifest(short_image_name, manifest):
-    for repo, repo_info in manifest.items():
+    for repo_info in manifest.values():
         for image in repo_info["images"]:
             if short_image_name == image.split('/')[-1]:
                 return repo_info["revision"]
@@ -97,10 +97,10 @@ def get_image_revision_from_manifest(short_image_name, manifest):
 
 
 def get_tag(image_fqdn):
-    return image_fqdn.split(":")[-1]
+    return image_fqdn.split(":")[-1].replace("latest-", "")
 
 
-def get_image_override(deployment_options, short_image_name, env_var_name, org="ocpmetal"):
+def get_image_override(deployment_options, short_image_name, env_var_name, org="edge-infrastructure"):
     # default tag is latest
     tag = "latest"
     image_from_env = os.environ.get(env_var_name)
@@ -108,11 +108,11 @@ def get_image_override(deployment_options, short_image_name, env_var_name, org="
         print("Deploying {} according to manifest: {}".format(short_image_name, deployment_options.deploy_manifest_path))
         with open(deployment_options.deploy_manifest_path, "r") as manifest_contnet:
             manifest = yaml.safe_load(manifest_contnet)
-        tag = get_image_revision_from_manifest(short_image_name, manifest)
+        tag = f"latest-{get_image_revision_from_manifest(short_image_name, manifest)}"
     elif deployment_options.deploy_manifest_tag:
         print("Deploying {} according to assisted-installer-deployment tag: {}".format(short_image_name, deployment_options.deploy_manifest_tag))
         manifest = get_manifest_from_url(deployment_options.deploy_manifest_tag)
-        tag = get_image_revision_from_manifest(short_image_name, manifest)
+        tag = f"latest-{get_image_revision_from_manifest(short_image_name, manifest)}"
     elif deployment_options.deploy_tag:
         print("Deploying {} with deploy tag {}".format(short_image_name, deployment_options.deploy_tag))
         tag = deployment_options.deploy_tag


### PR DESCRIPTION
# Assisted Pull Request

## Description

It seems like we're expecting docker images for a specific revision to be saved as ``<revision>`` instead of ``latest-<revision>``. The case for all our repositories should be the same, and it should be in the later pattern.

Also, using ``edge-infrastructure`` organization for the following images as well:
* assisted-service
* assisted-installer
* assisted-installer-controller
* assisted-installer-agent.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-8677

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @nshidlin 
/cc @hardengl 
/cc @eliorerz 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
