### PR TITLE
MGMT-9443: tenancy based auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,7 @@ _run_subsystem_test:
 	TEST_TOKEN_2="$(shell cat $(BUILD_FOLDER)/auth-tokenString2)" \
 	TEST_TOKEN_ADMIN="$(shell cat $(BUILD_FOLDER)/auth-tokenAdminString)" \
 	TEST_TOKEN_UNALLOWED="$(shell cat $(BUILD_FOLDER)/auth-tokenUnallowedString)" \
+	TEST_TOKEN_EDITOR="$(shell cat $(BUILD_FOLDER)/auth-tokenClusterEditor)" \
 	$(MAKE) _test TEST_SCENARIO=subsystem TIMEOUT=120m TEST="$(or $(TEST),./subsystem/...)"
 
 enable-kube-api-for-subsystem: $(BUILD_FOLDER)

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -195,14 +195,14 @@ type mockOCMAuthorization struct {
 	ocm.OCMAuthorization
 }
 
-var accessReviewMock func(ctx context.Context, username, action, resourceType string) (allowed bool, err error)
+var accessReviewMock func(ctx context.Context, username, action, subscription, resourceType string) (allowed bool, err error)
 
 var capabilityReviewMock = func(ctx context.Context, username, capabilityName, capabilityType string) (allowed bool, err error) {
 	return false, nil
 }
 
-func (m *mockOCMAuthorization) AccessReview(ctx context.Context, username, action, resourceType string) (allowed bool, err error) {
-	return accessReviewMock(ctx, username, action, resourceType)
+func (m *mockOCMAuthorization) AccessReview(ctx context.Context, username, action, subscription, resourceType string) (allowed bool, err error) {
+	return accessReviewMock(ctx, username, action, subscription, resourceType)
 }
 
 func (m *mockOCMAuthorization) CapabilityReview(ctx context.Context, username, capabilityName, capabilityType string) (allowed bool, err error) {

--- a/pkg/auth/auth_utils.go
+++ b/pkg/auth/auth_utils.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"net/http"
+
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/internal/common"
@@ -33,4 +35,14 @@ func shouldStorePayloadInCache(err error) bool {
 		return serr.StatusCode() < 500
 	}
 	return false
+}
+
+func isUpdateRequest(request *http.Request) bool {
+	return request != nil && (request.Method == http.MethodPost ||
+		request.Method == http.MethodPut ||
+		request.Method == http.MethodPatch)
+}
+
+func isDeleteRequest(request *http.Request) bool {
+	return request != nil && request.Method == http.MethodDelete
 }

--- a/pkg/auth/authz_handler.go
+++ b/pkg/auth/authz_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/golang-jwt/jwt/v4"
@@ -19,6 +20,7 @@ import (
 )
 
 type AuthzHandler struct {
+	cfg     *Config
 	Enabled bool
 	log     logrus.FieldLogger
 	client  *ocm.Client
@@ -27,6 +29,7 @@ type AuthzHandler struct {
 
 func NewAuthzHandler(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) *AuthzHandler {
 	a := &AuthzHandler{
+		cfg:     cfg,
 		Enabled: cfg.AuthType == TypeRHSSO,
 		client:  ocmCLient,
 		log:     log,
@@ -46,20 +49,134 @@ func (a *AuthzHandler) CreateAuthorizer() func(*http.Request) error {
 	return a.Authorizer
 }
 
-func (a *AuthzHandler) isObjectOwnedByUser(id string, obj interface{}, username string) (bool, error) {
-	if a.db != nil {
-		err := a.db.First(obj, "id = ? and user_name = ?", id, username).Error
-		if err != nil {
-			//if user is not the owner of the object return false
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return false, nil
-			}
-			//in case of a real db error, indicate it to the caller
-			return false, err
+func (a *AuthzHandler) isTenancyEnabled() bool {
+	return a.cfg.EnableOrgTenancy
+}
+
+func handleOwnershipQueryError(err error) (bool, error) {
+	if err != nil {
+		//if user is not the owner of the object return false
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
 		}
+		//in case of a real db error, indicate it to the caller
+		return false, err
+	}
+	return true, nil
+}
+
+func (a *AuthzHandler) isObjectOwnedByUser(id string, obj interface{}, payload *ocm.AuthPayload) (bool, error) {
+	if a.db != nil {
+		err := a.db.First(obj, "id = ? and user_name = ?", id, payload.Username).Error
+		return handleOwnershipQueryError(err)
 	}
 
 	return true, nil
+}
+
+func (a *AuthzHandler) isObjectOwnedByOrg(id string, obj interface{}, payload *ocm.AuthPayload) (bool, error) {
+	if a.db != nil {
+		err := a.db.First(obj, "id = ? and org_id = ?", id, payload.Organization).Error
+		return handleOwnershipQueryError(err)
+	}
+
+	return true, nil
+}
+
+func (a *AuthzHandler) hasOwnerAccess(id string, obj interface{}, payload *ocm.AuthPayload) (ownedBy bool, err error) {
+	//MGMT-9443 TODO: cache this
+	//If the object is owned by the requested user, always approve the access
+	if ownedBy, err = a.isObjectOwnedByUser(id, obj, payload); ownedBy {
+		return true, nil
+	}
+
+	//If the object is not owned by the user and tenancy access is enabled
+	//check if the user belongs to the same organization as the resource owner
+	if err == nil && a.isTenancyEnabled() {
+		return a.isObjectOwnedByOrg(id, obj, payload)
+	}
+
+	//in case error occured before, return it
+	return
+}
+
+func (a *AuthzHandler) hasSubscriptionAccess(clusterId string, action string, payload *ocm.AuthPayload) (isAllowed bool, err error) {
+	if isAllowed, err = a.isObjectOwnedByUser(clusterId, &common.Cluster{}, payload); isAllowed {
+		return true, nil
+	}
+
+	if a.isTenancyEnabled() {
+		var cluster common.Cluster
+		err = a.db.Select("ams_subscription_id").First(&cluster, "id = ?", clusterId).Error
+		if err != nil {
+			return handleOwnershipQueryError(err)
+		}
+
+		cacheKey := fmt.Sprintf("%s_%s_%s", payload.Username, payload.Organization, cluster.AmsSubscriptionID)
+		if cacheData, existInCache := a.client.Cache.Get(cacheKey); existInCache {
+			var ok bool
+			isAllowed, ok = cacheData.(bool)
+			if !ok {
+				return false, fmt.Errorf(
+					"error while retrieving cluster edit role from cache for %s",
+					cluster.AmsSubscriptionID.String())
+			}
+			return isAllowed, nil
+		}
+
+		isAllowed, err = a.hasClusterEditRole(payload, action, cluster.AmsSubscriptionID.String())
+		if shouldStorePayloadInCache(err) {
+			a.client.Cache.Set(cacheKey, isAllowed, 10*time.Minute)
+		}
+		return isAllowed, err
+	}
+
+	return false, err
+}
+
+func (a *AuthzHandler) checkClusterBasedAccess(id string, request *http.Request, payload *ocm.AuthPayload) (bool, error) {
+	if a.db == nil {
+		return true, nil
+	}
+
+	switch {
+	case isUpdateRequest(request):
+		return a.hasSubscriptionAccess(id, ocm.AMSActionUpdate, payload)
+	case isDeleteRequest(request):
+		return a.hasSubscriptionAccess(id, ocm.AMSActionDelete, payload)
+	default:
+		return a.hasOwnerAccess(id, &common.Cluster{}, payload)
+	}
+}
+
+func (a *AuthzHandler) checkInfraEnvBasedAccess(id string, request *http.Request, payload *ocm.AuthPayload) (bool, error) {
+	if a.db == nil {
+		return true, nil
+	}
+
+	if !a.isTenancyEnabled() {
+		return a.isObjectOwnedByUser(id, &common.InfraEnv{}, payload)
+	}
+
+	//if the infraenv is bound to a cluster the access check
+	//are performed based on the bound cluster data. As a fallback
+	//we test for ownership on the infraenv object itself
+	var infraEnv common.InfraEnv
+	err := a.db.Select("cluster_id").First(&infraEnv, "id = ?", id).Error
+	if err != nil {
+		a.log.WithError(err).Errorf("failed to retrieve infra-env record %s", id)
+		return false, err
+	}
+
+	if infraEnv.ClusterID != "" {
+		if isAllowed, _ := a.checkClusterBasedAccess(infraEnv.ClusterID.String(), request, payload); isAllowed {
+			return true, nil
+		}
+	}
+
+	//fallback option for both failures in bound infraEnv access checks and
+	//for non bound infraEnv related objects
+	return a.isObjectOwnedByUser(id, &common.InfraEnv{}, payload)
 }
 
 func (a *AuthzHandler) Authorizer(request *http.Request) error {
@@ -99,7 +216,7 @@ func (a *AuthzHandler) imageTokenAuthorizer(ctx context.Context) error {
 	return nil
 }
 
-// Authorizer is used to authorize a request after the Auth function was called using the "Auth*" functions
+// ocmAuthorizer is used to authorize a request after the Auth function was called using the "Auth*" functions
 // and the principal was stored in the context in the "AuthKey" context value.
 func (a *AuthzHandler) ocmAuthorizer(request *http.Request) error {
 	payload := ocm.PayloadFromContext(request.Context())
@@ -139,17 +256,19 @@ func (a *AuthzHandler) ocmAuthorizer(request *http.Request) error {
 	}
 
 	if payload.Role == ocm.UserRole {
-		ownedBy := true
+		//List requests and resources outside the scope of clusters or infraEnvs
+		//handle their authorization at the application level
+		isAllowed := true
 		if clusterID := params.GetParam(request.Context(), params.ClusterId); clusterID != "" {
-			ownedBy, err = a.isObjectOwnedByUser(clusterID, &common.Cluster{}, username)
+			isAllowed, err = a.checkClusterBasedAccess(clusterID, request, payload)
 		} else if infraEnvID := params.GetParam(request.Context(), params.InfraEnvId); infraEnvID != "" {
-			ownedBy, err = a.isObjectOwnedByUser(infraEnvID, &common.InfraEnv{}, username)
+			isAllowed, err = a.checkInfraEnvBasedAccess(infraEnvID, request, payload)
 		}
 		if err != nil {
 			a.log.Errorf("Failed to verify access to object. Error %v", err)
 			return common.NewApiError(http.StatusInternalServerError, err)
 		}
-		if !ownedBy {
+		if !isAllowed {
 			return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
 		}
 	}
@@ -159,7 +278,12 @@ func (a *AuthzHandler) ocmAuthorizer(request *http.Request) error {
 
 func (a *AuthzHandler) allowedToUseAssistedInstaller(username string) (bool, error) {
 	return a.client.Authorization.AccessReview(
-		context.Background(), username, ocm.AMSActionCreate, ocm.BareMetalClusterResource)
+		context.Background(), username, ocm.AMSActionCreate, "", ocm.BareMetalClusterResource)
+}
+
+func (a *AuthzHandler) hasClusterEditRole(payload *ocm.AuthPayload, action, subscriptionID string) (bool, error) {
+	return a.client.Authorization.AccessReview(
+		context.Background(), payload.Username, action, subscriptionID, ocm.Subscription)
 }
 
 func (a *AuthzHandler) hasSufficientRole(

--- a/pkg/auth/authz_handler_test.go
+++ b/pkg/auth/authz_handler_test.go
@@ -117,10 +117,12 @@ var _ = Describe("authz", func() {
 			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),
+			gomock.Any(),
 			gomock.Any()).Return(true, nil).Times(times)
 	}
 	failAccessReview := func(times int) {
 		mockOcmAuthz.EXPECT().AccessReview(
+			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),

--- a/pkg/ocm/mock_authorization.go
+++ b/pkg/ocm/mock_authorization.go
@@ -35,18 +35,18 @@ func (m *MockOCMAuthorization) EXPECT() *MockOCMAuthorizationMockRecorder {
 }
 
 // AccessReview mocks base method.
-func (m *MockOCMAuthorization) AccessReview(ctx context.Context, username, action, resourceType string) (bool, error) {
+func (m *MockOCMAuthorization) AccessReview(ctx context.Context, username, action, subscriptionId, resourceType string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AccessReview", ctx, username, action, resourceType)
+	ret := m.ctrl.Call(m, "AccessReview", ctx, username, action, subscriptionId, resourceType)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AccessReview indicates an expected call of AccessReview.
-func (mr *MockOCMAuthorizationMockRecorder) AccessReview(ctx, username, action, resourceType interface{}) *gomock.Call {
+func (mr *MockOCMAuthorizationMockRecorder) AccessReview(ctx, username, action, subscriptionId, resourceType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessReview", reflect.TypeOf((*MockOCMAuthorization)(nil).AccessReview), ctx, username, action, resourceType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessReview", reflect.TypeOf((*MockOCMAuthorization)(nil).AccessReview), ctx, username, action, subscriptionId, resourceType)
 }
 
 // CapabilityReview mocks base method.

--- a/pkg/ocm/utils.go
+++ b/pkg/ocm/utils.go
@@ -13,8 +13,11 @@ import (
 const (
 	BareMetalClusterResource string = "BareMetalCluster"
 	AMSActionCreate          string = "create"
+	AMSActionUpdate          string = "update"
+	AMSActionDelete          string = "delete"
 	CapabilityName           string = "bare_metal_installer_admin"
 	CapabilityType           string = "Account"
+	Subscription             string = "Subscription"
 	EmailDelimiter           string = "@"
 
 	// AdminUsername for disabled auth

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -100,6 +100,31 @@ var _ = Describe("test authorization", func() {
 		})
 	})
 
+	Context("with cluster editor role", func() {
+		BeforeEach(func() {
+			if !Options.EnableOrgTenancy {
+				Skip("tenancy based auth is disabled")
+			}
+		})
+
+		It("can delete cluster", func() {
+			_, err := editclusterUserBMClient.Installer.V2DeregisterCluster(ctx, &installer.V2DeregisterClusterParams{ClusterID: userClusterID})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("can get bound infra-env", func() {
+			infraEnvID := registerInfraEnv(&userClusterID, models.ImageTypeMinimalIso).ID
+			_, err := editclusterUserBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("can't get unbound infra-env", func() {
+			infraEnvID := registerInfraEnv(nil, models.ImageTypeMinimalIso).ID
+			_, err := editclusterUserBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("regular user", func() {
 		It("can get owned cluster", func() {
 			_, err := userBMClient.Installer.V2GetCluster(ctx, &installer.V2GetClusterParams{ClusterID: userClusterID})


### PR DESCRIPTION

The current authorization scheme in the SaaS grants read and write
access only to the cluster's owner. To align with the OCM authorization
scheme, we would like to allow the following:

- A tenancy-based read-only access to resources.
- Users should be allowed to grant editing capabilities to their
  resources to other users in their organization.

To establish a tenancy-based authorization, the auth middleware now
performs the following:

- 'Ownership' is now defined on an organization level (a user is allowed
   access if they belong to the same organization as the resource's creator).

- For Update and Delete of cluster-related APIs, the authorizer shall issue
   an additional query to AMS to check if the user is allowed to change the
   resource. This change supports the 'Cluster Editor' role assignment.

- If the API is related to a cluster-bound InfraEnv, the access permission is
  established by the bound cluster as described above.

- If the API is related to a non-bound InfraEnv, ownership for reading access
  is established on the organization level. Update and Delete operations are
  allowed only to the resource creator.



## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
