### PR TITLE
AGENT-39: Define NMStateConfig NetConfig struct bindings

### DIFF
--- a/api/v1beta1/nmstate_config_types.go
+++ b/api/v1beta1/nmstate_config_types.go
@@ -29,15 +29,56 @@ type Interface struct {
 	MacAddress string `json:"macAddress"`
 }
 
-type RawNetConfig []byte
+type Address struct {
+	IP           string `json:"ip,omitempty"`
+	PrefixLength string `json:"prefix-length,omitempty"`
+}
 
-// NetConfig contains the namestatectl yaml [1] as string instead of golang struct
-// so we don't need to be in sync with the schema.
-//
-// [1] https://github.com/nmstate/nmstate/blob/base/libnmstate/schemas/operational-state.yaml
-// +kubebuilder:validation:Type=object
+type IPV4 struct {
+	Enabled string    `json:"enabled,omitempty"`
+	Address []Address `json:"address,omitempty"`
+	DHCP    string    `json:"dhcp,omitempty"`
+}
+
+type IPV6 struct {
+	Enabled  string    `json:"enabled,omitempty"`
+	Address  []Address `json:"address,omitempty"`
+	AutoConf string    `json:"autoconf,omitempty"`
+	DHCP     string    `json:"dhcp,omitempty"`
+}
+
+type NetConfigInterfaces struct {
+	Name       string `json:"name,omitempty"`
+	Type       string `json:"type,omitempty"`
+	State      string `json:"state,omitempty"`
+	MacAddress string `json:"mac-address,omitempty"`
+	IPV4       IPV4   `json:ipv4,omitempty`
+	IPV6       IPV6   `json:ipv6,omitempty`
+}
+
+type DNSConfig struct {
+	Server []string `json:"server,omitempty"`
+}
+
+type DNSResolver struct {
+	DNSConfig DNSConfig `json:"config,omitempty"`
+}
+
+type RoutesConfig struct {
+	Destination      string `json:"destination,omitempty"`
+	NextHopAddress   string `json:"next-hop-address,omitempty"`
+	NextHopInterface string `json:"next-hop-interface,omitempty"`
+	TableID          string `json:"table-id,omitempty"`
+}
+
+type NetConfigRoutes struct {
+	Config []RoutesConfig `json:"config,omitempty"`
+}
+
 type NetConfig struct {
-	Raw RawNetConfig `json:"-"`
+	Interfaces  []NetConfigInterfaces `json:"interfaces,omitempty"`
+	DNSResolver DNSResolver           `json:"dns-resolver,omitempty"`
+	Routes      NetConfigRoutes       `json:"routes,omitempty"`
 }
 
 type NMStateConfigSpec struct {

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -220,9 +220,10 @@ func (r *InfraEnvReconciler) processNMStateConfig(ctx context.Context, log logru
 	}
 
 	for _, nmStateConfig := range nmStateConfigs.Items {
+		networkYaml, _ := json.Marshal(nmStateConfig.Spec.NetConfig.Interfaces)
 		staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
 			MacInterfaceMap: r.buildMacInterfaceMap(log, nmStateConfig),
-			NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+			NetworkYaml:     networkYaml,
 		})
 	}
 	return staticNetworkConfig, nil


### PR DESCRIPTION
The fleeting tool https://github.com/openshift-agent-team/fleeting uses assisted-service internally. Fleeting needs to read `NMStateConfig.yaml`, validate and parse the host IP from the file. The host IP parsed is used to identify node0 by the fleeting tool. This PR defines the struct bindings to help fleeting parse the data from `NMStateConfig.yaml`

The struct bindings refer to the `NMStateConfig.yaml` file https://github.com/openshift/assisted-service/blob/master/docs/hive-integration/crds/nmstate.yaml

Ref: https://issues.redhat.com/browse/AGENT-39
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
