### PR TITLE
NO-ISSUE: Use agent's status role instead of spec

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1422,8 +1422,8 @@ func (r *BMACReconciler) formatMCSCertificateIgnition(mcsCert string) (string, e
 
 func (r *BMACReconciler) validateWorkerForDay2(log logrus.FieldLogger, agent *aiv1beta1.Agent) bool {
 	// Only worker role is supported for day2 operation
-	if agent.Spec.Role != models.HostRoleWorker || agent.Spec.ClusterDeploymentName == nil {
-		log.Debugf("Skipping spoke BareMetalHost reconcile for  agent %s/%s, role %s and clusterDeployment %s.", agent.Namespace, agent.Name, agent.Spec.Role, agent.Spec.ClusterDeploymentName)
+	if agent.Status.Role != models.HostRoleWorker || agent.Spec.ClusterDeploymentName == nil {
+		log.Debugf("Skipping spoke BareMetalHost reconcile for  agent %s/%s, role %s and clusterDeployment %s.", agent.Namespace, agent.Name, agent.Status.Role, agent.Spec.ClusterDeploymentName)
 		return false
 	}
 	return true

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -701,7 +701,7 @@ var _ = Describe("bmac reconcile", func() {
 			clusterName := "test-cluster"
 			pullSecretName := "pull-secret"
 
-			agent.Spec.Role = models.HostRoleWorker
+			agent.Status.Role = models.HostRoleWorker
 			agent.Spec.ClusterDeploymentName = &v1beta1.ClusterReference{Name: clusterName, Namespace: testNamespace}
 			Expect(c.Create(ctx, agent)).To(BeNil())
 


### PR DESCRIPTION
# Assisted Pull Request

## Description

BMAC was using the agent spec's role field rather than the status. This worked fine because, so far, it's
been a requirement to set the role annotation for the BMH. However, if this annotation is not set, the service
will auto-dected the role of the host, which means the spec's role field will remain empty, while the status' one
will be correctly populated.

Since the status role field is always populated, BMAC should just stick to using that to know what role the agent is.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @ori-amizur 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
