### PR TITLE
MGMT-9057: Add KubeAPI support for schedulable masters property

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -161,6 +161,10 @@ type AgentClusterInstallSpec struct {
 	// Proxy defines the proxy settings used for the install config
 	// +optional
 	Proxy *Proxy `json:"proxy,omitempty"`
+
+	// SchedulableMasters enables ability to schedule workload on masters
+	// +optional
+	SchedulableMasters bool `json:"schedulableMasters,omitempty"`
 }
 
 // IgnitionEndpoint stores the data to of the custom ignition endpoint.

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -325,6 +325,10 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
+              schedulableMasters:
+                description: SchedulableMasters enables ability to schedule workload
+                  on masters
+                type: boolean
               sshPublicKey:
                 description: SSHPublicKey will be added to all cluster hosts for use
                   in debugging.

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -323,6 +323,10 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
+              schedulableMasters:
+                description: SchedulableMasters enables ability to schedule workload
+                  on masters
+                type: boolean
               sshPublicKey:
                 description: SSHPublicKey will be added to all cluster hosts for use
                   in debugging.

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -323,6 +323,10 @@ spec:
                       CIDRs for which the proxy should not be used.
                     type: string
                 type: object
+              schedulableMasters:
+                description: SchedulableMasters enables ability to schedule workload
+                  on masters
+                type: boolean
               sshPublicKey:
                 description: SSHPublicKey will be added to all cluster hosts for use
                   in debugging.

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4218,7 +4218,7 @@ var _ = Describe("cluster", func() {
 			Expect(reply).To(BeAssignableToTypeOf(common.NewApiError(http.StatusNotFound, errors.Errorf(""))))
 		})
 
-		It("Update SchedulableMasters", func() {
+		It("Update schedulable masters", func() {
 
 			mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 			clusterID = strfmt.UUID(uuid.New().String())

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -866,6 +866,11 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 		params.NoProxy = swag.String("")
 	}
 
+	if cluster.SchedulableMasters == nil || *cluster.SchedulableMasters != clusterInstall.Spec.SchedulableMasters {
+		params.SchedulableMasters = swag.Bool(clusterInstall.Spec.SchedulableMasters)
+		update = true
+	}
+
 	if !update {
 		return cluster, nil
 	}
@@ -1063,6 +1068,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 		SSHPublicKey:          clusterInstall.Spec.SSHPublicKey,
 		CPUArchitecture:       swag.StringValue(releaseImage.CPUArchitecture),
 		UserManagedNetworking: swag.Bool(isUserManagedNetwork(clusterInstall)),
+		SchedulableMasters:    swag.Bool(false),
 	}
 
 	if len(clusterInstall.Spec.Networking.ClusterNetwork) > 0 {

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -713,19 +713,20 @@ var _ = Describe("cluster reconcile", func() {
 		sId := strfmt.UUID(uuid.New().String())
 		backEndCluster := &common.Cluster{
 			Cluster: models.Cluster{
-				ID:               &sId,
-				Name:             clusterName,
-				OpenshiftVersion: "4.8",
-				ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-				ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-				NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-				Status:           swag.String(models.ClusterStatusReady),
-				IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-				APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-				BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-				SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-				Hyperthreading:   models.ClusterHyperthreadingAll,
-				Kind:             swag.String(models.ClusterKindCluster),
+				ID:                 &sId,
+				Name:               clusterName,
+				OpenshiftVersion:   "4.8",
+				ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+				ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+				NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+				Status:             swag.String(models.ClusterStatusReady),
+				IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+				APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+				BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+				SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+				Hyperthreading:     models.ClusterHyperthreadingAll,
+				Kind:               swag.String(models.ClusterKindCluster),
+				SchedulableMasters: swag.Bool(false),
 			},
 			PullSecret: testPullSecretVal,
 		}
@@ -1114,19 +1115,20 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
 			backEndCluster = &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusReady),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
-					Kind:             swag.String(models.ClusterKindCluster),
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusReady),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					Kind:               swag.String(models.ClusterKindCluster),
+					SchedulableMasters: swag.Bool(false),
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2015,18 +2017,19 @@ var _ = Describe("cluster reconcile", func() {
 		getDefaultTestCluster := func() *common.Cluster {
 			return &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusInsufficient),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInsufficient),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					SchedulableMasters: swag.Bool(false),
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2122,6 +2125,36 @@ var _ = Describe("cluster reconcile", func() {
 				}).Return(updateReply, nil)
 
 			aci.Spec.Proxy = &hiveext.Proxy{HTTPProxy: httpProxy, HTTPSProxy: httpsProxy, NoProxy: noProxy}
+			Expect(c.Update(ctx, aci)).Should(BeNil())
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			aci = getTestClusterInstall()
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterSyncedOkReason))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Reason).To(Equal(hiveext.ClusterNotReadyReason))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Message).To(Equal(hiveext.ClusterNotReadyMsg))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionFalse))
+		})
+
+		It("Update schedulable masters property", func() {
+			backEndCluster := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:   &sId,
+					Name: clusterName,
+				},
+			}
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+			updateReply := getDefaultTestCluster()
+
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, param installer.V2UpdateClusterParams) {
+					Expect(param.ClusterUpdateParams.SchedulableMasters).NotTo(BeNil())
+					Expect(*param.ClusterUpdateParams.SchedulableMasters).To(Equal(true))
+				}).Return(updateReply, nil)
+
+			aci.Spec.SchedulableMasters = true
 			Expect(c.Update(ctx, aci)).Should(BeNil())
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
@@ -2281,20 +2314,21 @@ var _ = Describe("cluster reconcile", func() {
 		It("only state changed", func() {
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusInsufficient),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
-					Kind:             swag.String(models.ClusterKindCluster),
-					ValidationsInfo:  "{\"some-check\":[{\"id\":\"checking1\",\"status\":\"failure\",\"message\":\"Check1 is not OK\"},{\"id\":\"checking2\",\"status\":\"success\",\"message\":\"Check2 is OK\"},{\"id\":\"checking3\",\"status\":\"failure\",\"message\":\"Check3 is not OK\"}]}",
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInsufficient),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					Kind:               swag.String(models.ClusterKindCluster),
+					SchedulableMasters: swag.Bool(false),
+					ValidationsInfo:    "{\"some-check\":[{\"id\":\"checking1\",\"status\":\"failure\",\"message\":\"Check1 is not OK\"},{\"id\":\"checking2\",\"status\":\"success\",\"message\":\"Check2 is OK\"},{\"id\":\"checking3\",\"status\":\"failure\",\"message\":\"Check3 is not OK\"}]}",
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2361,18 +2395,19 @@ var _ = Describe("cluster reconcile", func() {
 		It("add install config overrides annotation", func() {
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusInsufficient),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInsufficient),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					SchedulableMasters: swag.Bool(false),
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2415,6 +2450,7 @@ var _ = Describe("cluster reconcile", func() {
 					BaseDNSDomain:          defaultClusterSpec.BaseDomain,
 					SSHPublicKey:           defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:         models.ClusterHyperthreadingAll,
+					SchedulableMasters:     swag.Bool(false),
 					InstallConfigOverrides: `{"controlPlane": {"hyperthreading": "Disabled"}}`,
 				},
 				PullSecret: testPullSecretVal,
@@ -2454,6 +2490,7 @@ var _ = Describe("cluster reconcile", func() {
 					BaseDNSDomain:          defaultClusterSpec.BaseDomain,
 					SSHPublicKey:           defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:         models.ClusterHyperthreadingAll,
+					SchedulableMasters:     swag.Bool(false),
 					InstallConfigOverrides: `{"controlPlane": {"hyperthreading": "Disabled"}}`,
 				},
 				PullSecret: testPullSecretVal,
@@ -2485,18 +2522,19 @@ var _ = Describe("cluster reconcile", func() {
 		It("invalid install config overrides annotation", func() {
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusInsufficient),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInsufficient),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					SchedulableMasters: swag.Bool(false),
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2535,18 +2573,19 @@ var _ = Describe("cluster reconcile", func() {
 		It("SSHPublicKey in ClusterDeployment has spaces in suffix", func() {
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:               &sId,
-					Name:             clusterName,
-					OpenshiftVersion: "4.8",
-					ClusterNetworks:  clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:  serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:      swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:           swag.String(models.ClusterStatusInsufficient),
-					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
-					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:   models.ClusterHyperthreadingAll,
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInsufficient),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					SchedulableMasters: swag.Bool(false),
 				},
 				PullSecret: testPullSecretVal,
 			}
@@ -2584,6 +2623,7 @@ var _ = Describe("cluster reconcile", func() {
 					BaseDNSDomain:        defaultClusterSpec.BaseDomain,
 					SSHPublicKey:         defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:       models.ClusterHyperthreadingAll,
+					SchedulableMasters:   swag.Bool(false),
 					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
 				},
 				PullSecret: testPullSecretVal,
@@ -2611,19 +2651,20 @@ var _ = Describe("cluster reconcile", func() {
 		It("DHCP is enabled", func() {
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:                &sId,
-					Name:              clusterName,
-					OpenshiftVersion:  "4.8",
-					ClusterNetworks:   clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
-					ServiceNetworks:   serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
-					NetworkType:       swag.String(models.ClusterNetworkTypeOpenShiftSDN),
-					Status:            swag.String(models.ClusterStatusInstalling),
-					IngressVip:        defaultAgentClusterInstallSpec.IngressVIP,
-					APIVip:            defaultAgentClusterInstallSpec.APIVIP,
-					BaseDNSDomain:     defaultClusterSpec.BaseDomain,
-					SSHPublicKey:      defaultAgentClusterInstallSpec.SSHPublicKey,
-					Hyperthreading:    models.ClusterHyperthreadingAll,
-					VipDhcpAllocation: swag.Bool(true),
+					ID:                 &sId,
+					Name:               clusterName,
+					OpenshiftVersion:   "4.8",
+					ClusterNetworks:    clusterNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ClusterNetwork),
+					ServiceNetworks:    serviceNetworksEntriesToArray(defaultAgentClusterInstallSpec.Networking.ServiceNetwork),
+					NetworkType:        swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+					Status:             swag.String(models.ClusterStatusInstalling),
+					IngressVip:         defaultAgentClusterInstallSpec.IngressVIP,
+					APIVip:             defaultAgentClusterInstallSpec.APIVIP,
+					BaseDNSDomain:      defaultClusterSpec.BaseDomain,
+					SSHPublicKey:       defaultAgentClusterInstallSpec.SSHPublicKey,
+					Hyperthreading:     models.ClusterHyperthreadingAll,
+					SchedulableMasters: swag.Bool(false),
+					VipDhcpAllocation:  swag.Bool(true),
 				},
 				PullSecret: testPullSecretVal,
 			}


### PR DESCRIPTION
SchedulableMasters property allows scheduling workload on the master
nodes of the OCP cluster. In #2075 the ability to set that has been
added to the REST API. In order to keep the feature parity with K8s API,
we are extending the AgentClusterInstall CRD so that we have ability to
use that feature.

Closes: [MGMT-9057](https://issues.redhat.com/browse/MGMT-9057)

---

Piggybacking a cyclomatic complexity reduction in order to unblock the main change of this PR:

This commit reduces cyclomatic complexity of the updateIfNeeded()
function by extracting part responsible for updating Cluster, Machine
and Service networks.

As the Cluster object grows by adding more properties, this causes
development of the new logic more troublesome and requires refactoring
some of the already existing parts. This change here is one of those as
it does not impact the logic of the code and is purely a visual change.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
