### PR TITLE
MGMT-10375: Get the ironic image from the release image for the arch

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -26,6 +26,8 @@ import (
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/ignition"
+	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
@@ -53,6 +55,9 @@ type PreprovisioningImageReconciler struct {
 	Installer              bminventory.InstallerInternals
 	CRDEventsHandler       CRDEventsHandler
 	IronicIgniotionBuilder ignition.IronicIgniotionBuilder
+	VersionsHandler        versions.Handler
+	ocRelease              oc.Release
+	ReleaseImageMirror     string
 	IronicServiceURL       string
 }
 
@@ -127,8 +132,8 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 }
 
 // getConvergedDiscoveryTemplate merge the ironic ignition with the discovery ignition
-func (r *PreprovisioningImageReconciler) getIronicIgnitionConfig(log logrus.FieldLogger, infraEnvInternal common.InfraEnv) (string, error) {
-	config, err := r.IronicIgniotionBuilder.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, "")
+func (r *PreprovisioningImageReconciler) getIronicIgnitionConfig(log logrus.FieldLogger, infraEnvInternal common.InfraEnv, ironicAgentImage string) (string, error) {
+	config, err := r.IronicIgniotionBuilder.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, ironicAgentImage)
 	if err != nil {
 		log.WithError(err).Error("failed to generate Ironic ignition config")
 		return "", err
@@ -280,9 +285,17 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 		log.WithError(err).Error("failed to get corresponding infraEnv")
 		return ctrl.Result{}, err
 	}
+	ironicAgentImage := ""
+	if infraEnvInternal.OpenshiftVersion != "" {
+		ironicAgentImage, err = r.getIronicAgentImage(log, *infraEnvInternal)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get ironicAgentImage from clusterRef: %+v", *infraEnv.Spec.ClusterRef)
+		}
+	}
 
-	// if the infraEnv doesn't have the enableIronicAgent annotation add the ironicIgnition to the invfraEnv and set the annotation and notify the infraEnv changed
-	conf, err := r.getIronicIgnitionConfig(log, *infraEnvInternal)
+	// if the infraEnv doesn't have the enableIronicAgent annotation add the ironicIgnition to the invfraEnv
+	// set the annotation and notify the infraEnv changed
+	conf, err := r.getIronicIgnitionConfig(log, *infraEnvInternal, ironicAgentImage)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -303,6 +316,18 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	// TODO: if the annotation is enough to trigger the infraEnv reconciliation remove the notification
 	r.CRDEventsHandler.NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace)
 	return ctrl.Result{}, err
+}
+
+func (r *PreprovisioningImageReconciler) getIronicAgentImage(log logrus.FieldLogger, infraEnv common.InfraEnv) (string, error) {
+	releaseImage, err := r.VersionsHandler.GetReleaseImage(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+	if err != nil {
+		return "", err
+	}
+	ironicAgentImage, err := r.ocRelease.GetIronicAgentImage(log, *releaseImage.URL, r.ReleaseImageMirror, infraEnv.PullSecret)
+	if err != nil {
+		return "", err
+	}
+	return ironicAgentImage, nil
 }
 
 func IronicAgentEnabled(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) bool {

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -50,6 +50,21 @@ func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, platformType)
 }
 
+// GetIronicAgentImage mocks base method.
+func (m *MockRelease) GetIronicAgentImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIronicAgentImage", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIronicAgentImage indicates an expected call of GetIronicAgentImage.
+func (mr *MockReleaseMockRecorder) GetIronicAgentImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIronicAgentImage", reflect.TypeOf((*MockRelease)(nil).GetIronicAgentImage), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
 // GetMCOImage mocks base method.
 func (m *MockRelease) GetMCOImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	mcoImageName        = "machine-config-operator"
-	mustGatherImageName = "must-gather"
-	DefaultTries        = 5
-	DefaltRetryDelay    = time.Second * 5
+	mcoImageName         = "machine-config-operator"
+	ironicAgentImageName = "ironic-agent"
+	mustGatherImageName  = "must-gather"
+	DefaultTries         = 5
+	DefaltRetryDelay     = time.Second * 5
 )
 
 type Config struct {
@@ -34,6 +35,7 @@ type Config struct {
 //go:generate mockgen -source=release.go -package=oc -destination=mock_release.go
 type Release interface {
 	GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
+	GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
@@ -69,6 +71,12 @@ const (
 // Else gets it from the source releaseImage
 func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
 	return r.getImageByName(log, mcoImageName, releaseImage, releaseImageMirror, pullSecret)
+}
+
+// GetIronicAgentImage gets the ironic agent image url from the releaseImageMirror if provided.
+// Else gets it from the source releaseImage
+func (r *release) GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	return r.getImageByName(log, ironicAgentImageName, releaseImage, releaseImageMirror, pullSecret)
 }
 
 // GetMustGatherImage gets must-gather image URL from the release image or releaseImageMirror, if provided.


### PR DESCRIPTION
This is required in order to allow the converged flow to work on ARM machines.
Since the ironic agent image isn't a multi-arch image we need to get the agent image from the release image that match the arch we are trying to install, hence we will get it from the release image for the installation.
In case the service fails to get the ironic agent from the release image it will fall back to the default ironic agent image provided via env. 

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? ZTP using dev scripts 
- Any logs, screenshots, etc that can help with the review process? we can check which ironic agent image is used on the node prior to the node installation.

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-10375
- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?
WIP
<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
