### PR TITLE
WIP MGMT-8818: Fetch Ignition for day 2 workers via HTTPS if possible

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1316,7 +1316,8 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	log.Infof("Pre-update TransformClusterToDay2Internal %v", cluster.IgnitionEndpoint)
+	log.Infof("Pre-update TransformClusterToDay2Internal APIVIP %v", cluster.APIVip)
+	log.Infof("Pre-update TransformClusterToDay2Internal APIVIPDNSName %v", cluster.APIVipDNSName)
 	if cluster.IgnitionEndpoint == nil || cluster.IgnitionEndpoint.URL == nil {
 		// Set custom Ignition endpoint so that day2 workers would join using HTTPS endpoint
 		// ensureMCSCert would add ignition override with MCS secret
@@ -1370,7 +1371,10 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 			return nil, common.NewApiError(http.StatusInternalServerError, err)
 		}
 
-		log.Infof("Post-update TransformClusterToDay2Internal %v", cluster.IgnitionEndpoint)
+		if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
+			log.Infof("Post-update TransformClusterToDay2Internal URL %v", &cluster.IgnitionEndpoint.URL)
+		}
+		log.Infof("Post-update TransformClusterToDay2Internal APIVIP %v", cluster.APIVip)
 	}
 
 	err = b.clusterApi.TransformClusterToDay2(ctx, cluster, b.db)

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1362,6 +1362,14 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 		}
 		txSuccess = true
 
+		if cluster, err = common.GetClusterFromDB(b.db, clusterID, common.UseEagerLoading); err != nil {
+			log.WithError(err).Errorf("failed to find cluster %s", clusterID)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, common.NewApiError(http.StatusNotFound, err)
+			}
+			return nil, common.NewApiError(http.StatusInternalServerError, err)
+		}
+
 		log.Infof("Post-update TransformClusterToDay2Internal %v", cluster.IgnitionEndpoint)
 	}
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -745,6 +745,7 @@ func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context
 		url.Path = path.Join(url.Path, host.MachineConfigPoolName)
 		ignitionEndpointUrl = url.String()
 	}
+	log.Info("Host %s for cluster %s boots using Ignition URL %s", host.ID, cluster.ID, ignitionEndpointUrl)
 
 	var caCert *string = nil
 	if cluster.IgnitionEndpoint != nil {
@@ -1315,9 +1316,11 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
+	log.Infof("Pre-update TransformClusterToDay2Internal %v", cluster.IgnitionEndpoint)
 	if cluster.IgnitionEndpoint == nil || cluster.IgnitionEndpoint.URL == nil {
 		// Set custom Ignition endpoint so that day2 workers would join using HTTPS endpoint
 		// ensureMCSCert would add ignition override with MCS secret
+		log.Infof("Empty IgnitionEndpoint found")
 		ignitionEndpoint := fmt.Sprintf("%s/config/%s", common.GetMCSUrlBase(cluster), models.HostRoleWorker)
 		params := installer.V2UpdateClusterParams{
 			ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -1332,6 +1335,7 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 		if errClusterUpdate != nil {
 			return nil, err
 		}
+		log.Infof("Post-update TransformClusterToDay2Internal %v", c.IgnitionEndpoint)
 	}
 
 	err = b.clusterApi.TransformClusterToDay2(ctx, cluster, b.db)
@@ -1339,6 +1343,7 @@ func (b *bareMetalInventory) TransformClusterToDay2Internal(ctx context.Context,
 		return nil, err
 	}
 
+	log.Infof("TransformClusterToDay2Internal result %v", err)
 	return b.GetClusterInternal(ctx, installer.V2GetClusterParams{ClusterID: clusterID})
 }
 
@@ -1757,6 +1762,7 @@ func (b *bareMetalInventory) v2UpdateClusterIgnitionEndpoint(ctx context.Context
 	var cluster *common.Cluster
 	var err error
 	updates := map[string]interface{}{}
+	log.Infof("update cluster %s with params: %+v", params.ClusterID, params.ClusterUpdateParams)
 
 	if params, err = b.validateAndUpdateClusterParams(ctx, &params); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2025,6 +2025,7 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 			optionalParam(params.ClusterUpdateParams.IgnitionEndpoint.CaCertificate, "ignition_endpoint_ca_certificate", updates)
 		}
 	}
+	log.Infof("updateClusterData updates %v", updates)
 
 	if len(updates) > 0 {
 		updates["trigger_monitor_timestamp"] = time.Now()

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/models"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
@@ -387,4 +388,12 @@ func GetTagFromImageRef(ref string) string {
 	default:
 		return ""
 	}
+}
+
+func GetMCSUrlBase(cluster *Cluster) string {
+	// URL needs to use api-int DNS name if APIVIP is not set (i.e. platform:none)
+	if cluster.APIVip == "" {
+		return fmt.Sprintf("https://%s.%s:22623", constants.APIInternalName, cluster.BaseDNSDomain)
+	}
+	return fmt.Sprintf("https://%s:22623", cluster.APIVip)
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1234,13 +1234,14 @@ func (r *ClusterDeploymentsReconciler) TransformClusterToDay2(
 			Url:                    ignitionEndpoint,
 			CaCertificateReference: nil,
 		}
-		log.Infof("Pre-update ClusterInstall.status %v", clusterInstall.Status)
+		log.Infof("Pre-update ClusterInstall.status %v", clusterInstall.Status.APIVIP)
 		if err = r.Update(ctx, clusterInstall); err != nil {
 			log.WithError(err).Errorf("failed to write new IgnitionEndpoint for cluster %s", cluster.ID.String())
 			return ctrl.Result{Requeue: true}, err
 		}
-		log.Infof("Post-update ClusterInstall.status %v", clusterInstall.Status)
+		log.Infof("Post-update ClusterInstall.status %v", clusterInstall.Status.APIVIP)
 		log.Infof("Post-update ClusterInstall.IgnitionEndpoint %v", clusterInstall.Spec.IgnitionEndpoint)
+		log.Infof("Post-update c.APIVIP %v", c.APIVip)
 	}
 	return r.updateStatus(ctx, log, clusterInstall, c, err)
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -834,6 +834,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 		return cluster, errors.Wrap(err, "Couldn't resolve clusterdeployment ignition fields")
 	}
 	if shouldUpdate {
+		log.Infof("Updating Ignition params: %v", params.IgnitionEndpoint)
 		update = true
 	}
 
@@ -910,6 +911,7 @@ func (r *ClusterDeploymentsReconciler) updateIfNeeded(ctx context.Context,
 	}
 
 	log.Infof("Updated clusterDeployment %s/%s", clusterDeployment.Namespace, clusterDeployment.Name)
+	log.Infof("Cluster IgnitionEndpoint after update: %v", cluster.IgnitionEndpoint)
 
 	return clusterAfterUpdate, nil
 }
@@ -1232,10 +1234,13 @@ func (r *ClusterDeploymentsReconciler) TransformClusterToDay2(
 			Url:                    ignitionEndpoint,
 			CaCertificateReference: nil,
 		}
+		log.Infof("Pre-update ClusterInstall.status %v", clusterInstall.Status)
 		if err = r.Update(ctx, clusterInstall); err != nil {
 			log.WithError(err).Errorf("failed to write new IgnitionEndpoint for cluster %s", cluster.ID.String())
 			return ctrl.Result{Requeue: true}, err
 		}
+		log.Infof("Post-update ClusterInstall.status %v", clusterInstall.Status)
+		log.Infof("Post-update ClusterInstall.IgnitionEndpoint %v", clusterInstall.Spec.IgnitionEndpoint)
 	}
 	return r.updateStatus(ctx, log, clusterInstall, c, err)
 }

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1222,6 +1222,7 @@ func (r *ClusterDeploymentsReconciler) TransformClusterToDay2(
 	clusterInstall *hiveext.AgentClusterInstall) (ctrl.Result, error) {
 	log.Infof("transforming day1 cluster %s into day2 cluster", cluster.ID.String())
 	c, err := r.Installer.TransformClusterToDay2Internal(ctx, *cluster.ID)
+	log.Infof("c.APIVIP %s", cluster.APIVip)
 	if err != nil {
 		log.WithError(err).Errorf("failed to transform cluster %s into day2 cluster", cluster.ID.String())
 	}
@@ -1234,14 +1235,10 @@ func (r *ClusterDeploymentsReconciler) TransformClusterToDay2(
 			Url:                    ignitionEndpoint,
 			CaCertificateReference: nil,
 		}
-		log.Infof("Pre-update ClusterInstall.status %v", clusterInstall.Status.APIVIP)
 		if err = r.Update(ctx, clusterInstall); err != nil {
 			log.WithError(err).Errorf("failed to write new IgnitionEndpoint for cluster %s", cluster.ID.String())
 			return ctrl.Result{Requeue: true}, err
 		}
-		log.Infof("Post-update ClusterInstall.status %v", clusterInstall.Status.APIVIP)
-		log.Infof("Post-update ClusterInstall.IgnitionEndpoint %v", clusterInstall.Spec.IgnitionEndpoint)
-		log.Infof("Post-update c.APIVIP %v", c.APIVip)
 	}
 	return r.updateStatus(ctx, log, clusterInstall, c, err)
 }

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1369,6 +1369,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(result).To(Equal(ctrl.Result{}))
 			aci = getTestClusterInstall()
 			Expect(aci.Status.DebugInfo.State).To(Equal(models.ClusterStatusAddingHosts))
+			Expect(aci.Spec.IgnitionEndpoint.Url).To(Equal(fmt.Sprintf("https://%s:22623/config/worker", backEndCluster.APIVip)))
 		})
 
 		It("update kubeconfig ingress", func() {

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	mutableFields = []string{"ClusterMetadata"}
+	mutableFields = []string{"ClusterMetadata", "IgnitionEndpoint"}
 )
 
 // AgentClusterInstallValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.


### PR DESCRIPTION
In ZTP mode each host has additional Ignition override set by BMH controller. This override has MCS certificate data set, so that machineconfig pool Ignition could be fetched. This PR updates MCS URL to use HTTPS.

In OCM mode HTTP port would be used as the hosts don't have this override set

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] Cloud
- [x] Operator Managed Deployments

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @filanov 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
