### PR TITLE
MGMT-10160: remove cache for subscription access review

### DIFF
--- a/pkg/auth/rhsso_authz_handler.go
+++ b/pkg/auth/rhsso_authz_handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -133,22 +132,7 @@ func (a *AuthzHandler) hasSubscriptionAccess(clusterId string, action string, pa
 		if err != nil {
 			return handleOwnershipQueryError(err)
 		}
-
-		cacheKey := fmt.Sprintf("%s_%s_%s_%s", payload.Username, payload.Organization, cluster.AmsSubscriptionID, action)
-		if cacheData, existInCache := a.client.Cache.Get(cacheKey); existInCache {
-			var ok bool
-			isAllowed, ok = cacheData.(bool)
-			if !ok {
-				return false, fmt.Errorf(
-					"error while retrieving cluster edit role from cache for %s",
-					cluster.AmsSubscriptionID.String())
-			}
-			return isAllowed, nil
-		}
 		isAllowed, err = a.hasClusterEditRole(payload, action, cluster.AmsSubscriptionID.String())
-		if shouldStorePayloadInCache(err) {
-			a.client.Cache.Set(cacheKey, isAllowed, 10*time.Minute)
-		}
 		return isAllowed, err
 	}
 

--- a/pkg/auth/rhsso_authz_handler_test.go
+++ b/pkg/auth/rhsso_authz_handler_test.go
@@ -377,12 +377,11 @@ var _ = Describe("HasAccessTo", func() {
 
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), "user2", gomock.Any(), subscription.String(), gomock.Any()).
-				Return(true, nil).Times(1)
+				Return(true, nil).Times(2)
 			cluster, _ := common.GetClusterFromDB(db, id1, common.SkipEagerLoading)
 			Expect(authzHandler.HasAccessTo(ctx, cluster, ReadAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, cluster, UpdateAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, cluster, DeleteAction)).To(BeTrue())
-			Expect(authzHandler.client.Cache.ItemCount()).To(Equal(1)) //delete is mapped to update
 		})
 
 		It("others can read but not write", func() {
@@ -391,7 +390,7 @@ var _ = Describe("HasAccessTo", func() {
 
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), "user2", gomock.Any(), subscription.String(), gomock.Any()).
-				Return(false, nil).Times(1)
+				Return(false, nil).Times(2)
 			cluster, _ := common.GetClusterFromDB(db, id1, common.SkipEagerLoading)
 			Expect(authzHandler.HasAccessTo(ctx, cluster, ReadAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, cluster, UpdateAction)).To(BeFalse())
@@ -419,7 +418,7 @@ var _ = Describe("HasAccessTo", func() {
 
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(false, nil).Times(2) //delete action is funneled to an update check
+				Return(false, nil).Times(4) //delete action is funneled to an update check
 
 			cluster, _ := common.GetClusterFromDB(db, id1, common.SkipEagerLoading)
 			Expect(authzHandler.HasAccessTo(ctx, cluster, ReadAction)).To(BeTrue())
@@ -452,19 +451,17 @@ var _ = Describe("HasAccessTo", func() {
 
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), "user2", gomock.Any(), subscription.String(), gomock.Any()).
-				Return(true, nil).Times(1)
+				Return(true, nil).Times(2)
 			infraEnv, _ := common.GetInfraEnvFromDB(db, id1)
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, ReadAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, UpdateAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, DeleteAction)).To(BeTrue())
-			Expect(authzHandler.client.Cache.ItemCount()).To(Equal(1)) //delete is mapped to update
 
 			By("unbound infra-env rules according to infra-env")
 			infraEnv, _ = common.GetInfraEnvFromDB(db, id2)
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, ReadAction)).To(BeTrue()) //user2 has access rights because of the org
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, UpdateAction)).To(BeFalse())
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, DeleteAction)).To(BeFalse())
-			Expect(authzHandler.client.Cache.ItemCount()).To(Equal(1)) //nothing was added to the cache
 		})
 
 		It("others can read but not write", func() {
@@ -473,12 +470,11 @@ var _ = Describe("HasAccessTo", func() {
 
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), "user2", gomock.Any(), subscription.String(), gomock.Any()).
-				Return(false, nil).Times(1)
+				Return(false, nil).Times(2)
 			infraEnv, _ := common.GetInfraEnvFromDB(db, id1)
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, ReadAction)).To(BeTrue()) //org based access
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, UpdateAction)).To(BeFalse())
 			Expect(authzHandler.HasAccessTo(ctx, infraEnv, DeleteAction)).To(BeFalse()) //delete is mapped to update
-			Expect(authzHandler.client.Cache.ItemCount()).To(Equal(1))
 		})
 	})
 
@@ -505,7 +501,7 @@ var _ = Describe("HasAccessTo", func() {
 			host, _ := common.GetHostFromDBbyHostId(db, id2)
 			mockOcmAuthorization.EXPECT().AccessReview(
 				gomock.Any(), "user2", gomock.Any(), "other", gomock.Any()).
-				Return(true, nil).Times(1) //delete is mapped to update
+				Return(true, nil).Times(2) //delete is mapped to update
 			Expect(authzHandler.HasAccessTo(ctx, host, ReadAction)).To(BeFalse())
 			Expect(authzHandler.HasAccessTo(ctx, host, UpdateAction)).To(BeTrue())
 			Expect(authzHandler.HasAccessTo(ctx, host, DeleteAction)).To(BeTrue())


### PR DESCRIPTION
Removed the caching of the response for ocm.Subscription AccessReview.
This should prevent redundant wait when granting/removing ClusterEditor role.
We should investigate later if/how cache impl can be done.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered  
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
