### PR TITLE
NO-ISSUE: Log stack trace when failing to recover

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -1172,7 +1173,8 @@ func (b *bareMetalInventory) InstallSingleDay2HostInternal(ctx context.Context, 
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("InstallSingleDay2HostInternal failed")
+			log.Errorf("InstallSingleDay2HostInternal failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -1366,7 +1368,8 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("UpdateClusterInstallConfigInternal failed to recover")
+			log.Errorf("UpdateClusterInstallConfigInternal failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -1621,7 +1624,8 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("update cluster failed")
+			log.Errorf("update cluster failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -3351,7 +3355,8 @@ func (b *bareMetalInventory) CancelInstallationInternal(ctx context.Context, par
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("cancel installation failed")
+			log.Errorf("cancel installation failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -4249,7 +4254,8 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("RegisterHost failed")
+			log.Errorf("RegisterHost failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -4411,7 +4417,8 @@ func (b *bareMetalInventory) V2GetNextSteps(ctx context.Context, params installe
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("get next steps failed")
+			log.Errorf("get next steps failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()
@@ -4924,7 +4931,8 @@ func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params in
 			tx.Rollback()
 		}
 		if r := recover(); r != nil {
-			log.Error("update host failed")
+			log.Errorf("update host failed to recover: %s", r)
+			log.Error(string(debug.Stack()))
 			tx.Rollback()
 		}
 	}()


### PR DESCRIPTION
This commit makes sure assisted always logs the output of debug.Stack() when
failing to recover. Failing to recover means a go-routing crashed/paniced and
we need to have access to the failure data from the logs

Signed-off-by: Flavio Percoco <flavio@redhat.com>

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I used this change to debug a failure in one of our ZTPFW environments

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mkowalski 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
