### PR TITLE
WIP Several fixes to support running tests via `kind`

### DIFF
--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -1,6 +1,11 @@
 apiVersion: v1
 kind: List
 items:
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: assisted-service
+    namespace: REPLACE_NAMESPACE
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
`kind` is k8s distro, running k8s components in containers. Unlike minikube it doesn't need virtualization, as it requires docker or podman (including rootless).
This PR tweaks a few minor things so that `make deploy-test` could be run via kind.

Use 
```
cat <<EOF | kind create cluster --config=-
kind: Cluster   
apiVersion: kind.x-k8s.io/v1alpha4
networking:
  podSubnet: "10.244.0.0/16"
  serviceSubnet: "10.96.0.0/12"
nodes:
- role: control-plane
  extraPortMappings:
  - containerPort: 30950
    hostPort: 30950
  - containerPort: 30951
    hostPort: 30951
EOF
```
to create a cluster wit two hostPorts exposed (for `assisted-service` and `assisted-image-service`).

During installation a manual edit is required:
`$ oc -n assisted-installer edit svc assisted-service` and change the following:
```
spec:
  externalIPs:
  - 192.168.1.162
```
(set it to host IP) and 
```
spec:
  ports:
  - nodePort: 30951
```
Its being allocated randomly, but it needs to be edited to point to 30950 or 30951


## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Automation (CI, tools, etc)

## How was this code tested?

- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed
