### PR TITLE
MGMT-8085: Change the cluster ssh_public_key field to text type

### DIFF
--- a/internal/migrations/20220113152127_change_cluster_ssh_key_to_text.go
+++ b/internal/migrations/20220113152127_change_cluster_ssh_key_to_text.go
@@ -1,0 +1,9 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+)
+
+func changeClusterSshKeyToText() *gormigrate.Migration {
+	return migrateToText("20220113152127", "clusters", "ssh_public_key")
+}

--- a/internal/migrations/20220113152127_change_cluster_ssh_key_to_text_test.go
+++ b/internal/migrations/20220113152127_change_cluster_ssh_key_to_text_test.go
@@ -1,0 +1,70 @@
+package migrations
+
+import (
+	"strings"
+
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("changeClusterSshKeyToText", func() {
+	var (
+		db        *gorm.DB
+		dbName    string
+		gm        *gormigrate.Gormigrate
+		clusterID strfmt.UUID
+		err       error
+		sshKey    = "some ssh key"
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, post())
+
+		// create cluster in order to get rows from DB
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster := common.Cluster{Cluster: models.Cluster{
+			ID:           &clusterID,
+			SSHPublicKey: sshKey,
+		}}
+		err = db.Create(&cluster).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		err = gm.MigrateTo("20220113152127")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Migrates down and up", func() {
+		t, err := getColumnType(db, &common.Cluster{}, "ssh_public_key")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.ToUpper(t)).To(Equal("TEXT"))
+
+		err = gm.RollbackMigration(changeClusterSshKeyToText())
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &common.Cluster{}, "ssh_public_key")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.ToUpper(t)).To(Equal("VARCHAR"))
+
+		err = gm.MigrateTo("20220113152127")
+		Expect(err).ToNot(HaveOccurred())
+
+		t, err = getColumnType(db, &common.Cluster{}, "ssh_public_key")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.ToUpper(t)).To(Equal("TEXT"))
+
+		cluster := &common.Cluster{}
+		Expect(db.First(cluster).Error).ShouldNot(HaveOccurred())
+		Expect(cluster.SSHPublicKey).Should(Equal(sshKey))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -30,6 +30,7 @@ func post() []*gormigrate.Migration {
 	postMigrations := []*gormigrate.Migration{
 		changeOverridesToText(),
 		changeImageSSHKeyToText(),
+		changeClusterSshKeyToText(),
 		changeClusterValidationsInfoToText(),
 		changeHostValidationsInfoToText(),
 		multipleNetworks(),


### PR DESCRIPTION
Previously this was varchar(1024) but we should be able to support ssh
keys larger than that.

This was fixed for new deployments in
dcae87ef02533706758fda476dc999e065539a7f, but that commit didn't add a
migration. This means that the SaaS environments still have the old
column types.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-8085

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

### Manual test steps

- Deployed the service locally with an edit to the swagger yaml to not automigrate the column in question to text
- Built and deployed an image from this branch
- Observed the column get migrated to the new type

## Assignees

/cc @filanov 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
