### PR TITLE
MGMT-9175: Use an interface with a Mac address

### DIFF
--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -429,6 +429,7 @@ func getInventory(hostname, bootMode string, ipv4, ipv6 bool) models.Inventory {
 				IPV4Addresses: []string{},
 				IPV6Addresses: []string{},
 				MacAddress:    "some MAC address",
+				Type:          "physical",
 			},
 		},
 	}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -102,6 +102,7 @@ var (
 					defaultCIDRv4,
 				},
 				MacAddress: "e6:53:3d:a7:77:b4",
+				Type:       "physical",
 			},
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
@@ -145,6 +146,7 @@ func getValidWorkerHwInfoWithCIDR(cidr string) *models.Inventory {
 					cidr,
 				},
 				MacAddress: "e6:53:3d:a7:77:b4",
+				Type:       "physical",
 			},
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
@@ -1170,7 +1172,10 @@ var _ = Describe("cluster install", func() {
 		log.Infof("Register cluster %s", cluster.ID.String())
 		infraEnvID = registerInfraEnv(cluster.ID, models.ImageTypeMinimalIso).ID
 	})
-
+	AfterEach(func() {
+		deregisterResources()
+		clearDB()
+	})
 	getSuggestedRole := func(id strfmt.UUID) models.HostRole {
 		reply, err := userBMClient.Installer.V2GetHost(ctx, &installer.V2GetHostParams{
 			InfraEnvID: *infraEnvID,
@@ -4029,6 +4034,7 @@ var _ = Describe("disk encryption", func() {
 						defaultCIDRv4,
 					},
 					MacAddress: "e6:53:3d:a7:77:b4",
+					Type:       "physical",
 				},
 			},
 			SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
@@ -4273,6 +4279,7 @@ var _ = Describe("Ovirt provider tests", func() {
 						defaultCIDRv4,
 					},
 					MacAddress: "e6:53:3d:a7:77:b4",
+					Type:       "physical",
 				},
 			},
 			SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "RHEL", SerialNumber: "3534"},
@@ -4446,6 +4453,7 @@ func getoVirtInventory() *models.Inventory {
 					defaultCIDRv4,
 				},
 				MacAddress: "e6:53:3d:a7:77:b4",
+				Type:       "physical",
 			},
 		},
 		SystemVendor: &models.SystemVendor{

--- a/subsystem/ipv6_test.go
+++ b/subsystem/ipv6_test.go
@@ -27,6 +27,7 @@ var (
 				IPV6Addresses: []string{
 					defaultCIDRv6,
 				},
+				Type: "physical",
 			},
 		},
 		SystemVendor: &models.SystemVendor{Manufacturer: "manu", ProductName: "prod", SerialNumber: "3534"},
@@ -100,6 +101,7 @@ func registerHostsAndSetRolesV6(clusterID, infraEnvID strfmt.UUID, numHosts int)
 		hostname := fmt.Sprintf("h%d", i)
 		host := &registerHost(infraEnvID).Host
 		validHwInfoV6.Interfaces[0].IPV6Addresses = []string{ips[i]}
+		validHwInfoV6.Interfaces[0].MacAddress = "e6:53:3d:a7:77:b4"
 		generateEssentialHostStepsWithInventory(ctx, host, hostname, validHwInfoV6)
 		var role models.HostRole
 		if i < 3 {


### PR DESCRIPTION
[MGMT-9175](https://issues.redhat.com/browse/MGMT-9175)
Part of epic https://issues.redhat.com/browse/MGMT-10087
The assisted installer agent has changes to
pass all interfaces to the assisted service.
PR for the agent changes:
https://github.com/openshift/assisted-installer-agent/pull/360
Originally, the assisted service selected the first interface
in the list, which might not have a MAC address.
This change now looks for an interface with a MAC
address and uses it for the install config.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
