### PR TITLE
MGMT-7365: Deprecate single network configuration fields

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2224,12 +2224,11 @@ var _ = Describe("cluster", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
 			infraEnvID = strfmt.UUID(uuid.New().String())
 			err := db.Create(&common.Cluster{Cluster: models.Cluster{
-				ID:                 &clusterID,
-				OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
-				APIVip:             "10.11.12.13",
-				IngressVip:         "10.11.12.14",
-				MachineNetworks:    []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}},
-				MachineNetworkCidr: "10.11.0.0/16", // TODO MGMT-7365: Deprecate single network
+				ID:               &clusterID,
+				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+				APIVip:           "10.11.12.13",
+				IngressVip:       "10.11.12.14",
+				MachineNetworks:  []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}},
 			}}).Error
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -4034,14 +4033,6 @@ var _ = Describe("cluster", func() {
 						Expect(db.Save(network).Error).ShouldNot(HaveOccurred())
 					}
 
-					// TODO MGMT-7365: Deprecate single network
-					Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterID).Updates(map[string]interface{}{
-						"cluster_network_cidr":        clusterNetworks[0].Cidr,
-						"cluster_network_host_prefix": clusterNetworks[0].HostPrefix,
-						"machine_network_cidr":        machineNetworks[0].Cidr,
-						"service_network_cidr":        serviceNetworks[0].Cidr,
-					}).Error).ShouldNot(HaveOccurred())
-
 					cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
 					Expect(err).ToNot(HaveOccurred())
 					validateNetworkConfiguration(&cluster.Cluster, &clusterNetworks, &serviceNetworks, &machineNetworks)
@@ -4081,7 +4072,8 @@ var _ = Describe("cluster", func() {
 					Expect(actual.Payload.MachineNetworks).To(BeEmpty())
 				})
 
-				It("Empty networks (old API) - valid", func() {
+				// TODO(MGMT-9751-remove-single-network)
+				It("Empty networks (old API) - no action", func() {
 					mockSuccess(1)
 					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
@@ -4095,9 +4087,29 @@ var _ = Describe("cluster", func() {
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated)
 
-					Expect(actual.Payload.ClusterNetworks).To(BeEmpty())
-					Expect(actual.Payload.ServiceNetworks).To(BeEmpty())
-					Expect(actual.Payload.MachineNetworks).To(BeEmpty())
+					Expect(actual.Payload.ClusterNetworks).To(Equal(clusterNetworks))
+					Expect(actual.Payload.ServiceNetworks).To(Equal(serviceNetworks))
+					Expect(actual.Payload.MachineNetworks).To(Equal(machineNetworks))
+				})
+
+				// TODO(MGMT-9751-remove-single-network)
+				It("Override networks with old API - no action", func() {
+					mockSuccess(1)
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							ClusterNetworkCidr:       swag.String("10.128.0.0/14"),
+							ClusterNetworkHostPrefix: swag.Int64(23),
+							ServiceNetworkCidr:       swag.String("172.30.0.0/16"),
+							MachineNetworkCidr:       swag.String("192.168.145.0/24"),
+						},
+					})
+					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated)
+
+					Expect(actual.Payload.ClusterNetworks).To(Equal(clusterNetworks))
+					Expect(actual.Payload.ServiceNetworks).To(Equal(serviceNetworks))
+					Expect(actual.Payload.MachineNetworks).To(Equal(machineNetworks))
 				})
 
 				It("Empty networks - invalid empty ClusterNetwork", func() {
@@ -4124,16 +4136,6 @@ var _ = Describe("cluster", func() {
 					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
 				})
 
-				It("Empty networks (old API) - invalid CIDR, ClusterNetwork", func() {
-					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-						ClusterID: clusterID,
-						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							ClusterNetworkCidr: swag.String(""),
-						},
-					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
-				})
-
 				It("Empty networks (new API - invalid HostPrefix, ClusterNetwork", func() {
 					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
@@ -4144,16 +4146,6 @@ var _ = Describe("cluster", func() {
 						},
 					})
 					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network CIDR : Failed to parse CIDR '': invalid CIDR address: ")
-				})
-
-				It("Empty networks (old API) - invalid HostPrefix, ClusterNetwork", func() {
-					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-						ClusterID: clusterID,
-						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							ClusterNetworkHostPrefix: swag.Int64(0),
-						},
-					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Cluster network host prefix 0: Host prefix, now 0, must be a positive integer")
 				})
 
 				It("Empty networks - invalid empty ServiceNetwork", func() {
@@ -4238,28 +4230,6 @@ var _ = Describe("cluster", func() {
 							ServiceNetworks:   serviceNetworks,
 							MachineNetworks:   machineNetworks,
 							VipDhcpAllocation: swag.Bool(true),
-						},
-					})
-					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-					actual := reply.(*installer.V2UpdateClusterCreated)
-
-					validateNetworkConfiguration(actual.Payload, &clusterNetworks, &serviceNetworks, &machineNetworks)
-				})
-
-				It("Override networks with old API", func() {
-					clusterNetworks = []*models.ClusterNetwork{{Cidr: "10.128.0.0/14", HostPrefix: 23}}
-					serviceNetworks = []*models.ServiceNetwork{{Cidr: "172.30.0.0/16"}}
-					machineNetworks = []*models.MachineNetwork{{Cidr: "192.168.145.0/24"}}
-
-					mockSuccess(1)
-					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-						ClusterID: clusterID,
-						ClusterUpdateParams: &models.V2ClusterUpdateParams{
-							ClusterNetworkCidr:       swag.String("10.128.0.0/14"),
-							ClusterNetworkHostPrefix: swag.Int64(23),
-							ServiceNetworkCidr:       swag.String("172.30.0.0/16"),
-							MachineNetworkCidr:       swag.String("192.168.145.0/24"),
-							VipDhcpAllocation:        swag.Bool(true),
 						},
 					})
 					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
@@ -6187,14 +6157,6 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						network.ClusterID = clusterID
 						Expect(db.Save(network).Error).ShouldNot(HaveOccurred())
 					}
-
-					// TODO MGMT-7365: Deprecate single network
-					Expect(db.Model(&common.Cluster{}).Where("id = ?", clusterID).Updates(map[string]interface{}{
-						"cluster_network_cidr":        clusterNetworks[0].Cidr,
-						"cluster_network_host_prefix": clusterNetworks[0].HostPrefix,
-						"machine_network_cidr":        machineNetworks[0].Cidr,
-						"service_network_cidr":        serviceNetworks[0].Cidr,
-					}).Error).ShouldNot(HaveOccurred())
 
 					cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
 					Expect(err).ToNot(HaveOccurred())
@@ -13080,15 +13042,9 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 			Expect(cluster.ClusterNetworks[index].Cidr).To(Equal((*clusterNetworks)[index].Cidr))
 			Expect(cluster.ClusterNetworks[index].HostPrefix).To(Equal((*clusterNetworks)[index].HostPrefix))
 		}
-
-		// TODO MGMT-7365: Deprecate single network
-		if len(*clusterNetworks) > 0 {
-			Expect(cluster.ClusterNetworkCidr).To(Equal(string((*clusterNetworks)[0].Cidr)))
-			Expect(cluster.ClusterNetworkHostPrefix).To(Equal((*clusterNetworks)[0].HostPrefix))
-		} else {
-			Expect(cluster.ClusterNetworkCidr).To(Equal(""))
-			Expect(cluster.ClusterNetworkHostPrefix).To(Equal(""))
-		}
+		// TODO(MGMT-9751-remove-single-network)
+		Expect(cluster.ClusterNetworkCidr).To(Equal(""))
+		Expect(cluster.ClusterNetworkHostPrefix).To(Equal(int64(0)))
 	}
 	if serviceNetworks != nil {
 		Expect(cluster.ServiceNetworks).To(HaveLen(len(*serviceNetworks)))
@@ -13096,13 +13052,8 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 			Expect(cluster.ServiceNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.ServiceNetworks[index].Cidr).To(Equal((*serviceNetworks)[index].Cidr))
 		}
-
-		// TODO MGMT-7365: Deprecate single network
-		if len(*serviceNetworks) > 0 {
-			Expect(cluster.ServiceNetworkCidr).To(Equal(string((*serviceNetworks)[0].Cidr)))
-		} else {
-			Expect(cluster.ServiceNetworkCidr).To(Equal(""))
-		}
+		// TODO(MGMT-9751-remove-single-network)
+		Expect(cluster.ServiceNetworkCidr).To(Equal(""))
 	}
 	if machineNetworks != nil {
 		Expect(cluster.MachineNetworks).To(HaveLen(len(*machineNetworks)))
@@ -13110,13 +13061,8 @@ func validateNetworkConfiguration(cluster *models.Cluster, clusterNetworks *[]*m
 			Expect(cluster.MachineNetworks[index].ClusterID).To(Equal(*cluster.ID))
 			Expect(cluster.MachineNetworks[index].Cidr).To(Equal((*machineNetworks)[index].Cidr))
 		}
-
-		// TODO MGMT-7365: Deprecate single network
-		if len(*machineNetworks) > 0 {
-			Expect(cluster.MachineNetworkCidr).To(Equal(string((*machineNetworks)[0].Cidr)))
-		} else {
-			Expect(cluster.MachineNetworkCidr).To(Equal(""))
-		}
+		// TODO(MGMT-9751-remove-single-network)
+		Expect(cluster.MachineNetworkCidr).To(Equal(""))
 	}
 }
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1125,7 +1125,6 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				ClusterNetworks:       common.TestIPv4Networking.ClusterNetworks,
 				ServiceNetworks:       common.TestIPv4Networking.ServiceNetworks,
 				MachineNetworks:       network.CreateMachineNetworksArray(t.machineNetworkCIDR),
-				MachineNetworkCidr:    t.machineNetworkCIDR, // TODO MGMT-7365: Deprecate single network
 				VipDhcpAllocation:     swag.Bool(t.dhcpEnabled),
 				UserManagedNetworking: swag.Bool(t.userManagedNetworking),
 			}}
@@ -1151,11 +1150,11 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			cluster := getClusterFromDB(id, db)
 			if t.expectedMachineCIDR == "" {
 				Expect(cluster.MachineNetworks).To(BeEmpty())
-				Expect(cluster.MachineNetworkCidr).To(Equal("")) // TODO MGMT-7365: Deprecate single network
+				Expect(cluster.MachineNetworkCidr).To(Equal("")) // TODO(MGMT-9751-remove-single-network)
 			} else {
 				Expect(cluster.MachineNetworks).NotTo(BeEmpty())
 				Expect(network.GetMachineCidrById(&cluster, 0)).To(Equal(t.expectedMachineCIDR))
-				Expect(cluster.MachineNetworkCidr).To(Equal(t.expectedMachineCIDR)) // TODO MGMT-7365: Deprecate single network
+				Expect(cluster.MachineNetworkCidr).To(Equal("")) // TODO(MGMT-9751-remove-single-network)
 			}
 
 			ctrl.Finish()

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -267,9 +267,7 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr string)
 			}
 		}
 
-		// TODO MGMT-7365: Deprecate single network
 		return db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(map[string]interface{}{
-			"machine_network_cidr":            machineCidr,
 			"machine_network_cidr_updated_at": time.Now(),
 		}).Error
 	}

--- a/internal/cluster/common_test.go
+++ b/internal/cluster/common_test.go
@@ -338,18 +338,11 @@ var _ = Describe("UpdateMachineCidr", func() {
 	for i := range tests {
 		test := tests[i]
 		It(test.name, func() {
-			// TODO MGMT-7365: Deprecate single network
-			primaryMachineCidr := ""
-			if common.IsSliceNonEmpty(test.clusterMachineNetworks) {
-				primaryMachineCidr = string(test.clusterMachineNetworks[0].Cidr)
-			}
-
 			id := strfmt.UUID(uuid.New().String())
 			cluster := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:                 &id,
-					MachineNetworks:    test.clusterMachineNetworks,
-					MachineNetworkCidr: primaryMachineCidr,
+					ID:              &id,
+					MachineNetworks: test.clusterMachineNetworks,
 				},
 				MachineNetworkCidrUpdatedAt: time.Now().Add(-2 * time.Minute),
 			}
@@ -368,8 +361,8 @@ var _ = Describe("UpdateMachineCidr", func() {
 				Expect(clusterFromDb.MachineNetworks[idx].Cidr).To(Equal(test.expectedClusterMachineNetworks[idx].Cidr))
 			}
 
-			// TODO MGMT-7365: Deprecate single network
-			Expect(clusterFromDb.MachineNetworkCidr).To(Equal(test.newMachineCidr))
+			// TODO(MGMT-9751-remove-single-network)
+			Expect(clusterFromDb.MachineNetworkCidr).To(Equal(""))
 
 			if test.update {
 				Expect(clusterFromDb.MachineNetworkCidrUpdatedAt).NotTo(Equal(cluster.MachineNetworkCidrUpdatedAt))

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -4391,7 +4391,6 @@ var _ = Describe("Refresh Host", func() {
 			statusInfoChecker      statusInfoChecker
 			validationsChecker     *validationsChecker
 			IPAddressPool          []string
-			machineNetworkCIDR     string
 			machineNetworks        []*models.MachineNetwork
 			ipType                 int
 		}{

--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -493,7 +493,6 @@ var _ = Describe("installcfg", func() {
 	})
 
 	Context("networking", func() {
-		// TODO MGMT-7365: Deprecate single network
 		It("Single network fields", func() {
 			var result installcfg.InstallerConfigBaremetal
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)

--- a/internal/migrations/20220325125504_multiple_networks_cleanup.go
+++ b/internal/migrations/20220325125504_multiple_networks_cleanup.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"github.com/openshift/assisted-service/internal/common"
+	"gorm.io/gorm"
+)
+
+func multipleNetworksCleanup() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		if tx.Migrator().HasTable(&common.Cluster{}) {
+			// Clear values of the selected columns. We don't need to handle errors as those
+			// columns are meant to disappear in the future, so this migration should gracefuly
+			// handle the scenario when those do not exist.
+			tx.Exec("UPDATE clusters SET cluster_network_cidr='';")
+			tx.Exec("UPDATE clusters SET cluster_network_host_prefix=0;")
+			tx.Exec("UPDATE clusters SET machine_network_cidr='';")
+			tx.Exec("UPDATE clusters SET service_network_cidr='';")
+		}
+
+		return nil
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		// Don't really want to ever recalculate values back.
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20220325125504",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/20220325125504_multiple_networks_cleanup_test.go
+++ b/internal/migrations/20220325125504_multiple_networks_cleanup_test.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("multipleNetworksCleanup", func() {
+	var (
+		db        *gorm.DB
+		dbName    string
+		clusterID strfmt.UUID
+		cluster   *common.Cluster
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster = &common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID,
+			},
+		}
+		Expect(db.Save(cluster).Error).ShouldNot(HaveOccurred())
+
+		_, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		var value []string
+		db.Raw("UPDATE clusters SET cluster_network_cidr = ? WHERE id = ? RETURNING id", "1.3.0.0/16", clusterID).Scan(&value)
+		db.Raw("UPDATE clusters SET cluster_network_host_prefix = ? WHERE id = ? RETURNING id", 24, clusterID).Scan(&value)
+		db.Raw("UPDATE clusters SET machine_network_cidr = ? WHERE id = ? RETURNING id", "1.2.3.0/24", clusterID).Scan(&value)
+		db.Raw("UPDATE clusters SET service_network_cidr = ? WHERE id = ? RETURNING id", "1.2.5.0/24", clusterID).Scan(&value)
+
+		db.Raw("SELECT cluster_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("1.3.0.0/16"))
+		db.Raw("SELECT cluster_network_host_prefix FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("24"))
+		db.Raw("SELECT machine_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("1.2.3.0/24"))
+		db.Raw("SELECT service_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("1.2.5.0/24"))
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Migrates up", func() {
+		// setup
+		err := migrateTo(db, "20220325125504")
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		var valueStr []string
+		db.Raw("SELECT cluster_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&valueStr)
+		Expect(valueStr[0]).To(Equal(""))
+		db.Raw("SELECT machine_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&valueStr)
+		Expect(valueStr[0]).To(Equal(""))
+		db.Raw("SELECT service_network_cidr FROM clusters WHERE id = ?", clusterID).Scan(&valueStr)
+		Expect(valueStr[0]).To(Equal(""))
+
+		var valueNum []int
+		db.Raw("SELECT cluster_network_host_prefix FROM clusters WHERE id = ?", clusterID).Scan(&valueNum)
+		Expect(valueNum[0]).To(Equal(0))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -38,6 +38,7 @@ func post() []*gormigrate.Migration {
 		createInfraEnvImageTokenKey(),
 		migrateHostsPkey(),
 		changeStaticConfigFormat(),
+		multipleNetworksCleanup(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })

--- a/models/cluster_network.go
+++ b/models/cluster_network.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// ClusterNetwork IP address block for pod IP blocks.
+// ClusterNetwork A network from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
 //
 // swagger:model cluster_network
 type ClusterNetwork struct {
@@ -26,7 +26,7 @@ type ClusterNetwork struct {
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 
-	// The prefix size to allocate to each node from the CIDR. For example, 24 would allocate 2^8=256 adresses to each node.
+	// The subnet prefix length to assign to each individual node. For example if is set to 23, then each node is assigned a /23 subnet out of the given CIDR, which allows for 510 (2^(32 - 23) - 2) pod IPs addresses.
 	// Maximum: 128
 	// Minimum: 1
 	HostPrefix int64 `json:"host_prefix,omitempty"`

--- a/models/machine_network.go
+++ b/models/machine_network.go
@@ -14,12 +14,12 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// MachineNetwork IP address block for node IP blocks.
+// MachineNetwork A network that all hosts belonging to the cluster should have an interface with IP address in. The VIPs (if exist) belong to this network.
 //
 // swagger:model machine_network
 type MachineNetwork struct {
 
-	// The IP block address pool for machines within the cluster.
+	// The IP block address pool.
 	Cidr Subnet `json:"cidr,omitempty" gorm:"primaryKey"`
 
 	// The cluster that this network is associated with.

--- a/models/service_network.go
+++ b/models/service_network.go
@@ -22,7 +22,7 @@ type ServiceNetwork struct {
 	// The IP block address pool.
 	Cidr Subnet `json:"cidr,omitempty" gorm:"primaryKey"`
 
-	// The cluster that this network is associated with.
+	// A network to use for service IP addresses. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Format: uuid
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"primaryKey"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5929,7 +5929,7 @@ func init() {
       }
     },
     "cluster_network": {
-      "description": "IP address block for pod IP blocks.",
+      "description": "A network from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.",
       "type": "object",
       "properties": {
         "cidr": {
@@ -5943,7 +5943,7 @@ func init() {
           "x-go-custom-tag": "gorm:\"primaryKey\""
         },
         "host_prefix": {
-          "description": "The prefix size to allocate to each node from the CIDR. For example, 24 would allocate 2^8=256 adresses to each node.",
+          "description": "The subnet prefix length to assign to each individual node. For example if is set to 23, then each node is assigned a /23 subnet out of the given CIDR, which allows for 510 (2^(32 - 23) - 2) pod IPs addresses.",
           "type": "integer",
           "maximum": 128,
           "minimum": 1
@@ -7846,11 +7846,11 @@ func init() {
       }
     },
     "machine_network": {
-      "description": "IP address block for node IP blocks.",
+      "description": "A network that all hosts belonging to the cluster should have an interface with IP address in. The VIPs (if exist) belong to this network.",
       "type": "object",
       "properties": {
         "cidr": {
-          "description": "The IP block address pool for machines within the cluster.",
+          "description": "The IP block address pool.",
           "$ref": "#/definitions/subnet"
         },
         "cluster_id": {
@@ -8426,7 +8426,7 @@ func init() {
           "$ref": "#/definitions/subnet"
         },
         "cluster_id": {
-          "description": "The cluster that this network is associated with.",
+          "description": "A network to use for service IP addresses. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primaryKey\""
@@ -14881,7 +14881,7 @@ func init() {
       }
     },
     "cluster_network": {
-      "description": "IP address block for pod IP blocks.",
+      "description": "A network from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.",
       "type": "object",
       "properties": {
         "cidr": {
@@ -14895,7 +14895,7 @@ func init() {
           "x-go-custom-tag": "gorm:\"primaryKey\""
         },
         "host_prefix": {
-          "description": "The prefix size to allocate to each node from the CIDR. For example, 24 would allocate 2^8=256 adresses to each node.",
+          "description": "The subnet prefix length to assign to each individual node. For example if is set to 23, then each node is assigned a /23 subnet out of the given CIDR, which allows for 510 (2^(32 - 23) - 2) pod IPs addresses.",
           "type": "integer",
           "maximum": 128,
           "minimum": 1
@@ -16720,11 +16720,11 @@ func init() {
       }
     },
     "machine_network": {
-      "description": "IP address block for node IP blocks.",
+      "description": "A network that all hosts belonging to the cluster should have an interface with IP address in. The VIPs (if exist) belong to this network.",
       "type": "object",
       "properties": {
         "cidr": {
-          "description": "The IP block address pool for machines within the cluster.",
+          "description": "The IP block address pool.",
           "$ref": "#/definitions/subnet"
         },
         "cluster_id": {
@@ -17300,7 +17300,7 @@ func init() {
           "$ref": "#/definitions/subnet"
         },
         "cluster_id": {
-          "description": "The cluster that this network is associated with.",
+          "description": "A network to use for service IP addresses. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
           "type": "string",
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"primaryKey\""

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -630,12 +630,11 @@ var _ = Describe("V2ListClusters", func() {
 
 		registerClusterReply, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
-				BaseDNSDomain:            "example.com",
-				ClusterNetworkHostPrefix: 23,
-				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(openshiftVersion),
-				PullSecret:               swag.String(pullSecret),
-				SSHPublicKey:             sshPublicKey,
+				BaseDNSDomain:    "example.com",
+				Name:             swag.String("test-cluster"),
+				OpenshiftVersion: swag.String(openshiftVersion),
+				PullSecret:       swag.String(pullSecret),
+				SSHPublicKey:     sshPublicKey,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -26,11 +26,10 @@ var _ = Describe("[V2ClusterTests]", func() {
 	BeforeEach(func() {
 		clusterReq, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
-				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(openshiftVersion),
-				PullSecret:               swag.String(pullSecret),
-				BaseDNSDomain:            "example.com",
-				ClusterNetworkHostPrefix: 23,
+				Name:             swag.String("test-cluster"),
+				OpenshiftVersion: swag.String(openshiftVersion),
+				PullSecret:       swag.String(pullSecret),
+				BaseDNSDomain:    "example.com",
 			},
 		})
 

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -49,11 +49,10 @@ var _ = Describe("Infra_Env", func() {
 		infraEnv = registerInfraEnv(nil, models.ImageTypeFullIso)
 		clusterResp, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
-				Name:                     swag.String("test-cluster"),
-				OpenshiftVersion:         swag.String(openshiftVersion),
-				PullSecret:               swag.String(pullSecret),
-				BaseDNSDomain:            "example.com",
-				ClusterNetworkHostPrefix: 23,
+				Name:             swag.String("test-cluster"),
+				OpenshiftVersion: swag.String(openshiftVersion),
+				PullSecret:       swag.String(pullSecret),
+				BaseDNSDomain:    "example.com",
 			},
 		})
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6117,7 +6117,7 @@ definitions:
 
   cluster_network:
     type: object
-    description: IP address block for pod IP blocks.
+    description: A network from which Pod IPs are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the Pod network, and if you need to access the Pods from an external network, configure load balancers and routers to manage the traffic.
     properties:
       cluster_id:
         type: string
@@ -6129,13 +6129,13 @@ definitions:
         description: The IP block address pool.
       host_prefix:
         type: integer
-        description: The prefix size to allocate to each node from the CIDR. For example, 24 would allocate 2^8=256 adresses to each node.
+        description: The subnet prefix length to assign to each individual node. For example if is set to 23, then each node is assigned a /23 subnet out of the given CIDR, which allows for 510 (2^(32 - 23) - 2) pod IPs addresses.
         minimum: 1
         maximum: 128
 
   machine_network:
     type: object
-    description: IP address block for node IP blocks.
+    description: A network that all hosts belonging to the cluster should have an interface with IP address in. The VIPs (if exist) belong to this network.
     properties:
       cluster_id:
         type: string
@@ -6144,7 +6144,7 @@ definitions:
         x-go-custom-tag: gorm:"primaryKey"
       cidr:
         $ref: '#/definitions/subnet'
-        description: The IP block address pool for machines within the cluster.
+        description: The IP block address pool.
 
   service_network:
     type: object
@@ -6153,7 +6153,7 @@ definitions:
       cluster_id:
         type: string
         format: uuid
-        description: The cluster that this network is associated with.
+        description: A network to use for service IP addresses. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
         x-go-custom-tag: gorm:"primaryKey"
       cidr:
         $ref: '#/definitions/subnet'


### PR DESCRIPTION
During the dual-stack implementation the new structures have been
introduced - machine_networks, cluster_networks and service_networks
(all of them of type []string). In order to preserve backwards
compatibility, there were wrappers created that translate e.g.
machine_network_cidr (of type string) to machine_networks (of type
[]string).

Usage of the old parameters makes it impossible to pass multiple
networks (because of type mismatch). Given that in API v2 the new
structures ([]string) are fully implemented, there is no need to
support old ones any more.

This PR does not modify DB schema, however it modifies existing clusters
so that the value of deprecated fields becomes empty or zeroed. A
following PR will completely remove the fields from the swagger and from
the DB and will be tracked by MGMT-9751.

Closes: [MGMT-7365](https://issues.redhat.com/browse/MGMT-7365)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->
/cc @carbonin
/cc @nmagnezi

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
