### PR TITLE
MGMT-8741: Accept full name OR tag for agent version

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11396,8 +11396,8 @@ var _ = Describe("update image version", func() {
 		ctrl.Finish()
 	})
 
-	It("same image", func() {
-		agentImage := fmt.Sprintf("%s:%s", "quay.io/example/agent", uuid.New().String())
+	It("same image full name", func() {
+		agentImage := fmt.Sprintf("quay.io:5000/example/agent:%s", uuid.New().String())
 		bm.AgentDockerImg = agentImage
 		params.NewHostParams.DiscoveryAgentVersion = agentImage
 		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
@@ -11405,8 +11405,18 @@ var _ = Describe("update image version", func() {
 		Expect(logHook.AllEntries()).To(BeEmpty())
 	})
 
-	It("image tag mismatch", func() {
-		imageName := "quay.io/example/assisted-installer-agent"
+	It("same image tag", func() {
+		tag := uuid.New().String()
+		agentImage := fmt.Sprintf("quay.io:5000/example/agent:%s", tag)
+		bm.AgentDockerImg = agentImage
+		params.NewHostParams.DiscoveryAgentVersion = tag
+		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logHook.AllEntries()).To(BeEmpty())
+	})
+
+	It("image tag mismatch in full name", func() {
+		imageName := "quay.io:5000/example/assisted-installer-agent"
 		bm.AgentDockerImg = fmt.Sprintf("%s:%s", imageName, uuid.New().String())
 		params.NewHostParams.DiscoveryAgentVersion = fmt.Sprintf("%s:%s", imageName, uuid.New().String())
 		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
@@ -11414,10 +11424,18 @@ var _ = Describe("update image version", func() {
 		Expect(logHook.LastEntry().Message).To(ContainSubstring("uses an outdated agent image"))
 	})
 
+	It("image tag mismatch when tag only", func() {
+		bm.AgentDockerImg = fmt.Sprintf("quay.io:5000/example/assisted-installer-agent:%s", uuid.New().String())
+		params.NewHostParams.DiscoveryAgentVersion = uuid.New().String()
+		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logHook.LastEntry().Message).To(ContainSubstring("uses an outdated agent image"))
+	})
+
 	It("image name mismatch", func() {
 		imageTag := uuid.New().String()
-		bm.AgentDockerImg = fmt.Sprintf("%s:%s", "quay.io/edge-infrastructure/assisted-installer-agent", imageTag)
-		params.NewHostParams.DiscoveryAgentVersion = fmt.Sprintf("%s:%s", "quay.io/ocpmetal/agent", imageTag)
+		bm.AgentDockerImg = fmt.Sprintf("quay.io:5000/example/assisted-installer-agent:%s", imageTag)
+		params.NewHostParams.DiscoveryAgentVersion = fmt.Sprintf("quay.io:5000/example/agent:%s", imageTag)
 		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logHook.LastEntry().Message).To(ContainSubstring("uses an outdated agent image"))
@@ -11426,8 +11444,8 @@ var _ = Describe("update image version", func() {
 	It("image registry mismatch", func() {
 		imageTag := uuid.New().String()
 		imageName := "example/assisted-installer-agent"
-		bm.AgentDockerImg = fmt.Sprintf("%s/%s:%s", "quay.io", imageName, imageTag)
-		params.NewHostParams.DiscoveryAgentVersion = fmt.Sprintf("%s/%s:%s", "docker.io", imageName, imageTag)
+		bm.AgentDockerImg = fmt.Sprintf("quay.io:5000/%s:%s", imageName, imageTag)
+		params.NewHostParams.DiscoveryAgentVersion = fmt.Sprintf("docker.io:5000/%s:%s", imageName, imageTag)
 		_, err := bm.generateV2NextStepRunnerCommand(ctx, params)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logHook.LastEntry().Message).To(ContainSubstring("uses an outdated agent image"))


### PR DESCRIPTION
It seems that the semantics of agent version may
change over time, being reperesented either by a
full image name or just by the image tag. We make
the log message that informs about agent update
more robust by accomodating both these variants.
That is, if the agent version is a tag we compare
it to the tag in `AGENT_DOCKER_IMAGE`, but if it
is a full name we compare it to the entire content
of `AGENT_DOCKER_IMAGE`.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ori-amizur 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
