### PR TITLE
NO-ISSUE: tenancy authz - added PATCH cluster test

### DIFF
--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -112,6 +112,12 @@ var _ = Describe("test authorization", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
+		It("can update cluster", func() {
+			_, err := editclusterUserBMClient.Installer.V2UpdateCluster(ctx, &installer.V2UpdateClusterParams{ClusterID: userClusterID,
+				ClusterUpdateParams: &models.V2ClusterUpdateParams{Name: swag.String("update-test")}})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
 		It("can get bound infra-env", func() {
 			infraEnvID := registerInfraEnv(&userClusterID, models.ImageTypeMinimalIso).ID
 			_, err := editclusterUserBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID})
@@ -166,6 +172,13 @@ var _ = Describe("test authorization", func() {
 			_, err = userBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID2})
 			Expect(err).Should(HaveOccurred())
 			Expect(err).To(BeAssignableToTypeOf(installer.NewGetInfraEnvNotFound()))
+		})
+
+		It("can't update not owned cluster", func() {
+			_, err := userBMClient.Installer.V2UpdateCluster(ctx, &installer.V2UpdateClusterParams{ClusterID: userClusterID2,
+				ClusterUpdateParams: &models.V2ClusterUpdateParams{Name: swag.String("update-test")}})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterNotFound()))
 		})
 	})
 


### PR DESCRIPTION
Added update cluster test to authz_test when org tenancy is enabled - to ensure authorization for PATCH requests.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
