### PR TITLE
MGMT-9259: Enhance the schedulable masters feature (simplified)

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -109,9 +109,6 @@ type ClusterCreateParams struct {
 	// Required: true
 	PullSecret *string `json:"pull_secret"`
 
-	// Schedule workloads on masters
-	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
-
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr *string `json:"service_network_cidr,omitempty"`

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1283,10 +1283,8 @@ func (m *Manager) GenerateAdditionalManifests(ctx context.Context, cluster *comm
 		return errors.Wrap(err, "failed to add telemeter manifest")
 	}
 
-	if common.AreMastersSchedulable(cluster) {
-		if err := m.manifestsGeneratorAPI.AddSchedulableMastersManifest(ctx, log, cluster); err != nil {
-			return errors.Wrap(err, "failed to add schedulable masters manifest")
-		}
+	if err := m.manifestsGeneratorAPI.AddSchedulableMastersManifest(ctx, log, cluster); err != nil {
+		return errors.Wrap(err, "failed to add schedulable masters manifest")
 	}
 
 	if err := m.manifestsGeneratorAPI.AddDiskEncryptionManifest(ctx, log, cluster); err != nil {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2547,6 +2547,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		manifestsGenerator.EXPECT().AddDnsmasqForSingleNode(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+		manifestsGenerator.EXPECT().AddSchedulableMastersManifest(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
 		err := capi.GenerateAdditionalManifests(ctx, &c)
@@ -2569,6 +2570,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 		manifestsGenerator.EXPECT().IsSNODNSMasqEnabled().Return(false).Times(1)
 		manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 		manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+		manifestsGenerator.EXPECT().AddSchedulableMastersManifest(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockOperatorMgr.EXPECT().GenerateManifests(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		c.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
 		err := capi.GenerateAdditionalManifests(ctx, &c)
@@ -2593,6 +2595,7 @@ var _ = Describe("GenerateAdditionalManifests", func() {
 			mockOperatorMgr.EXPECT().GenerateManifests(ctx, &c).Return(nil)
 			manifestsGenerator.EXPECT().AddTelemeterManifest(ctx, gomock.Any(), &c).Return(nil)
 			manifestsGenerator.EXPECT().AddDiskEncryptionManifest(ctx, gomock.Any(), &c).Return(nil)
+			manifestsGenerator.EXPECT().AddSchedulableMastersManifest(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 			err := capi.GenerateAdditionalManifests(ctx, &c)
 			Expect(err).To(Not(HaveOccurred()))

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -112,10 +112,6 @@ func IsDay2Cluster(cluster *Cluster) bool {
 	return swag.StringValue(cluster.Kind) == models.ClusterKindAddHostsCluster
 }
 
-func AreMastersSchedulable(cluster *Cluster) bool {
-	return swag.BoolValue(cluster.SchedulableMasters)
-}
-
 func GetEffectiveRole(host *models.Host) models.HostRole {
 	if host.Role == models.HostRoleAutoAssign && host.SuggestedRole != "" {
 		return host.SuggestedRole

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -109,9 +109,6 @@ type ClusterCreateParams struct {
 	// Required: true
 	PullSecret *string `json:"pull_secret"`
 
-	// Schedule workloads on masters
-	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
-
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr *string `json:"service_network_cidr,omitempty"`

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5525,7 +5525,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -5593,6 +5593,11 @@ func init() {
             },
             "type": "Time"
           }
+        },
+        "use_scheduling_defaults": {
+          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
+          "type": "boolean",
+          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -5761,11 +5766,6 @@ func init() {
         "pull_secret": {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at console.redhat.com/openshift/install/pull-secret.",
           "type": "string"
-        },
-        "schedulable_masters": {
-          "description": "Schedule workloads on masters",
-          "type": "boolean",
-          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -8972,7 +8972,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -8993,6 +8993,11 @@ func init() {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string",
           "x-nullable": true
+        },
+        "use_scheduling_defaults": {
+          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
+          "type": "boolean",
+          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -14741,7 +14746,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -14809,6 +14814,11 @@ func init() {
             },
             "type": "Time"
           }
+        },
+        "use_scheduling_defaults": {
+          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
+          "type": "boolean",
+          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -14977,11 +14987,6 @@ func init() {
         "pull_secret": {
           "description": "The pull secret obtained from Red Hat OpenShift Cluster Manager at console.redhat.com/openshift/install/pull-secret.",
           "type": "string"
-        },
-        "schedulable_masters": {
-          "description": "Schedule workloads on masters",
-          "type": "boolean",
-          "default": false
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -18108,7 +18113,7 @@ func init() {
         "schedulable_masters": {
           "description": "Schedule workloads on masters",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
@@ -18129,6 +18134,11 @@ func init() {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string",
           "x-nullable": true
+        },
+        "use_scheduling_defaults": {
+          "description": "False if the scheduling of workloads on masters has been set by the user through the API.",
+          "type": "boolean",
+          "default": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4286,10 +4286,6 @@ definitions:
         description: "The desired network type used."
         enum: ['OpenShiftSDN', 'OVNKubernetes']
         default: 'OpenShiftSDN'
-      schedulable_masters:
-        type: boolean
-        description: Schedule workloads on masters
-        default: false
       cluster_networks:
         type: array
         description: Cluster networks that are associated with this cluster.
@@ -4463,7 +4459,11 @@ definitions:
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters
-        default: false
+        default: true
+      use_scheduling_defaults:
+        type: boolean
+        description: False if the scheduling of workloads on masters has been set by the user through the API.
+        default: true
       cluster_networks:
         type: array
         description: Cluster networks that are associated with this cluster.
@@ -4674,7 +4674,11 @@ definitions:
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters
-        default: false
+        default: true
+      use_scheduling_defaults:
+        type: boolean
+        description: False if the scheduling of workloads on masters has been set by the user through the API.
+        default: true
       updated_at:
         type: string
         format: date-time

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -109,9 +109,6 @@ type ClusterCreateParams struct {
 	// Required: true
 	PullSecret *string `json:"pull_secret"`
 
-	// Schedule workloads on masters
-	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
-
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr *string `json:"service_network_cidr,omitempty"`

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// False if the scheduling of workloads on masters has been set by the user through the API.
+	UseSchedulingDefaults *bool `json:"use_scheduling_defaults,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 


### PR DESCRIPTION
The current API always returns the value of the 'schedulable_masters'
property saved in the database at cluster creation time (defaults to
"false" if omitted). However the UI needs the API to return the default
correct value depending on the number of hosts in the cluster.

The proposed changes return the expected default values in case the
'schedulable_masters' property was not actively set.

## List all the issues related to this PR

- [x] New Feature
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- [ ] Are the title and description (in both PR and commit) meaningful and clear?
- [ ] Is there a bug required (and linked) for this change?
- [ ] Should this PR be backported?