### PR TITLE
OCPBUGSM-35526: Failed validation: Machine network CIDR : invalid CIDR address

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2870,7 +2870,7 @@ func (b *bareMetalInventory) updateNetworks(db *gorm.DB, params installer.V2Upda
 	if params.ClusterUpdateParams.MachineNetworks != nil {
 		for _, machineNetwork := range params.ClusterUpdateParams.MachineNetworks {
 			if err = network.VerifyMachineCIDR(string(machineNetwork.Cidr), common.IsSingleNodeCluster(cluster)); err != nil {
-				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR %s", string(machineNetwork.Cidr)))
+				return common.NewApiError(http.StatusBadRequest, errors.Wrapf(err, "Machine network CIDR '%s'", string(machineNetwork.Cidr)))
 			}
 		}
 		cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5279,7 +5279,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks (new API) - invalid CIDR, ClusterNetwork", func() {
@@ -5291,7 +5291,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks (old API) - invalid CIDR, ClusterNetwork", func() {
@@ -5301,7 +5301,7 @@ var _ = Describe("cluster", func() {
 							ClusterNetworkCidr: swag.String(""),
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks (new API - invalid HostPrefix, ClusterNetwork", func() {
@@ -5313,7 +5313,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks (old API) - invalid HostPrefix, ClusterNetwork", func() {
@@ -5335,7 +5335,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid CIDR, ServiceNetwork", func() {
@@ -5347,7 +5347,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid empty MachineNetwork", func() {
@@ -5359,7 +5359,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR '': Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid CIDR, MachineNetwork", func() {
@@ -5371,7 +5371,7 @@ var _ = Describe("cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{Cidr: ""}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR '': Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Override networks with new API", func() {
@@ -7228,7 +7228,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid CIDR, ClusterNetwork", func() {
@@ -7240,7 +7240,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid HostPrefix, ClusterNetwork", func() {
@@ -7252,7 +7252,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid empty ServiceNetwork", func() {
@@ -7264,7 +7264,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid CIDR, ServiceNetwork", func() {
@@ -7276,7 +7276,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Service network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid empty MachineNetwork", func() {
@@ -7288,7 +7288,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR '': Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Empty networks - invalid CIDR, MachineNetwork", func() {
@@ -7300,7 +7300,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							MachineNetworks: []*models.MachineNetwork{{Cidr: ""}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR : invalid CIDR address: ")
+					verifyApiErrorString(reply, http.StatusBadRequest, "Machine network CIDR '': Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
 				It("Override networks", func() {

--- a/internal/network/cidr_validations.go
+++ b/internal/network/cidr_validations.go
@@ -15,15 +15,24 @@ const MinMachineMaskDelta = 4
 // Minimum mask size for Machine CIDR to allow at least 2 addresses
 const MinSNOMachineMaskDelta = 1
 
+// When illegal CIDR is passed to net.ParseCIDR, the error message might be misleading in case the cidr is empty
+func parseCIDR(cidr string) (ip net.IP, ipnet *net.IPNet, err error) {
+	ip, ipnet, err = net.ParseCIDR(cidr)
+	if err != nil {
+		err = errors.Wrapf(err, "Failed to parse CIDR '%s'", cidr)
+	}
+	return
+}
+
 func netsOverlap(aCidrStr, bCidrStr string) error {
 	if aCidrStr == "" || bCidrStr == "" {
 		return nil
 	}
-	_, acidr, err := net.ParseCIDR(aCidrStr)
+	_, acidr, err := parseCIDR(aCidrStr)
 	if err != nil {
 		return err
 	}
-	_, bcidr, err := net.ParseCIDR(bCidrStr)
+	_, bcidr, err := parseCIDR(bCidrStr)
 	if err != nil {
 		return err
 	}
@@ -35,7 +44,7 @@ func netsOverlap(aCidrStr, bCidrStr string) error {
 }
 
 func verifySubnetCIDR(cidrStr string, minSubnetMaskSize int) error {
-	ip, cidr, err := net.ParseCIDR(cidrStr)
+	ip, cidr, err := parseCIDR(cidrStr)
 	if err != nil {
 		return err
 	}
@@ -80,7 +89,7 @@ func min(x, y int) int {
 }
 
 func VerifyClusterCidrSize(hostNetworkPrefix int, clusterNetworkCIDR string, numberOfHosts int) error {
-	_, cidr, err := net.ParseCIDR(clusterNetworkCIDR)
+	_, cidr, err := parseCIDR(clusterNetworkCIDR)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


When an empty CIDR is passed to one of the CIDR validations,
the function net.ParseCIDR return and error 'nvalid CIDR address'
This was misleading because there were cases that by mistake the user
thought other parameters are wrong such as illegal network prefix size.
In case such error occures in CIDR validations, it will be preceeded
by "Failed to parse CIDR '%s'" which will make it clearer.
This handles this bug https://bugzilla.redhat.com/show_bug.cgi?id=2007723
and https://bugzilla.redhat.com/show_bug.cgi?id=2007730

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 


## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
