### PR TITLE
Fix disk encryption role error in day2

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6288,6 +6288,12 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		c = &cluster.Cluster
 	}
 
+	//day2 host is always a worker
+	if hostutil.IsDay2Host(host) {
+		host.Role = models.HostRoleWorker
+		host.MachineConfigPoolName = string(models.HostRoleWorker)
+	}
+
 	if err = b.hostApi.RegisterHost(ctx, host, tx); err != nil {
 		log.WithError(err).Errorf("failed to register host <%s> infra-env <%s>",
 			params.NewHostParams.HostID.String(), params.InfraEnvID.String())

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -393,11 +393,9 @@ func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) Va
 		return ValidationPending
 	}
 
-	role := common.GetEffectiveRole(c.host)
-	if role == models.HostRoleAutoAssign {
-		return ValidationPending
-	}
-
+	//day2 validation is taking the disk encryption data solely from
+	//the host inventory and set the diskEncryption field on the cluster
+	//according to that information
 	if hostutil.IsDay2Host(c.host) {
 		luks, err := v.getDiskEncryptionForDay2(c.host)
 		if err != nil {
@@ -421,6 +419,13 @@ func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) Va
 			// Only Tpm2 and Tang are available for disk encryption
 			return ValidationFailure
 		}
+	}
+
+	//day 1 validation is relying on the host's role and the user
+	//configuration to check if the disk encryption setup is valid
+	role := common.GetEffectiveRole(c.host)
+	if role == models.HostRoleAutoAssign {
+		return ValidationPending
 	}
 
 	if !isDiskEncryptionEnabledForRole(*c.cluster.DiskEncryption, role) {

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -395,10 +395,12 @@ var _ = Describe("Day2 cluster tests", func() {
 
 		h1 = getHostV2(infraEnvID, *h1.ID)
 		Expect(*h1.Status).Should(Equal("insufficient"))
-		Expect(h1.Role).Should(Equal(models.HostRoleAutoAssign))
+		Expect(h1.Role).Should(Equal(models.HostRoleWorker))
+		Expect(h1.MachineConfigPoolName).Should(Equal(string(models.HostRoleWorker)))
 		h2 = getHostV2(infraEnvID, *h2.ID)
 		Expect(*h2.Status).Should(Equal("insufficient"))
-		Expect(h2.Role).Should(Equal(models.HostRoleAutoAssign))
+		Expect(h2.Role).Should(Equal(models.HostRoleWorker))
+		Expect(h1.MachineConfigPoolName).Should(Equal(string(models.HostRoleWorker)))
 
 		c := getCluster(clusterID)
 		Expect(*c.Status).Should(Equal("adding-hosts"))
@@ -802,10 +804,10 @@ var _ = Describe("[V2UpdateCluster] Day2 cluster tests", func() {
 
 		h1 = getHostV2(infraEnvID, *h1.ID)
 		Expect(*h1.Status).Should(Equal("insufficient"))
-		Expect(h1.Role).Should(Equal(models.HostRoleAutoAssign))
+		Expect(h1.Role).Should(Equal(models.HostRoleWorker))
 		h2 = getHostV2(infraEnvID, *h2.ID)
 		Expect(*h2.Status).Should(Equal("insufficient"))
-		Expect(h2.Role).Should(Equal(models.HostRoleAutoAssign))
+		Expect(h2.Role).Should(Equal(models.HostRoleWorker))
 
 		c := getCluster(clusterID)
 		Expect(*c.Status).Should(Equal("adding-hosts"))
@@ -1071,10 +1073,11 @@ var _ = Describe("Installation progress", func() {
 			infraEnvID = *res.GetPayload().ID
 
 			// register host to be used by the test as day2 host
+			// day2 host is now initialized as a worker
 			registerHost(infraEnvID)
 			c = getCluster(*c.ID)
 
-			Expect(c.Hosts[0].ProgressStages).To(BeEmpty())
+			Expect(c.Hosts[0].ProgressStages).To(Equal(hostpkg.WorkerStages[:5]))
 			Expect(c.Hosts[0].Progress.InstallationPercentage).To(Equal(int64(0)))
 			expectProgressToBe(c, 0, 0, 0)
 		})
@@ -1178,10 +1181,11 @@ var _ = Describe("Installation progress", func() {
 			infraEnvID = *res.GetPayload().ID
 
 			// register host to be used by the test as day2 host
+			// day2 host is now initialized as a worker
 			registerHost(infraEnvID)
 			c = getCluster(*c.ID)
 
-			Expect(c.Hosts[0].ProgressStages).To(BeEmpty())
+			Expect(c.Hosts[0].ProgressStages).To(Equal(hostpkg.WorkerStages[:5]))
 			Expect(c.Hosts[0].Progress.InstallationPercentage).To(Equal(int64(0)))
 		})
 


### PR DESCRIPTION
This hotfix contains to fixed in master:
-  [MGMT-9233](https://issues.redhat.com/browse/MGMT-9233): set MachineConfigPoolName for day2
-  [MGMT-9233](https://issues.redhat.com/browse/MGMT-9233): disk validation fails for day2 hosts


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
