### PR TITLE
MGMT-10548: internal/network: fix NewConfig to avoid throwing errors

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -486,9 +486,8 @@ func (m *ManifestsGenerator) AddTelemeterManifest(ctx context.Context, log logru
 // NewConfig returns network config if env vars can be parsed
 func NewConfig() (*Config, error) {
 	networkCfg := Config{}
-	if err := envconfig.Process("", networkCfg); err != nil {
-		// TODO: throw error here?
-		return &networkCfg, fmt.Errorf("failed to process env var to build network config")
+	if err := envconfig.Process("", &networkCfg); err != nil {
+		return &networkCfg, errors.Wrapf(err, "failed to process env var to build network config")
 	}
 	return &networkCfg, nil
 }

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -601,4 +602,35 @@ var _ = Describe("disk encryption manifest", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	}
+})
+
+var _ = Describe("network config", func() {
+	It("Default NewConfig doesn't throw errors", func() {
+		_, err := NewConfig()
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("NewConfig with env var set to true", func() {
+		err := os.Setenv("ENABLE_SINGLE_NODE_DNSMASQ", "True")
+		Expect(err).ShouldNot(HaveOccurred())
+		cfg, err := NewConfig()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(cfg.EnableSingleNodeDnsmasq).Should(BeTrue())
+	})
+
+	It("NewConfig with env var set to false", func() {
+		err := os.Setenv("ENABLE_SINGLE_NODE_DNSMASQ", "false")
+		Expect(err).ShouldNot(HaveOccurred())
+		cfg, err := NewConfig()
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(cfg.EnableSingleNodeDnsmasq).Should(BeFalse())
+	})
+
+	It("NewConfig with env var set to unknown", func() {
+		err := os.Setenv("ENABLE_SINGLE_NODE_DNSMASQ", "foobar")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = NewConfig()
+		Expect(err).Should(HaveOccurred())
+	})
+
 })


### PR DESCRIPTION
envconfig.Process requires a pointer to the structure, not the structure itself. As a result, `NewConfig` has been throwing errors all the time.

Added unit tests to ensure it no longer happens and networkCfg has expected values based on env vars

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @tsorya 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
