### PR TITLE
MGMT-8698: update status_info, progress when extra workers fails to install

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -708,10 +708,17 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, clusterID strfmt.UU
 		totalHostsDoneStages += float64(currentIndex + 1)
 		totalHostsStages += float64(len(stages))
 	}
-
 	installingStagePercentage := int64((totalHostsDoneStages / totalHostsStages) * 100)
-	totalPercentage := int64(common.ProgressWeightPreparingForInstallationStage*float64(cluster.Progress.PreparingForInstallationStagePercentage) +
-		common.ProgressWeightInstallingStage*float64(installingStagePercentage))
+
+	var totalPercentage int64
+	if swag.StringValue(cluster.Status) == models.ClusterStatusInstalled {
+		//if the cluster is in INSTALLED stage, force the progress bar to reach 100%
+		//even if there are hosts that are not ready yet
+		totalPercentage = int64(100)
+	} else {
+		totalPercentage = int64(common.ProgressWeightPreparingForInstallationStage*float64(cluster.Progress.PreparingForInstallationStagePercentage) +
+			common.ProgressWeightInstallingStage*float64(installingStagePercentage))
+	}
 	updates := map[string]interface{}{
 		"progress_installing_stage_percentage": installingStagePercentage,
 		"progress_total_percentage":            totalPercentage,

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -32,6 +32,7 @@ const (
 	statusInfoFinalizing                      = "Finalizing cluster installation"
 	statusInfoInstalled                       = "Cluster is installed"
 	StatusInfoDegraded                        = "Cluster is installed but degraded"
+	StatusInfoNotAllWorkersInstalled          = "Cluster is installed but some workers did not join"
 	statusInfoPreparingForInstallation        = "Preparing cluster for installation"
 	statusInfoPreparingForInstallationTimeout = "Preparing cluster for installation timeout"
 	statusInfoFinalizingTimeout               = "Cluster installation timeout while finalizing"
@@ -174,6 +175,19 @@ func NumberOfWorkers(c *common.Cluster) int {
 		num += 1
 	}
 	return num
+}
+
+func HostsInStatus(c *common.Cluster, statuses []string) (int, int) {
+	mappedMastersByRole := MapMasterHostsByStatus(c)
+	mappedWorkersByRole := MapWorkersHostsByStatus(c)
+	mastersInSomeInstallingStatus := 0
+	workersInSomeInstallingStatus := 0
+
+	for _, status := range statuses {
+		mastersInSomeInstallingStatus += len(mappedMastersByRole[status])
+		workersInSomeInstallingStatus += len(mappedWorkersByRole[status])
+	}
+	return mastersInSomeInstallingStatus, workersInSomeInstallingStatus
 }
 
 func MapMasterHostsByStatus(c *common.Cluster) map[string][]*models.Host {

--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -94,19 +94,6 @@ var _ = Describe("host count with 1 cluster", func() {
 		dbName  string
 	)
 
-	createHost := func(clusterId strfmt.UUID, state string, db *gorm.DB) {
-		hostId := strfmt.UUID(uuid.New().String())
-		host := models.Host{
-			ID:         &hostId,
-			InfraEnvID: clusterId,
-			ClusterID:  &clusterId,
-			Role:       models.HostRoleMaster,
-			Status:     swag.String(state),
-			Inventory:  common.GenerateTestDefaultInventory(),
-		}
-		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-	}
-
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
 		id := strfmt.UUID(uuid.New().String())
@@ -195,19 +182,6 @@ var _ = Describe("host count with 2 cluster", func() {
 		id2    = strfmt.UUID(uuid.New().String())
 		dbName string
 	)
-
-	createHost := func(clusterId strfmt.UUID, state string, db *gorm.DB) {
-		hostId := strfmt.UUID(uuid.New().String())
-		host := models.Host{
-			ID:         &hostId,
-			ClusterID:  &clusterId,
-			InfraEnvID: clusterId,
-			Role:       models.HostRoleMaster,
-			Status:     swag.String(state),
-			Inventory:  common.GenerateTestDefaultInventory(),
-		}
-		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-	}
 
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()


### PR DESCRIPTION
In case 3 hosts and 2 workers are installed the cluster is considered installed
even if there are additional workers that fails to install

In such cases:
1. Add status_info message like  "Cluster is installed but some workers did not join"
2. Change the progress bar logic to return 100% if status is "installed"

# Assisted Pull Request

## Description
In case 3 hosts and 2 workers are installed the cluster is considered installed
even if there are additional workers that fails to install

In such cases:
1. Add status_info message like  "Cluster is installed but some workers did not join"
2. Change the progress bar logic to return 100% if status is "installed"

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
