### PR TITLE
Bug 2049034: Simplify IPv6 Network Manager configuration

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -47,12 +47,20 @@ ipv6.dhcp-duid=ll
 `
 
 // Configuration to be used by MCO manifest to get consistent IPv6 DHCP client identification.
-const Ipv6DuidRuntimeConf = `
+const Ipv6DuidRuntimeConfPre410 = `
 [connection]
 ipv6.dhcp-iaid=mac
 ipv6.dhcp-duid=ll
 [keyfile]
 path=/etc/NetworkManager/system-connections-merged
+`
+
+// Configuration of consistent IPv6 DHCP without the keyfile path set. This is because starting in
+// RHCOS 4.10 it is breaking the Network Manager configuration.
+const Ipv6DuidRuntimeConf = `
+[connection]
+ipv6.dhcp-iaid=mac
+ipv6.dhcp-duid=ll
 `
 
 // configuration of NM to disable handling of /etc/resolv.conf

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -57,24 +57,6 @@ const (
 	workerIgn = "worker.ign"
 )
 
-const SystemConnectionsMerged = `
-[Unit]
-After=systemd-tmpfiles-setup.service
-[Mount]
-Where=/etc/NetworkManager/system-connections-merged
-What=overlay
-Type=overlay
-Options=lowerdir=/etc/NetworkManager/system-connections,upperdir=/run/nm-system-connections,workdir=/run/nm-system-connections-work
-[Install]
-WantedBy=multi-user.target
-`
-
-const kniTempFile = `
-D /run/nm-system-connections 0755 root root - -
-D /run/nm-system-connections-work 0755 root root - -
-d /etc/NetworkManager/system-connections-merged 0755 root root -
-`
-
 const agentMessageOfTheDay = `
 **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  **  ** **  **  **  **  **  **  **
 This is a host being installed by the OpenShift Assisted Installer.
@@ -853,40 +835,27 @@ func (g *installerGenerator) updateDhcpFiles() error {
 	return nil
 }
 
-func encodeIpv6Contents() string {
-	return fmt.Sprintf("data:,%s", url.PathEscape(common.Ipv6DuidRuntimeConf))
+func encodeIpv6Contents(config string) string {
+	return fmt.Sprintf("data:,%s", url.PathEscape(config))
 }
 
+// addIpv6FileInIgnition adds a NetworkManager configuration ensuring that IPv6 DHCP requests use
+// consistent client identification.
 func (g *installerGenerator) addIpv6FileInIgnition(ignition string) error {
 	path := filepath.Join(g.workDir, ignition)
 	config, err := parseIgnitionFile(path)
 	if err != nil {
 		return err
 	}
-	setFileInIgnition(config, "/etc/NetworkManager/conf.d/01-ipv6.conf", encodeIpv6Contents(), false, 0o644)
-	err = writeIgnitionFile(path, config)
+	is410Version, err := common.VersionGreaterOrEqual(g.cluster.OpenshiftVersion, "4.10.0-0.alpha")
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func (g *installerGenerator) addStaticNetworkConfigToIgnition(ignition string) error {
-	path := filepath.Join(g.workDir, ignition)
-	config, err := parseIgnitionFile(path)
-	if err != nil {
-		return err
+	v6config := common.Ipv6DuidRuntimeConfPre410
+	if is410Version {
+		v6config = common.Ipv6DuidRuntimeConf
 	}
-	is47Version, err := common.VersionGreaterOrEqual(g.cluster.OpenshiftVersion, "4.7")
-	if err != nil {
-		return err
-	}
-	if (swag.BoolValue(g.cluster.UserManagedNetworking) && is47Version) || !is47Version {
-		// add overlay configuration for NM in case of 4.7 and None platform.
-		// TODO - remove once this configuration is integrated in MCO for None platform (Bugzilla 1928473)
-		setFileInIgnition(config, "/etc/tmpfiles.d/kni.conf", fmt.Sprintf("data:,%s", url.PathEscape(kniTempFile)), false, 420)
-		setUnitInIgnition(config, SystemConnectionsMerged, "etc-NetworkManager-system\\x2dconnections\\x2dmerged.mount", true)
-	}
+	setFileInIgnition(config, "/etc/NetworkManager/conf.d/01-ipv6.conf", encodeIpv6Contents(v6config), false, 0o644)
 	err = writeIgnitionFile(path, config)
 	if err != nil {
 		return err
@@ -927,12 +896,6 @@ func (g *installerGenerator) updateIgnitions() error {
 		for _, ignition := range []string{masterIgn, workerIgn} {
 			if err = g.addIpv6FileInIgnition(ignition); err != nil {
 				return err
-			}
-
-			if g.cluster.StaticNetworkConfigured {
-				if err := g.addStaticNetworkConfigToIgnition(ignition); err != nil {
-					return err
-				}
 			}
 		}
 	}
@@ -1085,6 +1048,8 @@ func setFileInIgnition(config *config_latest_types.Config, filePath string, file
 	config.Storage.Files = append(config.Storage.Files, file)
 }
 
+//lint:ignore U1000 Ignore unused function
+//nolint:unused,deadcode
 func setUnitInIgnition(config *config_latest_types.Config, contents, name string, enabled bool) {
 	newUnit := config_latest_types.Unit{
 		Contents: swag.String(contents),


### PR DESCRIPTION
This commit simplifies confguration of the Network Manager in case IPv6
is used. Till now we were

* configuring consistent DHCPv6 client identification
* creating system-connections-merged overlay configuration
* manually configuring keyfile path

We are able to simplify this flow for the following reasons

* with the introduction of InfraEnvs, the static network configuration
  is now a property of InfraEnv and not of a cluster
* RHCOS handles creation of systemConnectionMerged whenever needed and
  if so, it handles configuration of the keyfile paths

Until now, the configuration applied by Assisted Service was not causing
problems as in RHCOS <=4.9 the keyfile paths were overriden whenever a
different overlay directory has been created.

Starting from RHCOS 4.10 this is no longer the case and network
configurations do not need to be stored in any merged directory. With
the removal of the custom keyfile path, we are leveraging the following
properties

* default path is /etc/NetworkManager/system-connections
* aforementioned path contains all the configurations coming from the
  custom NMStateConfig

Closes: [MGMT-8894](https://issues.redhat.com/browse/MGMT-8894)
Closes: Bug-2030289
Relates-to: Bug-2040195
Cherry-picks: #3199
Cherry-picks: #3226

/cc @nshidlin 
/cc @filanov 