### PR TITLE
MGMT-8894: Catch FCs and nightlies when comparing OCP versions

### DIFF
--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -231,6 +231,25 @@ var _ = Describe("get hosts by role", func() {
 	})
 })
 
+var _ = Describe("compare OCP 4.10 versions", func() {
+	It("GA release", func() {
+		is410Version, _ := VersionGreaterOrEqual("4.10.0", "4.10.0-0.alpha")
+		Expect(is410Version).Should(BeTrue())
+	})
+	It("pre-release", func() {
+		is410Version, _ := VersionGreaterOrEqual("4.10.0-fc.1", "4.10.0-0.alpha")
+		Expect(is410Version).Should(BeTrue())
+	})
+	It("pre-release z-stream", func() {
+		is410Version, _ := VersionGreaterOrEqual("4.10.1-fc.1", "4.10.0-0.alpha")
+		Expect(is410Version).Should(BeTrue())
+	})
+	It("nightly release", func() {
+		is410Version, _ := VersionGreaterOrEqual("4.10.0-0.nightly-2022-01-23-013716", "4.10.0-0.alpha")
+		Expect(is410Version).Should(BeTrue())
+	})
+})
+
 func createHost(hostRole models.HostRole, state string) *models.Host {
 	hostId := strfmt.UUID(uuid.New().String())
 	clusterId := strfmt.UUID(uuid.New().String())

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -869,7 +869,7 @@ func (g *installerGenerator) addIpv6FileInIgnition(ignition string) error {
 	if err != nil {
 		return err
 	}
-	is410Version, err := common.VersionGreaterOrEqual(g.cluster.OpenshiftVersion, "4.10")
+	is410Version, err := common.VersionGreaterOrEqual(g.cluster.OpenshiftVersion, "4.10.0-0.alpha")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit extends the OCP version used when comparing in order to
comply with rules of the semantic versioning and release naming schema
in OCP.

This is because only "4.10" does not catch "4.10.0-fc.1" nor e.g. a
nightly release "4.10.0-0.nightly-2022-01-23-013716" - as per rules,
pre-releases have lower priority over normal versions.

In order to catch all of those, we are comparing against
"4.10.0-0.alpha" so that we cover FC releases as well as nightlies.

Closes: [MGMT-8894](https://issues.redhat.com/browse/MGMT-8894)
Closes: Bug-2030289
Relates-to: Bug-2040195

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nshidlin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
