### PR TITLE
AGENT-34: Allow preconfiguration of bootstrap host

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -86,6 +86,7 @@ type Config struct {
 	ResetTimeout            time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
 	MonitorBatchSize        int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
 	DisabledHostvalidations DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:""` // Which host validations to disable (should not run in preprocess)
+	BootstrapHostMAC        string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
 }
 
 //go:generate mockgen -package=host -aux_files=github.com/openshift/assisted-service/internal/host/hostcommands=instruction_manager.go -destination=mock_host_api.go . API
@@ -319,6 +320,25 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	if err != nil {
 		log.WithError(err).Errorf("not updating inventory - failed to find infra env %s", h.InfraEnvID.String())
 		return common.NewApiError(http.StatusNotFound, err)
+	}
+
+	if m.Config.BootstrapHostMAC != "" && !h.Bootstrap {
+		for _, iface := range inventory.Interfaces {
+			if iface.MacAddress == m.Config.BootstrapHostMAC {
+				log.Infof("selected local bootstrap host %s for cluster %s", h.ID, cluster.ID)
+				err = updateRole(log, h, models.HostRoleMaster, models.HostRoleMaster, db, string(h.Role))
+				if err != nil {
+					log.WithError(err).Errorf("failed to set master role on bootstrap host for cluster %s", cluster.ID)
+					return errors.Wrapf(err, "Failed to set master role on bootstrap host for cluster %s", cluster.ID)
+				}
+				err = m.SetBootstrap(ctx, h, true, db)
+				if err != nil {
+					log.WithError(err).Errorf("failed to update bootstrap host for cluster %s", cluster.ID)
+					return errors.Wrapf(err, "Failed to update bootstrap host for cluster %s", cluster.ID)
+				}
+				break
+			}
+		}
 	}
 
 	err = m.populateDisksEligibility(ctx, inventory, infraEnv, cluster, h)


### PR DESCRIPTION
If the environment variable BOOTSTRAP_HOST_MAC is set, select a host
with that MAC address as the bootstrap and ensure it is designated to be
a control plane host.

This will be used in the ephemeral installer to ensure that the host
running assisted-service is also used as the bootstrap.

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] Ephemeral Installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @flaper87 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
