### PR TITLE
MGMT-9109: separate clusterID and infraenvID in register host utils

### DIFF
--- a/subsystem/ams_subscriptions_test.go
+++ b/subsystem/ams_subscriptions_test.go
@@ -340,7 +340,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			By("update subscription with openshfit (external) cluster ID", func() {
 				// in order to simulate infra env generation
 				generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-				registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+				registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 				setClusterAsInstalling(ctx, clusterID)
 			})
 
@@ -380,7 +380,7 @@ var _ = Describe("test AMS subscriptions", func() {
 			By("update subscription with openshfit (external) cluster ID", func() {
 				// in order to simulate infra env generation
 				generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-				registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+				registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 				reply, err = userBMClient.Installer.InstallCluster(context.Background(), &installer.InstallClusterParams{ClusterID: clusterID})
 				Expect(err).NotTo(HaveOccurred())
 				c := reply.GetPayload()

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Make sure that sensitive files are accessible only by owners o
 		Expect(err).ToNot(HaveOccurred())
 		clusterID = cID
 		generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-		registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+		registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 		setClusterAsFinalizing(ctx, clusterID)
 		res, err := agentBMClient.Installer.UploadClusterIngressCert(ctx, &installer.UploadClusterIngressCertParams{ClusterID: clusterID, IngressCertParams: models.IngressCertParams(ingressCa)})
 		Expect(err).NotTo(HaveOccurred())
@@ -233,7 +233,7 @@ var _ = Describe("Cluster credentials should be accessed only by cluster owner",
 		Expect(err).ToNot(HaveOccurred())
 		clusterID = cID
 		generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-		registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+		registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 		setClusterAsFinalizing(ctx, clusterID)
 		res, err := agentBMClient.Installer.UploadClusterIngressCert(ctx, &installer.UploadClusterIngressCertParams{ClusterID: clusterID, IngressCertParams: models.IngressCertParams(ingressCa)})
 		Expect(err).NotTo(HaveOccurred())

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1176,7 +1176,7 @@ var _ = Describe("cluster install", func() {
 	It("auto-assign", func() {
 		By("register 3 hosts all with master hw information cluster expected to be ready")
 		clusterID := *cluster.ID
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		h1, h2, h3 := hosts[0], hosts[1], hosts[2]
 		waitForClusterState(ctx, clusterID, models.ClusterStatusReady, defaultWaitForClusterStateTimeout,
 			IgnoreStateInfo)
@@ -1252,7 +1252,7 @@ var _ = Describe("cluster install", func() {
 	It("Schedulable masters", func() {
 		By("register 3 hosts all with master hw information cluster expected to be ready")
 		clusterID := *cluster.ID
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		h1, h2, h3 := hosts[0], hosts[1], hosts[2]
 		for _, h := range hosts {
 			generateDomainResolution(ctx, h, "test-cluster", "example.com")
@@ -1296,7 +1296,7 @@ var _ = Describe("cluster install", func() {
 	It("[V2UpdateCluster] Schedulable masters", func() {
 		By("register 3 hosts all with master hw information cluster expected to be ready")
 		clusterID := *cluster.ID
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		h1, h2, h3 := hosts[0], hosts[1], hosts[2]
 		for _, h := range hosts {
 			generateDomainResolution(ctx, h, "test-cluster", "example.com")
@@ -1584,7 +1584,7 @@ var _ = Describe("cluster install", func() {
 		var clusterID strfmt.UUID
 		BeforeEach(func() {
 			clusterID = *cluster.ID
-			registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+			registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 		})
 
 		Context("NTP cases", func() {
@@ -2161,7 +2161,7 @@ var _ = Describe("cluster install", func() {
 			By("Download before upload")
 			{
 
-				nodes, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+				nodes, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 				file, err := ioutil.TempFile("", "tmp")
 				Expect(err).NotTo(HaveOccurred())
 				_, err = userBMClient.Installer.V2DownloadClusterLogs(ctx, &installer.V2DownloadClusterLogsParams{ClusterID: clusterID, HostID: nodes[1].ID}, file)
@@ -2173,7 +2173,7 @@ var _ = Describe("cluster install", func() {
 			{
 				kubeconfigFile, err := os.Open("test_kubeconfig")
 				Expect(err).NotTo(HaveOccurred())
-				_, _ = register3nodes(ctx, clusterID, defaultCIDRv4)
+				_, _ = register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 				_, err = agentBMClient.Installer.V2UploadLogs(ctx, &installer.V2UploadLogsParams{ClusterID: clusterID, LogsType: string(models.LogsTypeController), Upfile: kubeconfigFile})
 				Expect(err).NotTo(HaveOccurred())
 				logsType := string(models.LogsTypeController)
@@ -2190,7 +2190,7 @@ var _ = Describe("cluster install", func() {
 			{
 				kubeconfigFile, err := os.Open("test_kubeconfig")
 				Expect(err).NotTo(HaveOccurred())
-				hosts, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+				hosts, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 				_, err = agentBMClient.Installer.UploadHostLogs(ctx, &installer.UploadHostLogsParams{ClusterID: clusterID, HostID: *hosts[0].ID, Upfile: kubeconfigFile})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -2213,7 +2213,7 @@ var _ = Describe("cluster install", func() {
 				cmd := exec.Command("head", "-c", "200MB", "/dev/urandom")
 				err = cmd.Run()
 				Expect(err).NotTo(HaveOccurred())
-				nodes, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+				nodes, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 				// test hosts logs
 				kubeconfigFile, err := os.Open(filePath)
 				Expect(err).NotTo(HaveOccurred())
@@ -2252,7 +2252,7 @@ var _ = Describe("cluster install", func() {
 		})
 
 		It("Download cluster logs", func() {
-			nodes, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+			nodes, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 			for _, host := range nodes {
 				kubeconfigFile, err := os.Open("test_kubeconfig")
 				Expect(err).NotTo(HaveOccurred())
@@ -2893,7 +2893,7 @@ spec:
 
 		checkUpdateAtWhileStatic(ctx, clusterID)
 
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		newIPs := hostutil.GenerateIPv4Addresses(2, ips[2])
 		h4 := &registerHost(clusterID).Host
 		h5 := registerNode(ctx, clusterID, "h5", newIPs[0])
@@ -3219,7 +3219,7 @@ spec:
 	It("unique_hostname_validation", func() {
 		clusterID := *cluster.ID
 		//define h1 as known master
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		_, err := userBMClient.Installer.V2UpdateHost(ctx, &installer.V2UpdateHostParams{
 			HostUpdateParams: &models.HostUpdateParams{
 				HostRole: swag.String(string(models.HostRoleMaster)),
@@ -3338,7 +3338,7 @@ spec:
 		localhost := "localhost"
 		clusterID := *cluster.ID
 
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		_, err := userBMClient.Installer.V2UpdateHost(ctx, &installer.V2UpdateHostParams{
 			HostUpdateParams: &models.HostUpdateParams{
 				HostRole: swag.String(string(models.HostRoleMaster)),
@@ -3384,7 +3384,7 @@ spec:
 
 	It("different_roles_stages", func() {
 		clusterID := *cluster.ID
-		registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+		registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 		c := installCluster(clusterID)
 		Expect(len(c.Hosts)).Should(Equal(5))
 
@@ -3406,7 +3406,7 @@ spec:
 
 	It("set_requested_hostnames", func() {
 		clusterID := *cluster.ID
-		hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+		hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 		_, err := userBMClient.Installer.V2UpdateHost(ctx, &installer.V2UpdateHostParams{
 			HostUpdateParams: &models.HostUpdateParams{
 				HostRole: swag.String(string(models.HostRoleMaster)),
@@ -3669,7 +3669,7 @@ var _ = Describe("cluster install, with default network params", func() {
 
 	It("install cluster", func() {
 		clusterID := *cluster.ID
-		registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+		registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 		rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
 		c := rep.GetPayload()
@@ -3700,7 +3700,7 @@ var _ = Describe("cluster install, with default network params", func() {
 	Context("fail disk speed", func() {
 		It("first host", func() {
 			clusterID := *cluster.ID
-			registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+			registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 			rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
 			c := rep.GetPayload()
@@ -3712,7 +3712,7 @@ var _ = Describe("cluster install, with default network params", func() {
 		})
 		It("all hosts", func() {
 			clusterID := *cluster.ID
-			registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+			registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 			rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
 			c := rep.GetPayload()
@@ -3724,7 +3724,7 @@ var _ = Describe("cluster install, with default network params", func() {
 		})
 		It("last host", func() {
 			clusterID := *cluster.ID
-			registerHostsAndSetRoles(clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
+			registerHostsAndSetRoles(clusterID, clusterID, 5, cluster.Name, cluster.BaseDNSDomain)
 			rep, err := userBMClient.Installer.GetCluster(ctx, &installer.GetClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
 			c := rep.GetPayload()
@@ -3778,14 +3778,14 @@ var _ = Describe("Verify ISO is deleted on cluster de-registration", func() {
 	})
 })
 
-func registerHostsAndSetRoles(clusterID strfmt.UUID, numHosts int, clusterName string, baseDNSDomain string) []*models.Host {
+func registerHostsAndSetRoles(clusterID, infraenvID strfmt.UUID, numHosts int, clusterName string, baseDNSDomain string) []*models.Host {
 	ctx := context.Background()
 	hosts := make([]*models.Host, 0)
 
 	ips := hostutil.GenerateIPv4Addresses(numHosts, defaultCIDRv4)
 	for i := 0; i < numHosts; i++ {
 		hostname := fmt.Sprintf("h%d", i)
-		host := registerNode(ctx, clusterID, hostname, ips[i])
+		host := registerNode(ctx, infraenvID, hostname, ips[i])
 		var role models.HostRole
 		if i < 3 {
 			role = models.HostRoleMaster
@@ -3797,7 +3797,7 @@ func registerHostsAndSetRoles(clusterID strfmt.UUID, numHosts int, clusterName s
 				HostRole: swag.String(string(role)),
 			},
 			HostID:     *host.ID,
-			InfraEnvID: clusterID,
+			InfraEnvID: infraenvID,
 		})
 		Expect(err).NotTo(HaveOccurred())
 		hosts = append(hosts, host)

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -149,7 +149,7 @@ spec:
 		clusterID := *cluster.ID
 
 		By("install cluster", func() {
-			registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+			registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 			reply, err := userBMClient.Installer.InstallCluster(context.Background(), &installer.InstallClusterParams{ClusterID: clusterID})
 			Expect(err).NotTo(HaveOccurred())
 			c := reply.GetPayload()
@@ -444,7 +444,7 @@ spec:
 				By("install cluster", func() {
 
 					generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-					registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+					registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 					reply, err := userBMClient.Installer.InstallCluster(ctx, &installer.InstallClusterParams{ClusterID: clusterID})
 					Expect(err).NotTo(HaveOccurred())
 					c := reply.GetPayload()

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Metrics tests", func() {
 
 		BeforeEach(func() {
 			//start host installation process
-			registerHostsAndSetRoles(clusterID, 3, "test-cluster", "example.com")
+			registerHostsAndSetRoles(clusterID, clusterID, 3, "test-cluster", "example.com")
 			c = installCluster(clusterID)
 			for _, host := range c.Hosts {
 				waitForHostState(ctx, clusterID, "installing", defaultWaitForHostStateTimeout, host)
@@ -1025,7 +1025,7 @@ var _ = Describe("Metrics tests", func() {
 		It("'all-hosts-are-ready-to-install' failed", func() {
 
 			// create a validation success
-			hosts, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+			hosts, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 			c := getCluster(clusterID)
 			for _, h := range c.Hosts {
 				generateDomainResolution(ctx, h, "test-cluster", "example.com")
@@ -1056,7 +1056,7 @@ var _ = Describe("Metrics tests", func() {
 		It("'all-hosts-are-ready-to-install' got fixed", func() {
 
 			// create a validation failure
-			hosts, ips := register3nodes(ctx, clusterID, defaultCIDRv4)
+			hosts, ips := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 			c := getCluster(clusterID)
 			for _, h := range c.Hosts {
 				generateDomainResolution(ctx, h, "test-cluster", "example.com")
@@ -1088,7 +1088,7 @@ var _ = Describe("Metrics tests", func() {
 		It("'sufficient-masters-count' failed", func() {
 
 			// create a validation success
-			hosts, _ := register3nodes(ctx, clusterID, defaultCIDRv4)
+			hosts, _ := register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 			waitForClusterValidationStatus(clusterID, "success", models.ClusterValidationIDSufficientMastersCount)
 
 			oldChangedMetricCounter := getValidationMetricCounter(string(models.ClusterValidationIDSufficientMastersCount), clusterValidationChangedMetric)
@@ -1113,7 +1113,7 @@ var _ = Describe("Metrics tests", func() {
 			waitForClusterValidationStatus(clusterID, "failure", models.ClusterValidationIDSufficientMastersCount)
 
 			// create a validation success
-			register3nodes(ctx, clusterID, defaultCIDRv4)
+			register3nodes(ctx, clusterID, clusterID, defaultCIDRv4)
 			waitForClusterValidationStatus(clusterID, "success", models.ClusterValidationIDSufficientMastersCount)
 
 			// check generated events

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -267,7 +267,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			clusterID = cID
 			// in order to simulate infra env generation
 			generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-			registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+			registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 		})
 
 		It("All OLM operators available", func() {
@@ -326,7 +326,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			clusterID = cID
 			// in order to simulate infra env generation
 			generateClusterISO(clusterID, models.ImageTypeMinimalIso)
-			registerHostsAndSetRoles(clusterID, minHosts, "test-cluster", "example.com")
+			registerHostsAndSetRoles(clusterID, clusterID, minHosts, "test-cluster", "example.com")
 		})
 
 		It("All OLM operators available", func() {

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -442,8 +442,8 @@ func generateEssentialPrepareForInstallationSteps(ctx context.Context, hosts ...
 	}
 }
 
-func registerNode(ctx context.Context, clusterID strfmt.UUID, name, ip string) *models.Host {
-	h := &registerHost(clusterID).Host
+func registerNode(ctx context.Context, infraenvID strfmt.UUID, name, ip string) *models.Host {
+	h := &registerHost(infraenvID).Host
 	generateEssentialHostSteps(ctx, h, name, ip)
 	generateEssentialPrepareForInstallationSteps(ctx, h)
 	return h
@@ -547,11 +547,11 @@ func v2UpdateVipParams(ctx context.Context, clusterID strfmt.UUID) {
 	Expect(err).ShouldNot(HaveOccurred())
 }
 
-func register3nodes(ctx context.Context, clusterID strfmt.UUID, cidr string) ([]*models.Host, []string) {
+func register3nodes(ctx context.Context, clusterID, infraenvID strfmt.UUID, cidr string) ([]*models.Host, []string) {
 	ips := hostutil.GenerateIPv4Addresses(3, cidr)
-	h1 := registerNode(ctx, clusterID, "h1", ips[0])
-	h2 := registerNode(ctx, clusterID, "h2", ips[1])
-	h3 := registerNode(ctx, clusterID, "h3", ips[2])
+	h1 := registerNode(ctx, infraenvID, "h1", ips[0])
+	h2 := registerNode(ctx, infraenvID, "h2", ips[1])
+	h3 := registerNode(ctx, infraenvID, "h3", ips[2])
 	updateVipParams(ctx, clusterID)
 	generateFullMeshConnectivity(ctx, ips[0], h1, h2, h3)
 


### PR DESCRIPTION
Prepare for converting tests to use v2 RegisterCluster by making sure that all register host utilities in subsystem use infraEnvID for host manipulation and clusterID for cluster manipulation.

Right now the same ID serves for both purposes, but this will change with the main PR that will introduce the new cluster/infraenv flow

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
