### PR TITLE
MGMT-8300: Allow API VIP on cluster creation

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -346,17 +346,6 @@ func (b *bareMetalInventory) validateRegisterClusterInternalParams(params *insta
 		return err
 	}
 
-	if swag.BoolValue(params.NewClusterParams.UserManagedNetworking) {
-		if swag.BoolValue(params.NewClusterParams.VipDhcpAllocation) {
-			err = errors.Errorf("VIP DHCP Allocation cannot be enabled with User Managed Networking")
-			return common.NewApiError(http.StatusBadRequest, err)
-		}
-		if params.NewClusterParams.IngressVip != "" {
-			err = errors.Errorf("Ingress VIP cannot be set with User Managed Networking")
-			return common.NewApiError(http.StatusBadRequest, err)
-		}
-	}
-
 	if params.NewClusterParams.AdditionalNtpSource != nil {
 		ntpSource := swag.StringValue(params.NewClusterParams.AdditionalNtpSource)
 
@@ -455,6 +444,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			ID:                    &id,
 			Href:                  swag.String(url.String()),
 			Kind:                  swag.String(models.ClusterKindCluster),
+			APIVip:                params.NewClusterParams.APIVip,
 			BaseDNSDomain:         params.NewClusterParams.BaseDNSDomain,
 			IngressVip:            params.NewClusterParams.IngressVip,
 			Name:                  swag.StringValue(params.NewClusterParams.Name),

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -24,6 +24,10 @@ type ClusterCreateParams struct {
 	// A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.
 	AdditionalNtpSource *string `json:"additional_ntp_source,omitempty"`
 
+	// The virtual IP used to reach the OpenShift cluster's API.
+	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))?$
+	APIVip string `json:"api_vip,omitempty"`
+
 	// Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 	BaseDNSDomain string `json:"base_dns_domain,omitempty"`
 
@@ -129,6 +133,10 @@ type ClusterCreateParams struct {
 func (m *ClusterCreateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAPIVip(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateClusterNetworkCidr(formats); err != nil {
 		res = append(res, err)
 	}
@@ -200,6 +208,18 @@ func (m *ClusterCreateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *ClusterCreateParams) validateAPIVip(formats strfmt.Registry) error {
+	if swag.IsZero(m.APIVip) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("api_vip", "body", m.APIVip, `^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))?$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5505,6 +5505,11 @@ func init() {
           "type": "string",
           "x-nullable": true
         },
+        "api_vip": {
+          "description": "The virtual IP used to reach the OpenShift cluster's API.",
+          "type": "string",
+          "pattern": "^(?:(?:(?:[0-9]{1,3}\\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))?$"
+        },
         "base_dns_domain": {
           "description": "Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.",
           "type": "string"
@@ -14345,6 +14350,11 @@ func init() {
           "description": "A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.",
           "type": "string",
           "x-nullable": true
+        },
+        "api_vip": {
+          "description": "The virtual IP used to reach the OpenShift cluster's API.",
+          "type": "string",
+          "pattern": "^(?:(?:(?:[0-9]{1,3}\\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))?$"
         },
         "base_dns_domain": {
           "description": "Base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.",

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1438,6 +1438,8 @@ var _ = Describe("cluster install", func() {
 		It("report usage new dual-stack cluster", func() {
 			registerClusterReply, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
+					APIVip:        "1.2.3.8",
+					IngressVip:    "1.2.3.9",
 					BaseDNSDomain: "example.com",
 					ClusterNetworks: []*models.ClusterNetwork{
 						{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23},

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4123,6 +4123,10 @@ definitions:
         description: The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
         pattern: '^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$'
         default: "172.30.0.0/16"
+      api_vip:
+        type: string
+        pattern: '^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))?$'
+        description: The virtual IP used to reach the OpenShift cluster's API.
       ingress_vip:
         type: string
         pattern: '^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3})|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,}))$'


### PR DESCRIPTION
This commit changes the behaviour of cluster creation in order to allow
passing API VIP directly when creating a cluster. This is in order to
remove a need for a subsequent cluster update in order to provide the
value.

This changes the cluster creation API as before it did not allow passing
API VIP. A set of validators is created in order to make sure that API
VIP is allowed for a specific set of scenarios and not unconditionally
for any arbitrary network configuration.

Closes: [MGMT-8300](https://issues.redhat.com/browse/MGMT-8300)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ori-amizur 
/cc @filanov 
/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
