### PR TITLE
MGMT-8727: KubeAPI Controllers to use V2 Events endpoint

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -314,7 +314,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		}
 		status := *h.Status
 		if clusterId != nil {
-			err := r.populateEventsURL(log, agent, (*clusterId).String(), h.InfraEnvID.String())
+			err := r.populateEventsURL(log, agent, h.InfraEnvID.String())
 			if err != nil {
 				return ctrl.Result{Requeue: true}, nil
 			}
@@ -337,9 +337,9 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 	return ctrl.Result{}, nil
 }
 
-func (r *AgentReconciler) populateEventsURL(log logrus.FieldLogger, agent *aiv1beta1.Agent, clusterId, infraEnvId string) error {
-	if agent.Status.DebugInfo.EventsURL == "" || !strings.Contains(agent.Status.DebugInfo.EventsURL, clusterId) {
-		eventUrl, err := r.eventsURL(log, clusterId, infraEnvId, agent.Name)
+func (r *AgentReconciler) populateEventsURL(log logrus.FieldLogger, agent *aiv1beta1.Agent, infraEnvId string) error {
+	if agent.Status.DebugInfo.EventsURL == "" {
+		eventUrl, err := r.generateEventsURL(log, infraEnvId, agent.Name)
 		if err != nil {
 			log.WithError(err).Error("failed to generate Events URL")
 			return err
@@ -349,8 +349,8 @@ func (r *AgentReconciler) populateEventsURL(log logrus.FieldLogger, agent *aiv1b
 	return nil
 }
 
-func (r *AgentReconciler) eventsURL(log logrus.FieldLogger, clusterId, infraEnvId, agentId string) (string, error) {
-	eventsURL := fmt.Sprintf("%s%s/v1/clusters/%s/events?host_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId, agentId)
+func (r *AgentReconciler) generateEventsURL(log logrus.FieldLogger, infraEnvId, agentId string) (string, error) {
+	eventsURL := fmt.Sprintf("%s%s/v2/events?host_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, agentId)
 	if r.AuthType != auth.TypeLocal {
 		return eventsURL, nil
 	}

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -669,7 +669,7 @@ var _ = Describe("agent reconcile", func() {
 		serviceBaseURL := "http://acme.com"
 		hr.ServiceBaseURL = serviceBaseURL
 		hostId := strfmt.UUID(uuid.New().String())
-		expectedEventUrlPrefix := fmt.Sprintf("%s/api/assisted-install/v1/clusters/%s/events?host_id=%s", serviceBaseURL, sId, hostId.String())
+		expectedEventUrlPrefix := fmt.Sprintf("%s/api/assisted-install/v2/events?host_id=%s", serviceBaseURL, hostId.String())
 		commonHost := &common.Host{
 			Host: models.Host{
 				ID:         &hostId,

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1411,7 +1411,7 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 func (r *ClusterDeploymentsReconciler) populateEventsURL(log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster) error {
 	if *c.Status != models.ClusterStatusInstalled {
 		if clusterInstall.Status.DebugInfo.EventsURL == "" {
-			eventUrl, err := r.eventsURL(log, string(*c.ID))
+			eventUrl, err := r.generateEventsURL(log, string(*c.ID))
 			if err != nil {
 				log.WithError(err).Error("failed to generate Events URL")
 				return err
@@ -1432,8 +1432,8 @@ func (r *ClusterDeploymentsReconciler) populateLogsURL(ctx context.Context, log 
 	return nil
 }
 
-func (r *ClusterDeploymentsReconciler) eventsURL(log logrus.FieldLogger, clusterId string) (string, error) {
-	eventsURL := fmt.Sprintf("%s%s/v1/clusters/%s/events", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId)
+func (r *ClusterDeploymentsReconciler) generateEventsURL(log logrus.FieldLogger, clusterId string) (string, error) {
+	eventsURL := fmt.Sprintf("%s%s/v2/events?cluster_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId)
 	if r.AuthType != auth.TypeLocal {
 		return eventsURL, nil
 	}

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -661,7 +661,7 @@ var _ = Describe("cluster reconcile", func() {
 				Status: swag.String(models.ClusterStatusInsufficient),
 			},
 		}
-		expectedEventUrlPrefix := fmt.Sprintf("%s/api/assisted-install/v1/clusters/%s/events", serviceBaseURL, sId)
+		expectedEventUrlPrefix := fmt.Sprintf("%s/api/assisted-install/v2/events?cluster_id=%s", serviceBaseURL, sId)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 
 		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)

--- a/internal/controller/controllers/controller_event_wrapper_test.go
+++ b/internal/controller/controllers/controller_event_wrapper_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Controller events wrapper", func() {
 	Context("With events", func() {
 		It("Adding a cluster event", func() {
 			mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(cluster1.KubeKeyName, cluster1.KubeKeyNamespace).Times(1)
-			cEventsWrapper.AddEvent(context.TODO(), *cluster1.ID, nil, models.EventSeverityInfo, "the event1", time.Now())
+			cEventsWrapper.V2AddEvent(context.TODO(), cluster1.ID, nil, nil, models.EventSeverityInfo, "the event1", time.Now())
 			Expect(numOfEvents(cluster1.ID, nil, nil)).Should(Equal(1))
 			Expect(numOfEvents(cluster2.ID, nil, nil)).Should(Equal(0))
 
@@ -104,7 +104,7 @@ var _ = Describe("Controller events wrapper", func() {
 			Expect(evs[0]).Should(WithSeverity(swag.String(models.EventSeverityInfo)))
 
 			mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(cluster2.KubeKeyName, cluster2.KubeKeyNamespace).Times(1)
-			cEventsWrapper.AddEvent(context.TODO(), *cluster2.ID, nil, models.EventSeverityInfo, "event2", time.Now())
+			cEventsWrapper.V2AddEvent(context.TODO(), cluster2.ID, nil, nil, models.EventSeverityInfo, "event2", time.Now())
 			Expect(numOfEvents(cluster1.ID, nil, nil)).Should(Equal(1))
 			Expect(numOfEvents(cluster2.ID, nil, nil)).Should(Equal(1))
 		})
@@ -114,7 +114,7 @@ var _ = Describe("Controller events wrapper", func() {
 			host1 := common.Host{
 				Host: models.Host{
 					ID:         &hostID1,
-					InfraEnvID: *cluster1.ID,
+					InfraEnvID: *infraEnv1.ID,
 					ClusterID:  cluster1.ID,
 					Status:     swag.String(models.HostStatusKnown),
 					Kind:       swag.String(models.HostKindHost),
@@ -126,9 +126,9 @@ var _ = Describe("Controller events wrapper", func() {
 
 			mockCRDEventsHandler.EXPECT().NotifyAgentUpdates(host1.ID.String(), host1.KubeKeyNamespace).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyClusterDeploymentUpdates(cluster1.KubeKeyName, cluster1.KubeKeyNamespace).Times(1)
-			cEventsWrapper.AddEvent(context.TODO(), *cluster1.ID, host1.ID, models.EventSeverityInfo, "event2", time.Now())
-			Expect(numOfEvents(cluster1.ID, nil, nil)).Should(Equal(1))
-			Expect(numOfEvents(cluster1.ID, host1.ID, nil)).Should(Equal(1))
+			cEventsWrapper.V2AddEvent(context.TODO(), nil, host1.ID, infraEnv1.ID, models.EventSeverityInfo, "event2", time.Now())
+			Expect(numOfEvents(nil, host1.ID, nil)).Should(Equal(1))
+			Expect(numOfEvents(nil, host1.ID, infraEnv1.ID)).Should(Equal(1))
 		})
 
 		It("Sending a cluster event", func() {

--- a/internal/events/events_api.go
+++ b/internal/events/events_api.go
@@ -77,5 +77,5 @@ func (a *Api) V2ListEvents(ctx context.Context, params events.V2ListEventsParams
 			Props:      ev.Props,
 		}
 	}
-	return events.NewListEventsOK().WithPayload(ret)
+	return events.NewV2ListEventsOK().WithPayload(ret)
 }

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1544,11 +1544,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return kubeClient.Update(ctx, agent)
 		}, "30s", "10s").Should(BeNil())
 
-		By("Check Agent Event URL exists")
+		By("Check that Agent Event URL is valid")
 		Eventually(func() string {
 			agent := getAgentCRD(ctx, kubeClient, key)
 			return agent.Status.DebugInfo.EventsURL
-		}, "30s", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*host_id=%s", host.ID.String())))
 
 		By("Wait for installing")
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterCompletedCondition, hiveext.ClusterInstallationInProgressReason)
@@ -2479,11 +2479,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
 		}
 		generateDomainResolution(ctx, host, clusterDeploymentSpec.ClusterName, "hive.example.com")
-		By("Check ACI Event URL exists")
+		By("Check that ACI Event URL is valid")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.EventsURL
-		}, "30s", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*cluster_id=%s", cluster.ID.String())))
 
 		By("Check ACI Logs URL is empty")
 		// Should not show the URL since no logs were collected
@@ -2506,11 +2506,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return kubeClient.Update(ctx, agent)
 		}, "30s", "10s").Should(BeNil())
 
-		By("Check Agent Event URL exists")
+		By("Check that Agent Event URL is valid")
 		Eventually(func() string {
 			agent := getAgentCRD(ctx, kubeClient, key)
 			return agent.Status.DebugInfo.EventsURL
-		}, "30s", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*host_id=%s", host.ID.String())))
 
 		By("Wait for installing")
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterCompletedCondition, hiveext.ClusterInstallationInProgressReason)
@@ -2620,11 +2620,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		configSecret = getSecret(ctx, kubeClient, configkey)
 		Expect(configSecret.Data["kubeconfig"]).NotTo(BeNil())
 
-		By("Check Event URL still exist")
+		By("Check that Event URL is still valid")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.EventsURL
-		}, "1m", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*cluster_id=%s", cluster.ID.String())))
 
 		By("Check ACI Logs URL still exists")
 		Eventually(func() string {
@@ -2670,11 +2670,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      host.ID.String(),
 		}
 
-		By("Check Agent Event URL exists")
+		By("Check that Agent Event URL is valid")
 		Eventually(func() string {
 			agent := getAgentCRD(ctx, kubeClient, key)
 			return agent.Status.DebugInfo.EventsURL
-		}, "30s", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*host_id=%s", host.ID.String())))
 		firstAgentEventsURL := getAgentCRD(ctx, kubeClient, key).Status.DebugInfo.EventsURL
 
 		By("Create New Infraenv")
@@ -2703,11 +2703,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return agent.Spec.ClusterDeploymentName.Name
 		}, "30s", "10s").Should(Equal(clusterDeploymentSpec2.ClusterName))
 
-		By("Check Agent event URL changed")
+		By("Check Agent event URL has not changed")
 		Eventually(func() string {
 			agent := getAgentCRD(ctx, kubeClient, key)
 			return agent.Status.DebugInfo.EventsURL
-		}, "30s", "10s").Should(Not(Equal(firstAgentEventsURL)))
+		}, "30s", "10s").Should(Equal(firstAgentEventsURL))
 
 		By("Check host is removed from first backend cluster")
 		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKey, waitForReconcileTimeout)
@@ -3004,11 +3004,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		Expect(*cluster.Kind).Should(Equal(models.ClusterKindAddHostsCluster))
 		Expect(*cluster.Status).Should(Equal(models.ClusterStatusAddingHosts))
 
-		By("Check ACI Event URL exists")
+		By("Check that ACI Event URL is valid")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.EventsURL
-		}, "30s", "10s").ShouldNot(Equal(""))
+		}, "30s", "10s").Should(MatchRegexp(fmt.Sprintf("/v2/events.*cluster_id=%s", cluster.ID.String())))
 
 		By("Verify ClusterDeployment Agents were not deleted")
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

With this change, both `ACI` and `Agent` controllers will use
the V2 Events endpoint for `DebugInfo.EventsURL`.

In addition, this change `controllerEventsWrapper` to use V2
Events instead of V1. Lastly, subsystem tests will now match
EventsURL with a relevant regex (to accommodate for auth
token additions) instead of asserting some non-empty value
in EventsURL.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @rollandf 
/cc @avishayt 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
