### PR TITLE
Bug 2035638: Stop BMH reconcile if InfraEnv label is missing

### DIFF
--- a/deploy/assisted-service.yaml
+++ b/deploy/assisted-service.yaml
@@ -137,7 +137,7 @@ spec:
             - name: S3_USE_SSL
               value: "false"
             - name: LOG_LEVEL
-              value: "info"
+              value: "debug"
             - name: LOG_FORMAT
               value: "text"
             - name: INSTALL_RH_CA

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -617,11 +617,6 @@ func (r *BMACReconciler) reconcileUnboundAgent(log logrus.FieldLogger, bmh *bmh_
 //       to contain multiple informations instead of a bunch of variables that are later on
 //       separately interpreted.
 func shouldReconcileBMH(bmh *bmh_v1alpha1.BareMetalHost, infraEnv *aiv1beta1.InfraEnv) (bool, bool, time.Duration, string) {
-	// Stop `Reconcile` if BMH does not have an InfraEnv.
-	if infraEnv == nil {
-		return false, false, 0, "BMH does not have an InfraEnv"
-	}
-
 	// This is a separate check because an existing
 	// InfraEnv with an empty ISODownloadURL means the
 	// global `Reconcile` function should also return
@@ -700,6 +695,11 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 
 	if err != nil {
 		return reconcileError{err}
+	}
+
+	// Stop `Reconcile` if BMH does not have an InfraEnv.
+	if infraEnv == nil {
+		return reconcileComplete{stop: true}
 	}
 
 	dirty := false


### PR DESCRIPTION
The reconcile loop was already stopping the BMH reconcile for CR's that
didn't have the infraenv label. However, this was happening after the
`inspect` label and cleaning were disabled, which caused BMAC to modify
BMH CR's that weren't part of the ZTP flow.

Move the infraenv check earlier in the `reconcileBMH` step so that BMAC
can stop the loop before doing changes to the CR.

Signed-off-by: Flavio Percoco <flavio@redhat.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
