### PR TITLE
MGMT-10713: Soften IP-stack checks for host_network propagation

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2501,7 +2501,7 @@ func (b *bareMetalInventory) calculateHostNetworks(log logrus.FieldLogger, clust
 		}
 		for _, intf := range inventory.Interfaces {
 			var addrRange []string
-			if b.Config.IPv6Support {
+			if b.Config.IPv6Support || (len(intf.IPV4Addresses) > 0 && len(intf.IPV6Addresses) > 0) {
 				addrRange = append(intf.IPV4Addresses, intf.IPV6Addresses...)
 			} else {
 				addrRange = intf.IPV4Addresses


### PR DESCRIPTION
This commit softens the checks for IP stack when `cluster.HostNetworks`
are propagated from the hosts' inventory. Currently disabled
`cfg.IPv6Support` implies that all the IPv6 subnets will be removed and as
a result dual-stack hosts will create a cluster with only IPv4 host
networks.

This issue is only affecting clusters created using the UI. This is
because UI propagates its forms with `cluster.HostNetworks` property
whereas users of the API are requested to manually provide
`cluster.MachineNetworks`.

This is not a desired behaviour as it prevents from forming a correct
host networks. With this change, if host contains both IPv4 and IPv6
subnets in its inventory, we will form host networks from both stacks
even if `cfg.IPv6Support` is False.

This goes in line with our current approach that `cfg.IPv6Support` refers
to support of IPv6-only clusters and should not affect dual-stack
clusters. The former is because we don't want to allow IPv6-only due to
the fact that api.openshift.com does not have IPv6 endpoint. For
dual-stack clusters this is not an issue as those clusters can connect
using a regular IPv4 endpoint.

With this change the propagation will look as follows

* disabled `cfg.IPv6Support`
  * dual-stack host - HostNetworks with both stacks
  * IPv4 host - HostNetworks with IPv4
  * IPv6 host - empty HostNetworks
* enabled `cfg.IPv6Support`
  * dual-stack host - HostNetworks with both stacks
  * IPv4 host - HostNetworks with IPv4
  * IPv6 host - HostNetworks with IPv6

Please note that this change will not transparently allow for creation
of IPv6-only clusters if the hosts are dual-stack. This is because the
service implements a separate set of checks so that when
`cfg.IPv6Support` is False it is forbidden to select an IPv6 subnet as
any of the networks. If such an attempt is detected, the service will
return the error message `IPv6 is not supported in this setup`.

Closes: [MGMT-10713](https://issues.redhat.com//browse/MGMT-10713)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
