### PR TITLE
MGMT-8738: Media disconnection status doesn't updated

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2675,13 +2675,6 @@ func (b *bareMetalInventory) handleReplyError(params installer.V2PostStepReplyPa
 
 func (b *bareMetalInventory) handleMediaDisconnection(params installer.V2PostStepReplyParams, ctx context.Context, log logrus.FieldLogger, h *models.Host) error {
 	status := models.HostStatusError
-
-	if hostutil.IsBeforeInstallation(*h.Status) {
-		status = models.HostStatusDisconnected
-	} else if hostutil.IsUnboundHost(h) {
-		status = models.HostStatusDisconnectedUnbound
-	}
-
 	statusInfo := fmt.Sprintf("%s - %s", string(models.HostStageFailed), mediaDisconnectionMessage)
 
 	// Install command reports its status with a different API, directly from the assisted-installer.
@@ -2697,7 +2690,7 @@ func (b *bareMetalInventory) handleMediaDisconnection(params installer.V2PostSte
 		statusInfo = fmt.Sprintf("%s. %s", statusInfo, params.Reply.Error)
 	}
 
-	_, err := hostutil.UpdateHostStatus(ctx, log, b.db, b.eventsHandler, *h.ClusterID, *h.ID,
+	_, err := hostutil.UpdateHostStatus(ctx, log, b.db, b.eventsHandler, h.InfraEnvID, *h.ID,
 		swag.StringValue(h.Status), status, statusInfo)
 
 	return err

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -963,7 +963,7 @@ var _ = Describe("PostStepReply", func() {
 
 			Expect(bm.V2PostStepReply(ctx, params)).Should(BeAssignableToTypeOf(installer.NewV2PostStepReplyNoContent()))
 			Expect(db.Take(host, "cluster_id = ? and id = ?", clusterId.String(), hostId.String()).Error).ToNot(HaveOccurred())
-			Expect(*host.Status).To(BeEquivalentTo(models.HostStatusDisconnected))
+			Expect(*host.Status).To(BeEquivalentTo(models.HostStatusError))
 			Expect(*host.StatusInfo).To(BeEquivalentTo(errorMessage))
 		})
 
@@ -1509,7 +1509,7 @@ var _ = Describe("v2PostStepReply", func() {
 
 			Expect(bm.V2PostStepReply(ctx, params)).Should(BeAssignableToTypeOf(installer.NewV2PostStepReplyNoContent()))
 			Expect(db.Take(host, "cluster_id = ? and id = ?", clusterId.String(), hostId.String()).Error).ToNot(HaveOccurred())
-			Expect(*host.Status).To(BeEquivalentTo(models.HostStatusDisconnected))
+			Expect(*host.Status).To(BeEquivalentTo(models.HostStatusError))
 			Expect(*host.StatusInfo).To(BeEquivalentTo(errorMessage))
 		})
 


### PR DESCRIPTION
1. Calling hostutil.UpdateHostStatus with InfraEnvID rather than ClusterId.
   InfraEnvID is expected by UpdateHostStatus, but this reference wasn't updated.
2. Reverting https://github.com/openshift/assisted-service/pull/3225/. Setting the status of the host to Error instead of Disconnected.
Currently, after setting the status to Disconnected, the stateMachine reverts the status to the original cluster status.


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
