### PR TITLE
MGMT-9110: v1 host related UpdateCluster to v2

### DIFF
--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -574,17 +574,13 @@ func getCluster(ctx context.Context, cli *client.AssistedInstall) error {
 }
 
 func updateCluster(ctx context.Context, cli *client.AssistedInstall) error {
+	dnsDomain := "a.com"
 	_, err := cli.Installer.UpdateCluster(
 		ctx,
 		&installer.UpdateClusterParams{
 			ClusterID: strfmt.UUID(uuid.New().String()),
 			ClusterUpdateParams: &models.ClusterUpdateParams{
-				HostsNames: []*models.ClusterUpdateParamsHostsNamesItems0{
-					{
-						Hostname: "test",
-						ID:       strfmt.UUID(uuid.New().String()),
-					},
-				},
+				BaseDNSDomain: &dnsDomain,
 			}})
 	return err
 }


### PR DESCRIPTION
This PR converts usages of UpdateCluster for host-related
parameters to v2 V2UpdateHost

- Tests that have exact parallels in v2 are removed
- Other tests are merged with v2 update host tests
- Setting hostname in v2 SNO should no longer return an error

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
