### PR TITLE
NO-ISSUE: OKD: expand /var if its less than 6GB

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -152,7 +152,10 @@ mkdir ${tmpd}/{upper,work}
 mount -t overlay -o lowerdir=/usr,upperdir=${tmpd}/upper,workdir=${tmpd}/work overlay /usr
 rpm -Uvh /tmp/rpms/*
 podman rmi -f "${RPMS_IMAGE}"
-# Expand /var to 6G (3.2G on 16GB VM in insufficient)
+# Expand /var to 6G if necessary
+if (( $(stat -c%%s /run/ephemeral.xfsloop) > 6*1024*1024*1024 )); then
+  exit 0
+fi
 /bin/truncate -s 6G /run/ephemeral.xfsloop
 losetup -c /dev/loop0
 xfs_growfs /var


### PR DESCRIPTION
16GB VM creates 3.2GB /var partition. Larger nodes however create bigger partitions, so downsizing /var to 6GB breaks the install. This commit ensures that we resize /var only if necessary

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)
  https://kubernetes.slack.com/archives/C6AD6JM17/p1644846272611069

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @romfreiman 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
