### PR TITLE
MGMT-9416 - InfraEnv should not use any NMStateConfig if no selector is specified

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -201,6 +201,12 @@ func (r *InfraEnvReconciler) processNMStateConfig(ctx context.Context, log logru
 		return staticNetworkConfig, errors.Wrapf(err, "invalid label selector for InfraEnv %v", infraEnv)
 	}
 
+	if selector.Empty() {
+		// If the user didn't specify any labels, it's probably because they don't want any NMStateConfigs,
+		// not because they want *all of them*, so we return an empty slice.
+		return staticNetworkConfig, nil
+	}
+
 	nmStateConfigs := &aiv1beta1.NMStateConfigList{}
 	if err = r.List(ctx, nmStateConfigs, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return staticNetworkConfig, errors.Wrapf(err, "failed to list nmstate configs for InfraEnv %v", infraEnv)


### PR DESCRIPTION
Currently, an InfraEnv takes all nmstateconfigs in namespace if no
selector is specified

Original behavior:
1. Create an NMStateConfig
2. Create an InfraEnv without any selectors
3. Infraenv uses the NMStateConfig

New behavior:
1. Create an NMStateConfig
2. Create an InfraEnv without any selectors
3. Infraenv doesn't use the NMStateConfig

InfraEnv should not use any NMStateConfig if no NMStateConfig selectors
are specified on it

If the user didn't specify any labels, it's probably because they don't
want any NMStateConfigs, not because they want *all of them*.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @slaviered
/cc @nmagnezi

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md