### PR TITLE
MGMT-10411: Allow enabling virtual interfaces

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -239,6 +239,41 @@ func GenerateTestDefaultInventory() string {
 	return string(b)
 }
 
+func GenerateTestInventoryWithVirtualInterface() string {
+	inventory := &models.Inventory{
+		Interfaces: []*models.Interface{
+			{
+				Name: "eth0",
+				IPV4Addresses: []string{
+					"192.0.2.0/24",
+				},
+				IPV6Addresses: []string{
+					"2001:db8::/32",
+				},
+				Type: "physical",
+			},
+			{
+				Name: "cni1",
+				IPV4Addresses: []string{
+					"198.51.100.0/24",
+				},
+				IPV6Addresses: []string{
+					"2001:db8::/32",
+				},
+				Type: "device",
+			},
+		},
+		Disks: []*models.Disk{
+			TestDefaultConfig.Disks,
+		},
+		Routes: TestDefaultRouteConfiguration,
+	}
+
+	b, err := json.Marshal(inventory)
+	Expect(err).To(Not(HaveOccurred()))
+	return string(b)
+}
+
 func GenerateTest2IPv4AddressesInventory() string {
 	inventory := &models.Inventory{
 		Interfaces: []*models.Interface{

--- a/internal/provider/baremetal/base.go
+++ b/internal/provider/baremetal/base.go
@@ -11,7 +11,7 @@ type baremetalProvider struct {
 	Log logrus.FieldLogger
 }
 
-// NewBaremetalProvider creates a new vSphere provider.
+// NewBaremetalProvider creates a new baremetal provider.
 func NewBaremetalProvider(log logrus.FieldLogger) provider.Provider {
 	return &baremetalProvider{
 		Log: log,

--- a/internal/provider/baremetal/installConfig.go
+++ b/internal/provider/baremetal/installConfig.go
@@ -43,13 +43,9 @@ func (p baremetalProvider) AddPlatformToInstallConfig(
 		}
 
 		for _, iface := range inventory.Interfaces {
-			//TODO: modify the filter depending on the environment variable set in MGMT-10411 to show virtual interfaces
-			// Only allow interfaces that we previous filtered for (physical, bonds, and vlans) or empty type (backwards compatibility)
-			if !(iface.Type == "physical" || iface.Type == "bond" || iface.Type == "vlan" || iface.Type == "") {
-				continue
-			}
 			if iface.MacAddress != "" {
 				hosts[yamlHostIdx].BootMACAddress = iface.MacAddress
+				break
 			}
 		}
 		if hosts[yamlHostIdx].BootMACAddress == "" {


### PR DESCRIPTION
[MGMT-10411](https://issues.redhat.com/browse/MGMT-10411)
As part of epic https://issues.redhat.com/browse/MGMT-10087
Exposes an environment variable in the service
that allows virtual interfaces to be
used.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment: deployed and installed nodes after using this service image and adding `ENABLE_VIRTUAL_INTERFACES` to the configmap
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
