### PR TITLE
Bug 2065288: Add support for Ignition overrides for day2 worker

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -737,9 +737,9 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 	return &newCluster, nil
 }
 
-func (b *bareMetalInventory) createAndUploadNodeIgnition(ctx context.Context, cluster *common.Cluster, host *models.Host, ignitionEndpointToken string) error {
+func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context, cluster *common.Cluster, host *models.Host, ignitionEndpointToken string) error {
 	log := logutil.FromContext(ctx, b.log)
-	log.Infof("Starting createAndUploadNodeIgnition for cluster %s, host %s", cluster.ID, host.ID)
+	log.Infof("Starting createAndUploadDay2NodeIgnition for cluster %s, host %s", cluster.ID, host.ID)
 
 	// Specify ignition endpoint based on cluster configuration:
 	address := cluster.APIVip
@@ -762,16 +762,11 @@ func (b *bareMetalInventory) createAndUploadNodeIgnition(ctx context.Context, cl
 		caCert = cluster.IgnitionEndpoint.CaCertificate
 	}
 
-	ignitionBytes, err := b.IgnitionBuilder.FormatSecondDayWorkerIgnitionFile(ignitionEndpointUrl, caCert, ignitionEndpointToken)
+	fullIgnition, err := b.IgnitionBuilder.FormatSecondDayWorkerIgnitionFile(ignitionEndpointUrl, caCert, ignitionEndpointToken, host)
 	if err != nil {
-		return errors.Errorf("Failed to create ignition string for cluster %s", cluster.ID)
+		return errors.Wrapf(err, "Failed to create ignition string for cluster %s, host %s", cluster.ID, host.ID)
 	}
 
-	// Update host ignition hostname:
-	fullIgnition, err := ignition.SetHostnameForNodeIgnition(ignitionBytes, host)
-	if err != nil {
-		return errors.Errorf("Failed to create ignition string for cluster %s, host %s", cluster.ID, host.ID)
-	}
 	fileName := fmt.Sprintf("%s/worker-%s.ign", cluster.ID, host.ID)
 	log.Infof("Uploading ignition file <%s>", fileName)
 	err = b.objectHandler.Upload(ctx, fullIgnition, fileName)
@@ -1406,7 +1401,7 @@ func (b *bareMetalInventory) InstallSingleDay2HostInternal(ctx context.Context, 
 	}
 
 	// move host to installing
-	err = b.createAndUploadNodeIgnition(ctx, cluster, &h.Host, h.IgnitionEndpointToken)
+	err = b.createAndUploadDay2NodeIgnition(ctx, cluster, &h.Host, h.IgnitionEndpointToken)
 	if err != nil {
 		log.Errorf("Failed to upload ignition for host %s", h.RequestedHostname)
 		return err
@@ -1478,7 +1473,7 @@ func (b *bareMetalInventory) V2InstallHost(ctx context.Context, params installer
 	if cluster, err = common.GetClusterFromDB(b.db, *h.ClusterID, common.SkipEagerLoading); err != nil {
 		return common.GenerateErrorResponder(err)
 	}
-	err = b.createAndUploadNodeIgnition(ctx, cluster, h, host.IgnitionEndpointToken)
+	err = b.createAndUploadDay2NodeIgnition(ctx, cluster, h, host.IgnitionEndpointToken)
 	if err != nil {
 		log.Errorf("Failed to upload ignition for host %s", h.RequestedHostname)
 		return common.GenerateErrorResponder(err)
@@ -5066,6 +5061,8 @@ func (b *bareMetalInventory) V2UpdateHostIgnitionInternal(ctx context.Context, p
 			log.WithError(err).Errorf("Failed to parse host ignition config patch %s", params.HostIgnitionParams)
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}
+	} else {
+		log.Infof("Removing custom ignition override from host %s in infra-env %s", params.HostID, params.InfraEnvID)
 	}
 
 	err = b.db.Model(&common.Host{}).Where(identity.AddUserFilter(ctx, "id = ? and infra_env_id = ?"), params.HostID, params.InfraEnvID).Update("ignition_config_overrides", params.HostIgnitionParams.Config).Error

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6573,10 +6573,10 @@ var _ = Describe("infraEnvs", func() {
 			verifyApiErrorString(reply, http.StatusBadRequest, "CPU architecture doesn't match")
 		})
 
-		It("Invalid Ignition", func() {
+		It("Invalid Ignition - too recent", func() {
 			mockVersions.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 			MinimalOpenShiftVersionForNoneHA := "4.8.0-fc.0"
-			override := `{"ignition": {"wdd": "3.9.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+			override := `{"ignition": {"version": "9.9.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 			mockEvents.EXPECT().SendInfraEnvEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.InfraEnvRegistrationFailedEventName),
 				eventstest.WithMessageContainsMatcher("error parsing ignition: unsupported config version"))).Times(1)
@@ -8948,6 +8948,17 @@ var _ = Describe("UpdateInfraEnv - Ignition", func() {
 		response := bm.UpdateInfraEnv(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.Errorf("error"))))
 	})
+
+	It("returns bad request when provided too recent version", func() {
+		// Wrong version
+		override := `{"ignition": {"version": "9.9.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+		params := installer.UpdateInfraEnvParams{
+			InfraEnvID:           *infraEnv.ID,
+			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{IgnitionConfigOverride: override},
+		}
+		response := bm.UpdateInfraEnv(ctx, params)
+		Expect(response).To(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.Errorf("error"))))
+	})
 })
 
 var _ = Describe("GetSupportedPlatformsFromInventory", func() {
@@ -9323,7 +9334,7 @@ var _ = Describe("Install Host test", func() {
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
 		res := bm.V2InstallHost(ctx, params)
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2InstallHostAccepted()))
 	})
@@ -9341,7 +9352,7 @@ var _ = Describe("Install Host test", func() {
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile("http://example.com", gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile("http://example.com", gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
 		res := bm.V2InstallHost(ctx, params)
 		Expect(res).Should(BeAssignableToTypeOf(installer.NewV2InstallHostAccepted()))
 	})
@@ -9389,7 +9400,7 @@ var _ = Describe("Install Host test", func() {
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(0)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ign failure")).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("ign failure")).Times(1)
 		res := bm.V2InstallHost(ctx, params)
 		verifyApiError(res, http.StatusInternalServerError)
 	})
@@ -9404,7 +9415,7 @@ var _ = Describe("Install Host test", func() {
 		mockHostApi.EXPECT().AutoAssignRole(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(1)
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")).Times(1)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
 		res := bm.V2InstallHost(ctx, params)
 		verifyApiError(res, http.StatusInternalServerError)
 	})
@@ -9453,7 +9464,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
 		res := bm.InstallSingleDay2HostInternal(ctx, clusterID, clusterID, hostId)
 		Expect(res).Should(BeNil())
 	})
@@ -9466,7 +9477,7 @@ var _ = Describe("InstallSingleDay2Host test", func() {
 		mockHostApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().Install(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockS3Client.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
+		mockIgnitionBuilder.EXPECT().FormatSecondDayWorkerIgnitionFile(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(secondDayWorkerIgnition, nil).Times(1)
 		res := bm.InstallSingleDay2HostInternal(ctx, clusterID, clusterID, hostId)
 		Expect(res.Error()).Should(Equal(expectedErrMsg))
 	})
@@ -11038,6 +11049,18 @@ var _ = Describe("V2UpdateHostIgnition", func() {
 	It("returns bad request when provided an old version", func() {
 		// Wrong version
 		override := `{"ignition": {"version": "3.0.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+		params := installer.V2UpdateHostIgnitionParams{
+			InfraEnvID:         infraEnvID,
+			HostID:             hostID,
+			HostIgnitionParams: &models.HostIgnitionParams{Config: override},
+		}
+		response := bm.V2UpdateHostIgnition(ctx, params)
+		verifyApiError(response, http.StatusBadRequest)
+	})
+
+	It("returns bad request when provided too recent version", func() {
+		// Wrong version
+		override := `{"ignition": {"version": "9.9.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		params := installer.V2UpdateHostIgnitionParams{
 			InfraEnvID:         infraEnvID,
 			HostID:             hostID,

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -388,7 +388,7 @@ type Generator interface {
 //go:generate mockgen -source=ignition.go -package=ignition -destination=mock_ignition.go
 type IgnitionBuilder interface {
 	FormatDiscoveryIgnitionFile(ctx context.Context, infraEnv *common.InfraEnv, cfg IgnitionConfig, safeForLogs bool, authType auth.AuthType) (string, error)
-	FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error)
+	FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string, host *models.Host) ([]byte, error)
 }
 
 type installerGenerator struct {
@@ -1078,17 +1078,22 @@ func uploadToS3(ctx context.Context, workDir string, cluster *common.Cluster, s3
 	return nil
 }
 
+// ParseToLatest takes the Ignition config and tries to parse it as v3.2 and if that fails,
+// as v3.1. This is in order to support the latest possible Ignition as well as to preserve
+// backwards-compatibility with OCP 4.6 that supports only Ignition up to v3.1
 func ParseToLatest(content []byte) (*config_latest_types.Config, error) {
 	config, _, err := config_latest.Parse(content)
 	if err != nil {
-		configv31, _, err := config_31.Parse(content)
+		// TODO(deprecate-ignition-3.1.0)
+		// We always want to work with the object of the type v3.2 but carry a value of v3.1 inside.
+		// For this reason we are translating the config to v3.2 and manually override the Version.
+		configBackwards, _, err := config_31.Parse(content)
 		if err != nil {
 			return nil, errors.Errorf("error parsing ignition: %v", err)
 		}
-		config = config_latest_trans.Translate(configv31)
+		config = config_latest_trans.Translate(configBackwards)
 		config.Ignition.Version = "3.1.0"
 	}
-
 	return &config, nil
 }
 
@@ -1262,12 +1267,21 @@ func MergeIgnitionConfig(base []byte, overrides []byte) (string, error) {
 		return "", err
 	}
 
-	// Validate after we marshal to use the Parse functions
+	// TODO(deprecate-ignition-3.1.0)
+	// We want to validate if users do not try to override with putting features of 3.2.0 into
+	// ignition manifest of 3.1.0. Because the merger function from ignition package is
+	// version-agnostic and returns only interface{}, we need to hack our way into accessing
+	// the content as a regular Config
 	var report report.Report
-	if baseConfig.Ignition.Version == "3.1.0" {
-		_, report, err = config_31.Parse(res)
-	} else {
-		_, report, err = config_latest.Parse(res)
+	switch v := mergeResult.(type) {
+	case config_latest_types.Config:
+		if v.Ignition.Version == "3.1.0" {
+			_, report, err = config_31.Parse(res)
+		} else {
+			_, report, err = config_latest.Parse(res)
+		}
+	default:
+		return "", errors.Errorf("merged ignition config has invalid type: %T", v)
 	}
 	if err != nil {
 		return "", err
@@ -1493,7 +1507,7 @@ func (ib *ignitionBuilder) prepareStaticNetworkConfigForIgnition(ctx context.Con
 	return filesList, nil
 }
 
-func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error) {
+func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string, host *models.Host) ([]byte, error) {
 	var ignitionParams = map[string]interface{}{
 		// https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigServer.md#endpoint
 		"SOURCE":  url,
@@ -1516,7 +1530,22 @@ func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert 
 	if err = tmpl.Execute(buf, ignitionParams); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+
+	overrides := buf.String()
+	if host.IgnitionConfigOverrides != "" {
+		overrides, err = MergeIgnitionConfig(buf.Bytes(), []byte(host.IgnitionConfigOverrides))
+		if err != nil {
+			return []byte(""), errors.Wrapf(err, "Failed to apply ignition override for host %s", host.ID)
+		}
+		ib.log.Infof("Applied ignition override for host %s", host.ID)
+	}
+
+	res, err := SetHostnameForNodeIgnition([]byte(overrides), host)
+	if err != nil {
+		return []byte(""), errors.Wrapf(err, "Failed to set hostname in ignition for host %s", host.ID)
+	}
+
+	return res, nil
 }
 
 func QuoteSshPublicKeys(sshPublicKeys string) string {

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	cluster              *common.Cluster
+	hostInventory        string
 	installerCacheDir    string
 	log                  = logrus.New()
 	workDir              string
@@ -58,6 +59,8 @@ var _ = BeforeEach(func() {
 		},
 	}
 	cluster.ImageInfo = &models.ImageInfo{}
+
+	hostInventory = `{"bmc_address":"0.0.0.0","bmc_v6address":"::/0","boot":{"current_boot_mode":"bios"},"cpu":{"architecture":"x86_64","count":4,"flags":["fpu","vme","de","pse","tsc","msr","pae","mce","cx8","apic","sep","mtrr","pge","mca","cmov","pat","pse36","clflush","mmx","fxsr","sse","sse2","ss","syscall","nx","pdpe1gb","rdtscp","lm","constant_tsc","arch_perfmon","rep_good","nopl","xtopology","cpuid","tsc_known_freq","pni","pclmulqdq","vmx","ssse3","fma","cx16","pcid","sse4_1","sse4_2","x2apic","movbe","popcnt","tsc_deadline_timer","aes","xsave","avx","f16c","rdrand","hypervisor","lahf_lm","abm","3dnowprefetch","cpuid_fault","invpcid_single","pti","ssbd","ibrs","ibpb","stibp","tpr_shadow","vnmi","flexpriority","ept","vpid","ept_ad","fsgsbase","tsc_adjust","bmi1","hle","avx2","smep","bmi2","erms","invpcid","rtm","mpx","avx512f","avx512dq","rdseed","adx","smap","clflushopt","clwb","avx512cd","avx512bw","avx512vl","xsaveopt","xsavec","xgetbv1","xsaves","arat","umip","pku","ospke","md_clear","arch_capabilities"],"frequency":2095.076,"model_name":"Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz"},"disks":[{"by_path":"/dev/disk/by-path/pci-0000:00:06.0","drive_type":"HDD","model":"unknown","name":"vda","path":"/dev/vda","serial":"unknown","size_bytes":21474836480,"vendor":"0x1af4","wwn":"unknown"}],"hostname":"test-infra-cluster-master-1.redhat.com","interfaces":[{"flags":["up","broadcast","multicast"],"has_carrier":true,"ipv4_addresses":["192.168.126.11/24"],"ipv6_addresses":["fe80::5054:ff:fe42:1e8d/64"],"mac_address":"52:54:00:42:1e:8d","mtu":1500,"name":"eth0","product":"0x0001","speed_mbps":-1,"vendor":"0x1af4"},{"flags":["up","broadcast","multicast"],"has_carrier":true,"ipv4_addresses":["192.168.140.133/24"],"ipv6_addresses":["fe80::5054:ff:feca:7b16/64"],"mac_address":"52:54:00:ca:7b:16","mtu":1500,"name":"eth1","product":"0x0001","speed_mbps":-1,"vendor":"0x1af4"}],"memory":{"physical_bytes":17809014784,"usable_bytes":17378611200},"system_vendor":{"manufacturer":"Red Hat","product_name":"KVM"}}`
 
 	ctrl = gomock.NewController(GinkgoT())
 	mockOperatorManager = operators.NewMockAPI(ctrl)
@@ -97,13 +100,11 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		}
 	  }`
 
-	const inventory1 = `{"bmc_address":"0.0.0.0","bmc_v6address":"::/0","boot":{"current_boot_mode":"bios"},"cpu":{"architecture":"x86_64","count":4,"flags":["fpu","vme","de","pse","tsc","msr","pae","mce","cx8","apic","sep","mtrr","pge","mca","cmov","pat","pse36","clflush","mmx","fxsr","sse","sse2","ss","syscall","nx","pdpe1gb","rdtscp","lm","constant_tsc","arch_perfmon","rep_good","nopl","xtopology","cpuid","tsc_known_freq","pni","pclmulqdq","vmx","ssse3","fma","cx16","pcid","sse4_1","sse4_2","x2apic","movbe","popcnt","tsc_deadline_timer","aes","xsave","avx","f16c","rdrand","hypervisor","lahf_lm","abm","3dnowprefetch","cpuid_fault","invpcid_single","pti","ssbd","ibrs","ibpb","stibp","tpr_shadow","vnmi","flexpriority","ept","vpid","ept_ad","fsgsbase","tsc_adjust","bmi1","hle","avx2","smep","bmi2","erms","invpcid","rtm","mpx","avx512f","avx512dq","rdseed","adx","smap","clflushopt","clwb","avx512cd","avx512bw","avx512vl","xsaveopt","xsavec","xgetbv1","xsaves","arat","umip","pku","ospke","md_clear","arch_capabilities"],"frequency":2095.076,"model_name":"Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz"},"disks":[{"by_path":"/dev/disk/by-path/pci-0000:00:06.0","drive_type":"HDD","model":"unknown","name":"vda","path":"/dev/vda","serial":"unknown","size_bytes":21474836480,"vendor":"0x1af4","wwn":"unknown"}],"hostname":"test-infra-cluster-master-1.redhat.com","interfaces":[{"flags":["up","broadcast","multicast"],"has_carrier":true,"ipv4_addresses":["192.168.126.11/24"],"ipv6_addresses":["fe80::5054:ff:fe42:1e8d/64"],"mac_address":"52:54:00:42:1e:8d","mtu":1500,"name":"eth0","product":"0x0001","speed_mbps":-1,"vendor":"0x1af4"},{"flags":["up","broadcast","multicast"],"has_carrier":true,"ipv4_addresses":["192.168.140.133/24"],"ipv6_addresses":["fe80::5054:ff:feca:7b16/64"],"mac_address":"52:54:00:ca:7b:16","mtu":1500,"name":"eth1","product":"0x0001","speed_mbps":-1,"vendor":"0x1af4"}],"memory":{"physical_bytes":17809014784,"usable_bytes":17378611200},"system_vendor":{"manufacturer":"Red Hat","product_name":"KVM"}}`
-
 	var (
 		err          error
 		examplePath  string
 		bmh          *bmh_v1alpha1.BareMetalHost
-		config       config_32_types.Config
+		config       *config_32_types.Config
 		mockS3Client *s3wrapper.MockAPI
 	)
 
@@ -116,7 +117,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 
 		cluster.Hosts = []*models.Host{
 			{
-				Inventory:         inventory1,
+				Inventory:         hostInventory,
 				RequestedHostname: "example1",
 				Role:              models.HostRoleMaster,
 			},
@@ -126,9 +127,16 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 
 		err = g.updateBootstrap(context.Background(), examplePath)
 
+		// TODO(deprecate-ignition-3.1.0)
 		bootstrapBytes, _ := ioutil.ReadFile(examplePath)
-		config, _, err1 = config_32.Parse(bootstrapBytes)
+		config, err1 = ParseToLatest(bootstrapBytes)
 		Expect(err1).NotTo(HaveOccurred())
+		Expect(config.Ignition.Version).To(Equal("3.2.0"))
+		bytes, err1 := json.Marshal(config)
+		Expect(err1).ToNot(HaveOccurred())
+		v32Config, _, err1 := config_32.Parse(bytes)
+		Expect(err1).ToNot(HaveOccurred())
+		Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
 
 		var file *config_32_types.File
 		foundNMConfig := false
@@ -804,15 +812,24 @@ var _ = Describe("downloadManifest", func() {
 })
 
 var _ = Describe("ParseToLatest", func() {
+	const v99ignition = `{"ignition": {"version": "9.9.0"},"storage": {"files": []}}`
 	const v32ignition = `{"ignition": {"version": "3.2.0"},"storage": {"files": []}}`
 	const v31ignition = `{"ignition": {"version": "3.1.0"},"storage": {"files": []}}`
-	It("parses a v32 config", func() {
+	const v32override = `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+	const v31override = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+	It("parses a v32 config as 3.2.0", func() {
 		config, err := ParseToLatest([]byte(v32ignition))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(config.Ignition.Version).To(Equal("3.2.0"))
+
+		bytes, err := json.Marshal(config)
+		Expect(err).ToNot(HaveOccurred())
+		v32Config, _, err := config_32.Parse(bytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
 	})
 
-	It("parses a v31 config", func() {
+	It("parses a v31 config as 3.1.0", func() {
 		config, err := ParseToLatest([]byte(v31ignition))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(config.Ignition.Version).To(Equal("3.1.0"))
@@ -822,6 +839,41 @@ var _ = Describe("ParseToLatest", func() {
 		v31Config, _, err := config_31.Parse(bytes)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
+	})
+
+	It("parses a v31 config with v31 override as 3.1.0", func() {
+		merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v31override))
+		Expect(err).ToNot(HaveOccurred())
+
+		config, err := ParseToLatest([]byte(merge))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config.Ignition.Version).To(Equal("3.1.0"))
+
+		bytes, err := json.Marshal(config)
+		Expect(err).ToNot(HaveOccurred())
+		v31Config, _, err := config_31.Parse(bytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
+	})
+
+	It("parses a v31 config with v32 override as 3.2.0", func() {
+		merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v32override))
+		Expect(err).ToNot(HaveOccurred())
+
+		config, err := ParseToLatest([]byte(merge))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(config.Ignition.Version).To(Equal("3.2.0"))
+
+		bytes, err := json.Marshal(config)
+		Expect(err).ToNot(HaveOccurred())
+		v32Config, _, err := config_32.Parse(bytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
+	})
+
+	It("does not parse v99 config", func() {
+		_, err := ParseToLatest([]byte(v99ignition))
+		Expect(err.Error()).To(ContainSubstring("unsupported config version"))
 	})
 })
 
@@ -1023,6 +1075,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(config.Ignition.Version).To(Equal("3.1.0"))
 	})
 
+	// TODO(deprecate-ignition-3.1.0)
 	It("produces a valid ignition v3.1 spec with overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO)
@@ -1041,7 +1094,31 @@ var _ = Describe("IgnitionBuilder", func() {
 		config, report, err = config_31.Parse([]byte(text))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(report.IsFatal()).To(BeFalse())
+		Expect(config.Ignition.Version).To(Equal("3.1.0"))
 		Expect(len(config.Storage.Files)).To(Equal(numOfFiles + 1))
+	})
+
+	It("produces a valid ignition spec with v3.2 overrides", func() {
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO)
+		Expect(err).NotTo(HaveOccurred())
+
+		config, report, err := config_31.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+		Expect(config.Ignition.Version).To(Equal("3.1.0"))
+		numOfFiles := len(config.Storage.Files)
+
+		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO)
+		Expect(err).NotTo(HaveOccurred())
+
+		config2, report, err := config_32.Parse([]byte(text))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(report.IsFatal()).To(BeFalse())
+		Expect(config2.Ignition.Version).To(Equal("3.2.0"))
+		Expect(len(config2.Storage.Files)).To(Equal(numOfFiles + 1))
 	})
 
 	It("fails when given overrides with an incompatible version", func() {
@@ -1050,6 +1127,22 @@ var _ = Describe("IgnitionBuilder", func() {
 		_, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO)
 
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("applies day2 overrides successfuly", func() {
+		hostID := strfmt.UUID(uuid.New().String())
+		cluster.Hosts = []*models.Host{{
+			ID:                      &hostID,
+			RequestedHostname:       "day2worker.example.com",
+			Role:                    models.HostRoleWorker,
+			IgnitionConfigOverrides: `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`,
+		}}
+		serviceBaseURL := "http://10.56.20.70:7878"
+
+		text, err := builder.FormatSecondDayWorkerIgnitionFile(serviceBaseURL, nil, "", cluster.Hosts[0])
+
+		Expect(err).Should(BeNil())
+		Expect(text).Should(ContainSubstring("/tmp/example"))
 	})
 
 	Context("static network config", func() {
@@ -1208,6 +1301,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		builder                           IgnitionBuilder
 		mockStaticNetworkConfig           *staticnetworkconfig.MockStaticNetworkConfig
 		mockMirrorRegistriesConfigBuilder *mirrorregistries.MockMirrorRegistriesConfigBuilder
+		mockHost                          *models.Host
 	)
 
 	BeforeEach(func() {
@@ -1215,13 +1309,14 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
+		mockHost = &models.Host{Inventory: hostInventory}
 		builder = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
 	})
 
 	Context("test custom ignition endpoint", func() {
 
 		It("are rendered properly without ca cert and token", func() {
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, "")
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, "", mockHost)
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1233,7 +1328,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 
 		It("are rendered properly with token", func() {
 			token := "xyzabc123"
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, token)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("http://url.com", nil, token, mockHost)
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1250,7 +1345,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
 			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, "")
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, "", mockHost)
 			Expect(err).NotTo(HaveOccurred())
 
 			ignConfig, _, err := config_31.Parse(ign)
@@ -1267,7 +1362,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 				"aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk" +
 				"2lyDI6UR3Fbz4pVVAxGXnVhBExjBE=\n-----END CERTIFICATE-----"
 			encodedCa := base64.StdEncoding.EncodeToString([]byte(ca))
-			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, token)
+			ign, err := builder.FormatSecondDayWorkerIgnitionFile("https://url.com", &encodedCa, token, mockHost)
 
 			Expect(err).NotTo(HaveOccurred())
 

--- a/internal/ignition/mock_ignition.go
+++ b/internal/ignition/mock_ignition.go
@@ -118,16 +118,16 @@ func (mr *MockIgnitionBuilderMockRecorder) FormatDiscoveryIgnitionFile(ctx, infr
 }
 
 // FormatSecondDayWorkerIgnitionFile mocks base method.
-func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string) ([]byte, error) {
+func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert *string, bearerToken string, host *models.Host) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatSecondDayWorkerIgnitionFile", url, caCert, bearerToken)
+	ret := m.ctrl.Call(m, "FormatSecondDayWorkerIgnitionFile", url, caCert, bearerToken, host)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FormatSecondDayWorkerIgnitionFile indicates an expected call of FormatSecondDayWorkerIgnitionFile.
-func (mr *MockIgnitionBuilderMockRecorder) FormatSecondDayWorkerIgnitionFile(url, caCert, bearerToken interface{}) *gomock.Call {
+func (mr *MockIgnitionBuilderMockRecorder) FormatSecondDayWorkerIgnitionFile(url, caCert, bearerToken, host interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatSecondDayWorkerIgnitionFile", reflect.TypeOf((*MockIgnitionBuilder)(nil).FormatSecondDayWorkerIgnitionFile), url, caCert, bearerToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatSecondDayWorkerIgnitionFile", reflect.TypeOf((*MockIgnitionBuilder)(nil).FormatSecondDayWorkerIgnitionFile), url, caCert, bearerToken, host)
 }


### PR DESCRIPTION
Currently there is a bug that causes day-2 worker ignition override to
be ignored without any error message.

This PR changes the behaviour of ignition generator so that the function
handling day-2 nodes takes the override into account. Given that there
are separate functions for day-1 and day-2 nodes, this PR also renames
the latter so that it's clear that it's used only for day-2.

Closes: [MGMT-9064](https://issues.redhat.com/browse/MGMT-9064)
Closes: Bug-2065288
Closes: [MGMTBUGSM-201](https://issues.redhat.com/browse/MGMTBUGSM-201)
Supersedes: #3502

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eranco74

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
