### PR TITLE
MGMT-10912: Add anonymized user identifier to assisted daatabase

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// An unique user ID that is generated from the given user-name
+	UserID string `json:"user_id,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// An unique user ID that is generated from the given user-name
+	UserID string `json:"user_id,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5594,6 +5594,10 @@ func init() {
             "type": "Time"
           }
         },
+        "user_id": {
+          "description": "An unique user ID that is generated from the given user-name",
+          "type": "string"
+        },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
           "type": "boolean",
@@ -14839,6 +14843,10 @@ func init() {
             },
             "type": "Time"
           }
+        },
+        "user_id": {
+          "description": "An unique user ID that is generated from the given user-name",
+          "type": "string"
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4672,6 +4672,9 @@ definitions:
         format: int64
         description: All hosts associated to this cluster.
         x-go-custom-tag: gorm:"-"
+      user_id:
+        type: string
+        description: An unique user ID that is generated from the given user-name
       schedulable_masters:
         type: boolean
         description: Schedule workloads on masters

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -231,6 +231,9 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// An unique user ID that is generated from the given user-name
+	UserID string `json:"user_id,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 


### PR DESCRIPTION
As part of anonymizing elastic data this PR adds anonymized unique user ID alongside the user name/email stored in the DB.
This user-id will replace the user name/email on assisted events.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @gamli75 
