### PR TITLE
Bug 2084612: Add a retry in setup lso

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -18,7 +18,7 @@ function print_help() {
 function install_lso() {
   oc adm new-project openshift-local-storage || true
 
-  oc annotate project openshift-local-storage openshift.io/node-selector='' --overwrite=true
+  retry -- oc annotate project openshift-local-storage openshift.io/node-selector='' --overwrite=true
 
   catalog_source_name="redhat-operators"
   if [ "${DISCONNECTED}" = true ]; then

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -155,3 +155,40 @@ function nth_ip() {
 
   python -c "from ansible_collections.ansible.netcommon.plugins.filter import ipaddr; print(ipaddr.nthhost('"$network"', $idx))"
 }
+
+function retry() {
+    attempts=5
+    interval=1
+
+    local OPTIND
+    while getopts "a:i:" opt ; do
+      case "${opt}" in
+          a )
+              attempts="${OPTARG}"
+              ;;
+          i )
+              interval="${OPTARG}"
+              ;;
+          * )
+              ;;
+      esac
+    done
+    shift $((OPTIND-1))
+
+    rc=0
+    for attempt in $(seq "${attempts}")
+    do
+        echo "Attempt ${attempt}/${attempts} to execute \"$*\"..."
+
+        "$@"
+        rc=$?
+        if [[ ${rc} = 0 ]]
+        then
+            break
+        fi
+
+        sleep "${interval}"
+    done
+
+    return ${rc}
+}


### PR DESCRIPTION
From time to time, the `oc annotate` fails with the following error:
```
Created project openshift-local-storage
Error from server (Conflict): Operation cannot be fulfilled on namespaces "openshift-local-storage": the object has been modified; please apply your changes to
 the latest version and try again
```

This change works around this issue with a retry.
