### PR TITLE
MGMT-9223: Automatic agent inventory labels

### DIFF
--- a/docs/hive-integration/agent-labels.md
+++ b/docs/hive-integration/agent-labels.md
@@ -1,0 +1,18 @@
+# Agent Inventory Labels
+
+The operator automatically adds labels to each Agent CR based on its inventory.  The goal of these labels is to allow for easily filtering Agents based on these properties.
+
+These labels describe the Agent inventory and not any higher-level usability.  For example, there are labels indicating that virtualization is enabled on the CPU (VMX or SVM CPU flags), but no label indicating that the host is suitable for running CNV.
+
+An annotation on the Agent CR indicates a version for the labels, so clients can anticipate what labels will be applied ("feature.agent-install.openshift.io/version").
+
+## Label list
+Labels marked as boolean will have either the string "true" or "false".
+
+### v0.1
+* feature.agent-install.openshift.io/storage-hasnonrotationaldisk (boolean): Indicates if the Agent has at least one SSD
+* feature.agent-install.openshift.io/cpu-architecture (string): The CPU architecture (e.g., x86_64, arm64)
+* feature.agent-install.openshift.io/cpu-virtenabled (boolean): Indicates if the CPU has the virtualization flag (VMX or SVM)
+* feature.agent-install.openshift.io/host-manufacturer (string): The host's manufacturer
+* feature.agent-install.openshift.io/host-productname (string): The host's product name
+* feature.agent-install.openshift.io/host-isvirtual (boolean): Indicates if the host is a virtual machine

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,7 +55,9 @@ import (
 )
 
 const (
-	AgentFinalizerName = "agent." + aiv1beta1.Group + "/ai-deprovision"
+	AgentFinalizerName      = "agent." + aiv1beta1.Group + "/ai-deprovision"
+	InventoryLabelPrefix    = "inventory." + aiv1beta1.Group + "/"
+	InventoryHashAnnotation = InventoryLabelPrefix + "inventoryHash"
 )
 
 // AgentReconciler reconciles a Agent object
@@ -94,6 +97,13 @@ func (r *AgentReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get resource %s", req.NamespacedName)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if agent.ObjectMeta.Annotations == nil {
+		agent.ObjectMeta.Annotations = make(map[string]string)
+	}
+	if agent.ObjectMeta.Labels == nil {
+		agent.ObjectMeta.Labels = make(map[string]string)
 	}
 
 	if agent.ObjectMeta.DeletionTimestamp.IsZero() { // agent not being deleted
@@ -819,7 +829,29 @@ func (r *AgentReconciler) updateInventory(log logrus.FieldLogger, host *models.H
 			}
 		}
 	}
+
+	updateInventoryLabels(agent)
 	return nil
+}
+
+func updateInventoryLabels(agent *aiv1beta1.Agent) {
+	inventory := agent.Status.Inventory
+	hasSSD := false
+	for _, d := range inventory.Disks {
+		if d.DriveType == "SSD" {
+			hasSSD = true
+			break
+		}
+	}
+	hasVirt := funk.Contains(inventory.Cpu.Flags, "vmx") || funk.Contains(inventory.Cpu.Flags, "svm")
+
+	agent.ObjectMeta.Annotations[InventoryLabelPrefix+"version"] = "0.1"
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"storage-hasnonrotationaldisk"] = strconv.FormatBool(hasSSD)
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-architecture"] = inventory.Cpu.Architecture
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-virtenabled"] = strconv.FormatBool(hasVirt)
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-manufacturer"] = inventory.SystemVendor.Manufacturer
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-productname"] = inventory.SystemVendor.ProductName
+	agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-isvirtual"] = strconv.FormatBool(inventory.SystemVendor.Virtual)
 }
 
 func (r *AgentReconciler) updateHostIgnition(ctx context.Context, log logrus.FieldLogger, host *common.Host, agent *aiv1beta1.Agent) error {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1036,6 +1036,15 @@ var _ = Describe("agent reconcile", func() {
 		macAddress := "some MAC address"
 		hostId := strfmt.UUID(uuid.New().String())
 		inventory := models.Inventory{
+			CPU: &models.CPU{
+				Architecture: common.DefaultCPUArchitecture,
+				Flags:        []string{"vmx"},
+			},
+			SystemVendor: &models.SystemVendor{
+				Manufacturer: "Red Hat",
+				ProductName:  "RHEL",
+				Virtual:      true,
+			},
 			Interfaces: []*models.Interface{
 				{
 					Name: "eth0",
@@ -1049,8 +1058,8 @@ var _ = Describe("agent reconcile", func() {
 				},
 			},
 			Disks: []*models.Disk{
-				{Path: "/dev/sda", Bootable: true},
-				{Path: "/dev/sdb", Bootable: false},
+				{Path: "/dev/sda", Bootable: true, DriveType: "HDD"},
+				{Path: "/dev/sdb", Bootable: false, DriveType: "HDD"},
 			},
 		}
 		inv, _ := json.Marshal(&inventory)
@@ -1072,7 +1081,7 @@ var _ = Describe("agent reconcile", func() {
 		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
-		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())
@@ -1088,6 +1097,17 @@ var _ = Describe("agent reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Reason).To(Equal(v1beta1.SyncedOkReason))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Status).To(Equal(corev1.ConditionTrue))
 		Expect(agent.Status.Inventory.Interfaces[0].MacAddress).To(Equal(macAddress))
+		Expect(agent.ObjectMeta.Annotations[InventoryLabelPrefix+"version"]).To(Equal("0.1"))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"storage-hasnonrotationaldisk"]).To(Equal("false"))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-architecture"]).To(Equal(common.DefaultCPUArchitecture))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-virtenabled"]).To(Equal("true"))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-manufacturer"]).To(Equal("Red Hat"))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-productname"]).To(Equal("RHEL"))
+		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-isvirtual"]).To(Equal("true"))
+
+		result, err = hr.Reconcile(ctx, newHostRequest(host))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
 	It("Agent ntp sources, role, bootstrap status", func() {


### PR DESCRIPTION
First, set an annotation with the inventory hash so that it is not computed on every single reconcile.
    
Second, add 3 inventory-based labels as a starting point:
1. storage-nonrotationaldisk (boolean): true if host has at least 1 SSD, aligns to NFD
2. cpu-architecture (string): The host's CPU architecture, does not exist in NFD
3. cpu-virtsupport (boolean): true if the CPU has the VMX or SVM flag on, does not exist in NFD
    
Third, add a label version annotation currently set at 0.1 so that clients can know what labels to expect.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
