### PR TITLE
MGMT-9732: add user authorization to BindHost

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4792,6 +4792,12 @@ func (b *bareMetalInventory) BindHostInternal(ctx context.Context, params instal
 	if err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, errors.Errorf("Failed to find cluster %s", params.BindHostParams.ClusterID))
 	}
+	allowed, err := b.authzHandler.HasAccessTo(ctx, cluster, auth.UpdateAction)
+	if !allowed {
+		msg := fmt.Sprintf("Failed to find cluster %s", params.BindHostParams.ClusterID)
+		b.log.WithError(err).Error(msg)
+		return nil, common.NewApiError(http.StatusNotFound, errors.New(msg))
+	}
 	infraEnv, err := common.GetInfraEnvFromDB(b.db, params.InfraEnvID)
 	if err != nil {
 		b.log.WithError(err).Errorf("Failed to get infra env %s", params.InfraEnvID)


### PR DESCRIPTION
Added proper authz to BindHostInternal func by using HasAccessTo API.
The specified cluster (the should be bounded to host) is checked for ensuring user's update permissions. I.e. cluster is owned by the user, or, if tenancy is enabled, we query AMS with the associated subscription.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
