### PR TITLE
NO-ISSUE - Add the ability to override image-service image when deploying the assisted-image-service

### DIFF
--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -27,7 +27,7 @@ items:
               requests:
                 cpu: 100m
                 memory: 400Mi
-            image: quay.io/edge-infrastructure/assisted-image-service:latest
+            image: REPLACE_IMAGE_SERVICE_IMAGE
             ports:
               - containerPort: 8080
             readinessProbe:

--- a/tools/deploy_image_service.py
+++ b/tools/deploy_image_service.py
@@ -1,8 +1,10 @@
-import os
-import utils
 import argparse
+import os
+
 import yaml
+
 import deployment_options
+import utils
 
 parser = argparse.ArgumentParser()
 deploy_options = deployment_options.load_deployment_options(parser)
@@ -11,13 +13,17 @@ log = utils.get_logger('deploy-image-service')
 SRC_FILE = os.path.join(os.getcwd(), 'deploy/assisted-image-service.yaml')
 DST_FILE = os.path.join(os.getcwd(), 'build', deploy_options.namespace, 'assisted-image-service.yaml')
 
+
 def main():
     utils.verify_build_directory(deploy_options.namespace)
 
     with open(SRC_FILE, "r") as src:
+        log.info(f"Loading source template file for assisted-image-service: {SRC_FILE}")
         raw_data = src.read()
         raw_data = raw_data.replace('REPLACE_NAMESPACE', f'"{deploy_options.namespace}"')
+        raw_data = raw_data.replace('REPLACE_IMAGE_SERVICE_IMAGE', os.environ.get("IMAGE_SERVICE"))
         data = yaml.safe_load(raw_data)
+        log.info(data)
 
     with open(DST_FILE, "w+") as dst:
         yaml.dump(data, dst, default_flow_style=False)
@@ -31,6 +37,7 @@ def main():
         namespace=deploy_options.namespace,
         file=DST_FILE
     )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Currently deploy-image-service image is defined statically at assisted-image-service.yam.
This PR add the option to override it using REPLACE_IMAGE_SERVICE_IMAGE key.
The IMAGE_SERVICE env var default is defined on the Makefile

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @osherdp 

