### PR TITLE
[release-ocm-2.4] BUG 2097820: CI - Retry cluster-info readiness 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ $(KUBECTL) rollout status  deployment assisted-service
 endef
 
 _verify_cluster:
-	$(KUBECTL) cluster-info
+	python3 ./tools/wait_for_cluster_info.py
 
 deploy-all: $(BUILD_FOLDER) _verify_cluster deploy-namespace deploy-postgres deploy-s3 deploy-ocm-secret deploy-route53 deploy-service
 	echo "Deployment done"

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ $(KUBECTL) rollout status  deployment assisted-service
 endef
 
 _verify_cluster:
-	python3 ./tools/wait_for_cluster_info.py
+	python3 ./tools/wait_for_cluster_info.py --namespace "$(NAMESPACE)"
 
 deploy-all: $(BUILD_FOLDER) _verify_cluster deploy-namespace deploy-postgres deploy-s3 deploy-ocm-secret deploy-route53 deploy-service
 	echo "Deployment done"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ twine==3.4.2
 vcversioner==2.16.0.0
 waiting==1.4.1
 wheel==0.37.0
+retry==0.9.2
 beautifulsoup4==4.10.0
 jira==3.0.1
 PyGithub>=1.54

--- a/tools/wait_for_cluster_info.py
+++ b/tools/wait_for_cluster_info.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import datetime
+
+import utils
+from retry import retry
+
+TRIES = 10
+DELAY = 5
+
+
+@retry(exceptions=RuntimeError, tries=TRIES, delay=DELAY)
+def is_cluster_info_ready(kubectl_cmd):
+    cmd = f"{kubectl_cmd} cluster-info"
+    print(f"{datetime.datetime.now()} DEBUG - {cmd}")
+    try:
+        res = utils.check_output(cmd)
+    except RuntimeError:
+        print(f"{datetime.datetime.now()} DEBUG - cluster is not ready yet.")
+        raise
+    print(res)
+    return
+
+
+def main():
+    is_cluster_info_ready(kubectl_cmd=utils.get_kubectl_command())
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/wait_for_cluster_info.py
+++ b/tools/wait_for_cluster_info.py
@@ -2,6 +2,7 @@
 import datetime
 
 import utils
+import deployment_options
 from retry import retry
 
 TRIES = 10
@@ -22,7 +23,8 @@ def is_cluster_info_ready(kubectl_cmd):
 
 
 def main():
-    is_cluster_info_ready(kubectl_cmd=utils.get_kubectl_command())
+    deploy_options = deployment_options.load_deployment_options()
+    is_cluster_info_ready(kubectl_cmd=utils.get_kubectl_command(namespace=deploy_options.namespace))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a modified version of the automated cherry-pick #3963

Modified to include missing Python requirements needed by the cherry-picked
code

/assign otuchfel
