### PR TITLE
Bug 2076333: Add clusterDeploymentRef as label to the Agent

### DIFF
--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -131,6 +131,7 @@ var _ = Describe("agent reconcile", func() {
 			Name:      "host",
 		}
 		Expect(c.Get(ctx, key, agent)).To(BeNil())
+		Expect(agent.GetLabels()[BaseLabelPrefix+"clusterdeployment-namespace"]).To(Equal(""))
 	})
 
 	It("cluster deployment not found", func() {
@@ -149,6 +150,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Get(ctx, key, agent)).To(BeNil())
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Reason).To(Equal(v1beta1.BackendErrorReason))
 		Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
+		Expect(agent.GetLabels()[BaseLabelPrefix+"clusterdeployment-namespace"]).To(Equal(""))
 	})
 
 	It("cluster not found in database", func() {
@@ -375,6 +377,7 @@ var _ = Describe("agent reconcile", func() {
 			Expect(conditionsv1.FindStatusCondition(agent.Status.Conditions, v1beta1.SpecSyncedCondition).Status).To(Equal(corev1.ConditionTrue))
 			Expect(agent.Status.DebugInfo.State).To(Equal(models.HostStatusKnown))
 			Expect(agent.Status.DebugInfo.StateInfo).To(Equal("I am known"))
+			Expect(agent.GetLabels()[BaseLabelPrefix+"clusterdeployment-namespace"]).To(Equal("test-namespace"))
 		}
 	})
 


### PR DESCRIPTION
This PR extends the Agent CR by creating labels with a reference to the
clusterDeployment. This is so that in the future it will be possible to
list agents belonging to a particular clusterDeployment only by
filtering Agents by label and not by iterating over all the objects and
querying their spec.

Due to the fact that maximum length for a label value is 63 characters 
but the resource name can be up to 253, we are labeling only the 
namespace as this one has the limit of 63 characters.

This leverages the fact that api server can filter objects by label, but
it cannot filter by the arbitrary field in spec.

The PR is part of a bigger change that is going to extend error
reporting in ClusterDeployment controller and AgentClusterInstall
controller.

Contributes-to: [MGMTBUGSM-307](https://issues.redhat.com//browse/MGMTBUGSM-307)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
