### PR TITLE
MGMT-9574: Improve error message when updating static IP

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -120,9 +120,8 @@ func (s *StaticNetworkConfigGenerator) executeNMStatectl(ctx context.Context, ho
 	}
 	stdout, stderr, retCode := executer.ExecuteWithContext(ctx, "nmstatectl", "gc", f.Name())
 	if retCode != 0 {
-		msg := fmt.Sprintf("<nmstatectl gc> failed, errorCode %d, stderr %s, input yaml <%s>", retCode, stderr, hostYAML)
-		s.log.Errorf("%s", msg)
-		return "", fmt.Errorf("%s", msg)
+		s.log.Errorf("<nmstatectl gc> failed, errorCode %d, stderr %s, input yaml <%s>", retCode, stderr, hostYAML)
+		return "", fmt.Errorf("failed to execute nmstatectl gc, check the value provided for 'network_yaml': %s", hostYAML)
 	}
 	return stdout, nil
 }

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -204,4 +204,18 @@ var _ = Describe("Infra_Env", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(script).To(HavePrefix("#!ipxe"))
 	})
+	It("fails when given invalid static network config", func() {
+		staticNetworkConfig := models.HostStaticNetworkConfig{
+			NetworkYaml: "aaaaa",
+		}
+		staticNetworkConfigs := []*models.HostStaticNetworkConfig{&staticNetworkConfig}
+		updateParams := &installer.UpdateInfraEnvParams{
+			InfraEnvID: infraEnvID,
+			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+				StaticNetworkConfig: staticNetworkConfigs,
+			},
+		}
+		_, err := userBMClient.Installer.UpdateInfraEnv(ctx, updateParams)
+		Expect(err).To(HaveOccurred())
+	})
 })


### PR DESCRIPTION
[MGMT-9574](https://issues.redhat.com/browse/MGMT-9574)
Previously when a user updates an infra env with an invalid
network yaml, the error message included a traceback given
from the stderr which is confusing and unclear.

This changes the message returned so that it's clear what
went wrong.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

1. Deploy assisted-service with changes
2. Run `make deploy_nodes` to deploy a cluster
3. Curl the infra-envs patch API
    ````bash
    curl -XPATCH  --header "Content-Type: application/json" $SERVICE_URL/api/assisted-install/v2/infra-envs/$INFRA_ENV_ID -d '{"static_network_config":[{"network_yaml":"aaaa","mac_interface_map":[{"mac_address":"52:54:00:ee:42:e1","logical_nic_name":"eth0"}]}]}'
    ````
5. Check the error message returned
## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)
    - I added a subsystem test

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
