### PR TITLE
Bug 2061317: when using nmstateconfigs ISO is re-generated for each nmstateconfig

### DIFF
--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -47,7 +47,7 @@ var _ = Describe("StaticNetworkConfig", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("check formating static network for DB", func() {
+	It("check formatting static network for DB", func() {
 		map1 := models.MacInterfaceMap{
 			&models.MacInterfaceMapItems0{MacAddress: "mac10", LogicalNicName: "nic10"},
 		}
@@ -65,7 +65,38 @@ var _ = Describe("StaticNetworkConfig", func() {
 		Expect(formattedOutput).To(Equal(string(expectedOutputAsBytes)))
 	})
 
-	It("check empty formating static network for DB", func() {
+	It("sorted formatting static network for DB", func() {
+		map1 := models.MacInterfaceMap{
+			&models.MacInterfaceMapItems0{MacAddress: "mac10", LogicalNicName: "nic10"},
+			&models.MacInterfaceMapItems0{MacAddress: "mac0", LogicalNicName: "nic0"},
+		}
+		sortedMap1 := models.MacInterfaceMap{
+			&models.MacInterfaceMapItems0{MacAddress: "mac0", LogicalNicName: "nic0"},
+			&models.MacInterfaceMapItems0{MacAddress: "mac10", LogicalNicName: "nic10"},
+		}
+		map2 := models.MacInterfaceMap{
+			&models.MacInterfaceMapItems0{MacAddress: "mac20", LogicalNicName: "nic20"},
+		}
+		unsortedStaticNetworkConfig := []*models.HostStaticNetworkConfig{
+			common.FormatStaticConfigHostYAML("nic20", "02000048ba48", "192.168.126.31", "192.168.141.31", "192.168.126.1", map2),
+			common.FormatStaticConfigHostYAML("nic10", "02000048ba38", "192.168.126.30", "192.168.141.30", "192.168.126.1", map1),
+		}
+		sortedStaticNetworkConfig := []*models.HostStaticNetworkConfig{
+			common.FormatStaticConfigHostYAML("nic10", "02000048ba38", "192.168.126.30", "192.168.141.30", "192.168.126.1", sortedMap1),
+			common.FormatStaticConfigHostYAML("nic20", "02000048ba48", "192.168.126.31", "192.168.141.31", "192.168.126.1", map2),
+		}
+
+		unexpectedOutputAsBytes, err := json.Marshal(unsortedStaticNetworkConfig)
+		Expect(err).ToNot(HaveOccurred())
+		formattedOutput, err := staticNetworkGenerator.FormatStaticNetworkConfigForDB(unsortedStaticNetworkConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(formattedOutput).ToNot(Equal(string(unexpectedOutputAsBytes)))
+		expectedOutputAsBytes, err := json.Marshal(sortedStaticNetworkConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(formattedOutput).To(Equal(string(expectedOutputAsBytes)))
+	})
+
+	It("check empty formatting static network for DB", func() {
 		formattedOutput, err := staticNetworkGenerator.FormatStaticNetworkConfigForDB(nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(formattedOutput).To(Equal(""))


### PR DESCRIPTION

When updating infra-env, static network configuration is saved if it is
present in the update parameters and if it is different from the
previous value already in the database. Updating infra-env causes
download URL regeneration which is undesirable.
Since this configuration is a slice of elements, that each of them
contains a slice, changing the order of items in any of the slices, may
cause the static network configuration to be different than the previous
value, but equivalent in terms of configuration when applied.
To prevent this, sort was added to verify that equivalent configurations
will generate same string value to be stored in the database.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] Unit tests

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
