### PR TITLE
MGMT-8582: Leader elector based on lease lock

### DIFF
--- a/subsystem/leader_test.go
+++ b/subsystem/leader_test.go
@@ -10,6 +10,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/pkg/leader"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -123,7 +125,8 @@ var _ = Describe("Leader tests", func() {
 		return
 	}
 
-	configMapName := "leader-test"
+	ctx := context.Background()
+	lockName := "leader-test"
 
 	kubeconfig := getKubeconfig()
 	if kubeconfig == "" {
@@ -150,6 +153,8 @@ var _ = Describe("Leader tests", func() {
 		for _, test := range tests {
 			test.stop()
 		}
+		_ = client.CoordinationV1().Leases(namespace).Delete(ctx, lockName, metav1.DeleteOptions{})
+		_ = client.CoreV1().ConfigMaps(namespace).Delete(ctx, lockName, metav1.DeleteOptions{})
 	})
 
 	BeforeEach(func() {
@@ -157,9 +162,9 @@ var _ = Describe("Leader tests", func() {
 	})
 
 	It("Leader test", func() {
-		leader1 := leader.NewElector(client, cf, configMapName, log)
-		leader2 := leader.NewElector(client, cf, configMapName, log)
-		leader3 := leader.NewElector(client, cf, configMapName, log)
+		leader1 := leader.NewElector(client, cf, lockName, log)
+		leader2 := leader.NewElector(client, cf, lockName, log)
+		leader3 := leader.NewElector(client, cf, lockName, log)
 
 		test1 := NewTest(leader1, "leader_1")
 		test2 := NewTest(leader2, "leader_2")
@@ -205,37 +210,69 @@ var _ = Describe("Leader tests", func() {
 
 	})
 
-	It("Bad config map name", func() {
-		By("Adding leader with bad configmap name, must fail. Will be the same for any configmap create error")
-		badConfigMap := leader.NewElector(client, cf, "badConfigMapName", log)
-		err := badConfigMap.StartLeaderElection(context.Background())
+	It("cleaning old leader lock configmap", func() {
+		By("create old lock config map and another one")
+		oldcm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      lockName,
+				Namespace: namespace,
+			},
+		}
+		othercm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-cm",
+				Namespace: namespace,
+			},
+		}
+		_, err := client.CoreV1().ConfigMaps(namespace).Create(ctx, oldcm, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = client.CoreV1().ConfigMaps(namespace).Create(ctx, othercm, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("create election leader")
+		leader := leader.NewElector(client, cf, lockName, log)
+		t := NewTest(leader, "leader_1")
+		tests = append(tests, t)
+		t.start()
+
+		By("verify that the old lock configmap is cleared but other configmaps are not")
+		_, err = client.CoreV1().ConfigMaps(namespace).Get(ctx, lockName, metav1.GetOptions{})
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		_, err = client.CoreV1().ConfigMaps(namespace).Get(ctx, "other-cm", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Bad lease name", func() {
+		By("Adding a leader with mismatched lock name and underlying resource")
+		leaderWithWrongResource := leader.NewElector(client, cf, "BADNAME", log)
+		err := leaderWithWrongResource.StartLeaderElection(ctx)
 		Expect(err).Should(HaveOccurred())
 	})
 
-	It("Test 2 leaders in parallel with different config map", func() {
-		leader1 := leader.NewElector(client, cf, configMapName, log)
+	It("Test 2 leaders in parallel with different leases", func() {
+		leader1 := leader.NewElector(client, cf, lockName, log)
 		test1 := NewTest(leader1, "leader_1")
 		tests = append(tests, test1)
 		test1.start()
 		waitForPredicate(timeout, test1.isLeader)
-		By("Adding leader with another configmap, must become a leader")
-		anotherConfigMap := leader.NewElector(client, cf, "another-config-map", log)
-		anotherConfigMapTest := NewTest(anotherConfigMap, "another-config-map")
-		tests = append(tests, anotherConfigMapTest)
-		anotherConfigMapTest.start()
-		waitForPredicate(timeout, anotherConfigMapTest.isLeader)
+		By("Adding leader with another lease, must become a leader")
+		anotherLease := leader.NewElector(client, cf, "another-lease", log)
+		anotherLeaseTest := NewTest(anotherLease, "another-lease")
+		tests = append(tests, anotherLeaseTest)
+		anotherLeaseTest.start()
+		waitForPredicate(timeout, anotherLeaseTest.isLeader)
 		log.Infof("Verify that previous leader was not changed")
 		waitForPredicate(timeout, test1.isLeader)
 	})
-	It("Deleting configmap in a loop", func() {
-		By("Deleting configmap in a loop (it must be recreated all the time), leader will loose leader and retake it")
-		leader1 := leader.NewElector(client, cf, configMapName, log)
+	It("Deleting lock underlying resource in a loop", func() {
+		By("Deleting leases in a loop (it must be recreated all the time), leader will loose leader and retake it")
+		leader1 := leader.NewElector(client, cf, lockName, log)
 		test1 := NewTest(leader1, "leader_1")
 		tests = append(tests, test1)
 		test1.start()
 		wasLost := false
 		for i := 0; i < 300; i++ {
-			_ = client.CoreV1().ConfigMaps(namespace).Delete(context.TODO(), configMapName, metav1.DeleteOptions{})
+			_ = client.CoordinationV1().Leases(namespace).Delete(ctx, lockName, metav1.DeleteOptions{})
 			if !test1.isLeader() {
 				wasLost = true
 				break
@@ -248,8 +285,8 @@ var _ = Describe("Leader tests", func() {
 	})
 	It("Verify run with leader", func() {
 		index := 0
-		leader1 := leader.NewElector(client, cf, configMapName, log)
-		leader2 := leader.NewElector(client, cf, configMapName, log)
+		leader1 := leader.NewElector(client, cf, lockName, log)
+		leader2 := leader.NewElector(client, cf, lockName, log)
 		test1 := NewTest(leader1, "leader_1")
 		tests = []*Test{test1}
 
@@ -260,7 +297,7 @@ var _ = Describe("Leader tests", func() {
 		By("leader2 run with leader, verify it waiting")
 
 		go func() {
-			err := leader2.RunWithLeader(context.Background(), func() error {
+			err := leader2.RunWithLeader(ctx, func() error {
 				index += 1
 				return nil
 			})


### PR DESCRIPTION
A leader is currently locked over ConfigMap resource. This kind of
locking mechanism is deprecated in favor of using Leases

Replace the lock with LeaseLock and clear any configmaps
that were previously being used for the locking mechanism

RBAC permissions were submitted in an earleir PR to
ensure framework readiness

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
