### PR TITLE
MGMT-9682: fix default disk size requirement

### DIFF
--- a/client/installer/v2_get_preflight_requirements_parameters.go
+++ b/client/installer/v2_get_preflight_requirements_parameters.go
@@ -61,7 +61,7 @@ type V2GetPreflightRequirementsParams struct {
 
 	/* ClusterID.
 
-	   The cluster to return preflight requrements for.
+	   The cluster to return preflight requirements for.
 
 	   Format: uuid
 	*/

--- a/data/default_hw_requirements.json
+++ b/data/default_hw_requirements.json
@@ -3,7 +3,7 @@
   "master": {
     "cpu_cores": 4,
     "ram_mib": 16384,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10,
     "network_latency_threshold_ms": 100,
     "packet_loss_percentage": 0
@@ -11,7 +11,7 @@
   "worker": {
     "cpu_cores": 2,
     "ram_mib": 8192,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10,
     "network_latency_threshold_ms": 1000,
     "packet_loss_percentage": 10
@@ -19,7 +19,7 @@
   "sno": {
     "cpu_cores": 8,
     "ram_mib": 16384,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10
   }
 }]

--- a/deploy/podman/configmap.yml
+++ b/deploy/podman/configmap.yml
@@ -15,7 +15,7 @@ data:
   DISK_ENCRYPTION_SUPPORT: "true"
   DUMMY_IGNITION: "false"
   ENABLE_SINGLE_NODE_DNSMASQ: "true"
-  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]'
+  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]'
   IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
   IPV6_SUPPORT: "true"
   LISTEN_PORT: "8888"

--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -15,7 +15,7 @@ data:
   DISK_ENCRYPTION_SUPPORT: "false"
   DUMMY_IGNITION: "false"
   ENABLE_SINGLE_NODE_DNSMASQ: "false"
-  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]'
+  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]'
   IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
   IPV6_SUPPORT: "true"
   LISTEN_PORT: "8888"

--- a/docs/dev/hardware-requirements.md
+++ b/docs/dev/hardware-requirements.md
@@ -1,6 +1,6 @@
 # Hardware requirements
 
-Hardware requirements are configured with `HW_VALIDATOR_REQUIREMENTS` environment variable, which must contain JSON mapping OpenShift version to specific master and worker hardware requirements. 
+Hardware requirements are configured with `HW_VALIDATOR_REQUIREMENTS` environment variable, which must contain JSON mapping OpenShift version to specific master and worker hardware requirements.
 For example:
 ```json
 [{
@@ -8,7 +8,7 @@ For example:
   "master": {
     "cpu_cores": 4,
     "ram_mib": 16384,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10,
     "network_latency_threshold_ms": 100,
     "packet_loss_percentage":0
@@ -16,7 +16,7 @@ For example:
   "worker": {
     "cpu_cores": 2,
     "ram_mib": 8192,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10,
     "network_latency_threshold_ms": 1000,
     "packet_loss_percentage":10
@@ -24,7 +24,7 @@ For example:
   "sno": {
     "cpu_cores": 8,
     "ram_mib": 16384,
-    "disk_size_gb": 120,
+    "disk_size_gb": 100,
     "installation_disk_speed_threshold_ms": 10
   }
 },

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -46,7 +46,7 @@ const (
 
 var _ = Describe("Disk eligibility", func() {
 	const (
-		minDiskSizeGb = 120
+		minDiskSizeGb = 100
 	)
 	var versionRequirements = VersionedRequirementsDecoder{
 		"default": {
@@ -408,17 +408,17 @@ var _ = Describe("Cluster host requirements", func() {
 			"master": map[string]interface{}{
 				"cpu_cores":    4,
 				"ram_mib":      16384,
-				"disk_size_gb": 120,
+				"disk_size_gb": 100,
 			},
 			"worker": map[string]interface{}{
 				"cpu_cores":    2,
 				"ram_mib":      8192,
-				"disk_size_gb": 120,
+				"disk_size_gb": 100,
 			},
 			"sno": map[string]interface{}{
 				"cpu_cores":    8,
 				"ram_mib":      16384,
-				"disk_size_gb": 120,
+				"disk_size_gb": 100,
 			},
 		},
 		{
@@ -426,7 +426,7 @@ var _ = Describe("Cluster host requirements", func() {
 			"master": map[string]interface{}{
 				"cpu_cores":                            5,
 				"ram_mib":                              17408,
-				"disk_size_gb":                         121,
+				"disk_size_gb":                         101,
 				"installation_disk_speed_threshold_ms": 1,
 				"network_latency_threshold_ms":         100,
 				"packet_loss_percentage":               0,
@@ -434,7 +434,7 @@ var _ = Describe("Cluster host requirements", func() {
 			"worker": map[string]interface{}{
 				"cpu_cores":                            3,
 				"ram_mib":                              9216,
-				"disk_size_gb":                         122,
+				"disk_size_gb":                         102,
 				"installation_disk_speed_threshold_ms": 2,
 				"network_latency_threshold_ms":         1000,
 				"packet_loss_percentage":               10,
@@ -442,7 +442,7 @@ var _ = Describe("Cluster host requirements", func() {
 			"sno": map[string]interface{}{
 				"cpu_cores":                            7,
 				"ram_mib":                              31744,
-				"disk_size_gb":                         124,
+				"disk_size_gb":                         104,
 				"installation_disk_speed_threshold_ms": 3,
 				"network_latency_threshold_ms":         1100,
 				"packet_loss_percentage":               11,
@@ -627,7 +627,7 @@ var _ = Describe("Cluster host requirements", func() {
 		},
 		table.Entry("Worker", models.HostRoleWorker, models.ClusterHostRequirementsDetails{
 			CPUCores:                         3,
-			DiskSizeGb:                       122,
+			DiskSizeGb:                       102,
 			RAMMib:                           9 * int64(units.KiB),
 			InstallationDiskSpeedThresholdMs: 2,
 			NetworkLatencyThresholdMs:        pointer.Float64Ptr(1000),
@@ -635,7 +635,7 @@ var _ = Describe("Cluster host requirements", func() {
 		}),
 		table.Entry("Master", models.HostRoleMaster, models.ClusterHostRequirementsDetails{
 			CPUCores:                         5,
-			DiskSizeGb:                       121,
+			DiskSizeGb:                       101,
 			RAMMib:                           17 * int64(units.KiB),
 			InstallationDiskSpeedThresholdMs: 1,
 			NetworkLatencyThresholdMs:        pointer.Float64Ptr(100),
@@ -669,13 +669,13 @@ var _ = Describe("Cluster host requirements", func() {
 		},
 		table.Entry("Worker", models.HostRoleWorker, models.ClusterHostRequirementsDetails{
 			CPUCores:                         2,
-			DiskSizeGb:                       120,
+			DiskSizeGb:                       100,
 			RAMMib:                           8 * int64(units.KiB),
 			InstallationDiskSpeedThresholdMs: 0,
 		}),
 		table.Entry("Master", models.HostRoleMaster, models.ClusterHostRequirementsDetails{
 			CPUCores:                         4,
-			DiskSizeGb:                       120,
+			DiskSizeGb:                       100,
 			RAMMib:                           16 * int64(units.KiB),
 			InstallationDiskSpeedThresholdMs: 0,
 		}),
@@ -722,17 +722,17 @@ var _ = Describe("Preflight host requirements", func() {
 			MasterRequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:   4,
 				RAMMib:     16384,
-				DiskSizeGb: 120,
+				DiskSizeGb: 100,
 			},
 			WorkerRequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:   2,
 				RAMMib:     8192,
-				DiskSizeGb: 120,
+				DiskSizeGb: 100,
 			},
 			SNORequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:   8,
 				RAMMib:     16384,
-				DiskSizeGb: 120,
+				DiskSizeGb: 100,
 			},
 		},
 		"4.7": {
@@ -740,19 +740,19 @@ var _ = Describe("Preflight host requirements", func() {
 			MasterRequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:                         5,
 				RAMMib:                           17408,
-				DiskSizeGb:                       121,
+				DiskSizeGb:                       101,
 				InstallationDiskSpeedThresholdMs: 1,
 			},
 			WorkerRequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:                         3,
 				RAMMib:                           9216,
-				DiskSizeGb:                       122,
+				DiskSizeGb:                       102,
 				InstallationDiskSpeedThresholdMs: 2,
 			},
 			SNORequirements: &models.ClusterHostRequirementsDetails{
 				CPUCores:   7,
 				RAMMib:     31744,
-				DiskSizeGb: 123,
+				DiskSizeGb: 103,
 			},
 		},
 	}
@@ -875,7 +875,7 @@ var _ = Describe("Preflight host requirements", func() {
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{
 					CPUCores:                         5,
-					DiskSizeGb:                       121,
+					DiskSizeGb:                       101,
 					RAMMib:                           17 * int64(units.KiB),
 					InstallationDiskSpeedThresholdMs: 1,
 				},
@@ -883,7 +883,7 @@ var _ = Describe("Preflight host requirements", func() {
 			Worker: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{
 					CPUCores:                         3,
-					DiskSizeGb:                       122,
+					DiskSizeGb:                       102,
 					RAMMib:                           9 * int64(units.KiB),
 					InstallationDiskSpeedThresholdMs: 2,
 				},

--- a/internal/hardware/versioned-requirements_test.go
+++ b/internal/hardware/versioned-requirements_test.go
@@ -48,19 +48,19 @@ var _ = Describe("Versioned Requirements", func() {
 						"master": map[string]interface{}{
 							"cpu_cores":                            4,
 							"ram_mib":                              16384,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 2,
 						},
 						"worker": map[string]interface{}{
 							"cpu_cores":                            2,
 							"ram_mib":                              8192,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 3,
 						},
 						"sno": map[string]interface{}{
 							"cpu_cores":                            8,
 							"ram_mib":                              32768,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 4,
 						},
 					},
@@ -68,11 +68,11 @@ var _ = Describe("Versioned Requirements", func() {
 				map[string]models.VersionedHostRequirements{
 					"4.6.0": {
 						Version: "4.6.0",
-						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 120,
+						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(16), InstallationDiskSpeedThresholdMs: 2},
-						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 120,
+						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(8), InstallationDiskSpeedThresholdMs: 3},
-						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 120,
+						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(32), InstallationDiskSpeedThresholdMs: 4},
 					}}),
 			table.Entry("Two versions - full",
@@ -82,19 +82,19 @@ var _ = Describe("Versioned Requirements", func() {
 						"master": map[string]interface{}{
 							"cpu_cores":                            4,
 							"ram_mib":                              16384,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 2,
 						},
 						"worker": map[string]interface{}{
 							"cpu_cores":                            2,
 							"ram_mib":                              8192,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 1,
 						},
 						"sno": map[string]interface{}{
 							"cpu_cores":                            8,
 							"ram_mib":                              32768,
-							"disk_size_gb":                         120,
+							"disk_size_gb":                         100,
 							"installation_disk_speed_threshold_ms": 4,
 						},
 					}, {
@@ -102,18 +102,18 @@ var _ = Describe("Versioned Requirements", func() {
 						"master": map[string]interface{}{
 							"cpu_cores":                            5,
 							"ram_mib":                              17408,
-							"disk_size_gb":                         121,
+							"disk_size_gb":                         101,
 							"installation_disk_speed_threshold_ms": 3,
 						},
 						"worker": map[string]interface{}{
 							"cpu_cores":    3,
 							"ram_mib":      9216,
-							"disk_size_gb": 122,
+							"disk_size_gb": 102,
 						},
 						"sno": map[string]interface{}{
 							"cpu_cores":                            7,
 							"ram_mib":                              31744,
-							"disk_size_gb":                         123,
+							"disk_size_gb":                         103,
 							"installation_disk_speed_threshold_ms": 4,
 						},
 					},
@@ -121,18 +121,18 @@ var _ = Describe("Versioned Requirements", func() {
 				map[string]models.VersionedHostRequirements{
 					"4.6.0": {
 						Version: "4.6.0",
-						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 120,
+						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(16), InstallationDiskSpeedThresholdMs: 2},
-						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 120,
+						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(8), InstallationDiskSpeedThresholdMs: 1},
-						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 120,
+						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 100,
 							RAMMib: conversions.GibToMib(32), InstallationDiskSpeedThresholdMs: 4},
 					},
 					"4.7.0": {Version: "4.7.0",
-						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 5, DiskSizeGb: 121,
+						MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 5, DiskSizeGb: 101,
 							RAMMib: conversions.GibToMib(17), InstallationDiskSpeedThresholdMs: 3},
-						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 3, DiskSizeGb: 122, RAMMib: conversions.GibToMib(9)},
-						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 7, DiskSizeGb: 123,
+						WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 3, DiskSizeGb: 102, RAMMib: conversions.GibToMib(9)},
+						SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 7, DiskSizeGb: 103,
 							RAMMib: conversions.GibToMib(31), InstallationDiskSpeedThresholdMs: 4},
 					}}),
 		)
@@ -222,19 +222,19 @@ var _ = Describe("Versioned Requirements", func() {
 					"master": map[string]interface{}{
 						"cpu_cores":                            4,
 						"ram_mib":                              16384,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 2,
 					},
 					"worker": map[string]interface{}{
 						"cpu_cores":                            2,
 						"ram_mib":                              8192,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 3,
 					},
 					"sno": map[string]interface{}{
 						"cpu_cores":                            8,
 						"ram_mib":                              32768,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 4,
 					},
 				},
@@ -247,11 +247,11 @@ var _ = Describe("Versioned Requirements", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expected := models.VersionedHostRequirements{
 				Version: "4.6.0",
-				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 120,
+				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(16), InstallationDiskSpeedThresholdMs: 2},
-				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 120,
+				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(8), InstallationDiskSpeedThresholdMs: 3},
-				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 120,
+				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(32), InstallationDiskSpeedThresholdMs: 4},
 			}
 			Expect(*requirements).To(BeEquivalentTo(expected))
@@ -264,19 +264,19 @@ var _ = Describe("Versioned Requirements", func() {
 					"master": map[string]interface{}{
 						"cpu_cores":                            4,
 						"ram_mib":                              16384,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 2,
 					},
 					"worker": map[string]interface{}{
 						"cpu_cores":                            2,
 						"ram_mib":                              8192,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 3,
 					},
 					"sno": map[string]interface{}{
 						"cpu_cores":                            8,
 						"ram_mib":                              32768,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 4,
 					},
 				},
@@ -285,18 +285,18 @@ var _ = Describe("Versioned Requirements", func() {
 					"master": map[string]interface{}{
 						"cpu_cores":                            5,
 						"ram_mib":                              17408,
-						"disk_size_gb":                         121,
+						"disk_size_gb":                         101,
 						"installation_disk_speed_threshold_ms": 3,
 					},
 					"worker": map[string]interface{}{
 						"cpu_cores":    3,
 						"ram_mib":      9216,
-						"disk_size_gb": 122,
+						"disk_size_gb": 102,
 					},
 					"sno": map[string]interface{}{
 						"cpu_cores":                            7,
 						"ram_mib":                              31744,
-						"disk_size_gb":                         123,
+						"disk_size_gb":                         103,
 						"installation_disk_speed_threshold_ms": 4,
 					},
 				},
@@ -309,11 +309,11 @@ var _ = Describe("Versioned Requirements", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expected := models.VersionedHostRequirements{
 				Version: "default",
-				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 120,
+				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(16), InstallationDiskSpeedThresholdMs: 2},
-				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 120,
+				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(8), InstallationDiskSpeedThresholdMs: 3},
-				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 120,
+				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(32), InstallationDiskSpeedThresholdMs: 4},
 			}
 			Expect(*requirements).To(BeEquivalentTo(expected))
@@ -326,19 +326,19 @@ var _ = Describe("Versioned Requirements", func() {
 					"master": map[string]interface{}{
 						"cpu_cores":                            4,
 						"ram_mib":                              16384,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 2,
 					},
 					"worker": map[string]interface{}{
 						"cpu_cores":                            2,
 						"ram_mib":                              8192,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 3,
 					},
 					"sno": map[string]interface{}{
 						"cpu_cores":                            8,
 						"ram_mib":                              32768,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 4,
 					},
 				},
@@ -351,11 +351,11 @@ var _ = Describe("Versioned Requirements", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expected := models.VersionedHostRequirements{
 				Version: "4.6.0",
-				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 120,
+				MasterRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 4, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(16), InstallationDiskSpeedThresholdMs: 2},
-				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 120,
+				WorkerRequirements: &models.ClusterHostRequirementsDetails{CPUCores: 2, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(8), InstallationDiskSpeedThresholdMs: 3},
-				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 120,
+				SNORequirements: &models.ClusterHostRequirementsDetails{CPUCores: 8, DiskSizeGb: 100,
 					RAMMib: conversions.GibToMib(32), InstallationDiskSpeedThresholdMs: 4},
 			}
 			Expect(*requirements).To(BeEquivalentTo(expected))
@@ -380,19 +380,19 @@ var _ = Describe("Versioned Requirements", func() {
 					"master": map[string]interface{}{
 						"cpu_cores":                            4,
 						"ram_mib":                              16384,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 2,
 					},
 					"worker": map[string]interface{}{
 						"cpu_cores":                            2,
 						"ram_mib":                              8192,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 3,
 					},
 					"sno": map[string]interface{}{
 						"cpu_cores":                            8,
 						"ram_mib":                              32768,
-						"disk_size_gb":                         120,
+						"disk_size_gb":                         100,
 						"installation_disk_speed_threshold_ms": 4,
 					},
 				},

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -40,7 +40,7 @@ var (
 	defaultMasterRequirements = models.ClusterHostRequirementsDetails{
 		CPUCores:                         4,
 		RAMMib:                           16384,
-		DiskSizeGb:                       120,
+		DiskSizeGb:                       100,
 		InstallationDiskSpeedThresholdMs: 10,
 		NetworkLatencyThresholdMs:        pointer.Float64Ptr(100),
 		PacketLossPercentage:             pointer.Float64Ptr(0),
@@ -48,7 +48,7 @@ var (
 	defaultWorkerRequirements = models.ClusterHostRequirementsDetails{
 		CPUCores:                         2,
 		RAMMib:                           8192,
-		DiskSizeGb:                       120,
+		DiskSizeGb:                       100,
 		InstallationDiskSpeedThresholdMs: 10,
 		NetworkLatencyThresholdMs:        pointer.Float64Ptr(1000),
 		PacketLossPercentage:             pointer.Float64Ptr(10),
@@ -56,7 +56,7 @@ var (
 	defaultSnoRequirements = models.ClusterHostRequirementsDetails{
 		CPUCores:                         8,
 		RAMMib:                           16384,
-		DiskSizeGb:                       120,
+		DiskSizeGb:                       100,
 		InstallationDiskSpeedThresholdMs: 10,
 	}
 )
@@ -1303,7 +1303,7 @@ func makeJsonChecker(expected map[validationID]validationCheckResult) *validatio
 
 var _ = Describe("Refresh Host", func() {
 	const (
-		minDiskSizeGb = 120
+		minDiskSizeGb = 100
 	)
 	var (
 		supportedGPU                  = models.Gpu{VendorID: "10de", DeviceID: "1db6"}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2339,7 +2339,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The cluster to return preflight requrements for.",
+            "description": "The cluster to return preflight requirements for.",
             "name": "cluster_id",
             "in": "path",
             "required": true
@@ -11372,7 +11372,7 @@ func init() {
           {
             "type": "string",
             "format": "uuid",
-            "description": "The cluster to return preflight requrements for.",
+            "description": "The cluster to return preflight requirements for.",
             "name": "cluster_id",
             "in": "path",
             "required": true

--- a/restapi/operations/installer/v2_get_preflight_requirements_parameters.go
+++ b/restapi/operations/installer/v2_get_preflight_requirements_parameters.go
@@ -31,7 +31,7 @@ type V2GetPreflightRequirementsParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The cluster to return preflight requrements for.
+	/*The cluster to return preflight requirements for.
 	  Required: true
 	  In: path
 	*/

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -3358,7 +3358,7 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 		clusterID             strfmt.UUID
 		masterOCPRequirements = models.ClusterHostRequirementsDetails{
 			CPUCores:                         4,
-			DiskSizeGb:                       120,
+			DiskSizeGb:                       100,
 			RAMMib:                           16384,
 			InstallationDiskSpeedThresholdMs: 10,
 			NetworkLatencyThresholdMs:        pointer.Float64Ptr(100),
@@ -3366,7 +3366,7 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 		}
 		workerOCPRequirements = models.ClusterHostRequirementsDetails{
 			CPUCores:                         2,
-			DiskSizeGb:                       120,
+			DiskSizeGb:                       100,
 			RAMMib:                           8192,
 			InstallationDiskSpeedThresholdMs: 10,
 			NetworkLatencyThresholdMs:        pointer.Float64Ptr(1000),

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2492,7 +2492,7 @@ paths:
       parameters:
         - in: path
           name: cluster_id
-          description: The cluster to return preflight requrements for.
+          description: The cluster to return preflight requirements for.
           type: string
           format: uuid
           required: true
@@ -5533,7 +5533,7 @@ definitions:
       key:
         description: The key for the label's key-value pair.
         type: string
-      value: 
+      value:
         description: The value for the label's key-value pair.
         type: string
 


### PR DESCRIPTION
Seems like since OCP 4.6, disk requirements were set on 100GB for all nodes:
https://docs.openshift.com/container-platform/4.6/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal

Since we don't support installation of OCP <= 4.5 in any environment, it makes sense to change it for all OCP minor releases.

This PR is not doing relevant changes for the operator (in the ``agentserviceconfig`` object), as it should follow BZ tickets instead of Jira ones.

I've tested local environments of minikube and podman, trying to create envs with different disk sizes. I'll also follow up checking integration env ``preflight-requirements`` endpoint.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

@gamli75 @eliorerz 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
