### PR TITLE
MGMT-10062: Remove default service version

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -23,7 +23,7 @@ type MustGatherVersion map[string]string
 type MustGatherVersions map[string]MustGatherVersion
 
 type Versions struct {
-	SelfVersion     string `envconfig:"SELF_VERSION" default:"quay.io/edge-infrastructure/assisted-service:latest"`
+	SelfVersion     string `envconfig:"SELF_VERSION" default:"Unknown"`
 	AgentDockerImg  string `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
 	InstallerImage  string `envconfig:"INSTALLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer:latest"`
 	ControllerImage string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-controller:latest"`

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -138,7 +138,7 @@ var _ = Describe("list versions", func() {
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
 			val, _ := reply.(*operations.V2ListComponentVersionsOK)
 			Expect(val.Payload.Versions["assisted-installer-service"]).
-				Should(Equal("quay.io/edge-infrastructure/assisted-service:latest"))
+				Should(Equal("Unknown"))
 			Expect(val.Payload.Versions["discovery-agent"]).Should(Equal("quay.io/edge-infrastructure/assisted-installer-agent:latest"))
 			Expect(val.Payload.Versions["assisted-installer"]).Should(Equal("quay.io/edge-infrastructure/assisted-installer:latest"))
 			Expect(val.Payload.ReleaseTag).Should(Equal(""))


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10062
Problem: When SERVICE_VERSION is unset, the service
provides a default value that's incorrect.

This PR removes the default value so that when
the SERVICE_VERSION is not set, it'll return
Unknown when queried.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment: deployed assisted service using this fix, removed `SERVICE_VERSION` from the configmap, and queried the endpoint `GET /v2/component-versions`. Result:
    ````
    {"versions":{"assisted-installer":"quay.io/edge-infrastructure/assisted-installer:latest","assisted-installer-controller":"quay.io/edge-infrastructure/assisted-installer-controller:latest","assisted-installer-service":"Unknown","discovery-agent":"quay.io/edge-infrastructure/assisted-installer-agent:latest"}}
    $ curl -s http://192.168.39.97:30780/api/assisted-install/v2/component-versions | jq '.versions."assisted-installer-service"'
    "Unknown"
    ````  
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @carbonin 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
