### PR TITLE
NO-ISSUE: Don't use deprecated APIs

### DIFF
--- a/tools/debug/s3-list-cron.yaml
+++ b/tools/debug/s3-list-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: s3-list


### PR DESCRIPTION
# Assisted Pull Request

## Description

The cc76ac838ed02b476c07f78cc464290774d25907 commit added this example
CronJob manifest:

>CronJob to periodically list objects in S3
>
>Useful for debugging the s3 object expiration, the job runs every 15
>minutes and you can see the list of objects in the pod's log.

It uses a deprecated kubernetes API that is going to be removed in
upcoming Kubernetes versions.

In case someone is still using this job somewhere, this commit updates
the manifest to use the newer API.

## List all the issues related to this PR

- [ ] New Feature
- [x] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md