### PR TITLE
NO-ISSUE: Minor clean up to the PULL_REQUEST template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,3 @@
-# Assisted Pull Request
-
-## Description
-
 <!--
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
@@ -22,7 +18,8 @@ how this code was tested. Here are some questions that may be worth answering:
 
 ## List all the issues related to this PR
 
-- [ ] New Feature
+- [ ] New Feature <!-- new functionality -->
+- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
 - [ ] Bug fix
 - [ ] Tests
 - [ ] Documentation
@@ -66,9 +63,9 @@ this PR directly to someone.
 
 ## Reviewers Checklist
 
-- [ ] Are the title and description (in both PR and commit) meaningful and clear?
-- [ ] Is there a bug required (and linked) for this change?
-- [ ] Should this PR be backported?
+- Are the title and description (in both PR and commit) meaningful and clear?
+- Is there a bug required (and linked) for this change?
+- Should this PR be backported?
 
 [Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
 [CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
* Remove the initial headers since not many people actually re-arrange the description under the right section
* Add an enhancement option to the list of changes types
* Make the reviewers checklist just a bullet list

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
