### PR TITLE
OCPRHV-637: Set 'replicas' to 0 in the machinset for the oVirt provider

### DIFF
--- a/internal/provider/ovirt/consts.go
+++ b/internal/provider/ovirt/consts.go
@@ -20,4 +20,7 @@ const (
 	TemplateNamePatternStr            = "template_name: +.*"
 	TemplateNameReplacementStrFmt     = "template_name: %s"
 	MachineManifestFileNameGlobStrFmt = "*_openshift-cluster-api_master-machines-%d.yaml"
+	ReplicasPatternStr                = "replicas: +.*"
+	ReplicasReplacementStrFmt         = "replicas: %d"
+	MachineSetFileNameGlobStr         = "*_openshift-cluster-api_worker-machineset-0.yaml"
 )

--- a/internal/provider/ovirt/installConfig.go
+++ b/internal/provider/ovirt/installConfig.go
@@ -41,7 +41,6 @@ func (p ovirtProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfi
 		cfg.Platform = installcfg.Platform{
 			Ovirt: ovirtPlatform,
 		}
-		cfg.Compute[0].Replicas = 0
 	}
 	return nil
 }


### PR DESCRIPTION
Set 'replicas' to 0 in the machinset instead of the install-config.yaml
This way we avoid the side effect of enabling the scheduling on masters
and MCO does not try to provision additional VMs at installation time.

This pull request depends on #3971 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eliorerz 
/cc @osherdp 
/cc @michaellevy101 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
