### PR TITLE
MGMT-10597 API address should be correct for SNO

### DIFF
--- a/deploy/operator/ztp/none_platform_utils.sh
+++ b/deploy/operator/ztp/none_platform_utils.sh
@@ -57,14 +57,13 @@ function render_load_balancer_config_file()
     render_frontend_and_backend "443 81"  "${worker_ips}" >> $fname
 }
 
-
 function setup_libvirt_dns()
 {
     name=$(oc get -n ${SPOKE_NAMESPACE} clusterdeployment | awk '!/NAME/{print $1}')
     cluster_name=$(oc get -n ${SPOKE_NAMESPACE} clusterdeployment ${name} -o jsonpath='{.spec.clusterName}' )
     base_domain=$(oc get -n ${SPOKE_NAMESPACE} clusterdeployment ${name} -o jsonpath='{.spec.baseDomain}' )
     suffix="${cluster_name}.${base_domain}"
-    xml="<host ip='${LOAD_BALANCER_IP}'><hostname>virthost</hostname><hostname>api.${suffix}</hostname><hostname>api-int.${suffix}</hostname><hostname>console-openshift-console.apps.${suffix}</hostname><hostname>canary-openshift-ingress-canary.apps.${suffix}</hostname><hostname>oauth-openshift.apps.${suffix}</hostname></host>"
+    xml="<host ip='${API_IP}'><hostname>virthost</hostname><hostname>api.${suffix}</hostname><hostname>api-int.${suffix}</hostname><hostname>console-openshift-console.apps.${suffix}</hostname><hostname>canary-openshift-ingress-canary.apps.${suffix}</hostname><hostname>oauth-openshift.apps.${suffix}</hostname></host>"
     virsh net-update ${LIBVIRT_NONE_PLATFORM_NETWORK} --command delete  --section dns-host "${xml}"
     virsh net-update ${LIBVIRT_NONE_PLATFORM_NETWORK} --command add  --section dns-host "${xml}" || exit 1
 }


### PR DESCRIPTION
The present implementation only uses the LOAD_BALANCER_IP, which works
fine for multi node but not for single node.

This commit changes that by obtaining the correct api IP for the single
node prior to setting up the libvirt DNS.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
