### PR TITLE
MGMT-10753: add base url to image-service deployment

### DIFF
--- a/deploy/assisted-image-service-service.yaml
+++ b/deploy/assisted-image-service-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  labels:
+    app: assisted-image-service
+  name: assisted-image-service
+  namespace: REPLACE_NAMESPACE
+spec:
+  ports:
+    - name: assisted-image-service
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: assisted-image-service
+  type: LoadBalancer

--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -51,24 +51,10 @@ items:
                 value: http
               - name: ASSISTED_SERVICE_HOST
                 value: assisted-service:8090
+              - name: IMAGE_SERVICE_SCHEME
+                value: REPLACE_IMAGE_SERVICE_SCHEME
+              - name: IMAGE_SERVICE_HOST
+                value: REPLACE_IMAGE_SERVICE_HOST
               - name: ALLOWED_DOMAINS
                 value: "*"
         serviceAccountName: assisted-service
-- apiVersion: v1
-  kind: Service
-  metadata:
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: nlb
-    labels:
-      app: assisted-image-service
-    name: assisted-image-service
-    namespace: REPLACE_NAMESPACE
-  spec:
-    ports:
-      - name: assisted-image-service
-        port: 8080
-        protocol: TCP
-        targetPort: 8080
-    selector:
-      app: assisted-image-service
-    type: LoadBalancer

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1034,6 +1034,8 @@ func (r *AgentServiceConfigReconciler) newImageServiceStatefulSet(ctx context.Co
 		"app": imageServiceName,
 	}
 
+	imageServiceScheme, imageServiceHost := r.getImageService(ctx, log)
+
 	container := corev1.Container{
 		Name:  imageServiceName,
 		Image: ImageServiceImage(),
@@ -1056,6 +1058,8 @@ func (r *AgentServiceConfigReconciler) newImageServiceStatefulSet(ctx context.Co
 			{Name: "HTTPS_CA_FILE", Value: "/etc/image-service/ca-bundle/service-ca.crt"},
 			{Name: "ASSISTED_SERVICE_SCHEME", Value: "https"},
 			{Name: "ASSISTED_SERVICE_HOST", Value: serviceName + "." + r.Namespace + ".svc:" + servicePort.String()},
+			{Name: "IMAGE_SERVICE_SCHEME", Value: imageServiceScheme},
+			{Name: "IMAGE_SERVICE_HOST", Value: imageServiceHost},
 			{Name: "INSECURE_SKIP_VERIFY", Value: skipVerifyTLS},
 			{Name: "DATA_DIR", Value: "/data"},
 		},
@@ -2171,4 +2175,20 @@ func getStorageRequests(pvcSpec *corev1.PersistentVolumeClaimSpec) map[corev1.Re
 		requests[key] = value
 	}
 	return requests
+}
+
+func (r *AgentServiceConfigReconciler) getImageService(ctx context.Context, log logrus.FieldLogger) (string, string) {
+	imageServiceURL, err := r.urlForRoute(ctx, imageServiceName)
+	if err != nil {
+		log.WithError(err).Warnf("Failed to get URL for route %s", imageServiceName)
+		return "", ""
+	}
+
+	imageServiceBaseURL, err := url.Parse(imageServiceURL)
+	if err != nil {
+		log.WithError(err).Warnf("failed to parse image service base URL")
+		return "", ""
+	}
+
+	return imageServiceBaseURL.Scheme, imageServiceBaseURL.Host
 }


### PR DESCRIPTION
Following the change in https://github.com/openshift/assisted-image-service/pull/83, added IMAGE_SERVICE_SCHEME and IMAGE_SERVICE_HOST to image-service Deployment.

deploy_image_service.py: parsed IMAGE_SERVICE_BASE_URL and set both env vars.
AgentServiceConfigReconciler: retrieved assisted-image-service route and extracted scheme/host to set in image-service StatefulSet.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
