### PR TITLE
 MGMT-9912: Handle a nil cluster_id with events that have an optional cluster_id

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -937,7 +937,8 @@ func (b *bareMetalInventory) updateExternalImageInfo(ctx context.Context, infraE
 		}
 
 		details := b.getIgnitionConfigForLogging(ctx, infraEnv, b.log, imageType)
-		eventgen.SendImageInfoUpdatedEvent(ctx, b.eventsHandler, &infraEnv.ClusterID, *infraEnv.ID, details)
+
+		eventgen.SendImageInfoUpdatedEvent(ctx, b.eventsHandler, common.StrFmtUUIDPtr(infraEnv.ClusterID), *infraEnv.ID, details)
 		updates["download_url"] = infraEnv.DownloadURL
 		updates["generated"] = true
 		infraEnv.Generated = true
@@ -2817,13 +2818,11 @@ func (b *bareMetalInventory) V2DeregisterHostInternal(ctx context.Context, param
 
 	// TODO: need to check that host can be deleted from the cluster
 	infraEnv, err := common.GetInfraEnvFromDB(b.db, params.InfraEnvID)
-	var clusterID strfmt.UUID
 	if err != nil {
 		log.WithError(err).Warnf("Get InfraEnv %s", params.InfraEnvID.String())
 		return err
 	}
-	clusterID = infraEnv.ClusterID
-	eventgen.SendHostDeregisteredEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, &clusterID,
+	eventgen.SendHostDeregisteredEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, common.StrFmtUUIDPtr(infraEnv.ClusterID),
 		hostutil.GetHostnameForMsg(&h.Host))
 	return nil
 }

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -363,7 +363,8 @@ func (b *bareMetalInventory) v2uploadLogs(ctx context.Context, params installer.
 		if err != nil {
 			return err
 		}
-		eventgen.SendHostLogsUploadedEvent(ctx, b.eventsHandler, *params.HostID, dbHost.InfraEnvID, &params.ClusterID,
+
+		eventgen.SendHostLogsUploadedEvent(ctx, b.eventsHandler, *params.HostID, dbHost.InfraEnvID, common.StrFmtUUIDPtr(params.ClusterID),
 			hostutil.GetHostnameForMsg(&dbHost.Host))
 		return nil
 	}

--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -44,3 +44,10 @@ func StrFmtUUIDVal(u *strfmt.UUID) strfmt.UUID {
 	}
 	return *u
 }
+
+func StrFmtUUIDPtr(u strfmt.UUID) *strfmt.UUID {
+	if u.String() == "" {
+		return nil
+	}
+	return &u
+}

--- a/internal/events/eventstest/events_test_utils.go
+++ b/internal/events/eventstest/events_test_utils.go
@@ -46,6 +46,12 @@ func WithClusterIdMatcher(expected string) eventPartMatcher {
 				return expected == ""
 			}
 			return e.GetClusterId().String() == expected
+		case eventsapi.InfraEnvEvent:
+			if e.GetClusterId() == nil {
+				// cluster_id is an optional parameter for infraEnv events
+				return expected == ""
+			}
+			return e.GetClusterId().String() == expected
 		default:
 			return false
 		}


### PR DESCRIPTION
With the current implementation, when image_info_updated gets
generated for an unbounded InfraEnv (meaning no clusterID),
we pass a pointer to an empty string rather than nil, which is what
the querying function expects. This change addresses this issue.

Additional events that have a similar problem with an optional cluster_id:
- host_logs_uploaded
- host_deregistered

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
