### PR TITLE
MGMT-8744: Add log indicating that with auth none image url will not change

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1183,7 +1183,7 @@ func (b *bareMetalInventory) updateExternalImageInfo(ctx context.Context, infraE
 
 	if string(imageType) != prevType || version != prevVersion || arch != prevArch || !infraEnv.Generated {
 		var expiresAt *strfmt.DateTime
-		infraEnv.DownloadURL, expiresAt, err = b.generateImageDownloadURL(infraEnv.ID.String(), string(imageType), version, arch, infraEnv.ImageTokenKey)
+		infraEnv.DownloadURL, expiresAt, err = b.generateImageDownloadURL(ctx, infraEnv.ID.String(), string(imageType), version, arch, infraEnv.ImageTokenKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to create download URL")
 		}


### PR DESCRIPTION
[MGMT-8744](https://issues.redhat.com/browse/MGMT-8744): Add log indicating that with auth none image url will not change

When using authorisation types "local" and "RHSSO"; it is expected that the ISO image URL will change due to digital signatures added to the URL.
When using an authorisation type of "none" this is not expected. It is desired that we notify the user in the log that the URL will not be changing.
This change seeks to address that.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [] No tests needed

* This was tested manually by first running the unit-tests and subsystem tests to check for any regressions, none were found.
* Then a manual test was applied to verify that this change affects the log output by deploying the dev test environment locally and then monitoring logs with...

`kubectl logs -f -n assisted-installer -l app=assisted-service `

Observed the following entry...

```
time="2022-01-26T13:07:12Z" level=info msg="prepare image for infraEnv ea4006f2-e020-474c-b6b7-000895cec03a" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).GenerateInfraEnvISOInternal" file="/home/paulmaidment/projects/red-hat/assisted-service/internal/bminventory/inventory.go:1383" go-id=409 pkg=Inventory request_id=40e74259-a270-4d03-9fb9-ff25f5c6d1a1
time="2022-01-26T13:07:12Z" level=warning msg="Auth type is none: image URL will remain as http://10.99.32.208:8080/images/ea4006f2-e020-474c-b6b7-000895cec03a?arch=x86_64&type=full-iso&version=4.9" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).generateImageDownloadURL" file="/home/paulmaidment/projects/red-hat/assisted-service/internal/bminventory/inventory_v2_handlers.go:542" go-id=409 pkg=Inventory request_id=40e74259-a270-4d03-9fb9-ff25f5c6d1a1
```
While using the UI to create a cluster.
Based on this, I am satisfied that the change works as requested.

## Assignees

/cc @osherdp 
/cc @flaper87
/cc @omertuc 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

The change does not include unit tests as it feels like overkill for the type of change being applied here, this is simply writing to a log.

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
