### PR TITLE
MGMT-8824: Copy additional NTP sources to chrony manifests

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -190,12 +190,8 @@ func createChronyManifestContent(c *common.Cluster, role models.HostRole, log lo
 		}
 
 		for _, source := range ntpSources {
-			if source.SourceState == models.SourceStateSynced {
-				if !funk.Contains(sources, source.SourceName) {
-					sources = append(sources, source.SourceName)
-				}
-
-				break
+			if !funk.Contains(sources, source.SourceName) {
+				sources = append(sources, source.SourceName)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

This PR addresses issue [MGMT-8824](https://issues.redhat.com/browse/MGMT-8824). 

#### High-level bug description

When a user defined [additional NTP sources](https://github.com/openshift/assisted-service/blob/master/swagger.yaml#L6976) (or via the [InfraEnv](https://github.com/openshift/assisted-service/blob/master/api/v1beta1/infraenv_types.go#L57) CR), only the sources that were in state `synchronized|synced` were copied into the respective [chrony](https://chrony.tuxfamily.org/) manifest, if any. Which resulted in the additional NTP sources missing from the chrony sources altogether. 

#### Fix 

With this change, all user defined additional NTP sources, irrespective of their state, are copied into the chrony manifest and are reflected in the chrony sources.

> The possible source states can also be found [here](https://chrony.tuxfamily.org/doc/3.3/chronyc.html), under the section `Time Sources`.

> To check the chrony sources of a host, you can use the [chronyc](https://chrony.tuxfamily.org/doc/4.2/chronyc.html) `sources` command: `chronyc sources -c -v`

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
