### PR TITLE
Bug 2066069: improve ClusterImageSet sync error message

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -391,7 +391,7 @@ func (r *ClusterDeploymentsReconciler) installDay1(ctx context.Context, log logr
 		}
 
 		// Ensure release image exists in versions cache
-		_, err = r.addReleaseImage(ctx, clusterInstall.Spec, pullSecret, cluster)
+		_, err = r.addReleaseImage(ctx, log, clusterInstall.Spec, pullSecret, cluster)
 		if err != nil {
 			log.WithError(err)
 			return r.updateStatus(ctx, log, clusterInstall, cluster, err)
@@ -1094,7 +1094,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 		return r.updateStatus(ctx, log, clusterInstall, nil, err)
 	}
 
-	releaseImage, err := r.addReleaseImage(ctx, clusterInstall.Spec, pullSecret, nil)
+	releaseImage, err := r.addReleaseImage(ctx, log, clusterInstall.Spec, pullSecret, nil)
 	if err != nil {
 		log.WithError(err)
 		_, _ = r.updateStatus(ctx, log, clusterInstall, nil, err)
@@ -1242,6 +1242,7 @@ func (r *ClusterDeploymentsReconciler) getReleaseImage(ctx context.Context, spec
 
 func (r *ClusterDeploymentsReconciler) addReleaseImage(
 	ctx context.Context,
+	log logrus.FieldLogger,
 	spec hiveext.AgentClusterInstallSpec,
 	pullSecret string,
 	cluster *common.Cluster) (*models.ReleaseImage, error) {
@@ -1269,8 +1270,9 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 	}
 
 	if err != nil {
-		err = errors.Wrapf(err, "failed to add release image: %s", releaseImageUrl)
-		return nil, err
+		log.Error(err)
+		errMsg := "failed to add release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid (contact your admin with this info)."
+		return nil, errors.New(fmt.Sprintf(errMsg, releaseImageUrl, spec.ImageSetRef.Name))
 	}
 
 	return releaseImage, nil

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -2160,7 +2160,8 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(result.Requeue).To(BeFalse())
 
 			aci = getTestClusterInstall()
-			expectedErr := fmt.Sprintf("failed to add release image: %s", releaseImageUrl)
+			expectedErr := fmt.Sprintf("failed to add release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid (contact your admin with this info).",
+				releaseImageUrl, imageSetName)
 			expectedState := fmt.Sprintf("%s %s", hiveext.ClusterBackendErrorMsg, expectedErr)
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterBackendErrorReason))
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))


### PR DESCRIPTION
Improved the error message on ClusterImageSet sync error to give the user better info on the source of the issue.
E.g.
'The Spec could not be synced due to backend error: failed to add release image 'quay.io/openshift-release-dev/ocp-release:4.10.invalid-x86_64'. Please ensure the releaseImage field in ClusterImageSet 'openshift-v4.10' is valid.'

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @nirfarkas 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
