### PR TITLE
Bug 2070949: Add support for Ignition overrides for day2 worker

### DIFF
--- a/internal/ignition/mock_ignition.go
+++ b/internal/ignition/mock_ignition.go
@@ -118,16 +118,16 @@ func (mr *MockIgnitionBuilderMockRecorder) FormatDiscoveryIgnitionFile(ctx, infr
 }
 
 // FormatSecondDayWorkerIgnitionFile mocks base method.
-func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(address, machineConfigPoolName string) ([]byte, error) {
+func (m *MockIgnitionBuilder) FormatSecondDayWorkerIgnitionFile(address, machineConfigPoolName string, host *models.Host) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FormatSecondDayWorkerIgnitionFile", address, machineConfigPoolName)
+	ret := m.ctrl.Call(m, "FormatSecondDayWorkerIgnitionFile", address, machineConfigPoolName, host)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FormatSecondDayWorkerIgnitionFile indicates an expected call of FormatSecondDayWorkerIgnitionFile.
-func (mr *MockIgnitionBuilderMockRecorder) FormatSecondDayWorkerIgnitionFile(address, machineConfigPoolName interface{}) *gomock.Call {
+func (mr *MockIgnitionBuilderMockRecorder) FormatSecondDayWorkerIgnitionFile(address, machineConfigPoolName, host interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatSecondDayWorkerIgnitionFile", reflect.TypeOf((*MockIgnitionBuilder)(nil).FormatSecondDayWorkerIgnitionFile), address, machineConfigPoolName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatSecondDayWorkerIgnitionFile", reflect.TypeOf((*MockIgnitionBuilder)(nil).FormatSecondDayWorkerIgnitionFile), address, machineConfigPoolName, host)
 }


### PR DESCRIPTION
Currently there is a bug that causes day-2 worker ignition override to
be ignored without any error message.

This PR changes the behaviour of ignition generator so that the function
handling day-2 nodes takes the override into account. Given that there
are separate functions for day-1 and day-2 nodes, this PR also renames
the latter so that it's clear that it's used only for day-2.

Cherry-picks: #3524
Closes: Bug-2070949

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
