### PR TITLE
MGMT-10914: fix ASC deployment reason on success

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -112,6 +112,8 @@ const (
 
 	// ReasonReconcileSucceeded when the reconcile completes all operations without error.
 	ReasonReconcileSucceeded string = "ReconcileSucceeded"
+	// ReasonDeploymentSucceeded when configuring/deploying the assisted-service deployment completed without errors.
+	ReasonDeploymentSucceeded string = "DeploymentSucceeded"
 	// ReasonStorageFailure when there was a failure configuring/deploying storage.
 	ReasonStorageFailure string = "StorageFailure"
 	// ReasonImageHandlerServiceFailure when there was a failure related to the assisted-image-service's service.

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -309,7 +309,7 @@ func (r *AgentServiceConfigReconciler) Reconcile(origCtx context.Context, req ct
 	conditionsv1.SetStatusConditionNoHeartbeat(&instance.Status.Conditions, conditionsv1.Condition{
 		Type:    aiv1beta1.ConditionDeploymentsHealthy,
 		Status:  corev1.ConditionTrue,
-		Reason:  aiv1beta1.ReasonDeploymentFailure,
+		Reason:  aiv1beta1.ReasonDeploymentSucceeded,
 		Message: "All the deployments managed by Infrastructure-operator are healthy.",
 	})
 

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -367,7 +367,7 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 
 		Expect(err).To(BeNil())
 		Expect(conditionsv1.FindStatusCondition(instance.Status.Conditions, aiv1beta1.ConditionDeploymentsHealthy).Status).To(Equal(corev1.ConditionTrue))
-		Expect(conditionsv1.FindStatusCondition(instance.Status.Conditions, aiv1beta1.ConditionDeploymentsHealthy).Reason).To(Equal(aiv1beta1.ReasonDeploymentFailure))
+		Expect(conditionsv1.FindStatusCondition(instance.Status.Conditions, aiv1beta1.ConditionDeploymentsHealthy).Reason).To(Equal(aiv1beta1.ReasonDeploymentSucceeded))
 	})
 
 	Context("IPXE routes", func() {

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
@@ -112,6 +112,8 @@ const (
 
 	// ReasonReconcileSucceeded when the reconcile completes all operations without error.
 	ReasonReconcileSucceeded string = "ReconcileSucceeded"
+	// ReasonDeploymentSucceeded when configuring/deploying the assisted-service deployment completed without errors.
+	ReasonDeploymentSucceeded string = "DeploymentSucceeded"
 	// ReasonStorageFailure when there was a failure configuring/deploying storage.
 	ReasonStorageFailure string = "StorageFailure"
 	// ReasonImageHandlerServiceFailure when there was a failure related to the assisted-image-service's service.


### PR DESCRIPTION
When all deployments managed by infrastructure-operator are healthy,
the condition in AgentServiceConfig should have a success reason.
This fix changes the reason from DeploymentFailure to DeploymentSucceeded.

E.g.
```
Conditions:
  Message: All the deployments managed by Infrastructure-operator are healthy.
  Reason:  DeploymentSucceeded
  Status:  True
  Type:    DeploymentsHealthy
```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @carbonin 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
