### PR TITLE
MGMT-8364: use LabelSelectorAsSelector for nmstate

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -187,23 +188,25 @@ func (r *InfraEnvReconciler) buildMacInterfaceMap(log logrus.FieldLogger, nmStat
 
 func (r *InfraEnvReconciler) processNMStateConfig(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) ([]*models.HostStaticNetworkConfig, error) {
 	var staticNetworkConfig []*models.HostStaticNetworkConfig
+	var selector labels.Selector
+	var err error
 
-	if infraEnv.Spec.NMStateConfigLabelSelector.MatchLabels == nil {
-		return staticNetworkConfig, nil
+	//Find all NMStateConfig objects that are associated with the input infraEnv
+	selector, err = metav1.LabelSelectorAsSelector(&infraEnv.Spec.NMStateConfigLabelSelector)
+	if err != nil {
+		return staticNetworkConfig, errors.Wrapf(err, "invalid label selector for InfraEnv %v", infraEnv)
 	}
-	for labelName, labelValue := range infraEnv.Spec.NMStateConfigLabelSelector.MatchLabels {
-		nmStateConfigs := &aiv1beta1.NMStateConfigList{}
-		if err := r.List(ctx, nmStateConfigs, client.InNamespace(infraEnv.Namespace),
-			client.MatchingLabels(map[string]string{labelName: labelValue})); err != nil {
-			return staticNetworkConfig, err
-		}
-		for _, nmStateConfig := range nmStateConfigs.Items {
-			log.Debugf("found nmStateConfig: %s for infraEnv: %s", nmStateConfig.Name, infraEnv.Name)
-			staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
-				MacInterfaceMap: r.buildMacInterfaceMap(log, nmStateConfig),
-				NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
-			})
-		}
+
+	nmStateConfigs := &aiv1beta1.NMStateConfigList{}
+	if err = r.List(ctx, nmStateConfigs, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return staticNetworkConfig, errors.Wrapf(err, "failed to list nmstate configs for InfraEnv %v", infraEnv)
+	}
+
+	for _, nmStateConfig := range nmStateConfigs.Items {
+		staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
+			MacInterfaceMap: r.buildMacInterfaceMap(log, nmStateConfig),
+			NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+		})
 	}
 	return staticNetworkConfig, nil
 }


### PR DESCRIPTION
# Assisted Pull Request

## Description
Convert the code that computes the static addresses to use LabelSelectorAsSelector function

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
