### PR TITLE
AGENT-40: Supply TLS certs for kubeconfig to openshift-install

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -146,6 +146,9 @@ var Options struct {
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
 	AllowConvergedFlow             bool          `envconfig:"ALLOW_COVERGED_FLOW" default:"true"`
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
+
+	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
+	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`
 }
 
 func InitLogs() *logrus.Entry {
@@ -380,7 +383,7 @@ func main() {
 	failOnError(err, "failed to create valid bm config S3 endpoint URL from %s", Options.BMConfig.S3EndpointURL)
 	Options.BMConfig.S3EndpointURL = newUrl
 
-	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, operatorsManager, providerRegistry)
+	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, operatorsManager, providerRegistry, Options.ClusterTLSCertOverrideDir)
 	var crdUtils bminventory.CRDUtils
 	if ctrlMgr != nil {
 		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient(), hostApi)

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -495,6 +495,9 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 		"OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="+g.releaseImage,
 		"OPENSHIFT_INSTALL_INVOKER="+g.installInvoker,
 	)
+	if g.clusterTLSCertOverrideDir != "" {
+		envVars = append(envVars, "OPENSHIFT_INSTALL_LOAD_CLUSTER_CERTS=true")
+	}
 
 	// write installConfig to install-config.yaml so openshift-install can read it
 	err = ioutil.WriteFile(installConfigPath, installConfig, 0600)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -36,22 +36,24 @@ type Config struct {
 
 type installGenerator struct {
 	Config
-	log              logrus.FieldLogger
-	s3Client         s3wrapper.API
-	operatorsApi     operators.API
-	workDir          string
-	providerRegistry registry.ProviderRegistry
+	log                       logrus.FieldLogger
+	s3Client                  s3wrapper.API
+	operatorsApi              operators.API
+	workDir                   string
+	providerRegistry          registry.ProviderRegistry
+	clusterTLSCertOverrideDir string
 }
 
 func New(log logrus.FieldLogger, s3Client s3wrapper.API, cfg Config, workDir string,
-	operatorsApi operators.API, providerRegistry registry.ProviderRegistry) *installGenerator {
+	operatorsApi operators.API, providerRegistry registry.ProviderRegistry, clusterTLSCertOverrideDir string) *installGenerator {
 	return &installGenerator{
-		Config:           cfg,
-		log:              log,
-		s3Client:         s3Client,
-		operatorsApi:     operatorsApi,
-		workDir:          filepath.Join(workDir, "install-config-generate"),
-		providerRegistry: providerRegistry,
+		Config:                    cfg,
+		log:                       log,
+		s3Client:                  s3Client,
+		operatorsApi:              operatorsApi,
+		workDir:                   filepath.Join(workDir, "install-config-generate"),
+		providerRegistry:          providerRegistry,
+		clusterTLSCertOverrideDir: clusterTLSCertOverrideDir,
 	}
 }
 
@@ -96,7 +98,7 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 		generator = ignition.NewDummyGenerator(clusterWorkDir, &cluster, k.s3Client, log)
 	} else {
 		generator = ignition.NewGenerator(clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror,
-			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi, k.providerRegistry, installerReleaseImageOverride)
+			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi, k.providerRegistry, installerReleaseImageOverride, k.clusterTLSCertOverrideDir)
 	}
 	err = generator.Generate(ctx, cfg, k.getClusterPlatformType(cluster))
 	if err != nil {


### PR DESCRIPTION
Allow the ephemeral installer to supply the TLS certificates needed to generate the kubeconfig. Copy these certs to the installer work dir. This enables the ephemeral installer to pre-generate a kubeconfig alongside the ISO and later have it accepted by the cluster.

Enhancement proposal: openshift/enhancements#1125

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [X] Ephemeral installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @mhrivnak 
/cc @avishayt 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
