### PR TITLE
Automatically label deploy/ directory with valid-bug

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,3 +25,6 @@ filters:
   ^docs/events.yaml:
     labels:
       - api-review
+  ^deploy/.*:
+    labels:
+      - bugzilla/valid-bug


### PR DESCRIPTION
Scripts stored under deploy/ are not included in the product, therefore
a requirement of opening a dedicated Bugzilla for master as well as
cherry-pick branch are an unnecessary burden. With this PR, whenever
such a change is opened against the OCM-2.5 branch the label will be
autoamtically applied in order to streamline the process.

Please note that we are not introducing this change in the master branch
as that one requires a manual review, but on the other hand does not
require opening a Bugzilla.

/cc @osherdp 
/cc @eranco74 