### PR TITLE
MGMT-9810: check cluster update authz in RegisterInfraEnv

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4062,7 +4062,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 
-	err = b.validateClusterInfraEnvRegister(params.InfraenvCreateParams.ClusterID, params.InfraenvCreateParams.CPUArchitecture)
+	err = b.validateClusterInfraEnvRegister(ctx, params.InfraenvCreateParams.ClusterID, params.InfraenvCreateParams.CPUArchitecture)
 	if err != nil {
 		return nil, err
 	}
@@ -4195,12 +4195,19 @@ func (b *bareMetalInventory) getOsImageOrLatest(version string, cpuArch string) 
 	return osImage, nil
 }
 
-func (b *bareMetalInventory) validateClusterInfraEnvRegister(clusterId *strfmt.UUID, arch string) error {
+func (b *bareMetalInventory) validateClusterInfraEnvRegister(ctx context.Context, clusterId *strfmt.UUID, arch string) error {
 	if clusterId != nil {
 		cluster, err := common.GetClusterFromDB(b.db, *clusterId, common.SkipEagerLoading)
 		if err != nil {
 			err = errors.Errorf("Cluster ID %s does not exists", clusterId.String())
 			return common.NewApiError(http.StatusBadRequest, err)
+		}
+
+		allowed, err := b.authzHandler.HasAccessTo(ctx, cluster, auth.UpdateAction)
+		if !allowed {
+			msg := fmt.Sprintf("Failed to find cluster %s", clusterId)
+			b.log.WithError(err).Error(msg)
+			return common.NewApiError(http.StatusNotFound, errors.New(msg))
 		}
 
 		if cluster.CPUArchitecture != "" && cluster.CPUArchitecture != arch {


### PR DESCRIPTION
When cluster_id is specified in RegisterInfraEnv request, ensure user authorization for updating the cluster.
No need to check authorization when registering without a specific cluster_id.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered
/cc @avishayt

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
