### PR TITLE
AGENT-227: Don't exit when inventory not available

### DIFF
--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -54,6 +54,11 @@ func ApplyHostConfigs(ctx context.Context, log *log.Logger, bmInventory *client.
 func applyHostConfig(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall, host *models.Host, hostConfigs HostConfigs) error {
 	log.Infof("Checking configuration for host %s", *host.ID)
 
+	if len(host.Inventory) == 0 {
+		log.Info("Inventory information not yet available")
+		return nil
+	}
+
 	inventory := &models.Inventory{}
 	err := inventory.UnmarshalBinary([]byte(host.Inventory))
 	if err != nil {


### PR DESCRIPTION
Before an agent's inventory has been discovered, we cannot match it to
any host configuration (which would require knowing the MAC addresses).
Therefore, treat it as equivalent to the host not having shown up yet.

Previously we exited with an error caused by trying to Unmarshal from
zero-length data, which results in the install failing when the
configuration command runs before inventory is available.

Part of [AGENT-227](https://issues.redhat.com/browse/AGENT-227)

This change will need to be backported to the release-4.11 branch, possibly as part of #4026.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] Ephemeral installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @pawanpinjarkar 
/cc @celebdor 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
