### PR TITLE
MGMT-8744: Change image URL auth type log from warning to info

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -539,7 +539,7 @@ func (b *bareMetalInventory) generateImageDownloadURL(ctx context.Context, infra
 			return "", nil, errors.Wrap(err, "failed to sign image URL with token")
 		}
 	} else if b.authHandler.AuthType() == auth.TypeNone {
-		log.Warn("Auth type is none: image URL will remain as " + urlString)
+		log.Infof("Auth type is none: image URL will remain as %s", urlString)
 	}
 
 	// parse the exp claim out of the url


### PR DESCRIPTION
This log does not indicate an issue, just information for the user,
there's no good reason for it to be a warning

Originally added in 224c267c321d6fb1120941bbce443bdbb94961b3

Changing this was previously suggested in this comment that came in too late
https://github.com/openshift/assisted-service/pull/3246#discussion_r793383981

Some users were complaining about this log thinking it was the cause
for the issues they were having

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov
/cc @paul-maidment

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md