### PR TITLE
MGMT-10855: Do not format bootable LVM logical volumes

### DIFF
--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -218,24 +218,27 @@ var _ = Describe("installcmd", func() {
 
 		It("format_multiple_bootable_skip", func() {
 			sdi := createDisk("sdi", true)
-			sdi.ByPath = "pci-0000:04:00.0-fc-0x5006016b08603d0d-lun-0"
+			sdi.DriveType = models.DriveTypeFC
 			sdg := createDisk("sdg", true)
-			sdg.ByPath = "ip-10.188.2.249:3260-iscsi-iqn.2001-05.com.equallogic:0-fe83b6-aaea957cc-b6e9d343a9758fdc-volume-50a72e0c-0a4a-4b2d-92ab-b0500dfe5c64-lun-0"
+			sdg.DriveType = models.DriveTypeISCSI
 			sdd := createDisk("sdd", false)
 			sdd.IsInstallationMedia = true
 			sdj := createDisk("sdj", true)
 			sdj.ByPath = "/dev/mmcblk1boot1"
+			sdk := createDisk("sdk", true)
+			sdk.DriveType = models.DriveTypeLVM
 
 			disks := []*models.Disk{
 				sdb,                      //installation disk
 				sdh,                      //non-bootable-disk
 				sda,                      //bootable disk #1
 				sdc,                      //bootable disk #2
-				sdi,                      //skip bootable disk -fc-
-				sdg,                      //skip bootable disk -iscsi-
+				sdi,                      //skip bootable disk FC
+				sdg,                      //skip bootable disk iSCSI
 				createDisk("sdf", false), //non-bootable disk
 				sdd,                      //skip installation media
 				sdj,                      //skip mmcblk device
+				sdk,                      //skip bootable disk LVM
 			}
 			host.Inventory = getInventory(disks)
 			mockFormatEvent(sda, 1)
@@ -251,6 +254,7 @@ var _ = Describe("installcmd", func() {
 			verifyDiskFormatCommand(stepReply[0], sdi.ID, false)
 			verifyDiskFormatCommand(stepReply[0], sdg.ID, false)
 			verifyDiskFormatCommand(stepReply[0], sdj.ID, false)
+			verifyDiskFormatCommand(stepReply[0], sdk.ID, false)
 		})
 	})
 


### PR DESCRIPTION
Now that LVM volumes are returned in the inventory we should be sure not
to format them.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
