### PR TITLE
MGMT-8448: Redirect v1 image downloads to the image service

### DIFF
--- a/client/installer/download_cluster_i_s_o_responses.go
+++ b/client/installer/download_cluster_i_s_o_responses.go
@@ -30,6 +30,12 @@ func (o *DownloadClusterISOReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return result, nil
+	case 301:
+		result := NewDownloadClusterISOMovedPermanently()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 400:
 		result := NewDownloadClusterISOBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -105,6 +111,35 @@ func (o *DownloadClusterISOOK) readResponse(response runtime.ClientResponse, con
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
+	}
+
+	return nil
+}
+
+// NewDownloadClusterISOMovedPermanently creates a DownloadClusterISOMovedPermanently with default headers values
+func NewDownloadClusterISOMovedPermanently() *DownloadClusterISOMovedPermanently {
+	return &DownloadClusterISOMovedPermanently{}
+}
+
+/* DownloadClusterISOMovedPermanently describes a response with status code 301, with default header values.
+
+Redirect.
+*/
+type DownloadClusterISOMovedPermanently struct {
+	Location string
+}
+
+func (o *DownloadClusterISOMovedPermanently) Error() string {
+	return fmt.Sprintf("[GET /v1/clusters/{cluster_id}/downloads/image][%d] downloadClusterISOMovedPermanently ", 301)
+}
+
+func (o *DownloadClusterISOMovedPermanently) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// hydrates response header Location
+	hdrLocation := response.GetHeader("Location")
+
+	if hdrLocation != "" {
+		o.Location = hdrLocation
 	}
 
 	return nil

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -999,6 +999,11 @@ func (b *bareMetalInventory) DownloadISOInternal(ctx context.Context, infraEnvID
 		return common.GenerateErrorResponder(err)
 	}
 
+	if b.ImageServiceBaseURL != "" && infraEnv.DownloadURL != "" {
+		log.Warnf("Redirecting image download to %s: download is not supported at this endpoint", infraEnv.DownloadURL)
+		return installer.NewDownloadClusterISOMovedPermanently().WithLocation(infraEnv.DownloadURL)
+	}
+
 	imgName := getImageName(infraEnv.ID)
 	exists, err := b.objectHandler.DoesObjectExist(ctx, imgName)
 	if err != nil {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -1486,6 +1486,14 @@ func init() {
               "format": "binary"
             }
           },
+          "301": {
+            "description": "Redirect.",
+            "headers": {
+              "Location": {
+                "type": "string"
+              }
+            }
+          },
           "400": {
             "description": "Error.",
             "schema": {
@@ -14976,6 +14984,14 @@ func init() {
             "schema": {
               "type": "string",
               "format": "binary"
+            }
+          },
+          "301": {
+            "description": "Redirect.",
+            "headers": {
+              "Location": {
+                "type": "string"
+              }
             }
           },
           "400": {

--- a/restapi/operations/installer/download_cluster_i_s_o_responses.go
+++ b/restapi/operations/installer/download_cluster_i_s_o_responses.go
@@ -56,6 +56,52 @@ func (o *DownloadClusterISOOK) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
+// DownloadClusterISOMovedPermanentlyCode is the HTTP code returned for type DownloadClusterISOMovedPermanently
+const DownloadClusterISOMovedPermanentlyCode int = 301
+
+/*DownloadClusterISOMovedPermanently Redirect.
+
+swagger:response downloadClusterISOMovedPermanently
+*/
+type DownloadClusterISOMovedPermanently struct {
+	/*
+
+	 */
+	Location string `json:"Location"`
+}
+
+// NewDownloadClusterISOMovedPermanently creates DownloadClusterISOMovedPermanently with default headers values
+func NewDownloadClusterISOMovedPermanently() *DownloadClusterISOMovedPermanently {
+
+	return &DownloadClusterISOMovedPermanently{}
+}
+
+// WithLocation adds the location to the download cluster i s o moved permanently response
+func (o *DownloadClusterISOMovedPermanently) WithLocation(location string) *DownloadClusterISOMovedPermanently {
+	o.Location = location
+	return o
+}
+
+// SetLocation sets the location to the download cluster i s o moved permanently response
+func (o *DownloadClusterISOMovedPermanently) SetLocation(location string) {
+	o.Location = location
+}
+
+// WriteResponse to the client
+func (o *DownloadClusterISOMovedPermanently) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	// response header Location
+
+	location := o.Location
+	if location != "" {
+		rw.Header().Set("Location", location)
+	}
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+
+	rw.WriteHeader(301)
+}
+
 // DownloadClusterISOBadRequestCode is the HTTP code returned for type DownloadClusterISOBadRequest
 const DownloadClusterISOBadRequestCode int = 400
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -666,6 +666,11 @@ paths:
           schema:
             type: string
             format: binary
+        "301":
+          description: Redirect.
+          headers:
+            Location:
+              type: string
         "400":
           description: Error.
           schema:


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR backports https://github.com/openshift/assisted-service/pull/3023 for redirecting v1 downloads to image service. This is required to avoid failing when calling the service directly for downloading the discovery image.

This scenario is relevant for the 'cloud_hotfix_releases' branch since the deployment is actually done using 'master' branch - which means that the assisted-image-service is being used.

Specifically, this change fixes day2-periodic test in CI as that e2e test still uses v1 API.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @carbonin 
/cc @osherdp 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
