### PR TITLE
MGMT-9673: Add HasAccessTo API to authz

### DIFF
--- a/pkg/auth/auth_utils.go
+++ b/pkg/auth/auth_utils.go
@@ -37,12 +37,21 @@ func shouldStorePayloadInCache(err error) bool {
 	return false
 }
 
-func isUpdateRequest(request *http.Request) bool {
-	return request != nil && (request.Method == http.MethodPost ||
-		request.Method == http.MethodPut ||
-		request.Method == http.MethodPatch)
-}
+func toAction(request *http.Request) Action {
+	if request == nil {
+		return NoneAction
+	}
 
-func isDeleteRequest(request *http.Request) bool {
-	return request != nil && request.Method == http.MethodDelete
+	switch {
+	case request.Method == http.MethodPost ||
+		request.Method == http.MethodPut ||
+		request.Method == http.MethodPatch:
+		return UpdateAction
+	case request.Method == http.MethodDelete:
+		return DeleteAction
+	case request.Method == http.MethodGet:
+		return ReadAction
+	default:
+		return NoneAction
+	}
 }

--- a/pkg/auth/authz.go
+++ b/pkg/auth/authz.go
@@ -9,10 +9,18 @@ import (
 	"gorm.io/gorm"
 )
 
+type Action string
+
+const ReadAction Action = "read"
+const UpdateAction Action = "update"
+const DeleteAction Action = "delete"
+const NoneAction Action = "none"
+
 type Authorizer interface {
 	/* Limits the database query to access records that are owned by the current user,
 	 * according to the configured access policy.
 	 */
+
 	OwnedBy(ctx context.Context, db *gorm.DB) *gorm.DB
 
 	/* Limits the database query to access records owned only by the input user,
@@ -20,6 +28,11 @@ type Authorizer interface {
 	 * is not supported, the function effectively will not limit access.
 	 */
 	OwnedByUser(ctx context.Context, db *gorm.DB, username string) *gorm.DB
+
+	/* verify that the current user has access rights (depending on the requested)
+	 * action) to the input resource
+	 */
+	HasAccessTo(ctx context.Context, obj interface{}, action Action) (bool, error)
 
 	/* Provides the middleware authorization algorithm */
 	CreateAuthorizer() func(*http.Request) error

--- a/pkg/auth/none_authz_handler.go
+++ b/pkg/auth/none_authz_handler.go
@@ -28,3 +28,7 @@ func (*NoneHandler) OwnedBy(ctx context.Context, db *gorm.DB) *gorm.DB {
 func (*NoneHandler) OwnedByUser(ctx context.Context, db *gorm.DB, username string) *gorm.DB {
 	return db
 }
+
+func (*NoneHandler) HasAccessTo(ctx context.Context, obj interface{}, action Action) (bool, error) {
+	return true, nil
+}

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -117,18 +117,6 @@ var _ = Describe("test authorization", func() {
 				ClusterUpdateParams: &models.V2ClusterUpdateParams{Name: swag.String("update-test")}})
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-
-		It("can get bound infra-env", func() {
-			infraEnvID := registerInfraEnv(&userClusterID, models.ImageTypeMinimalIso).ID
-			_, err := editclusterUserBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID})
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("can't get unbound infra-env", func() {
-			infraEnvID := registerInfraEnv(nil, models.ImageTypeMinimalIso).ID
-			_, err := editclusterUserBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: *infraEnvID})
-			Expect(err).To(HaveOccurred())
-		})
 	})
 
 	Context("regular user", func() {


### PR DESCRIPTION
Authorization becomes more complex with the tenancy-based feature and more authorization schemes added for other projects.
In the current implementation, the application layer is using stateless utilities to check for access permission to objects on top of the existing mechanism. These checks are sometimes redundant and or not quite aligned with the new authorization scheme.

Using stateless utilities makes us expose feature flags and states in the auth API where they do not belong. For all those reasons, an API for authorization that will be shared by all authorization handlers and expose coherent access control algorithms to the application is required.

This is the second installment of the enhancement. It defines The HasAccessTo interface that queries whether the current user can access an object, based on the active authorization layer.

The objects that participate in the authorization are cluster, infra-env, and host.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
