### PR TITLE
MGMT-9379: Add notApplicable option to the high-availability-mode enum.

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -52,7 +52,7 @@ type ClusterCreateParams struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Enum: [Full None]
+	// Enum: [Full None NotApplicable]
 	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// A proxy URL to use for creating HTTP connections outside the cluster.
@@ -303,7 +303,7 @@ var clusterCreateParamsTypeHighAvailabilityModePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["Full","None"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Full","None","NotApplicable"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -318,6 +318,9 @@ const (
 
 	// ClusterCreateParamsHighAvailabilityModeNone captures enum value "None"
 	ClusterCreateParamsHighAvailabilityModeNone string = "None"
+
+	// ClusterCreateParamsHighAvailabilityModeNotApplicable captures enum value "NotApplicable"
+	ClusterCreateParamsHighAvailabilityModeNotApplicable string = "NotApplicable"
 )
 
 // prop value enum

--- a/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -44,8 +44,9 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
+	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
+	HighAvailabilityMode *string `json:"high_availability_mode"`
 
 	// Host id
 	// Required: true
@@ -205,8 +206,9 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-	if swag.IsZero(m.HighAvailabilityMode) { // not required
-		return nil
+
+	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
+		return err
 	}
 
 	// value enum

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -52,7 +52,7 @@ type ClusterCreateParams struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Enum: [Full None]
+	// Enum: [Full None NotApplicable]
 	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// A proxy URL to use for creating HTTP connections outside the cluster.
@@ -303,7 +303,7 @@ var clusterCreateParamsTypeHighAvailabilityModePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["Full","None"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Full","None","NotApplicable"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -318,6 +318,9 @@ const (
 
 	// ClusterCreateParamsHighAvailabilityModeNone captures enum value "None"
 	ClusterCreateParamsHighAvailabilityModeNone string = "None"
+
+	// ClusterCreateParamsHighAvailabilityModeNotApplicable captures enum value "NotApplicable"
+	ClusterCreateParamsHighAvailabilityModeNotApplicable string = "NotApplicable"
 )
 
 // prop value enum

--- a/models/install_cmd_request.go
+++ b/models/install_cmd_request.go
@@ -44,8 +44,9 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
+	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
+	HighAvailabilityMode *string `json:"high_availability_mode"`
 
 	// Host id
 	// Required: true
@@ -205,8 +206,9 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-	if swag.IsZero(m.HighAvailabilityMode) { // not required
-		return nil
+
+	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
+		return err
 	}
 
 	// value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5668,7 +5668,8 @@ func init() {
           "default": "Full",
           "enum": [
             "Full",
-            "None"
+            "None",
+            "NotApplicable"
           ]
         },
         "http_proxy": {
@@ -7643,7 +7644,8 @@ func init() {
         "role",
         "boot_device",
         "controller_image",
-        "installer_image"
+        "installer_image",
+        "high_availability_mode"
       ],
       "properties": {
         "boot_device": {
@@ -14855,7 +14857,8 @@ func init() {
           "default": "Full",
           "enum": [
             "Full",
-            "None"
+            "None",
+            "NotApplicable"
           ]
         },
         "http_proxy": {
@@ -16762,7 +16765,8 @@ func init() {
         "role",
         "boot_device",
         "controller_image",
-        "installer_image"
+        "installer_image",
+        "high_availability_mode"
       ],
       "properties": {
         "boot_device": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4180,7 +4180,7 @@ definitions:
         description: Name of the OpenShift cluster.
       high_availability_mode:
         type: string
-        enum: ['Full', 'None']
+        enum: ['Full', 'None', 'NotApplicable']
         default: 'Full'
         description: |
           Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
@@ -5722,6 +5722,7 @@ definitions:
       - boot_device
       - controller_image
       - installer_image
+      - high_availability_mode
     properties:
       cluster_id:
         type: string

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -52,7 +52,7 @@ type ClusterCreateParams struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
-	// Enum: [Full None]
+	// Enum: [Full None NotApplicable]
 	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
 
 	// A proxy URL to use for creating HTTP connections outside the cluster.
@@ -303,7 +303,7 @@ var clusterCreateParamsTypeHighAvailabilityModePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["Full","None"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Full","None","NotApplicable"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -318,6 +318,9 @@ const (
 
 	// ClusterCreateParamsHighAvailabilityModeNone captures enum value "None"
 	ClusterCreateParamsHighAvailabilityModeNone string = "None"
+
+	// ClusterCreateParamsHighAvailabilityModeNotApplicable captures enum value "NotApplicable"
+	ClusterCreateParamsHighAvailabilityModeNotApplicable string = "NotApplicable"
 )
 
 // prop value enum

--- a/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -44,8 +44,9 @@ type InstallCmdRequest struct {
 	// Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster
 	// over multiple master nodes whereas 'None' installs a full cluster over one node.
 	//
+	// Required: true
 	// Enum: [Full None]
-	HighAvailabilityMode *string `json:"high_availability_mode,omitempty"`
+	HighAvailabilityMode *string `json:"high_availability_mode"`
 
 	// Host id
 	// Required: true
@@ -205,8 +206,9 @@ func (m *InstallCmdRequest) validateHighAvailabilityModeEnum(path, location stri
 }
 
 func (m *InstallCmdRequest) validateHighAvailabilityMode(formats strfmt.Registry) error {
-	if swag.IsZero(m.HighAvailabilityMode) { // not required
-		return nil
+
+	if err := validate.Required("high_availability_mode", "body", m.HighAvailabilityMode); err != nil {
+		return err
 	}
 
 	// value enum


### PR DESCRIPTION
A recent change made the high-availability-mode non mandatory for some
scenarios, this change reverts that and introduces a "NotApplicable"
entry to the enum so that in scerarios where HA mode is not relevant, we
can use this instead.

This is to support the addition of Day2 workers, nodes that are in the
role of worker should not consider high-availability-mode relevant and
this provides a means by which we can specify this.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @nmagnezi 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
