### PR TITLE
Bug 2069101: fail SNO deployment with SDN

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -636,6 +636,10 @@ func validateAndUpdateSingleNodeParams(newClusterParams *models.ClusterCreatePar
 		return errors.Errorf("VIP DHCP Allocation cannot be enabled on single node OpenShift")
 	}
 
+	if swag.StringValue(newClusterParams.NetworkType) == models.ClusterNetworkTypeOpenShiftSDN {
+		return errors.Errorf("OpenShiftSDN network type is not allowed in single node mode")
+	}
+
 	return nil
 }
 
@@ -1679,6 +1683,10 @@ func (b *bareMetalInventory) v2NoneHaModeClusterUpdateValidations(cluster *commo
 
 	if params.ClusterUpdateParams.UserManagedNetworking != nil && !swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) {
 		return errors.Errorf("disabling UserManagedNetworking is not allowed in single node mode")
+	}
+
+	if swag.StringValue(params.ClusterUpdateParams.NetworkType) == models.ClusterNetworkTypeOpenShiftSDN {
+		return errors.Errorf("OpenShiftSDN network type is not allowed in single node mode")
 	}
 
 	return nil

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -840,6 +840,37 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 	})
 
+	It("Verify NetworkType configuration with SNO", func() {
+		snoSpec := getDefaultSNOAgentClusterInstallSpec(clusterDeploymentSpec.ClusterName)
+		snoSpec.Networking.NetworkType = models.ClusterNetworkTypeOpenShiftSDN
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, snoSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+
+		By("Spec Sync should fail with SDN Configuration")
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterInputErrorReason)
+
+		By("Spec sync should succeed when applying OVN")
+		Eventually(func() error {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			aci.Spec.Networking.NetworkType = models.ClusterNetworkTypeOVNKubernetes
+			return kubeClient.Update(ctx, aci)
+		}, "1m", "20s").Should(BeNil())
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterSyncedOkReason)
+
+		By("re-applying SDN should fail with spec sync")
+		Eventually(func() error {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			aci.Spec.Networking.NetworkType = models.ClusterNetworkTypeOpenShiftSDN
+			return kubeClient.Update(ctx, aci)
+		}, "1m", "20s").Should(BeNil())
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterInputErrorReason)
+	})
+
 	It("deploy CD with ACI and agents - wait for ready, delete CD and verify ACI and agents deletion", func() {
 		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
 		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)


### PR DESCRIPTION
When creating aci with "networkType: OpenShiftSDN" and "controlPlaneAgents: 1", the
aci is created and synced, only for the validation network-type-valid to fail.

This PR validates the network type on creation and update and make sure
that with SNO there is no SDN configured.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
