### PR TITLE
MGMT-9172: Misleading "No networks found for host" errors reported for hosts which don't have any IPv4 addresses

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -253,6 +253,27 @@ func GenerateTest2IPv4AddressesInventory() string {
 	return string(b)
 }
 
+func GenerateTestIPv6Inventory() string {
+	inventory := &models.Inventory{
+		Interfaces: []*models.Interface{
+			{
+				Name: "eth0",
+				IPV6Addresses: []string{
+					"1001:db8::10/120",
+				},
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		Routes: TestDefaultRouteConfiguration,
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 func GenerateTestDefaultVmwareInventory() string {
 	inventory := &models.Inventory{
 		Interfaces: []*models.Interface{

--- a/internal/host/hostcommands/free_addresses_cmd_test.go
+++ b/internal/host/hostcommands/free_addresses_cmd_test.go
@@ -55,6 +55,13 @@ var _ = Describe("free_addresses", func() {
 		Expect(stepErr).To(HaveOccurred())
 	})
 
+	It("IPv6 only", func() {
+		host.Inventory = common.GenerateTestIPv6Inventory()
+		stepReply, stepErr = fCmd.GetSteps(ctx, &host)
+		Expect(stepReply).To(BeNil())
+		Expect(stepErr).ShouldNot(HaveOccurred())
+	})
+
 	AfterEach(func() {
 		// cleanup
 		common.DeleteTestDB(db, dbName)


### PR DESCRIPTION


Free addresses runs for IPv4 only.  Currently GetNextSteps for
Free addresses generates error message in the log.
In case IPv6 addresses exist, no such message will be written to the
log.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
