### PR TITLE
MGMT-10109: return status forbidden for manipulation ops

### DIFF
--- a/subsystem/wiremock_stubs.go
+++ b/subsystem/wiremock_stubs.go
@@ -64,6 +64,7 @@ const (
 	fakePayloadClusterEditor             string      = "alice@example.com"
 	FakePS                               string      = "dXNlcjpwYXNzd29yZAo="
 	FakePS2                              string      = "dXNlcjI6cGFzc3dvcmQK"
+	FakePS3                              string      = "dXNlcjM6cGFzc3dvcmQ="
 	FakeAdminPS                          string      = "dXNlcjpwYXNzd29yZAy="
 	WrongPullSecret                      string      = "wrong_secret"
 	FakeSubscriptionID                   strfmt.UUID = "1h89fvtqeelulpo0fl5oddngj2ao7tt8"
@@ -91,6 +92,10 @@ func (w *WireMock) CreateWiremockStubsForOCM() error {
 	}
 
 	if _, err := w.createStubTokenAuth(FakePS2, fakePayloadUsername2); err != nil {
+		return err
+	}
+
+	if _, err := w.createStubTokenAuth(FakePS3, fakePayloadClusterEditor); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
For scenarios in which a user can't manipulate an object (i.e. update/delete cluster/infraenv), but, is allowed to read the object - return StatusForbidden (403). If a user can't read nor write - return StatusNotFound (404).

This is required to avoid exposing any information for users who can't read the object.
While returning a specific error for users allowed to get the object.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
