### PR TITLE
MGMT-10956: Do not enable multipathd on OKD agent

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -191,7 +191,11 @@ const discoveryIgnitionConfigFormat = `{
         "name": "selinux.service",
         "enabled": true,
         "contents": "[Service]\nType=oneshot\nExecStartPre=checkmodule -M -m -o /root/assisted.mod /root/assisted.te\nExecStartPre=semodule_package -o /root/assisted.pp -m /root/assisted.mod\nExecStart=semodule -i /root/assisted.pp\n\n[Install]\nWantedBy=multi-user.target"
-    }{{if .StaticNetworkConfig}},
+    }{{if .OKDBinaries | not}},
+    {
+        "name": "multipathd.service",
+        "enabled": true
+    }{{end}}{{if .StaticNetworkConfig}},
     {
         "name": "pre-network-manager-config.service",
         "enabled": true,
@@ -201,10 +205,6 @@ const discoveryIgnitionConfigFormat = `{
         "name": "okd-overlay.service",
         "enabled": true,
         "contents": "[Service]\nType=oneshot\nExecStart=/usr/local/bin/okd-binaries.sh\n\n[Unit]\nWants=network-online.target\nAfter=network-online.target\n\n[Install]\nWantedBy=multi-user.target"
-    },
-	{
-        "name": "multipathd.service",
-        "enabled": true,
     },
     {
         "name": "systemd-journal-gatewayd.socket",
@@ -231,16 +231,16 @@ const discoveryIgnitionConfigFormat = `{
           "name": "root"
       },
       "contents": { "source": "data:,{{.AGENT_MOTD}}" }
-    },
+    }{{if .OKDBinaries | not}},
     {
-		"overwrite": true,
-		"path": "/etc/multipath.conf",
-		"mode": 420,
-		"user": {
-			"name": "root"
-		},
-		"contents": { "source": "data:text/plain;charset=utf-8;base64,ZGVmYXVsdHMgewogICAgdXNlcl9mcmllbmRseV9uYW1lcyB5ZXMKICAgIGZpbmRfbXVsdGlwYXRocyB5ZXMKICAgIGVuYWJsZV9mb3JlaWduICJeJCIKfQpibGFja2xpc3RfZXhjZXB0aW9ucyB7CiAgICBwcm9wZXJ0eSAiKFNDU0lfSURFTlRffElEX1dXTikiCn0KYmxhY2tsaXN0IHsKfQo=" }
-	},
+      "overwrite": true,
+      "path": "/etc/multipath.conf",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,ZGVmYXVsdHMgewogICAgdXNlcl9mcmllbmRseV9uYW1lcyB5ZXMKICAgIGZpbmRfbXVsdGlwYXRocyB5ZXMKICAgIGVuYWJsZV9mb3JlaWduICJeJCIKfQpibGFja2xpc3RfZXhjZXB0aW9ucyB7CiAgICBwcm9wZXJ0eSAiKFNDU0lfSURFTlRffElEX1dXTikiCn0KYmxhY2tsaXN0IHsKfQo=" }
+    }{{end}},
     {
       "overwrite": true,
       "path": "/etc/NetworkManager/conf.d/01-ipv6.conf",

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1172,6 +1172,24 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).Should(ContainSubstring("/tmp/example"))
 	})
 
+	It("no multipath for okd", func() {
+		config := IgnitionConfig{OKDRPMsImage: "image"}
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO)
+
+		Expect(err).Should(BeNil())
+		Expect(text).ShouldNot(ContainSubstring("multipathd"))
+	})
+
+	It("multipath configured for non-okd", func() {
+		config := IgnitionConfig{}
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO)
+
+		Expect(err).Should(BeNil())
+		Expect(text).Should(ContainSubstring("multipathd"))
+	})
+
 	Context("static network config", func() {
 		formattedInput := "some formated input"
 		staticnetworkConfigOutput := []staticnetworkconfig.StaticNetworkConfigData{


### PR DESCRIPTION
OKD doesn't have multipathd installed, so don't try to enable it in the
agent's ignition config.

Fixes #3976

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @vrutkovs 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
