### PR TITLE
MGMT-9710: Provide extended networking defaults in default-config API

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -28,6 +29,12 @@ type ClusterDefaultConfig struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// cluster networks dualstack
+	ClusterNetworksDualstack []*ClusterNetwork `json:"cluster_networks_dualstack"`
+
+	// cluster networks ipv4
+	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 
@@ -37,6 +44,12 @@ type ClusterDefaultConfig struct {
 	// service network cidr
 	// Pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\/]([1-9]|[1-2][0-9]|3[0-2]?)$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`
+
+	// service networks dualstack
+	ServiceNetworksDualstack []*ServiceNetwork `json:"service_networks_dualstack"`
+
+	// service networks ipv4
+	ServiceNetworksIPV4 []*ServiceNetwork `json:"service_networks_ipv4"`
 }
 
 // Validate validates this cluster default config
@@ -51,7 +64,23 @@ func (m *ClusterDefaultConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateClusterNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateClusterNetworksIPV4(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateServiceNetworkCidr(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksIPV4(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,6 +118,58 @@ func (m *ClusterDefaultConfig) validateClusterNetworkHostPrefix(formats strfmt.R
 	return nil
 }
 
+func (m *ClusterDefaultConfig) validateClusterNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+		if swag.IsZero(m.ClusterNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateClusterNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+		if swag.IsZero(m.ClusterNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
 func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registry) error {
 	if swag.IsZero(m.ServiceNetworkCidr) { // not required
 		return nil
@@ -101,8 +182,161 @@ func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registr
 	return nil
 }
 
-// ContextValidate validates this cluster default config based on context it is used
+func (m *ClusterDefaultConfig) validateServiceNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+		if swag.IsZero(m.ServiceNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateServiceNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+		if swag.IsZero(m.ServiceNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this cluster default config based on the context it is used
 func (m *ClusterDefaultConfig) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateClusterNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateClusterNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -87,29 +87,32 @@ const (
 
 type Config struct {
 	ignition.IgnitionConfig
-	AgentDockerImg                  string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
-	ServiceBaseURL                  string            `envconfig:"SERVICE_BASE_URL"`
-	ImageServiceBaseURL             string            `envconfig:"IMAGE_SERVICE_BASE_URL"`
-	ServiceCACertPath               string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
-	S3EndpointURL                   string            `envconfig:"S3_ENDPOINT_URL" default:"http://10.35.59.36:30925"`
-	S3Bucket                        string            `envconfig:"S3_BUCKET" default:"test"`
-	ImageExpirationTime             time.Duration     `envconfig:"IMAGE_EXPIRATION_TIME" default:"4h"`
-	AwsAccessKeyID                  string            `envconfig:"AWS_ACCESS_KEY_ID" default:"accessKey1"`
-	AwsSecretAccessKey              string            `envconfig:"AWS_SECRET_ACCESS_KEY" default:"verySecretKey1"`
-	BaseDNSDomains                  map[string]string `envconfig:"BASE_DNS_DOMAINS" default:""`
-	SkipCertVerification            bool              `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
-	InstallRHCa                     bool              `envconfig:"INSTALL_RH_CA" default:"false"`
-	RhQaRegCred                     string            `envconfig:"REGISTRY_CREDS" default:""`
-	AgentTimeoutStart               time.Duration     `envconfig:"AGENT_TIMEOUT_START" default:"3m"`
-	ServiceIPs                      string            `envconfig:"SERVICE_IPS" default:""`
-	DefaultNTPSource                string            `envconfig:"NTP_DEFAULT_SERVER"`
-	ISOCacheDir                     string            `envconfig:"ISO_CACHE_DIR" default:"/tmp/isocache"`
-	DefaultClusterNetworkCidr       string            `envconfig:"CLUSTER_NETWORK_CIDR" default:"10.128.0.0/14"`
-	DefaultClusterNetworkHostPrefix int64             `envconfig:"CLUSTER_NETWORK_HOST_PREFIX" default:"23"`
-	DefaultServiceNetworkCidr       string            `envconfig:"SERVICE_NETWORK_CIDR" default:"172.30.0.0/16"`
-	ISOImageType                    string            `envconfig:"ISO_IMAGE_TYPE" default:"full-iso"`
-	IPv6Support                     bool              `envconfig:"IPV6_SUPPORT" default:"true"`
-	DiskEncryptionSupport           bool              `envconfig:"DISK_ENCRYPTION_SUPPORT" default:"true"`
+	AgentDockerImg                      string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
+	ServiceBaseURL                      string            `envconfig:"SERVICE_BASE_URL"`
+	ImageServiceBaseURL                 string            `envconfig:"IMAGE_SERVICE_BASE_URL"`
+	ServiceCACertPath                   string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
+	S3EndpointURL                       string            `envconfig:"S3_ENDPOINT_URL" default:"http://10.35.59.36:30925"`
+	S3Bucket                            string            `envconfig:"S3_BUCKET" default:"test"`
+	ImageExpirationTime                 time.Duration     `envconfig:"IMAGE_EXPIRATION_TIME" default:"4h"`
+	AwsAccessKeyID                      string            `envconfig:"AWS_ACCESS_KEY_ID" default:"accessKey1"`
+	AwsSecretAccessKey                  string            `envconfig:"AWS_SECRET_ACCESS_KEY" default:"verySecretKey1"`
+	BaseDNSDomains                      map[string]string `envconfig:"BASE_DNS_DOMAINS" default:""`
+	SkipCertVerification                bool              `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+	InstallRHCa                         bool              `envconfig:"INSTALL_RH_CA" default:"false"`
+	RhQaRegCred                         string            `envconfig:"REGISTRY_CREDS" default:""`
+	AgentTimeoutStart                   time.Duration     `envconfig:"AGENT_TIMEOUT_START" default:"3m"`
+	ServiceIPs                          string            `envconfig:"SERVICE_IPS" default:""`
+	DefaultNTPSource                    string            `envconfig:"NTP_DEFAULT_SERVER"`
+	ISOCacheDir                         string            `envconfig:"ISO_CACHE_DIR" default:"/tmp/isocache"`
+	DefaultClusterNetworkCidr           string            `envconfig:"CLUSTER_NETWORK_CIDR" default:"10.128.0.0/14"`
+	DefaultClusterNetworkHostPrefix     int64             `envconfig:"CLUSTER_NETWORK_HOST_PREFIX" default:"23"`
+	DefaultClusterNetworkCidrIPv6       string            `envconfig:"CLUSTER_NETWORK_CIDR_IPV6" default:"fd01::/48"`
+	DefaultClusterNetworkHostPrefixIPv6 int64             `envconfig:"CLUSTER_NETWORK_HOST_PREFIX_IPV6" default:"64"`
+	DefaultServiceNetworkCidr           string            `envconfig:"SERVICE_NETWORK_CIDR" default:"172.30.0.0/16"`
+	DefaultServiceNetworkCidrIPv6       string            `envconfig:"SERVICE_NETWORK_CIDR_IPV6" default:"fd02::/112"`
+	ISOImageType                        string            `envconfig:"ISO_IMAGE_TYPE" default:"full-iso"`
+	IPv6Support                         bool              `envconfig:"IPV6_SUPPORT" default:"true"`
+	DiskEncryptionSupport               bool              `envconfig:"DISK_ENCRYPTION_SUPPORT" default:"true"`
 }
 
 const minimalOpenShiftVersionForSingleNode = "4.8.0-0.0"

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -299,10 +299,37 @@ func (b *bareMetalInventory) V2GetClusterDefaultConfig(_ context.Context, _ inst
 	body := &models.ClusterDefaultConfig{}
 
 	body.NtpSource = b.Config.DefaultNTPSource
+	body.InactiveDeletionHours = int64(b.gcConfig.DeregisterInactiveAfter.Hours())
+
+	// TODO(MGMT-9751-remove-single-network)
 	body.ClusterNetworkCidr = b.Config.DefaultClusterNetworkCidr
 	body.ServiceNetworkCidr = b.Config.DefaultServiceNetworkCidr
 	body.ClusterNetworkHostPrefix = b.Config.DefaultClusterNetworkHostPrefix
-	body.InactiveDeletionHours = int64(b.gcConfig.DeregisterInactiveAfter.Hours())
+
+	body.ClusterNetworksIPV4 = []*models.ClusterNetwork{
+		{
+			Cidr:       models.Subnet(b.Config.DefaultClusterNetworkCidr),
+			HostPrefix: b.Config.DefaultClusterNetworkHostPrefix,
+		},
+	}
+	body.ServiceNetworksIPV4 = []*models.ServiceNetwork{
+		{Cidr: models.Subnet(b.Config.DefaultServiceNetworkCidr)},
+	}
+
+	body.ClusterNetworksDualstack = []*models.ClusterNetwork{
+		{
+			Cidr:       models.Subnet(b.Config.DefaultClusterNetworkCidr),
+			HostPrefix: b.Config.DefaultClusterNetworkHostPrefix,
+		},
+		{
+			Cidr:       models.Subnet(b.Config.DefaultClusterNetworkCidrIPv6),
+			HostPrefix: b.Config.DefaultClusterNetworkHostPrefixIPv6,
+		},
+	}
+	body.ServiceNetworksDualstack = []*models.ServiceNetwork{
+		{Cidr: models.Subnet(b.Config.DefaultServiceNetworkCidr)},
+		{Cidr: models.Subnet(b.Config.DefaultServiceNetworkCidrIPv6)},
+	}
 
 	return installer.NewV2GetClusterDefaultConfigOK().WithPayload(body)
 }

--- a/models/cluster_default_config.go
+++ b/models/cluster_default_config.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -28,6 +29,12 @@ type ClusterDefaultConfig struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// cluster networks dualstack
+	ClusterNetworksDualstack []*ClusterNetwork `json:"cluster_networks_dualstack"`
+
+	// cluster networks ipv4
+	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 
@@ -37,6 +44,12 @@ type ClusterDefaultConfig struct {
 	// service network cidr
 	// Pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\/]([1-9]|[1-2][0-9]|3[0-2]?)$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`
+
+	// service networks dualstack
+	ServiceNetworksDualstack []*ServiceNetwork `json:"service_networks_dualstack"`
+
+	// service networks ipv4
+	ServiceNetworksIPV4 []*ServiceNetwork `json:"service_networks_ipv4"`
 }
 
 // Validate validates this cluster default config
@@ -51,7 +64,23 @@ func (m *ClusterDefaultConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateClusterNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateClusterNetworksIPV4(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateServiceNetworkCidr(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksIPV4(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,6 +118,58 @@ func (m *ClusterDefaultConfig) validateClusterNetworkHostPrefix(formats strfmt.R
 	return nil
 }
 
+func (m *ClusterDefaultConfig) validateClusterNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+		if swag.IsZero(m.ClusterNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateClusterNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+		if swag.IsZero(m.ClusterNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
 func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registry) error {
 	if swag.IsZero(m.ServiceNetworkCidr) { // not required
 		return nil
@@ -101,8 +182,161 @@ func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registr
 	return nil
 }
 
-// ContextValidate validates this cluster default config based on context it is used
+func (m *ClusterDefaultConfig) validateServiceNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+		if swag.IsZero(m.ServiceNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateServiceNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+		if swag.IsZero(m.ServiceNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this cluster default config based on the context it is used
 func (m *ClusterDefaultConfig) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateClusterNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateClusterNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5930,6 +5930,20 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "cluster_networks_dualstack": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cluster_network"
+          }
+        },
+        "cluster_networks_ipv4": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cluster_network"
+          }
+        },
         "inactive_deletion_hours": {
           "type": "integer"
         },
@@ -5940,6 +5954,20 @@ func init() {
         "service_network_cidr": {
           "type": "string",
           "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\\/]([1-9]|[1-2][0-9]|3[0-2]?)$"
+        },
+        "service_networks_dualstack": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/service_network"
+          }
+        },
+        "service_networks_ipv4": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/service_network"
+          }
         }
       }
     },
@@ -15146,6 +15174,20 @@ func init() {
           "maximum": 32,
           "minimum": 1
         },
+        "cluster_networks_dualstack": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cluster_network"
+          }
+        },
+        "cluster_networks_ipv4": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/cluster_network"
+          }
+        },
         "inactive_deletion_hours": {
           "type": "integer"
         },
@@ -15156,6 +15198,20 @@ func init() {
         "service_network_cidr": {
           "type": "string",
           "pattern": "^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\\/]([1-9]|[1-2][0-9]|3[0-2]?)$"
+        },
+        "service_networks_dualstack": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/service_network"
+          }
+        },
+        "service_networks_ipv4": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/service_network"
+          }
         }
       }
     },

--- a/subsystem/cluster_default_config_test.go
+++ b/subsystem/cluster_default_config_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/models"
 )
 
 var _ = Describe("V2GetClusterDefaultConfig", func() {
@@ -14,5 +15,25 @@ var _ = Describe("V2GetClusterDefaultConfig", func() {
 		res, err := userBMClient.Installer.V2GetClusterDefaultConfig(context.Background(), &installer.V2GetClusterDefaultConfigParams{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.GetPayload().InactiveDeletionHours).To(Equal(int64(Options.DeregisterInactiveAfter.Hours())))
+	})
+	It("Default IPv4 networks", func() {
+		res, err := userBMClient.Installer.V2GetClusterDefaultConfig(context.Background(), &installer.V2GetClusterDefaultConfigParams{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.GetPayload().ClusterNetworksIPV4[0].Cidr).To(Equal(models.Subnet("10.128.0.0/14")))
+		Expect(res.GetPayload().ClusterNetworksIPV4[0].HostPrefix).To(Equal(int64(23)))
+		Expect(res.GetPayload().ServiceNetworksIPV4[0].Cidr).To(Equal(models.Subnet("172.30.0.0/16")))
+	})
+	It("Default dual-stack networks", func() {
+		res, err := userBMClient.Installer.V2GetClusterDefaultConfig(context.Background(), &installer.V2GetClusterDefaultConfigParams{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res.GetPayload().ClusterNetworksDualstack[0].Cidr).To(Equal(models.Subnet("10.128.0.0/14")))
+		Expect(res.GetPayload().ClusterNetworksDualstack[0].HostPrefix).To(Equal(int64(23)))
+		Expect(res.GetPayload().ServiceNetworksDualstack[0].Cidr).To(Equal(models.Subnet("172.30.0.0/16")))
+
+		Expect(res.GetPayload().ClusterNetworksDualstack[1].Cidr).To(Equal(models.Subnet("fd01::/48")))
+		Expect(res.GetPayload().ClusterNetworksDualstack[1].HostPrefix).To(Equal(int64(64)))
+		Expect(res.GetPayload().ServiceNetworksDualstack[1].Cidr).To(Equal(models.Subnet("fd02::/112")))
 	})
 })

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5125,6 +5125,26 @@ definitions:
       ntp_source:
         type: string
         x-omitempty: false
+      cluster_networks_ipv4:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/cluster_network'
+      cluster_networks_dualstack:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/cluster_network'
+      service_networks_ipv4:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/service_network'
+      service_networks_dualstack:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/service_network'
 
   infra_error:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -28,6 +29,12 @@ type ClusterDefaultConfig struct {
 	// Minimum: 1
 	ClusterNetworkHostPrefix int64 `json:"cluster_network_host_prefix,omitempty"`
 
+	// cluster networks dualstack
+	ClusterNetworksDualstack []*ClusterNetwork `json:"cluster_networks_dualstack"`
+
+	// cluster networks ipv4
+	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 
@@ -37,6 +44,12 @@ type ClusterDefaultConfig struct {
 	// service network cidr
 	// Pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\/]([1-9]|[1-2][0-9]|3[0-2]?)$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`
+
+	// service networks dualstack
+	ServiceNetworksDualstack []*ServiceNetwork `json:"service_networks_dualstack"`
+
+	// service networks ipv4
+	ServiceNetworksIPV4 []*ServiceNetwork `json:"service_networks_ipv4"`
 }
 
 // Validate validates this cluster default config
@@ -51,7 +64,23 @@ func (m *ClusterDefaultConfig) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateClusterNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateClusterNetworksIPV4(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateServiceNetworkCidr(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksDualstack(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateServiceNetworksIPV4(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -89,6 +118,58 @@ func (m *ClusterDefaultConfig) validateClusterNetworkHostPrefix(formats strfmt.R
 	return nil
 }
 
+func (m *ClusterDefaultConfig) validateClusterNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+		if swag.IsZero(m.ClusterNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateClusterNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+		if swag.IsZero(m.ClusterNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
 func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registry) error {
 	if swag.IsZero(m.ServiceNetworkCidr) { // not required
 		return nil
@@ -101,8 +182,161 @@ func (m *ClusterDefaultConfig) validateServiceNetworkCidr(formats strfmt.Registr
 	return nil
 }
 
-// ContextValidate validates this cluster default config based on context it is used
+func (m *ClusterDefaultConfig) validateServiceNetworksDualstack(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksDualstack) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+		if swag.IsZero(m.ServiceNetworksDualstack[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) validateServiceNetworksIPV4(formats strfmt.Registry) error {
+	if swag.IsZero(m.ServiceNetworksIPV4) { // not required
+		return nil
+	}
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+		if swag.IsZero(m.ServiceNetworksIPV4[i]) { // not required
+			continue
+		}
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].Validate(formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// ContextValidate validate this cluster default config based on the context it is used
 func (m *ClusterDefaultConfig) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateClusterNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateClusterNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksDualstack(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateServiceNetworksIPV4(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksDualstack); i++ {
+
+		if m.ClusterNetworksDualstack[i] != nil {
+			if err := m.ClusterNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateClusterNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ClusterNetworksIPV4); i++ {
+
+		if m.ClusterNetworksIPV4[i] != nil {
+			if err := m.ClusterNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("cluster_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksDualstack(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksDualstack); i++ {
+
+		if m.ServiceNetworksDualstack[i] != nil {
+			if err := m.ServiceNetworksDualstack[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_dualstack" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (m *ClusterDefaultConfig) contextValidateServiceNetworksIPV4(ctx context.Context, formats strfmt.Registry) error {
+
+	for i := 0; i < len(m.ServiceNetworksIPV4); i++ {
+
+		if m.ServiceNetworksIPV4[i] != nil {
+			if err := m.ServiceNetworksIPV4[i].ContextValidate(ctx, formats); err != nil {
+				if ve, ok := err.(*errors.Validation); ok {
+					return ve.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("service_networks_ipv4" + "." + strconv.Itoa(i))
+				}
+				return err
+			}
+		}
+
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR extends the default-config API to contain more defaults
regarding network configuration. This is driven by the fact that
Assisted UI allows now to create single- as well as dual-stack clusters
with multiple combinations of IPv4 and IPv6, therefore it's useful to
have an endpoint that will provide suggested values.

Closes: [MGMT-9710](https://issues.redhat.com/browse/MGMT-9710)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @batzionb

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
