### PR TITLE
NO-ISSUE: Remove code for deleting ISOs from S3

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11170,7 +11170,6 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("deregister cluster that don't have 'Reserved' subscriptions", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
-			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
 				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
 			mockClusterRegisterSuccess(true)
@@ -11365,7 +11364,6 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("register and deregister cluster happy flow - nil OCM client", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
-			mockS3Client.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).Times(1)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
 				db, mockEvents, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
 			bm.ocmClient = nil

--- a/internal/infraenv/infraenv.go
+++ b/internal/infraenv/infraenv.go
@@ -2,7 +2,6 @@ package infraenv
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/internal/common"
@@ -87,20 +86,6 @@ func (m Manager) DeregisterInfraEnv(ctx context.Context, infraEnvId strfmt.UUID)
 	infraEnv, err := common.GetInfraEnvFromDB(m.db, infraEnvId)
 	if err != nil {
 		return err
-	}
-	// Delete discovery image for deregistered infraEnv
-	discoveryImage := fmt.Sprintf("%s.iso", fmt.Sprintf(s3wrapper.DiscoveryImageTemplate, infraEnvId.String()))
-	exists, err := m.objectHandler.DoesObjectExist(ctx, discoveryImage)
-	if err != nil {
-		log.WithError(err).Errorf("failed to deregister infraEnv %s", infraEnvId)
-		return err
-	}
-	if exists {
-		_, err = m.objectHandler.DeleteObject(ctx, discoveryImage)
-		if err != nil {
-			log.WithError(err).Errorf("failed to deregister infraEnv %s", infraEnvId)
-			return err
-		}
 	}
 
 	if err = m.db.Delete(infraEnv).Error; err != nil {

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	awsEndpointSuffix      = ".amazonaws.com"
-	DiscoveryImageTemplate = "discovery-image-%s"
+	awsEndpointSuffix = ".amazonaws.com"
 )
 
 //go:generate mockgen --build_flags=--mod=mod -package=s3wrapper -destination=mock_s3wrapper.go . API


### PR DESCRIPTION
Recently all the remaining ISOs were removed from all S3 environments so
this kind of code should never be needed from now on.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nmagnezi 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
