### PR TITLE
Revert "MGMT-9379: Do not pass "HA mode" parameter for worker nodes."

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -114,11 +114,6 @@ func (i *installCmd) getFullInstallerCommand(cluster *common.Cluster, host *mode
 		BootDevice:           swag.String(bootdevice),
 	}
 
-	// The HA mode is not relevant for workers.
-	if string(role) == models.HostUpdateParamsHostRoleWorker {
-		request.HighAvailabilityMode = nil
-	}
-
 	// those flags are not used on day2 installation
 	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
 		releaseImage, err := i.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion, cluster.CPUArchitecture)

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -350,16 +350,6 @@ var _ = Describe("installcmd arguments", func() {
 			Expect(*request.HighAvailabilityMode).To(Equal(models.ClusterHighAvailabilityModeNone))
 		})
 
-		It("verify high-availability-mode is Nil when host role is worker", func() {
-			installCmd := NewInstallCmd(common.GetTestLog(), db, validator, mockRelease, InstructionConfig{}, mockEvents, mockVersions)
-			host.Role = "worker"
-			stepReply, err := installCmd.GetSteps(ctx, &host)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(stepReply).NotTo(BeNil())
-			request := getRequest(stepReply[0])
-			Expect(request.HighAvailabilityMode).To(BeNil())
-		})
-
 		It("verify empty value", func() {
 			mockRelease = oc.NewMockRelease(ctrl)
 			mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()


### PR DESCRIPTION
Reverts openshift/assisted-service#3769
Causing failures in integration environment, reverting while we investigate.