### PR TITLE
Bug 2077921: Operator deployment script doesn't wait after patching the Provisioning CR

### DIFF
--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -80,7 +80,9 @@ oc get secret "${ASSISTED_PRIVATEKEY_NAME}" -n "${SPOKE_NAMESPACE}" || \
     oc create secret generic "${ASSISTED_PRIVATEKEY_NAME}" --from-file=ssh-privatekey=/root/.ssh/id_rsa --type=kubernetes.io/ssh-auth -n "${SPOKE_NAMESPACE}"
 
 for manifest in $(find ${__dir}/generated -type f); do
-    tee < "${manifest}" >(oc apply -f -)
+    echo "Applying $manifest"
+    cat "${manifest}"
+    oc apply -f "${manifest}"
 done
 
 wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "ImageCreated" "5m" "${SPOKE_NAMESPACE}"


### PR DESCRIPTION
# Change 1:

Patching the Provisioning CR triggers a rollout of the metal3
deployment. Since the metal3 deployment has just 1 replica, during the
rollout the metal admission webhook is unavailable. As a result any
interaction during that time with BMH resources causes an error (as the
webhook is down).

This is why after patching the Provisioning CR we have to wait for that
process to complete. This includes waiting a few seconds for the
baremetal operator to notice our patch (there's no simple robust way to
do this. It usually happens almost immediately, but we wait 10 seconds
just in case). Then we wait for the deployment to finish rolling out,
and finally we wait for the metal3 pod to be ready.

# Change 2:

When applying the spoke cluster ZTP manifests generated by the ansible
playbook, we used this loop:

```bash
for manifest in $(find ${__dir}/generated -type f); do
    tee < "${manifest}" >(oc apply -f -)
done
```

The issue is that due to `>(oc apply -f -)` running in a subshell, `oc apply`
errors went unnoticed by the bash `errexit` / `pipefail` options and the
script quietly went on as if nothing happened. This made the issue
harder to notice and diagnose.

To fix this, the loop has been modified to use this more readable and
`errexit` / `pipefail` friendly form:

```bash
for manifest in $(find ${__dir}/generated -type f); do
    echo "Applying $manifest"
    cat "${manifest}"
    oc apply -f "${manifest}"
done
```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @osherdp

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md