### PR TITLE
MGMT-9379: Service changes to allow day 2 workers on single node

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -44,9 +44,8 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode"`
+	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// Host id
 	// Required: true
@@ -206,9 +205,8 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-
-	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
-		return err
+	if swag.IsZero(m.HighAvailabilityMode) { // not required
+		return nil
 	}
 
 	// value enum

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4278,13 +4278,17 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
 		}
-		if common.IsSingleNodeCluster(cluster) {
+
+		if common.IsDay2Cluster(cluster) {
+			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
+			host.Role = models.HostRoleWorker
+			host.MachineConfigPoolName = string(models.HostRoleWorker)
+		} else if common.IsSingleNodeCluster(cluster) {
+			// The question of whether the host's cluster is single node or not only matters for a Day 1 installation.
 			host.Role = models.HostRoleMaster
 			host.Bootstrap = true
 		}
-		if swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster {
-			host.Kind = swag.String(models.HostKindAddToExistingClusterHost)
-		}
+
 		host.ClusterID = cluster.ID
 		c = &cluster.Cluster
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -110,9 +110,12 @@ func GetBootstrapHost(cluster *Cluster) *models.Host {
 	return nil
 }
 
-// IsSingleNodeCluster if this cluster is single-node or not
 func IsSingleNodeCluster(cluster *Cluster) bool {
 	return swag.StringValue(cluster.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone
+}
+
+func IsDay2Cluster(cluster *Cluster) bool {
+	return swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster
 }
 
 func AreMastersSchedulable(cluster *Cluster) bool {

--- a/models/install_cmd_request.go
+++ b/models/install_cmd_request.go
@@ -44,9 +44,8 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode"`
+	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// Host id
 	// Required: true
@@ -206,9 +205,8 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-
-	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
-		return err
+	if swag.IsZero(m.HighAvailabilityMode) { // not required
+		return nil
 	}
 
 	// value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7623,8 +7623,7 @@ func init() {
         "role",
         "boot_device",
         "controller_image",
-        "installer_image",
-        "high_availability_mode"
+        "installer_image"
       ],
       "properties": {
         "boot_device": {
@@ -16721,8 +16720,7 @@ func init() {
         "role",
         "boot_device",
         "controller_image",
-        "installer_image",
-        "high_availability_mode"
+        "installer_image"
       ],
       "properties": {
         "boot_device": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5704,7 +5704,6 @@ definitions:
       - boot_device
       - controller_image
       - installer_image
-      - high_availability_mode
     properties:
       cluster_id:
         type: string

--- a/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -44,9 +44,8 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode"`
+	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// Host id
 	// Required: true
@@ -206,9 +205,8 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-
-	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
-		return err
+	if swag.IsZero(m.HighAvailabilityMode) { // not required
+		return nil
 	}
 
 	// value enum


### PR DESCRIPTION
1: When A day2 worker node is trying to join a single node cluster, the
   node was being incorrectly assigned the wrong role (master instead of
worker) this code fixes that problem.

2: Ensure that the High Availability Mode install command parameter is
   not mandatory.

It used to be the case that a day 2 worker could only be added to an HA
cluster. We are making this change to allow the addition of a day 2
worker to a non HA cluster.

The condition [1] was blocking this.

That validation ensures that Day 1 SNO clusters will only accept Master
or Bootsrap roles for the host being installed.

So an ideal solution was to pass an empty string for "HA mode" whenever
the role of the host is "Worker" as when adding a worker "High
Availability" mode is not relevant. (Especially when sometimes it is not
possible to know the true High Availability Mode of the cluster. For
example during a SaaS Day 2 installation.)

We have only changed the API to allow us to not pass the HA mode
parameter. Presently the assisted-service will still pass a non nil
value for High Availability Mode for workers. We need to bump the 
service dependency of the agent to use this new api change before the
service can omit the HA mode for workers.

[1] https://github.com/openshift/assisted-installer/blob/d67d2843d0e757ef5643e6c873b49e61ef83a0ea/src/config/config.go#L93-L99


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
