### PR TITLE
MGMT-9673: Ownerhsip API to authz

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -417,7 +417,7 @@ func main() {
 	}
 
 	bm := bminventory.NewBareMetalInventory(db, log.WithField("pkg", "Inventory"), hostApi, clusterApi, infraEnvApi, Options.BMConfig,
-		generator, eventsHandler, objectHandler, metricsManager, usageManager, operatorsManager, authHandler, ocpClient, ocmClient,
+		generator, eventsHandler, objectHandler, metricsManager, usageManager, operatorsManager, authHandler, authzHandler, ocpClient, ocmClient,
 		lead, pullSecretValidator, versionHandler, isoEditorFactory, crdUtils, ignitionBuilder, hwValidator, dnsApi, installConfigBuilder, staticNetworkConfig,
 		Options.GCConfig, providerRegistry)
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -179,6 +179,7 @@ type bareMetalInventory struct {
 	operatorManagerApi   operators.API
 	generator            generator.ISOInstallConfigGenerator
 	authHandler          auth.Authenticator
+	authzHandler         auth.Authorizer
 	k8sClient            k8sclient.K8SClient
 	ocmClient            *ocm.Client
 	leaderElector        leader.Leader
@@ -208,6 +209,7 @@ func NewBareMetalInventory(
 	usageApi usage.API,
 	operatorManagerApi operators.API,
 	authHandler auth.Authenticator,
+	authzHandler auth.Authorizer,
 	k8sClient k8sclient.K8SClient,
 	ocmClient *ocm.Client,
 	leaderElector leader.Leader,
@@ -238,6 +240,7 @@ func NewBareMetalInventory(
 		usageApi:             usageApi,
 		operatorManagerApi:   operatorManagerApi,
 		authHandler:          authHandler,
+		authzHandler:         authzHandler,
 		k8sClient:            k8sClient,
 		ocmClient:            ocmClient,
 		leaderElector:        leaderElector,
@@ -2652,31 +2655,29 @@ func (b *bareMetalInventory) calculateHostNetworks(log logrus.FieldLogger, clust
 func (b *bareMetalInventory) listClustersInternal(ctx context.Context, params installer.V2ListClustersParams) ([]*models.Cluster, error) {
 	log := logutil.FromContext(ctx, b.log)
 	db := b.db
+
+	var dbClusters []*common.Cluster
+	var clusters []*models.Cluster
+
 	if swag.BoolValue(params.GetUnregisteredClusters) {
 		if !identity.IsAdmin(ctx) {
 			return nil, common.NewApiError(http.StatusForbidden, errors.New("only admin users are allowed to get unregistered clusters"))
 		}
 		db = db.Unscoped()
 	}
-	var dbClusters []*common.Cluster
-	var clusters []*models.Cluster
-	whereCondition := make([]string, 0)
 
-	filterByOrg := b.authHandler.EnableOrgTenancy()
-	if user := identity.AddOwnerFilter(ctx, "", filterByOrg, swag.StringValue(params.Owner)); user != "" {
-		whereCondition = append(whereCondition, user)
-	}
+	db = b.authzHandler.OwnedByUser(ctx, db, swag.StringValue(params.Owner))
 
 	if params.OpenshiftClusterID != nil {
-		whereCondition = append(whereCondition, fmt.Sprintf("openshift_cluster_id = '%s'", *params.OpenshiftClusterID))
+		db = db.Where("openshift_cluster_id = ?", *params.OpenshiftClusterID)
 	}
 
 	if len(params.AmsSubscriptionIds) > 0 {
-		whereCondition = append(whereCondition, fmt.Sprintf("ams_subscription_id IN %s", common.ToSqlList(params.AmsSubscriptionIds)))
+		db = db.Where("ams_subscription_id IN (?)", params.AmsSubscriptionIds)
 	}
 
 	dbClusters, err := common.GetClustersFromDBWhere(db, common.UseEagerLoading,
-		common.DeleteRecordsState(swag.BoolValue(params.GetUnregisteredClusters)), strings.Join(whereCondition, " AND "))
+		common.DeleteRecordsState(swag.BoolValue(params.GetUnregisteredClusters)))
 	if err != nil {
 		log.WithError(err).Error("Failed to list clusters in db")
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
@@ -3950,14 +3951,13 @@ func (b *bareMetalInventory) ListInfraEnvs(ctx context.Context, params installer
 	var dbInfraEnvs []*common.InfraEnv
 	var infraEnvs []*models.InfraEnv
 
-	condition := ""
-	if params.ClusterID != nil {
-		condition = fmt.Sprintf("cluster_id = '%s'", params.ClusterID)
-	}
-	filterByOrg := b.authHandler.EnableOrgTenancy()
-	whereCondition := identity.AddOwnerFilter(ctx, condition, filterByOrg, swag.StringValue(params.Owner))
+	db = b.authzHandler.OwnedByUser(ctx, db, swag.StringValue(params.Owner))
 
-	dbInfraEnvs, err := common.GetInfraEnvsFromDBWhere(db, whereCondition)
+	if params.ClusterID != nil {
+		db = db.Where("cluster_id = ?", params.ClusterID)
+	}
+
+	dbInfraEnvs, err := common.GetInfraEnvsFromDBWhere(db)
 	if err != nil {
 		log.WithError(err).Error("Failed to list infraEnvs in db")
 		return common.NewApiError(http.StatusInternalServerError, err)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -194,6 +194,10 @@ func getTestAuthHandler() auth.Authenticator {
 	return auth.NewNoneAuthenticator(common.GetTestLog().WithField("pkg", "auth"))
 }
 
+func getTestAuthzHandler() auth.Authorizer {
+	return &auth.NoneHandler{}
+}
+
 func strToUUID(s string) *strfmt.UUID {
 	u := strfmt.UUID(s)
 	return &u
@@ -6468,9 +6472,10 @@ var _ = Describe("infraEnvs", func() {
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
-			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg := &auth.Config{JwkCert: string(cert), AuthType: auth.TypeRHSSO}
 			cfg.EnableOrgTenancy = true
 			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+			bm.authzHandler = auth.NewAuthzHandler(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
 
 			payload := &ocm.AuthPayload{Role: ocm.UserRole}
 			payload.Username = userName1
@@ -6533,9 +6538,10 @@ var _ = Describe("infraEnvs", func() {
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
-			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg := &auth.Config{JwkCert: string(cert), AuthType: auth.TypeRHSSO}
 			cfg.EnableOrgTenancy = true
 			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+			bm.authzHandler = auth.NewAuthzHandler(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
 
 			payload := &ocm.AuthPayload{Role: ocm.UserRole}
 			payload.Username = userName1
@@ -8358,9 +8364,10 @@ var _ = Describe("List clusters", func() {
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
-			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg := &auth.Config{JwkCert: string(cert), AuthType: auth.TypeRHSSO}
 			cfg.EnableOrgTenancy = true
 			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+			bm.authzHandler = auth.NewAuthzHandler(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
 
 			payload := &ocm.AuthPayload{Role: ocm.UserRole}
 			payload.Username = userName1
@@ -8425,9 +8432,10 @@ var _ = Describe("List clusters", func() {
 
 		BeforeEach(func() {
 			_, cert := auth.GetTokenAndCert(false)
-			cfg := &auth.Config{JwkCert: string(cert)}
+			cfg := &auth.Config{JwkCert: string(cert), AuthType: auth.TypeRHSSO}
 			cfg.EnableOrgTenancy = true
 			bm.authHandler = auth.NewRHSSOAuthenticator(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+			bm.authzHandler = auth.NewAuthzHandler(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
 
 			payload := &ocm.AuthPayload{Role: ocm.UserRole}
 			payload.Username = userName1
@@ -12252,7 +12260,7 @@ func createInventory(db *gorm.DB, cfg Config) *bareMetalInventory {
 	gcConfig := garbagecollector.Config{DeregisterInactiveAfter: 20 * 24 * time.Hour}
 	return NewBareMetalInventory(db, common.GetTestLog(), mockHostApi, mockClusterApi, mockInfraEnvApi, cfg,
 		mockGenerator, mockEvents, mockS3Client, mockMetric, mockUsage, mockOperatorManager,
-		getTestAuthHandler(), mockK8sClient, ocmClient, nil, mockSecretValidator, mockVersions,
+		getTestAuthHandler(), getTestAuthzHandler(), mockK8sClient, ocmClient, nil, mockSecretValidator, mockVersions,
 		mockIsoEditorFactory, mockCRDUtils, mockIgnitionBuilder, mockHwValidator, dnsApi, mockInstallConfigBuilder, mockStaticNetworkConfig,
 		gcConfig, mockProviderRegistry)
 }

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -361,12 +359,6 @@ func (c *Cluster) AfterFind(db *gorm.DB) error {
 	}
 	c.TotalHostCount = int64(len(c.Hosts))
 	return nil
-}
-
-func ToSqlList(strs []string) string {
-	res := strings.Join(strs, `', '`)
-	res = fmt.Sprintf("('%s')", res)
-	return res
 }
 
 func CreateInfraEnvForCluster(db *gorm.DB, cluster *Cluster, imageType models.ImageType) error {

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+type Authorizer interface {
+	/* Limits the database query to access records that are owned by the current user,
+	 * according to the configured access policy.
+	 */
+	OwnedBy(ctx context.Context, db *gorm.DB) *gorm.DB
+
+	/* Limits the database query to access records owned only by the input user,
+	 * regardless of the configured access policy. If user-based authentication
+	 * is not supported, the function effectively will not limit access.
+	 */
+	OwnedByUser(ctx context.Context, db *gorm.DB, username string) *gorm.DB
+
+	/* Provides the middleware authorization algorithm */
+	CreateAuthorizer() func(*http.Request) error
+}
+
+func NewAuthzHandler(cfg *Config, ocmCLient *ocm.Client, log logrus.FieldLogger, db *gorm.DB) Authorizer {
+	if cfg.AuthType == TypeRHSSO {
+		return &AuthzHandler{
+			cfg:    cfg,
+			client: ocmCLient,
+			log:    log,
+			db:     db,
+		}
+	}
+	return &NoneHandler{}
+}

--- a/pkg/auth/none_authz_handler.go
+++ b/pkg/auth/none_authz_handler.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"gorm.io/gorm"
+)
+
+/* NoneHandler is the authorizer middleware that is being used for
+   non-RHSSO authentication cases. It will basically authorize any
+   request, as there is no user and tenancy based concepts in these
+   cases
+*/
+type NoneHandler struct {
+}
+
+func (*NoneHandler) CreateAuthorizer() func(*http.Request) error {
+	return func(*http.Request) error {
+		return nil
+	}
+}
+
+func (*NoneHandler) OwnedBy(ctx context.Context, db *gorm.DB) *gorm.DB {
+	return db
+}
+
+func (*NoneHandler) OwnedByUser(ctx context.Context, db *gorm.DB, username string) *gorm.DB {
+	return db
+}


### PR DESCRIPTION
Authorization becomes more complex with the tenancy based feature and more authorization scheme added for other projects.

In the current implementation the application layer is using stateless utilities to check for access permission to object on top of the existing mechanism. These checks are sometimes redundant and or not quite aligned with new authorization schemes.

Using stateless utilities make us expose feature flags and states in the auth API where they do not belong. For all those reasons an API for authorization that will be shared by all authorization handlers and expose a coherent access control algorithms to the application is required.

This is the first installment of the enhancement. It defines The `OwnedBy` interface that wraps the db object with authorization-related conditions based on the active authorization layer.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
