### PR TITLE
MGMT-8516: Allow filtering infra-env list by cluster id

### DIFF
--- a/client/installer/list_infra_envs_parameters.go
+++ b/client/installer/list_infra_envs_parameters.go
@@ -58,6 +58,15 @@ func NewListInfraEnvsParamsWithHTTPClient(client *http.Client) *ListInfraEnvsPar
    Typically these are written to a http.Request.
 */
 type ListInfraEnvsParams struct {
+
+	/* ClusterID.
+
+	   If provided, returns only infra-envs which directly reference this cluster.
+
+	   Format: uuid
+	*/
+	ClusterID *strfmt.UUID
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -111,6 +120,17 @@ func (o *ListInfraEnvsParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithClusterID adds the clusterID to the list infra envs params
+func (o *ListInfraEnvsParams) WithClusterID(clusterID *strfmt.UUID) *ListInfraEnvsParams {
+	o.SetClusterID(clusterID)
+	return o
+}
+
+// SetClusterID adds the clusterId to the list infra envs params
+func (o *ListInfraEnvsParams) SetClusterID(clusterID *strfmt.UUID) {
+	o.ClusterID = clusterID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListInfraEnvsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -118,6 +138,23 @@ func (o *ListInfraEnvsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		return err
 	}
 	var res []error
+
+	if o.ClusterID != nil {
+
+		// query param cluster_id
+		var qrClusterID strfmt.UUID
+
+		if o.ClusterID != nil {
+			qrClusterID = *o.ClusterID
+		}
+		qClusterID := qrClusterID.String()
+		if qClusterID != "" {
+
+			if err := r.SetQueryParam("cluster_id", qClusterID); err != nil {
+				return err
+			}
+		}
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5722,7 +5722,12 @@ func (b *bareMetalInventory) ListInfraEnvs(ctx context.Context, params installer
 	db := b.db
 	var dbInfraEnvs []*common.InfraEnv
 	var infraEnvs []*models.InfraEnv
-	whereCondition := identity.AddUserFilter(ctx, "")
+
+	condition := ""
+	if params.ClusterID != nil {
+		condition = fmt.Sprintf("cluster_id = '%s'", params.ClusterID)
+	}
+	whereCondition := identity.AddUserFilter(ctx, condition)
 
 	dbInfraEnvs, err := common.GetInfraEnvsFromDBWhere(db, whereCondition)
 	if err != nil {

--- a/models/infra_env.go
+++ b/models/infra_env.go
@@ -26,7 +26,7 @@ type InfraEnv struct {
 
 	// If set, all hosts that register will be associated with the specified cluster.
 	// Format: uuid
-	ClusterID strfmt.UUID `json:"cluster_id,omitempty"`
+	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"index"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7095,6 +7095,15 @@ func init() {
           "installer"
         ],
         "operationId": "ListInfraEnvs",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "If provided, returns only infra-envs which directly reference this cluster.",
+            "name": "cluster_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success.",
@@ -11796,7 +11805,8 @@ func init() {
         "cluster_id": {
           "description": "If set, all hosts that register will be associated with the specified cluster.",
           "type": "string",
-          "format": "uuid"
+          "format": "uuid",
+          "x-go-custom-tag": "gorm:\"index\""
         },
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
@@ -20436,6 +20446,15 @@ func init() {
           "installer"
         ],
         "operationId": "ListInfraEnvs",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "If provided, returns only infra-envs which directly reference this cluster.",
+            "name": "cluster_id",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success.",
@@ -25209,7 +25228,8 @@ func init() {
         "cluster_id": {
           "description": "If set, all hosts that register will be associated with the specified cluster.",
           "type": "string",
-          "format": "uuid"
+          "format": "uuid",
+          "x-go-custom-tag": "gorm:\"index\""
         },
         "cpu_architecture": {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",

--- a/restapi/operations/installer/list_infra_envs_urlbuilder.go
+++ b/restapi/operations/installer/list_infra_envs_urlbuilder.go
@@ -9,11 +9,17 @@ import (
 	"errors"
 	"net/url"
 	golangswaggerpaths "path"
+
+	"github.com/go-openapi/strfmt"
 )
 
 // ListInfraEnvsURL generates an URL for the list infra envs operation
 type ListInfraEnvsURL struct {
+	ClusterID *strfmt.UUID
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -42,6 +48,18 @@ func (o *ListInfraEnvsURL) Build() (*url.URL, error) {
 		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var clusterIDQ string
+	if o.ClusterID != nil {
+		clusterIDQ = o.ClusterID.String()
+	}
+	if clusterIDQ != "" {
+		qs.Set("cluster_id", clusterIDQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3311,6 +3311,13 @@ paths:
         - userAuth: [admin, read-only-admin, user]
       description: Retrieves the list of infra-envs.
       operationId: ListInfraEnvs
+      parameters:
+        - in: query
+          name: cluster_id
+          description: If provided, returns only infra-envs which directly reference this cluster.
+          type: string
+          format: uuid
+          required: false
       responses:
         "200":
           description: Success.
@@ -8984,6 +8991,7 @@ definitions:
         type: string
         format: uuid
         description: If set, all hosts that register will be associated with the specified cluster.
+        x-go-custom-tag: gorm:"index"
       size_bytes:
         type: integer
         minimum: 0


### PR DESCRIPTION
## Description

This PR adds an optional cluster id parameter to the infra-env list endpoint (`/v2/infra-envs`).
When provided, the endpoint will only return infra-envs which are _directly_ related to the given cluster.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-8516

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

1. Deployed assisted-service locally on minikube
2. Created several infra-envs (some with cluster ids, some without)
3. Tested list infra-envs endpoint with and without cluster parameter

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @yevgeny-shnaidman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?