### PR TITLE
NO-ISSUE: Don't wait for CI to update coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: no
+    wait_for_ci: no
 
 coverage:
   precision: 2


### PR DESCRIPTION
Don't wait for all the CI jobs to complete to send the coverage report.
We will then get the coverage as soon as the unit tests have run.
