### PR TITLE
MGMT-10868 - Fix unbound `DAY2_LATE_BINDING` variable error

### DIFF
--- a/deploy/operator/common.sh
+++ b/deploy/operator/common.sh
@@ -23,6 +23,9 @@ export HIVE_NAMESPACE="${HIVE_NAMESPACE:-hive}"
 export ASSISTED_UPGRADE_OPERATOR="${ASSISTED_UPGRADE_OPERATOR:-false}"
 export ASSISTED_SERVICE_OPERATOR_CATALOG="assisted-service-operator-catalog"
 
+export ASSISTED_CLUSTER_DEPLOYMENT_NAME="${ASSISTED_CLUSTER_DEPLOYMENT_NAME:-assisted-test-cluster}"
+export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
+
 ############
 # Versions #
 ############

--- a/deploy/operator/ztp/add-remote-nodes-playbook.yaml
+++ b/deploy/operator/ztp/add-remote-nodes-playbook.yaml
@@ -8,6 +8,8 @@
     - infraenv_name: "{{ lookup('env', 'ASSISTED_INFRAENV_NAME') }}"
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
     - cluster_deployment_name: "{{ lookup('env', 'ASSISTED_CLUSTER_DEPLOYMENT_NAME') }}"
+    - pull_secret_name: "{{ lookup('env', 'ASSISTED_PULLSECRET_NAME') }}"
+    - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
     - day2: "true"
   
   tasks:

--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -8,11 +8,12 @@ source ${__dir}/../common.sh
 source ${__dir}/../utils.sh
 
 export REMOTE_BAREMETALHOSTS_FILE="${REMOTE_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/remote_baremetalhosts.json}"
-export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
+
+export DAY2_LATE_BINDING=${DAY2_LATE_BINDING:-}
 
 # If performing late binding then we need to generate an infraenv for this.
 # Generation is handled within "add-remote-nodes-playbook"
-if [ -z "${DAY2_LATE_BINDING}" ] ; then
+if [[ "${DAY2_LATE_BINDING}" != "" ]]; then
   export LATE_BINDING_ASSISTED_CLUSTER_DEPLOYMENT_NAME=${ASSISTED_CLUSTER_DEPLOYMENT_NAME}
   export ASSISTED_CLUSTER_DEPLOYMENT_NAME=""
   export ASSISTED_INFRAENV_NAME=${ASSISTED_INFRAENV_NAME}-latebinding
@@ -54,7 +55,7 @@ export -f remote_done_agents
 
 # If we are performing late binding then each of the agents needs to have the correct clusterDeploymentRef applied.
 # This needs to happen after the agents are available. They cannot move to "done" until the clusterDeploymentRef is applied.
-if [ -z "${DAY2_LATE_BINDING}" ] ; then
+if [[ "${DAY2_LATE_BINDING}" != "" ]]; then
   clusterDeploymentName=${LATE_BINDING_ASSISTED_CLUSTER_DEPLOYMENT_NAME}
 
   # Generate a patch to assign the correct cluster name.
@@ -78,7 +79,7 @@ PATCH
   done
 
 fi
-\z
+
 timeout 60m bash -c "wait_for_cmd_amount ${amount} 30 remote_done_agents"
 
 echo "Remote worker agents installation completed successfully!"

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -9,9 +9,7 @@ source ${__dir}/none_platform_utils.sh
 set -x
 
 export ASSISTED_CLUSTER_NAME="${ASSISTED_CLUSTER_NAME:-assisted-test-cluster}"
-export ASSISTED_CLUSTER_DEPLOYMENT_NAME="${ASSISTED_CLUSTER_DEPLOYMENT_NAME:-assisted-test-cluster}"
 export ASSISTED_AGENT_CLUSTER_INSTALL_NAME="${ASSISTED_AGENT_CLUSTER_INSTALL_NAME:-assisted-agent-cluster-install}"
-export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
 export ASSISTED_PULLSECRET_NAME="${ASSISTED_PULLSECRET_NAME:-assisted-pull-secret}"
 export ASSISTED_PULLSECRET_JSON="${ASSISTED_PULLSECRET_JSON:-${PULL_SECRET_FILE}}"
 export ASSISTED_PRIVATEKEY_NAME="${ASSISTED_PRIVATEKEY_NAME:-assisted-ssh-private-key}"


### PR DESCRIPTION
Following https://github.com/omertuc/assisted-service/commit/8306b067be6e8441739fd3897a7175dbb70f2f66

A default value for `DAY2_LATE_BINDING` was not set, and as a result, jobs
that don't set it began failing since it merged. e.g. https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-operator-ztp-sno-day2-workers-periodic/1540851047231131648

Also `ASSISTED_CLUSTER_DEPLOYMENT_NAME` was not defined in that file, so
I moved it and `ASSISTED_INFRAENV_NAME` to `common.sh` as they're used
by both the spoke script and the day-2 script.

Also some ansible variables needed for the late-binding infraenv
templates were missing from the day-2 playbook

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @paul-maidment
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md