### PR TITLE
MGMT-9180 - Fix bad SNO OVN/SDN doc example CR

### DIFF
--- a/docs/user-guide/network-configuration.md
+++ b/docs/user-guide/network-configuration.md
@@ -84,7 +84,7 @@ Sample CR for deploying a SNO cluster using Assisted Service. In this scenario o
 
 ```yaml
   networking:
-    networkType: OpenShiftSDN
+    networkType: OVNKubernetes
     clusterNetwork:
     - cidr: 10.128.0.0/14
       hostPrefix: 23


### PR DESCRIPTION
The documentation clearly states that on SNO only OVNKubernetes is
allowed yet uses OpenShiftSDN in one of the example CRs for SNO

This commit fixes that documentation mistake

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @romfreiman
/cc @empovit

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md