### PR TITLE
Bug 2073413: expose API/Ingress VIPs in ACI

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -218,6 +218,14 @@ type AgentClusterInstallStatus struct {
 	// +optional
 	DebugInfo DebugInfo `json:"debugInfo"`
 
+	// APIVIP is the virtual IP used to reach the OpenShift cluster's API.
+	// +optional
+	APIVIP string `json:"apiVIP,omitempty"`
+
+	// IngressVIP is the virtual IP used for cluster ingress traffic.
+	// +optional
+	IngressVIP string `json:"ingressVIP,omitempty"`
+
 	// ValidationsInfo is a JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
 	// +optional
 	ValidationsInfo common.ValidationsStatus `json:"validationsInfo,omitempty"`

--- a/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/config/crd/bases/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -355,6 +355,10 @@ spec:
             description: AgentClusterInstallStatus defines the observed state of the
               AgentClusterInstall.
             properties:
+              apiVIP:
+                description: APIVIP is the virtual IP used to reach the OpenShift
+                  cluster's API.
+                type: string
               conditions:
                 description: Conditions includes more detailed status for the cluster
                   install.
@@ -420,6 +424,10 @@ spec:
                       the AgentClusterInstall
                     type: string
                 type: object
+              ingressVIP:
+                description: IngressVIP is the virtual IP used for cluster ingress
+                  traffic.
+                type: string
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
                 items:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -353,6 +353,10 @@ spec:
             description: AgentClusterInstallStatus defines the observed state of the
               AgentClusterInstall.
             properties:
+              apiVIP:
+                description: APIVIP is the virtual IP used to reach the OpenShift
+                  cluster's API.
+                type: string
               conditions:
                 description: Conditions includes more detailed status for the cluster
                   install.
@@ -418,6 +422,10 @@ spec:
                       the AgentClusterInstall
                     type: string
                 type: object
+              ingressVIP:
+                description: IngressVIP is the virtual IP used for cluster ingress
+                  traffic.
+                type: string
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
                 items:

--- a/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
+++ b/deploy/olm-catalog/manifests/extensions.hive.openshift.io_agentclusterinstalls.yaml
@@ -353,6 +353,10 @@ spec:
             description: AgentClusterInstallStatus defines the observed state of the
               AgentClusterInstall.
             properties:
+              apiVIP:
+                description: APIVIP is the virtual IP used to reach the OpenShift
+                  cluster's API.
+                type: string
               conditions:
                 description: Conditions includes more detailed status for the cluster
                   install.
@@ -418,6 +422,10 @@ spec:
                       the AgentClusterInstall
                     type: string
                 type: object
+              ingressVIP:
+                description: IngressVIP is the virtual IP used for cluster ingress
+                  traffic.
+                type: string
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
                 items:

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1442,6 +1442,8 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 			} else {
 				clusterInstall.Status.Progress.TotalPercentage = c.Progress.TotalPercentage
 			}
+			clusterInstall.Status.APIVIP = c.APIVip
+			clusterInstall.Status.IngressVIP = c.IngressVip
 			status := *c.Status
 			var err error
 			err = r.populateEventsURL(log, clusterInstall, c)

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -2197,6 +2197,40 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Message).To(Equal(hiveext.ClusterReadyMsg))
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionTrue))
 		})
+
+		It("install cluster with API VIP and Ingress VIP", func() {
+			backEndCluster.Status = swag.String(models.ClusterStatusReady)
+			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
+			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
+			mockHostApi.EXPECT().IsInstallable(gomock.Any()).Return(true).Times(5)
+			mockInstallerInternal.EXPECT().GetCommonHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(&common.Host{Approved: true}, nil).Times(5)
+			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
+			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, backEndCluster.CPUArchitecture).Return(releaseImage, nil)
+
+			installClusterReply := &common.Cluster{
+				Cluster: models.Cluster{
+					ID:         backEndCluster.ID,
+					APIVip:     defaultAgentClusterInstallSpec.APIVIP,
+					IngressVip: defaultAgentClusterInstallSpec.IngressVIP,
+					Status:     swag.String(models.ClusterStatusPreparingForInstallation),
+					StatusInfo: swag.String("Waiting for control plane"),
+				},
+			}
+			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
+				Return(installClusterReply, nil)
+
+			request := newClusterDeploymentRequest(cluster)
+			result, err := cr.Reconcile(ctx, request)
+			Expect(err).To(BeNil())
+			Expect(result).To(Equal(ctrl.Result{}))
+
+			aci = getTestClusterInstall()
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Reason).To(Equal(hiveext.ClusterInstallationInProgressReason))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Message).To(Equal(hiveext.ClusterInstallationInProgressMsg + " Waiting for control plane"))
+			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterCompletedCondition).Status).To(Equal(corev1.ConditionFalse))
+			Expect(aci.Status.APIVIP).To(Equal(defaultAgentClusterInstallSpec.APIVIP))
+			Expect(aci.Status.IngressVIP).To(Equal(defaultAgentClusterInstallSpec.IngressVIP))
+		})
 	})
 
 	It("reconcile on installed sno cluster should not return an error or requeue", func() {

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -2828,6 +2828,18 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return aci.Status.DebugInfo.LogsURL
 		}, "30s", "10s").Should(Equal(""))
 
+		By("Ensure APIVIP exists in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.APIVIP
+		}, "30s", "1s").Should(Equal(aciSNOSpec.APIVIP))
+
+		By("Ensure IngressVIP exists in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.IngressVIP
+		}, "30s", "1s").Should(Equal(aciSNOSpec.IngressVIP))
+
 		By("Verify Agent labels")
 		labels[v1beta1.InfraEnvNameLabel] = infraNsName.Name
 		Eventually(func() bool {
@@ -3341,6 +3353,18 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.DebugInfo.LogsURL
 		}, "30s", "10s").ShouldNot(Equal(""))
+
+		By("Ensure APIVIP exists in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.APIVIP
+		}, "30s", "1s").Should(Equal(aciSpec.APIVIP))
+
+		By("Ensure IngressVIP exists in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.IngressVIP
+		}, "30s", "1s").Should(Equal(aciSpec.IngressVIP))
 
 		By("Complete Installation")
 		completeInstallation(agentBMClient, *cluster.ID)


### PR DESCRIPTION
Exposed APIVIP and IngressVIP in the status of AgentClusterInstall CRD.
The values are now copied from the cluster when updating ACI's status in ClusterDeploymentsReconciler.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @ori-amizur 
/cc @eranco74 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
