### PR TITLE
MGMT-9371: added owner query param to clusters/infraenvs requests

### DIFF
--- a/client/installer/list_infra_envs_parameters.go
+++ b/client/installer/list_infra_envs_parameters.go
@@ -67,6 +67,12 @@ type ListInfraEnvsParams struct {
 	*/
 	ClusterID *strfmt.UUID
 
+	/* Owner.
+
+	   If provided, returns only infra-envs that are owned by the specified user.
+	*/
+	Owner *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -131,6 +137,17 @@ func (o *ListInfraEnvsParams) SetClusterID(clusterID *strfmt.UUID) {
 	o.ClusterID = clusterID
 }
 
+// WithOwner adds the owner to the list infra envs params
+func (o *ListInfraEnvsParams) WithOwner(owner *string) *ListInfraEnvsParams {
+	o.SetOwner(owner)
+	return o
+}
+
+// SetOwner adds the owner to the list infra envs params
+func (o *ListInfraEnvsParams) SetOwner(owner *string) {
+	o.Owner = owner
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListInfraEnvsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -151,6 +168,23 @@ func (o *ListInfraEnvsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt
 		if qClusterID != "" {
 
 			if err := r.SetQueryParam("cluster_id", qClusterID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Owner != nil {
+
+		// query param owner
+		var qrOwner string
+
+		if o.Owner != nil {
+			qrOwner = *o.Owner
+		}
+		qOwner := qrOwner
+		if qOwner != "" {
+
+			if err := r.SetQueryParam("owner", qOwner); err != nil {
 				return err
 			}
 		}

--- a/client/installer/v2_list_clusters_parameters.go
+++ b/client/installer/v2_list_clusters_parameters.go
@@ -80,6 +80,12 @@ type V2ListClustersParams struct {
 	*/
 	OpenshiftClusterID *strfmt.UUID
 
+	/* Owner.
+
+	   If provided, returns only clusters that are owned by the specified user.
+	*/
+	Owner *string
+
 	/* WithHosts.
 
 	   Include hosts in the returned list.
@@ -186,6 +192,17 @@ func (o *V2ListClustersParams) SetOpenshiftClusterID(openshiftClusterID *strfmt.
 	o.OpenshiftClusterID = openshiftClusterID
 }
 
+// WithOwner adds the owner to the v2 list clusters params
+func (o *V2ListClustersParams) WithOwner(owner *string) *V2ListClustersParams {
+	o.SetOwner(owner)
+	return o
+}
+
+// SetOwner adds the owner to the v2 list clusters params
+func (o *V2ListClustersParams) SetOwner(owner *string) {
+	o.Owner = owner
+}
+
 // WithWithHosts adds the withHosts to the v2 list clusters params
 func (o *V2ListClustersParams) WithWithHosts(withHosts bool) *V2ListClustersParams {
 	o.SetWithHosts(withHosts)
@@ -236,6 +253,23 @@ func (o *V2ListClustersParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		if qOpenshiftClusterID != "" {
 
 			if err := r.SetQueryParam("openshift_cluster_id", qOpenshiftClusterID); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Owner != nil {
+
+		// query param owner
+		var qrOwner string
+
+		if o.Owner != nil {
+			qrOwner = *o.Owner
+		}
+		qOwner := qrOwner
+		if qOwner != "" {
+
+			if err := r.SetQueryParam("owner", qOwner); err != nil {
 				return err
 			}
 		}

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2787,7 +2787,8 @@ func (b *bareMetalInventory) listClustersInternal(ctx context.Context, params in
 	var clusters []*models.Cluster
 	whereCondition := make([]string, 0)
 
-	if user := identity.AddOwnerFilter(ctx, "", b.authHandler.EnableOrgTenancy()); user != "" {
+	filterByOrg := b.authHandler.EnableOrgTenancy()
+	if user := identity.AddOwnerFilter(ctx, "", filterByOrg, swag.StringValue(params.Owner)); user != "" {
 		whereCondition = append(whereCondition, user)
 	}
 
@@ -4072,7 +4073,8 @@ func (b *bareMetalInventory) ListInfraEnvs(ctx context.Context, params installer
 	if params.ClusterID != nil {
 		condition = fmt.Sprintf("cluster_id = '%s'", params.ClusterID)
 	}
-	whereCondition := identity.AddOwnerFilter(ctx, condition, b.authHandler.EnableOrgTenancy())
+	filterByOrg := b.authHandler.EnableOrgTenancy()
+	whereCondition := identity.AddOwnerFilter(ctx, condition, filterByOrg, swag.StringValue(params.Owner))
 
 	dbInfraEnvs, err := common.GetInfraEnvsFromDBWhere(db, whereCondition)
 	if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6245,6 +6245,11 @@ var _ = Describe("infraEnvs", func() {
 		ctx        = context.Background()
 		infraEnvID strfmt.UUID
 		dbName     string
+		orgID1     = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
+		orgID2     = "DD71FD12-57FC-4480-917E-6F1900826543"
+		userName1  = "test_user_1"
+		userName2  = "test_user_2"
+		userName3  = "test_user_3"
 	)
 
 	const (
@@ -6360,13 +6365,7 @@ var _ = Describe("infraEnvs", func() {
 	})
 
 	Context("Filter based on organization ID", func() {
-		var (
-			authCtx   context.Context
-			orgID1    = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
-			orgID2    = "DD71FD12-57FC-4480-917E-6F1900826543"
-			userName1 = "test_user_1"
-			userName2 = "test_user_2"
-		)
+		var authCtx context.Context
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
@@ -6427,6 +6426,73 @@ var _ = Describe("infraEnvs", func() {
 			payload := resp.(*installer.ListInfraEnvsOK).Payload
 			Expect(len(payload)).Should(Equal(1))
 			Expect(payload[0].OrgID).Should(Equal(orgID1))
+		})
+	})
+
+	Context("Filter by owner query param", func() {
+		var authCtx context.Context
+
+		BeforeEach(func() {
+			_, cert := auth.GetTokenAndCert(false)
+			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg.EnableOrgTenancy = true
+			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+
+			payload := &ocm.AuthPayload{Role: ocm.UserRole}
+			payload.Username = userName1
+			payload.Organization = orgID1
+			authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
+
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID1,
+				UserName: userName2,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+				ID:       &infraEnvID,
+				OrgID:    orgID2,
+				UserName: userName3,
+			}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Owner query param is not specified", func() {
+			params := installer.ListInfraEnvsParams{}
+			resp := bm.ListInfraEnvs(authCtx, params)
+			Expect(resp).Should(BeAssignableToTypeOf(installer.NewListInfraEnvsOK()))
+			payload := resp.(*installer.ListInfraEnvsOK).Payload
+			Expect(len(payload)).Should(Equal(2))
+		})
+
+		It("Owner query param is specified - user in org", func() {
+			params := installer.ListInfraEnvsParams{}
+			params.Owner = &userName1
+			resp := bm.ListInfraEnvs(authCtx, params)
+			Expect(resp).Should(BeAssignableToTypeOf(installer.NewListInfraEnvsOK()))
+			payload := resp.(*installer.ListInfraEnvsOK).Payload
+			Expect(len(payload)).Should(Equal(1))
+			Expect(payload[0].UserName).Should(Equal(userName1))
+		})
+
+		It("Owner query param is specified - user not in org", func() {
+			params := installer.ListInfraEnvsParams{}
+			params.Owner = &userName3
+			resp := bm.ListInfraEnvs(authCtx, params)
+			Expect(resp).Should(BeAssignableToTypeOf(installer.NewListInfraEnvsOK()))
+			payload := resp.(*installer.ListInfraEnvsOK).Payload
+			Expect(len(payload)).Should(Equal(0))
 		})
 	})
 
@@ -8035,6 +8101,11 @@ var _ = Describe("List clusters", func() {
 		hostID             strfmt.UUID
 		openshiftClusterID = strToUUID("41940ee8-ec99-43de-8766-174381b4921d")
 		amsSubscriptionID  = strToUUID("1sOMjCKRmEHYanIsp1bPbplb47t")
+		orgID1             = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
+		orgID2             = "DD71FD12-57FC-4480-917E-6F1900826543"
+		userName1          = "test_user_1"
+		userName2          = "test_user_2"
+		userName3          = "test_user_3"
 		c                  common.Cluster
 		kubeconfigFile     *os.File
 		dbName             string
@@ -8184,13 +8255,7 @@ var _ = Describe("List clusters", func() {
 	})
 
 	Context("Filter based on organization ID", func() {
-		var (
-			authCtx   context.Context
-			orgID1    = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
-			orgID2    = "DD71FD12-57FC-4480-917E-6F1900826543"
-			userName1 = "test_user_1"
-			userName2 = "test_user_2"
-		)
+		var authCtx context.Context
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
@@ -8253,6 +8318,73 @@ var _ = Describe("List clusters", func() {
 			payload := resp.(*installer.V2ListClustersOK).Payload
 			Expect(len(payload)).Should(Equal(1))
 			Expect(payload[0].OrgID).Should(Equal(orgID1))
+		})
+	})
+
+	Context("Filter by owner query param", func() {
+		var authCtx context.Context
+
+		BeforeEach(func() {
+			_, cert := auth.GetTokenAndCert(false)
+			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg.EnableOrgTenancy = true
+			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+
+			payload := &ocm.AuthPayload{Role: ocm.UserRole}
+			payload.Username = userName1
+			payload.Organization = orgID1
+			authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID1,
+				UserName: userName1,
+			}}
+			err := db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID1,
+				UserName: userName2,
+			}}
+			err = db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			clusterID = strfmt.UUID(uuid.New().String())
+			c = common.Cluster{Cluster: models.Cluster{
+				ID:       &clusterID,
+				OrgID:    orgID2,
+				UserName: userName3,
+			}}
+			err = db.Create(&c).Error
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("Owner query param is not specified", func() {
+			params := installer.V2ListClustersParams{}
+			resp := bm.V2ListClusters(authCtx, params)
+			payload := resp.(*installer.V2ListClustersOK).Payload
+			Expect(len(payload)).Should(Equal(2))
+		})
+
+		It("Owner query param is specified - user in org", func() {
+			params := installer.V2ListClustersParams{}
+			params.Owner = &userName1
+			resp := bm.V2ListClusters(authCtx, params)
+			payload := resp.(*installer.V2ListClustersOK).Payload
+			Expect(len(payload)).Should(Equal(1))
+			Expect(payload[0].UserName).Should(Equal(userName1))
+		})
+
+		It("Owner query param is specified - user not in org", func() {
+			params := installer.V2ListClustersParams{}
+			params.Owner = &userName3
+			resp := bm.V2ListClusters(authCtx, params)
+			payload := resp.(*installer.V2ListClustersOK).Payload
+			Expect(len(payload)).Should(Equal(0))
 		})
 	})
 })

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -25,7 +25,7 @@ func AddUserFilter(ctx context.Context, query string) string {
 	return query
 }
 
-func AddOwnerFilter(ctx context.Context, query string, filterByOrg bool) string {
+func AddOwnerFilter(ctx context.Context, query string, filterByOrg bool, owner string) string {
 	if IsAdmin(ctx) {
 		return query
 	}
@@ -35,6 +35,10 @@ func AddOwnerFilter(ctx context.Context, query string, filterByOrg bool) string 
 		}
 		orgId := ocm.OrgIDFromContext(ctx)
 		query += fmt.Sprintf("org_id = '%s'", orgId)
+		if owner != "" {
+			query += " and "
+			query += fmt.Sprintf("user_name = '%s'", owner)
+		}
 		return query
 	}
 	return AddUserFilter(ctx, query)

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -77,61 +77,77 @@ var _ = Describe("Identity", func() {
 	})
 
 	Context("AddOwnerFilter", func() {
-		It("admin user - empty query - filter by user", func() {
+		It("admin user - empty query - org tenancy disabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Role = ocm.AdminRole
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "", false)
+			query := AddOwnerFilter(ctx, "", false, "")
 			Expect(query).Should(Equal(""))
 		})
-		It("admin user - non-empty query - filter by user", func() {
+		It("admin user - non-empty query - org tenancy disabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Role = ocm.AdminRole
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "id = ?", false)
+			query := AddOwnerFilter(ctx, "id = ?", false, "")
 			Expect(query).Should(Equal("id = ?"))
 		})
-		It("non-admin user - empty query - filter by user", func() {
+		It("non-admin user - empty query - org tenancy disabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Username = "test_user"
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "", false)
+			query := AddOwnerFilter(ctx, "", false, "")
 			Expect(query).Should(Equal("user_name = 'test_user'"))
 		})
-		It("non-admin user - non-empty query - filter by user", func() {
+		It("non-admin user - non-empty query - org tenancy disabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Username = "test_user"
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "id = ?", false)
+			query := AddOwnerFilter(ctx, "id = ?", false, "")
 			Expect(query).Should(Equal("id = ? and user_name = 'test_user'"))
 		})
-		It("admin user - empty query - filter by org", func() {
+		It("admin user - empty query - org tenancy enabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Role = ocm.AdminRole
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "", true)
+			query := AddOwnerFilter(ctx, "", true, "")
 			Expect(query).Should(Equal(""))
 		})
-		It("admin user - non-empty query - filter by org", func() {
+		It("admin user - non-empty query - org tenancy enabled", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Role = ocm.AdminRole
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "id = ?", true)
+			query := AddOwnerFilter(ctx, "id = ?", true, "")
 			Expect(query).Should(Equal("id = ?"))
 		})
 		It("non-admin user - empty query - filter by org", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Organization = "test_org"
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "", true)
+			query := AddOwnerFilter(ctx, "", true, "")
 			Expect(query).Should(Equal("org_id = 'test_org'"))
 		})
 		It("non-admin user - non-empty query - filter by org", func() {
 			payload := &ocm.AuthPayload{}
 			payload.Organization = "test_org"
 			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
-			query := AddOwnerFilter(ctx, "id = ?", true)
+			query := AddOwnerFilter(ctx, "id = ?", true, "")
 			Expect(query).Should(Equal("id = ? and org_id = 'test_org'"))
+		})
+		It("non-admin user - empty query - filter by org and by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Organization = "test_org"
+			payload.Username = "test_user"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "", true, payload.Username)
+			Expect(query).Should(Equal("org_id = 'test_org' and user_name = 'test_user'"))
+		})
+		It("non-admin user - non-empty query - filter by org and by user", func() {
+			payload := &ocm.AuthPayload{}
+			payload.Organization = "test_org"
+			payload.Username = "test_user"
+			ctx = context.WithValue(ctx, restapi.AuthKey, payload)
+			query := AddOwnerFilter(ctx, "id = ?", true, payload.Username)
+			Expect(query).Should(Equal("id = ? and org_id = 'test_org' and user_name = 'test_user'"))
 		})
 	})
 })

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -88,6 +88,12 @@ func init() {
             "name": "with_hosts",
             "in": "query",
             "allowEmptyValue": true
+          },
+          {
+            "type": "string",
+            "description": "If provided, returns only clusters that are owned by the specified user.",
+            "name": "owner",
+            "in": "query"
           }
         ],
         "responses": {
@@ -2737,6 +2743,12 @@ func init() {
             "format": "uuid",
             "description": "If provided, returns only infra-envs which directly reference this cluster.",
             "name": "cluster_id",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "If provided, returns only infra-envs that are owned by the specified user.",
+            "name": "owner",
             "in": "query"
           }
         ],
@@ -8801,6 +8813,12 @@ func init() {
             "name": "with_hosts",
             "in": "query",
             "allowEmptyValue": true
+          },
+          {
+            "type": "string",
+            "description": "If provided, returns only clusters that are owned by the specified user.",
+            "name": "owner",
+            "in": "query"
           }
         ],
         "responses": {
@@ -11450,6 +11468,12 @@ func init() {
             "format": "uuid",
             "description": "If provided, returns only infra-envs which directly reference this cluster.",
             "name": "cluster_id",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "If provided, returns only infra-envs that are owned by the specified user.",
+            "name": "owner",
             "in": "query"
           }
         ],

--- a/restapi/operations/installer/list_infra_envs_parameters.go
+++ b/restapi/operations/installer/list_infra_envs_parameters.go
@@ -36,6 +36,10 @@ type ListInfraEnvsParams struct {
 	  In: query
 	*/
 	ClusterID *strfmt.UUID
+	/*If provided, returns only infra-envs that are owned by the specified user.
+	  In: query
+	*/
+	Owner *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -51,6 +55,11 @@ func (o *ListInfraEnvsParams) BindRequest(r *http.Request, route *middleware.Mat
 
 	qClusterID, qhkClusterID, _ := qs.GetOK("cluster_id")
 	if err := o.bindClusterID(qClusterID, qhkClusterID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOwner, qhkOwner, _ := qs.GetOK("owner")
+	if err := o.bindOwner(qOwner, qhkOwner, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -93,5 +102,23 @@ func (o *ListInfraEnvsParams) validateClusterID(formats strfmt.Registry) error {
 	if err := validate.FormatOf("cluster_id", "query", "uuid", o.ClusterID.String(), formats); err != nil {
 		return err
 	}
+	return nil
+}
+
+// bindOwner binds and validates parameter Owner from query.
+func (o *ListInfraEnvsParams) bindOwner(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Owner = &raw
+
 	return nil
 }

--- a/restapi/operations/installer/list_infra_envs_urlbuilder.go
+++ b/restapi/operations/installer/list_infra_envs_urlbuilder.go
@@ -16,6 +16,7 @@ import (
 // ListInfraEnvsURL generates an URL for the list infra envs operation
 type ListInfraEnvsURL struct {
 	ClusterID *strfmt.UUID
+	Owner     *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -57,6 +58,14 @@ func (o *ListInfraEnvsURL) Build() (*url.URL, error) {
 	}
 	if clusterIDQ != "" {
 		qs.Set("cluster_id", clusterIDQ)
+	}
+
+	var ownerQ string
+	if o.Owner != nil {
+		ownerQ = *o.Owner
+	}
+	if ownerQ != "" {
+		qs.Set("owner", ownerQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/restapi/operations/installer/v2_list_clusters_parameters.go
+++ b/restapi/operations/installer/v2_list_clusters_parameters.go
@@ -57,6 +57,10 @@ type V2ListClustersParams struct {
 	  In: query
 	*/
 	OpenshiftClusterID *strfmt.UUID
+	/*If provided, returns only clusters that are owned by the specified user.
+	  In: query
+	*/
+	Owner *string
 	/*Include hosts in the returned list.
 	  In: query
 	  Default: false
@@ -86,6 +90,11 @@ func (o *V2ListClustersParams) BindRequest(r *http.Request, route *middleware.Ma
 
 	qOpenshiftClusterID, qhkOpenshiftClusterID, _ := qs.GetOK("openshift_cluster_id")
 	if err := o.bindOpenshiftClusterID(qOpenshiftClusterID, qhkOpenshiftClusterID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOwner, qhkOwner, _ := qs.GetOK("owner")
+	if err := o.bindOwner(qOwner, qhkOwner, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -183,6 +192,24 @@ func (o *V2ListClustersParams) validateOpenshiftClusterID(formats strfmt.Registr
 	if err := validate.FormatOf("openshift_cluster_id", "query", "uuid", o.OpenshiftClusterID.String(), formats); err != nil {
 		return err
 	}
+	return nil
+}
+
+// bindOwner binds and validates parameter Owner from query.
+func (o *V2ListClustersParams) bindOwner(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Owner = &raw
+
 	return nil
 }
 

--- a/restapi/operations/installer/v2_list_clusters_urlbuilder.go
+++ b/restapi/operations/installer/v2_list_clusters_urlbuilder.go
@@ -18,6 +18,7 @@ import (
 type V2ListClustersURL struct {
 	AmsSubscriptionIds []string
 	OpenshiftClusterID *strfmt.UUID
+	Owner              *string
 	WithHosts          bool
 
 	_basePath string
@@ -77,6 +78,14 @@ func (o *V2ListClustersURL) Build() (*url.URL, error) {
 	}
 	if openshiftClusterIDQ != "" {
 		qs.Set("openshift_cluster_id", openshiftClusterIDQ)
+	}
+
+	var ownerQ string
+	if o.Owner != nil {
+		ownerQ = *o.Owner
+	}
+	if ownerQ != "" {
+		qs.Set("owner", ownerQ)
 	}
 
 	withHostsQ := swag.FormatBool(o.WithHosts)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -130,6 +130,11 @@ paths:
           type: boolean
           allowEmptyValue: true
           default: false
+        - in: query
+          name: owner
+          description: If provided, returns only clusters that are owned by the specified user.
+          type: string
+          required: false
       responses:
         "200":
           description: Success.
@@ -408,6 +413,11 @@ paths:
           description: If provided, returns only infra-envs which directly reference this cluster.
           type: string
           format: uuid
+          required: false
+        - in: query
+          name: owner
+          description: If provided, returns only infra-envs that are owned by the specified user.
+          type: string
           required: false
       responses:
         "200":


### PR DESCRIPTION
Added owner query param to the following GET list: clusters and infra-evns.
If the owner param is provided, the returned list includes only clusters/infra-envs that are owned by the specified user.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
