### PR TITLE
MGMT-8710: Assisted-service fail to get the agent ignition token

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -536,6 +536,7 @@ func main() {
 
 			failOnError((&controllers.AgentReconciler{
 				Client:           ctrlMgr.GetClient(),
+				APIReader:        ctrlMgr.GetAPIReader(),
 				Log:              log,
 				Scheme:           ctrlMgr.GetScheme(),
 				Installer:        bm,

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -73,6 +73,7 @@ type AgentReconciler struct {
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents/ai-deprovision,verbs=update
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx := addRequestIdIfNeeded(origCtx)

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -70,6 +70,7 @@ var _ = Describe("agent reconcile", func() {
 
 		hr = &AgentReconciler{
 			Client:    c,
+			APIReader: c,
 			Scheme:    scheme.Scheme,
 			Log:       common.GetTestLog(),
 			Installer: mockInstallerInternal,


### PR DESCRIPTION
When installing day2 hosts using the capi-provider-agent the provider saves the ignition endpoint CA cert and token in a secret.
Currently the agent_controller fail to get the token:
`"Failed to get user-data secret clusters-test-infra-cluster-fbe4fef1/user-data-test-infra-cluster-fbe4fef1-a7e8660f: Secret \"user-data-test-infra-cluster-fbe4fef1-a7e8660f\" not found`

The agent_controller is missing the rbac permissions to get secrets, yet that's not what caused the failure because the pod does have get, list & watch permissions for secrets thanks to the clusterdeployment_controller.
The root cause for this error is the secrets cache added [here](https://github.com/openshift/assisted-service/blob/76c1586d1a351af02e56205aece963298207ef76/cmd/main.go#L808)
In order to get the secret (that might not have the required label), the agent_controller should get the secret directly from the API. 

- Should this PR be tested by the reviewer? no, I'm testing it locally
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? yes, with CAPI env
- Any logs, screenshots, etc that can help with the review process? see the failure log above

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment 
- [ ] `make delete_all_virsh_resources && ENABLE_KUBE_API=true make run && make deploy_capi_env && ENABLE_KUBE_API=true make test TEST=./src/tests/test_kube_api.py TEST_FUNC=test_capi_provider KUBECONFIG=$HOME/.kube/config `
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @rollandf 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
