### PR TITLE
MGMT-9982: Alter ipxe-script endpoint to handle boot order

### DIFF
--- a/client/installer/get_infra_env_presigned_file_url_parameters.go
+++ b/client/installer/get_infra_env_presigned_file_url_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewGetInfraEnvPresignedFileURLParams creates a new GetInfraEnvPresignedFileURLParams object,
@@ -58,6 +59,12 @@ func NewGetInfraEnvPresignedFileURLParamsWithHTTPClient(client *http.Client) *Ge
    Typically these are written to a http.Request.
 */
 type GetInfraEnvPresignedFileURLParams struct {
+
+	/* BootControl.
+
+	   Verify that script is served to hosts without installed disk.
+	*/
+	BootControl *bool
 
 	/* FileName.
 
@@ -126,6 +133,17 @@ func (o *GetInfraEnvPresignedFileURLParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithBootControl adds the bootControl to the get infra env presigned file URL params
+func (o *GetInfraEnvPresignedFileURLParams) WithBootControl(bootControl *bool) *GetInfraEnvPresignedFileURLParams {
+	o.SetBootControl(bootControl)
+	return o
+}
+
+// SetBootControl adds the bootControl to the get infra env presigned file URL params
+func (o *GetInfraEnvPresignedFileURLParams) SetBootControl(bootControl *bool) {
+	o.BootControl = bootControl
+}
+
 // WithFileName adds the fileName to the get infra env presigned file URL params
 func (o *GetInfraEnvPresignedFileURLParams) WithFileName(fileName string) *GetInfraEnvPresignedFileURLParams {
 	o.SetFileName(fileName)
@@ -155,6 +173,23 @@ func (o *GetInfraEnvPresignedFileURLParams) WriteToRequest(r runtime.ClientReque
 		return err
 	}
 	var res []error
+
+	if o.BootControl != nil {
+
+		// query param boot_control
+		var qrBootControl bool
+
+		if o.BootControl != nil {
+			qrBootControl = *o.BootControl
+		}
+		qBootControl := swag.FormatBool(qrBootControl)
+		if qBootControl != "" {
+
+			if err := r.SetQueryParam("boot_control", qBootControl); err != nil {
+				return err
+			}
+		}
+	}
 
 	// query param file_name
 	qrFileName := o.FileName

--- a/client/installer/v2_download_infra_env_files_parameters.go
+++ b/client/installer/v2_download_infra_env_files_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2DownloadInfraEnvFilesParams creates a new V2DownloadInfraEnvFilesParams object,
@@ -59,6 +60,12 @@ func NewV2DownloadInfraEnvFilesParamsWithHTTPClient(client *http.Client) *V2Down
 */
 type V2DownloadInfraEnvFilesParams struct {
 
+	/* BootControl.
+
+	   Verify that script is served to hosts without installed disk.
+	*/
+	BootControl *bool
+
 	/* FileName.
 
 	   The file to be downloaded.
@@ -72,6 +79,14 @@ type V2DownloadInfraEnvFilesParams struct {
 	   Format: uuid
 	*/
 	InfraEnvID strfmt.UUID
+
+	/* Mac.
+
+	   Mac address of the host running ipxe script.
+
+	   Format: mac
+	*/
+	Mac *strfmt.MAC
 
 	timeout    time.Duration
 	Context    context.Context
@@ -126,6 +141,17 @@ func (o *V2DownloadInfraEnvFilesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithBootControl adds the bootControl to the v2 download infra env files params
+func (o *V2DownloadInfraEnvFilesParams) WithBootControl(bootControl *bool) *V2DownloadInfraEnvFilesParams {
+	o.SetBootControl(bootControl)
+	return o
+}
+
+// SetBootControl adds the bootControl to the v2 download infra env files params
+func (o *V2DownloadInfraEnvFilesParams) SetBootControl(bootControl *bool) {
+	o.BootControl = bootControl
+}
+
 // WithFileName adds the fileName to the v2 download infra env files params
 func (o *V2DownloadInfraEnvFilesParams) WithFileName(fileName string) *V2DownloadInfraEnvFilesParams {
 	o.SetFileName(fileName)
@@ -148,6 +174,17 @@ func (o *V2DownloadInfraEnvFilesParams) SetInfraEnvID(infraEnvID strfmt.UUID) {
 	o.InfraEnvID = infraEnvID
 }
 
+// WithMac adds the mac to the v2 download infra env files params
+func (o *V2DownloadInfraEnvFilesParams) WithMac(mac *strfmt.MAC) *V2DownloadInfraEnvFilesParams {
+	o.SetMac(mac)
+	return o
+}
+
+// SetMac adds the mac to the v2 download infra env files params
+func (o *V2DownloadInfraEnvFilesParams) SetMac(mac *strfmt.MAC) {
+	o.Mac = mac
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2DownloadInfraEnvFilesParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -155,6 +192,23 @@ func (o *V2DownloadInfraEnvFilesParams) WriteToRequest(r runtime.ClientRequest, 
 		return err
 	}
 	var res []error
+
+	if o.BootControl != nil {
+
+		// query param boot_control
+		var qrBootControl bool
+
+		if o.BootControl != nil {
+			qrBootControl = *o.BootControl
+		}
+		qBootControl := swag.FormatBool(qrBootControl)
+		if qBootControl != "" {
+
+			if err := r.SetQueryParam("boot_control", qBootControl); err != nil {
+				return err
+			}
+		}
+	}
 
 	// query param file_name
 	qrFileName := o.FileName
@@ -169,6 +223,23 @@ func (o *V2DownloadInfraEnvFilesParams) WriteToRequest(r runtime.ClientRequest, 
 	// path param infra_env_id
 	if err := r.SetPathParam("infra_env_id", o.InfraEnvID.String()); err != nil {
 		return err
+	}
+
+	if o.Mac != nil {
+
+		// query param mac
+		var qrMac strfmt.MAC
+
+		if o.Mac != nil {
+			qrMac = *o.Mac
+		}
+		qMac := qrMac.String()
+		if qMac != "" {
+
+			if err := r.SetQueryParam("mac", qMac); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/docs/user-guide/deploy-on-bare-metal.md
+++ b/docs/user-guide/deploy-on-bare-metal.md
@@ -55,9 +55,43 @@ initrd --name initrd http://assisted.example.com:8888/images/a7acfb01-d89f-40c8-
 kernel http://assisted.example.com:8888/boot-artifacts/kernel?arch=x86_64&version=4.9 initrd=initrd coreos.live.rootfs_url=http://assisted.example.com:8888/boot-artifacts/rootfs?arch=x86_64&version=4.9 random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8 coreos.inst.persistent-kargs="console=tty1 console=ttyS1,115200n8"
 boot
 ```
-
 A presigned URL for the script URL can be retrieved using:
 `GET /api/assisted-install/v2/infra-envs/{infra_env_id}/downloads/files-presigned?file_name=ipxe-script`
+
+#### Boot Control
+In order to complete installation using iPXE, iPXE script cannot always be served.  After the 
+disk image has been completely written to the disk and the node went to reboot, the node should 
+boot from the disk.  To enable this, the following boot order has to be set: `[hd, network]`
+(hd first).  This causes the node to attempt booting first from hard disk. If it fails to boot from 
+hd, it defaults to the network (iPXE).
+
+When using iPXE, it is more desirable to put the network first.  Also, even if the image has been 
+written to the disk and the installation has failed, the node should boot from network.  To enable this
+the boot order should be reversed to `[network, hd]`, and the assisted service manages this flow.
+
+To enable this flow, additional optional parameter `boot_control` has to be added to the iPXE download URL.
+The script download URL has this form:
+
+```
+GET /api/assisted-install/v2/infra-envs/{infra_env_id}/downloads/files?file_name=ipxe-script&boot_control=true
+```
+
+The assisted service returns a script having the following format:
+
+```
+#!ipxe
+chain http://assisted.example.com/api/assisted-install/v2/infra-envs/{infra_env_id}/downloads/files?mac=${net0/mac}
+```
+
+This script is actually a redirect script.  It indicates to IPXE to call again with the provided 
+URL which contains the mac address.  The iPXE infrastructure replaces the macro ${net0/mac} to the 
+mac address.  The mac address is used to recognize the host.  The assisted service will skip serving 
+the boot script in case it is in stage that requires booting from hd.
+
+To get a presigned URL with boot_control enabled, the boot_control parameter can be added to the
+presigning URL request:
+
+`GET /api/assisted-install/v2/infra-envs/{infra_env_id}/downloads/files-presigned?file_name=ipxe-script&boot_control=true`
 
 ### Booting the nodes from iPXE
 

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -605,13 +606,67 @@ func (b *bareMetalInventory) signURL(ctx context.Context, infraEnvID, urlString,
 	return urlString, &expiresAt, nil
 }
 
-const ipxeScriptFormat = `#!ipxe
+const ipxeRedirectScriptFormat = `#!ipxe
+chain %s&mac=${net0/mac}
+`
+
+const ipxeBootScriptFormat = `#!ipxe
 initrd --name initrd %s
 kernel %s initrd=initrd coreos.live.rootfs_url=%s random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8 coreos.inst.persistent-kargs="console=tty1 console=ttyS1,115200n8"
 boot
 `
 
-func (b *bareMetalInventory) infraEnvIPXEScript(ctx context.Context, infraEnv *common.InfraEnv) (string, error) {
+func (b *bareMetalInventory) hostRedirectIPXEScript(ctx context.Context, infraEnv *common.InfraEnv) (string, error) {
+	parsedURL, err := url.Parse(b.ServiceBaseURL)
+	if err != nil {
+		return "", err
+	}
+	if b.insecureIPXEURLs {
+		parsedURL.Scheme = "http"
+	}
+	builder := installer.V2DownloadInfraEnvFilesURL{
+		InfraEnvID: *infraEnv.ID,
+		FileName:   "ipxe-script",
+	}
+	redirectUrl := builder.StringFull(parsedURL.Scheme, parsedURL.Host)
+	redirectUrl, _, err = b.signURL(ctx, infraEnv.ID.String(), redirectUrl, infraEnv.ImageTokenKey)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(ipxeRedirectScriptFormat, redirectUrl), nil
+}
+
+func (b *bareMetalInventory) canServeHostIPXEScript(infraEnv *common.InfraEnv, mac *strfmt.MAC) error {
+	var hosts []*models.Host
+	macStr := mac.String()
+	if err := b.db.Where("infra_env_id = ? and (inventory like ? or inventory like ?)", infraEnv.ID.String(), fmt.Sprintf("%%%s%%", strings.ToUpper(macStr)),
+		fmt.Sprintf("%%%s%%", strings.ToLower(macStr))).Find(&hosts).Error; err != nil {
+		return common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "IPXE booting skipped. InfraEnv %s: Host with mac %s", infraEnv.ID.String(), macStr))
+	}
+	switch len(hosts) {
+	case 0:
+		return nil
+	case 1:
+	default:
+		return common.NewApiError(http.StatusInternalServerError, errors.Errorf("IPXE booting skipped. Unexpected number of hosts %d with mac %s", len(hosts), macStr))
+	}
+	h := hosts[0]
+	switch swag.StringValue(h.Status) {
+	case models.HostStatusInstalled:
+		return common.NewApiError(http.StatusNotFound, errors.Errorf("IPXE booting skipped. InfraEnv %s: host %s having mac %s is already installed", infraEnv.ID.String(), h.ID.String(), macStr))
+	case models.HostStatusInstallingInProgress:
+		if h.Progress != nil {
+			switch h.Progress.CurrentStage {
+			case models.HostStageDone, models.HostStageConfiguring, models.HostStageJoined, models.HostStageRebooting, models.HostStageWaitingForIgnition:
+				return common.NewApiError(http.StatusNotFound, errors.Errorf("IPXE booting skipped. InfraEnv %s: host %s having mac %s is in stage %s", infraEnv.ID.String(), h.ID.String(), macStr,
+					h.Progress.CurrentStage))
+			}
+		}
+	}
+	return nil
+}
+
+func (b *bareMetalInventory) bootIPXEScript(ctx context.Context, infraEnv *common.InfraEnv) (string, error) {
 	osImage, err := b.getOsImageOrLatest(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
 	if err != nil {
 		return "", err
@@ -638,18 +693,33 @@ func (b *bareMetalInventory) infraEnvIPXEScript(ctx context.Context, infraEnv *c
 		return "", errors.Wrap(err, "failed to sign initrd URL")
 	}
 
-	return fmt.Sprintf(ipxeScriptFormat, initrdURL, kernelURL, rootfsURL), nil
+	return fmt.Sprintf(ipxeBootScriptFormat, initrdURL, kernelURL, rootfsURL), nil
+}
+
+func (b *bareMetalInventory) infraEnvIPXEScript(ctx context.Context, infraEnv *common.InfraEnv, mac *strfmt.MAC, bootControl bool) (string, error) {
+	if mac != nil && *mac != "" {
+		if err := b.canServeHostIPXEScript(infraEnv, mac); err != nil {
+			return "", err
+		}
+	} else if bootControl {
+		return b.hostRedirectIPXEScript(ctx, infraEnv)
+	}
+	return b.bootIPXEScript(ctx, infraEnv)
 }
 
 func (b *bareMetalInventory) GetInfraEnvPresignedFileURL(ctx context.Context, params installer.GetInfraEnvPresignedFileURLParams) middleware.Responder {
+	if swag.BoolValue(params.BootControl) && params.FileName != "ipxe-script" {
+		return common.NewApiError(http.StatusBadRequest, errors.New(`boot_control can be set only for "ipxe-script"`))
+	}
 	infraEnv, err := common.GetInfraEnvFromDB(b.db, params.InfraEnvID)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}
 
 	builder := &installer.V2DownloadInfraEnvFilesURL{
-		InfraEnvID: params.InfraEnvID,
-		FileName:   params.FileName,
+		InfraEnvID:  params.InfraEnvID,
+		FileName:    params.FileName,
+		BootControl: params.BootControl,
 	}
 	filesURL, err := builder.Build()
 	if err != nil {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3247,6 +3247,19 @@ func init() {
             "name": "file_name",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "mac",
+            "description": "Mac address of the host running ipxe script.",
+            "name": "mac",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "Verify that script is served to hosts without installed disk.",
+            "name": "boot_control",
+            "in": "query"
           }
         ],
         "responses": {
@@ -3339,6 +3352,12 @@ func init() {
             "name": "file_name",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "Verify that script is served to hosts without installed disk.",
+            "name": "boot_control",
+            "in": "query"
           }
         ],
         "responses": {
@@ -12362,6 +12381,19 @@ func init() {
             "name": "file_name",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "mac",
+            "description": "Mac address of the host running ipxe script.",
+            "name": "mac",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "Verify that script is served to hosts without installed disk.",
+            "name": "boot_control",
+            "in": "query"
           }
         ],
         "responses": {
@@ -12454,6 +12486,12 @@ func init() {
             "name": "file_name",
             "in": "query",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "Verify that script is served to hosts without installed disk.",
+            "name": "boot_control",
+            "in": "query"
           }
         ],
         "responses": {

--- a/restapi/operations/installer/get_infra_env_presigned_file_url_parameters.go
+++ b/restapi/operations/installer/get_infra_env_presigned_file_url_parameters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
@@ -32,6 +33,10 @@ type GetInfraEnvPresignedFileURLParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Verify that script is served to hosts without installed disk.
+	  In: query
+	*/
+	BootControl *bool
 	/*The file to be downloaded.
 	  Required: true
 	  In: query
@@ -55,6 +60,11 @@ func (o *GetInfraEnvPresignedFileURLParams) BindRequest(r *http.Request, route *
 
 	qs := runtime.Values(r.URL.Query())
 
+	qBootControl, qhkBootControl, _ := qs.GetOK("boot_control")
+	if err := o.bindBootControl(qBootControl, qhkBootControl, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	qFileName, qhkFileName, _ := qs.GetOK("file_name")
 	if err := o.bindFileName(qFileName, qhkFileName, route.Formats); err != nil {
 		res = append(res, err)
@@ -67,6 +77,29 @@ func (o *GetInfraEnvPresignedFileURLParams) BindRequest(r *http.Request, route *
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindBootControl binds and validates parameter BootControl from query.
+func (o *GetInfraEnvPresignedFileURLParams) bindBootControl(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("boot_control", "query", "bool", raw)
+	}
+	o.BootControl = &value
+
 	return nil
 }
 

--- a/restapi/operations/installer/get_infra_env_presigned_file_url_urlbuilder.go
+++ b/restapi/operations/installer/get_infra_env_presigned_file_url_urlbuilder.go
@@ -12,13 +12,15 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // GetInfraEnvPresignedFileURLURL generates an URL for the get infra env presigned file URL operation
 type GetInfraEnvPresignedFileURLURL struct {
 	InfraEnvID strfmt.UUID
 
-	FileName string
+	BootControl *bool
+	FileName    string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -60,6 +62,14 @@ func (o *GetInfraEnvPresignedFileURLURL) Build() (*url.URL, error) {
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 
 	qs := make(url.Values)
+
+	var bootControlQ string
+	if o.BootControl != nil {
+		bootControlQ = swag.FormatBool(*o.BootControl)
+	}
+	if bootControlQ != "" {
+		qs.Set("boot_control", bootControlQ)
+	}
 
 	fileNameQ := o.FileName
 	if fileNameQ != "" {

--- a/restapi/operations/installer/v2_download_infra_env_files_parameters.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_parameters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
@@ -32,6 +33,10 @@ type V2DownloadInfraEnvFilesParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
+	/*Verify that script is served to hosts without installed disk.
+	  In: query
+	*/
+	BootControl *bool
 	/*The file to be downloaded.
 	  Required: true
 	  In: query
@@ -42,6 +47,10 @@ type V2DownloadInfraEnvFilesParams struct {
 	  In: path
 	*/
 	InfraEnvID strfmt.UUID
+	/*Mac address of the host running ipxe script.
+	  In: query
+	*/
+	Mac *strfmt.MAC
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -55,6 +64,11 @@ func (o *V2DownloadInfraEnvFilesParams) BindRequest(r *http.Request, route *midd
 
 	qs := runtime.Values(r.URL.Query())
 
+	qBootControl, qhkBootControl, _ := qs.GetOK("boot_control")
+	if err := o.bindBootControl(qBootControl, qhkBootControl, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
 	qFileName, qhkFileName, _ := qs.GetOK("file_name")
 	if err := o.bindFileName(qFileName, qhkFileName, route.Formats); err != nil {
 		res = append(res, err)
@@ -64,9 +78,37 @@ func (o *V2DownloadInfraEnvFilesParams) BindRequest(r *http.Request, route *midd
 	if err := o.bindInfraEnvID(rInfraEnvID, rhkInfraEnvID, route.Formats); err != nil {
 		res = append(res, err)
 	}
+
+	qMac, qhkMac, _ := qs.GetOK("mac")
+	if err := o.bindMac(qMac, qhkMac, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindBootControl binds and validates parameter BootControl from query.
+func (o *V2DownloadInfraEnvFilesParams) bindBootControl(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("boot_control", "query", "bool", raw)
+	}
+	o.BootControl = &value
+
 	return nil
 }
 
@@ -133,6 +175,43 @@ func (o *V2DownloadInfraEnvFilesParams) bindInfraEnvID(rawData []string, hasKey 
 func (o *V2DownloadInfraEnvFilesParams) validateInfraEnvID(formats strfmt.Registry) error {
 
 	if err := validate.FormatOf("infra_env_id", "path", "uuid", o.InfraEnvID.String(), formats); err != nil {
+		return err
+	}
+	return nil
+}
+
+// bindMac binds and validates parameter Mac from query.
+func (o *V2DownloadInfraEnvFilesParams) bindMac(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: mac
+	value, err := formats.Parse("mac", raw)
+	if err != nil {
+		return errors.InvalidType("mac", "query", "strfmt.MAC", raw)
+	}
+	o.Mac = (value.(*strfmt.MAC))
+
+	if err := o.validateMac(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateMac carries on validations for parameter Mac
+func (o *V2DownloadInfraEnvFilesParams) validateMac(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("mac", "query", "mac", o.Mac.String(), formats); err != nil {
 		return err
 	}
 	return nil

--- a/restapi/operations/installer/v2_download_infra_env_files_urlbuilder.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_urlbuilder.go
@@ -12,13 +12,16 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // V2DownloadInfraEnvFilesURL generates an URL for the v2 download infra env files operation
 type V2DownloadInfraEnvFilesURL struct {
 	InfraEnvID strfmt.UUID
 
-	FileName string
+	BootControl *bool
+	FileName    string
+	Mac         *strfmt.MAC
 
 	_basePath string
 	// avoid unkeyed usage
@@ -61,9 +64,25 @@ func (o *V2DownloadInfraEnvFilesURL) Build() (*url.URL, error) {
 
 	qs := make(url.Values)
 
+	var bootControlQ string
+	if o.BootControl != nil {
+		bootControlQ = swag.FormatBool(*o.BootControl)
+	}
+	if bootControlQ != "" {
+		qs.Set("boot_control", bootControlQ)
+	}
+
 	fileNameQ := o.FileName
 	if fileNameQ != "" {
 		qs.Set("file_name", fileNameQ)
+	}
+
+	var macQ string
+	if o.Mac != nil {
+		macQ = o.Mac.String()
+	}
+	if macQ != "" {
+		qs.Set("mac", macQ)
 	}
 
 	_result.RawQuery = qs.Encode()

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1637,6 +1637,17 @@ paths:
           type: string
           enum: [discovery.ign, ipxe-script]
           required: true
+        - in: query
+          name: mac
+          description: Mac address of the host running ipxe script.
+          type: string
+          format: mac
+          required: false
+        - in: query
+          name: boot_control
+          description: Verify that script is served to hosts without installed disk.
+          type: boolean
+          required: false
       responses:
         "200":
           description: Success.
@@ -1698,6 +1709,11 @@ paths:
           type: string
           enum: [discovery.ign, ipxe-script]
           required: true
+        - in: query
+          name: boot_control
+          description: Verify that script is served to hosts without installed disk.
+          type: boolean
+          required: false
       responses:
         "200":
           description: Success.


### PR DESCRIPTION
When using iPXE would like to handle any boot order.  The options are
[network, hd], and [hd, network].
Currently we are only handling the second case, where we attempt to boot
from hd first.  If we fail, then we attempt to boot from network.
If network is first, we need to handle the case that hd is already
installed and host is rebooting, or installed.  In this case we would
like to avoid using the iPXE booting and boot from hd instead.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @carbonin 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
