### PR TITLE
MGMT-9550: Fix automatic agent inventory labels

### DIFF
--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1086,7 +1086,7 @@ var _ = Describe("agent reconcile", func() {
 			},
 			SystemVendor: &models.SystemVendor{
 				Manufacturer: "Red Hat",
-				ProductName:  "RHEL",
+				ProductName:  "-bad-label-name",
 				Virtual:      true,
 			},
 			Interfaces: []*models.Interface{
@@ -1141,13 +1141,13 @@ var _ = Describe("agent reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Reason).To(Equal(v1beta1.SyncedOkReason))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Status).To(Equal(corev1.ConditionTrue))
 		Expect(agent.Status.Inventory.Interfaces[0].MacAddress).To(Equal(macAddress))
-		Expect(agent.ObjectMeta.Annotations[InventoryLabelPrefix+"version"]).To(Equal("0.1"))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"storage-hasnonrotationaldisk"]).To(Equal("false"))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-architecture"]).To(Equal(common.DefaultCPUArchitecture))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"cpu-virtenabled"]).To(Equal("true"))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-manufacturer"]).To(Equal("Red Hat"))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-productname"]).To(Equal("RHEL"))
-		Expect(agent.ObjectMeta.Labels[InventoryLabelPrefix+"host-isvirtual"]).To(Equal("true"))
+		Expect(agent.GetAnnotations()[InventoryLabelPrefix+"version"]).To(Equal("0.1"))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"storage-hasnonrotationaldisk"]).To(Equal("false"))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"cpu-architecture"]).To(Equal(common.DefaultCPUArchitecture))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"cpu-virtenabled"]).To(Equal("true"))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"host-manufacturer"]).To(Equal("RedHat"))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"host-productname"]).To(Equal(""))
+		Expect(agent.GetLabels()[InventoryLabelPrefix+"host-isvirtual"]).To(Equal("true"))
 
 		result, err = hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -2808,10 +2808,18 @@ var _ = Describe("[kube-api]cluster installation", func() {
 
 		By("Verify Agent labels")
 		labels[v1beta1.InfraEnvNameLabel] = infraNsName.Name
-		Eventually(func() map[string]string {
+		Eventually(func() bool {
 			agent := getAgentCRD(ctx, kubeClient, key)
-			return agent.ObjectMeta.Labels
-		}, "30s", "1s").Should(Equal(labels))
+			allFound := true
+			for labelKey, labelValue := range labels {
+				val, ok := agent.ObjectMeta.Labels[labelKey]
+				if !ok || val != labelValue {
+					allFound = false
+					break
+				}
+			}
+			return allFound
+		}, "30s", "1s").Should(Equal(true))
 
 		By("Approve Agent")
 		Eventually(func() error {


### PR DESCRIPTION
Ensures that label values are valid and updates the Agent CR when labels
are added/changed.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees
/assign @nmagnezi 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
