### PR TITLE
Bug-2084410: Deploying OCP 4.8 on RHCOS with assisted-installer Failing validation blocks deployment with Insufficient error message

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -160,12 +160,23 @@ var TestIPv4Networking = TestNetworking{
 	IngressVip:      "1.2.3.6",
 }
 
+// TestIPv6Networking The values of TestIPv6Networking and TestEquivalentIPv6Networking are not equal, but are equivalent
+// in terms of their values. If any of the values in TestIPv6Networking change, please change also the corresponding
+// values in TestEquivalentIPv6Networking
 var TestIPv6Networking = TestNetworking{
 	ClusterNetworks: []*models.ClusterNetwork{{Cidr: "1003:db8::/53", HostPrefix: 64}},
 	ServiceNetworks: []*models.ServiceNetwork{{Cidr: "1002:db8::/119"}},
 	MachineNetworks: []*models.MachineNetwork{{Cidr: "1001:db8::/120"}},
 	APIVip:          "1001:db8::64",
 	IngressVip:      "1001:db8::65",
+}
+
+var TestEquivalentIPv6Networking = TestNetworking{
+	ClusterNetworks: []*models.ClusterNetwork{{Cidr: "1003:0db8:0::/53", HostPrefix: 64}},
+	ServiceNetworks: []*models.ServiceNetwork{{Cidr: "1002:0db8:0::/119"}},
+	MachineNetworks: []*models.MachineNetwork{{Cidr: "1001:0db8:0::/120"}},
+	APIVip:          "1001:0db8:0::64",
+	IngressVip:      "1001:0db8:0::65",
 }
 
 var TestDualStackNetworking = TestNetworking{

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -2337,6 +2337,7 @@ var _ = Describe("Refresh Host", func() {
 			machineNetworks       []*models.MachineNetwork
 			serviceNetworks       []*models.ServiceNetwork
 			connectivity          string
+			addL3Connectivity     bool
 			userManagedNetworking bool
 			isDay2                bool
 
@@ -2344,6 +2345,8 @@ var _ = Describe("Refresh Host", func() {
 			operators          []*models.MonitoredOperator
 			hostRequirements   *models.ClusterHostRequirementsDetails
 			disksInfo          string
+
+			machineNetworksForGroups []*models.MachineNetwork
 		}{
 			{
 				name:              "discovering to disconnected",
@@ -3355,6 +3358,125 @@ var _ = Describe("Refresh Host", func() {
 				errorExpected: false,
 			},
 			{
+				name:                     "pending to known IPv6 - equivalent machine networks",
+				validCheckInTime:         true,
+				srcState:                 models.HostStatusPendingForInput,
+				dstState:                 models.HostStatusKnown,
+				machineNetworks:          common.TestIPv6Networking.MachineNetworks,
+				machineNetworksForGroups: common.TestEquivalentIPv6Networking.MachineNetworks,
+				ntpSources:               defaultNTPSources,
+				imageStatuses:            map[string]*models.ContainerImageAvailability{common.TestDefaultConfig.ImageName: common.TestImageStatusesSuccess},
+				role:                     models.HostRoleWorker,
+				statusInfoChecker:        makeValueChecker(statusInfoKnown),
+				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
+					IsConnected:          {status: ValidationSuccess, messagePattern: "Host is connected"},
+					HasInventory:         {status: ValidationSuccess, messagePattern: "Valid inventory exists for the host"},
+					HasMinCPUCores:       {status: ValidationSuccess, messagePattern: "Sufficient CPU cores"},
+					HasMinMemory:         {status: ValidationSuccess, messagePattern: "Sufficient minimum RAM"},
+					HasMinValidDisks:     {status: ValidationSuccess, messagePattern: "Sufficient disk capacity"},
+					IsMachineCidrDefined: {status: ValidationSuccess, messagePattern: "Machine Network CIDR is defined"},
+					HasCPUCoresForRole:   {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:     {status: ValidationSuccess, messagePattern: "Sufficient RAM for role worker"},
+					IsHostnameUnique:     {status: ValidationSuccess, messagePattern: " is unique in cluster"},
+					BelongsToMachineCidr: {status: ValidationSuccess, messagePattern: "Host belongs to all machine network CIDRs"},
+					IsHostnameValid:      {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
+					IsNTPSynced:          {status: ValidationSuccess, messagePattern: "Host NTP is synced"},
+					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
+				}),
+				inventory:     hostutil.GenerateMasterInventoryV6(),
+				errorExpected: false,
+			},
+			{
+				name:                     "pending to known IPv6 - equivalent machine networks with L3 connectivity",
+				validCheckInTime:         true,
+				srcState:                 models.HostStatusPendingForInput,
+				dstState:                 models.HostStatusKnown,
+				machineNetworks:          common.TestIPv6Networking.MachineNetworks,
+				machineNetworksForGroups: common.TestEquivalentIPv6Networking.MachineNetworks,
+				ntpSources:               defaultNTPSources,
+				imageStatuses:            map[string]*models.ContainerImageAvailability{common.TestDefaultConfig.ImageName: common.TestImageStatusesSuccess},
+				role:                     models.HostRoleWorker,
+				statusInfoChecker:        makeValueChecker(statusInfoKnown),
+				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
+					IsConnected:          {status: ValidationSuccess, messagePattern: "Host is connected"},
+					HasInventory:         {status: ValidationSuccess, messagePattern: "Valid inventory exists for the host"},
+					HasMinCPUCores:       {status: ValidationSuccess, messagePattern: "Sufficient CPU cores"},
+					HasMinMemory:         {status: ValidationSuccess, messagePattern: "Sufficient minimum RAM"},
+					HasMinValidDisks:     {status: ValidationSuccess, messagePattern: "Sufficient disk capacity"},
+					IsMachineCidrDefined: {status: ValidationSuccess, messagePattern: "Machine Network CIDR is defined"},
+					HasCPUCoresForRole:   {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:     {status: ValidationSuccess, messagePattern: "Sufficient RAM for role worker"},
+					IsHostnameUnique:     {status: ValidationSuccess, messagePattern: " is unique in cluster"},
+					BelongsToMachineCidr: {status: ValidationSuccess, messagePattern: "Host belongs to all machine network CIDRs"},
+					IsHostnameValid:      {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
+					IsNTPSynced:          {status: ValidationSuccess, messagePattern: "Host NTP is synced"},
+					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
+				}),
+				inventory:         hostutil.GenerateMasterInventoryV6(),
+				errorExpected:     false,
+				addL3Connectivity: true,
+			},
+			{
+				name:                     "pending to insufficient IPv6 - IPv4 connectivity groups",
+				validCheckInTime:         true,
+				srcState:                 models.HostStatusPendingForInput,
+				dstState:                 models.HostStatusInsufficient,
+				machineNetworks:          common.TestIPv6Networking.MachineNetworks,
+				machineNetworksForGroups: common.TestIPv4Networking.MachineNetworks,
+				ntpSources:               defaultNTPSources,
+				imageStatuses:            map[string]*models.ContainerImageAvailability{common.TestDefaultConfig.ImageName: common.TestImageStatusesSuccess},
+				role:                     models.HostRoleWorker,
+				statusInfoChecker:        makeRegexChecker("Host cannot be installed due to following failing validation"),
+				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
+					IsConnected:            {status: ValidationSuccess, messagePattern: "Host is connected"},
+					HasInventory:           {status: ValidationSuccess, messagePattern: "Valid inventory exists for the host"},
+					HasMinCPUCores:         {status: ValidationSuccess, messagePattern: "Sufficient CPU cores"},
+					HasMinMemory:           {status: ValidationSuccess, messagePattern: "Sufficient minimum RAM"},
+					HasMinValidDisks:       {status: ValidationSuccess, messagePattern: "Sufficient disk capacity"},
+					IsMachineCidrDefined:   {status: ValidationSuccess, messagePattern: "Machine Network CIDR is defined"},
+					HasCPUCoresForRole:     {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:       {status: ValidationSuccess, messagePattern: "Sufficient RAM for role worker"},
+					IsHostnameUnique:       {status: ValidationSuccess, messagePattern: " is unique in cluster"},
+					BelongsToMachineCidr:   {status: ValidationSuccess, messagePattern: "Host belongs to all machine network CIDRs"},
+					BelongsToMajorityGroup: {status: ValidationPending, messagePattern: "Not enough hosts in cluster to calculate connectivity groups"},
+					IsHostnameValid:        {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
+					IsNTPSynced:            {status: ValidationSuccess, messagePattern: "Host NTP is synced"},
+					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
+				}),
+				inventory:     hostutil.GenerateMasterInventoryV6(),
+				errorExpected: false,
+			},
+			{
+				name:              "pending to known IPv6 - with L3 connectivity key",
+				validCheckInTime:  true,
+				srcState:          models.HostStatusPendingForInput,
+				dstState:          models.HostStatusInsufficient,
+				machineNetworks:   common.TestIPv6Networking.MachineNetworks,
+				ntpSources:        defaultNTPSources,
+				imageStatuses:     map[string]*models.ContainerImageAvailability{common.TestDefaultConfig.ImageName: common.TestImageStatusesSuccess},
+				role:              models.HostRoleWorker,
+				statusInfoChecker: makeRegexChecker("Host cannot be installed due to following failing validation"),
+				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
+					IsConnected:            {status: ValidationSuccess, messagePattern: "Host is connected"},
+					HasInventory:           {status: ValidationSuccess, messagePattern: "Valid inventory exists for the host"},
+					HasMinCPUCores:         {status: ValidationSuccess, messagePattern: "Sufficient CPU cores"},
+					HasMinMemory:           {status: ValidationSuccess, messagePattern: "Sufficient minimum RAM"},
+					HasMinValidDisks:       {status: ValidationSuccess, messagePattern: "Sufficient disk capacity"},
+					IsMachineCidrDefined:   {status: ValidationSuccess, messagePattern: "Machine Network CIDR is defined"},
+					HasCPUCoresForRole:     {status: ValidationSuccess, messagePattern: "Sufficient CPU cores for role worker"},
+					HasMemoryForRole:       {status: ValidationSuccess, messagePattern: "Sufficient RAM for role worker"},
+					IsHostnameUnique:       {status: ValidationSuccess, messagePattern: " is unique in cluster"},
+					BelongsToMachineCidr:   {status: ValidationSuccess, messagePattern: "Host belongs to all machine network CIDRs"},
+					BelongsToMajorityGroup: {status: ValidationPending, messagePattern: "Not enough hosts in cluster to calculate connectivity groups"},
+					IsHostnameValid:        {status: ValidationSuccess, messagePattern: "Hostname .* is allowed"},
+					IsNTPSynced:            {status: ValidationSuccess, messagePattern: "Host NTP is synced"},
+					SucessfullOrUnknownContainerImagesAvailability: {status: ValidationSuccess, messagePattern: "All required container images were either pulled successfully or no attempt was made to pull them"},
+				}),
+				inventory:     hostutil.GenerateMasterInventoryV6(),
+				errorExpected: false,
+				connectivity:  fmt.Sprintf("{\"%s\":[]}", network.IPv4.String()),
+			},
+			{
 				name:              "known to known",
 				validCheckInTime:  true,
 				srcState:          models.HostStatusKnown,
@@ -3743,10 +3865,17 @@ var _ = Describe("Refresh Host", func() {
 					if t.userManagedNetworking {
 						cluster.ConnectivityMajorityGroups = fmt.Sprintf("{\"%s\":[\"%s\"]}", network.IPv4.String(), hostId.String())
 					} else {
-						cluster.ConnectivityMajorityGroups = generateMajorityGroup(t.machineNetworks, hostId)
+						machineNetworks := t.machineNetworks
+						if t.machineNetworksForGroups != nil {
+							machineNetworks = t.machineNetworksForGroups
+						}
+						cluster.ConnectivityMajorityGroups = generateMajorityGroup(machineNetworks, hostId)
 					}
 				} else {
 					cluster.ConnectivityMajorityGroups = t.connectivity
+				}
+				if t.addL3Connectivity {
+					cluster.ConnectivityMajorityGroups = addL3Connectivity(cluster.ConnectivityMajorityGroups, hostId)
 				}
 
 				cluster.MonitoredOperators = t.operators
@@ -5328,6 +5457,17 @@ func generateMajorityGroup(machineNetworks []*models.MachineNetwork, hostId strf
 	if err != nil {
 		return ""
 	}
+	return string(tmp)
+}
+
+func addL3Connectivity(majorityGroupsStr string, hostId strfmt.UUID) string {
+	majorityGroups := make(map[string][]string)
+	if majorityGroupsStr != "" {
+		Expect(json.Unmarshal([]byte(majorityGroupsStr), &majorityGroups)).ToNot(HaveOccurred())
+	}
+	majorityGroups[network.IPv4.String()] = []string{hostId.String()}
+	tmp, err := json.Marshal(majorityGroups)
+	Expect(err).ToNot(HaveOccurred())
 	return string(tmp)
 }
 

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -774,12 +775,37 @@ func (v *validator) belongsToL2MajorityGroup(c *validationContext, majorityGroup
 
 	// TODO(mko) This rule should be revised as soon as OCP supports multiple machineNetwork
 	//           entries using the same IP stack.
-	ret := true
-	for _, machineNet := range c.cluster.MachineNetworks {
-		ret = ret && funk.Contains(majorityGroups[string(machineNet.Cidr)], *c.host.ID)
+	areNetworksEqual := func(ipnet1, ipnet2 *net.IPNet) bool {
+		return ipnet1.IP.Equal(ipnet2.IP) && bytes.Equal(ipnet1.Mask, ipnet2.Mask)
 	}
 
-	return boolValue(ret)
+	groupForNetwork := func(ipnet *net.IPNet) []strfmt.UUID {
+		for key, groups := range majorityGroups {
+			_, groupIpnet, err := net.ParseCIDR(key)
+
+			// majority groups may contain keys other than CIDRS (For instance IPv4 for L3).  Therefore, in case of
+			// parse error we can skip safely
+			if err != nil {
+				continue
+			}
+			if areNetworksEqual(ipnet, groupIpnet) {
+				return groups
+			}
+		}
+		return nil
+	}
+
+	for _, machineNet := range c.cluster.MachineNetworks {
+		_, machineIpnet, err := net.ParseCIDR(string(machineNet.Cidr))
+		if err != nil {
+			return ValidationError
+		}
+		if !funk.Contains(groupForNetwork(machineIpnet), *c.host.ID) {
+			return ValidationFailure
+		}
+	}
+
+	return ValidationSuccess
 }
 
 func (v *validator) belongsToL3MajorityGroup(c *validationContext, majorityGroups map[string][]strfmt.UUID) ValidationStatus {


### PR DESCRIPTION
When using single stack IPv6 or dual stack, and the machine networks
and connectivity groups contain unequal but equivalent values, then the
belongs-to-connectivity-group validations fails.
Ex: 1001:db8::/120 vs 1001:0db8:0::/120
Changed validation that it checks equivalence for machine-networks instead of
equality.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
