### PR TITLE
NO-ISSUE: deploy_route53: don't use "is" for comparison

### DIFF
--- a/tools/deploy_route53.py
+++ b/tools/deploy_route53.py
@@ -9,7 +9,7 @@ deploy_options = deployment_options.load_deployment_options(parser)
 
 
 def deploy_secret():
-    if deploy_options.secret is "":
+    if deploy_options.secret == "":
         return
 
     # Renderized secret with specified secret


### PR DESCRIPTION
`deploy_options.secret is ""` would compare var types, not their values

## List all the issues related to this PR

- [x] Tests

## What environments does this code impact?

- [x] None

## How was this code tested?

- [x] No tests needed