### PR TITLE
MGMT-9742: Populate API VIP and  Machine Networks in cluster creation via KubeAPI

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -10547,21 +10547,6 @@ var _ = Describe("TestRegisterCluster", func() {
 				Expect(actual.MachineNetworks).To(Equal(common.TestDualStackNetworking.MachineNetworks))
 				Expect(actual.ServiceNetworks).To(Equal(common.TestDualStackNetworking.ServiceNetworks))
 			})
-			It("Dual-stack with empty VIPs", func() {
-				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
-					eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
-					eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
-
-				reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
-					NewClusterParams: &models.ClusterCreateParams{
-						ClusterNetworks:   common.TestDualStackNetworking.ClusterNetworks,
-						MachineNetworks:   common.TestDualStackNetworking.MachineNetworks,
-						ServiceNetworks:   common.TestDualStackNetworking.ServiceNetworks,
-						VipDhcpAllocation: swag.Bool(false),
-					},
-				})
-				verifyApiErrorString(reply, http.StatusBadRequest, "api-vip <> does not belong to machine-network-cidr <1.2.3.0/24>")
-			})
 		})
 
 	})

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -479,10 +479,9 @@ func ValidateIPAddresses(ipV6Supported bool, obj interface{}) error {
 		}
 	} else {
 		if len(machineNetworks) > 0 {
-			err = network.VerifyVips(nil, string(machineNetworks[0].Cidr), apiVip, ingressVip, reqDualStack, nil)
+			err = network.VerifyVips(nil, string(machineNetworks[0].Cidr), apiVip, ingressVip, false, nil)
 		} else if reqDualStack {
 			err = errors.Errorf("Dual-stack cluster cannot be created with empty Machine Networks")
-			return common.NewApiError(http.StatusBadRequest, err)
 		} else {
 			err = network.VerifyDifferentVipAddresses(apiVip, ingressVip)
 		}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1092,6 +1092,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 		OlmOperators:          nil, // TODO: handle operators
 		PullSecret:            swag.String(pullSecret),
 		VipDhcpAllocation:     swag.Bool(false),
+		APIVip:                clusterInstall.Spec.APIVIP,
 		IngressVip:            clusterInstall.Spec.IngressVIP,
 		SSHPublicKey:          clusterInstall.Spec.SSHPublicKey,
 		CPUArchitecture:       swag.StringValue(releaseImage.CPUArchitecture),
@@ -1110,6 +1111,14 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 		for _, cidr := range clusterInstall.Spec.Networking.ServiceNetwork {
 			clusterParams.ServiceNetworks = append(clusterParams.ServiceNetworks, &models.ServiceNetwork{
 				Cidr: models.Subnet(cidr),
+			})
+		}
+	}
+
+	if len(clusterInstall.Spec.Networking.MachineNetwork) > 0 {
+		for _, net := range clusterInstall.Spec.Networking.MachineNetwork {
+			clusterParams.MachineNetworks = append(clusterParams.MachineNetworks, &models.MachineNetwork{
+				Cidr: models.Subnet(net.CIDR),
 			})
 		}
 	}


### PR DESCRIPTION
This PR implements a missing piece that populates Machine Networks
    as well as API VIP defined in the AgentClusterInstall's spec already
    during cluster creation and not only during its reconciliation.
    
This is a left over from the implementation of dual-stack in KubeAPI
    that has been discovered only after network validations became more
    strict in the PR #3258.

Closes: [MGMT-9742](https://issues.redhat.com/browse/MGMT-9742)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @adriengentil 
/cc @flaper87 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
