### PR TITLE
MGMT-9131: Remove V1 GetClusterHostRequirements, GetPreflightRequirements, ListManagedDomains, ListComponentVersions, ListSupportedOpenshiftVersions

### DIFF
--- a/docs/user-guide/rest-api-v1-v2-transition-guide.md
+++ b/docs/user-guide/rest-api-v1-v2-transition-guide.md
@@ -106,15 +106,18 @@ DeregisterHost | DELETE /v1/clusters/{cluster_id}/hosts/{host_id} |	DELETE /v2/i
 
 
 #### Misc Host APIs
-Operation ID            | V1                                                                                       | V2                                                      | Notes
-------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------|------------------------------------
-UpdateHostInstallerArgs | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args                           | PATCH /v2/infra-envs/{infra_env_id}/hosts/{host_id}/installer-args	| Moved from Cluster to InfraEnv
-EnableHost              | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable	                           | N/A                                                                | Deprecated in favor of `BindHost`
-DisableHost	            | DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable                          | N/A                                                                | Deprecated in favor of `UnbindHost`
-InstallHost	            | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install                           | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/install	| Moved from Cluster to InfraEnv
-ResetHost	            | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset	                           | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/reset	| Moved from Cluster to InfraEnv
-ResetHostValidation	    | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id} | N/A				                                             	|
-UpdateHostIgnition	    | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition	                               | PATCH /v2/infra-envs/{infra_env_id}/hosts/{host_id}/ignition	    | Moved from Cluster to InfraEnv
-GetHostIgnition	        | GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition	                               | GET /v2/infra-envs/{infra_env_id}/hosts/{host_id}/ignition	    	| Moved from Cluster to InfraEnv
-BindHost	            | N/A                                                                                      | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/bind    |
-UnbindHost	            | N/A                                                                                      | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/unbind  |
+Operation ID                   | V1                                                                                       | V2                                                                 | Notes
+-------------------------------|------------------------------------------------------------------------------------------|--------------------------------------------------------------------|------------------------------------
+UpdateHostInstallerArgs        | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/installer-args                           | PATCH /v2/infra-envs/{infra_env_id}/hosts/{host_id}/installer-args | Moved from Cluster to InfraEnv
+EnableHost                     | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable	                          | N/A                                                                | Deprecated in favor of `BindHost`
+DisableHost	                   | DELETE /v1/clusters/{cluster_id}/hosts/{host_id}/actions/enable                          | N/A                                                                | Deprecated in favor of `UnbindHost`
+InstallHost	                   | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/install                           | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/install | Moved from Cluster to InfraEnv
+ResetHost	                   | POST /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset	                          | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/reset   | Moved from Cluster to InfraEnv
+ResetHostValidation	           | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/actions/reset-validation/{validation_id} | N/A				                                             	   |
+UpdateHostIgnition	           | PATCH /v1/clusters/{cluster_id}/hosts/{host_id}/ignition	                              | PATCH /v2/infra-envs/{infra_env_id}/hosts/{host_id}/ignition	   | Moved from Cluster to InfraEnv
+GetHostIgnition	               | GET /v1/clusters/{cluster_id}/hosts/{host_id}/ignition	                                  | GET /v2/infra-envs/{infra_env_id}/hosts/{host_id}/ignition	       | Moved from Cluster to InfraEnv
+BindHost	                   | N/A                                                                                      | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/bind    |
+UnbindHost	                   | N/A                                                                                      | POST /v2/infra-envs/{infra_env_id}/hosts/{host_id}/actions/unbind  |
+ListManagedDomains             | GET /v1/domains                                                                          | GET /v2/domains                                                    |
+ListComponentVersions          | GET /v1/component-versions                                                               | GET /v2/component-versions                                         |
+ListSupportedOpenshiftVersions | GET /v1/openshift_versions                                                               | GET /v2/openshift-versions                                         |

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5344,25 +5344,11 @@ func (b *bareMetalInventory) GetHostByKubeKey(key types.NamespacedName) (*common
 }
 
 func (b *bareMetalInventory) GetClusterHostRequirements(ctx context.Context, params installer.GetClusterHostRequirementsParams) middleware.Responder {
-
-	cluster, err := b.getCluster(ctx, params.ClusterID.String(), common.UseEagerLoading)
-	if err != nil {
-		return common.GenerateErrorResponder(err)
-	}
-	requirementsList := models.ClusterHostRequirementsList{}
-	for _, clusterHost := range cluster.Hosts {
-		hostRequirements, err := b.hwValidator.GetClusterHostRequirements(ctx, cluster, clusterHost)
-		if err != nil {
-			return common.GenerateErrorResponder(err)
-		}
-		requirementsList = append(requirementsList, hostRequirements)
-	}
-
-	return installer.NewGetClusterHostRequirementsOK().WithPayload(requirementsList)
+	return common.NewApiError(http.StatusNotFound, errors.New(common.APINotFound))
 }
 
 func (b *bareMetalInventory) GetPreflightRequirements(ctx context.Context, params installer.GetPreflightRequirementsParams) middleware.Responder {
-	return b.V2GetPreflightRequirements(ctx, installer.V2GetPreflightRequirementsParams{ClusterID: params.ClusterID})
+	return common.NewApiError(http.StatusNotFound, errors.New(common.APINotFound))
 }
 
 func (b *bareMetalInventory) V2ResetHostValidation(ctx context.Context, params installer.V2ResetHostValidationParams) middleware.Responder {

--- a/internal/domains/managed_domains.go
+++ b/internal/domains/managed_domains.go
@@ -2,6 +2,7 @@ package domains
 
 import (
 	"context"
+	"net/http"
 	"regexp"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -34,19 +35,13 @@ func (h *Handler) parseDomainProvider(val string) (string, error) {
 }
 
 func (h *Handler) ListManagedDomains(ctx context.Context, params operations.ListManagedDomainsParams) middleware.Responder {
-	managedDomains, err := h.getManagedDomains()
-	if err != nil {
-		return operations.NewListManagedDomainsInternalServerError().
-			WithPayload(common.GenerateInternalFromError(err))
-	}
-
-	return operations.NewListManagedDomainsOK().WithPayload(managedDomains)
+	return common.NewApiError(http.StatusNotFound, errors.New(common.APINotFound))
 }
 
 func (h *Handler) V2ListManagedDomains(ctx context.Context, params operations.V2ListManagedDomainsParams) middleware.Responder {
 	managedDomains, err := h.getManagedDomains()
 	if err != nil {
-		return operations.NewListManagedDomainsInternalServerError().
+		return operations.NewV2ListManagedDomainsInternalServerError().
 			WithPayload(common.GenerateInternalFromError(err))
 	}
 

--- a/internal/domains/managed_domains_test.go
+++ b/internal/domains/managed_domains_test.go
@@ -24,9 +24,9 @@ var _ = Describe("list base domains", func() {
 			"example.com": "abc/route53",
 		}
 		h = NewHandler(baseDNSDomains)
-		reply := h.ListManagedDomains(context.Background(), operations.ListManagedDomainsParams{})
-		Expect(reply).Should(BeAssignableToTypeOf(operations.NewListManagedDomainsOK()))
-		val, _ := reply.(*operations.ListManagedDomainsOK)
+		reply := h.V2ListManagedDomains(context.Background(), operations.V2ListManagedDomainsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListManagedDomainsOK()))
+		val, _ := reply.(*operations.V2ListManagedDomainsOK)
 		domains := val.Payload
 		Expect(len(domains)).Should(Equal(1))
 		Expect(domains[0].Domain).Should(Equal("example.com"))
@@ -35,9 +35,9 @@ var _ = Describe("list base domains", func() {
 	It("empty", func() {
 		baseDNSDomains = map[string]string{}
 		h = NewHandler(baseDNSDomains)
-		reply := h.ListManagedDomains(context.Background(), operations.ListManagedDomainsParams{})
-		Expect(reply).Should(BeAssignableToTypeOf(operations.NewListManagedDomainsOK()))
-		val, _ := reply.(*operations.ListManagedDomainsOK)
+		reply := h.V2ListManagedDomains(context.Background(), operations.V2ListManagedDomainsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListManagedDomainsOK()))
+		val, _ := reply.(*operations.V2ListManagedDomainsOK)
 		domains := val.Payload
 		Expect(len(domains)).Should(Equal(0))
 	})
@@ -46,7 +46,7 @@ var _ = Describe("list base domains", func() {
 			"example.com": "abcroute53",
 		}
 		h = NewHandler(baseDNSDomains)
-		reply := h.ListManagedDomains(context.Background(), operations.ListManagedDomainsParams{})
-		Expect(reply).Should(BeAssignableToTypeOf(operations.NewListManagedDomainsInternalServerError()))
+		reply := h.V2ListManagedDomains(context.Background(), operations.V2ListManagedDomainsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListManagedDomainsInternalServerError()))
 	})
 })

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -3,6 +3,7 @@ package versions
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -77,7 +78,7 @@ type handler struct {
 }
 
 func (h *handler) ListComponentVersions(ctx context.Context, params operations.ListComponentVersionsParams) middleware.Responder {
-	return h.V2ListComponentVersions(ctx, operations.V2ListComponentVersionsParams{})
+	return common.NewApiError(http.StatusNotFound, errors.New(common.APINotFound))
 }
 
 func (h *handler) V2ListComponentVersions(ctx context.Context, params operations.V2ListComponentVersionsParams) middleware.Responder {
@@ -94,7 +95,7 @@ func (h *handler) V2ListComponentVersions(ctx context.Context, params operations
 }
 
 func (h *handler) ListSupportedOpenshiftVersions(ctx context.Context, params operations.ListSupportedOpenshiftVersionsParams) middleware.Responder {
-	return h.V2ListSupportedOpenshiftVersions(ctx, operations.V2ListSupportedOpenshiftVersionsParams{})
+	return common.NewApiError(http.StatusNotFound, errors.New(common.APINotFound))
 }
 
 func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params operations.V2ListSupportedOpenshiftVersionsParams) middleware.Responder {

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -134,7 +134,7 @@ var _ = Describe("list versions", func() {
 			Expect(envconfig.Process("test", &versions)).ShouldNot(HaveOccurred())
 			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.ListComponentVersions(context.Background(), operations.ListComponentVersionsParams{})
+			reply := h.V2ListComponentVersions(context.Background(), operations.V2ListComponentVersionsParams{})
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
 			val, _ := reply.(*operations.V2ListComponentVersionsOK)
 			Expect(val.Payload.Versions["assisted-installer-service"]).
@@ -152,7 +152,7 @@ var _ = Describe("list versions", func() {
 			Expect(envconfig.Process("test", &versions)).ShouldNot(HaveOccurred())
 			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.ListComponentVersions(context.Background(), operations.ListComponentVersionsParams{})
+			reply := h.V2ListComponentVersions(context.Background(), operations.V2ListComponentVersionsParams{})
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
 			val, _ := reply.(*operations.V2ListComponentVersionsOK)
 			Expect(val.Payload.Versions["assisted-installer-service"]).Should(Equal("self-version"))
@@ -186,7 +186,7 @@ var _ = Describe("list versions", func() {
 
 			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.ListSupportedOpenshiftVersions(context.Background(), operations.ListSupportedOpenshiftVersionsParams{})
+			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
 			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
 
@@ -233,7 +233,7 @@ var _ = Describe("list versions", func() {
 		It("missing release images", func() {
 			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{}, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.ListSupportedOpenshiftVersions(context.Background(), operations.ListSupportedOpenshiftVersionsParams{})
+			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
 			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
 			Expect(val.Payload).Should(BeEmpty())

--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -924,9 +924,9 @@ func listEvents(ctx context.Context, cli *client.AssistedInstall) error {
 }
 
 func listManagedDomains(ctx context.Context, cli *client.AssistedInstall) error {
-	_, err := cli.ManagedDomains.ListManagedDomains(
+	_, err := cli.ManagedDomains.V2ListManagedDomains(
 		ctx,
-		&managed_domains.ListManagedDomainsParams{})
+		&managed_domains.V2ListManagedDomainsParams{})
 	return err
 }
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -3566,9 +3566,9 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 	})
 
 	It("should be reported for cluster", func() {
-		params := installer.GetPreflightRequirementsParams{ClusterID: clusterID}
+		params := installer.V2GetPreflightRequirementsParams{ClusterID: clusterID}
 
-		response, err := userBMClient.Installer.GetPreflightRequirements(ctx, &params)
+		response, err := userBMClient.Installer.V2GetPreflightRequirements(ctx, &params)
 
 		Expect(err).ToNot(HaveOccurred())
 		requirements := response.GetPayload()

--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -29,7 +29,7 @@ var _ = Describe("system-test image tests", func() {
 	)
 
 	BeforeEach(func() {
-		resp, err := userBMClient.Versions.ListSupportedOpenshiftVersions(ctx, &versions.ListSupportedOpenshiftVersionsParams{})
+		resp, err := userBMClient.Versions.V2ListSupportedOpenshiftVersions(ctx, &versions.V2ListSupportedOpenshiftVersionsParams{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Payload).ShouldNot(BeEmpty())
 		ocpVersions = resp.Payload

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -142,8 +142,8 @@ func init() {
 
 	// Test on first openshift version. We can't test on latest because quay.io/openshift-release-dev/ocp-release-nightly
 	// is not public, so we would have to add PULL_SECRET env var as mandatory to access the quay.
-	if reply, err := userBMClient.Versions.ListSupportedOpenshiftVersions(context.Background(),
-		&versions.ListSupportedOpenshiftVersionsParams{}); err == nil {
+	if reply, err := userBMClient.Versions.V2ListSupportedOpenshiftVersions(context.Background(),
+		&versions.V2ListSupportedOpenshiftVersionsParams{}); err == nil {
 		for openshiftVersion = range reply.GetPayload() {
 			break
 		}

--- a/subsystem/versions_test.go
+++ b/subsystem/versions_test.go
@@ -10,8 +10,8 @@ import (
 
 var _ = Describe("[minimal-set]test versions", func() {
 	It("get versions list", func() {
-		reply, err := userBMClient.Versions.ListComponentVersions(context.Background(),
-			&versions.ListComponentVersionsParams{})
+		reply, err := userBMClient.Versions.V2ListComponentVersions(context.Background(),
+			&versions.V2ListComponentVersionsParams{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// service, agent, installer, controller
@@ -19,8 +19,8 @@ var _ = Describe("[minimal-set]test versions", func() {
 	})
 
 	It("get openshift versions list", func() {
-		reply, err := userBMClient.Versions.ListSupportedOpenshiftVersions(context.Background(),
-			&versions.ListSupportedOpenshiftVersionsParams{})
+		reply, err := userBMClient.Versions.V2ListSupportedOpenshiftVersions(context.Background(),
+			&versions.V2ListSupportedOpenshiftVersionsParams{})
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(reply.GetPayload())).To(BeNumerically(">=", 1))
 	})


### PR DESCRIPTION


This change does the following:
- Remove `GetClusterHostRequirements`: Deprecated in favor of `GetPreflightRequirements`.
- `GetPreflightRequirements`: changed to `v2GetPreflightRequirements`.
- `ListManagedDomains`: changed to `V2ListManagedDomains`.
- `ListComponentVersions`: changed to `v2ListComponentVersions`.
- `ListSupportedOpenshiftVersions`: changed to `v2ListSupportedOpenshiftVersions`.
- Updates the doc `rest-api-v1-v2-transition-guide.md`.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
