### PR TITLE
MGMT-10163: return StatusNotFound on non-existent infra-env

### DIFF
--- a/pkg/auth/rhsso_authz_handler.go
+++ b/pkg/auth/rhsso_authz_handler.go
@@ -212,6 +212,10 @@ func (a *AuthzHandler) checkInfraEnvBasedAccess(id string, action Action, payloa
 	err = a.db.Select("cluster_id").First(&infraEnv, "id = ?", id).Error
 	if err != nil {
 		a.log.WithError(err).Errorf("failed to retrieve infra-env record %s", id)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// not returning err as the response should be StatusNotFound
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
@@ -176,6 +177,13 @@ var _ = Describe("test authorization", func() {
 				ClusterUpdateParams: &models.V2ClusterUpdateParams{Name: swag.String("update-test")}})
 			Expect(err).Should(HaveOccurred())
 			Expect(err).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterForbidden()))
+		})
+
+		It("can't get non-existent infra-env", func() {
+			infraEnvID := strfmt.UUID(uuid.New().String())
+			_, err := userBMClient.Installer.GetInfraEnv(ctx, &installer.GetInfraEnvParams{InfraEnvID: infraEnvID})
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(installer.NewGetInfraEnvNotFound()))
 		})
 	})
 


### PR DESCRIPTION
Ensuring StatusNotFound (404) is returned when fetching a non-existent infra-env.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
