### PR TITLE
MGMT-10958: UpdateHostName - Validate that the hostname is not forbidden.

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -22,6 +22,15 @@ const (
 	HostnamePattern   = "^[a-z0-9][a-z0-9-]{0,62}(?:[.][a-z0-9-]{1,63})*$"
 )
 
+var ForbiddenHostnames = []string{
+	"localhost",
+	"localhost.localdomain",
+	"localhost4",
+	"localhost4.localdomain4",
+	"localhost6",
+	"localhost6.localdomain6",
+}
+
 func GetCurrentHostName(host *models.Host) (string, error) {
 	var inventory models.Inventory
 	if host.RequestedHostname != "" {
@@ -76,6 +85,11 @@ func ValidateHostname(hostname string) error {
 	if !b {
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("Hostname does not pass required regex validation: %s. Hostname: %s", HostnamePattern, hostname))
 	}
+
+	if funk.ContainsString(ForbiddenHostnames, hostname) {
+		return common.NewApiError(http.StatusBadRequest, errors.Errorf("The host name %s is forbidden", hostname))
+	}
+
 	return nil
 }
 

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -69,6 +69,33 @@ var _ = Describe("Installation Disk selection", func() {
 	}
 })
 
+var _ = Describe("Validation", func() {
+	It("Should not allow forbidden hostnames", func() {
+		for _, hostName := range []string{
+			"localhost",
+			"localhost.localdomain",
+			"localhost4",
+			"localhost4.localdomain4",
+			"localhost6",
+			"localhost6.localdomain6",
+		} {
+			err := ValidateHostname(hostName)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
+	It("Should allow permitted hostnames", func() {
+		for _, hostName := range []string{
+			"foobar",
+			"foobar.local",
+			"arbitrary.hostname",
+		} {
+			err := ValidateHostname(hostName)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+})
+
 func TestHostUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "HostUtil Tests")

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -48,15 +48,6 @@ var (
 	invalidPlatforms = []string{
 		OpenStackPlatform,
 	}
-
-	forbiddenHostnames = []string{
-		"localhost",
-		"localhost.localdomain",
-		"localhost4",
-		"localhost4.localdomain4",
-		"localhost6",
-		"localhost6.localdomain6",
-	}
 )
 
 func (v ValidationStatus) String() string {
@@ -728,7 +719,7 @@ func (v *validator) isHostnameValid(c *validationContext) ValidationStatus {
 		return ValidationFailure
 	}
 
-	return boolValue(!funk.ContainsString(forbiddenHostnames, getRealHostname(c.host, c.inventory)))
+	return ValidationSuccess
 }
 
 func (v *validator) printHostnameValid(c *validationContext, status ValidationStatus) string {

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -3112,7 +3112,7 @@ spec:
 
 		waitForHostState(ctx, models.HostStatusKnown, 60*time.Second, h1)
 
-		By("Setting hostname to localhost")
+		By("Setting hostname to localhost should cause an API error")
 		_, err = userBMClient.Installer.V2UpdateHost(ctx, &installer.V2UpdateHostParams{
 			HostUpdateParams: &models.HostUpdateParams{
 				HostName: &localhost,
@@ -3120,9 +3120,9 @@ spec:
 			HostID:     *h1Host.ID,
 			InfraEnvID: h1Host.InfraEnvID,
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
-		waitForHostState(ctx, models.HostStatusInsufficient, 60*time.Second, h1)
+		waitForHostState(ctx, models.HostStatusKnown, 60*time.Second, h1)
 
 	})
 


### PR DESCRIPTION
Presently when changing a hostname using UpdateHostName, no validation
is performed to ensure that that hostname is permitted.

This commit addresses that by validating that the hostname is not in
"localhost", "localhost.localdomain", "localhost4",
"localhost4.localdomain4", "localhost6.localdomain6"

This is to fix a bug that was introduced in [MGMT-10722](https://issues.redhat.com//browse/MGMT-10722) and discovered during QA

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
