### PR TITLE
AGENT-34: Set local host to be bootstrap

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -89,6 +89,7 @@ type Config struct {
 	AgentDockerImg                  string            `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
 	ServiceBaseURL                  string            `envconfig:"SERVICE_BASE_URL"`
 	ImageServiceBaseURL             string            `envconfig:"IMAGE_SERVICE_BASE_URL"`
+	InEphemeralInstaller            bool              `envconfig:"EPHEMERAL_INSTALLER" default:"false"`
 	ServiceCACertPath               string            `envconfig:"SERVICE_CA_CERT_PATH" default:""`
 	S3EndpointURL                   string            `envconfig:"S3_ENDPOINT_URL" default:"http://10.35.59.36:30925"`
 	S3Bucket                        string            `envconfig:"S3_BUCKET" default:"test"`
@@ -4518,7 +4519,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 
 	// When the assisted service is running on the same host as the agent, this
 	// host must become the bootstrap so that it installs last
-	if hostutil.IsAssistedServiceHost(host) {
+	if b.InEphemeralInstaller && hostutil.IsAssistedServiceHost(host) {
 		log.Infof("host <%s> also hosts assisted-service", params.NewHostParams.HostID.String())
 		host.Role = models.HostRoleMaster
 		host.Bootstrap = true

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4516,6 +4516,14 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		c = &cluster.Cluster
 	}
 
+	// When the assisted service is running on the same host as the agent, this
+	// host must become the bootstrap so that it installs last
+	if hostutil.IsAssistedServiceHost(host) {
+		log.Infof("host <%s> also hosts assisted-service", params.NewHostParams.HostID.String())
+		host.Role = models.HostRoleMaster
+		host.Bootstrap = true
+	}
+
 	//day2 host is always a worker
 	if hostutil.IsDay2Host(host) {
 		host.Role = models.HostRoleWorker

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 
 	"github.com/go-openapi/swag"
@@ -17,6 +18,7 @@ import (
 
 const (
 	MaxHostnameLength = 253
+	localHostIDFile   = "/var/run/assisted-agent/host-id"
 )
 
 func GetCurrentHostName(host *models.Host) (string, error) {
@@ -152,6 +154,11 @@ func GetDiskByInstallationPath(disks []*models.Disk, installationPath string) *m
 
 func IgnitionFileName(host *models.Host) string {
 	return fmt.Sprintf("%s-%s.ign", common.GetEffectiveRole(host), host.ID)
+}
+
+func IsAssistedServiceHost(h *models.Host) bool {
+	localHostID, err := os.ReadFile(localHostIDFile)
+	return err == nil && h.ID != nil && string(localHostID) == h.ID.String()
 }
 
 func IsDay2Host(h *models.Host) bool {


### PR DESCRIPTION
In the ephemeral agent-based installer image, the host running
assisted-service must become the bootstrap host, so that the
assisted-service remains up until all of the other hosts are installed.

By writing the agent ID to a local file (in openshift/assisted-installer-agent#314), we allow assisted-service to
determine when a host registration is for the local host.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [X] Ephemeral installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt
/cc @filanov 