### PR TITLE
MGMT-8089: schedulableMasters field in clusters api returns wrong default values

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -201,6 +201,11 @@ type Cluster struct {
 	// Schedule workloads on masters
 	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
 
+	// Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.
+	// Set to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.
+	//
+	SchedulableMastersForcedTrue *bool `json:"schedulable_masters_forced_true,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -447,36 +447,37 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 
 	cluster := common.Cluster{
 		Cluster: models.Cluster{
-			ID:                    &id,
-			Href:                  swag.String(url.String()),
-			Kind:                  swag.String(models.ClusterKindCluster),
-			APIVip:                params.NewClusterParams.APIVip,
-			BaseDNSDomain:         params.NewClusterParams.BaseDNSDomain,
-			IngressVip:            params.NewClusterParams.IngressVip,
-			Name:                  swag.StringValue(params.NewClusterParams.Name),
-			OpenshiftVersion:      *releaseImage.Version,
-			OcpReleaseImage:       *releaseImage.URL,
-			SSHPublicKey:          params.NewClusterParams.SSHPublicKey,
-			UserName:              ocm.UserNameFromContext(ctx),
-			OrgID:                 ocm.OrgIDFromContext(ctx),
-			EmailDomain:           ocm.EmailDomainFromContext(ctx),
-			HTTPProxy:             swag.StringValue(params.NewClusterParams.HTTPProxy),
-			HTTPSProxy:            swag.StringValue(params.NewClusterParams.HTTPSProxy),
-			NoProxy:               swag.StringValue(params.NewClusterParams.NoProxy),
-			VipDhcpAllocation:     params.NewClusterParams.VipDhcpAllocation,
-			NetworkType:           params.NewClusterParams.NetworkType,
-			UserManagedNetworking: params.NewClusterParams.UserManagedNetworking,
-			AdditionalNtpSource:   swag.StringValue(params.NewClusterParams.AdditionalNtpSource),
-			MonitoredOperators:    monitoredOperators,
-			HighAvailabilityMode:  params.NewClusterParams.HighAvailabilityMode,
-			Hyperthreading:        swag.StringValue(params.NewClusterParams.Hyperthreading),
-			SchedulableMasters:    params.NewClusterParams.SchedulableMasters,
-			Platform:              params.NewClusterParams.Platform,
-			ClusterNetworks:       params.NewClusterParams.ClusterNetworks,
-			ServiceNetworks:       params.NewClusterParams.ServiceNetworks,
-			MachineNetworks:       params.NewClusterParams.MachineNetworks,
-			CPUArchitecture:       cpuArchitecture,
-			IgnitionEndpoint:      params.NewClusterParams.IgnitionEndpoint,
+			ID:                           &id,
+			Href:                         swag.String(url.String()),
+			Kind:                         swag.String(models.ClusterKindCluster),
+			APIVip:                       params.NewClusterParams.APIVip,
+			BaseDNSDomain:                params.NewClusterParams.BaseDNSDomain,
+			IngressVip:                   params.NewClusterParams.IngressVip,
+			Name:                         swag.StringValue(params.NewClusterParams.Name),
+			OpenshiftVersion:             *releaseImage.Version,
+			OcpReleaseImage:              *releaseImage.URL,
+			SSHPublicKey:                 params.NewClusterParams.SSHPublicKey,
+			UserName:                     ocm.UserNameFromContext(ctx),
+			OrgID:                        ocm.OrgIDFromContext(ctx),
+			EmailDomain:                  ocm.EmailDomainFromContext(ctx),
+			HTTPProxy:                    swag.StringValue(params.NewClusterParams.HTTPProxy),
+			HTTPSProxy:                   swag.StringValue(params.NewClusterParams.HTTPSProxy),
+			NoProxy:                      swag.StringValue(params.NewClusterParams.NoProxy),
+			VipDhcpAllocation:            params.NewClusterParams.VipDhcpAllocation,
+			NetworkType:                  params.NewClusterParams.NetworkType,
+			UserManagedNetworking:        params.NewClusterParams.UserManagedNetworking,
+			AdditionalNtpSource:          swag.StringValue(params.NewClusterParams.AdditionalNtpSource),
+			MonitoredOperators:           monitoredOperators,
+			HighAvailabilityMode:         params.NewClusterParams.HighAvailabilityMode,
+			Hyperthreading:               swag.StringValue(params.NewClusterParams.Hyperthreading),
+			SchedulableMasters:           params.NewClusterParams.SchedulableMasters,
+			SchedulableMastersForcedTrue: swag.Bool(true),
+			Platform:                     params.NewClusterParams.Platform,
+			ClusterNetworks:              params.NewClusterParams.ClusterNetworks,
+			ServiceNetworks:              params.NewClusterParams.ServiceNetworks,
+			MachineNetworks:              params.NewClusterParams.MachineNetworks,
+			CPUArchitecture:              cpuArchitecture,
+			IgnitionEndpoint:             params.NewClusterParams.IgnitionEndpoint,
 		},
 		KubeKeyName:             kubeKey.Name,
 		KubeKeyNamespace:        kubeKey.Namespace,
@@ -2734,6 +2735,13 @@ func (b *bareMetalInventory) V2DeregisterHostInternal(ctx context.Context, param
 	}
 	eventgen.SendHostDeregisteredEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, common.StrFmtUUIDPtr(infraEnv.ClusterID),
 		hostutil.GetHostnameForMsg(&h.Host))
+
+	if h.ClusterID != nil {
+		if err := b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *h.ClusterID); err != nil {
+			log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while de-registering host <%s> to cluster <%s>", h.ID, h.ClusterID)
+			return err
+		}
+	}
 	return nil
 }
 
@@ -4475,6 +4483,14 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 			WithPayload(common.GenerateError(http.StatusInternalServerError, err))
 	}
 
+	if host.ClusterID != nil {
+		if err := b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *host.ClusterID); err != nil {
+			log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while registering host <%s> to cluster <%s>", host.ID, host.ClusterID)
+			return installer.NewV2RegisterHostInternalServerError().
+				WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+		}
+	}
+
 	txSuccess = true
 
 	return installer.NewV2RegisterHostCreated().WithPayload(&hostRegistration)
@@ -4737,6 +4753,11 @@ func (b *bareMetalInventory) BindHostInternal(ctx context.Context, params instal
 		return nil, common.NewApiError(http.StatusInternalServerError, reset_err)
 	}
 
+	if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *cluster.ID); err != nil {
+		log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while binding host <%s> to cluster <%s>", host.ID, host.ClusterID)
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
+	}
+
 	host, err = common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())
 	if err != nil {
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
@@ -4774,6 +4795,11 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 
 	if _, err = b.refreshClusterStatus(ctx, host.ClusterID, b.db); err != nil {
 		log.WithError(err).Warnf("Failed to refresh cluster after unbind of host <%s>", params.HostID)
+	}
+
+	if err = b.clusterApi.RefreshSchedulableMastersForcedTrue(ctx, *host.ClusterID); err != nil {
+		log.WithError(err).Errorf("Failed to refresh SchedulableMastersForcedTrue while unbinding host <%s> to cluster <%s>", host.ID, host.ClusterID)
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
 	host, err = common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -420,6 +420,7 @@ var _ = Describe("RegisterHost", func() {
 				}
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
 						// validate that host is registered with auto-assign role
@@ -608,6 +609,7 @@ var _ = Describe("v2RegisterHost", func() {
 				}
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 				mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, h *models.Host, db *gorm.DB) error {
 						// validate that host is registered with auto-assign role
@@ -736,6 +738,7 @@ var _ = Describe("v2RegisterHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvId.String()))).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		By("trying to register a host bound to day2 cluster")
 		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
@@ -9949,6 +9952,19 @@ var _ = Describe("TestRegisterCluster", func() {
 		Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
 	})
 
+	It("SchedulableMastersForcedTrue default value", func() {
+		mockClusterRegisterSuccess(true)
+		mockAMSSubscription(ctx)
+
+		clusterParams := getDefaultClusterCreateParams()
+		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
+			NewClusterParams: clusterParams,
+		})
+		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
+		actual := reply.(*installer.V2RegisterClusterCreated)
+		Expect(actual.Payload.SchedulableMastersForcedTrue).To(Equal(swag.Bool(true)))
+	})
+
 	It("UserManagedNetworking default value", func() {
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
@@ -11774,6 +11790,7 @@ var _ = Describe("BindHost", func() {
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
@@ -11883,6 +11900,7 @@ var _ = Describe("BindHost", func() {
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.BindHostOK{}))
@@ -11917,6 +11935,7 @@ var _ = Describe("BindHost", func() {
 		}
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.BindHostOK{}))
@@ -12001,6 +12020,7 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		payload.Username = userName1
 		authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
@@ -12023,6 +12043,7 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		payload.Username = userName2
 		authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
@@ -12110,6 +12131,7 @@ var _ = Describe("UnbindHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any())
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		response := bm.UnbindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.UnbindHostOK{}))
 	})

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -458,6 +458,20 @@ func (mr *MockAPIMockRecorder) PrepareForInstallation(ctx, c, db interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareForInstallation", reflect.TypeOf((*MockAPI)(nil).PrepareForInstallation), ctx, c, db)
 }
 
+// RefreshSchedulableMastersForcedTrue mocks base method.
+func (m *MockAPI) RefreshSchedulableMastersForcedTrue(ctx context.Context, clusterID strfmt.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshSchedulableMastersForcedTrue", ctx, clusterID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshSchedulableMastersForcedTrue indicates an expected call of RefreshSchedulableMastersForcedTrue.
+func (mr *MockAPIMockRecorder) RefreshSchedulableMastersForcedTrue(ctx, clusterID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSchedulableMastersForcedTrue", reflect.TypeOf((*MockAPI)(nil).RefreshSchedulableMastersForcedTrue), ctx, clusterID)
+}
+
 // RefreshStatus mocks base method.
 func (m *MockAPI) RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm.DB) (*common.Cluster, error) {
 	m.ctrl.T.Helper()

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -113,7 +113,7 @@ func IsDay2Cluster(cluster *Cluster) bool {
 }
 
 func AreMastersSchedulable(cluster *Cluster) bool {
-	return swag.BoolValue(cluster.SchedulableMasters)
+	return swag.BoolValue(cluster.SchedulableMastersForcedTrue) || swag.BoolValue(cluster.SchedulableMasters)
 }
 
 func GetEffectiveRole(host *models.Host) models.HostRole {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -236,6 +237,32 @@ var _ = Describe("compare OCP 4.10 versions", func() {
 	It("nightly release", func() {
 		is410Version, _ := VersionGreaterOrEqual("4.10.0-0.nightly-2022-01-23-013716", "4.10.0-0.alpha")
 		Expect(is410Version).Should(BeTrue())
+	})
+})
+
+var _ = Describe("Test AreMastersSchedulable", func() {
+	Context("for every combination of schedulableMastersForcedTrue and schedulableMasters", func() {
+		for _, test := range []struct {
+			schedulableMastersForcedTrue bool
+			schedulableMasters           bool
+			expectedSchedulableMasters   bool
+		}{
+			{schedulableMastersForcedTrue: false, schedulableMasters: false, expectedSchedulableMasters: false},
+			{schedulableMastersForcedTrue: false, schedulableMasters: true, expectedSchedulableMasters: true},
+			{schedulableMastersForcedTrue: true, schedulableMasters: false, expectedSchedulableMasters: true},
+			{schedulableMastersForcedTrue: true, schedulableMasters: true, expectedSchedulableMasters: true},
+		} {
+			test := test
+			It(fmt.Sprintf("schedulableMastersForcedTrue=%v schedulableMasters=%v AreMastersSchedulable? %v", test.schedulableMastersForcedTrue, test.schedulableMasters, test.expectedSchedulableMasters), func() {
+				cluster := &Cluster{
+					Cluster: models.Cluster{
+						SchedulableMastersForcedTrue: &test.schedulableMastersForcedTrue,
+						SchedulableMasters:           &test.schedulableMasters,
+					},
+				}
+				Expect(AreMastersSchedulable(cluster)).Should(Equal(test.expectedSchedulableMasters))
+			})
+		}
 	})
 })
 

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -201,6 +201,11 @@ type Cluster struct {
 	// Schedule workloads on masters
 	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
 
+	// Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.
+	// Set to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.
+	//
+	SchedulableMastersForcedTrue *bool `json:"schedulable_masters_forced_true,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5527,6 +5527,11 @@ func init() {
           "type": "boolean",
           "default": false
         },
+        "schedulable_masters_forced_true": {
+          "description": "Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.\nSet to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.\n",
+          "type": "boolean",
+          "default": true
+        },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",
           "type": "string",
@@ -14772,6 +14777,11 @@ func init() {
           "description": "Schedule workloads on masters",
           "type": "boolean",
           "default": false
+        },
+        "schedulable_masters_forced_true": {
+          "description": "Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.\nSet to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.\n",
+          "type": "boolean",
+          "default": true
         },
         "service_network_cidr": {
           "description": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4676,6 +4676,12 @@ definitions:
         type: boolean
         description: Schedule workloads on masters
         default: false
+      schedulable_masters_forced_true:
+        type: boolean
+        description: |
+          Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.
+          Set to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.
+        default: true
       updated_at:
         type: string
         format: date-time

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -201,6 +201,11 @@ type Cluster struct {
 	// Schedule workloads on masters
 	SchedulableMasters *bool `json:"schedulable_masters,omitempty"`
 
+	// Indicates if schedule workloads on masters will be enabled regardless the value of 'schedulable_masters' property.
+	// Set to 'true' when not enough hosts are associated with this cluster to disable the scheduling on masters.
+	//
+	SchedulableMastersForcedTrue *bool `json:"schedulable_masters_forced_true,omitempty"`
+
 	// The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 	// Pattern: ^(?:(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}\/(?:(?:[0-9])|(?:[1-2][0-9])|(?:3[0-2])))|(?:(?:[0-9a-fA-F]*:[0-9a-fA-F]*){2,})/(?:(?:[0-9])|(?:[1-9][0-9])|(?:1[0-1][0-9])|(?:12[0-8])))$
 	ServiceNetworkCidr string `json:"service_network_cidr,omitempty"`


### PR DESCRIPTION
Create a new cluster property called `schedulableMastersForcedTrue` that
overrides `scheduleMasters` regardless its value when the number of
hosts (5) doesn't match the requirement for `scheduleMasters` to be
disabled.

This new property can be fetched from the UI and react accordingly
depending if the value for `scheduleMasters` can be set by the user or
not (e.g.: if `schedulableMastersForcedTrue == true` then disable the
toggle in the UI).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @avishayt 
/cc @mmartinv 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
