### PR TITLE
NO-ISSUE: Add a middleware to optionally disable v1 API

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -143,6 +143,7 @@ var Options struct {
 	EnableElasticAPM               bool          `envconfig:"ENABLE_ELASTIC_APM" default:"false"`
 	WorkDir                        string        `envconfig:"WORK_DIR" default:"/data/"`
 	LivenessValidationTimeout      time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
+	V1APIEnabled                   bool          `envconfig:"V1_API_ENABLED" default:"true"`
 }
 
 func InitLogs() *logrus.Entry {
@@ -466,6 +467,10 @@ func main() {
 		OperatorsAPI:          operatorsHandler,
 	})
 	failOnError(err, "Failed to init rest handler")
+
+	if !Options.V1APIEnabled {
+		h = app.DisableV1Middleware(h)
+	}
 
 	if Options.Auth.AllowedDomains != "" {
 		allowedDomains := strings.Split(strings.ReplaceAll(Options.Auth.AllowedDomains, " ", ""), ",")

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -114,6 +114,9 @@ parameters:
 - name: CNV_SNO_INSTALL_HPP
   value: "true"
   required: false
+- name: V1_API_ENABLED
+  value: "true"
+  required: false
 apiVersion: v1
 kind: Template
 metadata:
@@ -325,6 +328,8 @@ objects:
                 value: ${INFRAENV_DELETED_INACTIVE_AFTER}
               - name: CNV_SNO_INSTALL_HPP
                 value: ${CNV_SNO_INSTALL_HPP}
+              - name: V1_API_ENABLED
+                value: ${V1_API_ENABLED}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"

--- a/pkg/app/middleware.go
+++ b/pkg/app/middleware.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/openshift/assisted-service/pkg/thread"
@@ -60,4 +61,15 @@ func SetupCORSMiddleware(handler http.Handler, domains []string) http.Handler {
 		MaxAge: int((10 * time.Minute).Seconds()),
 	})
 	return corsHandler.Handler(handler)
+}
+
+func DisableV1Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/assisted-install/v1/") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("v1 API is currently disabled"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/pkg/app/middleware_test.go
+++ b/pkg/app/middleware_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -18,39 +19,74 @@ func TestMiddleWare(t *testing.T) {
 	RunSpecs(t, "Middleware test")
 }
 
-var _ = Describe("Middleware test", func() {
-
+var _ = Describe("WithHealthMiddleware", func() {
 	l := logrus.New()
 	l.SetOutput(ioutil.Discard)
 
-	It("Healthcheck test", func() {
-		timeout := 20 * time.Millisecond
-		mHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-		failure := thread.New(l, "failed test", 10*time.Millisecond, func() {
+	timeout := 20 * time.Millisecond
+	mHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	failure := thread.New(l, "failed test", 10*time.Millisecond, func() {
+	})
+	failure.Start()
+	req := httptest.NewRequest("GET", "/health", nil)
+	h1 := WithHealthMiddleware(mHandler, []*thread.Thread{failure}, l, timeout)
+
+	By("Testing healthycheck success when thread is running")
+	successCounter := 0
+	Eventually(func() bool {
+		rr := httptest.NewRecorder()
+		h1.ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			successCounter += 1
+		}
+		return successCounter == 3
+	}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+
+	By("Verifying healthcheck failed when thread stopped")
+
+	failure.Stop()
+	// wait more than monitored threshold
+	Eventually(func() bool {
+		rr := httptest.NewRecorder()
+		h1.ServeHTTP(rr, req)
+		return rr.Code == http.StatusInternalServerError
+	}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+})
+
+var _ = Describe("DisableV1Middleware", func() {
+	var (
+		server *httptest.Server
+		client *http.Client
+	)
+
+	BeforeEach(func() {
+		baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "Hello!")
 		})
-		failure.Start()
-		req := httptest.NewRequest("GET", "/health", nil)
-		h1 := WithHealthMiddleware(mHandler, []*thread.Thread{failure}, l, timeout)
 
-		By("Testing healthycheck success when thread is running")
-		successCounter := 0
-		Eventually(func() bool {
-			rr := httptest.NewRecorder()
-			h1.ServeHTTP(rr, req)
-			if rr.Code == http.StatusOK {
-				successCounter += 1
-			}
-			return successCounter == 3
-		}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+		server = httptest.NewServer(DisableV1Middleware(baseHandler))
+		client = server.Client()
+	})
 
-		By("Verifying healthcheck failed when thread stopped")
+	AfterEach(func() {
+		server.Close()
+	})
 
-		failure.Stop()
-		// wait more than monitored threshold
-		Eventually(func() bool {
-			rr := httptest.NewRecorder()
-			h1.ServeHTTP(rr, req)
-			return rr.Code == http.StatusInternalServerError
-		}, 1*time.Second, 10*time.Millisecond).Should(BeTrue())
+	expectStatusCode := func(path string, code int) {
+		resp, err := client.Get(server.URL + path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(code))
+	}
+
+	It("calls base handler for non-v1 paths", func() {
+		expectStatusCode("/api/assisted-install/v2/clusters", http.StatusOK)
+		expectStatusCode("/api/assisted-install/v3/clusters", http.StatusOK)
+		expectStatusCode("/api/assisted-install/whatever", http.StatusOK)
+	})
+
+	It("returns 404 for v1 paths", func() {
+		expectStatusCode("/api/assisted-install/v1/clusters", http.StatusNotFound)
+		expectStatusCode("/api/assisted-install/v1/events", http.StatusNotFound)
+		expectStatusCode("/api/assisted-install/v1/whatever", http.StatusNotFound)
 	})
 })


### PR DESCRIPTION
## Description

This will allow us to easily ensure that clients are no longer using v1
without removing the implementation entirely

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?
