### PR TITLE
MGMT-10275: When getting release image, let a single thread query it, and other threads wait for it

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -363,3 +363,7 @@ func CanonizeStrings(slice []string) (ret []string) {
 	}
 	return
 }
+
+func GetHostKey(host *models.Host) string {
+	return host.ID.String() + "@" + host.InfraEnvID.String()
+}

--- a/internal/common/expiring_cache.go
+++ b/internal/common/expiring_cache.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+type ExpiringCache interface {
+	GetOrInsert(key string, value interface{}) (interface{}, bool)
+	Get(key string) (interface{}, bool)
+	Set(key string, value interface{})
+}
+
+type expiringCache struct {
+	cache *cache.Cache
+	mutex sync.Mutex
+}
+
+func NewExpiringCache(defaultExpiration, cleanupInterval time.Duration) ExpiringCache {
+	return &expiringCache{cache: cache.New(defaultExpiration, cleanupInterval)}
+}
+
+func (e *expiringCache) GetOrInsert(key string, value interface{}) (actualIntf interface{}, loaded bool) {
+	actualIntf, loaded = e.Get(key)
+	if loaded {
+		return
+	}
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	actualIntf, loaded = e.Get(key)
+	if loaded {
+		return
+	}
+	e.cache.SetDefault(key, value)
+	return value, false
+}
+
+func (e *expiringCache) Get(key string) (interface{}, bool) {
+	actualIntf, loaded := e.cache.Get(key)
+	if loaded {
+		e.cache.SetDefault(key, actualIntf)
+	}
+	return actualIntf, loaded
+}
+
+func (e *expiringCache) Set(key string, value interface{}) {
+	e.cache.SetDefault(key, value)
+}

--- a/internal/connectivity/validator.go
+++ b/internal/connectivity/validator.go
@@ -2,7 +2,9 @@ package connectivity
 
 import (
 	"encoding/json"
+	"time"
 
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -15,15 +17,26 @@ type Validator interface {
 
 func NewValidator(log logrus.FieldLogger) Validator {
 	return &validator{
-		log: log,
+		log:   log,
+		cache: common.NewExpiringCache(10*time.Minute, 10*time.Minute),
 	}
 }
 
 type validator struct {
-	log logrus.FieldLogger
+	log   logrus.FieldLogger
+	cache common.ExpiringCache
 }
 
 func (v *validator) GetHostValidInterfaces(host *models.Host) ([]*models.Interface, error) {
+	key := common.GetHostKey(host)
+	val, exists := v.cache.Get(key)
+	if exists {
+		value, ok := val.([]*models.Interface)
+		if !ok {
+			return nil, errors.Errorf("unexpected cast error for host %s infra-env %s", host.ID.String(), host.InfraEnvID.String())
+		}
+		return value, nil
+	}
 	var inventory models.Inventory
 	if err := json.Unmarshal([]byte(host.Inventory), &inventory); err != nil {
 		return nil, err
@@ -31,5 +44,6 @@ func (v *validator) GetHostValidInterfaces(host *models.Host) ([]*models.Interfa
 	if len(inventory.Interfaces) == 0 {
 		return nil, errors.Errorf("host %s doesn't have interfaces", host.ID)
 	}
+	v.cache.Set(key, inventory.Interfaces)
 	return inventory.Interfaces, nil
 }

--- a/internal/host/hostcommands/connectivity_check_cmd.go
+++ b/internal/host/hostcommands/connectivity_check_cmd.go
@@ -2,18 +2,25 @@ package hostcommands
 
 import (
 	"context"
+	"sync"
+	"time"
 
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/connectivity"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
 )
+
+const maxConnectivityRequestsPerMinute = 150
 
 type connectivityCheckCmd struct {
 	baseCmd
 	db                     *gorm.DB
 	connectivityValidator  connectivity.Validator
 	connectivityCheckImage string
+	queue                  common.ExpiringCache
 }
 
 func NewConnectivityCheckCmd(log logrus.FieldLogger, db *gorm.DB, connectivityValidator connectivity.Validator, connectivityCheckImage string) *connectivityCheckCmd {
@@ -22,33 +29,70 @@ func NewConnectivityCheckCmd(log logrus.FieldLogger, db *gorm.DB, connectivityVa
 		db:                     db,
 		connectivityValidator:  connectivityValidator,
 		connectivityCheckImage: connectivityCheckImage,
+		queue:                  common.NewExpiringCache(5*time.Minute, time.Minute),
 	}
+}
+
+type clusterQueue struct {
+	mutex         sync.Mutex
+	admittedQueue []time.Time
+	waitingQueue  []string
+}
+
+// Throttle the pace of connectivity check requests up to maxConnectivityRequestsPerMinute (150) requests per minute
+// It maintains instance of clusterQueue per cluster id that its requests need to be throttled.
+// 2 queues are kept as part of clusterQueue:
+// - waitingQueue: Identification of hosts that previously requested admition, and were denied
+// - admittedQueue: Timestamps when hosts got admitted during the last minute
+// The function returns true if the index of the host in waiting queue is less than  maxConnectivityRequestsPerMinute - len(admittedQueue)
+// If the host is admitted, its id is removed from the waitingQueue, and the current time is added to admittedQueue
+func (c *connectivityCheckCmd) isAdmitted(host *models.Host) bool {
+	valIntf, _ := c.queue.GetOrInsert(host.ClusterID.String(), &clusterQueue{})
+	q := valIntf.(*clusterQueue)
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	firstValidIndex := 0
+	for ; firstValidIndex < len(q.admittedQueue) && time.Since(q.admittedQueue[firstValidIndex]) > time.Minute; firstValidIndex++ {
+	}
+	q.admittedQueue = q.admittedQueue[firstValidIndex:]
+	key := common.GetHostKey(host)
+	index := funk.IndexOfString(q.waitingQueue, key)
+	if index == -1 {
+		q.waitingQueue = append(q.waitingQueue, key)
+		index = len(q.waitingQueue) - 1
+	}
+	if index < (maxConnectivityRequestsPerMinute - len(q.admittedQueue)) {
+		q.waitingQueue = append(q.waitingQueue[:index], q.waitingQueue[index+1:]...)
+		q.admittedQueue = append(q.admittedQueue, time.Now())
+		return true
+	}
+	return false
 }
 
 func (c *connectivityCheckCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
 
 	var hosts []*models.Host
-	if err := c.db.Find(&hosts, "cluster_id = ?", host.ClusterID).Error; err != nil {
+	if err := c.db.Select("id", "inventory", "status").Find(&hosts, "cluster_id = ?", host.ClusterID).Error; err != nil {
 		c.log.WithError(err).Errorf("failed to get list of hosts for cluster %s", host.ClusterID)
 		return nil, err
 	}
+	if len(hosts) <= maxConnectivityRequestsPerMinute || c.isAdmitted(host) {
+		hostsData, err := convertHostsToConnectivityCheckParams(host.ID, hosts, c.connectivityValidator)
+		if err != nil {
+			c.log.WithError(err).Errorf("failed to convert hosts to connectivity params for host %s cluster %s", host.ID, host.ClusterID)
+			return nil, err
+		}
 
-	hostsData, err := convertHostsToConnectivityCheckParams(host.ID, hosts, c.connectivityValidator)
-	if err != nil {
-		c.log.WithError(err).Errorf("failed to convert hosts to connectivity params for host %s cluster %s", host.ID, host.ClusterID)
-		return nil, err
+		// Skip this step in case there is no hosts to check
+		if hostsData != "" {
+			step := &models.Step{
+				StepType: models.StepTypeConnectivityCheck,
+				Args: []string{
+					hostsData,
+				},
+			}
+			return []*models.Step{step}, nil
+		}
 	}
-
-	// Skip this step in case there is no hosts to check
-	if hostsData == "" {
-		return nil, nil
-	}
-
-	step := &models.Step{
-		StepType: models.StepTypeConnectivityCheck,
-		Args: []string{
-			hostsData,
-		},
-	}
-	return []*models.Step{step}, nil
+	return nil, nil
 }

--- a/internal/host/hostcommands/connectivity_check_cmd_test.go
+++ b/internal/host/hostcommands/connectivity_check_cmd_test.go
@@ -2,6 +2,8 @@ package hostcommands
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -53,4 +55,135 @@ var _ = Describe("connectivitycheckcmd", func() {
 		stepReply = nil
 		stepErr = nil
 	})
+})
+
+var _ = Describe("isAdmitted", func() {
+	type requester struct {
+		index          int
+		expectedResult bool
+	}
+	tests := []struct {
+		name                 string
+		numWaiting           int
+		numAdmitted          int
+		requesters           []requester
+		admittedDurationSecs int
+	}{
+		{
+			name: "Single",
+			requesters: []requester{
+				{
+					index:          500,
+					expectedResult: true,
+				},
+			},
+		},
+		{
+			name:       "Waiting full",
+			numWaiting: 200,
+			requesters: []requester{
+				{
+					index:          100,
+					expectedResult: true,
+				},
+				{
+					index:          200,
+					expectedResult: false,
+				},
+				{
+					index:          150,
+					expectedResult: false,
+				},
+				{
+					index:          149,
+					expectedResult: true,
+				},
+			},
+		},
+		{
+			name:        "Admitted full",
+			numAdmitted: 150,
+			requesters: []requester{
+				{
+					index:          0,
+					expectedResult: false,
+				},
+			},
+		},
+		{
+			name:                 "Admitted full - old",
+			numAdmitted:          150,
+			admittedDurationSecs: 61,
+			requesters: []requester{
+				{
+					index:          0,
+					expectedResult: true,
+				},
+				{
+					index:          149,
+					expectedResult: true,
+				},
+				{
+					index:          500,
+					expectedResult: true,
+				},
+			},
+		},
+		{
+			name:                 "Filling",
+			numWaiting:           140,
+			numAdmitted:          9,
+			admittedDurationSecs: 30,
+			requesters: []requester{
+				{
+					index:          500,
+					expectedResult: true,
+				},
+				{
+					index:          149,
+					expectedResult: false,
+				},
+				{
+					index:          139,
+					expectedResult: true,
+				},
+				{
+					index:          0,
+					expectedResult: true,
+				},
+			},
+		},
+	}
+	for i := range tests {
+		t := tests[i]
+		It(t.name, func() {
+			clusterId := strfmt.UUID(uuid.New().String())
+			infraenvId := strfmt.UUID(uuid.New().String())
+			hostForIndex := func(index int) *models.Host {
+				id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000%05x", index))
+				return &models.Host{
+					ID:         &id,
+					InfraEnvID: infraenvId,
+					ClusterID:  &clusterId,
+				}
+			}
+			cmd := NewConnectivityCheckCmd(common.GetTestLog(), nil, nil, "quay.io/example/connectivity_check:latest")
+			queue := cmd.queue
+			value := &clusterQueue{}
+			if t.numWaiting > 0 || t.numAdmitted > 0 {
+				queue.Set(clusterId.String(), value)
+			}
+			for j := 0; j != t.numWaiting; j++ {
+				value.waitingQueue = append(value.waitingQueue, common.GetHostKey(hostForIndex(j)))
+			}
+			timestamp := time.Now().Add(-(time.Duration(t.admittedDurationSecs) * time.Second))
+			for j := 0; j != t.numAdmitted; j++ {
+				value.admittedQueue = append(value.admittedQueue, timestamp)
+			}
+			for j := range t.requesters {
+				r := t.requesters[j]
+				Expect(cmd.isAdmitted(hostForIndex(r.index))).To(Equal(r.expectedResult))
+			}
+		})
+	}
 })


### PR DESCRIPTION
When installation starts, many threads attempt to get the image
concurrently.  Each creates a process that attempts to get it, but all
need the same information.
Added cache that verifies that an image is retrieved only once, and all
other threads are waiting for the result.

[MGMT-10271](https://issues.redhat.com//browse/MGMT-10271): Get only id, status, and inventory when querying hosts for connectivity check
Only these fields are needed to construct the connectivity-check step.

[MGMT-10267](https://issues.redhat.com//browse/MGMT-10267): Create cache for host valid interfaces
In order to construct the connectivity check step, each host valid
interfaces are needed.
Since the Unmarshal operation is costly, the valid interfaces of each
host are kept in cache to speed up the valid interfaces retrieval.

[MGMT-10270](https://issues.redhat.com//browse/MGMT-10270): Create queue to throttle connectivity requests
Since the connectivity check takes a lot of bandwidth, (both the request
and the reply size are proportional to the number of hosts), a mechanism
to throttle the number of requests per minute was created.  This
mechanism, limits the number of connectivity requests per minute for
clusters with more than 150 hosts.  The mechanism, allows to generate
up to 150 connectivity checks per minute.  The connectivty checks
requests that were not admitted to run, are kept in queue for next time
such step creation will be attempted.
The queue keeps the order according to "first come first serve" policy.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
