### PR TITLE
MGMT-9369: filter clusters and infraenvs by organization

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2777,7 +2777,7 @@ func (b *bareMetalInventory) listClustersInternal(ctx context.Context, params in
 	var clusters []*models.Cluster
 	whereCondition := make([]string, 0)
 
-	if user := identity.AddUserFilter(ctx, ""); user != "" {
+	if user := identity.AddOwnerFilter(ctx, "", b.authHandler.EnableOrgTenancy()); user != "" {
 		whereCondition = append(whereCondition, user)
 	}
 
@@ -4248,7 +4248,7 @@ func (b *bareMetalInventory) ListInfraEnvs(ctx context.Context, params installer
 	if params.ClusterID != nil {
 		condition = fmt.Sprintf("cluster_id = '%s'", params.ClusterID)
 	}
-	whereCondition := identity.AddUserFilter(ctx, condition)
+	whereCondition := identity.AddOwnerFilter(ctx, condition, b.authHandler.EnableOrgTenancy())
 
 	dbInfraEnvs, err := common.GetInfraEnvsFromDBWhere(db, whereCondition)
 	if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6327,6 +6327,77 @@ var _ = Describe("infraEnvs", func() {
 		})
 	})
 
+	Context("Filter based on organization ID", func() {
+		var (
+			authCtx   context.Context
+			orgID1    = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
+			orgID2    = "DD71FD12-57FC-4480-917E-6F1900826543"
+			userName1 = "test_user_1"
+			userName2 = "test_user_2"
+		)
+
+		BeforeEach(func() {
+			_, cert := auth.GetTokenAndCert(false)
+			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg.EnableOrgTenancy = true
+			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+
+			payload := &ocm.AuthPayload{Role: ocm.UserRole}
+			payload.Username = userName1
+			payload.Organization = orgID1
+			authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
+		})
+
+		It("multiple users in a single organization", func() {
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID1,
+				UserName: userName2,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			resp := bm.ListInfraEnvs(authCtx, installer.ListInfraEnvsParams{})
+			Expect(resp).Should(BeAssignableToTypeOf(installer.NewListInfraEnvsOK()))
+			payload := resp.(*installer.ListInfraEnvsOK).Payload
+			Expect(len(payload)).Should(Equal(2))
+			Expect(payload[0].OrgID).Should(Equal(orgID1))
+			Expect(payload[1].OrgID).Should(Equal(orgID1))
+		})
+
+		It("multiple organizations", func() {
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID2,
+				UserName: userName2,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			resp := bm.ListInfraEnvs(authCtx, installer.ListInfraEnvsParams{})
+			Expect(resp).Should(BeAssignableToTypeOf(installer.NewListInfraEnvsOK()))
+			payload := resp.(*installer.ListInfraEnvsOK).Payload
+			Expect(len(payload)).Should(Equal(1))
+			Expect(payload[0].OrgID).Should(Equal(orgID1))
+		})
+	})
+
 	Context("List Infra Env Hosts", func() {
 		var (
 			infraEnvId1, infraEnvId2 strfmt.UUID
@@ -8077,6 +8148,79 @@ var _ = Describe("List clusters", func() {
 			})
 			payload := resp.(*installer.V2ListClustersOK).Payload
 			Expect(len(payload)).Should(Equal(1))
+		})
+	})
+
+	Context("Filter based on organization ID", func() {
+		var (
+			authCtx   context.Context
+			orgID1    = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
+			orgID2    = "DD71FD12-57FC-4480-917E-6F1900826543"
+			userName1 = "test_user_1"
+			userName2 = "test_user_2"
+		)
+
+		BeforeEach(func() {
+			_, cert := auth.GetTokenAndCert(false)
+			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg.EnableOrgTenancy = true
+			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+
+			payload := &ocm.AuthPayload{Role: ocm.UserRole}
+			payload.Username = userName1
+			payload.Organization = orgID1
+			authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
+		})
+
+		It("multiple users in a single organization", func() {
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}
+			err := db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID1,
+				UserName: userName2,
+			}}
+			err = db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			resp := bm.V2ListClusters(authCtx, installer.V2ListClustersParams{})
+			payload := resp.(*installer.V2ListClustersOK).Payload
+			Expect(len(payload)).Should(Equal(2))
+			Expect(payload[0].OrgID).Should(Equal(orgID1))
+			Expect(payload[1].OrgID).Should(Equal(orgID1))
+		})
+
+		It("multiple organizations", func() {
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}
+			err := db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID2,
+				UserName: userName2,
+			}}
+			err = db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			resp := bm.V2ListClusters(authCtx, installer.V2ListClustersParams{})
+			payload := resp.(*installer.V2ListClustersOK).Payload
+			Expect(len(payload)).Should(Equal(1))
+			Expect(payload[0].OrgID).Should(Equal(orgID1))
 		})
 	})
 })

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -24,3 +24,18 @@ func AddUserFilter(ctx context.Context, query string) string {
 	}
 	return query
 }
+
+func AddOwnerFilter(ctx context.Context, query string, filterByOrg bool) string {
+	if IsAdmin(ctx) {
+		return query
+	}
+	if filterByOrg {
+		if query != "" {
+			query += " and "
+		}
+		orgId := ocm.OrgIDFromContext(ctx)
+		query += fmt.Sprintf("org_id = '%s'", orgId)
+		return query
+	}
+	return AddUserFilter(ctx, query)
+}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -75,4 +75,63 @@ var _ = Describe("Identity", func() {
 			Expect(query).Should(Equal("id = ? and user_name = 'test_user'"))
 		})
 	})
+
+	Context("AddOwnerFilter", func() {
+		It("admin user - empty query - filter by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Role = ocm.AdminRole
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "", false)
+			Expect(query).Should(Equal(""))
+		})
+		It("admin user - non-empty query - filter by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Role = ocm.AdminRole
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "id = ?", false)
+			Expect(query).Should(Equal("id = ?"))
+		})
+		It("non-admin user - empty query - filter by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Username = "test_user"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "", false)
+			Expect(query).Should(Equal("user_name = 'test_user'"))
+		})
+		It("non-admin user - non-empty query - filter by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Username = "test_user"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "id = ?", false)
+			Expect(query).Should(Equal("id = ? and user_name = 'test_user'"))
+		})
+		It("admin user - empty query - filter by org", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Role = ocm.AdminRole
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "", true)
+			Expect(query).Should(Equal(""))
+		})
+		It("admin user - non-empty query - filter by org", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Role = ocm.AdminRole
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "id = ?", true)
+			Expect(query).Should(Equal("id = ?"))
+		})
+		It("non-admin user - empty query - filter by org", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Organization = "test_org"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "", true)
+			Expect(query).Should(Equal("org_id = 'test_org'"))
+		})
+		It("non-admin user - non-empty query - filter by org", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Organization = "test_org"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "id = ?", true)
+			Expect(query).Should(Equal("id = ? and org_id = 'test_org'"))
+		})
+	})
 })

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -26,6 +26,7 @@ type Authenticator interface {
 	AuthURLAuth(token string) (interface{}, error)
 	AuthImageAuth(token string) (interface{}, error)
 	AuthType() AuthType
+	EnableOrgTenancy() bool
 }
 
 type Config struct {
@@ -34,8 +35,9 @@ type Config struct {
 	JwkCertURL     string   `envconfig:"JWKS_URL" default:"https://api.openshift.com/.well-known/jwks.json"`
 	ECPublicKeyPEM string   `envconfig:"EC_PUBLIC_KEY_PEM"`
 	// Will be split with "," as separator
-	AllowedDomains string   `envconfig:"ALLOWED_DOMAINS" default:""`
-	AdminUsers     []string `envconfig:"ADMIN_USERS" default:""`
+	AllowedDomains   string   `envconfig:"ALLOWED_DOMAINS" default:""`
+	AdminUsers       []string `envconfig:"ADMIN_USERS" default:""`
+	EnableOrgTenancy bool     `envconfig:"ENABLE_ORG_TENANCY" default:"false"`
 }
 
 func NewAuthenticator(cfg *Config, ocmClient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) (a Authenticator, err error) {

--- a/pkg/auth/local_authenticator.go
+++ b/pkg/auth/local_authenticator.go
@@ -51,6 +51,10 @@ func (a *LocalAuthenticator) AuthType() AuthType {
 	return TypeLocal
 }
 
+func (a *LocalAuthenticator) EnableOrgTenancy() bool {
+	return false
+}
+
 func (a *LocalAuthenticator) AuthAgentAuth(token string) (interface{}, error) {
 	t, err := validateToken(token, a.publicKey)
 	if err != nil {

--- a/pkg/auth/none_authenticator.go
+++ b/pkg/auth/none_authenticator.go
@@ -23,6 +23,10 @@ func (a *NoneAuthenticator) AuthType() AuthType {
 	return TypeNone
 }
 
+func (a *NoneAuthenticator) EnableOrgTenancy() bool {
+	return false
+}
+
 func (a *NoneAuthenticator) AuthAgentAuth(_ string) (interface{}, error) {
 	a.log.Debug("Agent Authentication Disabled")
 	return ocm.AdminPayload(), nil

--- a/pkg/auth/rhsso_authenticator.go
+++ b/pkg/auth/rhsso_authenticator.go
@@ -23,21 +23,23 @@ import (
 )
 
 type RHSSOAuthenticator struct {
-	KeyMap     map[string]*rsa.PublicKey
-	AdminUsers []string
-	utils      AUtilsInteface
-	log        logrus.FieldLogger
-	client     *ocm.Client
-	db         *gorm.DB
+	KeyMap            map[string]*rsa.PublicKey
+	AdminUsers        []string
+	OrgTenancyEnabled bool
+	utils             AUtilsInteface
+	log               logrus.FieldLogger
+	client            *ocm.Client
+	db                *gorm.DB
 }
 
 func NewRHSSOAuthenticator(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) *RHSSOAuthenticator {
 	a := &RHSSOAuthenticator{
-		AdminUsers: cfg.AdminUsers,
-		utils:      NewAuthUtils(cfg.JwkCert, cfg.JwkCertURL),
-		client:     ocmCLient,
-		log:        log,
-		db:         db,
+		AdminUsers:        cfg.AdminUsers,
+		OrgTenancyEnabled: cfg.EnableOrgTenancy,
+		utils:             NewAuthUtils(cfg.JwkCert, cfg.JwkCertURL),
+		client:            ocmCLient,
+		log:               log,
+		db:                db,
 	}
 	err := a.populateKeyMap()
 	if err != nil {
@@ -50,6 +52,10 @@ var _ Authenticator = &RHSSOAuthenticator{}
 
 func (a *RHSSOAuthenticator) AuthType() AuthType {
 	return TypeRHSSO
+}
+
+func (a *RHSSOAuthenticator) EnableOrgTenancy() bool {
+	return a.OrgTenancyEnabled
 }
 
 func (a *RHSSOAuthenticator) populateKeyMap() error {


### PR DESCRIPTION
Clusters/InfraEnvs should be filtered by organization instead of user when org tenancy is enabled:
* Added a feature flag to the Authenticator: EnableOrgTenancy
* Added AddOwnerFilter func to the identity helper.
* ListClusters and ListInfraEnvs are now filterred by organization when relevant.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
