### PR TITLE
MGMT-9485: validate manifests names uniqueness specified in configmaps

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -997,6 +997,9 @@ func (r *ClusterDeploymentsReconciler) getClusterDeploymentManifest(ctx context.
 			}
 			// Add data to manifests map
 			for k, v := range configMap.Data {
+				if _, exists := configuredManifests[k]; exists {
+					return nil, errors.Errorf("Conflict in manifest names ('%s' is not unique)", k)
+				}
 				configuredManifests[k] = v
 			}
 		}

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3583,12 +3583,13 @@ spec:
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterBackendErrorReason)
 
 		By("Deploy bad config map")
-		data := map[string]string{"test.yaml": content, "test.dc": "test"}
-		cm1 := deployOrUpdateConfigMap(ctx, kubeClient, refs[0].Name, data)
+		data1 := map[string]string{"test1.yaml": content, "test.dc.1": "test"}
+		data2 := map[string]string{"test2.yaml": content, "test.dc.2": "test"}
+		cm1 := deployOrUpdateConfigMap(ctx, kubeClient, refs[0].Name, data1)
 		defer func() {
 			_ = kubeClient.Delete(ctx, cm1)
 		}()
-		cm2 := deployOrUpdateConfigMap(ctx, kubeClient, refs[1].Name, data)
+		cm2 := deployOrUpdateConfigMap(ctx, kubeClient, refs[1].Name, data2)
 		defer func() {
 			_ = kubeClient.Delete(ctx, cm2)
 		}()
@@ -3601,9 +3602,8 @@ spec:
 		time.Sleep(30 * time.Second)
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterReadyReason)
 
-		data = map[string]string{"test.yaml": content, "test2.yaml": content}
-		deployOrUpdateConfigMap(ctx, kubeClient, refs[0].Name, data)
-		deployOrUpdateConfigMap(ctx, kubeClient, refs[1].Name, data)
+		deployOrUpdateConfigMap(ctx, kubeClient, refs[0].Name, map[string]string{"test1.yaml": content})
+		deployOrUpdateConfigMap(ctx, kubeClient, refs[1].Name, map[string]string{"test2.yaml": content})
 		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterAlreadyInstallingReason)
 	})
 


### PR DESCRIPTION
Detect key conflict when looping over data in each ManifestsConfigMap.
Spec sync status should be changed to error in case of a conflict.
(see discussion in the support [PR](https://github.com/openshift/assisted-service/pull/3342#discussion_r805353501))

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @avishayt 
/cc @mhrivnak
/cc @2uasimojo 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
