### PR TITLE
Bug 2034686: Expose a way for users to disable TLS verification in image service through the agent service config

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -246,6 +246,18 @@ After modifying content of the ConfigMap a new rollout of the Deployment has to 
 oc rollout restart deployment/assisted-service -n assisted-installer
 ```
 
+### Toggle TLS Check on Assisted Image Service
+
+It is possible to toggle TLS checking from the Assisted Image Service by using the annotation `"unsupported.agent-install.openshift.io/assisted-image-service-skip-verify-tls"` on the AgentServiceConfig CR. By default, this is set to `false`, meaning all TLS connections are verified. When this annotation is set to `true`, then the Assisted Image Service skips verifying TLS connections.
+
+It affects the following services: downloading ISO images from a secure server.
+
+Add the annotation to the AgentServiceConfig:
+
+```bash
+oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.openshift.io/assisted-image-service-skip-verify-tls=true
+```
+
 ### Mirror Registry Configuration
 
 A ConfigMap can be used to configure assisted service to create installations using mirrored content. The ConfigMap contains two keys:


### PR DESCRIPTION
[Bug 2034686](https://bugzilla.redhat.com/show_bug.cgi?id=2034686): Expose a way for users to disable TLS verification in image service through the agent service config. 
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): Created an OCP cluster, deployed OLM bundle, created AgentServiceConfig, and described the image service pod to see the environment variable appeared.
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
