### PR TITLE
NO-ISSUE: Add OKD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,12 @@ ifeq ($(DISABLE_TLS),true)
 	DISABLE_TLS_CMD := --disable-tls
 endif
 
+PODMAN_CONFIGMAP := deploy/podman/configmap.yml
+OKD := $(or ${OKD},false)
+ifeq ($(OKD),true)
+	PODMAN_CONFIGMAP := deploy/podman/okd-configmap.yml
+endif
+
 ifeq ($(ENABLE_KUBE_API),true)
 	ENABLE_KUBE_API_CMD = --enable-kube-api true
 	STORAGE = filesystem
@@ -383,7 +389,7 @@ podman-pull-service-from-docker-daemon:
 	podman pull "docker-daemon:${SERVICE}"
 
 deploy-onprem:
-	podman play kube --configmap deploy/podman/configmap.yml deploy/podman/pod.yml
+	podman play kube --configmap ${PODMAN_CONFIGMAP} deploy/podman/pod.yml
 	./hack/retry.sh 90 2 "curl -f http://127.0.0.1:8090/ready"
 	./hack/retry.sh 60 10 "curl -f http://127.0.0.1:8888/health"
 

--- a/data/default_okd_os_images.json
+++ b/data/default_okd_os_images.json
@@ -1,0 +1,9 @@
+[
+    {
+        "openshift_version": "4.9",
+        "cpu_architecture": "x86_64",
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
+        "rootfs_url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img",
+        "version": "34.20210626.3.1"
+    }
+]

--- a/data/default_okd_release_images.json
+++ b/data/default_okd_release_images.json
@@ -1,0 +1,9 @@
+[
+    {
+        "openshift_version": "4.9",
+        "cpu_architecture": "x86_64",
+        "url": "quay.io/openshift/okd:4.9.0-0.okd-2022-01-29-035536",
+        "version": "4.9.0-0.okd-2022-01-29-035536",
+        "default": true
+    }
+]

--- a/deploy/podman/README.md
+++ b/deploy/podman/README.md
@@ -35,3 +35,20 @@ podman play kube --down pod.yml
 Other environment variables may be set in configmap.yml. For example, custom
 agent (`AGENT_DOCKER_IMAGE`), installer (`INSTALLER_IMAGE`) and controller
 (`CONTROLLER_IMAGE`) images can be defined.
+
+## OKD configuration
+
+Assisted Service can install OKD clusters using a different set of parameters:
+```shell
+podman play kube --configmap okd_configmap.yml pod.yml
+```
+or
+```shell
+make deploy-onprem OKD=true
+```
+for developers
+
+Configuration differences are:
+* `OS_IMAGES` should point to Fedora CoreOS (see [Fedora CoreOS Release artifacts](https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable&arch=x86_64))
+* `RELEASE_IMAGES` lists available OKD versions (see [OKD Releases](https://github.com/openshift/okd/releases))
+* `OKD_RPMS_IMAGE` is additional image containing Kubelet/CRI-O RPMs (see [example repo](https://github.com/vrutkovs/okd-rpms))

--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  ASSISTED_SERVICE_HOST: 127.0.0.1:8090
+  ASSISTED_SERVICE_SCHEME: http
+  AUTH_TYPE: none
+  DB_HOST: 127.0.0.1
+  DB_NAME: installer
+  DB_PASS: admin
+  DB_PORT: "5432"
+  DB_USER: admin
+  DEPLOY_TARGET: onprem
+  DISK_ENCRYPTION_SUPPORT: "false"
+  DUMMY_IGNITION: "false"
+  ENABLE_SINGLE_NODE_DNSMASQ: "false"
+  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]'
+  IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
+  IPV6_SUPPORT: "true"
+  LISTEN_PORT: "8888"
+  NTP_DEFAULT_SERVER: ""
+  POSTGRESQL_DATABASE: installer
+  POSTGRESQL_PASSWORD: admin
+  POSTGRESQL_USER: admin
+  PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
+  SERVICE_BASE_URL: http://127.0.0.1:8090
+  STORAGE: filesystem
+  OS_IMAGES: '[{"openshift_version":"4.9","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso","rootfs_url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img","version":"34.20210626.3.1"}]'
+  RELEASE_IMAGES: '[{"openshift_version":"4.9","cpu_architecture":"x86_64","url":"quay.io/openshift/okd:4.9.0-0.okd-2022-01-29-035536","version":"4.9.0-0.okd-2022-01-29-035536","default":true}]'
+  OKD_RPMS_IMAGE: quay.io/vrutkovs/okd-rpms:4.9

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -88,6 +88,8 @@ function generate_events() {
 function generate_configuration() {
     OS_IMAGES=$(< ${__root}/data/default_os_images.json tr -d "\n\t ")
     RELEASE_IMAGES=$(< ${__root}/data/default_release_images.json tr -d "\n\t ")
+    OKD_OS_IMAGES=$(< ${__root}/data/default_okd_os_images.json tr -d "\n\t ")
+    OKD_RELEASE_IMAGES=$(< ${__root}/data/default_okd_release_images.json tr -d "\n\t ")
     MUST_GATHER_IMAGES=$(< ${__root}/data/default_must_gather_versions.json tr -d "\n\t ")
     OPERATOR_OS_IMAGES=$(< ${__root}/data/default_os_images.json jq -c 'del (.[] | select(.openshift_version == "4.6",.openshift_version == "4.7"))')
     PUBLIC_CONTAINER_REGISTRIES=$(< ${__root}/data/default_public_container_registries.txt)
@@ -99,8 +101,10 @@ function generate_configuration() {
 
     sed -i "s|OS_IMAGES:.*|OS_IMAGES: '${OS_IMAGES}'|" ${__root}/deploy/podman/configmap.yml
     sed -i "s|RELEASE_IMAGES:.*|RELEASE_IMAGES: '${RELEASE_IMAGES}'|" ${__root}/deploy/podman/configmap.yml
-    sed -i "s|PUBLIC_CONTAINER_REGISTRIES:.*|PUBLIC_CONTAINER_REGISTRIES: '${PUBLIC_CONTAINER_REGISTRIES}'|" ${__root}/deploy/podman/configmap.yml
-    sed -i "s|HW_VALIDATOR_REQUIREMENTS:.*|HW_VALIDATOR_REQUIREMENTS: '${HW_VALIDATOR_REQUIREMENTS}'|" ${__root}/deploy/podman/configmap.yml
+    sed -i "s|OS_IMAGES:.*|OS_IMAGES: '${OKD_OS_IMAGES}'|" ${__root}/deploy/podman/okd-configmap.yml
+    sed -i "s|RELEASE_IMAGES:.*|RELEASE_IMAGES: '${OKD_RELEASE_IMAGES}'|" ${__root}/deploy/podman/okd-configmap.yml
+    sed -i "s|PUBLIC_CONTAINER_REGISTRIES:.*|PUBLIC_CONTAINER_REGISTRIES: '${PUBLIC_CONTAINER_REGISTRIES}'|" ${__root}/deploy/podman/{okd-,}configmap.yml
+    sed -i "s|HW_VALIDATOR_REQUIREMENTS:.*|HW_VALIDATOR_REQUIREMENTS: '${HW_VALIDATOR_REQUIREMENTS}'|" ${__root}/deploy/podman/{okd-,}configmap.yml
 
     sed -i "s|OS_IMAGES=.*|OS_IMAGES=${OS_IMAGES}|" ${__root}/config/onprem-iso-fcc.yaml
     sed -i "s|RELEASE_IMAGES=.*|RELEASE_IMAGES=${RELEASE_IMAGES}|" ${__root}/config/onprem-iso-fcc.yaml

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -130,6 +130,44 @@ IMAGE=$(echo $1 | sed 's/:.*//')
 podman images | grep $IMAGE || podman rmi --force $1 || true
 `
 
+const okdBinariesOverlayTemplate = `#!/bin/env bash
+set -eux
+# Fetch an image with OKD rpms
+RPMS_IMAGE="%s"
+while ! podman pull --quiet "${RPMS_IMAGE}"
+do
+    echo "Pull failed. Retrying ${RPMS_IMAGE}..."
+    sleep 5
+done
+mnt=$(podman image mount "${RPMS_IMAGE}")
+# Extract machine-config-daemon binary
+cp -rvf ${mnt}/binaries/machine-config-daemon /usr/local/bin/machine-config-daemon
+chmod a+x /usr/local/bin/machine-config-daemon
+restorecon -Rv /usr/local/bin/machine-config-daemon
+# Install RPMs in overlayed FS
+mkdir /tmp/rpms
+cp -rvf ${mnt}/rpms/* /tmp/rpms
+tmpd=$(mktemp -d)
+mkdir ${tmpd}/{upper,work}
+mount -t overlay -o lowerdir=/usr,upperdir=${tmpd}/upper,workdir=${tmpd}/work overlay /usr
+rpm -Uvh /tmp/rpms/*
+podman rmi -f "${RPMS_IMAGE}"
+# Expand /var to 6G (3.2G on 16GB VM in insufficient)
+/bin/truncate -s 6G /run/ephemeral.xfsloop
+losetup -c /dev/loop0
+xfs_growfs /var
+mount -o remount,size=6G /run
+`
+
+const okdHoldAgentUntilBinariesLanded = `[Unit]
+Wants=okd-overlay.service
+After=okd-overlay.service
+`
+
+const okdHoldPivot = `[Unit]
+ConditionPathExists=/enoent
+`
+
 const discoveryIgnitionConfigFormat = `{
   "ignition": {
     "version": "3.1.0"{{if .PROXY_SETTINGS}},
@@ -155,7 +193,17 @@ const discoveryIgnitionConfigFormat = `{
         "name": "pre-network-manager-config.service",
         "enabled": true,
         "contents": "[Unit]\nDescription=Prepare network manager config content\nBefore=dracut-initqueue.service\nAfter=dracut-cmdline.service\nDefaultDependencies=no\n[Service]\nUser=root\nType=oneshot\nTimeoutSec=60\nExecStart=/bin/bash /usr/local/bin/pre-network-manager-config.sh\nPrivateTmp=true\nRemainAfterExit=no\n[Install]\nWantedBy=multi-user.target"
-    }{{end}}
+    }{{end}}{{if .OKDBinaries}},
+    {
+        "name": "okd-overlay.service",
+        "enabled": true,
+        "contents": "[Service]\nType=oneshot\nExecStart=/usr/local/bin/okd-binaries.sh\n\n[Unit]\nWants=network-online.target\nAfter=network-online.target\n\n[Install]\nWantedBy=multi-user.target"
+    },
+    {
+        "name": "systemd-journal-gatewayd.socket",
+        "enabled": true,
+        "contents": "[Unit]\nDescription = Fake systemd-journal-gatewayd.socket\n\n[Socket]\nListenStream = 19531\nAccept = yes\n\n[Install]\nWantedBy = sockets.target"
+		}{{end}}
     ]
   },
   "storage": {
@@ -265,6 +313,32 @@ const discoveryIgnitionConfigFormat = `{
         "name": "root"
       },
       "contents": { "source": "data:text/plain;base64,{{.FileContents}}"}
+    }{{end}}{{if .OKDBinaries}},
+    {
+      "path": "/usr/local/bin/okd-binaries.sh",
+      "mode": 755,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDBinaries}}" }
+    }{{end}}{{if .OKDHoldPivot}},{
+      "path": "/etc/systemd/system/release-image-pivot.service.d/wait-for-okd.conf",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDHoldPivot}}" }
+    }{{end}}{{if .OKDHoldAgent}},
+    {
+      "path": "/etc/systemd/system/agent.service.d/wait-for-okd.conf",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDHoldAgent}}" }
     }{{end}}]
   }
 }`
@@ -339,6 +413,7 @@ type IgnitionConfig struct {
 	ServiceCACertPath    string        `envconfig:"SERVICE_CA_CERT_PATH" default:""`
 	ServiceIPs           string        `envconfig:"SERVICE_IPS" default:""`
 	SkipCertVerification bool          `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	OKDRPMsImage         string        `envconfig:"OKD_RPMS_IMAGE" default:""`
 }
 
 type ignitionBuilder struct {
@@ -1367,6 +1442,13 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		}
 		ignitionParams["MirrorRegistriesConfig"] = base64.StdEncoding.EncodeToString(registriesContents)
 		ignitionParams["MirrorRegistriesCAConfig"] = base64.StdEncoding.EncodeToString(caContents)
+	}
+
+	if cfg.OKDRPMsImage != "" {
+		okdBinariesOverlay := fmt.Sprintf(okdBinariesOverlayTemplate, cfg.OKDRPMsImage)
+		ignitionParams["OKDBinaries"] = base64.StdEncoding.EncodeToString([]byte(okdBinariesOverlay))
+		ignitionParams["OKDHoldPivot"] = base64.StdEncoding.EncodeToString([]byte(okdHoldPivot))
+		ignitionParams["OKDHoldAgent"] = base64.StdEncoding.EncodeToString([]byte(okdHoldAgentUntilBinariesLanded))
 	}
 
 	tmpl, err := template.New("ignitionConfig").Parse(discoveryIgnitionConfigFormat)


### PR DESCRIPTION
This PR adds assisted-installer support for OKD clusters. Most notable difference between OCP and OKD install is that OKD starts with Fedora CoreOS instead of RHCOS. FCOS doesn't have kubelet/crio/mcd (but has podman), so in order to make bootstrap work on live CD we do the following:
* pull an image with RPMs (`OKD_RPMS_IMAGE` env var)
* create an overlayFS for `/usr` (as its read-only on rpm-ostree systems)
* extract RPMs from the image and use `rpm` to install them
* expand `/var` and `/run` partitions to 6 GB (in FCOS these partitions are 3.2 GB for 16 GB VM which is insufficient for bootstrap to complete)
* hold off agent.service until RPMs are installed
* add fake `systemd-journal-gatewayd.socket` (required from `mcd --once-from` to complete, as FCOS doesn't have journal gateway preinstalled)

This PR also makes easy to deploy OKD-specific version of AI via podman: use `make deploy-onprem OKD=true` to deploy service using `okd-configmap.yml`

TODO:
* [x] Update `generate.sh` to have `okd-configmap.yml` autoupdated when `configmap.yml` is being generated
       Fixed in 3327bcd1f8ab3a8a83b1d84a0161f3804510374e
* [x] Allow `agent.service` to restart on failure. This would make `systemctl start agent` unnecessary.
       Possible unintended consequences?
       Fixed in b84acd808584a68d6478b69121bbe59dd76eaf70 - `Wants/After` is a better solution (agent.service already restarts on failure)

## List all the issues related to this PR

- [x] Fixes #2580 
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @romfreiman 
/cc @tsorya 
/cc @eranco74 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
