### PR TITLE
MGMT-8894: Simplify IPv6 Network Manager configuration

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -59,12 +59,20 @@ ipv6.dhcp-duid=ll
 `
 
 // Configuration to be used by MCO manifest to get consistent IPv6 DHCP client identification.
-const Ipv6DuidRuntimeConf = `
+const Ipv6DuidRuntimeConfPre410 = `
 [connection]
 ipv6.dhcp-iaid=mac
 ipv6.dhcp-duid=ll
 [keyfile]
 path=/etc/NetworkManager/system-connections-merged
+`
+
+// Configuration of consistent IPv6 DHCP without the keyfile path set. This is because starting in
+// RHCOS 4.10 it is breaking the Network Manager configuration.
+const Ipv6DuidRuntimeConf = `
+[connection]
+ipv6.dhcp-iaid=mac
+ipv6.dhcp-duid=ll
 `
 
 // configuration of NM to disable handling of /etc/resolv.conf


### PR DESCRIPTION
This commit simplifies confguration of the Network Manager in case IPv6
is used. Till now we were

* configuring consistent DHCPv6 client identification
* creating system-connections-merged overlay configuration
* manually configuring keyfile path

We are able to simplify this flow for the following reasons

* with the introduction of InfraEnvs, the static network configuration
  is now a property of InfraEnv and not of a cluster
* RHCOS handles creation of systemConnectionMerged whenever needed and
  if so, it handles configuration of the keyfile paths

Until now, the configuration applied by Assisted Service was not causing
problems as in RHCOS <=4.9 the keyfile paths were overriden whenever a
different overlay directory has been created.

Starting from RHCOS 4.10 this is no longer the case and network
configurations do not need to be stored in any merged directory. With
the removal of the custom keyfile path, we are leveraging the following
properties

* default path is /etc/NetworkManager/system-connections
* aforementioned path contains all the configurations coming from the
  custom NMStateConfig

Closes: [MGMT-8894](https://issues.redhat.com/browse/MGMT-8894)
Closes: Bug-2030289
Relates-to: Bug-2040195

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @yevgeny-shnaidman 
/cc @flaper87 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
