### PR TITLE
Bug 2093503: Assisted service POD keeps crashing after a bare metal host is created

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/ignition"
-	"github.com/openshift/assisted-service/internal/oc"
-	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
@@ -71,8 +69,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCtrl              *gomock.Controller
 		mockInstallerInternal *bminventory.MockInstallerInternals
 		mockCRDEventsHandler  *MockCRDEventsHandler
-		mockVersionHandler    *versions.MockHandler
-		mockOcRelease         *oc.MockRelease
 		ironicIgnitionBuilder ignition.IronicIgniotionBuilder
 		ctx                   = context.Background()
 		sId                   strfmt.UUID
@@ -89,8 +85,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 		ironicIgnitionBuilder = ignition.NewIronicIgniotionBuilder(ignition.IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"})
-		mockVersionHandler = versions.NewMockHandler(mockCtrl)
-		mockOcRelease = oc.NewMockRelease(mockCtrl)
 		sId = strfmt.UUID(uuid.New().String())
 		pr = &PreprovisioningImageReconciler{
 			Client:                 c,
@@ -98,16 +92,12 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Installer:              mockInstallerInternal,
 			CRDEventsHandler:       mockCRDEventsHandler,
 			IronicIgniotionBuilder: ironicIgnitionBuilder,
-			VersionsHandler:        mockVersionHandler,
-			ocRelease:              mockOcRelease,
 			IronicServiceURL:       "ironic.url",
 		}
 	})
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		backendInfraEnv = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}
-
 	})
 
 	Context("reconcile new PreprovisioningImage - success", func() {
@@ -127,7 +117,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		AfterEach(func() {
 			mockCtrl.Finish()
 		})
-		It("Add the ironic Ignition to the infraEnv", func() {
+		It("Add the ironic Agent to the infraEnv", func() {
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -228,36 +218,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Get(ctx, key, ppi)).To(BeNil())
 			validateStatus(infraEnv.Status.ISODownloadURL, conditionsv1.FindStatusCondition(infraEnv.Status.Conditions, aiv1beta1.ImageCreatedCondition), ppi)
 		})
-		It("Add the ironic Ignition to the infraEnv using the ironic agent image from the release", func() {
 
-			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-			openshiftRelaseImage := "release-image:4.11.0"
-			ironicAgentImage := "ironic-image:4.11.0"
-			backendInfraEnv.OpenshiftVersion = "4.11.0-test.release"
-			backendInfraEnv.CPUArchitecture = "x86_64"
-			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-			mockVersionHandler.EXPECT().GetReleaseImage(backendInfraEnv.OpenshiftVersion, backendInfraEnv.CPUArchitecture).Return(&models.ReleaseImage{URL: &openshiftRelaseImage}, nil)
-			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), openshiftRelaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil)
-			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
-				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
-					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
-					Expect(params.InfraEnvUpdateParams.IgnitionConfigOverride).To(Equal(""))
-					Expect(*internalIgnitionConfig).Should(ContainSubstring("ironic"))
-					Expect(*internalIgnitionConfig).Should(ContainSubstring(ironicAgentImage))
-				}).Return(
-				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
-			Expect(err).To(BeNil())
-			Expect(res).To(Equal(ctrl.Result{}))
-
-			key := types.NamespacedName{
-				Namespace: testNamespace,
-				Name:      "testInfraEnv",
-			}
-			Expect(c.Get(ctx, key, infraEnv)).To(BeNil())
-			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
-		})
 		It("infraEnv not found", func() {
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -50,21 +50,6 @@ func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, platformType)
 }
 
-// GetIronicAgentImage mocks base method.
-func (m *MockRelease) GetIronicAgentImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIronicAgentImage", log, releaseImage, releaseImageMirror, pullSecret)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetIronicAgentImage indicates an expected call of GetIronicAgentImage.
-func (mr *MockReleaseMockRecorder) GetIronicAgentImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIronicAgentImage", reflect.TypeOf((*MockRelease)(nil).GetIronicAgentImage), log, releaseImage, releaseImageMirror, pullSecret)
-}
-
 // GetMCOImage mocks base method.
 func (m *MockRelease) GetMCOImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -20,11 +20,10 @@ import (
 )
 
 const (
-	mcoImageName         = "machine-config-operator"
-	ironicAgentImageName = "ironic-agent"
-	mustGatherImageName  = "must-gather"
-	DefaultTries         = 5
-	DefaltRetryDelay     = time.Second * 5
+	mcoImageName        = "machine-config-operator"
+	mustGatherImageName = "must-gather"
+	DefaultTries        = 5
+	DefaltRetryDelay    = time.Second * 5
 )
 
 type Config struct {
@@ -35,7 +34,6 @@ type Config struct {
 //go:generate mockgen -source=release.go -package=oc -destination=mock_release.go
 type Release interface {
 	GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
-	GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
@@ -71,12 +69,6 @@ const (
 // Else gets it from the source releaseImage
 func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
 	return r.getImageByName(log, mcoImageName, releaseImage, releaseImageMirror, pullSecret)
-}
-
-// GetIronicAgentImage gets the ironic agent image url from the releaseImageMirror if provided.
-// Else gets it from the source releaseImage
-func (r *release) GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
-	return r.getImageByName(log, ironicAgentImageName, releaseImage, releaseImageMirror, pullSecret)
 }
 
 // GetMustGatherImage gets must-gather image URL from the release image or releaseImageMirror, if provided.


### PR DESCRIPTION
    Revert "MGMT-10375: Get the ironic image from the default release image for the arch (#3868)"

This reverts commit cc02f4ba1358b0de8244d77be26d7e3572296fe3.

