### PR TITLE
MGMT-9334: Add an endpoint to download an ipxe-boot script

### DIFF
--- a/client/installer/v2_download_infra_env_files_responses.go
+++ b/client/installer/v2_download_infra_env_files_responses.go
@@ -30,6 +30,12 @@ func (o *V2DownloadInfraEnvFilesReader) ReadResponse(response runtime.ClientResp
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewV2DownloadInfraEnvFilesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewV2DownloadInfraEnvFilesUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -107,6 +113,38 @@ func (o *V2DownloadInfraEnvFilesOK) GetPayload() io.Writer {
 }
 
 func (o *V2DownloadInfraEnvFilesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewV2DownloadInfraEnvFilesBadRequest creates a V2DownloadInfraEnvFilesBadRequest with default headers values
+func NewV2DownloadInfraEnvFilesBadRequest() *V2DownloadInfraEnvFilesBadRequest {
+	return &V2DownloadInfraEnvFilesBadRequest{}
+}
+
+/* V2DownloadInfraEnvFilesBadRequest describes a response with status code 400, with default header values.
+
+Bad Request.
+*/
+type V2DownloadInfraEnvFilesBadRequest struct {
+	Payload *models.Error
+}
+
+func (o *V2DownloadInfraEnvFilesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /v2/infra-envs/{infra_env_id}/downloads/files][%d] v2DownloadInfraEnvFilesBadRequest  %+v", 400, o.Payload)
+}
+func (o *V2DownloadInfraEnvFilesBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *V2DownloadInfraEnvFilesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/docs/enhancements/ipxe-host-boot.md
+++ b/docs/enhancements/ipxe-host-boot.md
@@ -4,7 +4,7 @@ authors:
   - "@carbonin"
   - “@mhrivnak”
 creation-date: 2022-02-22
-last-updated: 2022-02-24
+last-updated: 2022-03-08
 ---
 
 # iPXE Host Boot
@@ -88,7 +88,7 @@ endpoint will be specific to an infra-env in order to embed the ignition.
 Assisted service APIs will be added to download the ipxe boot script and to 
 retrieve a presigned url for downloading the boot script.
 
-- `GET /v2/infra-envs/{infra-env-id}/downloads/ipxe-script`
+- `GET /v2/infra-envs/{infra-env-id}/downloads/files?file_name=ipxe-script`
   - Will return an iPXE boot script with artifact URLs pointing to the image service
   - Initrd URL will be presigned
 - `GET  /v2/infra-envs/{infra-env-id}/downloads/ipxe-script-url`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7461,7 +7461,8 @@ func init() {
           },
           {
             "enum": [
-              "discovery.ign"
+              "discovery.ign",
+              "ipxe-script"
             ],
             "type": "string",
             "description": "The file to be downloaded.",
@@ -7475,6 +7476,12 @@ func init() {
             "description": "Success.",
             "schema": {
               "type": "file"
+            }
+          },
+          "400": {
+            "description": "Bad Request.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "401": {
@@ -20697,7 +20704,8 @@ func init() {
           },
           {
             "enum": [
-              "discovery.ign"
+              "discovery.ign",
+              "ipxe-script"
             ],
             "type": "string",
             "description": "The file to be downloaded.",
@@ -20711,6 +20719,12 @@ func init() {
             "description": "Success.",
             "schema": {
               "type": "file"
+            }
+          },
+          "400": {
+            "description": "Bad Request.",
+            "schema": {
+              "$ref": "#/definitions/error"
             }
           },
           "401": {

--- a/restapi/operations/installer/v2_download_infra_env_files_parameters.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_parameters.go
@@ -98,7 +98,7 @@ func (o *V2DownloadInfraEnvFilesParams) bindFileName(rawData []string, hasKey bo
 // validateFileName carries on validations for parameter FileName
 func (o *V2DownloadInfraEnvFilesParams) validateFileName(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"discovery.ign"}, true); err != nil {
+	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"discovery.ign", "ipxe-script"}, true); err != nil {
 		return err
 	}
 

--- a/restapi/operations/installer/v2_download_infra_env_files_responses.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_responses.go
@@ -56,6 +56,50 @@ func (o *V2DownloadInfraEnvFilesOK) WriteResponse(rw http.ResponseWriter, produc
 	}
 }
 
+// V2DownloadInfraEnvFilesBadRequestCode is the HTTP code returned for type V2DownloadInfraEnvFilesBadRequest
+const V2DownloadInfraEnvFilesBadRequestCode int = 400
+
+/*V2DownloadInfraEnvFilesBadRequest Bad Request.
+
+swagger:response v2DownloadInfraEnvFilesBadRequest
+*/
+type V2DownloadInfraEnvFilesBadRequest struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.Error `json:"body,omitempty"`
+}
+
+// NewV2DownloadInfraEnvFilesBadRequest creates V2DownloadInfraEnvFilesBadRequest with default headers values
+func NewV2DownloadInfraEnvFilesBadRequest() *V2DownloadInfraEnvFilesBadRequest {
+
+	return &V2DownloadInfraEnvFilesBadRequest{}
+}
+
+// WithPayload adds the payload to the v2 download infra env files bad request response
+func (o *V2DownloadInfraEnvFilesBadRequest) WithPayload(payload *models.Error) *V2DownloadInfraEnvFilesBadRequest {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the v2 download infra env files bad request response
+func (o *V2DownloadInfraEnvFilesBadRequest) SetPayload(payload *models.Error) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *V2DownloadInfraEnvFilesBadRequest) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(400)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // V2DownloadInfraEnvFilesUnauthorizedCode is the HTTP code returned for type V2DownloadInfraEnvFilesUnauthorized
 const V2DownloadInfraEnvFilesUnauthorizedCode int = 401
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4426,13 +4426,17 @@ paths:
           name: file_name
           description: The file to be downloaded.
           type: string
-          enum: [discovery.ign]
+          enum: [discovery.ign, ipxe-script]
           required: true
       responses:
         "200":
           description: Success.
           schema:
             type: file
+        "400":
+          description: Bad Request.
+          schema:
+            $ref: '#/definitions/error'
         "401":
           description: Unauthorized.
           schema:


### PR DESCRIPTION
As described in [the enhancement](https://github.com/openshift/assisted-service/blob/c5eacda676475f5a6de123678c1af353a2368bd3/docs/enhancements/ipxe-host-boot.md
) this PR implements the ipxe-boot script download endpoint.

Specifically `GET /v2/infra-envs/{infra-env-id}/downloads/files?file_name=ipxe-script`.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed assisted service locally with podman, created an infra-env, called the new endpoint.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @CrystalChun 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
