### PR TITLE
MGMT-10494 Make sure that SNO is considered when auto approving CSRs

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -415,8 +415,8 @@ func (r *AgentReconciler) isDay2NonePlatformHostRebooting(ctx context.Context, a
 func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogger, agent, origAgent *aiv1beta1.Agent, h *models.Host, clusterId *strfmt.UUID, syncErr error, internal bool) (ctrl.Result, error) {
 
 	var (
-		err                 error
-		isNoneDay2Rebooting bool
+		err                   error
+		shouldAutoApproveCSRs bool
 	)
 	ret := ctrl.Result{}
 	specSynced(agent, syncErr, internal)
@@ -441,12 +441,12 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		}
 
 		if h.Progress != nil && h.Progress.CurrentStage != "" {
-			if isNoneDay2Rebooting, err = r.isDay2NonePlatformHostRebooting(ctx, agent, h); err != nil {
+			if shouldAutoApproveCSRs, err = r.isDay2NonePlatformHostRebooting(ctx, agent, h); err != nil {
 				log.WithError(err).Errorf("Failed to find if agent %s/%s belongs to none platform cluster and is rebooting", agent.Namespace, agent.Name)
 				return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
 			}
 
-			if isNoneDay2Rebooting {
+			if shouldAutoApproveCSRs {
 				agent.Status.Progress.CurrentStage = models.HostStageRebooting
 			} else {
 				agent.Status.Progress.CurrentStage = h.Progress.CurrentStage
@@ -484,7 +484,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 	} else {
 		setConditionsUnknown(agent)
 	}
-	if isNoneDay2Rebooting {
+	if shouldAutoApproveCSRs {
 		alreadyApproved := r.tryApproveDay2CSRs(ctx, agent)
 		if alreadyApproved {
 			agent.Status.Progress.CurrentStage = models.HostStageDone

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1447,11 +1447,51 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 		mockInstallerInternal *bminventory.MockInstallerInternals
 		mockClientFactory     *MockSpokeK8sClientFactory
 	)
-	newAgentClusterInstall := func(name, namespace string) *hiveext.AgentClusterInstall {
+	newAciWithUserManagedNetworkingNoSNO := func(name, namespace string) *hiveext.AgentClusterInstall {
 		return &hiveext.AgentClusterInstall{
 			Spec: hiveext.AgentClusterInstallSpec{
 				Networking: hiveext.Networking{
 					UserManagedNetworking: true,
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AgentClusterInstall",
+				APIVersion: "hiveextension/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	newAciNoUserManagedNetworkingNoSNO := func(name, namespace string) *hiveext.AgentClusterInstall {
+		return &hiveext.AgentClusterInstall{
+			Spec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{
+					UserManagedNetworking: false,
+				},
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AgentClusterInstall",
+				APIVersion: "hiveextension/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	newAciNoUserManagedNetworkingWithSNO := func(name, namespace string) *hiveext.AgentClusterInstall {
+		return &hiveext.AgentClusterInstall{
+			Spec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{
+					UserManagedNetworking: false,
+				},
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
 				},
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -1588,8 +1628,6 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			}}}
 		clusterDeployment := newClusterDeployment("clusterDeployment", testNamespace, getDefaultClusterDeploymentSpec("clusterDeployment-test", "test-cluster-aci", "pull-secret"))
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
-		aci := newAgentClusterInstall("test-cluster-aci", testNamespace)
-		Expect(c.Create(ctx, aci)).To(BeNil())
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		agentKey = types.NamespacedName{
 			Namespace: testNamespace,
@@ -1621,6 +1659,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 		expectedResult  ctrl.Result
 		expectedStatus  string
 		expectedStage   models.HostStage
+		clusterInstall  *hiveext.AgentClusterInstall
 	}{
 		{
 			name:           "No matching node - No csrs",
@@ -1630,9 +1669,39 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{RequeueAfter: time.Minute},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
-			name:         "Not ready matching node - 1 csrs",
+			name:         "Do not auto approve CSR for Not ready matching node and UserManagedNetworking is false and cluster is not SNO",
+			createClient: false,
+			hostname:     CommonHostname,
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CommonHostname,
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "192.168.111.28",
+						},
+					},
+				},
+			},
+			csrs:            serverCsrs(),
+			approveExpected: false,
+			expectedStatus:  models.HostStatusAddedToExistingCluster,
+			expectedStage:   models.HostStageDone,
+			clusterInstall:  newAciNoUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
+		},
+		{
+			name:         "Auto approve CSR for Not ready matching node and UserManagedNetworking is true",
 			createClient: true,
 			hostname:     CommonHostname,
 			node: &corev1.Node{
@@ -1661,6 +1730,41 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
+		},
+		{
+			name:         "Auto approve CSR for Not ready matching node and UserManagedNetworking is false for SNO cluster",
+			createClient: true,
+			hostname:     CommonHostname,
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: CommonHostname,
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+					Addresses: []corev1.NodeAddress{
+						{
+							Type:    corev1.NodeInternalIP,
+							Address: "192.168.111.28",
+						},
+					},
+				},
+			},
+			csrs:            serverCsrs(),
+			approveExpected: true,
+			expectedResult: ctrl.Result{
+				RequeueAfter: time.Minute,
+			},
+			expectedStatus: models.HostStatusAddedToExistingCluster,
+			expectedStage:  models.HostStageRebooting,
+
+			clusterInstall: newAciNoUserManagedNetworkingWithSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:            "Get node error",
@@ -1673,6 +1777,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:            "Node not found with server CSR",
@@ -1686,6 +1791,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:         "Not done Server CSR",
@@ -1712,6 +1818,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:         "Done Server CSR",
@@ -1741,6 +1848,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult:  ctrl.Result{},
 			expectedStatus:  models.HostStatusAddedToExistingCluster,
 			expectedStage:   models.HostStageDone,
+			clusterInstall:  newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:            "Not approved client CSR",
@@ -1754,6 +1862,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:            "Approved client CSR",
@@ -1767,6 +1876,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:         "Approved Server CSR",
@@ -1793,6 +1903,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageRebooting,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 		{
 			name:           "Already done",
@@ -1801,12 +1912,16 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{},
 			expectedStatus: models.HostStatusAddedToExistingCluster,
 			expectedStage:  models.HostStageDone,
+			clusterInstall: newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 		},
 	}
 
 	for i := range tests {
 		t := &tests[i]
 		It(t.name, func() {
+
+			Expect(c.Create(ctx, t.clusterInstall)).To(BeNil())
+
 			agentSpec := v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace}}
 			if t.hostname != "" {
 				agentSpec.Hostname = t.hostname
@@ -1835,6 +1950,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			result, err := hr.Reconcile(ctx, hostRequest)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(t.expectedResult))
+
 			agent := &v1beta1.Agent{}
 			Expect(c.Get(ctx, agentKey, agent)).To(BeNil())
 			Expect(agent.Status.DebugInfo.State).To(Equal(t.expectedStatus))

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -342,7 +342,7 @@ func isNonePlatformCluster(ctx context.Context, client client.Client, cd *hivev1
 	if err = client.Get(ctx, namespacedName, &clusterInstall); err != nil {
 		return false, !k8serrors.IsNotFound(err), errors.Wrapf(err, "Could not get AgentClusterInstall %s for ClusterDeployment %s", cd.Spec.ClusterInstallRef.Name, cd.Name)
 	}
-	return clusterInstall.Spec.Networking.UserManagedNetworking, false, nil
+	return isUserManagedNetwork(&clusterInstall), false, nil
 }
 
 //


### PR DESCRIPTION
Presently when using ZTP, if you have a single node and wish to approve
day2 CSRs, this is not possible because the AgentClusterInstall CR does
not have UserManagedNetworking set and we are unable to determine the
state of this for SNO. Therefore we will need to check based on the
number of control plane nodes requested.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @filanov 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
