### PR TITLE
[release-ocm-2.4] Bug 2072892: Backport `pin-latest.py` script

### DIFF
--- a/deploy/olm-catalog/pin-latest.py
+++ b/deploy/olm-catalog/pin-latest.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+# This script scans the operator bundle manifests for container images that
+# have a tag matching OPERATOR_MANIFESTS_TAG_TO_PIN (if unset, the value
+# "latest" is used by default). These images will be resolved for their
+# current digest at the time of running the script and will be replaced
+# inline with that digest instead of the original tag.
+
+import os
+from hashlib import sha256
+from pathlib import Path
+from typing import Iterable, List
+from functools import lru_cache
+import logging
+
+import ruamel.yaml
+from dxf import DXF
+
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
+
+script_dir = Path(__file__).resolve().parent
+
+tag_to_pin = os.environ.get("OPERATOR_MANIFESTS_TAG_TO_PIN", "latest")
+
+
+# The list of manifests and which specific paths within them have to be processed
+manifests = {
+    "assisted-service-operator.clusterserviceversion.yaml": (
+        "metadata.annotations.containerImage",
+        "spec.install.spec.deployments[].spec.template.spec.containers[].env[].value",
+        "spec.install.spec.deployments[].spec.template.spec.containers[].image",
+        "spec.relatedImages[].image",
+    )
+}
+
+
+def yaml_config():
+    yaml = ruamel.yaml.YAML()
+    yaml.preserve_quotes = True
+    return yaml
+
+
+def main():
+    yaml = yaml_config()
+
+    for manifest, paths in manifests.items():
+        fix_manifest(yaml, script_dir / "manifests" / manifest, paths)
+
+
+def fix_manifest(yaml: ruamel.yaml.YAML, manifest: Path, paths: Iterable[str]):
+    with manifest.open("r") as manifest_file:
+        csv = yaml.load(manifest_file)
+
+    for path in paths:
+        logging.info(f"{manifest}: Fixing {path}")
+        pin_path(csv, path.split("."))
+
+    with manifest.open("w") as manifest_file:
+        yaml.dump(csv, manifest_file)
+
+
+def is_tag_matching(value: str):
+    if type(value) != str:
+        return False
+
+    return value.endswith(f":{tag_to_pin}")
+
+
+def parse_image_loc(image_loc: str):
+    tag_splitter = ":" if "@" not in image_loc else "@"
+    domain_org_repo, tag = image_loc.rsplit(tag_splitter, maxsplit=1)
+    domain, org, repo = domain_org_repo.split("/")
+
+    return domain, org, repo, tag
+
+
+@lru_cache(maxsize=None)
+def resolve_tag(image_loc: str):
+    logging.info(f"Resolving {image_loc}")
+    domain, org, repo, tag = parse_image_loc(image_loc)
+    dxf = DXF(domain, f"{org}/{repo}", tag, None)
+    hash = sha256(dxf.get_manifest(tag_to_pin).encode("utf-8")).hexdigest()
+    resolved = f"{domain}/{org}/{repo}@sha256:{hash}"
+    logging.info(f"{resolved}")
+    return resolved
+
+
+def pin_path(obj: dict, path: List[str]):
+    logging.info(f"Iterating {'.'.join(path)}")
+
+    current_key, *rest = path
+
+    if not rest:
+        current_value = obj.get(current_key, "")
+        if is_tag_matching(current_value):
+            new_value = resolve_tag(current_value)
+            obj[current_key] = new_value
+
+        return
+
+    current_key, is_list = current_key.rstrip("[]"), current_key.endswith("[]")
+
+    if is_list:
+        for list_child in obj[current_key]:
+            pin_path(list_child, rest)
+    else:
+        pin_path(obj[current_key], rest)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/olm-catalog/requirements.txt
+++ b/deploy/olm-catalog/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml
+python-dxf


### PR DESCRIPTION
# Assisted Pull Request
## Description

When publishing the Infrastructure Operator bundle and catalog to quay
for the master branch, we scan the operator's manifests
(clusterserviceversion in particular) for the "latest" tag and pin it to
a particular image manifest digest. This is done using the pin-latest.py
script.

We would like to use the same script for doing similar pinning but for
our release branches.

This is needed because currently our
`periodic-ci-openshift-assisted-service-release-ocm-2.4-e2e-metal-assisted-kube-api-late-binding-single-node-periodic`
job is failing because it's using an outdated operator catalog image
that's no longer being published.

This script is needed for the new publishing process that we already
have in place for `release-ocm-2.5` and `master`.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @adriengentil

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md