### PR TITLE
MGMT-7705: ignore empty OpenshiftVersions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,10 +202,11 @@ func main() {
 
 	var openshiftVersionsMap models.OpenshiftVersions
 	if Options.OpenshiftVersions == "" {
-		log.Fatal("OpenShift versions is empty")
+		log.Info("OpenShift versions is empty - using values from OS_IMAGES and RELEASE_IMAGES")
+	} else {
+		failOnError(json.Unmarshal([]byte(Options.OpenshiftVersions), &openshiftVersionsMap),
+			"Failed to parse supported openshift versions JSON %s", Options.OpenshiftVersions)
 	}
-	failOnError(json.Unmarshal([]byte(Options.OpenshiftVersions), &openshiftVersionsMap),
-		"Failed to parse supported openshift versions JSON %s", Options.OpenshiftVersions)
 
 	var osImagesArray models.OsImages
 	if Options.OsImages == "" {


### PR DESCRIPTION
# Assisted Pull Request

## Description

This PR backports part of https://github.com/openshift/assisted-service/pull/2708.
It is required since we use the new operator scripts also in release-ocm-2.4 branch
of assisted-test-infra: https://github.com/openshift/assisted-test-infra/pull/1276.

I.e. the OPENSHIFT_VERSIONS var should be optional since the operator deployment
script is specifying only OS_IMAGES and RELEASE_IMAGES in release-ocm-2.4 branch
of assisted-test-infra.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eliorerz 
/cc @osherdp 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
