### PR TITLE
MGMT-9682: fix default disk size requirement

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -44,6 +44,8 @@ function generate_configuration() {
     PUBLIC_CONTAINER_REGISTRIES=$(< ${__root}/data/default_public_container_registries.txt)
     HW_VALIDATOR_REQUIREMENTS=$(< ${__root}/data/default_hw_requirements.json tr -d "\n\t ")
 
+    cp "${__root}/data/default_hw_requirements.json" "${__root}/internal/controller/controllers/default_controller_hw_requirements.json"
+
     sed -i "s|value: '.*' # os images|value: '${OS_IMAGES}' # os images|" ${__root}/openshift/template.yaml
     sed -i "s|value: '.*' # release images|value: '${RELEASE_IMAGES}' # release images|" ${__root}/openshift/template.yaml
     sed -i "s|value: '.*' # must-gather images|value: '${MUST_GATHER_IMAGES}' # must-gather images|" ${__root}/openshift/template.yaml

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -929,6 +930,9 @@ func (r *AgentServiceConfigReconciler) urlForRoute(ctx context.Context, routeNam
 	return u.String(), nil
 }
 
+//go:embed default_controller_hw_requirements.json
+var defaultControllerHardwareRequirements string
+
 func (r *AgentServiceConfigReconciler) newAssistedCM(ctx context.Context, log logrus.FieldLogger, instance *aiv1beta1.AgentServiceConfig) (client.Object, controllerutil.MutateFn, error) {
 	serviceURL, err := r.urlForRoute(ctx, serviceName)
 	if err != nil {
@@ -987,7 +991,7 @@ func (r *AgentServiceConfigReconciler) newAssistedCM(ctx context.Context, log lo
 			"IPV6_SUPPORT":                "True",
 			"JWKS_URL":                    "https://api.openshift.com/.well-known/jwks.json",
 			"PUBLIC_CONTAINER_REGISTRIES": "quay.io,registry.svc.ci.openshift.org",
-			"HW_VALIDATOR_REQUIREMENTS":   `[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]`,
+			"HW_VALIDATOR_REQUIREMENTS":   defaultControllerHardwareRequirements,
 
 			"NAMESPACE":       r.Namespace,
 			"INSTALL_INVOKER": "assisted-installer-operator",

--- a/internal/controller/controllers/default_controller_hw_requirements.json
+++ b/internal/controller/controllers/default_controller_hw_requirements.json
@@ -1,0 +1,25 @@
+[{
+  "version": "default",
+  "master": {
+    "cpu_cores": 4,
+    "ram_mib": 16384,
+    "disk_size_gb": 100,
+    "installation_disk_speed_threshold_ms": 10,
+    "network_latency_threshold_ms": 100,
+    "packet_loss_percentage": 0
+  },
+  "worker": {
+    "cpu_cores": 2,
+    "ram_mib": 8192,
+    "disk_size_gb": 100,
+    "installation_disk_speed_threshold_ms": 10,
+    "network_latency_threshold_ms": 1000,
+    "packet_loss_percentage": 10
+  },
+  "sno": {
+    "cpu_cores": 8,
+    "ram_mib": 16384,
+    "disk_size_gb": 100,
+    "installation_disk_speed_threshold_ms": 10
+  }
+}]


### PR DESCRIPTION
This change b9ec6db2eb58e48022dd89c1d880ac7b1d934fd7 (#3802) was
incomplete. It didn't adjust the default hardware requirements set by
the AgentServiceConfig controller in the default configmap.

I made it so from now on code generation would make sure to keep them in
sync.

This caused us trouble when
https://github.com/openshift/assisted-test-infra/pull/1693 was merged
because now the controller expects 120GB for the SNO control-plane node
but it only has 100GB., as can be seen in
[this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-kube-api-late-binding-single-node-periodic/1537621678526304256)
job failure

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @adriengentil
/cc @osherdp

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md