### PR TITLE
MGMT-8722: Populate EventsURL in InfraEnv

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -518,6 +518,8 @@ func main() {
 				Log:              log,
 				Installer:        bm,
 				CRDEventsHandler: crdEventsHandler,
+				ServiceBaseURL:   Options.BMConfig.ServiceBaseURL,
+				AuthType:         Options.Auth.AuthType,
 			}).SetupWithManager(ctrlMgr), "unable to create controller InfraEnv")
 
 			failOnError((&controllers.ClusterDeploymentsReconciler{

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -744,7 +744,7 @@ var _ = Describe("agent reconcile", func() {
 		}
 		Expect(c.Get(ctx, key, agent)).To(BeNil())
 
-		Expect(agent.Status.DebugInfo.EventsURL).NotTo(BeNil())
+		Expect(agent.Status.DebugInfo.EventsURL).NotTo(BeEmpty())
 		Expect(agent.Status.DebugInfo.EventsURL).To(HavePrefix(expectedEventUrlPrefix))
 	})
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1408,7 +1408,8 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 func (r *ClusterDeploymentsReconciler) populateEventsURL(log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall, c *common.Cluster) error {
 	if *c.Status != models.ClusterStatusInstalled {
 		if clusterInstall.Status.DebugInfo.EventsURL == "" {
-			eventUrl, err := r.generateEventsURL(log, string(*c.ID))
+			tokenGen := gencrypto.CryptoPair{JWTKeyType: gencrypto.ClusterKey, JWTKeyValue: c.ID.String()}
+			eventUrl, err := generateEventsURL(r.ServiceBaseURL, r.AuthType, tokenGen, "cluster_id", c.ID.String())
 			if err != nil {
 				log.WithError(err).Error("failed to generate Events URL")
 				return err
@@ -1427,19 +1428,6 @@ func (r *ClusterDeploymentsReconciler) populateLogsURL(ctx context.Context, log 
 		}
 	}
 	return nil
-}
-
-func (r *ClusterDeploymentsReconciler) generateEventsURL(log logrus.FieldLogger, clusterId string) (string, error) {
-	eventsURL := fmt.Sprintf("%s%s/v2/events?cluster_id=%s", r.ServiceBaseURL, restclient.DefaultBasePath, clusterId)
-	if r.AuthType != auth.TypeLocal {
-		return eventsURL, nil
-	}
-	eventsURL, err := gencrypto.SignURL(eventsURL, clusterId, gencrypto.ClusterKey)
-	if err != nil {
-		log.WithError(err).Error("failed to get Events URL")
-		return "", err
-	}
-	return eventsURL, nil
 }
 
 func (r *ClusterDeploymentsReconciler) getNumOfClusterAgents(ctx context.Context, c *common.Cluster) (int, int, error) {

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -698,7 +698,7 @@ var _ = Describe("cluster reconcile", func() {
 			Name:      agentClusterInstallName,
 		}
 		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstall)).To(BeNil())
-		Expect(clusterInstall.Status.DebugInfo.EventsURL).NotTo(BeNil())
+		Expect(clusterInstall.Status.DebugInfo.EventsURL).NotTo(BeEmpty())
 		Expect(clusterInstall.Status.DebugInfo.EventsURL).To(HavePrefix(expectedEventUrlPrefix))
 	})
 

--- a/internal/gencrypto/token.go
+++ b/internal/gencrypto/token.go
@@ -16,6 +16,11 @@ const (
 	ClusterKey  LocalJWTKeyType = "cluster_id"
 )
 
+type CryptoPair struct {
+	JWTKeyType  LocalJWTKeyType
+	JWTKeyValue string
+}
+
 func LocalJWT(id string, keyType LocalJWTKeyType) (string, error) {
 	key, ok := os.LookupEnv("EC_PRIVATE_KEY_PEM")
 	if !ok || key == "" {


### PR DESCRIPTION
# Assisted Pull Request

## Description

Populate EventsURL in InfraEnv

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
