### PR TITLE
MGMT-9014: Fix OpenShift Virtualization disk validation message for HPP disk

### DIFF
--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -288,12 +288,15 @@ func getDeviceKey(vendorID string, deviceID string) string {
 // If CNV is deployed on SNO, we want at least one non bootable disk (i.e. discoverable by LSO)
 // with certain size threshold for the hpp storage pool
 func validDiscoverableSNODisk(disks []*models.Disk, installationDiskID string, diskThresholdGi int64) error {
+	thresholdBytes := conversions.GibToBytes(diskThresholdGi)
+	thresholdGB := conversions.BytesToGb(thresholdBytes)
+
 	for _, disk := range disks {
 		if (disk.DriveType == ocs.SsdDrive || disk.DriveType == ocs.HddDrive) && installationDiskID != disk.ID && disk.SizeBytes != 0 {
-			if disk.SizeBytes > conversions.GibToBytes(diskThresholdGi) {
+			if disk.SizeBytes > thresholdBytes {
 				return nil
 			}
 		}
 	}
-	return fmt.Errorf("OpenShift Virtualization on SNO requires an additional disk with %d Gi in order to provide persistent storage for VMs, using hostpath-provisioner", diskThresholdGi)
+	return fmt.Errorf("OpenShift Virtualization on SNO requires an additional disk with %d GB (%d Gi) in order to provide persistent storage for VMs, using hostpath-provisioner", thresholdGB, diskThresholdGi)
 }

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -264,7 +264,7 @@ var _ = Describe("CNV operator", func() {
 			table.Entry("SNO and there is no disk with bigger size than threshold for HPP",
 				&common.Cluster{Cluster: models.Cluster{OpenshiftVersion: "4.10", HighAvailabilityMode: &noneHaMode, Hosts: []*models.Host{masterWithLessDiskSizeAndVirt}}},
 				masterWithLessDiskSizeAndVirt,
-				api.ValidationResult{Status: api.Failure, ValidationId: cnvOperator.GetHostValidationID(), Reasons: []string{"OpenShift Virtualization on SNO requires an additional disk with 50 Gi in order to provide persistent storage for VMs, using hostpath-provisioner"}},
+				api.ValidationResult{Status: api.Failure, ValidationId: cnvOperator.GetHostValidationID(), Reasons: []string{"OpenShift Virtualization on SNO requires an additional disk with 53 GB (50 Gi) in order to provide persistent storage for VMs, using hostpath-provisioner"}},
 			),
 			table.Entry("SNO and there is a disk with bigger size than threshold for HPP",
 				&common.Cluster{Cluster: models.Cluster{OpenshiftVersion: "4.10", HighAvailabilityMode: &noneHaMode, Hosts: []*models.Host{masterWithOneSatisfyingDiskAndVirt}}},

--- a/pkg/conversions/conversions.go
+++ b/pkg/conversions/conversions.go
@@ -22,6 +22,10 @@ func MibToGiB(mib int64) int64 {
 	return mib / int64(units.KiB)
 }
 
+func BytesToGb(bytes int64) int64 {
+	return bytes / int64(units.GB)
+}
+
 func BytesToGiB(bytes int64) int64 {
 	return bytes / int64(units.GiB)
 }


### PR DESCRIPTION
Fix OpenShift Virtualization disk validation message to display size in GB instead of Gi
(We expect GB since AI is aligned to GB when it comes to storage).

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @lalon4 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
