### PR TITLE
MGMT-9561: VSphere platform lacking setting disk.EnableUUID guidance

### DIFF
--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -155,6 +155,20 @@ func (mr *MockValidatorMockRecorder) GetPreflightInfraEnvHardwareRequirements(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreflightInfraEnvHardwareRequirements", reflect.TypeOf((*MockValidator)(nil).GetPreflightInfraEnvHardwareRequirements), ctx, infraEnv)
 }
 
+// IsValidStorageDeviceType mocks base method.
+func (m *MockValidator) IsValidStorageDeviceType(disk *models.Disk) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsValidStorageDeviceType", disk)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsValidStorageDeviceType indicates an expected call of IsValidStorageDeviceType.
+func (mr *MockValidatorMockRecorder) IsValidStorageDeviceType(disk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidStorageDeviceType", reflect.TypeOf((*MockValidator)(nil).IsValidStorageDeviceType), disk)
+}
+
 // ListEligibleDisks mocks base method.
 func (m *MockValidator) ListEligibleDisks(inventory *models.Inventory) []*models.Disk {
 	m.ctrl.T.Helper()

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -279,6 +279,11 @@ func newValidations(v *validator) []validation {
 			condition: v.nonOverlappingSubnets,
 			formatter: v.printNonOverlappingSubnets,
 		},
+		{
+			id:        VSphereHostUUIDEnabled,
+			condition: v.isVSphereDiskUUIDEnabled,
+			formatter: v.printVSphereUUIDEnabled,
+		},
 	}
 }
 

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -42,6 +42,7 @@ const (
 	IsDNSWildcardNotConfigured                     = validationID(models.HostValidationIDDNSWildcardNotConfigured)
 	DiskEncryptionRequirementsSatisfied            = validationID(models.HostValidationIDDiskEncryptionRequirementsSatisfied)
 	NonOverlappingSubnets                          = validationID(models.HostValidationIDNonOverlappingSubnets)
+	VSphereHostUUIDEnabled                         = validationID(models.HostValidationIDVsphereDiskUUIDEnabled)
 )
 
 func (v validationID) category() (string, error) {
@@ -74,6 +75,7 @@ func (v validationID) category() (string, error) {
 		IsHostnameUnique,
 		IsHostnameValid,
 		CompatibleWithClusterPlatform,
+		VSphereHostUUIDEnabled,
 		DiskEncryptionRequirementsSatisfied:
 		return "hardware", nil
 	case AreLsoRequirementsSatisfied,


### PR DESCRIPTION
The parameter disk.EnableUUID is necessary so that the VMDK always presents a consistent UUID to the VM, thus allowing the disk to be mounted properly.
Please read https://access.redhat.com/solutions/4606201

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
