### PR TITLE
Bug 2072728: ensure secret is labelled when it is being reconciled

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -230,7 +230,7 @@ func (r *ClusterDeploymentsReconciler) Reconcile(origCtx context.Context, req ct
 
 	if swag.StringValue(cluster.Kind) == models.ClusterKindCluster && !clusterInstall.Spec.HoldInstallation {
 		// Day 1
-		pullSecret, err := getPullSecretData(ctx, r.Client, r.APIReader, clusterDeployment.Spec.PullSecretRef, req.Namespace)
+		pullSecret, err := getAndLabelPullSecret(ctx, r.Client, r.APIReader, clusterDeployment.Spec.PullSecretRef, req.Namespace)
 		if err != nil {
 			log.WithError(err).Error("failed to get pull secret")
 			return r.updateStatus(ctx, log, clusterInstall, nil, err)
@@ -843,7 +843,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	if userManagedNetwork := isUserManagedNetwork(clusterInstall); userManagedNetwork != swag.BoolValue(cluster.UserManagedNetworking) {
 		params.UserManagedNetworking = swag.Bool(userManagedNetwork)
 	}
-	pullSecretData, err := getPullSecretData(ctx, r.Client, r.APIReader, spec.PullSecretRef, clusterDeployment.Namespace)
+	pullSecretData, err := getAndLabelPullSecret(ctx, r.Client, r.APIReader, spec.PullSecretRef, clusterDeployment.Namespace)
 	if err != nil {
 		return cluster, errors.Wrap(err, "failed to get pull secret for update")
 	}
@@ -1088,7 +1088,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 	log.Infof("Creating a new cluster %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
 	spec := clusterDeployment.Spec
 
-	pullSecret, err := getPullSecretData(ctx, r.Client, r.APIReader, spec.PullSecretRef, key.Namespace)
+	pullSecret, err := getAndLabelPullSecret(ctx, r.Client, r.APIReader, spec.PullSecretRef, key.Namespace)
 	if err != nil {
 		log.WithError(err).Error("failed to get pull secret")
 		return r.updateStatus(ctx, log, clusterInstall, nil, err)

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -162,7 +162,7 @@ func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.Fiel
 		updateParams.InfraEnvUpdateParams.SSHAuthorizedKey = &infraEnv.Spec.SSHAuthorizedKey
 	}
 
-	pullSecret, err := getPullSecretData(ctx, r.Client, r.APIReader, infraEnv.Spec.PullSecretRef, infraEnv.Namespace)
+	pullSecret, err := getAndLabelPullSecret(ctx, r.Client, r.APIReader, infraEnv.Spec.PullSecretRef, infraEnv.Namespace)
 	if err != nil {
 		log.WithError(err).Error("failed to get pull secret")
 		return nil, err
@@ -337,7 +337,7 @@ func (r *InfraEnvReconciler) ensureISO(ctx context.Context, log logrus.FieldLogg
 
 func (r *InfraEnvReconciler) createInfraEnv(ctx context.Context, log logrus.FieldLogger, key *types.NamespacedName, infraEnv *aiv1beta1.InfraEnv, cluster *common.Cluster) (*common.InfraEnv, error) {
 
-	pullSecret, err := getPullSecretData(ctx, r.Client, r.APIReader, infraEnv.Spec.PullSecretRef, key.Namespace)
+	pullSecret, err := getAndLabelPullSecret(ctx, r.Client, r.APIReader, infraEnv.Spec.PullSecretRef, key.Namespace)
 	if err != nil {
 		log.WithError(err).Error("failed to get pull secret")
 		return nil, err


### PR DESCRIPTION
This change makes sure InfraEnv secrets are being labelled for backup when infraenv is being created/updated. We don't manage the secret directly, but since its required for InfraEnv to be restored correctly.

Fixes https://github.com/stolostron/backlog/issues/21490

TODO:
* [ ] Add unit-tests

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] None

## How was this code tested?

- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
