### PR TITLE
[release-ocm-2.5] Bug 2069974: Host status change to insufficient when binding a host to a cluster

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -811,12 +811,16 @@ var _ = Describe("Auto assign machine CIDR", func() {
 		srcState                string
 		machineNetworkCIDR      string
 		expectedMachineCIDR     string
+		expectedMachineNetworks []string
 		apiVip                  string
 		hosts                   []*models.Host
 		eventCallExpected       bool
 		userActionResetExpected bool
 		dhcpEnabled             bool
 		userManagedNetworking   bool
+		sno                     bool
+		clusterNetworks         []*models.ClusterNetwork
+		serviceNetworks         []*models.ServiceNetwork
 	}{
 		{
 			name:        "No hosts",
@@ -1112,6 +1116,106 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			machineNetworkCIDR:      "192.168.0.0/16",
 			dhcpEnabled:             false,
 		},
+		{
+			name:     "Pending SNO IPv4",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+			},
+			sno:                 true,
+			expectedMachineCIDR: "1.2.3.0/24",
+			expectedMachineNetworks: []string{
+				"1.2.3.0/24",
+			},
+			dhcpEnabled: false,
+		},
+		{
+			name:     "Pending SNO IPv6",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+			},
+			sno:                 true,
+			clusterNetworks:     common.TestIPv6Networking.ClusterNetworks,
+			serviceNetworks:     common.TestIPv6Networking.ServiceNetworks,
+			expectedMachineCIDR: "1001:db8::/120",
+			expectedMachineNetworks: []string{
+				"1001:db8::/120",
+			},
+			dhcpEnabled: false,
+		},
+		{
+			name:     "Pending SNO Dual stack",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+			},
+			sno:                 true,
+			clusterNetworks:     common.TestDualStackNetworking.ClusterNetworks,
+			serviceNetworks:     common.TestDualStackNetworking.ServiceNetworks,
+			expectedMachineCIDR: "1.2.3.0/24",
+			expectedMachineNetworks: []string{
+				"1.2.3.0/24",
+				"1001:db8::/120",
+			},
+			dhcpEnabled: false,
+		},
+		{
+			name:     "Pending SNO IPv4 2 addresses",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTest2IPv4AddressesInventory(),
+				},
+			},
+			sno:                     true,
+			expectedMachineCIDR:     "",
+			expectedMachineNetworks: []string{},
+			dhcpEnabled:             false,
+		},
+		{
+			name:     "Pending SNO IPv6",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTest2IPv4AddressesInventory(),
+				},
+			},
+			sno:                 true,
+			clusterNetworks:     common.TestIPv6Networking.ClusterNetworks,
+			serviceNetworks:     common.TestIPv6Networking.ServiceNetworks,
+			expectedMachineCIDR: "1001:db8::/120",
+			expectedMachineNetworks: []string{
+				"1001:db8::/120",
+			},
+			dhcpEnabled: false,
+		},
+		{
+			name:     "Pending SNO conflicting service/cluster networks",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+			},
+			sno:                     true,
+			serviceNetworks:         common.TestIPv6Networking.ServiceNetworks,
+			expectedMachineCIDR:     "",
+			expectedMachineNetworks: []string{},
+			dhcpEnabled:             false,
+		},
 	}
 	for _, t := range tests {
 		t := t
@@ -1129,6 +1233,16 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				VipDhcpAllocation:     swag.Bool(t.dhcpEnabled),
 				UserManagedNetworking: swag.Bool(t.userManagedNetworking),
 			}}
+			if t.sno {
+				c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
+				c.UserManagedNetworking = swag.Bool(true)
+			}
+			if t.clusterNetworks != nil {
+				c.ClusterNetworks = t.clusterNetworks
+			}
+			if t.serviceNetworks != nil {
+				c.ServiceNetworks = t.serviceNetworks
+			}
 			Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
 			for _, h := range t.hosts {
 				hostId := strfmt.UUID(uuid.New().String())
@@ -1156,6 +1270,12 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				Expect(cluster.MachineNetworks).NotTo(BeEmpty())
 				Expect(network.GetMachineCidrById(&cluster, 0)).To(Equal(t.expectedMachineCIDR))
 				Expect(cluster.MachineNetworkCidr).To(Equal(t.expectedMachineCIDR)) // TODO MGMT-7365: Deprecate single network
+			}
+			if t.expectedMachineNetworks != nil {
+				Expect(cluster.MachineNetworks).To(HaveLen(len(t.expectedMachineNetworks)))
+				for _, m := range t.expectedMachineNetworks {
+					Expect(t.expectedMachineNetworks).To(ContainElement(m))
+				}
 			}
 
 			ctrl.Finish()

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -589,7 +589,7 @@ func (v *clusterValidator) isNetworksSameAddressFamilies(c *clusterPreprocessCon
 		v.log.WithError(err).Errorf("Getting cluster address families for cluster %s", c.cluster.ID.String())
 		return ValidationError
 	}
-	clusterNetworkFamilies = common.CanonizeStrings(clusterNetworkFamilies)
+	clusterNetworkFamilies = network.CanonizeAddressFamilies(clusterNetworkFamilies)
 	if !reflect.DeepEqual(serviceNetworkFamilies, clusterNetworkFamilies) {
 		return ValidationFailure
 	}
@@ -599,7 +599,7 @@ func (v *clusterValidator) isNetworksSameAddressFamilies(c *clusterPreprocessCon
 			v.log.WithError(err).Errorf("Getting machine address families for cluster %s", c.cluster.ID.String())
 			return ValidationError
 		}
-		machineNetworkFamilies = common.CanonizeStrings(machineNetworkFamilies)
+		machineNetworkFamilies = network.CanonizeAddressFamilies(machineNetworkFamilies)
 		if !reflect.DeepEqual(serviceNetworkFamilies, machineNetworkFamilies) {
 			return ValidationFailure
 		}

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -228,6 +228,31 @@ func GenerateTestDefaultInventory() string {
 	return string(b)
 }
 
+func GenerateTest2IPv4AddressesInventory() string {
+	inventory := &models.Inventory{
+		Interfaces: []*models.Interface{
+			{
+				Name: "eth0",
+				IPV4Addresses: []string{
+					"1.2.3.4/24",
+					"7.8.9.10/24",
+				},
+				IPV6Addresses: []string{
+					"1001:db8::10/120",
+				},
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		Routes: TestDefaultRouteConfiguration,
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 func GenerateTestDefaultVmwareInventory() string {
 	inventory := &models.Inventory{
 		Interfaces: []*models.Interface{

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -344,6 +344,19 @@ func GetClusterNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
 	return ret
 }
 
+func GetClusterNetworksByFamily(hosts []*models.Host, log logrus.FieldLogger) (map[AddressFamily][]string, error) {
+	networks := GetClusterNetworks(hosts, log)
+	ret := make(map[AddressFamily][]string)
+	for _, n := range networks {
+		family, err := CidrToAddressFamily(n)
+		if err != nil {
+			return nil, err
+		}
+		ret[family] = append(ret[family], n)
+	}
+	return ret, nil
+}
+
 func IsHostInPrimaryMachineNetCidr(log logrus.FieldLogger, cluster *common.Cluster, host *models.Host) bool {
 	// The host should belong to all the networks specified as Machine Networks.
 


### PR DESCRIPTION


When SNO cluster is created without machine CIDR, the cluster will not
become ready until machine CIDR is set.
There are cases that the machine networks can be deduced from the
discovered networks, and the configuration of service and cluster
networks.
When both of these configurations have the same address familes,
and there is a single discovered network per family in (service/cluster)
networks, then the machine networks can be auto assigned for SNO.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
