### PR TITLE
MGMT-9470: Make script to pin catalog compatible with python 3.6

### DIFF
--- a/deploy/olm-catalog/pin-latest.py
+++ b/deploy/olm-catalog/pin-latest.py
@@ -3,7 +3,7 @@
 import os
 from hashlib import sha256
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List
 from functools import lru_cache
 import logging
 
@@ -75,7 +75,7 @@ def resolve_tag(image_loc: str):
     return resolved
 
 
-def pin_path(obj: dict, path: list[str]):
+def pin_path(obj: dict, path: List[str]):
     logging.info(f"Iterating {'.'.join(path)}")
 
     current_key, *rest = path


### PR DESCRIPTION
Make the script compatible with Python 3.6 because it is the version
available in the base iamge we are using for developement and CI
(registry.ci.openshift.org/openshift/release:golang-1.17).
