### PR TITLE
MGMT-9726: Wait for assisted-image-service when deploying the operator

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -206,6 +206,7 @@ EOCR
   wait_for_operator "assisted-service-operator" "${ASSISTED_NAMESPACE}"
   wait_for_condition "agentserviceconfigs/agent" "ReconcileCompleted" "5m"
   wait_for_pod "assisted-service" "${ASSISTED_NAMESPACE}" "app=assisted-service"
+  wait_for_pod "assisted-image-service" "${ASSISTED_NAMESPACE}" "app=assisted-image-service"
 
   echo "Enabling configuration of BMH resources outside of openshift-machine-api namespace"
   oc patch provisioning provisioning-configuration --type merge -p '{"spec":{"watchAllNamespaces": true}}'


### PR DESCRIPTION
In the late binding job, we try to download the ISO image from the
assisted-image-service but this one is not available yet.

This change waits for the assisted-image-service to be up before exiting the
deployment script.
