### PR TITLE
MGMT-10263: Do not call refresh status from bm-inventory if called from Kube API

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (b *bareMetalInventory) V2UpdateHost(ctx context.Context, params installer.V2UpdateHostParams) middleware.Responder {
-	host, err := b.V2UpdateHostInternal(ctx, params)
+	host, err := b.V2UpdateHostInternal(ctx, params, Interactive)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -519,16 +519,16 @@ func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostInstallerArgsInternal(
 }
 
 // V2UpdateHostInternal mocks base method.
-func (m *MockInstallerInternals) V2UpdateHostInternal(arg0 context.Context, arg1 installer.V2UpdateHostParams) (*common.Host, error) {
+func (m *MockInstallerInternals) V2UpdateHostInternal(arg0 context.Context, arg1 installer.V2UpdateHostParams, arg2 Interactivity) (*common.Host, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2UpdateHostInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "V2UpdateHostInternal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*common.Host)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // V2UpdateHostInternal indicates an expected call of V2UpdateHostInternal.
-func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostInternal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2UpdateHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2UpdateHostInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2UpdateHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2UpdateHostInternal), arg0, arg1, arg2)
 }

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -1169,7 +1169,7 @@ func (r *AgentReconciler) updateIfNeeded(ctx context.Context, log logrus.FieldLo
 			models.HostStatusBinding,
 		}
 		if funk.ContainsString(hostStatusesBeforeInstallationOrUnbound, swag.StringValue(internalHost.Status)) {
-			returnedHost, err = r.Installer.V2UpdateHostInternal(ctx, *params)
+			returnedHost, err = r.Installer.V2UpdateHostInternal(ctx, *params, bminventory.NonInteractive)
 
 			if err != nil {
 				log.WithError(err).Errorf("Failed to update host params %s %s", agent.Name, agent.Namespace)

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -326,8 +326,8 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(beforeUpdateHost, nil).Times(1)
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(afterUpdateHost, nil).Times(1)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
-		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any()).
-			Do(func(ctx context.Context, param installer.V2UpdateHostParams) {
+		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).
+			Do(func(ctx context.Context, param installer.V2UpdateHostParams, interactive bminventory.Interactivity) {
 				Expect(param.HostUpdateParams.DisksSelectedConfig[0].ID).To(Equal(&newInstallDiskPath))
 				Expect(param.HostUpdateParams.DisksSelectedConfig[0].Role).To(Equal(models.DiskRoleInstall))
 				Expect(swag.StringValue(param.HostUpdateParams.HostName)).To(Equal(newHostName))
@@ -411,7 +411,7 @@ var _ = Describe("agent reconcile", func() {
 
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
-		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any()).Return(commonHost, nil).Times(1)
+		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).Return(commonHost, nil).Times(1)
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())
@@ -449,7 +449,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
-		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).Return(nil, nil).Times(0)
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())
@@ -490,7 +490,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
-		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(0)
+		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).Return(nil, nil).Times(0)
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
 		Expect(err).To(BeNil())
@@ -533,7 +533,7 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
 		errString := "update internal error"
-		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any()).Return(nil, common.NewApiError(http.StatusInternalServerError,
+		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).Return(nil, common.NewApiError(http.StatusInternalServerError,
 			errors.New(errString)))
 		Expect(c.Create(ctx, host)).To(BeNil())
 		result, err := hr.Reconcile(ctx, newHostRequest(host))

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -239,3 +239,35 @@ func GetIPv4Networks(inventory *models.Inventory) (ret []string, err error) {
 func GetIPv6Networks(inventory *models.Inventory) (ret []string, err error) {
 	return getHostNetworks(inventory, func(i *models.Interface) []string { return i.IPV6Addresses })
 }
+
+func areListsEquivalent(len1, len2 int, areItemsEquivalent func(int, int) bool) bool {
+	if len1 != len2 {
+		return false
+	}
+	containsEquivalentItem := func(index, length int) bool {
+		for i := 0; i != length; i++ {
+			if areItemsEquivalent(index, i) {
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i != len1; i++ {
+		if !containsEquivalentItem(i, len1) {
+			return false
+		}
+	}
+	return true
+}
+
+func AreMachineNetworksIdentical(n1, n2 []*models.MachineNetwork) bool {
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].Cidr == n2[j].Cidr })
+}
+
+func AreServiceNetworksIdentical(n1, n2 []*models.ServiceNetwork) bool {
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].Cidr == n2[j].Cidr })
+}
+
+func AreClusterNetworksIdentical(n1, n2 []*models.ClusterNetwork) bool {
+	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].Cidr == n2[j].Cidr && n1[i].HostPrefix == n2[j].HostPrefix })
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -350,3 +350,320 @@ var _ = Describe("cluster IP address families", func() {
 		Expect(v6).To(BeTrue())
 	})
 })
+
+var _ = Describe("AreMachineNetworksIdentical", func() {
+	tests := []struct {
+		name           string
+		n1, n2         []*models.MachineNetwork
+		expectedResult bool
+	}{
+		{
+			name:           "Both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "One nil, one empty",
+			n1:             []*models.MachineNetwork{},
+			expectedResult: true,
+		},
+		{
+			name:           "Both empty",
+			n1:             []*models.MachineNetwork{},
+			n2:             []*models.MachineNetwork{},
+			expectedResult: true,
+		},
+		{
+			name: "Identical, ignore cluster id",
+			n1: []*models.MachineNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.MachineNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "1.2.3.0/24",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Different length",
+			n1: []*models.MachineNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.MachineNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "1.2.3.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Different contents",
+			n1: []*models.MachineNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.MachineNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+	}
+	for i := range tests {
+		t := tests[i]
+		It(t.name, func() {
+			Expect(AreMachineNetworksIdentical(t.n1, t.n2)).To(Equal(t.expectedResult))
+		})
+	}
+})
+
+var _ = Describe("ArServiceNetworksIdentical", func() {
+	tests := []struct {
+		name           string
+		n1, n2         []*models.ServiceNetwork
+		expectedResult bool
+	}{
+		{
+			name:           "Both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "One nil, one empty",
+			n1:             []*models.ServiceNetwork{},
+			expectedResult: true,
+		},
+		{
+			name:           "Both empty",
+			n1:             []*models.ServiceNetwork{},
+			n2:             []*models.ServiceNetwork{},
+			expectedResult: true,
+		},
+		{
+			name: "Identical, ignore cluster id",
+			n1: []*models.ServiceNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.ServiceNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "1.2.3.0/24",
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Different length",
+			n1: []*models.ServiceNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.ServiceNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "1.2.3.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Different contents",
+			n1: []*models.ServiceNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.ServiceNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+	}
+	for i := range tests {
+		t := tests[i]
+		It(t.name, func() {
+			Expect(AreServiceNetworksIdentical(t.n1, t.n2)).To(Equal(t.expectedResult))
+		})
+	}
+})
+
+var _ = Describe("ArClusterNetworksIdentical", func() {
+	tests := []struct {
+		name           string
+		n1, n2         []*models.ClusterNetwork
+		expectedResult bool
+	}{
+		{
+			name:           "Both nil",
+			expectedResult: true,
+		},
+		{
+			name:           "One nil, one empty",
+			n1:             []*models.ClusterNetwork{},
+			expectedResult: true,
+		},
+		{
+			name:           "Both empty",
+			n1:             []*models.ClusterNetwork{},
+			n2:             []*models.ClusterNetwork{},
+			expectedResult: true,
+		},
+		{
+			name: "Identical, ignore cluster id",
+			n1: []*models.ClusterNetwork{
+				{
+					Cidr:       "1.2.3.0/24",
+					HostPrefix: 4,
+					ClusterID:  "id",
+				},
+				{
+					Cidr:       "5.6.7.0/24",
+					HostPrefix: 4,
+				},
+			},
+			n2: []*models.ClusterNetwork{
+				{
+					Cidr:       "5.6.7.0/24",
+					HostPrefix: 4,
+				},
+				{
+					Cidr:       "1.2.3.0/24",
+					HostPrefix: 4,
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Different host prefix",
+			n1: []*models.ClusterNetwork{
+				{
+					Cidr:       "1.2.3.0/24",
+					HostPrefix: 4,
+					ClusterID:  "id",
+				},
+				{
+					Cidr:       "5.6.7.0/24",
+					HostPrefix: 4,
+				},
+			},
+			n2: []*models.ClusterNetwork{
+				{
+					Cidr:       "5.6.7.0/24",
+					HostPrefix: 4,
+				},
+				{
+					Cidr:       "1.2.3.0/24",
+					HostPrefix: 5,
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Different length",
+			n1: []*models.ClusterNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.ClusterNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "1.2.3.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Different contents",
+			n1: []*models.ClusterNetwork{
+				{
+					Cidr:      "1.2.3.0/24",
+					ClusterID: "id",
+				},
+				{
+					Cidr: "5.6.7.0/24",
+				},
+			},
+			n2: []*models.ClusterNetwork{
+				{
+					Cidr: "5.6.7.0/24",
+				},
+				{
+					Cidr: "2.2.3.0/24",
+				},
+			},
+			expectedResult: false,
+		},
+	}
+	for i := range tests {
+		t := tests[i]
+		It(t.name, func() {
+			Expect(AreClusterNetworksIdentical(t.n1, t.n2)).To(Equal(t.expectedResult))
+		})
+	}
+})


### PR DESCRIPTION

Calling refresh-status not from monitor produces excessive load.  To
avoid this load, refresh status was removed in bm-inventory if
called from Kube API.
The refresh was kept for REST API since UI expects immediate affect to
update operation.
In addition, the refresh status was removed from install if no role was
updated as part of auto-assign operation.
This change also verifies that refresh will be triggered if any of the
networks were actually changed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
