### PR TITLE
MGMT-9315: Create inventory cache during refresh status preprocessing, to avoid unnecessary inventory unmarshalling

### DIFF
--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -128,6 +128,7 @@ func (m *Manager) clusterHostMonitoring() int64 {
 		}
 
 		for _, c := range clusters {
+			inventoryCache := make(InventoryCache)
 			for _, host := range sortHosts(c.Hosts) {
 				if !m.leaderElector.IsLeader() {
 					m.log.Debugf("Not a leader, exiting cluster HostMonitoring")
@@ -135,7 +136,7 @@ func (m *Manager) clusterHostMonitoring() int64 {
 				}
 				if !m.SkipMonitoring(host) {
 					monitored += 1
-					err = m.refreshStatusInternal(ctx, host, c, nil, m.db)
+					err = m.refreshStatusInternal(ctx, host, c, nil, inventoryCache, m.db)
 					if err != nil {
 						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
 					}
@@ -182,6 +183,7 @@ func (m *Manager) infraEnvHostMonitoring() int64 {
 		}
 
 		for _, i := range infraEnvs {
+			inventoryCache := make(InventoryCache)
 			for _, host := range i.Hosts {
 				if !m.leaderElector.IsLeader() {
 					m.log.Debugf("Not a leader, exiting infra-env HostMonitoring")
@@ -189,7 +191,7 @@ func (m *Manager) infraEnvHostMonitoring() int64 {
 				}
 				if funk.ContainsString(monitorStates, swag.StringValue(host.Status)) {
 					monitored += 1
-					err = m.refreshStatusInternal(ctx, &host.Host, nil, i, m.db)
+					err = m.refreshStatusInternal(ctx, &host.Host, nil, i, inventoryCache, m.db)
 					if err != nil {
 						log.WithError(err).Errorf("failed to refresh host %s state", *host.ID)
 					}


### PR DESCRIPTION


When running refresh-status on cluster hosts, hostname-unique validation
checks that the current hostname is unique.  In order to get a host's
hostname, there is a need to unmarshall its inventory.  For cluster with
many hosts, the number of unmarshalls is (# of hosts)^2 (squared), since
each host has to unmarshall the inventory of the other hosts.
To change that, an inventory cache was added, so each inventory is
unmarshalled once per monitoring cycle.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
