### PR TITLE
MGMT-10264: In GetClusterInternal, do not bring hosts also from db unless requested explicitly

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2406,35 +2406,7 @@ var _ = Describe("cluster", func() {
 				Expect(actual.Payload.APIVip).To(BeEquivalentTo("10.11.12.13"))
 				Expect(actual.Payload.IngressVip).To(BeEquivalentTo("10.11.12.14"))
 				validateNetworkConfiguration(actual.Payload, nil, nil, &[]*models.MachineNetwork{{Cidr: "10.11.0.0/16"}})
-				expectedNetworks := sortedNetworks([]*models.HostNetwork{
-					{
-						Cidr: "1.2.3.0/24",
-						HostIds: sortedHosts([]strfmt.UUID{
-							masterHostId1,
-							masterHostId2,
-							masterHostId3,
-						}),
-					},
-					{
-						Cidr: "10.11.0.0/16",
-						HostIds: sortedHosts([]strfmt.UUID{
-							masterHostId1,
-							masterHostId2,
-						}),
-					},
-					{
-						Cidr: "7.8.9.0/24",
-						HostIds: []strfmt.UUID{
-							masterHostId3,
-						},
-					},
-				})
-				actualNetworks := sortedNetworks(actual.Payload.HostNetworks)
-				Expect(len(actualNetworks)).To(Equal(3))
-				actualNetworks[0].HostIds = sortedHosts(actualNetworks[0].HostIds)
-				actualNetworks[1].HostIds = sortedHosts(actualNetworks[1].HostIds)
-				actualNetworks[2].HostIds = sortedHosts(actualNetworks[2].HostIds)
-				Expect(actualNetworks).To(Equal(expectedNetworks))
+				Expect(actual.Payload.HostNetworks).To(BeEmpty())
 			})
 
 			It("Unfamilliar ID", func() {

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -253,11 +253,11 @@ func (v *validator) GetPreflightInfraEnvHardwareRequirements(ctx context.Context
 }
 
 func (v *validator) GetInstallationDiskSpeedThresholdMs(ctx context.Context, cluster *common.Cluster, host *models.Host) (int64, error) {
-	requirements, err := v.GetClusterHostRequirements(ctx, cluster, host)
+	ocpRequirements, err := v.getOCPClusterHostRoleRequirementsForVersion(cluster, common.GetEffectiveRole(host))
 	if err != nil {
 		return 0, err
 	}
-	return requirements.Total.InstallationDiskSpeedThresholdMs, nil
+	return ocpRequirements.InstallationDiskSpeedThresholdMs, nil
 }
 
 func totalizeRequirements(ocpRequirements models.ClusterHostRequirementsDetails, operatorRequirements []*models.OperatorHostRequirements) models.ClusterHostRequirementsDetails {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -310,7 +310,7 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	}
 
 	if h.ClusterID != nil && h.ClusterID.String() != "" {
-		cluster, err = common.GetClusterFromDB(m.db, *h.ClusterID, common.UseEagerLoading)
+		cluster, err = common.GetClusterFromDB(m.db, *h.ClusterID, common.SkipEagerLoading)
 		if err != nil {
 			log.WithError(err).Errorf("not updating inventory - failed to find cluster %s", h.ClusterID.String())
 			return common.NewApiError(http.StatusNotFound, err)

--- a/internal/host/hostcommands/dhcp_allocate_cmd.go
+++ b/internal/host/hostcommands/dhcp_allocate_cmd.go
@@ -55,10 +55,12 @@ func (f *dhcpAllocateCmd) prepareParam(host *models.Host, cluster *common.Cluste
 }
 
 func (f *dhcpAllocateCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
-	cluster, err := common.GetClusterFromDB(f.db, *host.ClusterID, common.UseEagerLoading)
-	if err != nil {
+	cluster := &common.Cluster{}
+	if err := f.db.Preload(common.MachineNetworksTable).Select("id", "vip_dhcp_allocation", "api_vip_lease", "ingress_vip_lease").
+		Take(cluster, "id = ?", host.ClusterID.String()).Error; err != nil {
 		return nil, err
 	}
+
 	/*
 	 * Since this function may be invoked in case that DHCP allocate command should not be sent to the host
 	 * filtering is done here to remove all valid (not errored) cases that the command should not be invoked.

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -51,7 +51,8 @@ func (i *installCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models
 	step := &models.Step{}
 	step.StepType = models.StepTypeInstall
 
-	cluster, err := common.GetClusterFromDBWithHosts(i.db, *host.ClusterID)
+	db := i.db.Preload(common.HostsTable, "bootstrap = TRUE")
+	cluster, err := common.GetClusterFromDB(common.LoadClusterTablesFromDB(db, common.HostsTable), *host.ClusterID, common.SkipEagerLoading)
 	if err != nil {
 		i.log.Errorf("failed to get cluster %s", host.ClusterID)
 		return nil, err

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -89,7 +89,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 			models.HostStatusDiscovering:              {[]CommandGetter{inventoryCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusPendingForInput:          {[]CommandGetter{inventoryCmd, connectivityCmd, freeAddressesCmd, dhcpAllocateCmd, ntpSynchronizerCmd, domainNameResolutionCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusInstalling:               {[]CommandGetter{installCmd, dhcpAllocateCmd}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
-			models.HostStatusInstallingInProgress:     {[]CommandGetter{inventoryCmd, dhcpAllocateCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue}, //TODO inventory step here is a temporary solution until format command is moved to a different state
+			models.HostStatusInstallingInProgress:     {[]CommandGetter{dhcpAllocateCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue}, //TODO inventory step here is a temporary solution until format command is moved to a different state
 			models.HostStatusPreparingForInstallation: {[]CommandGetter{dhcpAllocateCmd, diskPerfCheckCmd, imageAvailabilityCmd}, defaultNextInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusDisabled:                 {[]CommandGetter{}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},
 			models.HostStatusResetting:                {[]CommandGetter{}, defaultBackedOffInstructionInSec, models.StepsPostStepActionContinue},

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -237,7 +237,7 @@ var _ = Describe("instruction_manager", func() {
 			})
 			It("installing-in-progress", func() {
 				checkStep(models.HostStatusInstallingInProgress, []models.StepType{
-					models.StepTypeInventory, models.StepTypeDhcpLeaseAllocate,
+					models.StepTypeDhcpLeaseAllocate,
 				})
 			})
 			It("reset", func() {


### PR DESCRIPTION
When cluster starts installation, all the workers poll the service to
find if there are already 2 masters that joined the control plane in
before they reboot. For this they query first the cluster.
Even if the hosts are not returned from the service, parallel invocation
of this query may cause out of memory contention, since the result from
the database consumes a lot of space.

[MGMT-10265](https://issues.redhat.com//browse/MGMT-10265): Skip eager loading when getting installation disk speed threshold
Eager loading is not needed to find out the installation disk speed
threshold since the data is part of the cluster.

[MGMT-10268](https://issues.redhat.com//browse/MGMT-10268): When getting cluster for update inventory, skip eager loading
Eager loading is not needed when updating the inventory.

[MGMT-10272](https://issues.redhat.com//browse/MGMT-10272): With dhcp step creation load machine networks, and skip the rest of the tables
In addition, bring only fields (id, vip_dhcp_allocation, api_vip_lease, ingress_vip_lease)
since the others are not needed.

[MGMT-10273](https://issues.redhat.com//browse/MGMT-10273): For install command, from host table get only the bootstrap host
Only the bootstrap host is needed to get the primary machine network.
The rest of the hosts are not needed.

[MGMT-10274](https://issues.redhat.com//browse/MGMT-10274): Do not ask to run inventory step after starting the installation

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
