### PR TITLE
Bug 2038903: Add proxy env vars to image service

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -857,6 +857,12 @@ func (r *AgentServiceConfigReconciler) newImageServiceDeployment(ctx context.Con
 		},
 	}
 
+	for _, key := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		if value, ok := os.LookupEnv(key); ok {
+			container.Env = append(container.Env, corev1.EnvVar{Name: key, Value: value})
+		}
+	}
+
 	volumes := []corev1.Volume{
 		{
 			Name: "tls-certs",


### PR DESCRIPTION
## Description

Previously the proxy env vars were provided to the the assisted service, but not to the image service.

## List all the issues related to this PR

https://bugzilla.redhat.com/show_bug.cgi?id=2038903

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Deployed with the operator, set the proxy values on the subscription and make sure they're set on the image service.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?