### PR TITLE
MGMT-9758: replace AddUserFilter with HasAccessTo API

### DIFF
--- a/pkg/auth/auth_handler_test_utils.go
+++ b/pkg/auth/auth_handler_test_utils.go
@@ -86,3 +86,9 @@ func GenJSJWKS(privKey crypto.PublicKey, pubKey crypto.PublicKey) ([]byte, []byt
 	}
 	return pubJSJWKS, privJSJWKS, kid, nil
 }
+
+func GetConfigRHSSO() *Config {
+	_, cert := GetTokenAndCert(false)
+	cfg := &Config{JwkCert: string(cert), AuthType: TypeRHSSO, EnableOrgTenancy: true}
+	return cfg
+}


### PR DESCRIPTION
Replaced identity.AddUserFilter in V2UpdateHostInstallerArgsInternal and V2UpdateHostIgnition funcs.
Instead, used authzHandler.HasAccessTo API. When tenancy is enabled, HasAccessTo should query AMS
and check whether the user has update perms for the cluster associated to the host (i.e. if there's a bounded cluster).
Otherwise, the relevant filter should be added to the db query.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
