### PR TITLE
NO-ISSUE: add 'generate-bundle' to the 'generate' target

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -56,4 +56,4 @@ generate-vendor:
 	cd api && go mod vendor
 	cd models && go mod vendor
 
-generate: generate-vendor generate-from-swagger generate-events generate-mocks generate-configuration
+generate: generate-vendor generate-from-swagger generate-events generate-mocks generate-configuration generate-bundle


### PR DESCRIPTION
After viewing openshift/assisted-service#3830, it seems like we don't have the ``generate-bundle`` makefile target called when we're doing ``generate``. It means OCP bumps PRs (both manual and automatic) might
include non-intended changes.

This change aims to include ``generate-bundle``, to handle code-generation verification right when developer introduced changes in the bundles.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
