### PR TITLE
NO-ISSUE: use OpenshiftVersion as key in openshift-versions API

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -100,7 +100,7 @@ func (h *handler) ListSupportedOpenshiftVersions(ctx context.Context, params ope
 func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params operations.V2ListSupportedOpenshiftVersionsParams) middleware.Responder {
 	openshiftVersions := models.OpenshiftVersions{}
 	for _, releaseImage := range h.releaseImages {
-		key := *releaseImage.Version
+		key := *releaseImage.OpenshiftVersion
 		if swag.StringValue(releaseImage.CPUArchitecture) == "" {
 			// Empty implies default architecture
 			*releaseImage.CPUArchitecture = common.DefaultCPUArchitecture
@@ -111,7 +111,7 @@ func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params o
 			openshiftVersion = models.OpenshiftVersion{
 				CPUArchitectures: []string{*releaseImage.CPUArchitecture},
 				Default:          releaseImage.Default,
-				DisplayName:      key,
+				DisplayName:      *releaseImage.Version,
 				SupportLevel:     h.getSupportLevel(*releaseImage),
 			}
 			openshiftVersions[key] = openshiftVersion

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -191,7 +191,7 @@ var _ = Describe("list versions", func() {
 			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
 
 			for _, releaseImage := range *releaseImages {
-				key := *releaseImage.Version
+				key := *releaseImage.OpenshiftVersion
 				version := val.Payload[key]
 				architecture := *releaseImage.CPUArchitecture
 				if architecture == "" {


### PR DESCRIPTION
Use the previous behaviour of using the OpenshiftVersion as key in /openshift-versions API.
This would avoid an failure in test-infra on release image override flow, as the version
is truncated to x.y:
https://github.com/openshift/assisted-test-infra/blob/b3888faa715871a5e6b56df23f72a85f0d247aa3/src/assisted_test_infra/test_infra/utils/utils.py#L497

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @osherdp 
/cc @eliorerz 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
