### PR TITLE
BZ-2089683: Disable ZTP converged flow

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -144,7 +144,7 @@ var Options struct {
 	LivenessValidationTimeout      time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
 	ApproveCsrsRequeueDuration     time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
-	AllowConvergedFlow             bool          `envconfig:"ALLOW_COVERGED_FLOW" default:"true"`
+	AllowConvergedFlow             bool          `envconfig:"ALLOW_COVERGED_FLOW" default:"false"` // set to true once https://bugzilla.redhat.com/show_bug.cgi?id=2089683 is resolved
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -583,6 +583,8 @@ func main() {
 					Log:                    log,
 					Installer:              bm,
 					CRDEventsHandler:       crdEventsHandler,
+					VersionsHandler:        versionHandler,
+					OcRelease:              releaseHandler,
 					IronicIgniotionBuilder: ignition.NewIronicIgniotionBuilder(Options.IronicIgnitionBuilderConfig),
 					IronicServiceURL:       ironicBaseURL,
 				}).SetupWithManager(ctrlMgr), "failed to create PreprovisioningImage ceontroller")

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -56,7 +56,7 @@ type PreprovisioningImageReconciler struct {
 	CRDEventsHandler       CRDEventsHandler
 	IronicIgniotionBuilder ignition.IronicIgniotionBuilder
 	VersionsHandler        versions.Handler
-	ocRelease              oc.Release
+	OcRelease              oc.Release
 	ReleaseImageMirror     string
 	IronicServiceURL       string
 }
@@ -323,7 +323,7 @@ func (r *PreprovisioningImageReconciler) getIronicAgentImage(log logrus.FieldLog
 	if err != nil {
 		return "", err
 	}
-	ironicAgentImage, err := r.ocRelease.GetIronicAgentImage(log, *releaseImage.URL, r.ReleaseImageMirror, infraEnv.PullSecret)
+	ironicAgentImage, err := r.OcRelease.GetIronicAgentImage(log, *releaseImage.URL, r.ReleaseImageMirror, infraEnv.PullSecret)
 	if err != nil {
 		return "", err
 	}

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			CRDEventsHandler:       mockCRDEventsHandler,
 			IronicIgniotionBuilder: ironicIgnitionBuilder,
 			VersionsHandler:        mockVersionHandler,
-			ocRelease:              mockOcRelease,
+			OcRelease:              mockOcRelease,
 			IronicServiceURL:       "ironic.url",
 		}
 	})


### PR DESCRIPTION
This should be reverted once https://bugzilla.redhat.com/show_bug.cgi?id=2089683 is resolved
Users can enable the ZTP converged flow by setting `ALLOW_COVERGED_FLOW="true"` in the assisted environment.
  

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? dev scripts
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR
https://bugzilla.redhat.com/show_bug.cgi?id=2089683

- [x] New Feature <!-- new functionality --> disabling new functionality :smirk: 
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @romfreiman 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
