### PR TITLE
MGMT-9404: remove user filter from UpdateHostApproved

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3867,6 +3867,8 @@ func (b *bareMetalInventory) GetCommonHostInternal(_ context.Context, infraEnvId
 	return common.GetHostFromDB(b.db, infraEnvId, hostId)
 }
 
+// Updates host's approved field by a specified flag.
+// Used execlusively by kube-api.
 func (b *bareMetalInventory) UpdateHostApprovedInternal(ctx context.Context, infraEnvId, hostId string, approved bool) error {
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Updating Approved to %t Host %s InfraEnv %s", approved, hostId, infraEnvId)
@@ -3874,7 +3876,7 @@ func (b *bareMetalInventory) UpdateHostApprovedInternal(ctx context.Context, inf
 	if err != nil {
 		return err
 	}
-	err = b.db.Model(&common.Host{}).Where(identity.AddUserFilter(ctx, "id = ? and infra_env_id = ?"), hostId, infraEnvId).Update("approved", approved).Error
+	err = b.db.Model(&common.Host{}).Where("id = ? and infra_env_id = ?", hostId, infraEnvId).Update("approved", approved).Error
 	if err != nil {
 		log.WithError(err).Errorf("failed to update 'approved' in host: %s", hostId)
 		return err


### PR DESCRIPTION
UpdateHostApprovedInternal is currently filtering hosts by user_name when the entity is fetched.
Since this func is used exclusively in kube-api [flow](https://github.com/openshift/assisted-service/blob/f28bddc8d95a89a4804b77b362dda721e3e14214/internal/controller/controllers/agent_controller.go#L1175), the filter has no effect (kube-api uses kube_key_namespace to [retrieve](https://github.com/openshift/assisted-service/blob/f28bddc8d95a89a4804b77b362dda721e3e14214/internal/controller/controllers/agent_controller.go#L144) the host). Hence, we can safely remove AddUserFilter from the func.

Note: perhaps we should consider marking UpdateHostApprovedInternal as relevant only for kube-api. I.e. to avoid missing authorization if ever exposed to the external API.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @slaviered 
/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
