### PR TITLE
Bug 2089337: Fix the retry function to actually retry

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -180,14 +180,13 @@ function retry() {
     do
         echo "Attempt ${attempt}/${attempts} to execute \"$*\"..."
 
-        "$@"
-        rc=$?
-        if [[ ${rc} = 0 ]]
-        then
-            break
+        if "$@"; then
+            return 0
+        else
+            rc=$?
+            echo "Failed with exit code ${rc}, retrying \"$*\"..."
+            sleep "${interval}"
         fi
-
-        sleep "${interval}"
     done
 
     return ${rc}


### PR DESCRIPTION
The function didn't actually retry in the way it was
written, it just gave up after the first failure.

Not sure why exactly (it didn't seem to be because of errexit),
but I've rewritten it in a different way and it now works.

Originally introduced in f45e1b54d6a6b8b91f7127fb0937e7d08e8a187a


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    - Made sure it retries properly
- [ ] No tests needed

## Assignees

/cc @adriengentil

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md