### PR TITLE
MGMTBUGSM-112: validate ImageSetRef in ACI webhook

### DIFF
--- a/pkg/validating-webhooks/hiveextension/v1beta1/agentclusterinstall_admission_hook_test.go
+++ b/pkg/validating-webhooks/hiveextension/v1beta1/agentclusterinstall_admission_hook_test.go
@@ -199,6 +199,38 @@ var _ = Describe("ACI web validate", func() {
 			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
+		{
+			name: "Test AgentClusterInstall.Spec.ImageSetRef is immutable (updates not allowed)",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ImageSetRef: &hivev1.ClusterImageSetReference{Name: "someimage"},
+			},
+			conditions: []hivev1.ClusterInstallCondition{
+				{
+					Type:   hiveext.ClusterCompletedCondition,
+					Reason: hiveext.ClusterInstalledReason,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				ImageSetRef: &hivev1.ClusterImageSetReference{Name: "someotherimage"},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test AgentClusterInstall.Spec.ImageSetRef is immutable (delete not allowed)",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ImageSetRef: &hivev1.ClusterImageSetReference{Name: "someimage"},
+			},
+			conditions: []hivev1.ClusterInstallCondition{
+				{
+					Type:   hiveext.ClusterCompletedCondition,
+					Reason: hiveext.ClusterInstalledReason,
+				},
+			},
+			oldSpec:         hiveext.AgentClusterInstallSpec{},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
 	}
 
 	for i := range cases {


### PR DESCRIPTION
ImageSetRef is immutable after creating an AgentClusterInstall, hence, added a proper validation in the ValidatingAdmissionHook. When updating ImageSetRef an error as follows should be displayed:
admission webhook "agentclusterinstallvalidators.admission.agentinstall.openshift.io" denied the request: Attempted to change AgentClusterInstall.ImageSetRef which is immutable

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
