### PR TITLE
Bug 2066196: ensure secrets have backup labels

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -649,6 +649,9 @@ func (r *AgentServiceConfigReconciler) newAgentLocalAuthSecret(ctx context.Conte
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      agentLocalAuthSecretName,
 			Namespace: r.Namespace,
+			Labels: map[string]string{
+				BackupLabel: BackupLabelValue,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 	}
@@ -681,6 +684,9 @@ func (r *AgentServiceConfigReconciler) newPostgresSecret(ctx context.Context, lo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      databaseName,
 			Namespace: r.Namespace,
+			Labels: map[string]string{
+				BackupLabel: BackupLabelValue,
+			},
 		},
 		Type: corev1.SecretTypeOpaque,
 	}

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -823,6 +823,7 @@ var _ = Describe("ensureAgentLocalAuthSecret", func() {
 
 			Expect(foundAfterNextEnsure.StringData["ec-private-key.pem"]).To(Equal(foundPrivateKey))
 			Expect(foundAfterNextEnsure.StringData["ec-public-key.pem"]).To(Equal(foundPublicKey))
+			Expect(foundAfterNextEnsure.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
 		})
 	})
 })
@@ -882,6 +883,7 @@ var _ = Describe("ensurePostgresSecret", func() {
 			Expect(found.StringData["db.user"]).To(Equal("admin"))
 			Expect(found.StringData["db.name"]).To(Equal("installer"))
 			Expect(found.StringData["db.port"]).To(Equal(databasePort.String()))
+			Expect(found.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
 			// password will be random
 			foundPass := found.StringData["db.password"]
 			Expect(foundPass).ToNot(BeNil())

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -805,6 +805,9 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 	if err != nil {
 		return reconcileError{err}
 	}
+	if err = ensureSecretIsLabelled(ctx, r.Client, secret, key); err != nil {
+		return reconcileError{err}
+	}
 
 	spokeClient, err := r.getSpokeClient(secret)
 	if err != nil {
@@ -1142,6 +1145,9 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 		log.WithError(err).Errorf("failed to get secret %s", key)
 		return reconcileError{err}
 	}
+	if err = ensureSecretIsLabelled(ctx, r.Client, secret, key); err != nil {
+		return reconcileError{err}
+	}
 
 	spokeClient, err := r.getSpokeClient(secret)
 	if err != nil {
@@ -1217,6 +1223,10 @@ func (r *BMACReconciler) ensureSpokeBMHSecret(ctx context.Context, log logrus.Fi
 	secret, err := getSecret(ctx, r.Client, r.APIReader, key)
 	if err != nil {
 		log.WithError(err).Errorf("failed to get secret resource %s/%s", key.Namespace, key.Name)
+		return secret, err
+	}
+	if err := ensureSecretIsLabelled(ctx, r.Client, secret, key); err != nil {
+		log.WithError(err).Errorf("failed to label secret resource %s/%s", key.Namespace, key.Name)
 		return secret, err
 	}
 	secretSpoke, mutateFn := r.newSpokeBMHSecret(secret)

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1271,6 +1271,9 @@ func (r *BMACReconciler) newSpokeBMHSecret(secret *corev1.Secret) (*corev1.Secre
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secret.Name,
 			Namespace: OPENSHIFT_MACHINE_API_NAMESPACE,
+			Labels: map[string]string{
+				BackupLabel: BackupLabelValue,
+			},
 		},
 	}
 	mutateFn := func() error {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -884,6 +884,8 @@ var _ = Describe("bmac reconcile", func() {
 				err = spokeClient.Get(ctx, types.NamespacedName{Name: adminKubeconfigSecret.Name, Namespace: OPENSHIFT_MACHINE_API_NAMESPACE}, spokeSecret)
 				Expect(err).To(BeNil())
 				Expect(spokeSecret.Data).To(Equal(adminKubeconfigSecret.Data))
+				Expect(spokeSecret.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
+
 			})
 			It("should not set spoke BMH - None platform", func() {
 				clusterInstall.Spec.Networking.UserManagedNetworking = true
@@ -919,7 +921,8 @@ var _ = Describe("bmac reconcile", func() {
 					Namespace: cluster.Namespace,
 				}
 				Expect(c.Get(ctx, secretKey, secret)).To(BeNil())
-				Expect(secret.Labels[WatchResourceLabel]).To(Equal(WatchResourceValue))
+				Expect(secret.Labels).To(HaveKeyWithValue(WatchResourceLabel, WatchResourceValue))
+				Expect(secret.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
 			})
 
 			It("ClusterDeployment not set in Agent", func() {


### PR DESCRIPTION
ACM 2.5 will GA the DR (disaster recovery) feature, which will automatically backup all required resources created by each component on hub side, then in case the hub goes down, DR can use the backed up resources to recreate the info on a new hub. In order for AI ClusterDeployments to support this all generated secrets need to have either `hive.openshift.io/secret-type` (kubeconfig) or `cluster.open-cluster-management.io/backup` labels (agent auth, postgres secret, BMH secret).

`kubeconfig` is already labelled with `hive.openshift.io/secret-type=kubeconfig`, so this PR labels remaining secrets with  `cluster.open-cluster-management.io/backup=true`

TODO:
* [x] Break out label part from `getSecret` into `addLabeltoSecret` to keep it cleaner

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Operator Managed Deployments

## How was this code tested?

- [x] Manual (Elaborate on how it was tested)

Not entirely sure how to test that the whole env can be backed up / restored

## Assignees

/cc @avishayt 
/cc @omertuc 