### PR TITLE
MGMT-10678: Add `compatible-agent` validation

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
@@ -124,6 +124,9 @@ const (
 
 	// HostValidationIDVsphereDiskUUIDEnabled captures enum value "vsphere-disk-uuid-enabled"
 	HostValidationIDVsphereDiskUUIDEnabled HostValidationID = "vsphere-disk-uuid-enabled"
+
+	// HostValidationIDCompatibleAgent captures enum value "compatible-agent"
+	HostValidationIDCompatibleAgent HostValidationID = "compatible-agent"
 )
 
 // for schema
@@ -131,7 +134,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -62,6 +62,7 @@ type ValidatorCfg struct {
 	MaximumAllowedTimeDiffMinutes int64                        `envconfig:"HW_VALIDATOR_MAX_TIME_DIFF_MINUTES" default:"4"`
 	VersionedRequirements         VersionedRequirementsDecoder `envconfig:"HW_VALIDATOR_REQUIREMENTS" default:"[]"`
 	MaxHostDisconnectionTime      time.Duration                `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
+	AgentDockerImage              string                       `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
 }
 
 type validator struct {

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -82,24 +82,26 @@ func GenerateTestHostByKind(hostID, infraEnvID strfmt.UUID, clusterID *strfmt.UU
 			StageStartedAt: now,
 			StageUpdatedAt: now,
 		},
-		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
-		Connectivity:       GenerateTestConnectivityReport(),
+		APIVipConnectivity:    GenerateTestAPIVIpConnectivity(""),
+		Connectivity:          GenerateTestConnectivityReport(),
+		DiscoveryAgentVersion: defaultAgentImage,
 	}
 }
 
 func GenerateTestHostWithInfraEnv(hostID, infraEnvID strfmt.UUID, state string, role models.HostRole) models.Host {
 	now := strfmt.DateTime(time.Now())
 	return models.Host{
-		ID:                 &hostID,
-		InfraEnvID:         infraEnvID,
-		Status:             swag.String(state),
-		Inventory:          common.GenerateTestDefaultInventory(),
-		Role:               role,
-		Kind:               swag.String(models.HostKindHost),
-		CheckedInAt:        now,
-		StatusUpdatedAt:    now,
-		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
-		Connectivity:       GenerateTestConnectivityReport(),
+		ID:                    &hostID,
+		InfraEnvID:            infraEnvID,
+		Status:                swag.String(state),
+		Inventory:             common.GenerateTestDefaultInventory(),
+		Role:                  role,
+		Kind:                  swag.String(models.HostKindHost),
+		CheckedInAt:           now,
+		StatusUpdatedAt:       now,
+		APIVipConnectivity:    GenerateTestAPIVIpConnectivity(""),
+		Connectivity:          GenerateTestConnectivityReport(),
+		DiscoveryAgentVersion: defaultAgentImage,
 	}
 }
 
@@ -120,7 +122,8 @@ func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUI
 			StageStartedAt: now,
 			StageUpdatedAt: now,
 		},
-		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
+		APIVipConnectivity:    GenerateTestAPIVIpConnectivity(""),
+		DiscoveryAgentVersion: defaultAgentImage,
 	}
 	return &h
 }
@@ -454,3 +457,5 @@ func generateIPAddresses(count int, ipAddress net.IP, mask int) []string {
 	}
 	return ret
 }
+
+const defaultAgentImage = "quay.io/edge-infrastructure/assisted-installer-agent:latest"

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -284,6 +284,11 @@ func newValidations(v *validator) []validation {
 			condition: v.isVSphereDiskUUIDEnabled,
 			formatter: v.printVSphereUUIDEnabled,
 		},
+		{
+			id:        CompatibleAgent,
+			condition: v.compatibleAgent,
+			formatter: v.printCompatibleAgent,
+		},
 	}
 }
 

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -78,6 +78,7 @@ func createValidatorCfg() *hardware.ValidatorCfg {
 		},
 		MaximumAllowedTimeDiffMinutes: 4,
 		MaxHostDisconnectionTime:      MaxHostDisconnectionTime,
+		AgentDockerImage:              "quay.io/edge-infrastructure/assisted-installer-agent:latest",
 	}
 }
 

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -43,6 +43,7 @@ const (
 	DiskEncryptionRequirementsSatisfied            = validationID(models.HostValidationIDDiskEncryptionRequirementsSatisfied)
 	NonOverlappingSubnets                          = validationID(models.HostValidationIDNonOverlappingSubnets)
 	VSphereHostUUIDEnabled                         = validationID(models.HostValidationIDVsphereDiskUUIDEnabled)
+	CompatibleAgent                                = validationID(models.HostValidationIDCompatibleAgent)
 )
 
 func (v validationID) category() (string, error) {
@@ -76,7 +77,8 @@ func (v validationID) category() (string, error) {
 		IsHostnameValid,
 		CompatibleWithClusterPlatform,
 		VSphereHostUUIDEnabled,
-		DiskEncryptionRequirementsSatisfied:
+		DiskEncryptionRequirementsSatisfied,
+		CompatibleAgent:
 		return "hardware", nil
 	case AreLsoRequirementsSatisfied,
 		AreOdfRequirementsSatisfied,

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -673,4 +673,47 @@ var _ = Describe("Validations test", func() {
 			Expect(status).To(BeEquivalentTo(ValidationSuccess))
 		})
 	})
+
+	Context("Agent compatibility validation", func() {
+		var (
+			host    models.Host
+			cluster common.Cluster
+		)
+
+		BeforeEach(func() {
+			cluster = hostutil.GenerateTestCluster(clusterID, common.TestIPv4Networking.MachineNetworks)
+			Expect(db.Create(&cluster).Error).ToNot(HaveOccurred())
+			hostId := strfmt.UUID(uuid.New().String())
+			infraEnvId := strfmt.UUID(uuid.New().String())
+			host = hostutil.GenerateTestHostByKind(hostId, infraEnvId, &clusterID, models.HostStatusKnown, models.HostKindHost, models.HostRoleMaster)
+			host.Inventory = hostutil.GenerateMasterInventory()
+			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
+		})
+
+		It("Passes if the agent and the service use the same image", func() {
+			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
+			mockAndRefreshStatus(&host)
+			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
+			status, message, ok := getValidationResult(host.ValidationsInfo, CompatibleAgent)
+			Expect(ok).To(BeTrue())
+			Expect(status).To(Equal(ValidationSuccess))
+			Expect(message).To(Equal("Host agent is compatible with the service"))
+		})
+
+		It("Fails if the agent and the service use different images", func() {
+			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
+			host.DiscoveryAgentVersion = "quay.io/edge-infrastructure/assisted-installer-agent:wrong"
+			mockAndRefreshStatus(&host)
+			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
+			status, message, ok := getValidationResult(host.ValidationsInfo, CompatibleAgent)
+			Expect(ok).To(BeTrue())
+			Expect(status).To(Equal(ValidationFailure))
+			Expect(message).To(Equal(
+				"The installation cannot start just yet because this host's agent is in " +
+					"the process of being upgraded to a newer version, please wait, this " +
+					"could take a few minutes",
+			))
+		})
+	})
 })

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1473,3 +1473,22 @@ func (v *validator) printVSphereUUIDEnabled(_ *validationContext, status Validat
 		return fmt.Sprintf("Unexpected status %s", status)
 	}
 }
+
+func (v *validator) compatibleAgent(c *validationContext) ValidationStatus {
+	if c.host.DiscoveryAgentVersion != v.hwValidatorCfg.AgentDockerImage {
+		return ValidationFailure
+	}
+	return ValidationSuccess
+}
+
+func (v *validator) printCompatibleAgent(c *validationContext, status ValidationStatus) string {
+	switch status {
+	case ValidationSuccess:
+		return "Host agent is compatible with the service"
+	case ValidationFailure:
+		return "The installation cannot start just yet because this host's agent is in " +
+			"the process of being upgraded to a newer version, please wait, this " +
+			"could take a few minutes"
+	}
+	return fmt.Sprintf("Unexpected status %s", status)
+}

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -124,6 +124,9 @@ const (
 
 	// HostValidationIDVsphereDiskUUIDEnabled captures enum value "vsphere-disk-uuid-enabled"
 	HostValidationIDVsphereDiskUUIDEnabled HostValidationID = "vsphere-disk-uuid-enabled"
+
+	// HostValidationIDCompatibleAgent captures enum value "compatible-agent"
+	HostValidationIDCompatibleAgent HostValidationID = "compatible-agent"
 )
 
 // for schema
@@ -131,7 +134,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7230,7 +7230,8 @@ func init() {
         "dns-wildcard-not-configured",
         "disk-encryption-requirements-satisfied",
         "non-overlapping-subnets",
-        "vsphere-disk-uuid-enabled"
+        "vsphere-disk-uuid-enabled",
+        "compatible-agent"
       ]
     },
     "host_network": {
@@ -16375,7 +16376,8 @@ func init() {
         "dns-wildcard-not-configured",
         "disk-encryption-requirements-satisfied",
         "non-overlapping-subnets",
-        "vsphere-disk-uuid-enabled"
+        "vsphere-disk-uuid-enabled",
+        "compatible-agent"
       ]
     },
     "host_network": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5626,6 +5626,7 @@ definitions:
       - 'disk-encryption-requirements-satisfied'
       - 'non-overlapping-subnets'
       - 'vsphere-disk-uuid-enabled'
+      - 'compatible-agent'
 
 
   dhcp_allocation_request:

--- a/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
+++ b/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
@@ -124,6 +124,9 @@ const (
 
 	// HostValidationIDVsphereDiskUUIDEnabled captures enum value "vsphere-disk-uuid-enabled"
 	HostValidationIDVsphereDiskUUIDEnabled HostValidationID = "vsphere-disk-uuid-enabled"
+
+	// HostValidationIDCompatibleAgent captures enum value "compatible-agent"
+	HostValidationIDCompatibleAgent HostValidationID = "compatible-agent"
 )
 
 // for schema
@@ -131,7 +134,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
This patch adds a new `comptible-agent` validatio that checks that the
agent image expected by the service and the agent image actually used by
the host are compatible.

As neither the service nor the agent use semantic versioning for this
image, the compatibility check just compares the value of the
`AGENT_DOCKER_IMAGE` environment variable of the service with the
`discovery_agent_version` column of the `hosts` table.

This is part of the agent upgrade feature described
[here](https://github.com/openshift/assisted-service/pull/3928).

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
