### PR TITLE
MGMT-8741: Use full name when logging agent update

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3709,11 +3709,10 @@ func (b *bareMetalInventory) getImageInfo(clusterId *strfmt.UUID) (*models.Image
 
 func (b *bareMetalInventory) generateV2NextStepRunnerCommand(ctx context.Context, params *installer.V2RegisterHostParams) *models.HostRegistrationResponseAO1NextStepRunnerCommand {
 
-	currentImageTag := extractImageTag(b.AgentDockerImg)
-	if params.NewHostParams.DiscoveryAgentVersion != currentImageTag {
+	if params.NewHostParams.DiscoveryAgentVersion != b.AgentDockerImg {
 		log := logutil.FromContext(ctx, b.log)
-		log.Infof("Host %s in infra-env %s has outdated agent image %s, updating to %s",
-			params.NewHostParams.HostID.String(), params.InfraEnvID.String(), params.NewHostParams.DiscoveryAgentVersion, currentImageTag)
+		log.Infof("Host %s in infra-env %s uses an outdated agent image %s, updating to %s",
+			params.NewHostParams.HostID.String(), params.InfraEnvID.String(), params.NewHostParams.DiscoveryAgentVersion, b.AgentDockerImg)
 	}
 
 	config := hostcommands.V2NextStepRunnerConfig{
@@ -3729,11 +3728,6 @@ func (b *bareMetalInventory) generateV2NextStepRunnerCommand(ctx context.Context
 		Command: command,
 		Args:    *args,
 	}
-}
-
-func extractImageTag(fullName string) string {
-	suffix := strings.Split(fullName, ":")
-	return suffix[len(suffix)-1]
 }
 
 func returnRegisterHostTransitionError(


### PR DESCRIPTION
# Assisted Pull Request

## Description

When checking if an agent image has changed, a full image name was compared to an image tag. This resulted in an agent update message being printed to the log even when the image remained the same. Example:

```
"Host 1cd887cd-fc53-4cae-9e6e-f1b5c5a66925 in infra-env 1b4bdb7b-cd30-4a92-a497-93bbbed1250e has outdated agent image quay.io/edge-infrastructure/assisted-installer-agent@sha256:cfdc7488e142c2d3c21d0aec58725e14fe8af798bb88346db6473106405af4a2, updating to cfdc7488e142c2d3c21d0aec58725e14fe8af798bb88346db6473106405af4a2"
```

Comparing the full image name used by a registering host to the full image name configured on the service should solve the problem and produce an agent update message only when there was an actual change in agent image or version.

The message is used for troubleshooting and does not affect the flow. Originally implemented in #541

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
  * Register a host, keep the ISO. There are no agent update messages in the log
  * Modify the value of `AGENT_DOCKER_IMAGE` and restart the assisted service
  * Restart the host from the original ISO and verify that an agent update message is written to the log
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @rollandf 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
