### PR TITLE
MGMT-8853: Prevents machine networks conflict errors

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -69,6 +69,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -2963,7 +2964,8 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 		}
 		for _, machineNetwork := range cluster.MachineNetworks {
 			machineNetwork.ClusterID = *cluster.ID
-			if err = db.Save(machineNetwork).Error; err != nil {
+			// MGMT-8853: Nothing is done when there's a conflict since there's no change to what's being inserted/updated.
+			if err = db.Clauses(clause.OnConflict{DoNothing: true}).Create(machineNetwork).Error; err != nil {
 				err = errors.Wrapf(err, "failed to update machine network %v of cluster %s", *machineNetwork, params.ClusterID)
 				return common.NewApiError(http.StatusInternalServerError, err)
 			}

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -248,7 +249,10 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 
 	if machineCidr != previousPrimaryMachineCidr {
 		if machineCidr != "" {
-			if err := db.Save(&models.MachineNetwork{
+			// MGMT-8853: Nothing is done when there's a conflict since there's no change to what's being inserted/updated.
+			if err := db.Clauses(clause.OnConflict{
+				DoNothing: true,
+			}).Create(&models.MachineNetwork{
 				ClusterID: *cluster.ID,
 				Cidr:      models.Subnet(machineCidr),
 			}).Error; err != nil {


### PR DESCRIPTION
[MGMT-8853](https://issues.redhat.com/browse/MGMT-8853): Prevents conflict errors with machine networks table in database.

**Context**: Subsystem tests were failing due to the infrequent error
```
time="2022-02-02T00:45:24Z" level=error msg=updateClusterData func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).updateClusterInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:2403" cluster_id=fbf88971-6338-4be3-b6e1-0c4a6ccd3e14 \
error="failed to update machine network {1.2.3.0/24 fbf88971-6338-4be3-b6e1-0c4a6ccd3e14} of cluster fbf88971-6338-4be3-b6e1-0c4a6ccd3e14: ERROR: duplicate key value violates unique constraint \"machine_networks_pkey\" (SQLSTATE 23505)" go-id=127982 pkg=Inventory request_id=4ddeda08-b8fd-4dc7-adcf-b8771099e49e
```

**Root cause**: Both the monitoring and the updateCluster were inserting into the machine networks table in different gorm (DB) transactions. Occasionally when monitoring inserted just before the updateCluster inserted into the machine networks table, the unique pkey error above occurs for the subsystem test (since it uses the update cluster) since they both insert the exact same data into the table.

**Solution**: Use the `Create` function instead of the original `Save` function so that way any conflicts can be ignored. In this scenario, nothing is done when there's a conflict since there's no changes to what's being inserted/updated. 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Testing Details:

1. Run assisted-service on minikube locally
2. Reran a failing subsystem test 1000 times and see if the error occurs
```bash
for i in {1..1001} 
    do make test FOCUS="localhost is not valid" VERBOSE=true SKIP="metrics"
done
```
3. Check the logs to see if the error occurs
```bash
kubectl logs -n assisted-installer $(kubectl get po --no-headers -n assisted-installer | grep assisted-service | awk '{print $1}') | grep "failed to update machine network"
```

Previously, the error would occur once every ~100 trials. After the fix, it does not occur.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
