### PR TITLE
MGMT-8871: updates Ingress usage to v1

### DIFF
--- a/deploy/assisted-installer-ingress-tls.yaml
+++ b/deploy/assisted-installer-ingress-tls.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: assisted-installer
   namespace: REPLACE_NAMESPACE
@@ -17,18 +17,30 @@ spec:
       http:
         paths:
           - path: "/api"
+            pathType: Prefix
             backend:
-              serviceName: assisted-service
-              servicePort: 8090
+              service:
+                name: assisted-service
+                port:
+                  number: 8090
           - path: "/ready"
+            pathType: Prefix
             backend:
-              serviceName: assisted-service
-              servicePort: 8090
+              service:
+                name: assisted-service
+                port:
+                  number: 8090
           - path: "/images"
+            pathType: Prefix
             backend:
-              serviceName: assisted-image-service
-              servicePort: 8080
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080
           - path: "/health"
+            pathType: Prefix
             backend:
-              serviceName: assisted-image-service
-              servicePort: 8080
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080

--- a/deploy/assisted-installer-ingress.yaml
+++ b/deploy/assisted-installer-ingress.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: assisted-installer
   namespace: REPLACE_NAMESPACE
@@ -11,18 +11,30 @@ spec:
       http:
         paths:
           - path: "/api"
+            pathType: Prefix
             backend:
-              serviceName: assisted-service
-              servicePort: 8090
+              service:
+                name: assisted-service
+                port:
+                  number: 8090
           - path: "/ready"
+            pathType: Prefix
             backend:
-              serviceName: assisted-service
-              servicePort: 8090
+              service:
+                name: assisted-service
+                port:
+                  number: 8090
           - path: "/images"
+            pathType: Prefix
             backend:
-              serviceName: assisted-image-service
-              servicePort: 8080
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080
           - path: "/health"
+            pathType: Prefix
             backend:
-              serviceName: assisted-image-service
-              servicePort: 8080
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080


### PR DESCRIPTION
The v1beta1 API for Ingress was deprecated in k8s 1.19 and removed in
1.22. OCP 4.9 is based on k8s 1.22, so these manifests stopped working
and caused `make deploy-all` to fail.

I tested these changes by running `make deploy-all TARGET=oc-ingress`
successfully.

# Assisted Pull Request

## Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-8871

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

`make deploy-all TARGET=oc-ingress`

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
