### PR TITLE
MGMT-8783: support multiple patch versions of os/release images

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -611,7 +611,7 @@ func uploadISOs(objectHandler s3wrapper.API, versionHandler versions.Handler, lo
 	versions := versionHandler.GetOpenshiftVersions()
 	for _, version := range versions {
 		currVersion := version
-		cpuArchitectures, _ := versionHandler.GetCPUArchitectures(currVersion)
+		cpuArchitectures := versionHandler.GetCPUArchitectures(currVersion)
 		for _, cpuArchitecture := range cpuArchitectures {
 			currCpuArchitecture := cpuArchitecture
 			errs.Go(func() error {

--- a/docs/hive-integration/kube-api-select-ocp-versions.md
+++ b/docs/hive-integration/kube-api-select-ocp-versions.md
@@ -75,7 +75,7 @@ The flow of adding a new version is a follows:
 * If a new RHCOS image is required:
   * Set ```OSImage``` in AgentServiceConfig under ```spec.osImages```
   * ```OSImage``` should include:
-    * ```openshiftVersion``` the OCP version in major.minor format.
+    * ```openshiftVersion``` the OCP version in major.minor or major.minor.patch format.
     * ```url``` the RHCOS image (optionally a mirror).
     * ```version``` the RHOCS version.
   * Upon starting the service, the relevant host [boot-files](https://github.com/openshift/assisted-service/blob/3823630a0900c7f7a7113d7be4ff5a404a35186b/swagger.yaml#L16) are uploaded to S3/File storage.

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -769,10 +769,7 @@ func (b *bareMetalInventory) getNewClusterCPUArchitecture(newClusterParams *mode
 		return "", errors.Errorf("Non x86_64 CPU architectures are supported only with User Managed Networking")
 	}
 
-	cpuArchitectures, err := b.versionsHandler.GetCPUArchitectures(*newClusterParams.OpenshiftVersion)
-	if err != nil {
-		return "", err
-	}
+	cpuArchitectures := b.versionsHandler.GetCPUArchitectures(*newClusterParams.OpenshiftVersion)
 	for _, cpuArchitecture := range cpuArchitectures {
 		if cpuArchitecture == newClusterParams.CPUArchitecture {
 			return cpuArchitecture, nil

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11794,7 +11794,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
 		mockVersions.EXPECT().GetCPUArchitectures(gomock.Any()).Return(
-			[]string{common.TestDefaultConfig.OpenShiftVersion, "arm64"}, nil).Times(1)
+			[]string{common.TestDefaultConfig.OpenShiftVersion, "arm64"}).Times(1)
 
 		reply := bm.RegisterCluster(ctx, installer.RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -53,12 +53,11 @@ func (mr *MockHandlerMockRecorder) AddReleaseImage(arg0, arg1, arg2, arg3 interf
 }
 
 // GetCPUArchitectures mocks base method.
-func (m *MockHandler) GetCPUArchitectures(arg0 string) ([]string, error) {
+func (m *MockHandler) GetCPUArchitectures(arg0 string) []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCPUArchitectures", arg0)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetCPUArchitectures indicates an expected call of GetCPUArchitectures.


### PR DESCRIPTION
Added support to maintain OS and release images with cpu_architecture in major.minor.patch format. This functionality is a means to allow multiple z-stream versions concurrently, instead of the previous behaviour which limited a single z-stream for every y-stream.

The following changes were made in versions package in order to introduce the new behaviour:
* GetReleaseImgae:
  * Returns an image based on the specified x.y.z.
  * If missing, fallback to x.y (as previously).
* GetOsImage:
  * Returns an image based on the specified x.y.z.
  * If missing, fallback to x.y (as previously).
  * If x.y is not available, try to find the latest applicable image for the specified x.y.z. This is done to avoid forcing a direct version match between OS and release image. E.g. for kube-api custom z-stream release versions support.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
