### PR TITLE
MGMT-8664: Fix ACI template breaking dual-stack configuration

### DIFF
--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -31,11 +31,11 @@ spec:
 {% endif %}
     serviceNetwork:
     - {{ service_subnet }}
-{% if user_managed_networking %}
-    userManagedNetworking: {{ user_managed_networking }}
-{% endif %}
 {% if service_subnet_additional|length %}
     - {{ service_subnet_additional }}
+{% endif %}
+{% if user_managed_networking %}
+    userManagedNetworking: {{ user_managed_networking }}
 {% endif %}
   provisionRequirements:
     controlPlaneAgents: {{ spoke_controlplane_agents }}


### PR DESCRIPTION
This commit fixes the AgentClusterInstall template used by the CI jobs.
In its current form the template generates a wrong template when applied
to a dual-stack cluster, i.e.

```
    serviceNetwork:
    - 172.30.0.0/16
    userManagedNetworking: false
    - fd02::/112
```

The initial change has been introduced in #3084.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @ori-amizur 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
