### PR TITLE
MGMT-10868: Add late binding to Day2 remote script.

### DIFF
--- a/deploy/operator/ztp/add-remote-nodes-playbook.yaml
+++ b/deploy/operator/ztp/add-remote-nodes-playbook.yaml
@@ -7,18 +7,28 @@
     - baremetalhosts: "{{ lookup('file', lookup('env', 'REMOTE_BAREMETALHOSTS_FILE')) | from_json }}"
     - infraenv_name: "{{ lookup('env', 'ASSISTED_INFRAENV_NAME') }}"
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
+    - cluster_deployment_name: "{{ lookup('env', 'ASSISTED_CLUSTER_DEPLOYMENT_NAME') }}"
     - day2: "true"
-
-  tasks:
-  - name: create directory for generated CRDs
-    file:
-      name: generated
-      state: directory
-
-  - name: write the remote baremetalHost crds
-    template:
-      src: "baremetalHost.j2"
-      dest: "generated/remote_host_manifests.yaml"
   
-  - name: apply baremetalhosts with oc
-    ansible.builtin.command: "oc apply -f generated/remote_host_manifests.yaml"
+  tasks:
+  - name: optional-latebinding 
+    block:
+    - name: write the infraEnv crd
+      template:
+        src: "infraEnv-latebinding.j2"
+        dest: "generated/day2-latebinding-infraenv.yaml"
+    - name: apply infraenvs with oc
+      ansible.builtin.command: "oc apply -f generated/day2-latebinding-infraenv.yaml"
+    when: cluster_deployment_name == ""
+  - name: generate-crds-and-apply 
+    block:
+    - name: create directory for generated CRDs
+      file:
+        name: generated
+        state: directory
+    - name: write the remote baremetalHost crds
+      template:
+        src: "baremetalHost.j2"
+        dest: "generated/remote_host_manifests.yaml"
+    - name: apply baremetalhosts with oc
+      ansible.builtin.command: "oc apply -f generated/remote_host_manifests.yaml"

--- a/deploy/operator/ztp/infraEnv-latebinding.j2
+++ b/deploy/operator/ztp/infraEnv-latebinding.j2
@@ -1,0 +1,11 @@
+# infraEnv.j2 and this file should generally be kept in sync
+# This version exists to present an infraenv that is used in a late binding scenario.
+apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  name: '{{ infraenv_name }}-latebinding'
+  namespace: '{{ spoke_namespace }}'
+spec:
+  pullSecretRef:
+    name: '{{ pull_secret_name }}'
+  sshAuthorizedKey: '{{ ssh_public_key }}'

--- a/deploy/operator/ztp/infraEnv.j2
+++ b/deploy/operator/ztp/infraEnv.j2
@@ -1,3 +1,5 @@
+# infraEnv-latebinding.j2 and this file should generally be kept in sync
+# infraEnv-latebinding.j2 to present an infraenv that is used in a late binding scenario.
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:


### PR DESCRIPTION
This is to facilitate testing of late binding functionality and is
powered by an environment variable.

If you set DAY2_LATE_BINDING to True and then call the
add_day2_remote_nodes.sh;

1: A new infraenv is generated, with no cluster reference
2: Internally within the script, this is used wherever we need an
   infraenv.
3: A note is kept of the proper cluster reference and this is used later
   to assign the cluster reference to any agents that need it.



## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @osherdp 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
