### PR TITLE
MGMT-10780: Copy CAPI deploy scripts to ocm-2.5 branch

### DIFF
--- a/deploy/operator/capi/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/capi/assisted-installer-crds-playbook.yaml
@@ -1,0 +1,48 @@
+- name: Create CRDs for Assisted Installer
+  hosts: localhost
+  collections:
+   - community.general
+  gather_facts: no
+  vars:
+    - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
+    - spoke_controlplane_agents: "{{ lookup('env', 'SPOKE_CONTROLPLANE_AGENTS') }}"
+    - spoke_api_vip: "{{ lookup('env', 'SPOKE_API_VIP') }}"
+    - spoke_ingress_vip: "{{ lookup('env', 'SPOKE_INGRESS_VIP') }}"
+    - cluster_name: "{{ lookup('env', 'ASSISTED_CLUSTER_NAME') }}"
+    - cluster_image_set_name: "{{ lookup('env', 'ASSISTED_OPENSHIFT_VERSION') }}"
+    - cluster_release_image: "{{ lookup('env', 'ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE') }}"
+    - cluster_deployment_name: "{{ lookup('env', 'ASSISTED_CLUSTER_DEPLOYMENT_NAME') }}"
+    - infraenv_name: "{{ lookup('env', 'ASSISTED_INFRAENV_NAME') }}"
+    - agent_cluster_install_name: "{{ lookup('env', 'ASSISTED_AGENT_CLUSTER_INSTALL_NAME') }}"
+    - pull_secret_name: "{{ lookup('env', 'ASSISTED_PULLSECRET_NAME') }}"
+    - ssh_private_key_name: "{{ lookup('env', 'ASSISTED_PRIVATEKEY_NAME') }}"
+    - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+    - cluster_subnet: "{{ lookup('env', 'CLUSTER_SUBNET') }}"
+    - cluster_host_prefix: "{{ lookup('env', 'CLUSTER_HOST_PREFIX') }}"
+    - external_subnet: "{{ lookup('env', 'EXTERNAL_SUBNET') }}"
+    - service_subnet: "{{ lookup('env', 'SERVICE_SUBNET') }}"
+    - cluster_subnet_additional: "{{ lookup('env', 'CLUSTER_SUBNET_ADDITIONAL') }}"
+    - cluster_host_prefix_additional: "{{ lookup('env', 'CLUSTER_HOST_PREFIX_ADDITIONAL') }}"
+    - external_subnet_additional: "{{ lookup('env', 'EXTERNAL_SUBNET_ADDITIONAL') }}"
+    - service_subnet_additional: "{{ lookup('env', 'SERVICE_SUBNET_ADDITIONAL') }}"
+    - baremetalhosts: "{{ lookup('file', lookup('env', 'EXTRA_BAREMETALHOSTS_FILE')) | from_json }}"
+    - assisted_upgrade_operator: "{{ lookup('env', 'ASSISTED_UPGRADE_OPERATOR') }}"
+    - assisted_stop_after_agent_discovery: "{{ lookup('env', 'ASSISTED_STOP_AFTER_AGENT_DISCOVERY') }}"
+    - user_managed_networking: "{{ lookup('env', 'USER_MANAGED_NETWORKING') }}"
+    - day2: "false"
+
+  tasks:
+  - name: create directory for generated CRDs
+    file:
+      name: generated
+      state: directory
+
+  - name: write the infraEnv crd
+    template:
+      src: "infraEnv.j2"
+      dest: "generated/infraEnv.yaml"
+
+  - name: write the baremetalHost crd
+    template:
+      src: "baremetalHost.j2"
+      dest: "generated/baremetalHost.yaml"

--- a/deploy/operator/capi/baremetalHost.j2
+++ b/deploy/operator/capi/baremetalHost.j2
@@ -1,0 +1,48 @@
+{% set ns = namespace(counter=1) %}
+{% set bmhs = [] %}
+{% if day2|string == "true" %}
+      {% set bmhs = baremetalhosts %}
+{% else %}
+{% if assisted_upgrade_operator|string == "true" %}
+## Use the first baremetalhost to install SNO before upgrading the operator
+      {{ bmhs.append( baremetalhosts[0] ) }}
+{% elif ( assisted_stop_after_agent_discovery|string == "true" ) and ( baremetalhosts|length > 1) %}
+## When operator has already been upgraded, use the other baremetalhost to install SNO after the operator upgrade
+      {{ bmhs.append( baremetalhosts[1] ) }}
+{% else %}
+      {% set bmhs = baremetalhosts %}
+{% endif %}
+{% endif %}
+{% for host in bmhs %}
+{% if day2|string == "true"  or ns.counter <= spoke_controlplane_agents|int%}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ host["name"] }}-bmc-secret'
+  namespace: '{{ spoke_namespace }}'
+type: Opaque
+data:
+  username: '{{ host["driver_info"]["username"] | b64encode }}'
+  password: '{{ host["driver_info"]["password"] | b64encode }}'
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: '{{ host["name"] }}'
+  namespace: '{{ spoke_namespace }}'
+  labels:
+    infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
+  annotations:
+    bmac.agent-install.openshift.io/hostname: '{{ host["name"] }}'
+spec:
+  online: true
+  bootMACAddress: '{{ host["ports"][0]["address"] }}'
+  bmc:
+    address: '{{ host["driver_info"]["address"] }}'
+    credentialsName: '{{ host["name"] }}-bmc-secret'
+{% endif %}
+{% set ns.counter = ns.counter + 1 %}
+{% endfor %}

--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__root="$(realpath ${__dir}/../../..)"
+source ${__dir}/../common.sh
+source ${__dir}/../utils.sh
+
+set -x
+
+export ASSISTED_CLUSTER_NAME="${ASSISTED_CLUSTER_NAME:-assisted-test-cluster}"
+export ASSISTED_CLUSTER_DEPLOYMENT_NAME="${ASSISTED_CLUSTER_DEPLOYMENT_NAME:-assisted-test-cluster}"
+export ASSISTED_AGENT_CLUSTER_INSTALL_NAME="${ASSISTED_AGENT_CLUSTER_INSTALL_NAME:-assisted-agent-cluster-install}"
+export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
+export ASSISTED_PULLSECRET_NAME="${ASSISTED_PULLSECRET_NAME:-assisted-pull-secret}"
+export ASSISTED_PULLSECRET_JSON="${ASSISTED_PULLSECRET_JSON:-${PULL_SECRET_FILE}}"
+export ASSISTED_PRIVATEKEY_NAME="${ASSISTED_PRIVATEKEY_NAME:-assisted-ssh-private-key}"
+export EXTRA_BAREMETALHOSTS_FILE="${EXTRA_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/extra_baremetalhosts.json}"
+export SPOKE_CONTROLPLANE_AGENTS="${SPOKE_CONTROLPLANE_AGENTS:-1}"
+export SPOKE_API_VIP="${SPOKE_API_VIP:-}"
+export SPOKE_INGRESS_VIP="${SPOKE_INGRESS_VIP:-}"
+export ASSISTED_STOP_AFTER_AGENT_DISCOVERY="${ASSISTED_STOP_AFTER_AGENT_DISCOVERY:-false}"
+export ASSISTED_UPGRADE_OPERATOR="${ASSISTED_UPGRADE_OPERATOR:-false}"
+export USER_MANAGED_NETWORKING="${USER_MANAGED_NETWORKING:-false}"
+export SPAWN_NONE_PLATFORM_LOAD_BALANCER="${SPAWN_NONE_PLATFORM_LOAD_BALANCER:-false}"
+export ADD_NONE_PLATFORM_LIBVIRT_DNS="${ADD_NONE_PLATFORM_LIBVIRT_DNS:-false}"
+export LIBVIRT_NONE_PLATFORM_NETWORK="${LIBVIRT_NONE_PLATFORM_NETWORK:-ostestbm}"
+export LOAD_BALANCER_IP="${LOAD_BALANCER_IP:-192.168.111.1}"
+export HYPERSHIFT_IMAGE="quay.io/eranco74/hypershift:fix_kubeconfig" # FIXME(mko) Change this after the issue from https://bugzilla.redhat.com/show_bug.cgi?id=2079177 is solved
+# export HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
+
+if [[ "${IP_STACK}" == "v4" ]]; then
+    export CLUSTER_SUBNET="${CLUSTER_SUBNET_V4}"
+    export CLUSTER_HOST_PREFIX="${CLUSTER_HOST_PREFIX_V4}"
+    if [ "${USER_MANAGED_NETWORKING}" != "true" ] ; then
+        export EXTERNAL_SUBNET="${EXTERNAL_SUBNET_V4}"
+    else
+        unset EXTERNAL_SUBNET
+    fi
+    export SERVICE_SUBNET="${SERVICE_SUBNET_V4}"
+elif [[ "${IP_STACK}" == "v6" ]]; then
+    export CLUSTER_SUBNET="${CLUSTER_SUBNET_V6}"
+    export CLUSTER_HOST_PREFIX="${CLUSTER_HOST_PREFIX_V6}"
+    export EXTERNAL_SUBNET="${EXTERNAL_SUBNET_V6}"
+    export SERVICE_SUBNET="${SERVICE_SUBNET_V6}"
+elif [[ "${IP_STACK}" == "v4v6" ]]; then
+    export CLUSTER_SUBNET="${CLUSTER_SUBNET_V4}"
+    export CLUSTER_HOST_PREFIX="${CLUSTER_HOST_PREFIX_V4}"
+    export EXTERNAL_SUBNET="${EXTERNAL_SUBNET_V4}"
+    export SERVICE_SUBNET="${SERVICE_SUBNET_V4}"
+    export CLUSTER_SUBNET_ADDITIONAL="${CLUSTER_SUBNET_V6}"
+    export CLUSTER_HOST_PREFIX_ADDITIONAL="${CLUSTER_HOST_PREFIX_V6}"
+    export EXTERNAL_SUBNET_ADDITIONAL="${EXTERNAL_SUBNET_V6}"
+    export SERVICE_SUBNET_ADDITIONAL="${SERVICE_SUBNET_V6}"
+fi
+
+#  If spoke is a multi cluster then we need to pick IPs for API and Ingress
+if [ ${SPOKE_CONTROLPLANE_AGENTS} -ne 1 ] && [ "${USER_MANAGED_NETWORKING}" != "true" ] ; then
+    export SPOKE_API_VIP=${SPOKE_API_VIP:-$(nth_ip $EXTERNAL_SUBNET 85)}
+    export SPOKE_INGRESS_VIP=${SPOKE_INGRESS_VIP:-$(nth_ip $EXTERNAL_SUBNET 87)}
+fi
+
+if [ "${DISCONNECTED}" = "true" ]; then
+    ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE="${LOCAL_REGISTRY}/$(get_image_without_registry ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})"
+fi
+
+# TODO: make SSH public key configurable
+
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
+
+echo "Running Ansible playbook to create kubernetes objects"
+ansible-playbook "${__dir}/assisted-installer-crds-playbook.yaml"
+
+oc get namespace "${SPOKE_NAMESPACE}" || oc create namespace "${SPOKE_NAMESPACE}"
+
+oc get secret "${ASSISTED_PULLSECRET_NAME}" -n "${SPOKE_NAMESPACE}" || \
+    oc create secret generic "${ASSISTED_PULLSECRET_NAME}" --from-file=.dockerconfigjson="${ASSISTED_PULLSECRET_JSON}" --type=kubernetes.io/dockerconfigjson -n "${SPOKE_NAMESPACE}"
+oc get secret "${ASSISTED_PRIVATEKEY_NAME}" -n "${SPOKE_NAMESPACE}" || \
+    oc create secret generic "${ASSISTED_PRIVATEKEY_NAME}" --from-file=ssh-privatekey=/root/.ssh/id_rsa --type=kubernetes.io/ssh-auth -n "${SPOKE_NAMESPACE}"
+
+for manifest in $(find ${__dir}/generated -type f); do
+    tee < "${manifest}" >(oc apply -f -)
+done
+
+wait_for_condition "infraenv/${ASSISTED_INFRAENV_NAME}" "ImageCreated" "5m" "${SPOKE_NAMESPACE}"
+
+echo "Waiting until at least ${SPOKE_CONTROLPLANE_AGENTS} agents are available..."
+
+function get_agents() {
+  oc get agent -n ${SPOKE_NAMESPACE} --no-headers
+}
+
+export -f wait_for_cmd_amount
+export -f get_agents
+timeout 20m bash -c "wait_for_cmd_amount ${SPOKE_CONTROLPLANE_AGENTS} 30 get_agents"
+echo "All ${SPOKE_CONTROLPLANE_AGENTS} agents have been discovered!"
+
+if [[ "${ASSISTED_STOP_AFTER_AGENT_DISCOVERY}" == "true" ]]; then
+    echo "Agents have been discovered, do not wait for the cluster installtion to finish."
+    exit
+fi
+
+# We need a storage for etcd of the hosted cluster
+oc patch storageclass assisted-service -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+### Hypershift CLI needs access to the kubeconfig, pull-secret and public SSH key
+function hypershift() {
+  podman run -it --net host --rm --entrypoint /usr/bin/hypershift -v $KUBECONFIG:/root/.kube/config -v $ASSISTED_PULLSECRET_JSON:/root/pull-secret.json -v /root/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub $HYPERSHIFT_IMAGE "$@"
+}
+
+echo "Installing HyperShift using upstream image"
+hypershift install --hypershift-image $HYPERSHIFT_IMAGE --namespace hypershift
+wait_for_pods "hypershift"
+
+echo "Creating HostedCluster"
+hypershift create cluster agent --name $ASSISTED_CLUSTER_NAME --base-domain redhat.example --pull-secret /root/pull-secret.json  --ssh-key /root/.ssh/id_rsa.pub --agent-namespace $SPOKE_NAMESPACE --namespace $SPOKE_NAMESPACE --control-plane-operator-image $HYPERSHIFT_IMAGE
+
+# Wait for a running hypershift cluster with no worker nodes
+wait_for_pods "$SPOKE_NAMESPACE-$ASSISTED_CLUSTER_NAME"
+wait_for_condition "nodepool/$ASSISTED_CLUSTER_NAME" "Ready" "10m" "$SPOKE_NAMESPACE"
+wait_for_condition "hostedcluster/$ASSISTED_CLUSTER_NAME" "Available" "10m" "$SPOKE_NAMESPACE"
+
+# Scale up
+echo "Scaling the hosted cluster up to contain ${SPOKE_CONTROLPLANE_AGENTS} worker nodes"
+oc scale nodepool/$ASSISTED_CLUSTER_NAME -n $SPOKE_NAMESPACE --replicas=${SPOKE_CONTROLPLANE_AGENTS}
+
+# Wait for node to appear in the CAPI-deployed cluster
+oc extract -n $SPOKE_NAMESPACE secret/$ASSISTED_CLUSTER_NAME-admin-kubeconfig --to=- > /tmp/$ASSISTED_CLUSTER_NAME-kubeconfig
+export KUBECONFIG=/tmp/$ASSISTED_CLUSTER_NAME-kubeconfig
+
+wait_for_object_amount node ${SPOKE_CONTROLPLANE_AGENTS} 10
+echo "Worker nodes have been detected successfuly in the created cluster!"

--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -25,8 +25,7 @@ export SPAWN_NONE_PLATFORM_LOAD_BALANCER="${SPAWN_NONE_PLATFORM_LOAD_BALANCER:-f
 export ADD_NONE_PLATFORM_LIBVIRT_DNS="${ADD_NONE_PLATFORM_LIBVIRT_DNS:-false}"
 export LIBVIRT_NONE_PLATFORM_NETWORK="${LIBVIRT_NONE_PLATFORM_NETWORK:-ostestbm}"
 export LOAD_BALANCER_IP="${LOAD_BALANCER_IP:-192.168.111.1}"
-export HYPERSHIFT_IMAGE="quay.io/eranco74/hypershift:fix_kubeconfig" # FIXME(mko) Change this after the issue from https://bugzilla.redhat.com/show_bug.cgi?id=2079177 is solved
-# export HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
+export HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
 
 if [[ "${IP_STACK}" == "v4" ]]; then
     export CLUSTER_SUBNET="${CLUSTER_SUBNET_V4}"

--- a/deploy/operator/capi/infraEnv.j2
+++ b/deploy/operator/capi/infraEnv.j2
@@ -1,0 +1,9 @@
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  name: '{{ infraenv_name }}'
+  namespace: '{{ spoke_namespace }}'
+spec:
+  pullSecretRef:
+    name: '{{ pull_secret_name }}'
+  sshAuthorizedKey: '{{ ssh_public_key }}'

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -38,6 +38,15 @@ function wait_for_pod() {
     wait_for_condition "pod" "Ready" "30m" "${namespace}" "${selector}"
 }
 
+function wait_for_pods(){
+  while [[ $(oc get pods -n $1 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'| tr ' ' '\n'  | sort -u) != "True" ]]; do
+    echo "Waiting for pods in namespace $1 to be ready"
+    oc get pods -n $1 -o 'jsonpath={..status.containerStatuses}' | jq "."
+    sleep 5;
+  done
+  echo "Pods in namespace $1 are ready"
+}
+
 function hash() {
     input=$1
     length=$2


### PR DESCRIPTION
This is a cherry-pick of #3690 and #3735. It is needed so that https://github.com/openshift/release/pull/29440 can use deploy/capi/* scripts in the OCM-2.5 branch.

/cc @eranco74 