### PR TITLE
MGMT-10705: Allow installation on FC multipath

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -36,6 +36,9 @@ type Disk struct {
 	// hctl
 	Hctl string `json:"hctl,omitempty"`
 
+	// A comma-separated list of disk names that this disk belongs to
+	Holders string `json:"holders,omitempty"`
+
 	// Determine the disk's unique identifier which is the by-id field if it exists and fallback to the by-path field otherwise
 	ID string `json:"id,omitempty"`
 

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -37,18 +37,18 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 }
 
 // DiskIsEligible mocks base method.
-func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, infraEnv *common.InfraEnv, cluster *common.Cluster, host *models.Host) ([]string, error) {
+func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, infraEnv *common.InfraEnv, cluster *common.Cluster, host *models.Host, allDisks []*models.Disk) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiskIsEligible", ctx, disk, infraEnv, cluster, host)
+	ret := m.ctrl.Call(m, "DiskIsEligible", ctx, disk, infraEnv, cluster, host, allDisks)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DiskIsEligible indicates an expected call of DiskIsEligible.
-func (mr *MockValidatorMockRecorder) DiskIsEligible(ctx, disk, infraEnv, cluster, host interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) DiskIsEligible(ctx, disk, infraEnv, cluster, host, allDisks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), ctx, disk, infraEnv, cluster, host)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), ctx, disk, infraEnv, cluster, host, allDisks)
 }
 
 // GetClusterHostRequirements mocks base method.

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -251,7 +251,7 @@ func (m *Manager) populateDisksEligibility(ctx context.Context, inventory *model
 		}
 
 		// Append to the existing reasons already filled in by the agent
-		reasons, err := m.hwValidator.DiskIsEligible(ctx, disk, infraEnv, cluster, host)
+		reasons, err := m.hwValidator.DiskIsEligible(ctx, disk, infraEnv, cluster, host, inventory.Disks)
 		if err != nil {
 			return err
 		}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1088,7 +1088,7 @@ var _ = Describe("UpdateInventory", func() {
 			It(test.testName, func() {
 				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
 				inventoryStr, err := common.MarshalInventory(&test.inventory)
 				Expect(err).ToNot(HaveOccurred())
@@ -1148,7 +1148,7 @@ var _ = Describe("UpdateInventory", func() {
 		} {
 			test := test
 			It(test.testName, func() {
-				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(append(test.agentReasons, test.serviceReasons...), nil)
+				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(append(test.agentReasons, test.serviceReasons...), nil)
 
 				testInventory := models.Inventory{Disks: []*models.Disk{
 					{InstallationEligibility: models.DiskInstallationEligibility{
@@ -1217,7 +1217,7 @@ var _ = Describe("UpdateInventory", func() {
 					},
 				}
 
-				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(inventory.Disks)
 				if test.expectMatch {
 					mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
@@ -1251,7 +1251,7 @@ var _ = Describe("UpdateInventory", func() {
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 		})
 		It("Happy flow", func() {
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			)
@@ -1276,7 +1276,7 @@ var _ = Describe("UpdateInventory", func() {
 			host.Inventory = common.GenerateTestDefaultInventory()
 			host.InstallationDiskPath = ""
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 		})
 
@@ -1292,7 +1292,7 @@ var _ = Describe("UpdateInventory", func() {
 			Expect(h.InstallationDiskID).To(Equal(diskId))
 
 			// Now make sure it gets removed if the disk is no longer in the inventory
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{},
 			)
@@ -1315,7 +1315,7 @@ var _ = Describe("UpdateInventory", func() {
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			)
-			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
 			h = hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))

--- a/models/disk.go
+++ b/models/disk.go
@@ -36,6 +36,9 @@ type Disk struct {
 	// hctl
 	Hctl string `json:"hctl,omitempty"`
 
+	// A comma-separated list of disk names that this disk belongs to
+	Holders string `json:"holders,omitempty"`
+
 	// Determine the disk's unique identifier which is the by-id field if it exists and fallback to the by-path field otherwise
 	ID string `json:"id,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6271,6 +6271,10 @@ func init() {
         "hctl": {
           "type": "string"
         },
+        "holders": {
+          "description": "A comma-separated list of disk names that this disk belongs to",
+          "type": "string"
+        },
         "id": {
           "description": "Determine the disk's unique identifier which is the by-id field if it exists and fallback to the by-path field otherwise",
           "type": "string"
@@ -15470,6 +15474,10 @@ func init() {
           "type": "boolean"
         },
         "hctl": {
+          "type": "string"
+        },
+        "holders": {
+          "description": "A comma-separated list of disk names that this disk belongs to",
           "type": "string"
         },
         "id": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5237,6 +5237,9 @@ definitions:
         type: string
       io_perf:
         $ref: '#/definitions/io_perf'
+      holders:
+        type: string
+        description: A comma-separated list of disk names that this disk belongs to
 
   io_perf:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -36,6 +36,9 @@ type Disk struct {
 	// hctl
 	Hctl string `json:"hctl,omitempty"`
 
+	// A comma-separated list of disk names that this disk belongs to
+	Holders string `json:"holders,omitempty"`
+
 	// Determine the disk's unique identifier which is the by-id field if it exists and fallback to the by-path field otherwise
 	ID string `json:"id,omitempty"`
 


### PR DESCRIPTION
This PR allows installation on disks that are identified as multipath, and where all paths are Fibre Channel (not iSCSI, for example).

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
