### PR TITLE
MGMT-10473: Add interface type to Interface API

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/interface.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/interface.go
@@ -50,6 +50,9 @@ type Interface struct {
 	// speed mbps
 	SpeedMbps int64 `json:"speed_mbps,omitempty"`
 
+	// type
+	Type string `json:"type,omitempty"`
+
 	// vendor
 	Vendor string `json:"vendor,omitempty"`
 }

--- a/models/interface.go
+++ b/models/interface.go
@@ -50,6 +50,9 @@ type Interface struct {
 	// speed mbps
 	SpeedMbps int64 `json:"speed_mbps,omitempty"`
 
+	// type
+	Type string `json:"type,omitempty"`
+
 	// vendor
 	Vendor string `json:"vendor,omitempty"`
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7795,6 +7795,9 @@ func init() {
         "speed_mbps": {
           "type": "integer"
         },
+        "type": {
+          "type": "string"
+        },
         "vendor": {
           "type": "string"
         }
@@ -16913,6 +16916,9 @@ func init() {
         },
         "speed_mbps": {
           "type": "integer"
+        },
+        "type": {
+          "type": "string"
         },
         "vendor": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5175,6 +5175,8 @@ definitions:
           type: string
       speed_mbps:
         type: integer
+      type:
+        type: string
 
   disk:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/interface.go
+++ b/vendor/github.com/openshift/assisted-service/models/interface.go
@@ -50,6 +50,9 @@ type Interface struct {
 	// speed mbps
 	SpeedMbps int64 `json:"speed_mbps,omitempty"`
 
+	// type
+	Type string `json:"type,omitempty"`
+
 	// vendor
 	Vendor string `json:"vendor,omitempty"`
 }


### PR DESCRIPTION
[MGMT-10473](https://issues.redhat.com/browse/MGMT-10473)
As part of epic https://issues.redhat.com/browse/MGMT-10087
This field will be populated by the agent and will allow
the service to filter interfaces as the agent has done
previously. The filtering on the service side prevents
 the additional interfaces from being stored if the
user has not requested the additional interfaces.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

1. Deployed the service image with the new property added
2. Deployed a node using assisted-test-infra
3. Posted to the API with the following json:
    ````
    $ cat data.json
    {"step_type":"inventory","output":"{\"interfaces\":[{\"name\":\"lo\",\"type\":\"physical\",\"ipv4_addresses\":[\"127.0.0.1\"],\"ipv6_addresses\":[],\"flags\":[\"up\",\"broadcast\",\"multicast\"]}]}"}
    $ curl $SERVICE_URL/api/assisted-install/v2/infra-envs/$INFRA_ENV_ID/hosts/$HOST_ID/instructions -X POST -H "Content-Type: application/json" -d @data.json
    ````
5. Curled the API to see if the inventory got the update
    ````
    $ curl $SERVICE_URL/api/assisted-install/v2/infra-envs/$INFRA_ENV_ID/hosts/$HOST_ID | jq -r '.inventory' | jq '.interfaces'
    [
      {
        "flags": [
          "up",
          "broadcast",
          "multicast"
        ],
        "type": "physical",
        "ipv4_addresses": [
          "127.0.0.1"
        ],
        "ipv6_addresses": [],
        "name": "lo"
      }
    ]
    ````
## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
