### PR TITLE
MGMT-9233: set MachineConfigPoolName for day2

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6122,6 +6122,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 	//day2 host is always a worker
 	if hostutil.IsDay2Host(host) {
 		host.Role = models.HostRoleWorker
+		host.MachineConfigPoolName = string(models.HostRoleWorker)
 	}
 
 	if err = b.hostApi.RegisterHost(ctx, host, tx); err != nil {

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -396,9 +396,11 @@ var _ = Describe("Day2 cluster tests", func() {
 		h1 = getHostV2(infraEnvID, *h1.ID)
 		Expect(*h1.Status).Should(Equal("insufficient"))
 		Expect(h1.Role).Should(Equal(models.HostRoleWorker))
+		Expect(h1.MachineConfigPoolName).Should(Equal(string(models.HostRoleWorker)))
 		h2 = getHostV2(infraEnvID, *h2.ID)
 		Expect(*h2.Status).Should(Equal("insufficient"))
 		Expect(h2.Role).Should(Equal(models.HostRoleWorker))
+		Expect(h2.MachineConfigPoolName).Should(Equal(string(models.HostRoleWorker)))
 
 		c := getCluster(clusterID)
 		Expect(*c.Status).Should(Equal("adding-hosts"))


### PR DESCRIPTION
In V2RegisterHost day2 flow, MachineConfigPoolName was previously set to worker only if the role was auto-assign.
As we set role to worker in day2 flow, fixed it by setting MachineConfigPoolName explicitly to worker when the host is registered.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
