### PR TITLE
 MGMT-10790: Always use APIVipDNSName to obtain API address

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -779,13 +779,7 @@ func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Starting createAndUploadDay2NodeIgnition for cluster %s, host %s", cluster.ID, host.ID)
 
-	// Specify ignition endpoint based on cluster configuration:
-	address := cluster.APIVip
-	if address == "" {
-		address = swag.StringValue(cluster.APIVipDNSName)
-	}
-
-	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", address, host.MachineConfigPoolName)
+	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", common.GetAPIHostname(cluster), host.MachineConfigPoolName)
 	if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
 		url, err := url.Parse(*cluster.IgnitionEndpoint.URL)
 		if err != nil {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -392,3 +392,16 @@ func GetTagFromImageRef(ref string) string {
 		return ""
 	}
 }
+
+func GetAPIHostname(c *Cluster) string {
+	// Despite the confusing name of this parameter, in day-2 scenarios where
+	// this function is used it could either be a DNS domain name that points
+	// at the API's IP address (this is the default) or it could also not be a
+	// DNS domain name at all - such as when the user chooses to override this
+	// parameter with an IP address. Such override is commonly done by users in
+	// day-2 SaaS imported clusters where the user never bothered to set up DNS
+	// for their day-1 cluster in the first place and just wants the worker to
+	// connect to the API directly. The UI even has a special dialog to help users
+	// do that.
+	return swag.StringValue(c.APIVipDNSName)
+}

--- a/internal/host/hostcommands/api_vip_connectivity_check_cmd.go
+++ b/internal/host/hostcommands/api_vip_connectivity_check_cmd.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
@@ -73,15 +72,11 @@ func (c *apivipConnectivityCheckCmd) GetSteps(ctx context.Context, host *models.
 }
 
 func getIngnitionEndPoint(cluster *common.Cluster, host *models.Host) (string, error) {
-	addressPart := swag.StringValue(cluster.APIVipDNSName)
-	if addressPart == "" {
-		addressPart = cluster.APIVip
-	}
 	poolName := string(common.GetEffectiveRole(host))
 	if host.MachineConfigPoolName != "" {
 		poolName = host.MachineConfigPoolName
 	}
-	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", addressPart, poolName)
+	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", common.GetAPIHostname(cluster), poolName)
 	if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
 		url, err := url.Parse(*cluster.IgnitionEndpoint.URL)
 		if err != nil {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -757,7 +757,7 @@ func (v *validator) isIgnitionDownloadable(c *validationContext) ValidationStatu
 	if c.infraEnv != nil {
 		return ValidationSuccessSuppressOutput
 	}
-	if !hostutil.IsDay2Host(c.host) || swag.BoolValue(c.cluster.UserManagedNetworking) {
+	if !hostutil.IsDay2Host(c.host) {
 		return ValidationSuccessSuppressOutput
 	}
 	if c.host.APIVipConnectivity == "" {


### PR DESCRIPTION
Presently we fetch the API address for ignition download and validation
using two independent pieces of code, these also prioritise cluster.APIVip and
cluster.APIVipDNSName in different ways, which leads to incorrect validation.

This commit addresses that by extracting this logic into a function that
may be called from both locations.

During the development of this feature, it was decided that the only
valid address during installation is cluster.APIVipDNSName and so this
function has been created to only return that.

At least for future modification, this logic is in a single location.

Additionally, the validation of whether or not an ignition is downloadable for Day2 hosts was skipped for hosts with user managed networking enabled. We have removed this so that the validation will be conducted for all day 2 hosts now.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
