### PR TITLE
MGMT-9409: Use AdminKubeconfigSecretRef if available to get secret name

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -753,7 +753,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 
 	key := types.NamespacedName{
 		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
-		Name:      fmt.Sprintf(adminKubeConfigStringTemplate, cd.Name),
+		Name:      getClusterDeploymentAdminKubeConfigSecretName(cd),
 	}
 	isNonePlatform, propagateError, err := isNonePlatformCluster(ctx, r.Client, cd)
 	if err != nil {
@@ -1100,9 +1100,10 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 	if !installed {
 		return reconcileComplete{}
 	}
+
 	key := types.NamespacedName{
 		Namespace: agent.Spec.ClusterDeploymentName.Namespace,
-		Name:      fmt.Sprintf(adminKubeConfigStringTemplate, cd.Name),
+		Name:      getClusterDeploymentAdminKubeConfigSecretName(cd),
 	}
 
 	secret, err := getSecret(ctx, r.Client, r.APIReader, key)

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -3240,3 +3240,32 @@ var _ = Describe("selectClusterNetworkType", func() {
 		})
 	}
 })
+
+var _ = Describe("Getting ClusterDeployment admin kubeconfig secret name", func() {
+	var (
+		clusterName             = "test-cluster"
+		agentClusterInstallName = "test-cluster-aci"
+		pullSecretName          = "pull-secret"
+		adminSecretName         = "admin-secret"
+		defaultClusterSpec      hivev1.ClusterDeploymentSpec
+	)
+	defaultClusterSpec = getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName)
+	cd := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+	Context("ClusterMetadata.AdminKubeconfigSecretRef.Name is not present", func() {
+		It("can make secret name from template", func() {
+			Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(fmt.Sprintf(adminKubeConfigStringTemplate, cd.Name)))
+		})
+	})
+	Context("ClusterMetadata.AdminKubeconfigSecretRef.Name is present", func() {
+		BeforeEach(func() {
+			cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+				AdminKubeconfigSecretRef: corev1.LocalObjectReference{
+					Name: adminSecretName,
+				},
+			}
+		})
+		It("can extract the secret from ClusterDeployment", func() {
+			Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(adminSecretName))
+		})
+	})
+})


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

So far we're using a template to get the secret name that holds the admin kubeconfig for a ClusterDeployment, but if a ClusterDeployment has a field specifying a SecretName, we should read it and use it instead of the templated name

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eranco74 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
