### PR TITLE
MGMT-9541: Fix mismatch swagger-codgen versions. Set both versions to v2.4.18

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -1,5 +1,5 @@
 # Generate python client
-FROM quay.io/ocpmetal/swagger-codegen-cli:2.4.21 as swagger_py
+FROM quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 as swagger_py
 COPY swagger.yaml .
 COPY tools/generate_python_client.sh .
 RUN chmod +x ./generate_python_client.sh && SWAGGER_FILE=swagger.yaml OUTPUT=/build ./generate_python_client.sh

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -32,7 +32,7 @@ function generate_python_client() {
         -v "${__root}"/swagger.yaml:/swagger.yaml:ro,Z \
         -v "${__root}"/tools/generate_python_client.sh:/script.sh:ro,Z \
         -e SWAGGER_FILE=/swagger.yaml -e OUTPUT=/local/assisted-service-client/ \
-        quay.io/ocpmetal/swagger-codegen-cli:2.4.15 /script.sh
+        quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /script.sh
      cd "${dest}"/assisted-service-client/ && python3 "${__root}"/tools/client_package_initializer.py "${dest}"/assisted-service-client/  https://github.com/openshift/assisted-service
      cp "${dest}"/assisted-service-client/dist/assisted-service-client-*.tar.gz "${dest}"
 }


### PR DESCRIPTION
Fix mismatch swagger-codgen versions. 
Since v2.4.19 the client Configuration object was created multiple times adding each time a new logging handler causing multiple log lines per entry.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eliorerz 
/cc @
