### PR TITLE
MGMT-5425: stop spamming logs from local authenticator

### DIFF
--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -79,7 +79,6 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 				a.cache.Set(infraEnvID, "", cache.DefaultExpiration)
 			} else {
 				err := errors.Errorf("infraEnv %s does not exist", infraEnvID)
-				a.log.Error(err)
 				return nil, common.NewInfraError(http.StatusUnauthorized, err)
 			}
 		}
@@ -91,7 +90,6 @@ func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 				a.cache.Set(clusterID, "", cache.DefaultExpiration)
 			} else {
 				err := errors.Errorf("Cluster %s does not exist", clusterID)
-				a.log.Error(err)
 				return nil, common.NewInfraError(http.StatusUnauthorized, err)
 			}
 		}


### PR DESCRIPTION
# Assisted Pull Request

## Description
[MGMT-5425](https://issues.redhat.com/projects/MGMT/issues/MGMT-5425): When either `InfraEnv` or `Cluster` objects don't exist, the local authenticator keeps spamming logs that they don't exist. This PR removes those logs.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): Created an `InfraEnv` object, deleted it, and queried the rest API to see if the logs still appeared.
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests): No

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
