### PR TITLE
bz-2096445: Bug Assisted service POD keeps crashing after a BMH is created

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -289,7 +289,7 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	if infraEnvInternal.OpenshiftVersion != "" {
 		ironicAgentImage, err = r.getIronicAgentImage(log, *infraEnvInternal)
 		if err != nil {
-			log.WithError(err).Errorf("Failed to get ironicAgentImage from clusterRef: %+v", *infraEnv.Spec.ClusterRef)
+			log.WithError(err).Errorf("Failed to get ironicAgentImage for infraEnv: %s", infraEnv.Name)
 		}
 	}
 


### PR DESCRIPTION
The controller dereference nil pointer while trying to log an error with the InfraEnv.Spec.ClusterRef

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? devscripts
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://bugzilla.redhat.com/show_bug.cgi?id=2096445

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @avishayt  

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
