### PR TITLE
Revert "MGMT-9259: Enhance the schedulable masters feature (#2861)"

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -235,9 +235,6 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -122,9 +122,6 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,9 +111,6 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -265,6 +265,8 @@ func main() {
 	Options.InstructionConfig.CheckClusterVersion = Options.CheckClusterVersion
 	Options.OperatorsConfig.CheckClusterVersion = Options.CheckClusterVersion
 	Options.GeneratorConfig.ReleaseImageMirror = Options.ReleaseImageMirror
+	//Initialize Provider API
+	providerRegistry := registry.InitProviderRegistry(log.WithField("pkg", "provider"))
 	// Make sure that prepare for installation timeout is more than the timeouts of all underlying tools + 2m extra
 	Options.ClusterConfig.PrepareConfig.PrepareForInstallationTimeout = maxDuration(Options.ClusterConfig.PrepareConfig.PrepareForInstallationTimeout,
 		maxDuration(Options.InstructionConfig.DiskCheckTimeout, Options.InstructionConfig.ImageAvailabilityTimeout)+2*time.Minute)
@@ -283,16 +285,13 @@ func main() {
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)
 	mirrorRegistriesBuilder := mirrorregistries.New()
 	ignitionBuilder := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder)
+	installConfigBuilder := installcfg.NewInstallConfigBuilder(log.WithField("pkg", "installcfg"), mirrorRegistriesBuilder, providerRegistry)
 
 	var objectHandler = createStorageClient(Options.DeployTarget, Options.Storage, &Options.S3Config,
 		Options.WorkDir, log, metricsManager, Options.FileSystemUsageThreshold)
 	createS3Bucket(objectHandler, log)
 
 	manifestsApi := manifests.NewManifestsAPI(db, log.WithField("pkg", "manifests"), objectHandler, usageManager)
-	//Initialize Provider API
-	providerRegistry := registry.NewProviderRegistry(manifestsApi)
-	providerRegistry.InitProviders(log.WithField("pkg", "provider"))
-	installConfigBuilder := installcfg.NewInstallConfigBuilder(log.WithField("pkg", "installcfg"), mirrorRegistriesBuilder, providerRegistry)
 	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler, extracterHandler)
 	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
@@ -359,7 +358,7 @@ func main() {
 	dnsApi := dns.NewDNSHandler(Options.BMConfig.BaseDNSDomains, log)
 	manifestsGenerator := network.NewManifestsGenerator(manifestsApi, Options.ManifestsGeneratorConfig)
 	clusterApi := cluster.NewManager(Options.ClusterConfig, log.WithField("pkg", "cluster-state"), db,
-		eventsHandler, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager, ocmClient, objectHandler, dnsApi, authHandler, providerRegistry)
+		eventsHandler, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager, ocmClient, objectHandler, dnsApi, authHandler)
 	infraEnvApi := infraenv.NewManager(log.WithField("pkg", "host-state"), db, objectHandler)
 
 	clusterStateMonitor := thread.New(

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -297,6 +297,9 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 	if params.NewClusterParams.Hyperthreading == nil {
 		params.NewClusterParams.Hyperthreading = swag.String(models.ClusterHyperthreadingAll)
 	}
+	if params.NewClusterParams.SchedulableMasters == nil {
+		params.NewClusterParams.SchedulableMasters = swag.Bool(false)
+	}
 	if params.NewClusterParams.Platform == nil {
 		params.NewClusterParams.Platform = &models.Platform{
 			Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
@@ -310,9 +313,6 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 			EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
 			Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 		}
-	}
-	if params.NewClusterParams.UseSchedulingDefaults == nil {
-		params.NewClusterParams.UseSchedulingDefaults = swag.Bool(true)
 	}
 
 	return params
@@ -467,7 +467,6 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 			HighAvailabilityMode:  params.NewClusterParams.HighAvailabilityMode,
 			Hyperthreading:        swag.StringValue(params.NewClusterParams.Hyperthreading),
 			SchedulableMasters:    params.NewClusterParams.SchedulableMasters,
-			UseSchedulingDefaults: params.NewClusterParams.UseSchedulingDefaults,
 			Platform:              params.NewClusterParams.Platform,
 			ClusterNetworks:       params.NewClusterParams.ClusterNetworks,
 			ServiceNetworks:       params.NewClusterParams.ServiceNetworks,
@@ -478,18 +477,6 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		KubeKeyName:             kubeKey.Name,
 		KubeKeyNamespace:        kubeKey.Namespace,
 		TriggerMonitorTimestamp: time.Now(),
-	}
-
-	if cluster.SchedulableMasters != nil {
-		cluster.UseSchedulingDefaults = swag.Bool(false)
-	}
-	if swag.BoolValue(cluster.UseSchedulingDefaults) {
-		var schedulableMasters bool
-		schedulableMasters, err = b.providerRegistry.GetActualSchedulableMasters(&cluster)
-		if err != nil {
-			return nil, common.NewApiError(http.StatusInternalServerError, err)
-		}
-		cluster.SchedulableMasters = swag.Bool(schedulableMasters)
 	}
 
 	pullSecret := swag.StringValue(params.NewClusterParams.PullSecret)
@@ -1954,28 +1941,10 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 			return common.NewApiError(http.StatusBadRequest, errors.Errorf(msg))
 		}
 	}
-
-	if params.ClusterUpdateParams.UseSchedulingDefaults != nil {
-		useSchedulingDefaults := swag.BoolValue(params.ClusterUpdateParams.UseSchedulingDefaults)
-		updates["use_scheduling_defaults"] = useSchedulingDefaults
-		if useSchedulingDefaults {
-			var schedulableMasters bool
-			schedulableMasters, err = b.providerRegistry.GetActualSchedulableMasters(cluster)
-			if err != nil {
-				msg := fmt.Sprintf("Can't update 'use_scheduling_defaults' to '%t' for cluster %s", useSchedulingDefaults, cluster.ID)
-				log.Error(msg)
-				return common.NewApiError(http.StatusInternalServerError, errors.Errorf(msg))
-			}
-			updates["schedulable_masters"] = schedulableMasters
-			b.setUsage(false, usage.SchedulableMasters, nil, usages)
-		}
-	}
-
 	if params.ClusterUpdateParams.SchedulableMasters != nil {
-		schedulableMasters := swag.BoolValue(params.ClusterUpdateParams.SchedulableMasters)
-		updates["schedulable_masters"] = schedulableMasters
-		updates["use_scheduling_defaults"] = false
-		b.setUsage(true, usage.SchedulableMasters, nil, usages)
+		value := swag.BoolValue(params.ClusterUpdateParams.SchedulableMasters)
+		updates["schedulable_masters"] = value
+		b.setUsage(value, usage.SchedulableMasters, nil, usages)
 	}
 
 	if params.ClusterUpdateParams.DiskEncryption != nil {
@@ -4668,38 +4637,12 @@ func (b *bareMetalInventory) BindHostInternal(ctx context.Context, params instal
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	if err = b.refreshSchedulableMasters(ctx, cluster); err != nil {
-		log.WithError(err).Errorf("Failed to refresh schedulable_masters while binding host <%s> to cluster <%s>",
-			params.HostID, *params.BindHostParams.ClusterID)
-		return nil, common.NewApiError(http.StatusInternalServerError, err)
-	}
-
 	host, err = common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())
 	if err != nil {
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
 	return host, nil
-}
-
-func (b *bareMetalInventory) refreshSchedulableMasters(ctx context.Context, cluster *common.Cluster) error {
-	if swag.BoolValue(cluster.UseSchedulingDefaults) {
-		schedulableMasters, err := b.providerRegistry.GetActualSchedulableMasters(cluster)
-		if err != nil {
-			return errors.Errorf("Failed get actual schedulable masters for cluster %s", cluster.ID)
-		}
-		clusterUpdateParams := installer.V2UpdateClusterParams{
-			ClusterID: *cluster.ID,
-			ClusterUpdateParams: &models.V2ClusterUpdateParams{
-				SchedulableMasters: swag.Bool(schedulableMasters),
-			},
-		}
-		_, err = b.UpdateClusterNonInteractive(ctx, clusterUpdateParams)
-		if err != nil {
-			return errors.Errorf("Failed to refresh schedulable_masters on cluster %s", cluster.ID)
-		}
-	}
-	return nil
 }
 
 func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params installer.UnbindHostParams) (*common.Host, error) {
@@ -4713,11 +4656,6 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 	}
 	if host.ClusterID == nil {
 		return nil, common.NewApiError(http.StatusConflict, errors.Errorf("Host %s is already unbound", params.HostID))
-	}
-
-	cluster, err := common.GetClusterFromDB(b.db, *host.ClusterID, common.SkipEagerLoading)
-	if err != nil {
-		return nil, common.NewApiError(http.StatusInternalServerError, errors.Errorf("Failed to find cluster %s", host.ClusterID))
 	}
 
 	infraEnv, err := common.GetInfraEnvFromDB(b.db, params.InfraEnvID)
@@ -4736,12 +4674,6 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 
 	if _, err = b.refreshClusterStatus(ctx, host.ClusterID, b.db); err != nil {
 		log.WithError(err).Warnf("Failed to refresh cluster after unbind of host <%s>", params.HostID)
-	}
-
-	if err = b.refreshSchedulableMasters(ctx, cluster); err != nil {
-		log.WithError(err).Errorf("Failed to refresh schedulable_masters while unbinding host <%s> from cluster <%s>",
-			params.HostID, *host.ClusterID)
-		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
 	host, err = common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -125,13 +125,11 @@ func mockClusterRegisterSteps() {
 	mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 	mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 }
 
 func mockClusterRegisterSuccess(withEvents bool) {
 	mockClusterRegisterSteps()
 	mockMetric.EXPECT().ClusterRegistered(common.TestDefaultConfig.ReleaseVersion, gomock.Any(), gomock.Any()).Times(1)
-	mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 
 	if withEvents {
 		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
@@ -2153,7 +2151,6 @@ var _ = Describe("cluster", func() {
 		Context("GetCluster", func() {
 			It("success", func() {
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3) // Number of hosts
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 				mockDurationsSuccess()
 				reply := bm.V2GetCluster(ctx, installer.V2GetClusterParams{
 					ClusterID: clusterID,
@@ -2277,7 +2274,6 @@ var _ = Describe("cluster", func() {
 			It("success", func() {
 				deleteCluster(false)
 				mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(3)
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 				resp := bm.V2GetCluster(ctx, installer.V2GetClusterParams{ClusterID: clusterID, GetUnregisteredClusters: swag.Bool(true)})
 				cluster := resp.(*installer.V2GetClusterOK).Payload
 				Expect(cluster.ID.String()).Should(Equal(clusterID.String()))
@@ -2315,7 +2311,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("happy flow", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2338,7 +2334,7 @@ var _ = Describe("cluster", func() {
 				eventstest.WithMessageContainsMatcher("Invalid OCP version (4.7) for Single node, Single node OpenShift is supported for version 4.8 and above"),
 				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7"
 			clusterParams := getDefaultClusterCreateParams()
@@ -2355,7 +2351,7 @@ var _ = Describe("cluster", func() {
 				eventstest.WithMessageContainsMatcher("Invalid OCP version (4.7.0-fc.1) for Single node, Single node OpenShift is supported for version 4.8 and above"),
 				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7.0-fc.1"
 			clusterParams := getDefaultClusterCreateParams()
@@ -2368,7 +2364,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2387,7 +2383,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is pre-release and greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2411,7 +2407,7 @@ var _ = Describe("cluster", func() {
 				eventstest.WithMessageContainsMatcher(errStr),
 				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams := getDefaultClusterCreateParams()
@@ -2429,7 +2425,7 @@ var _ = Describe("cluster", func() {
 				eventstest.WithMessageContainsMatcher("Failed to register cluster. Error: VIP DHCP Allocation cannot be enabled on single node OpenShift"),
 				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams := getDefaultClusterCreateParams()
@@ -2445,7 +2441,7 @@ var _ = Describe("cluster", func() {
 	})
 	It("create non ha cluster success, release version is ci-release and greater than minimal", func() {
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		mockClusterRegisterSuccess(true)
 		noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2531,7 +2527,7 @@ var _ = Describe("cluster", func() {
 
 		It("update cluster day1 with APIVipDNSName failed", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 
@@ -2588,7 +2584,7 @@ var _ = Describe("cluster", func() {
 			Context("V2 V2RegisterCluster", func() {
 				BeforeEach(func() {
 					bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-						db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+						db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 				})
 
 				It("OLM register default value - only builtins", func() {
@@ -4137,8 +4133,6 @@ var _ = Describe("cluster", func() {
 				eventstest.WithNameMatcher(eventgen.IgnitionConfigImageGeneratedEventName),
 				eventstest.WithClusterIdMatcher(clusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityInfo))).MinTimes(0)
-			mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
-			mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).AnyTimes()
 
 			reply := bm.V2InstallCluster(ctx, installer.V2InstallClusterParams{
 				ClusterID: clusterID,
@@ -4383,8 +4377,6 @@ var _ = Describe("cluster", func() {
 				eventstest.WithNameMatcher(eventgen.IgnitionConfigImageGeneratedEventName),
 				eventstest.WithClusterIdMatcher(clusterID.String()),
 				eventstest.WithSeverityMatcher(models.EventSeverityError))).MinTimes(0)
-			mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
-			mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).AnyTimes()
 
 			reply := bm.V2InstallCluster(ctx, installer.V2InstallClusterParams{
 				ClusterID: clusterID,
@@ -4645,7 +4637,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 
 		It("update cluster day1 with APIVipDNSName failed", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 
@@ -4956,98 +4948,23 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 		})
 
 		It("Update SchedulableMasters", func() {
+
 			clusterID = strfmt.UUID(uuid.New().String())
 			err := db.Create(&common.Cluster{Cluster: models.Cluster{
 				ID: &clusterID,
 			}}).Error
 			Expect(err).ShouldNot(HaveOccurred())
-			By("Enable scheduling", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockSuccess()
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						SchedulableMasters: swag.Bool(true),
-					},
-				})
-				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-				actual := reply.(*installer.V2UpdateClusterCreated)
-				Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
-				Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+			mockSuccess()
+			reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+				ClusterID: clusterID,
+				ClusterUpdateParams: &models.V2ClusterUpdateParams{
+					SchedulableMasters: swag.Bool(true),
+				},
 			})
-			By("Disable scheduling", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockSuccess()
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						SchedulableMasters: swag.Bool(false),
-					},
-				})
-				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-				actual := reply.(*installer.V2UpdateClusterCreated)
-				Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(false)))
-				Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
-			})
-			By("Reset to scheduling defaults", func() {
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Times(1)
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockSuccess()
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						UseSchedulingDefaults: swag.Bool(true),
-					},
-				})
-				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-				actual := reply.(*installer.V2UpdateClusterCreated)
-				Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(true)))
-				Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(false)))
-			})
-			By("Enable scheduling and reset to scheduling defaults", func() {
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Times(1)
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockSuccess()
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						UseSchedulingDefaults: swag.Bool(true),
-						SchedulableMasters:    swag.Bool(true),
-					},
-				})
-				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-				actual := reply.(*installer.V2UpdateClusterCreated)
-				Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
-				Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
-			})
-			By("Disable scheduling and reset to scheduling defaults", func() {
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Times(1)
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockSuccess()
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						UseSchedulingDefaults: swag.Bool(true),
-						SchedulableMasters:    swag.Bool(false),
-					},
-				})
-				Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-				actual := reply.(*installer.V2UpdateClusterCreated)
-				Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
-				Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(false)))
-			})
-			By("Error disable scheduling and reset to scheduling defaults", func() {
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Return(false, errors.Errorf("Dummy")).Times(1)
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
-					ClusterID: clusterID,
-					ClusterUpdateParams: &models.V2ClusterUpdateParams{
-						UseSchedulingDefaults: swag.Bool(true),
-						SchedulableMasters:    swag.Bool(false),
-					},
-				})
-				verifyApiError(reply, http.StatusInternalServerError)
-			})
+			Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+			actual := reply.(*installer.V2UpdateClusterCreated)
+			Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
 		})
 
 		Context("Update Proxy", func() {
@@ -8058,7 +7975,7 @@ var _ = Describe("V2UploadClusterIngressCert test", func() {
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			db, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:               &clusterID,
 			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
@@ -8254,7 +8171,6 @@ var _ = Describe("List clusters", func() {
 		It("success", func() {
 			Expect(db.Delete(&c).Error).ShouldNot(HaveOccurred())
 			Expect(db.Delete(&host1).Error).ShouldNot(HaveOccurred())
-			mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 			resp := bm.V2ListClusters(ctx, installer.V2ListClustersParams{GetUnregisteredClusters: swag.Bool(true)})
 			payload := resp.(*installer.V2ListClustersOK).Payload
 			Expect(len(payload)).Should(Equal(1))
@@ -8268,7 +8184,6 @@ var _ = Describe("List clusters", func() {
 		It("with hosts success", func() {
 			Expect(db.Delete(&c).Error).ShouldNot(HaveOccurred())
 			Expect(db.Delete(&host1).Error).ShouldNot(HaveOccurred())
-			mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 			resp := bm.V2ListClusters(ctx, installer.V2ListClustersParams{GetUnregisteredClusters: swag.Bool(true), WithHosts: true})
 			clusterList := resp.(*installer.V2ListClustersOK).Payload
 			Expect(len(clusterList)).Should(Equal(1))
@@ -8315,7 +8230,6 @@ var _ = Describe("List clusters", func() {
 			It(fmt.Sprintf("%s role", test.role), func() {
 				payload := &ocm.AuthPayload{Role: test.role}
 				authCtx := context.WithValue(ctx, restapi.AuthKey, payload)
-				mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 
 				By("searching for an existing openshift cluster ID", func() {
 					resp := bm.V2ListClusters(authCtx, installer.V2ListClustersParams{OpenshiftClusterID: openshiftClusterID})
@@ -8341,7 +8255,6 @@ var _ = Describe("List clusters", func() {
 	It("filters based on AMS subscription ID", func() {
 		payload := &ocm.AuthPayload{Role: ocm.UserRole}
 		authCtx := context.WithValue(ctx, restapi.AuthKey, payload)
-		mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 
 		By("searching for a single existing AMS subscription ID", func() {
 			resp := bm.V2ListClusters(authCtx, installer.V2ListClustersParams{AmsSubscriptionIds: []string{amsSubscriptionID.String()}})
@@ -9404,7 +9317,7 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
@@ -9941,7 +9854,6 @@ var _ = Describe("Transform day1 cluster to a day2 cluster test", func() {
 
 	It("successfully transform day1 cluster to a day2 cluster", func() {
 		mockClusterApi.EXPECT().TransformClusterToDay2(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
-		mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).AnyTimes()
 		_, err := bm.TransformClusterToDay2Internal(ctx, clusterID)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
@@ -9966,10 +9878,9 @@ var _ = Describe("TestRegisterCluster", func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db, dbName = common.PrepareTestDB()
 		Expect(cfg.DiskEncryptionSupport).Should(BeTrue())
-		mockOperators := operators.NewMockAPI(ctrl)
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -9988,20 +9899,19 @@ var _ = Describe("TestRegisterCluster", func() {
 		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
 	})
 
-	It("SchedulableMasters defaults success", func() {
-		mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Return(true, nil).Times(1)
+	It("SchedulableMasters default value", func() {
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
+
 		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
 			NewClusterParams: getDefaultClusterCreateParams(),
 		})
 		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
 		actual := reply.(*installer.V2RegisterClusterCreated)
-		Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(true)))
-		Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
+		Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(false)))
 	})
 
-	It("SchedulableMasters enabled success", func() {
+	It("SchedulableMasters non default value", func() {
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
 		clusterParams := getDefaultClusterCreateParams()
@@ -10011,44 +9921,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		})
 		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
 		actual := reply.(*installer.V2RegisterClusterCreated)
-		Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
 		Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
-	})
-
-	It("SchedulableMasters disabled success", func() {
-		mockClusterRegisterSuccess(true)
-		mockAMSSubscription(ctx)
-		clusterParams := getDefaultClusterCreateParams()
-		clusterParams.SchedulableMasters = swag.Bool(false)
-		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
-			NewClusterParams: clusterParams,
-		})
-		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
-		actual := reply.(*installer.V2RegisterClusterCreated)
-		Expect(actual.Payload.UseSchedulingDefaults).To(Equal(swag.Bool(false)))
-		Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(false)))
-	})
-
-	It("SchedulableMasters scheduling defaults error", func() {
-		releaseImage := &models.ReleaseImage{
-			CPUArchitecture:  common.TestDefaultConfig.ReleaseImage.CPUArchitecture,
-			OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
-			URL:              common.TestDefaultConfig.ReleaseImage.URL,
-			Version:          &common.TestDefaultConfig.ReleaseVersion,
-			SupportLevel:     models.OpenshiftVersionSupportLevelProduction,
-		}
-		mockVersions.EXPECT().GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, common.TestDefaultConfig.CPUArchitecture).Return(releaseImage, nil).Times(1)
-		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
-		mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Return(false, errors.Errorf("Dummy")).Times(1)
-		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
-			eventstest.WithMessageContainsMatcher("Dummy"),
-			eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
-		clusterParams := getDefaultClusterCreateParams()
-		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
-			NewClusterParams: clusterParams,
-		})
-		verifyApiError(reply, http.StatusInternalServerError)
 	})
 
 	It("UserManagedNetworking default value", func() {
@@ -10281,7 +10154,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			var c *models.Cluster
 			diskEncryptionBm := createInventory(db, cfg)
 			diskEncryptionBm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil)
 
 			By("Register cluster", func() {
 
@@ -10361,7 +10234,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			mockUsageReports()
 		})
 
@@ -10614,7 +10487,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			mockUsageReports()
 		})
 
@@ -10841,7 +10714,6 @@ var _ = Describe("TestRegisterCluster", func() {
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-		mockProviderRegistry.EXPECT().GetActualSchedulableMasters(gomock.Any()).Times(1)
 
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.PullSecret = swag.String("")
@@ -11036,7 +10908,7 @@ var _ = Describe("AMS subscriptions", func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -11106,7 +10978,7 @@ var _ = Describe("AMS subscriptions", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
 
@@ -11128,7 +11000,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name happy flow", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -11161,7 +11033,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name with same name", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -11191,7 +11063,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster without name field", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -11281,7 +11153,6 @@ var _ = Describe("AMS subscriptions", func() {
 					mockGetInstallConfigSuccess(mockInstallConfigBuilder)
 					mockGenerateInstallConfigSuccess(mockGenerator, mockVersions)
 					mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(ignitionReader, int64(0), nil).MinTimes(0)
-					mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).AnyTimes()
 					if test.status == "succeed" {
 						mockAccountsMgmt.EXPECT().UpdateSubscriptionOpenshiftClusterID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 						mockClusterApi.EXPECT().HandlePreInstallSuccess(gomock.Any(), gomock.Any()).Times(1).Do(func(ctx, c interface{}) { doneChannel <- 1 })
@@ -11303,7 +11174,7 @@ var _ = Describe("AMS subscriptions", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil)
+				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
 			bm.ocmClient = nil
 			mockClusterRegisterSuccess(true)
 
@@ -11340,7 +11211,7 @@ var _ = Describe("[V2UpdateCluster] AMS subscriptions", func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -11353,7 +11224,7 @@ var _ = Describe("[V2UpdateCluster] AMS subscriptions", func() {
 
 		It("update cluster name happy flow", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -11388,7 +11259,7 @@ var _ = Describe("[V2UpdateCluster] AMS subscriptions", func() {
 
 		It("update cluster name with same name", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -11420,7 +11291,7 @@ var _ = Describe("[V2UpdateCluster] AMS subscriptions", func() {
 
 		It("update cluster without name field", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -12317,9 +12188,7 @@ var _ = Describe("UnbindHost", func() {
 		hostID = strfmt.UUID(uuid.New().String())
 		infraEnvID = strfmt.UUID(uuid.New().String())
 		bm = createInventory(db, cfg)
-		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID, Kind: swag.String(models.ClusterKindCluster)}}).Error
-		Expect(err).ShouldNot(HaveOccurred())
-		err = db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID}}).Error
+		err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
 		err = db.Create(&common.Host{Host: models.Host{ID: &hostID, InfraEnvID: infraEnvID, ClusterID: &clusterID}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
@@ -12340,7 +12209,6 @@ var _ = Describe("UnbindHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any())
-		mockClusterApi.EXPECT().RefreshStatus(ctx, gomock.Any(), gomock.Any())
 		response := bm.UnbindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.UnbindHostOK{}))
 	})
@@ -13302,7 +13170,7 @@ var _ = Describe("Platform tests", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
 		bm.ocmClient = nil
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.Name = swag.String("cluster")

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
-	"github.com/openshift/assisted-service/internal/provider/registry"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/commonutils"
@@ -156,13 +155,12 @@ type Manager struct {
 	dnsApi                dns.DNSApi
 	monitorQueryGenerator *common.MonitorClusterQueryGenerator
 	authHandler           auth.Authenticator
-	providerRegistry      registry.ProviderRegistry
 }
 
 func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, eventsHandler eventsapi.Handler,
 	hostAPI host.API, metricApi metrics.API, manifestsGeneratorAPI network.ManifestsGeneratorAPI,
 	leaderElector leader.Leader, operatorsApi operators.API, ocmClient *ocm.Client, objectHandler s3wrapper.API,
-	dnsApi dns.DNSApi, authHandler auth.Authenticator, providerRegistry registry.ProviderRegistry) *Manager {
+	dnsApi dns.DNSApi, authHandler auth.Authenticator) *Manager {
 	th := &transitionHandler{
 		log:                 log,
 		db:                  db,
@@ -189,7 +187,6 @@ func NewManager(cfg Config, log logrus.FieldLogger, db *gorm.DB, eventsHandler e
 		objectHandler:         objectHandler,
 		dnsApi:                dnsApi,
 		authHandler:           authHandler,
-		providerRegistry:      providerRegistry,
 	}
 }
 
@@ -1264,9 +1261,13 @@ func (m *Manager) GenerateAdditionalManifests(ctx context.Context, cluster *comm
 	if err := m.manifestsGeneratorAPI.AddTelemeterManifest(ctx, log, cluster); err != nil {
 		return errors.Wrap(err, "failed to add telemeter manifest")
 	}
-	if err := m.providerRegistry.GenerateProviderManifests(ctx, cluster); err != nil {
-		return errors.Wrap(err, "failed to add provider manifests")
+
+	if common.AreMastersSchedulable(cluster) {
+		if err := m.manifestsGeneratorAPI.AddSchedulableMastersManifest(ctx, log, cluster); err != nil {
+			return errors.Wrap(err, "failed to add schedulable masters manifest")
+		}
 	}
+
 	if err := m.manifestsGeneratorAPI.AddDiskEncryptionManifest(ctx, log, cluster); err != nil {
 		return errors.Wrap(err, "failed to add disk encryption manifest")
 	}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/operators/api"
-	"github.com/openshift/assisted-service/internal/provider/registry"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/leader"
@@ -64,7 +63,7 @@ var _ = Describe("stateMachine", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators = operators.NewMockAPI(ctrl)
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, nil, nil, nil, nil, dummy, mockOperators, nil, mockS3Client, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, nil, nil, nil, nil, dummy, mockOperators, nil, mockS3Client, nil, nil)
 	})
 
 	Context("unknown_cluster_state", func() {
@@ -133,7 +132,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 		dummy := &leader.DummyElector{}
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, mockS3Client, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, mockS3Client, nil, nil)
 		expectedState = ""
 		shouldHaveUpdated = false
 
@@ -685,7 +684,7 @@ var _ = Describe("lease timeout event", func() {
 		mockOperators := operators.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil)
 
 		mockMetric.EXPECT().MonitoredClusterCount(int64(1)).AnyTimes()
 		mockMetric.EXPECT().Duration("ClusterMonitoring", gomock.Any()).AnyTimes()
@@ -797,7 +796,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 		mockOperators := operators.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil)
 
 		mockMetric.EXPECT().MonitoredClusterCount(int64(1)).AnyTimes()
 		mockMetric.EXPECT().Duration("ClusterMonitoring", gomock.Any()).AnyTimes()
@@ -1304,7 +1303,7 @@ var _ = Describe("VerifyRegisterHost", func() {
 		mockOperators := operators.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			nil, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			nil, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 	})
 
 	checkVerifyRegisterHost := func(clusterStatus string, expectErr bool, errTemplate string) {
@@ -1365,7 +1364,7 @@ var _ = Describe("VerifyClusterUpdatability", func() {
 		mockOperators := operators.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			nil, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			nil, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 	})
 
 	checkVerifyClusterUpdatability := func(clusterStatus string, expectErr bool) {
@@ -1419,7 +1418,7 @@ var _ = Describe("CancelInstallation", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockOperators := operators.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil)
 		id := strfmt.UUID(uuid.New().String())
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:         &id,
@@ -1495,7 +1494,7 @@ var _ = Describe("ResetCluster", func() {
 		dummy := &leader.DummyElector{}
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 	})
 
 	It("reset_cluster", func() {
@@ -1725,7 +1724,7 @@ var _ = Describe("PrepareForInstallation", func() {
 		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		mockOperators := operators.NewMockAPI(ctrl)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 
@@ -1822,7 +1821,7 @@ var _ = Describe("HandlePreInstallationChanges", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
 		mockEvents = eventsapi.NewMockHandler(ctrl)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 		cluster := &common.Cluster{Cluster: models.Cluster{ID: &clusterId, Status: swag.String(models.ClusterStatusPreparingForInstallation)}}
 		Expect(db.Create(cluster).Error).ShouldNot(HaveOccurred())
@@ -1894,7 +1893,7 @@ var _ = Describe("SetVipsData", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
 		mockOperators := operators.NewMockAPI(ctrl)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 	AfterEach(func() {
@@ -2074,7 +2073,7 @@ var _ = Describe("Majority groups", func() {
 		mockMetricApi = metrics.NewMockAPI(ctrl)
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, nil, mockMetricApi, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			mockEvents, nil, mockMetricApi, nil, dummy, mockOperators, nil, nil, nil, nil)
 		id = strfmt.UUID(uuid.New().String())
 		cluster = common.Cluster{Cluster: models.Cluster{
 			ID:              &id,
@@ -2177,7 +2176,7 @@ var _ = Describe("ready_state", func() {
 		dummy := &leader.DummyElector{}
 		mockOperators := operators.NewMockAPI(ctrl)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			mockEvents, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		id = strfmt.UUID(uuid.New().String())
 		cluster = common.Cluster{Cluster: models.Cluster{
 			ID:              &id,
@@ -2274,7 +2273,7 @@ var _ = Describe("insufficient_state", func() {
 		db, dbName = common.PrepareTestDB()
 		dummy := &leader.DummyElector{}
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 
 		id = strfmt.UUID(uuid.New().String())
 		cluster = common.Cluster{Cluster: models.Cluster{
@@ -2326,7 +2325,7 @@ var _ = Describe("prepare-for-installation refresh status", func() {
 		mockOperators = operators.NewMockAPI(ctrl)
 		mockOperators.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		dummy := &leader.DummyElector{}
-		capi = NewManager(cfg, common.GetTestLog(), db, mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		capi = NewManager(cfg, common.GetTestLog(), db, mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 		cl = common.Cluster{
 			Cluster: models.Cluster{
@@ -2406,7 +2405,7 @@ var _ = Describe("Cluster tarred files", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		dummy := &leader.DummyElector{}
 		mockOperators := operators.NewMockAPI(ctrl)
-		capi = NewManager(cfg, common.GetTestLog(), db, mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		capi = NewManager(cfg, common.GetTestLog(), db, mockEvents, mockHostAPI, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 		cl = common.Cluster{
 			Cluster: models.Cluster{
@@ -2507,17 +2506,16 @@ var _ = Describe("Cluster tarred files", func() {
 
 var _ = Describe("GenerateAdditionalManifests", func() {
 	var (
-		ctrl                 *gomock.Controller
-		ctx                  = context.Background()
-		db                   *gorm.DB
-		capi                 API
-		c                    common.Cluster
-		eventsHandler        eventsapi.Handler
-		mockMetric           *metrics.MockAPI
-		dbName               string
-		manifestsGenerator   *network.MockManifestsGeneratorAPI
-		mockOperatorMgr      *operators.MockAPI
-		mockProviderRegistry *registry.MockProviderRegistry
+		ctrl               *gomock.Controller
+		ctx                = context.Background()
+		db                 *gorm.DB
+		capi               API
+		c                  common.Cluster
+		eventsHandler      eventsapi.Handler
+		mockMetric         *metrics.MockAPI
+		dbName             string
+		manifestsGenerator *network.MockManifestsGeneratorAPI
+		mockOperatorMgr    *operators.MockAPI
 	)
 
 	BeforeEach(func() {
@@ -2528,9 +2526,8 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		eventsHandler = events.New(db, nil, logrus.New())
 		dummy := &leader.DummyElector{}
 		mockOperatorMgr = operators.NewMockAPI(ctrl)
-		mockProviderRegistry = registry.NewMockProviderRegistry(ctrl)
 		cfg := getDefaultConfig()
-		capi = NewManager(cfg, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, dummy, mockOperatorMgr, nil, nil, nil, nil, mockProviderRegistry)
+		capi = NewManager(cfg, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, dummy, mockOperatorMgr, nil, nil, nil, nil)
 		id := strfmt.UUID(uuid.New().String())
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:     &id,
@@ -2550,7 +2547,6 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		manifestsGenerator.EXPECT().IsSNODNSMasqEnabled().Return(true).Times(1)
 		manifestsGenerator.EXPECT().AddDnsmasqForSingleNode(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
-		mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
@@ -2569,11 +2565,10 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 
 	It("Single node manifests success with disabled dnsmasq", func() {
 		cfg2 := getDefaultConfig()
-		capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil, nil, mockProviderRegistry)
+		capi = NewManager(cfg2, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil, nil)
 		manifestsGenerator.EXPECT().AddChronyManifest(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().IsSNODNSMasqEnabled().Return(false).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
-		mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
@@ -2590,7 +2585,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 
 		BeforeEach(func() {
 			telemeterCfg = getDefaultConfig()
-			capi = NewManager(telemeterCfg, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil, nil, mockProviderRegistry)
+			capi = NewManager(telemeterCfg, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil, nil)
 		})
 
 		It("Happy flow", func() {
@@ -2598,7 +2593,6 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 			manifestsGenerator.EXPECT().AddChronyManifest(ctx, gomock.Any(), &c).Return(nil)
 			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
 			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
-			mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
 
 			err := capi.GenerateAdditionalManifests(ctx, &c)
@@ -2610,42 +2604,6 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 			manifestsGenerator.EXPECT().AddChronyManifest(ctx, gomock.Any(), &c).Return(nil)
 			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
 			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(errors.New("dummy"))
-
-			err := capi.GenerateAdditionalManifests(ctx, &c)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("GenerateProviderManifests", func() {
-
-		var (
-			cfg  Config
-			capi API
-		)
-
-		BeforeEach(func() {
-			cfg = getDefaultConfig()
-			capi = NewManager(cfg, common.GetTestLog(), db, eventsHandler, nil, mockMetric, manifestsGenerator, nil, mockOperatorMgr, nil, nil, nil, nil, mockProviderRegistry)
-		})
-
-		It("Happy flow", func() {
-
-			manifestsGenerator.EXPECT().AddChronyManifest(ctx, gomock.Any(), &c).Return(nil)
-			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
-			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
-			mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).Return(nil)
-			manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
-
-			err := capi.GenerateAdditionalManifests(ctx, &c)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		It("GenerateProviderManfests failed", func() {
-
-			manifestsGenerator.EXPECT().AddChronyManifest(ctx, gomock.Any(), &c).Return(nil)
-			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
-			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
-			mockProviderRegistry.EXPECT().GenerateProviderManifests(gomock.Any(), gomock.Any()).Return(errors.New("dummy"))
 
 			err := capi.GenerateAdditionalManifests(ctx, &c)
 			Expect(err).To(HaveOccurred())
@@ -2696,7 +2654,7 @@ var _ = Describe("Deregister inactive clusters", func() {
 		eventsHandler = events.New(db, nil, logrus.New())
 		dummy := &leader.DummyElector{}
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, mockS3Client, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, mockS3Client, nil, nil)
 		c = registerCluster()
 	})
 
@@ -2834,7 +2792,7 @@ var _ = Describe("Permanently delete clusters", func() {
 		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, nil, logrus.New())
 		dummy := &leader.DummyElector{}
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, dummy, mockOperators, nil, nil, nil, nil)
 		c1 = registerCluster()
 		c2 = registerCluster()
 		c3 = registerCluster()
@@ -2894,7 +2852,7 @@ var _ = Describe("Get cluster by Kube key", func() {
 		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, nil, logrus.New())
 		dummy := &leader.DummyElector{}
-		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil, nil)
+		state = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, dummy, mockOperators, nil, nil, nil, nil)
 		key = types.NamespacedName{
 			Namespace: kubeKeyNamespace,
 			Name:      kubeKeyName,
@@ -2942,7 +2900,7 @@ var _ = Describe("Transform day1 cluster to a day2 cluster", func() {
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
 		ctrl = gomock.NewController(GinkgoT())
-		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog(), db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog(), db, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 	})
 
@@ -3077,7 +3035,7 @@ var _ = Describe("Update AMS subscription ID", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		db, dbName = common.PrepareTestDB()
 		eventsHandler = events.New(db, nil, logrus.New())
-		api = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		api = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	AfterEach(func() {
@@ -3167,7 +3125,7 @@ var _ = Describe("Validation metrics and events", func() {
 		mockHost = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockS3Client = s3wrapper.NewMockAPI(ctrl)
-		m = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, mockHost, mockMetric, nil, nil, nil, nil, mockS3Client, nil, nil, nil)
+		m = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, mockHost, mockMetric, nil, nil, nil, nil, mockS3Client, nil, nil)
 		c = registerTestClusterWithValidationsAndHost()
 	})
 
@@ -3246,7 +3204,7 @@ var _ = Describe("Console-operator's availability", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		db, dbName = common.PrepareTestDB()
 		mockEvents = eventsapi.NewMockHandler(ctrl)
-		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	AfterEach(func() {

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Progress bar test", func() {
 		mockOperatorApi = operators.NewMockAPI(ctrl)
 		mockDnsApi = dns.NewMockDNSApi(ctrl)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil)
 	})
 
 	AfterEach(func() {

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Transition tests", func() {
 
 	Context("cancel_installation", func() {
 		BeforeEach(func() {
-			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 		})
 
 		It("cancel_installation", func() {
@@ -345,7 +345,7 @@ var _ = Describe("Transition tests", func() {
 				//duration measurements are always called (even in degraded or failed states)
 				mockMetric.EXPECT().ClusterInstallationFinished(gomock.Any(), models.ClusterStatusInstalled, models.ClusterStatusFinalizing, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
-				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil)
+				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, eventsHandler, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil)
 
 				// Test
 				clusterAfterRefresh, err := capi.RefreshStatus(ctx, &c, db)
@@ -394,7 +394,7 @@ var _ = Describe("Cancel cluster installation", func() {
 		mockEventsHandler = eventsapi.NewMockHandler(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 	})
 
 	acceptNewEvents := func(times int) {
@@ -468,7 +468,7 @@ var _ = Describe("Reset cluster", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = eventsapi.NewMockHandler(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, mockEventsHandler, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil)
 	})
 
 	acceptNewEvents := func(times int) {
@@ -634,7 +634,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1386,7 +1386,7 @@ var _ = Describe("Refresh Cluster - Same networks", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1646,7 +1646,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil)
 
 		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		hid1 = strfmt.UUID(uuid.New().String())
@@ -1872,7 +1872,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -2877,7 +2877,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3400,7 +3400,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3682,7 +3682,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					mockAccountsMgmt = ocm.NewMockOCMAccountsMgmt(ctrl)
 					ocmClient := &ocm.Client{AccountsMgmt: mockAccountsMgmt, Config: &ocm.Config{}}
 					clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-						mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil)
+						mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil)
 					if !t.requiresAMSUpdate {
 						cluster.IsAmsSubscriptionConsoleUrlSet = true
 					}
@@ -3784,7 +3784,7 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(logTimeoutConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 
@@ -3926,7 +3926,7 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -4226,7 +4226,7 @@ var _ = Describe("Single node", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil)
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
 		hid3 = strfmt.UUID(uuid.New().String())

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -111,6 +111,10 @@ func IsDay2Cluster(cluster *Cluster) bool {
 	return swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster
 }
 
+func AreMastersSchedulable(cluster *Cluster) bool {
+	return swag.BoolValue(cluster.SchedulableMasters)
+}
+
 func GetEffectiveRole(host *models.Host) models.HostRole {
 	if host.Role == models.HostRoleAutoAssign && host.SuggestedRole != "" {
 		return host.SuggestedRole

--- a/internal/operators/odf/validation_test.go
+++ b/internal/operators/odf/validation_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		var cfg clust.Config
 		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		clusterApi = clust.NewManager(cfg, common.GetTestLog().WithField("pkg", "cluster-monitor"), db,
-			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
+			mockEvents, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d")
 		hid2 = strfmt.UUID("514c8480-cda5-46e5-afce-e146def2066f")

--- a/internal/provider/baremetal/consts.go
+++ b/internal/provider/baremetal/consts.go
@@ -1,6 +1,1 @@
 package baremetal
-
-const (
-	// Minimal number of enabled hosts needed to install a cluster with workers
-	minimalEnabledHostCount = 5
-)

--- a/internal/provider/baremetal/inventory.go
+++ b/internal/provider/baremetal/inventory.go
@@ -1,9 +1,6 @@
 package baremetal
 
 import (
-	"errors"
-
-	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 )
@@ -14,19 +11,6 @@ func (p *baremetalProvider) SetPlatformValuesInDBUpdates(_ *models.Platform, _ m
 
 func (p *baremetalProvider) CleanPlatformValuesFromDBUpdates(_ map[string]interface{}) error {
 	return nil
-}
-
-func (p *baremetalProvider) GetActualSchedulableMasters(cluster *common.Cluster) (bool, error) {
-	if cluster == nil {
-		return false, errors.New("unexpected 'nil' cluster")
-	}
-	if cluster.SchedulableMasters != nil {
-		return *cluster.SchedulableMasters, nil
-	}
-	if cluster.EnabledHostCount < minimalEnabledHostCount {
-		return true, nil
-	}
-	return false, nil
 }
 
 func (p *baremetalProvider) SetPlatformUsages(

--- a/internal/provider/base.go
+++ b/internal/provider/base.go
@@ -33,6 +33,4 @@ type Provider interface {
 	PreCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error
 	// PostCreateManifestsHook allows the provider to perform additional tasks required after the cluster manifests are created
 	PostCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error
-	// GetActualSchedulableMasters allows the provider to set the default scheduling of workloads on masters' side
-	GetActualSchedulableMasters(cluster *common.Cluster) (bool, error)
 }

--- a/internal/provider/mock_base_provider.go
+++ b/internal/provider/mock_base_provider.go
@@ -80,21 +80,6 @@ func (mr *MockProviderMockRecorder) CleanPlatformValuesFromDBUpdates(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanPlatformValuesFromDBUpdates", reflect.TypeOf((*MockProvider)(nil).CleanPlatformValuesFromDBUpdates), arg0)
 }
 
-// GetActualSchedulableMasters mocks base method.
-func (m *MockProvider) GetActualSchedulableMasters(arg0 *common.Cluster) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActualSchedulableMasters", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActualSchedulableMasters indicates an expected call of GetActualSchedulableMasters.
-func (mr *MockProviderMockRecorder) GetActualSchedulableMasters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActualSchedulableMasters", reflect.TypeOf((*MockProvider)(nil).GetActualSchedulableMasters), arg0)
-}
-
 // IsHostSupported mocks base method.
 func (m *MockProvider) IsHostSupported(arg0 *models.Host) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/provider/ovirt/inventory.go
+++ b/internal/provider/ovirt/inventory.go
@@ -1,7 +1,6 @@
 package ovirt
 
 import (
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/internal/usage"
@@ -44,13 +43,6 @@ func (p *ovirtProvider) SetPlatformValuesInDBUpdates(
 	updates[DbFieldNetworkName] = platformParams.Ovirt.NetworkName
 	updates[DbFieldVnicProfileID] = platformParams.Ovirt.VnicProfileID
 	return nil
-}
-
-func (p *ovirtProvider) GetActualSchedulableMasters(cluster *common.Cluster) (bool, error) {
-	if cluster == nil {
-		return false, errors.New("unexpected 'nil' cluster")
-	}
-	return swag.BoolValue(cluster.SchedulableMasters), nil
 }
 
 func (p *ovirtProvider) SetPlatformUsages(

--- a/internal/provider/registry/mock_providerregistry.go
+++ b/internal/provider/registry/mock_providerregistry.go
@@ -5,7 +5,6 @@
 package registry
 
 import (
-	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -14,7 +13,6 @@ import (
 	provider "github.com/openshift/assisted-service/internal/provider"
 	usage "github.com/openshift/assisted-service/internal/usage"
 	models "github.com/openshift/assisted-service/models"
-	logrus "github.com/sirupsen/logrus"
 )
 
 // MockProviderRegistry is a mock of ProviderRegistry interface.
@@ -69,20 +67,6 @@ func (mr *MockProviderRegistryMockRecorder) AreHostsSupported(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreHostsSupported", reflect.TypeOf((*MockProviderRegistry)(nil).AreHostsSupported), arg0, arg1)
 }
 
-// GenerateProviderManifests mocks base method.
-func (m *MockProviderRegistry) GenerateProviderManifests(arg0 context.Context, arg1 *common.Cluster) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateProviderManifests", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GenerateProviderManifests indicates an expected call of GenerateProviderManifests.
-func (mr *MockProviderRegistryMockRecorder) GenerateProviderManifests(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateProviderManifests", reflect.TypeOf((*MockProviderRegistry)(nil).GenerateProviderManifests), arg0, arg1)
-}
-
 // Get mocks base method.
 func (m *MockProviderRegistry) Get(arg0 string) (provider.Provider, error) {
 	m.ctrl.T.Helper()
@@ -98,21 +82,6 @@ func (mr *MockProviderRegistryMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockProviderRegistry)(nil).Get), arg0)
 }
 
-// GetActualSchedulableMasters mocks base method.
-func (m *MockProviderRegistry) GetActualSchedulableMasters(arg0 *common.Cluster) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetActualSchedulableMasters", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActualSchedulableMasters indicates an expected call of GetActualSchedulableMasters.
-func (mr *MockProviderRegistryMockRecorder) GetActualSchedulableMasters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActualSchedulableMasters", reflect.TypeOf((*MockProviderRegistry)(nil).GetActualSchedulableMasters), arg0)
-}
-
 // GetSupportedProvidersByHosts mocks base method.
 func (m *MockProviderRegistry) GetSupportedProvidersByHosts(arg0 []*models.Host) ([]models.PlatformType, error) {
 	m.ctrl.T.Helper()
@@ -126,18 +95,6 @@ func (m *MockProviderRegistry) GetSupportedProvidersByHosts(arg0 []*models.Host)
 func (mr *MockProviderRegistryMockRecorder) GetSupportedProvidersByHosts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedProvidersByHosts", reflect.TypeOf((*MockProviderRegistry)(nil).GetSupportedProvidersByHosts), arg0)
-}
-
-// InitProviders mocks base method.
-func (m *MockProviderRegistry) InitProviders(arg0 logrus.FieldLogger) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "InitProviders", arg0)
-}
-
-// InitProviders indicates an expected call of InitProviders.
-func (mr *MockProviderRegistryMockRecorder) InitProviders(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitProviders", reflect.TypeOf((*MockProviderRegistry)(nil).InitProviders), arg0)
 }
 
 // IsHostSupported mocks base method.

--- a/internal/provider/registry/registry.go
+++ b/internal/provider/registry/registry.go
@@ -1,39 +1,18 @@
 package registry
 
 import (
-	"bytes"
-	"context"
-	"encoding/base64"
+	"errors"
 	"fmt"
-	"html/template"
 
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/installcfg"
-	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/internal/provider/baremetal"
 	"github.com/openshift/assisted-service/internal/provider/ovirt"
 	"github.com/openshift/assisted-service/internal/provider/vsphere"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
-	operations "github.com/openshift/assisted-service/restapi/operations/manifests"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	SchedulableMastersManifestFileName = "50-schedulable_masters.yaml"
-	SchedulableMastersManifestTemplate = `apiVersion: config.openshift.io/v1
-kind: Scheduler
-metadata:
-  name: cluster
-spec:
-  mastersSchedulable: {{.SCHEDULABLE_MASTERS}}
-  policy:
-    name: ""
-status: {}
-`
 )
 
 // ErrNoSuchProvider is returned or thrown in panic when the specified provider is not registered.
@@ -63,12 +42,6 @@ type ProviderRegistry interface {
 	PreCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error
 	// PostCreateManifestsHook allows the provider to perform additional tasks required after the cluster manifests are created
 	PostCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error
-	// InitProviders populates the registry with the implemented providers
-	InitProviders(log logrus.FieldLogger)
-	// GetActualSchedulableMasters allows the provider to set the default scheduling of workloads on masters
-	GetActualSchedulableMasters(cluster *common.Cluster) (bool, error)
-	// GenerateProviderManifests allows the registry to add custom manifests
-	GenerateProviderManifests(ctx context.Context, cluster *common.Cluster) error
 }
 
 //go:generate mockgen --build_flags=--mod=mod -package registry -destination mock_registry.go . Registry
@@ -82,15 +55,13 @@ type Registry interface {
 }
 
 type registry struct {
-	providers    map[string]provider.Provider
-	manifestsAPI manifestsapi.ManifestsAPI
+	providers map[string]provider.Provider
 }
 
 // NewProviderRegistry creates a new copy of a Registry.
-func NewProviderRegistry(manifestsAPI manifestsapi.ManifestsAPI) ProviderRegistry {
+func NewProviderRegistry() ProviderRegistry {
 	return &registry{
-		providers:    map[string]provider.Provider{},
-		manifestsAPI: manifestsAPI,
+		providers: map[string]provider.Provider{},
 	}
 }
 
@@ -108,12 +79,6 @@ func (r *registry) Get(name string) (provider.Provider, error) {
 // Name returns the name of the provider
 func (r *registry) Name() models.PlatformType {
 	return ""
-}
-
-func (r *registry) InitProviders(log logrus.FieldLogger) {
-	r.Register(ovirt.NewOvirtProvider(log))
-	r.Register(vsphere.NewVsphereProvider(log))
-	r.Register(baremetal.NewBaremetalProvider(log))
 }
 
 func (r *registry) AddPlatformToInstallConfig(p models.PlatformType, cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
@@ -209,87 +174,10 @@ func (r *registry) PostCreateManifestsHook(cluster *common.Cluster, envVars *[]s
 	return currentProvider.PostCreateManifestsHook(cluster, envVars, workDir)
 }
 
-func (r *registry) GetActualSchedulableMasters(cluster *common.Cluster) (bool, error) {
-	if cluster == nil || cluster.Platform == nil {
-		return false, errors.New("unable to get the platform type")
-	}
-	currentProviderStr := string(common.PlatformTypeValue(cluster.Platform.Type))
-	currentProvider, err := r.Get(currentProviderStr)
-	if err != nil {
-		return false, errors.Wrapf(err, "error while getting the actual schedulable masters value on platform %s",
-			currentProviderStr)
-	}
-	return currentProvider.GetActualSchedulableMasters(cluster)
-}
-
-func (r *registry) GenerateProviderManifests(ctx context.Context, cluster *common.Cluster) error {
-	manifests, err := r.generateProviderManifestsInternal(cluster)
-	if err != nil {
-		return errors.Wrapf(err, "failed to generate provider manifests")
-	}
-	for filename, content := range manifests {
-		if err = r.createClusterManifests(ctx, cluster, filename, content); err != nil {
-			return fmt.Errorf("error while creating the manifest '%s', error %w", filename, err)
-		}
-	}
-	return nil
-}
-
-func (r *registry) generateProviderManifestsInternal(cluster *common.Cluster) (map[string][]byte, error) {
-	manifests := make(map[string][]byte)
-	filename, content, err := r.generateSchedulableMastersManifest(cluster)
-	if err != nil {
-		return nil, err
-	}
-	if filename == "" {
-		return nil, errors.New("template filename cannot be empty")
-	}
-	manifests[filename] = content
-	return manifests, nil
-}
-
-func (r *registry) generateSchedulableMastersManifest(cluster *common.Cluster) (string, []byte, error) {
-	schedulableMasters, err := r.GetActualSchedulableMasters(cluster)
-	if err != nil {
-		return "", nil, err
-	}
-	templateParams := map[string]interface{}{
-		"SCHEDULABLE_MASTERS": schedulableMasters,
-	}
-	content, err := fillTemplate(templateParams, SchedulableMastersManifestTemplate, nil)
-	if err != nil {
-		return "", nil, err
-	}
-	return SchedulableMastersManifestFileName, content, nil
-}
-
-func (r *registry) createClusterManifests(ctx context.Context, cluster *common.Cluster, filename string, content []byte) error {
-	// all relevant logs of creating manifest will be inside CreateClusterManifest
-	_, err := r.manifestsAPI.CreateClusterManifestInternal(ctx, operations.V2CreateClusterManifestParams{
-		ClusterID: *cluster.ID,
-		CreateManifestParams: &models.CreateManifestParams{
-			Content:  swag.String(base64.StdEncoding.EncodeToString(content)),
-			FileName: &filename,
-			Folder:   swag.String(models.ManifestFolderOpenshift),
-		},
-	})
-
-	if err != nil {
-		return errors.Wrapf(err, "failed to create manifest %s", filename)
-	}
-
-	return nil
-}
-
-func fillTemplate(manifestParams map[string]interface{}, templateData string, log logrus.FieldLogger) ([]byte, error) {
-	tmpl, err := template.New("template").Parse(templateData)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create template")
-	}
-	buf := &bytes.Buffer{}
-	if err = tmpl.Execute(buf, manifestParams); err != nil {
-		log.WithError(err).Errorf("Failed to set manifest params %v to template", manifestParams)
-		return nil, err
-	}
-	return buf.Bytes(), nil
+func InitProviderRegistry(log logrus.FieldLogger) ProviderRegistry {
+	providerRegistry := NewProviderRegistry()
+	providerRegistry.Register(ovirt.NewOvirtProvider(log))
+	providerRegistry.Register(vsphere.NewVsphereProvider(log))
+	providerRegistry.Register(baremetal.NewBaremetalProvider(log))
+	return providerRegistry
 }

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -1,9 +1,7 @@
 package registry
 
 import (
-	context "context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -14,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/installcfg"
-	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/provider/ovirt"
 	"github.com/openshift/assisted-service/internal/provider/vsphere"
 	"github.com/openshift/assisted-service/internal/usage"
@@ -71,17 +68,12 @@ RxNEp7yHoXcwn+fXna+t5JWh1gxUZty3
 `
 
 var _ = Describe("Test GetSupportedProvidersByHosts", func() {
-	var (
-		manifestsApi *manifestsapi.MockManifestsAPI
-	)
 	bmInventory := getBaremetalInventoryStr("hostname0", "bootMode", true, false)
 	vsphereInventory := getVsphereInventoryStr("hostname0", "bootMode", true, false)
 	ovirtInventory := getOvirtInventoryStr("hostname0", "bootMode", true, false)
 	BeforeEach(func() {
+		providerRegistry = InitProviderRegistry(common.GetTestLog())
 		ctrl = gomock.NewController(GinkgoT())
-		manifestsApi = manifestsapi.NewMockManifestsAPI(ctrl)
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
 	})
 	It("no hosts", func() {
 		hosts := make([]*models.Host, 0)
@@ -199,12 +191,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 })
 
 var _ = Describe("Test AddPlatformToInstallConfig", func() {
-	var (
-		manifestsApi *manifestsapi.MockManifestsAPI
-	)
 	BeforeEach(func() {
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
+		providerRegistry = InitProviderRegistry(common.GetTestLog())
 		ctrl = gomock.NewController(GinkgoT())
 	})
 	Context("Unregistered Provider", func() {
@@ -336,14 +324,9 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 })
 
 var _ = Describe("Test SetPlatformValuesInDBUpdates", func() {
-	var (
-		manifestsApi *manifestsapi.MockManifestsAPI
-	)
 	BeforeEach(func() {
+		providerRegistry = InitProviderRegistry(common.GetTestLog())
 		ctrl = gomock.NewController(GinkgoT())
-		manifestsApi = manifestsapi.NewMockManifestsAPI(ctrl)
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
 	})
 	Context("Unregistered Provider", func() {
 		It("try to with an unregistered provider", func() {
@@ -378,15 +361,12 @@ var _ = Describe("Test SetPlatformValuesInDBUpdates", func() {
 
 var _ = Describe("Test SetPlatformUsages", func() {
 	var (
-		usageApi     *usage.MockAPI
-		manifestsApi *manifestsapi.MockManifestsAPI
+		usageApi *usage.MockAPI
 	)
 	BeforeEach(func() {
+		providerRegistry = InitProviderRegistry(common.GetTestLog())
 		ctrl = gomock.NewController(GinkgoT())
 		usageApi = usage.NewMockAPI(ctrl)
-		manifestsApi = manifestsapi.NewMockManifestsAPI(ctrl)
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
 	})
 	Context("Unregistered Provider", func() {
 		It("try to with an unregistered provider", func() {
@@ -420,217 +400,6 @@ var _ = Describe("Test SetPlatformUsages", func() {
 	})
 })
 
-var _ = Describe("Test GetActualSchedulableMasters", func() {
-	var (
-		manifestsApi *manifestsapi.MockManifestsAPI
-	)
-	hostStatusKnown := models.HostStatusKnown
-	platforms := []models.PlatformType{
-		models.PlatformTypeBaremetal,
-		models.PlatformTypeVsphere,
-		models.PlatformTypeOvirt,
-	}
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		manifestsApi = manifestsapi.NewMockManifestsAPI(ctrl)
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
-	})
-
-	Context("Wrong parameters", func() {
-		It("nil cluster", func() {
-			_, err := providerRegistry.GetActualSchedulableMasters(nil)
-			Expect(err).NotTo(BeNil())
-		})
-		It("Empty cluster", func() {
-			cluster := &common.Cluster{}
-			_, err := providerRegistry.GetActualSchedulableMasters(cluster)
-			Expect(err).NotTo(BeNil())
-		})
-		It("Unknown platform", func() {
-			cluster := &common.Cluster{}
-			cluster.Platform = &models.Platform{Type: models.NewPlatformType("NotRegisteredPlatform")}
-			_, err := providerRegistry.GetActualSchedulableMasters(cluster)
-			Expect(err).NotTo(BeNil())
-		})
-	})
-
-	for _, current_platform := range platforms {
-		platform := current_platform
-
-		Context(fmt.Sprintf("%v platform", platform), func() {
-			It("no hosts", func() {
-				hosts := make([]*models.Host, 0)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				By("Default value")
-				schedulableMasters, err := providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				if platform == models.PlatformTypeBaremetal {
-					Expect(schedulableMasters).To(BeTrue())
-				} else {
-					Expect(schedulableMasters).To(BeFalse())
-				}
-				By("Enable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(true)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeTrue())
-				By("Disable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(false)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeFalse())
-			})
-			It("3 masters", func() {
-				hosts := createHosts(3, 0, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				By("Default value")
-				schedulableMasters, err := providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				if platform == models.PlatformTypeBaremetal {
-					Expect(schedulableMasters).To(BeTrue())
-				} else {
-					Expect(schedulableMasters).To(BeFalse())
-				}
-				By("Enable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(true)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeTrue())
-				By("Disable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(false)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeFalse())
-			})
-			It("3 masters - 1 worker", func() {
-				hosts := createHosts(3, 1, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				By("Default value")
-				schedulableMasters, err := providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				if platform == models.PlatformTypeBaremetal {
-					Expect(schedulableMasters).To(BeTrue())
-				} else {
-					Expect(schedulableMasters).To(BeFalse())
-				}
-				By("Enable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(true)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeTrue())
-				By("Disable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(false)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeFalse())
-			})
-			It("3 masters - 2 workers", func() {
-				hosts := createHosts(3, 2, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				By("Default value")
-				schedulableMasters, err := providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeFalse())
-				By("Enable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(true)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeTrue())
-				By("Disable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(false)
-				schedulableMasters, err = providerRegistry.GetActualSchedulableMasters(&cluster)
-				Expect(err).To(BeNil())
-				Expect(schedulableMasters).To(BeFalse())
-			})
-		})
-	}
-})
-
-var _ = Describe("Test GenerateProviderManifests", func() {
-	var (
-		ctx          = context.Background()
-		manifestsApi *manifestsapi.MockManifestsAPI
-	)
-	hostStatusKnown := models.HostStatusKnown
-	platforms := []models.PlatformType{
-		models.PlatformTypeBaremetal,
-		models.PlatformTypeVsphere,
-		models.PlatformTypeOvirt,
-	}
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		manifestsApi = manifestsapi.NewMockManifestsAPI(ctrl)
-		providerRegistry = NewProviderRegistry(manifestsApi)
-		providerRegistry.InitProviders(common.GetTestLog())
-		manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Times(3)
-	})
-	for _, current_platform := range platforms {
-		platform := current_platform
-		Context(fmt.Sprintf("%v platform", platform), func() {
-			It("no hosts", func() {
-				By("Default value")
-				cluster := createClusterFromHosts(nil)
-				err := providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).NotTo(BeNil())
-				By("Enable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(true)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).NotTo(BeNil())
-				By("Disable schedulable masters")
-				cluster.SchedulableMasters = swag.Bool(false)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).NotTo(BeNil())
-			})
-			It("3 masters", func() {
-				hosts := createHosts(3, 0, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				cluster.SchedulableMasters = swag.Bool(true)
-				err := providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Enable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(true)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Disable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(false)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-			})
-			It("3 masters - 2 workers", func() {
-				hosts := createHosts(3, 2, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				err := providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Enable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(true)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Disable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(false)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-			})
-			It("3 masters - 2 workers ('SchedulableMasters' set)", func() {
-				hosts := createHosts(3, 2, hostStatusKnown, platform)
-				cluster := createClusterFromHostsPlatform(hosts, platform)
-				cluster.SchedulableMasters = swag.Bool(true)
-				err := providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Enable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(true)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-				// Disable schedulable masters
-				cluster.SchedulableMasters = swag.Bool(false)
-				err = providerRegistry.GenerateProviderManifests(ctx, &cluster)
-				Expect(err).To(BeNil())
-			})
-		})
-	}
-})
-
 func createHost(isMaster bool, state string, inventory string) *models.Host {
 	hostId := strfmt.UUID(uuid.New().String())
 	clusterId := strfmt.UUID(uuid.New().String())
@@ -649,37 +418,6 @@ func createHost(isMaster bool, state string, inventory string) *models.Host {
 		Inventory:  inventory,
 	}
 	return &host
-}
-
-func createHosts(masterNum, workerNum int, state string, platform models.PlatformType) []*models.Host {
-	hosts := make([]*models.Host, 0)
-	for masterNum > 0 {
-		hostname := fmt.Sprintf("master-%d", masterNum)
-		inventory := getPlatformInventoryStr(platform, hostname, "bios", true, false)
-		hosts = append(hosts, createHost(true, state, inventory))
-		masterNum--
-	}
-	for workerNum > 0 {
-		hostname := fmt.Sprintf("worker-%d", workerNum)
-		inventory := getPlatformInventoryStr(platform, hostname, "bios", true, false)
-		hosts = append(hosts, createHost(false, state, inventory))
-		workerNum--
-	}
-
-	return hosts
-}
-
-func getPlatformInventoryStr(platform models.PlatformType, hostname, bootMode string, ipv4, ipv6 bool) string {
-	switch platform {
-	case models.PlatformTypeOvirt:
-		return getOvirtInventoryStr(hostname, bootMode, ipv4, ipv6)
-	case models.PlatformTypeVsphere:
-		return getVsphereInventoryStr(hostname, bootMode, ipv4, ipv6)
-	case models.PlatformTypeBaremetal:
-		return getBaremetalInventoryStr(hostname, bootMode, ipv4, ipv6)
-	default:
-		return ""
-	}
 }
 
 func getInventory(hostname, bootMode string, ipv4, ipv6 bool) models.Inventory {
@@ -707,7 +445,7 @@ func getVsphereInventoryStr(hostname, bootMode string, ipv4, ipv6 bool) string {
 	inventory := getInventory(hostname, bootMode, ipv4, ipv6)
 	inventory.SystemVendor = &models.SystemVendor{
 		Manufacturer: "VMware, Inc.",
-		ProductName:  "VMware7,1",
+		ProductName:  "Mware7,1",
 		SerialNumber: "VMware-12 34 56 78 90 12 ab cd-ef gh 12 34 56 67 89 90",
 		Virtual:      true,
 	}
@@ -769,36 +507,14 @@ func createOvirtPlatformParams() *models.Platform {
 }
 
 func createClusterFromHosts(hosts []*models.Host) common.Cluster {
-	var enabledHosts int64
-	for _, host := range hosts {
-		if *host.Status != models.HostStatusDisabled {
-			enabledHosts++
-		}
-	}
-	ID := strfmt.UUID(uuid.New().String())
 	return common.Cluster{
 		Cluster: models.Cluster{
-			ID:               &ID,
 			APIVip:           "192.168.10.10",
 			Hosts:            hosts,
 			IngressVip:       "192.168.10.11",
 			OpenshiftVersion: "4.7",
-			EnabledHostCount: enabledHosts,
 		},
 	}
-}
-
-func createClusterFromHostsPlatform(hosts []*models.Host, platform models.PlatformType) common.Cluster {
-	cluster := createClusterFromHosts(hosts)
-	switch platform {
-	case models.PlatformTypeOvirt:
-		cluster.Platform = createOvirtPlatformParams()
-	case models.PlatformTypeVsphere:
-		cluster.Platform = createVspherePlatformParams()
-	case models.PlatformTypeBaremetal:
-		cluster.Platform = &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)}
-	}
-	return cluster
 }
 
 func getInstallerConfigBaremetal() installcfg.InstallerConfigBaremetal {

--- a/internal/provider/vsphere/inventory.go
+++ b/internal/provider/vsphere/inventory.go
@@ -1,10 +1,6 @@
 package vsphere
 
 import (
-	"errors"
-
-	"github.com/go-openapi/swag"
-	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 )
@@ -15,13 +11,6 @@ func (p *vsphereProvider) CleanPlatformValuesFromDBUpdates(_ map[string]interfac
 
 func (p *vsphereProvider) SetPlatformValuesInDBUpdates(_ *models.Platform, _ map[string]interface{}) error {
 	return nil
-}
-
-func (p *vsphereProvider) GetActualSchedulableMasters(cluster *common.Cluster) (bool, error) {
-	if cluster == nil {
-		return false, errors.New("unexpected 'nil' cluster")
-	}
-	return swag.BoolValue(cluster.SchedulableMasters), nil
 }
 
 func (p *vsphereProvider) SetPlatformUsages(

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -235,9 +235,6 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -122,9 +122,6 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -111,9 +111,6 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5513,7 +5513,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -5581,11 +5581,6 @@ func init() {
             },
             "type": "Time"
           }
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -5758,7 +5753,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -5778,11 +5773,6 @@ func init() {
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string"
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -8939,7 +8929,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -8960,11 +8950,6 @@ func init() {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string",
           "x-nullable": true
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -14700,7 +14685,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -14768,11 +14753,6 @@ func init() {
             },
             "type": "Time"
           }
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -14945,7 +14925,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -14965,11 +14945,6 @@ func init() {
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string"
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -18047,7 +18022,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -18068,11 +18043,6 @@ func init() {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string",
           "x-nullable": true
-        },
-        "use_scheduling_defaults": {
-          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
-          "type": "boolean",
-          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4272,11 +4272,7 @@ definitions:
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters
-        default: true
-      use_scheduling_defaults:
-        type: boolean
-        description: False if the scheduling of workloads on masters has been set by the user through the API.
-        default: true
+        default: false
       cluster_networks:
         type: array
         description: Cluster networks that are associated with this cluster.
@@ -4450,11 +4446,7 @@ definitions:
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters
-        default: true
-      use_scheduling_defaults:
-        type: boolean
-        description: False if the scheduling of workloads on masters has been set by the user through the API.
-        default: true
+        default: false
       cluster_networks:
         type: array
         description: Cluster networks that are associated with this cluster.
@@ -4665,11 +4657,7 @@ definitions:
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters
-        default: true
-      use_scheduling_defaults:
-        type: boolean
-        description: False if the scheduling of workloads on masters has been set by the user through the API.
-        default: true
+        default: false
       updated_at:
         type: string
         format: date-time

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -235,9 +235,6 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -122,9 +122,6 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,9 +111,6 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
-	// False if the scheduling of workloads on masters has been set by the user through the API.
-	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
-
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 


### PR DESCRIPTION
This reverts commit 7296f386338fe038eab9f7bf2463eac66eda7c63.

Following a couple of blocker bugs found by QE, we'd rather revert this
change for now and work for the fixes in 2.5.0.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @gamli75 
/cc @mmartinv 
/cc @omertuc 
/cc @lalon4 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
