### PR TITLE
auth: AuthUserAuth errors should be wrapped in HTTP 401

### DIFF
--- a/pkg/auth/rhsso_authenticator_test.go
+++ b/pkg/auth/rhsso_authenticator_test.go
@@ -195,6 +195,17 @@ var _ = Describe("auth handler test", func() {
 
 			if tt.expectedError != nil {
 				Expect(reflect.TypeOf(e).String()).To(Equal(reflect.TypeOf(tt.expectedError).String()))
+				// Unwrap the error and make sure the code it throws is "Unauthorized"
+				var wrappedErr interface{}
+				ok := errors.As(e, &wrappedErr)
+				Expect(ok).To(BeTrue())
+				wrappedErrPtr := reflect.ValueOf(wrappedErr)
+				authErrorInterface := reflect.Indirect(wrappedErrPtr).FieldByName("Payload").Interface()
+				if reflect.TypeOf(authErrorInterface).String() == "*models.InfraError" {
+					authError := authErrorInterface.(*models.InfraError)
+					expectedError := int32(http.StatusUnauthorized)
+					Expect(authError.Code).To(Equal(&expectedError))
+				}
 			} else {
 				Expect(e).To(BeNil())
 			}


### PR DESCRIPTION
Default golang http server type is 500, so instead of unauthorized users get "server error"

Found during schema test fuzzing - almost all endpoints return HTTP 500 instead of HTTP 401

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @osherdp 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
