### PR TITLE
MGMT-9122: Remove DisableHost from subsystem

### DIFF
--- a/subsystem/host_test.go
+++ b/subsystem/host_test.go
@@ -563,27 +563,6 @@ var _ = Describe("Host tests", func() {
 		})
 	})
 
-	It("disable enable", func() {
-		host := &registerHost(clusterID).Host
-		_, err := userBMClient.Installer.DisableHost(ctx, &installer.DisableHostParams{
-			ClusterID: clusterID,
-			HostID:    *host.ID,
-		})
-		Expect(err).NotTo(HaveOccurred())
-		host = getHost(clusterID, *host.ID)
-		Expect(*host.Status).Should(Equal("disabled"))
-		Expect(len(getNextSteps(clusterID, *host.ID).Instructions)).Should(Equal(0))
-
-		_, err = userBMClient.Installer.EnableHost(ctx, &installer.EnableHostParams{
-			ClusterID: clusterID,
-			HostID:    *host.ID,
-		})
-		Expect(err).NotTo(HaveOccurred())
-		host = getHost(clusterID, *host.ID)
-		Expect(*host.Status).Should(Equal("discovering"))
-		Expect(len(getNextSteps(clusterID, *host.ID).Instructions)).ShouldNot(Equal(0))
-	})
-
 	It("register_same_host_id", func() {
 		hostID := strToUUID(uuid.New().String())
 		// register to cluster1


### PR DESCRIPTION
This is a pre-requisite code for removing V1 RegisterCluster.

EnableHost/DisableHost are APIs that were replaced in V2 by either unbinding to deregistration. Once we move to use V2 RegsiterCluster, the subsystem tests can no longer use those APIs.

This PR deletes the tests that aim to check EnableHost/DisableHost flow because we will soon remove those flows from the BE.

In other cases, DisableHost was used to induce an error. In these cases, the test generates another type of error instead or uses V2DergisterHost API to remove the host altogether.

V2UnbindHost API can not replace DisableHost because the InfraEnv in the tests is bound to a cluster. It is illegal to unbound a host from such an InfraEnv.

The coverage rate may be reduced by this PR, but this will be soon corrected by removing the DisableHost/EnableHost code from the BE.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
