### PR TITLE
MGMT-10848: Fix double agent unbind when deregistering a cluster

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3437,8 +3437,7 @@ func (b *bareMetalInventory) V2ResetHost(ctx context.Context, params installer.V
 	}
 
 	if host.ClusterID == nil {
-		err = fmt.Errorf("host %s is not bound to any cluster, cannot reset host", params.HostID.String())
-		log.Errorf("ResetHost for host %s is forbidden: not a Day2 hosts", params.HostID.String())
+		log.Errorf("host %s is not bound to any cluster, cannot reset host", params.HostID.String())
 		return common.NewApiError(http.StatusConflict, fmt.Errorf("method only allowed when host assigned to an existing cluster"))
 	}
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3684,10 +3684,12 @@ func (b *bareMetalInventory) GetHostByKubeKey(key types.NamespacedName) (*common
 	var c *models.Cluster
 	if h.ClusterID != nil {
 		cluster, err = common.GetClusterFromDB(b.db, *h.ClusterID, common.SkipEagerLoading)
-		if err != nil {
-			return h, fmt.Errorf("can not find a cluster for host %s", h.ID.String())
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
 		}
-		c = &cluster.Cluster
+		if err == nil {
+			c = &cluster.Cluster
+		}
 	}
 
 	b.customizeHost(c, &h.Host)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -13911,3 +13911,69 @@ var _ = Describe("GetInfraEnvPresignedFileURL", func() {
 		verifyApiError(resp, http.StatusNotFound)
 	})
 })
+
+var _ = Describe("GetHostByKubeKey", func() {
+	var (
+		bm        *bareMetalInventory
+		cfg       Config
+		db        *gorm.DB
+		dbName    string
+		hostID    *strfmt.UUID
+		clusterID *strfmt.UUID
+		kubeKey   = types.NamespacedName{
+			Namespace: "test-namespace",
+			Name:      "test-host",
+		}
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		bm = createInventory(db, cfg)
+		cluster := createClusterWithAvailability(db, models.ClusterStatusReady, models.ClusterCreateParamsHighAvailabilityModeNone)
+		clusterID = cluster.ID
+		// this doesn't need to be a VM, but any host works for this test
+		addVMToCluster(cluster, db)
+		hostID = cluster.Hosts[0].ID
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+		ctrl.Finish()
+	})
+
+	var getHost = func(_ types.NamespacedName) (*common.Host, error) {
+		return common.GetHostFromDBbyHostId(db, *hostID)
+	}
+
+	It("returns successfully when the cluster exists", func() {
+		mockHostApi.EXPECT().GetHostByKubeKey(kubeKey).DoAndReturn(getHost)
+		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(host.SnoStages[:])
+		h, err := bm.GetHostByKubeKey(kubeKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h.ID).To(Equal(hostID))
+	})
+
+	It("returns successfully when the cluster ID is not set", func() {
+		Expect(db.Model(&common.Host{}).Where("id = ?", hostID.String()).Updates(map[string]interface{}{"cluster_id": nil}).Error).ToNot(HaveOccurred())
+		mockHostApi.EXPECT().GetHostByKubeKey(kubeKey).DoAndReturn(getHost)
+		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(host.SnoStages[:])
+		h, err := bm.GetHostByKubeKey(kubeKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h.ID).To(Equal(hostID))
+	})
+
+	It("returns successfully when the referenced cluster is deleted", func() {
+		Expect(db.Delete(&common.Cluster{}, clusterID).Error).NotTo(HaveOccurred())
+		mockHostApi.EXPECT().GetHostByKubeKey(kubeKey).DoAndReturn(getHost)
+		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(host.SnoStages[:])
+		h, err := bm.GetHostByKubeKey(kubeKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h.ID).To(Equal(hostID))
+	})
+
+	It("fails when getting the host fails", func() {
+		mockHostApi.EXPECT().GetHostByKubeKey(kubeKey).Return(nil, fmt.Errorf("Failed to get host"))
+		_, err := bm.GetHostByKubeKey(kubeKey)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -63,7 +63,29 @@ func (b *bareMetalInventory) V2GetCluster(ctx context.Context, params installer.
 }
 
 func (b *bareMetalInventory) V2DeregisterCluster(ctx context.Context, params installer.V2DeregisterClusterParams) middleware.Responder {
-	if err := b.DeregisterClusterInternal(ctx, params); err != nil {
+	log := logutil.FromContext(ctx, b.log)
+	cluster, err := common.GetClusterFromDB(b.db, params.ClusterID, common.UseEagerLoading)
+	if err != nil {
+		return common.NewApiError(http.StatusNotFound, err)
+	}
+
+	if b.ocmClient != nil {
+		if err = b.integrateWithAMSClusterDeregistration(ctx, cluster); err != nil {
+			log.WithError(err).Errorf("Cluster %s failed to integrate with AMS on cluster deregistration", params.ClusterID)
+			return common.NewApiError(http.StatusInternalServerError, err)
+		}
+	}
+
+	if err = b.deleteDNSRecordSets(ctx, *cluster); err != nil {
+		log.Warnf("failed to delete DNS record sets for base domain: %s", cluster.BaseDNSDomain)
+	}
+
+	if err = b.deleteOrUnbindHosts(ctx, cluster); err != nil {
+		log.WithError(err).Errorf("failed delete or unbind hosts when deregistering cluster: %s", params.ClusterID)
+		return common.NewApiError(http.StatusInternalServerError, err)
+	}
+
+	if err := b.DeregisterClusterInternal(ctx, cluster); err != nil {
 		return common.GenerateErrorResponder(err)
 	}
 	return installer.NewV2DeregisterClusterNoContent()

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -179,9 +179,7 @@ func (b *bareMetalInventory) V2ResetCluster(ctx context.Context, params installe
 		if err := b.hostApi.ResetHost(ctx, h, "cluster was reset by user", tx); err != nil {
 			return common.GenerateErrorResponder(err)
 		}
-		if err := b.customizeHost(&cluster.Cluster, h); err != nil {
-			return installer.NewV2ResetClusterInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
-		}
+		b.customizeHost(&cluster.Cluster, h)
 	}
 
 	if err := b.clusterApi.DeleteClusterFiles(ctx, cluster, b.objectHandler); err != nil {

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -86,7 +86,7 @@ func (mr *MockInstallerInternalsMockRecorder) CancelInstallationInternal(arg0, a
 }
 
 // DeregisterClusterInternal mocks base method.
-func (m *MockInstallerInternals) DeregisterClusterInternal(arg0 context.Context, arg1 installer.V2DeregisterClusterParams) error {
+func (m *MockInstallerInternals) DeregisterClusterInternal(arg0 context.Context, arg1 *common.Cluster) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterClusterInternal", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1314,9 +1314,7 @@ func (r *ClusterDeploymentsReconciler) deregisterClusterIfNeeded(ctx context.Con
 		return buildReply(err)
 	}
 
-	if err = r.Installer.DeregisterClusterInternal(ctx, installer.V2DeregisterClusterParams{
-		ClusterID: *c.ID,
-	}); err != nil {
+	if err = r.Installer.DeregisterClusterInternal(ctx, c); err != nil {
 		return buildReply(err)
 	}
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -301,7 +301,7 @@ func (r *ClusterDeploymentsReconciler) agentClusterInstallFinalizer(ctx context.
 				}
 			}
 			//Unbind agents
-			if err = r.UnbindAgents(ctx, log, req.NamespacedName); err != nil {
+			if err = r.unbindAgents(ctx, log, req.NamespacedName); err != nil {
 				return &ctrl.Result{Requeue: true}, err
 			}
 
@@ -1359,7 +1359,34 @@ func (r *ClusterDeploymentsReconciler) deleteClusterInstall(ctx context.Context,
 	return buildReply(err)
 }
 
-func (r *ClusterDeploymentsReconciler) UnbindAgents(ctx context.Context, log logrus.FieldLogger, clusterDeployment types.NamespacedName) error {
+func (r *ClusterDeploymentsReconciler) shouldDeleteAgentOnUnbind(ctx context.Context, agent aiv1beta1.Agent, clusterDeployment types.NamespacedName) bool {
+	log := logutil.FromContext(ctx, r.Log).WithFields(logrus.Fields{
+		"cluster_deployment":           clusterDeployment.Name,
+		"cluster_deployment_namespace": clusterDeployment.Namespace,
+	})
+	infraEnvName, ok := agent.Labels[aiv1beta1.InfraEnvNameLabel]
+	if !ok {
+		log.Errorf("Failed to find infraEnv name for agent %s in namespace %s", agent.Name, agent.Namespace)
+		return false
+	}
+
+	infraEnv := &aiv1beta1.InfraEnv{}
+	if err := r.Get(ctx, types.NamespacedName{Name: infraEnvName, Namespace: agent.Namespace}, infraEnv); err != nil {
+		log.Errorf("Failed to get infraEnv %s in namespace %s", infraEnvName, agent.Namespace)
+		return false
+	}
+
+	if infraEnv.Spec.ClusterRef != nil &&
+		infraEnv.Spec.ClusterRef.Name == clusterDeployment.Name &&
+		infraEnv.Spec.ClusterRef.Namespace == clusterDeployment.Namespace {
+
+		return true
+	}
+
+	return false
+}
+
+func (r *ClusterDeploymentsReconciler) unbindAgents(ctx context.Context, log logrus.FieldLogger, clusterDeployment types.NamespacedName) error {
 	agents := &aiv1beta1.AgentList{}
 	log = log.WithFields(logrus.Fields{"clusterDeployment": clusterDeployment.Name, "namespace": clusterDeployment.Namespace})
 	if err := r.List(ctx, agents); err != nil {
@@ -1369,11 +1396,19 @@ func (r *ClusterDeploymentsReconciler) UnbindAgents(ctx context.Context, log log
 		if clusterAgent.Spec.ClusterDeploymentName != nil &&
 			clusterAgent.Spec.ClusterDeploymentName.Name == clusterDeployment.Name &&
 			clusterAgent.Spec.ClusterDeploymentName.Namespace == clusterDeployment.Namespace {
-			log.Infof("unbind agent %s namespace %s", clusterAgent.Name, clusterAgent.Namespace)
-			agents.Items[i].Spec.ClusterDeploymentName = nil
-			if err := r.Update(ctx, &agents.Items[i]); err != nil {
-				log.WithError(err).Errorf("failed to add unbind resource %s %s", clusterAgent.Name, clusterAgent.Namespace)
-				return err
+			if r.shouldDeleteAgentOnUnbind(ctx, clusterAgent, clusterDeployment) {
+				log.Infof("deleting agent %s in namespace %s", clusterAgent.Name, clusterAgent.Namespace)
+				if err := r.Delete(ctx, &agents.Items[i]); err != nil {
+					log.WithError(err).Errorf("failed to delete agent %s in namespace %s", clusterAgent.Name, clusterAgent.Namespace)
+					return err
+				}
+			} else {
+				log.Infof("unbind agent %s namespace %s", clusterAgent.Name, clusterAgent.Namespace)
+				agents.Items[i].Spec.ClusterDeploymentName = nil
+				if err := r.Update(ctx, &agents.Items[i]); err != nil {
+					log.WithError(err).Errorf("failed to add unbind resource %s %s", clusterAgent.Name, clusterAgent.Namespace)
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When a cluster is removed in the kubeAPI the clusterdeployments
controller removes all the cluster references from all the agents. This
should cause the agent controller to unbind each of those agents.

The clusterdeployment controller also calls `DeregisterClusterInternal`
which also unbinds the hosts from the cluster.

This isn't a problem currently because both operations should be doing
the same thing, but it will become a problem when hosts should be moved
back to the infraEnv on unbind only if they are not associated with an
BMH, and the kubeAPI is being used. In this case the agent controller
will know if the host should be moved to the infraEnv or not, but the
unbind call from `DeregisterClusterInternal` would have to assume that
the hosts should _not_ be moved back to the infraEnv as it would also be
used in the SaaS REST API.

This difference in implementation would cause a race and needs to be
resolved.

This PR moves all the SaaS specific logic out of
`DeregisterClusterInternal` and into `V2DeregisterCluster`. This will
ensure that this logic is still run when it is needed, but avoid the
race with the controllers when using the kubeAPI.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-10848

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

#### Manual test steps:
- Deployed assisted with test-infra with kube-api enabled
- Created 3 unbound agents (created infra-env, booted hosts with discovery image)
- Created the cluster resources
- Waited for hosts to be bound and ready to install (did not approve hosts)
- Deleted clusterdeployment
- Observed hosts move to known-unbound

I also did the same test in a non-late-binding scenario with an infra-env that referenced a specific cluster deployment.
In this case when I deleted the clusterdeployment the agents were also deleted without issue.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
