### PR TITLE
Bug 2083075: Allow cluster name to start with number

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -214,6 +214,10 @@ var _ = Describe("Cluster name validation", func() {
 		err := ValidateClusterNameFormat("test-1")
 		Expect(err).ShouldNot(HaveOccurred())
 	})
+	It("success - name starts with number", func() {
+		err := ValidateClusterNameFormat("1-test")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
 	It("invalid format - special character", func() {
 		err := ValidateClusterNameFormat("test!")
 		Expect(err).Should(HaveOccurred())
@@ -222,12 +226,16 @@ var _ = Describe("Cluster name validation", func() {
 		err := ValidateClusterNameFormat("testA")
 		Expect(err).Should(HaveOccurred())
 	})
-	It("invalid format - starts with number", func() {
-		err := ValidateClusterNameFormat("1test")
+	It("invalid format - starts with capital letter", func() {
+		err := ValidateClusterNameFormat("Test")
 		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - ends with hyphen", func() {
 		err := ValidateClusterNameFormat("test-")
+		Expect(err).Should(HaveOccurred())
+	})
+	It("invalid format - starts with hyphen", func() {
+		err := ValidateClusterNameFormat("-test")
 		Expect(err).Should(HaveOccurred())
 	})
 })

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -28,7 +28,7 @@ type Config struct {
 }
 
 const (
-	clusterNameRegex    = "^([a-z]([-a-z0-9]*[a-z0-9])?)*$"
+	clusterNameRegex    = "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	CloudOpenShiftCom   = "cloud.openshift.com"
 	sshPublicKeyRegex   = "^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$"
 	dockerHubRegistry   = "docker.io"
@@ -204,7 +204,7 @@ func ValidateClusterNameFormat(name string) error {
 	if matched, _ := regexp.MatchString(clusterNameRegex, name); !matched {
 		return errors.Errorf("Cluster name format is not valid: '%s'. "+
 			"Name must consist of lower-case letters, numbers and hyphens. "+
-			"It must start with a letter and end with a letter or number.", name)
+			"It must start and end with either a letter or number.", name)
 	}
 	return nil
 }


### PR DESCRIPTION
[Bug 2083075](https://bugzilla.redhat.com/show_bug.cgi?id=2083075)
Previously, assisted installer only allowed cluster names
to start with a lowercase letter. OCP allows clusters that
start with a number.

This change allows the cluster name to start with either
a lowercase letter or a number.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): deployed assisted-service with change and curled the create cluster API with the cluster name '12-test'
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
