### PR TITLE
MGMT-8809: Fix e2e-metal-assisted-operator-disconnected CI job

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -91,10 +91,11 @@ function mirror_file() {
   httpd_path="${2}"
   base_mirror_url="${3}"
 
-  local file_name="$(basename ${remote_url})"
-  curl --retry 5 "${remote_url}" -o "${httpd_path}/${file_name}"
+  local url_path="$(echo ${remote_url} | cut -d / -f 4-)"
+  mkdir -p "$(dirname ${httpd_path}/${url_path})"
+  curl --retry 5 "${remote_url}" -o "${httpd_path}/${url_path}"
 
-  echo "${base_mirror_url}/${file_name}"
+  echo "${base_mirror_url}/${url_path}"
 }
 
 function disable_default_indexes() {


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->
In this PR we try to address are multiple problems when running e2e-metal-assisted-operator-disconnected CI job
Most of the problem arise only while running in disconnected mode:
- The assisted service operator catalog name is different while disconnected, and this needs to be consistent throughout the code
- If OS_IMAGES has multiple entries, all of them need to be mirrored
- While handling multiple mirrored artifacts we need to keep their full url path on the mirror to prevent name collisions
- Mirrored OS_IMAGES have to be added to AgentServiceConfig to override the default ones
- Due to a bug in hive, the condition that checks that ClusterDeployment is installed needs longer wait time

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
