### PR TITLE
MGMT-7709: optional openshift_version in infraenv

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -7739,7 +7739,7 @@ var _ = Describe("infraEnvs", func() {
 			reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:             swag.String("some-infra-env-name"),
-					OpenshiftVersion: swag.String(MinimalOpenShiftVersionForNoneHA),
+					OpenshiftVersion: MinimalOpenShiftVersionForNoneHA,
 					PullSecret:       swag.String("{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"),
 				},
 			})
@@ -7770,7 +7770,7 @@ var _ = Describe("infraEnvs", func() {
 			reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:             swag.String("some-infra-env-name"),
-					OpenshiftVersion: swag.String(MinimalOpenShiftVersionForNoneHA),
+					OpenshiftVersion: MinimalOpenShiftVersionForNoneHA,
 					PullSecret:       swag.String("{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"),
 					ClusterID:        &clusterID,
 					CPUArchitecture:  "x86_64",
@@ -7825,7 +7825,7 @@ var _ = Describe("infraEnvs", func() {
 			reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:             swag.String("some-infra-env-name"),
-					OpenshiftVersion: swag.String(MinimalOpenShiftVersionForNoneHA),
+					OpenshiftVersion: MinimalOpenShiftVersionForNoneHA,
 					PullSecret:       swag.String("{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"),
 					ClusterID:        &clusterID,
 					CPUArchitecture:  "arm64",
@@ -7844,7 +7844,7 @@ var _ = Describe("infraEnvs", func() {
 			reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:                   swag.String("some-infra-env-name"),
-					OpenshiftVersion:       swag.String(MinimalOpenShiftVersionForNoneHA),
+					OpenshiftVersion:       MinimalOpenShiftVersionForNoneHA,
 					PullSecret:             swag.String("{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"),
 					IgnitionConfigOverride: override,
 				},
@@ -7866,7 +7866,7 @@ var _ = Describe("infraEnvs", func() {
 				reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 					InfraenvCreateParams: &models.InfraEnvCreateParams{
 						Name:             swag.String(infraEnvName),
-						OpenshiftVersion: swag.String(common.TestDefaultConfig.OpenShiftVersion),
+						OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
 						PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
 					},
 				})

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -479,7 +479,7 @@ func (b *bareMetalInventory) GetInfraEnvDownloadURL(ctx context.Context, params 
 		return common.GenerateErrorResponder(err)
 	}
 
-	osImage, err := b.getOsImageOrLatest(&infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+	osImage, err := b.getOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -354,7 +354,7 @@ func (r *InfraEnvReconciler) createInfraEnv(ctx context.Context, log logrus.Fiel
 	}
 	if cluster != nil {
 		createParams.InfraenvCreateParams.ClusterID = cluster.ID
-		createParams.InfraenvCreateParams.OpenshiftVersion = &cluster.OpenshiftVersion
+		createParams.InfraenvCreateParams.OpenshiftVersion = cluster.OpenshiftVersion
 	}
 	staticNetworkConfig, err := r.processNMStateConfig(ctx, log, infraEnv)
 	if err != nil {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -282,8 +282,14 @@ func (h *handler) GetLatestOsImage(cpuArchitecture string) (*models.OsImage, err
 		if err != nil {
 			continue
 		}
-		if latest == nil || *osImage.OpenshiftVersion > *latest.OpenshiftVersion {
+		if latest == nil {
 			latest = osImage
+		} else {
+			imageVer, _ := version.NewVersion(*osImage.OpenshiftVersion)
+			latestVer, _ := version.NewVersion(*latest.OpenshiftVersion)
+			if imageVer.GreaterThan(latestVer) {
+				latest = osImage
+			}
 		}
 	}
 	if latest == nil {

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -576,11 +576,11 @@ var _ = Describe("list versions", func() {
 		)
 
 		It("only one OS image", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages[:2], *releaseImages, nil, "")
+			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages[0:1], *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			osImage, err = h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.9"))
+			Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.1"))
 			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
 		})
 
@@ -589,7 +589,7 @@ var _ = Describe("list versions", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			osImage, err = h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.9.1"))
+			Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.1"))
 			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
 		})
 	})

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -41,8 +41,7 @@ type InfraEnvCreateParams struct {
 	Name *string `json:"name"`
 
 	// Version of the OpenShift cluster (used to infer the RHCOS version - temporary until generic logic implemented).
-	// Required: true
-	OpenshiftVersion *string `json:"openshift_version"`
+	OpenshiftVersion string `json:"openshift_version,omitempty"`
 
 	// proxy
 	Proxy *Proxy `json:"proxy,omitempty" gorm:"embedded;embeddedPrefix:proxy_"`
@@ -71,10 +70,6 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateName(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateOpenshiftVersion(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -128,15 +123,6 @@ func (m *InfraEnvCreateParams) validateImageType(formats strfmt.Registry) error 
 func (m *InfraEnvCreateParams) validateName(formats strfmt.Registry) error {
 
 	if err := validate.Required("name", "body", m.Name); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *InfraEnvCreateParams) validateOpenshiftVersion(formats strfmt.Registry) error {
-
-	if err := validate.Required("openshift_version", "body", m.OpenshiftVersion); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -11982,7 +11982,6 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "openshift_version",
         "pull_secret"
       ],
       "properties": {
@@ -25415,7 +25414,6 @@ func init() {
       "type": "object",
       "required": [
         "name",
-        "openshift_version",
         "pull_secret"
       ],
       "properties": {

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Day2 cluster tests", func() {
 		res, err1 := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,
@@ -581,7 +581,7 @@ var _ = Describe("[V2UpdateCluster] Day2 cluster tests", func() {
 		res, err1 := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,
@@ -984,7 +984,7 @@ var _ = Describe("Day2 cluster with bind/unbind hosts", func() {
 		infraEnv, err := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,
@@ -1059,7 +1059,7 @@ var _ = Describe("Installation progress", func() {
 			res, err1 := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:             swag.String("test-infra-env"),
-					OpenshiftVersion: swag.String(openshiftVersion),
+					OpenshiftVersion: openshiftVersion,
 					PullSecret:       swag.String(pullSecret),
 					SSHAuthorizedKey: swag.String(sshPublicKey),
 					ImageType:        models.ImageTypeFullIso,
@@ -1166,7 +1166,7 @@ var _ = Describe("Installation progress", func() {
 			res, err1 := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{
 					Name:             swag.String("test-infra-env"),
-					OpenshiftVersion: swag.String(openshiftVersion),
+					OpenshiftVersion: openshiftVersion,
 					PullSecret:       swag.String(pullSecret),
 					SSHAuthorizedKey: swag.String(sshPublicKey),
 					ImageType:        models.ImageTypeFullIso,

--- a/subsystem/host_v2_test.go
+++ b/subsystem/host_v2_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Host tests v2", func() {
 		infraEnv, err = userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,
@@ -154,7 +154,7 @@ var _ = Describe("Host tests v2", func() {
 		infraEnv2, err := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("another test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,
@@ -232,7 +232,7 @@ var _ = Describe("Day2 Host tests v2", func() {
 		infraEnv, err = userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
-				OpenshiftVersion: swag.String(openshiftVersion),
+				OpenshiftVersion: openshiftVersion,
 				PullSecret:       swag.String(pullSecret),
 				SSHAuthorizedKey: swag.String(sshPublicKey),
 				ImageType:        models.ImageTypeFullIso,

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -20,7 +20,7 @@ var registerInfraEnv = func(clusterID *strfmt.UUID) *models.InfraEnv {
 	request, err := userBMClient.Installer.RegisterInfraEnv(context.Background(), &installer.RegisterInfraEnvParams{
 		InfraenvCreateParams: &models.InfraEnvCreateParams{
 			Name:             swag.String("test-infra-env"),
-			OpenshiftVersion: swag.String(openshiftVersion),
+			OpenshiftVersion: openshiftVersion,
 			PullSecret:       swag.String(pullSecret),
 			SSHAuthorizedKey: swag.String(sshPublicKey),
 			ImageType:        models.ImageTypeFullIso,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -9080,7 +9080,6 @@ definitions:
     type: object
     required:
       - name
-      - openshift_version
       - pull_secret
     properties:
       name:


### PR DESCRIPTION
When creating an infraenv, openshift_version should be optional:
* Removed openshift_version from required properties of infra-env-create-params.
* Register infraenv already fallbacks to latest OS image when OpenshiftVersion
  is not specified - fixed getOsImageOrLatest to use semantic version comparison.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @tsorya 
/cc @filanov 
/cc @osherdp 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
