### PR TITLE
MGMT-9672: align manifest authz

### DIFF
--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -10,10 +9,8 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	eventgen "github.com/openshift/assisted-service/internal/common/events"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
-	"github.com/openshift/assisted-service/internal/identity"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
-	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
@@ -216,21 +213,6 @@ func mapHostsByStatus(c *common.Cluster, role models.HostRole) map[string][]*mod
 
 func MapHostsByStatus(c *common.Cluster) map[string][]*models.Host {
 	return mapHostsByStatus(c, "")
-}
-
-// GetCluster returns the cluster entity fetched from the DB or an error if failed to
-func GetCluster(ctx context.Context, logger logrus.FieldLogger, db *gorm.DB, clusterID string) (*common.Cluster, *common.ApiErrorResponse) {
-	log := logutil.FromContext(ctx, logger)
-	var cluster common.Cluster
-	if err := db.First(&cluster, identity.AddUserFilter(ctx, "id = ?"), clusterID).Error; err != nil {
-		log.WithError(err).Errorf("failed to find cluster %s", clusterID)
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, common.NewApiError(http.StatusNotFound, err)
-		}
-
-		return nil, common.NewApiError(http.StatusInternalServerError, err)
-	}
-	return &cluster, nil
 }
 
 func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string) error {

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
@@ -135,6 +136,58 @@ spec:
 			}
 
 			Expect(found).Should(BeFalse())
+		})
+	})
+
+	Context("manifest tests where cluster doesn't exist", func() {
+		var non_exiting_id = strfmt.UUID(uuid.New().String())
+
+		It("create manifest returns not found", func() {
+			_, err := userBMClient.Manifests.V2CreateClusterManifest(ctx, &manifests.V2CreateClusterManifestParams{
+				ClusterID: non_exiting_id,
+				CreateManifestParams: &models.CreateManifestParams{
+					Content:  &base64Content,
+					FileName: &manifestFile.FileName,
+					Folder:   &manifestFile.Folder,
+				},
+			})
+			Expect(err).To(BeAssignableToTypeOf(manifests.NewV2CreateClusterManifestNotFound()))
+		})
+
+		It("list manifests returns not found", func() {
+			_, err := userBMClient.Manifests.V2ListClusterManifests(ctx, &manifests.V2ListClusterManifestsParams{
+				ClusterID: non_exiting_id,
+			})
+			Expect(err).To(BeAssignableToTypeOf(manifests.NewV2ListClusterManifestsNotFound()))
+
+		})
+
+		It("list manifests returns not found", func() {
+			_, err := userBMClient.Manifests.V2ListClusterManifests(ctx, &manifests.V2ListClusterManifestsParams{
+				ClusterID: non_exiting_id,
+			})
+			Expect(err).To(BeAssignableToTypeOf(manifests.NewV2ListClusterManifestsNotFound()))
+		})
+
+		It("download manifests returns not found", func() {
+			buffer := new(bytes.Buffer)
+
+			_, err := userBMClient.Manifests.V2DownloadClusterManifest(ctx, &manifests.V2DownloadClusterManifestParams{
+				ClusterID: non_exiting_id,
+				FileName:  manifestFile.FileName,
+				Folder:    &manifestFile.Folder,
+			}, buffer)
+			Expect(err).To(BeAssignableToTypeOf(manifests.NewV2DownloadClusterManifestNotFound()))
+		})
+
+		It("delete manifests returns not found", func() {
+			_, err := userBMClient.Manifests.V2DeleteClusterManifest(ctx, &manifests.V2DeleteClusterManifestParams{
+				ClusterID: non_exiting_id,
+				FileName:  manifestFile.FileName,
+				Folder:    &manifestFile.Folder,
+			})
+			Expect(err).To(BeAssignableToTypeOf(manifests.NewV2DeleteClusterManifestNotFound()))
+
 		})
 	})
 


### PR DESCRIPTION
The manifest handler implements its own access checks within the application layer. Those verifications are redundant and with the new tenancy policies also incorrect.

Since manifests are sub-objects of clusters, their access should is governed by the cluster access rules in the auth layer which should be the sole responsible for authorization checks.

Tests were changed accordingly and the case of missing cluster (which is handled by the auth middleware) was moved to the subsystem tests.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
