### PR TITLE
Bug 2066786: Set the correct stopping state for a day2 cluster.

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1672,7 +1672,7 @@ func clusterStopped(clusterInstall *hiveext.AgentClusterInstall, status string) 
 		condStatus = corev1.ConditionTrue
 		reason = hiveext.ClusterStoppedCanceledReason
 		msg = hiveext.ClusterStoppedCanceledMsg
-	case models.ClusterStatusInstalled:
+	case models.ClusterStatusInstalled, models.ClusterStatusAddingHosts:
 		condStatus = corev1.ConditionTrue
 		reason = hiveext.ClusterStoppedCompletedReason
 		msg = hiveext.ClusterStoppedCompletedMsg

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -3061,9 +3061,9 @@ var _ = Describe("TestConditions", func() {
 				},
 				{
 					Type:    hiveext.ClusterStoppedCondition,
-					Message: hiveext.ClusterNotStoppedMsg,
-					Reason:  hiveext.ClusterNotStoppedReason,
-					Status:  corev1.ConditionFalse,
+					Message: hiveext.ClusterStoppedCompletedMsg,
+					Reason:  hiveext.ClusterStoppedCompletedReason,
+					Status:  corev1.ConditionTrue,
 				},
 			},
 		},


### PR DESCRIPTION
Presently when setting a cluster to become "Day 2", the Stopped
condition is incorrectly configured with default values that do not make sense.

```
condStatus = corev1.ConditionFalse
reason = hiveext.ClusterNotStoppedReason
msg = hiveext.ClusterNotStoppedMsg
```

as a Day 2 cluster represents a completed Day 1 cluster, then the
Stopped condition should be set to a completed state as follows.

```
condStatus = corev1.ConditionTrue
reason = hiveext.ClusterStoppedCompletedReason
msg = hiveext.ClusterStoppedCompletedMsg
```

This commit addresses that issue.
So far I have executed the unit tests and the subsystem tests.

The bugzilla we are addressing is here https://bugzilla.redhat.com/show_bug.cgi?id=2066786

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @omertuc 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
