### PR TITLE
Bug 2090415: internal/controller/controllers: label mirrorRegistryRef configmap for backup

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1155,6 +1155,28 @@ var _ = Describe("ensureAssistedServiceDeployment", func() {
 					}),
 				)
 			})
+
+			It("should be labelled for backup", func() {
+				asc = newASCWithMirrorRegistryConfig()
+				mirrorCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testMirrorRegConfigmapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						mirrorRegistryRefRegistryConfKey: "foo",
+					},
+				}
+
+				ascr = newTestReconciler(asc, route, mirrorCM, assistedCM)
+				AssertReconcileSuccess(ctx, log, ascr.Client, asc, ascr.newAssistedServiceDeployment)
+
+				found := &corev1.ConfigMap{}
+				Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: testMirrorRegConfigmapName, Namespace: testNamespace}, found)).To(Succeed())
+				Expect(found.Labels).To(HaveLen(2))
+				Expect(found.Labels).To(HaveKeyWithValue(BackupLabel, BackupLabelValue))
+				Expect(found.Labels).To(HaveKeyWithValue(WatchResourceLabel, WatchResourceValue))
+			})
 		})
 
 		Context("with registries.conf and ca-bundle", func() {


### PR DESCRIPTION
This ensures that mirror registry configmap gets backed up along with other CRs required for DR

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @osherdp 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
