### PR TITLE
NO-ISSUE: ztp: set different disconnected release image

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -120,7 +120,13 @@ function ocp_mirror_release() {
   source_image="${2}"
   dest_mirror_repo="${3}"
 
+  mirror_logs_dir=$(mktemp -d -t mirror-XXXXXXXXXX)
   oc adm -a "${pull_secret_file}" release mirror \
          --from="${source_image}" \
-         --to="${dest_mirror_repo}"
+         --to="${dest_mirror_repo}" | tee "${mirror_logs_dir}/mirror.log"
+  echo "Extracting ICSP"
+  cat "${mirror_logs_dir}/mirror.log" | sed -n '/apiVersion/,$p' | tee "${mirror_logs_dir}/icsp.yaml"
+  echo "${mirror_logs_dir}/icsp.yaml"
+  echo "---"
+  oc apply -f "${mirror_logs_dir}/icsp.yaml"
 }


### PR DESCRIPTION
dev-scripts mirrors images to <local registry>/local-release-image:latest instead of preserving initial release image path.

This should fix permafailing [periodic-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-disconnected-periodic](https://testgrid.k8s.io/redhat-assisted-installer#periodic-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-disconnected-periodic).
* [dev-script mirroring log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-disconnected-periodic/1516950242136690688/artifacts/e2e-metal-assisted-operator-disconnected-periodic/baremetalds-devscripts-setup/artifacts/root/dev-scripts/logs/04_setup_ironic-2022-04-21-015907.log)
* [ClusterImageSet](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-disconnected-periodic/1516950242136690688/artifacts/e2e-metal-assisted-operator-disconnected-periodic/assisted-baremetal-operator-gather/artifacts/imageset/openshift-v4.10.yaml)
* [ClusterDeployment with InstallImagesNotResolved](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-e2e-metal-assisted-operator-disconnected-periodic/1516950242136690688/artifacts/e2e-metal-assisted-operator-disconnected-periodic/assisted-baremetal-operator-gather/artifacts/clusterdeployment/assisted-test-cluster.yaml)

## List all the issues related to this PR

- [x] Tests

## What environments does this code impact?

- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Waiting for CI to do a full test run

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @danielerez 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
