### PR TITLE
MGMT-8713: fix ovrit and vshere platform check

### DIFF
--- a/internal/provider/ovirt/base.go
+++ b/internal/provider/ovirt/base.go
@@ -27,6 +27,10 @@ func (p *ovirtProvider) Name() models.PlatformType {
 }
 
 func (p *ovirtProvider) IsHostSupported(host *models.Host) (bool, error) {
+	// during the discovery there is a short time that host didn't return its inventory to the service
+	if host.Inventory == "" {
+		return false, nil
+	}
 	hostInventory, err := common.UnmarshalInventory(host.Inventory)
 	if err != nil {
 		return false, fmt.Errorf("error marshaling host to inventory, error %w", err)

--- a/internal/provider/ovirt/base_test.go
+++ b/internal/provider/ovirt/base_test.go
@@ -1,0 +1,66 @@
+package ovirt
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("base", func() {
+	var log = common.GetTestLog()
+	Context("is host supported", func() {
+		var provider provider.Provider
+		var host *models.Host
+		BeforeEach(func() {
+			provider = NewOvirtProvider(log)
+			host = &models.Host{}
+		})
+
+		setHostInventory := func(inventory *models.Inventory, host *models.Host) {
+			data, err := json.Marshal(inventory)
+			Expect(err).To(BeNil())
+			host.Inventory = string(data)
+		}
+
+		It("supported", func() {
+			inventory := &models.Inventory{
+				SystemVendor: &models.SystemVendor{
+					Manufacturer: OvirtManufacturer,
+				},
+			}
+			setHostInventory(inventory, host)
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeTrue())
+		})
+
+		It("not supported", func() {
+			inventory := &models.Inventory{
+				SystemVendor: &models.SystemVendor{
+					Manufacturer: "",
+				},
+			}
+			setHostInventory(inventory, host)
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeFalse())
+		})
+
+		It("no inventory", func() {
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeFalse())
+		})
+
+		It("invalid inventory", func() {
+			host.Inventory = "invalid-inventory"
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(HaveOccurred())
+			Expect(supported).To(BeFalse())
+		})
+	})
+})

--- a/internal/provider/ovirt/ovirt_suite_test.go
+++ b/internal/provider/ovirt/ovirt_suite_test.go
@@ -1,0 +1,13 @@
+package ovirt
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOvirt(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ovirt tests")
+}

--- a/internal/provider/vsphere/base.go
+++ b/internal/provider/vsphere/base.go
@@ -27,6 +27,10 @@ func (p *vsphereProvider) Name() models.PlatformType {
 }
 
 func (p *vsphereProvider) IsHostSupported(host *models.Host) (bool, error) {
+	// during the discovery there is a short time that host didn't return its inventory to the service
+	if host.Inventory == "" {
+		return false, nil
+	}
 	hostInventory, err := common.UnmarshalInventory(host.Inventory)
 	if err != nil {
 		return false, fmt.Errorf("error marshaling host to inventory, error %w", err)

--- a/internal/provider/vsphere/base_test.go
+++ b/internal/provider/vsphere/base_test.go
@@ -1,0 +1,66 @@
+package vsphere
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("base", func() {
+	var log = common.GetTestLog()
+	Context("is host supported", func() {
+		var provider provider.Provider
+		var host *models.Host
+		BeforeEach(func() {
+			provider = NewVsphereProvider(log)
+			host = &models.Host{}
+		})
+
+		setHostInventory := func(inventory *models.Inventory, host *models.Host) {
+			data, err := json.Marshal(inventory)
+			Expect(err).To(BeNil())
+			host.Inventory = string(data)
+		}
+
+		It("supported", func() {
+			inventory := &models.Inventory{
+				SystemVendor: &models.SystemVendor{
+					Manufacturer: VmwareManufacturer,
+				},
+			}
+			setHostInventory(inventory, host)
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeTrue())
+		})
+
+		It("not supported", func() {
+			inventory := &models.Inventory{
+				SystemVendor: &models.SystemVendor{
+					Manufacturer: "",
+				},
+			}
+			setHostInventory(inventory, host)
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeFalse())
+		})
+
+		It("no inventory", func() {
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(BeNil())
+			Expect(supported).To(BeFalse())
+		})
+
+		It("invalid inventory", func() {
+			host.Inventory = "invalid-inventory"
+			supported, err := provider.IsHostSupported(host)
+			Expect(err).To(HaveOccurred())
+			Expect(supported).To(BeFalse())
+		})
+	})
+})

--- a/internal/provider/vsphere/vshpere_suite_test.go
+++ b/internal/provider/vsphere/vshpere_suite_test.go
@@ -1,0 +1,13 @@
+package vsphere
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVsphere(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "vsphere tests")
+}


### PR DESCRIPTION
# Assisted Pull Request

## Description

During discovery, host inventory may not be set yet, when checking for
supported platforms providers should consider this state and return
false in case host inventory is not populated
Once the inventorty is populated api will return all the supported
platforms

Added tests to ovirt and vsphere packages

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @rollandf 
/cc @osherdp 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
