### PR TITLE
MGMT-10637: Add default ironic agent for ARM platform

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -194,6 +194,11 @@ The assisted agent will not reboot the machine at the end of the installation, i
 the assisted agent service and let the ironic agent to manage the machine power state
 
 You can disable the converged flow by setting the `ALLOW_COVERGED_FLOW` env to false [here](../operator.md#configuring-the-assisted-service-deployment)
+To set a different default ironicAgent image you can override the following env vars:
+The environment var for the ironicAgent image to be used on X86_64 CPU architecture:
+`IRONIC_AGENT_IMAGE`
+The environment var for the ironicAgent image to be used on arm64 CPU architecture:
+`IRONIC_AGENT_IMAGE_ARM`
 
 ## Working with mirror registry
 In case all of your images are in mirror registries, the service, discovery ISO, and installed nodes must be configured with the proper registries.conf and authentication certificate.  To do so, see the Mirror Registry Configuration section [here](../operator.md#mirror-registry-configuration).

--- a/internal/ignition/ironic.go
+++ b/internal/ignition/ironic.go
@@ -13,8 +13,11 @@ type IronicIgniotionBuilder interface {
 }
 
 type IronicIgniotionBuilderConfig struct {
-	// The default ironic agent image was obtained by running oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64
+	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
 	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
+	// The default ironic agent image for arm architecture was obtained by running "oc adm release info --image-for=ironic-agent quay.io/openshift-release-dev/ocp-release@sha256:1b8e71b9bccc69c732812ebf2bfba62af6de77378f8329c8fec10b63a0dbc33c"
+	// The release image digest for arm architecture was obtained from this link https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp-dev-preview/4.11.0-fc.0/release.txt
+	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
 }
 
 type ironicIgniotionBuilder struct {
@@ -32,7 +35,12 @@ func (r *ironicIgniotionBuilder) GenerateIronicConfig(ironicBaseURL string, infr
 
 	httpProxy, httpsProxy, noProxy := common.GetProxyConfigs(infraEnv.Proxy)
 	if ironicAgentImage == "" {
-		ironicAgentImage = r.config.BaremetalIronicAgentImage
+		// if ironicAgentImage wasn't specified use the default image for the CPU arch
+		if infraEnv.CPUArchitecture == common.ARM64CPUArchitecture {
+			ironicAgentImage = r.config.BaremetalIronicAgentImageForArm
+		} else {
+			ironicAgentImage = r.config.BaremetalIronicAgentImage
+		}
 	}
 	// TODO: this should probably get the pullSecret as well
 	ib, err := iccignition.New([]byte{}, []byte{}, ironicBaseURL, ironicAgentImage, "", "", "", httpProxy, httpsProxy, noProxy, "")


### PR DESCRIPTION

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? devscripts
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-10637

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x]Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @tsorya 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
