### PR TITLE
Upgrade base image to centos9 and support both docker on docker and p…

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,31 +1,31 @@
-FROM quay.io/centos7/postgresql-12-centos7:latest
-
-COPY --from=quay.io/goswagger/swagger:v0.28.0 /usr/bin/swagger /usr/bin/goswagger
-COPY --from=quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /opt/swagger-codegen-cli /opt/swagger-codegen-cli
-COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
+FROM quay.io/centos/centos:stream9
 
 ENV GOPATH=/go
 ENV GOROOT=/usr/local/go
-ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+ENV VIRTUAL_ENV=/opt/venv
+# A directory in the path with write permission even for non-root users
+ENV TOOLS=/tools/
+ENV PATH="$VIRTUAL_ENV/bin:$GOROOT/bin:$GOPATH/bin:$TOOLS:$PATH"
+ENV CGO_CFLAGS="-g -O2 -Wno-return-local-addr"
 
-USER 0
-
-RUN mkdir build && chmod g+xw -R build/
-
-RUN yum install -y --setopt=skip_missing_names_on_install=False \
-        gcc genisoimage git libvirt-client libvirt-devel java && yum clean all
-
+COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=quay.io/goswagger/swagger:v0.28.0 /usr/bin/swagger /usr/bin/goswagger
+COPY --from=quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /opt/swagger-codegen-cli /opt/swagger-codegen-cli
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.17 /usr/bin/gotestsum /usr/bin/make /usr/bin/
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.17 /usr/local/go /usr/local/go
-
-COPY ./hack/setup_env.sh ./dev-requirements.txt ./
-RUN ./setup_env.sh assisted_service
-
-RUN chmod g+xw -R $GOPATH && chmod g+xw -R $(go env GOROOT)
-
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
 COPY --from=quay.io/operator-framework/upstream-opm-builder:v1.16.1 /bin/opm /bin
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install -y --enablerepo=crb \
+        postgresql sqlite gcc genisoimage git docker-ce-cli libvirt-client libvirt-devel java && \
+    dnf clean all
+
+WORKDIR /home/assisted-service
+RUN mkdir build $TOOLS --mode g+xw
+COPY ./hack/setup_env.sh ./dev-requirements.txt ./
+RUN ./setup_env.sh podman_remote && ./setup_env.sh assisted_service
+RUN chmod g+xw -R $GOPATH && chmod g+xw -R $(go env GOROOT)
 COPY ./data /tmp/data
 COPY . .
-
-RUN chmod g+xw -R .

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ By continuing to read this document you will learn how to build and deploy Assis
 
 ## Development Prerequisites
 
-1. Docker or Podman
+1. Docker or Podman. <br>
+For podman make sure to [enable podman socket](docs/dev/podman.md) and update skipper.yaml to map it properly
 1. skipper <https://github.com/stratoscale/skipper>
 1. minikube (for tests)
 1. kubectl

--- a/docs/dev/podman.md
+++ b/docs/dev/podman.md
@@ -1,0 +1,69 @@
+
+# Podman socket enablement
+
+Clean socket if exists
+--------------------------------------
+```shell
+systemctl disable --now podman.socket
+rm -rf /run/user/${UID}/podman
+rm -rf /run/podman
+```
+
+Open/Enable the socket
+--------------------------------------
+```shell
+systemctl enable --now podman.socket
+systemctl --user enable --now podman.socket
+loginctl enable-linger $USER
+```
+
+Verify it
+--------------------------------------
+```shell
+$ podman -r info | grep remoteSocket -A 2
+  remoteSocket:
+    exists: true
+    path: /run/podman/podman.sock
+```
+
+Enable minikube local registry
+---------------------------------------
+```shell
+minikube addons enable registry 
+```
+Expose the registry to the host machine on port 5000.
+Can be done by xinet, port-forward or use [assisted-test-infra](https://github.com/openshift/assisted-test-infra) which automate the xinet method:
+
+###xinet
+Change registry service to a LoadBalancer (minikube tunnel will assign an external IP)
+```shell
+kubectl patch service registry -n kube-system --type json -p='[{"op": "replace", "path": "/spec/type", "value":"LoadBalancer"}]'
+```
+Create a new xinet configuration file at ``/etc/xinetd.d/minikube-registry``:
+```shell
+{
+type		= UNLISTED
+socket_type	= stream
+protocol	= tcp
+user		= root
+wait		= no
+redirect	= EXTERNAL_IP EXTERNAL_PORT
+port		= 5000
+per_source	= UNLIMITED
+instances	= UNLIMITED
+}
+```
+Reboot the xinet service: ``systemctl restart xinetd.service``
+
+###port-forward
+```shell
+kubectl port-forward --namespace kube-system service/registry 5000:80
+```
+
+Use local registry 
+---------------------------------------
+```shell
+export SUBSYSTEM_LOCAL_REGISTRY=localhost:5000
+```
+
+

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+function running_from_skipper() {
+   # The SKIPPER_UID environment variable is an indication that we are running on a skipper container.
+   [ -n "${SKIPPER_UID+x}" ]
+}
+
+function get_container_runtime_command() {
+  # if CONTAINER_TOOL is defined skipping
+  if [ -z "${CONTAINER_TOOL+x}" ]; then
+    if running_from_skipper; then
+      if [ -z ${CONTAINER_RUNTIME_COMMAND+x} ]; then
+        echo "CONTAINER_RUNTIME_COMMAND doesn't set on old skipper version -> default to docker. Upgrade your skipper to the latest version" 1>&2;
+      fi
+
+      if [ "${CONTAINER_RUNTIME_COMMAND:-docker}" == "docker" ]; then
+        CONTAINER_TOOL="docker"
+      else
+        CONTAINER_TOOL=$( command -v podman &> /dev/null && echo "podman" || echo "podman-remote")
+      fi
+    else
+      CONTAINER_TOOL=$( command -v podman &> /dev/null && echo "podman" || echo "docker")
+    fi
+  fi
+
+  echo $CONTAINER_TOOL
+}
+
+# podman-remote4 cannot run against podman server 3 so the skipper image contains them both
+# here we select the right podman-remote version
+function select_podman_client() {
+  # already linked
+  if command -v podman-remote &> /dev/null; then
+    exit
+  fi
+
+  if [ "$(get_container_runtime_command)" = "podman-remote" ]; then
+    if podman-remote4 info 2>&1 | grep "server API version is too old" &> /dev/null; then
+      echo "using podman-remote version 3"
+      ln $(which podman-remote3) /tools/podman-remote
+    else
+      echo "using podman-remote version 4"
+      ln $(which podman-remote4) /tools/podman-remote
+    fi
+  fi
+}
+
+"$@"

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -27,8 +27,17 @@ volumes:
   - /var/run/libvirt/libvirt-sock:/var/run/libvirt/libvirt-sock
   - /var/lib/libvirt/:/var/lib/libvirt/
   - /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt
+
+  # podman - sharing the podman.socket between the host and the skipper container
+  # should be part of skipper implementation. https://github.com/Stratoscale/skipper/issues/153
+  # root user
+  - /run/podman/podman.sock:/run/podman/podman.sock
+  # other users
+  # - $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock
 env_file:
   - skipper.env
 env:
   GOCACHE: "/go/pkg/mod"
   KUBECONFIG: $KUBECONFIG
+  # a podman-remote env variable: the podman socket url to use
+  CONTAINER_HOST: unix://run/podman/podman.sock

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -3,17 +3,18 @@ import os
 import socket
 import subprocess
 import time
-import waiting
 import yaml
+import waiting
 from distutils.spawn import find_executable
 from functools import reduce
 from typing import Optional
-
 from deployment_options import INGRESS_REMOTE_TARGET, OCP_TARGET
+
 
 KUBECTL_CMD = 'kubectl'
 DOCKER = "docker"
 PODMAN = "podman"
+PODMAN_REMOTE = "podman-remote"
 
 
 def verify_build_directory(namespace):
@@ -285,13 +286,12 @@ def is_tool(name):
 
 
 def get_runtime_command():
-    if is_tool(DOCKER):
-        cmd = DOCKER
-    elif is_tool(PODMAN):
-        cmd = PODMAN
+    runtime_commands = (DOCKER, PODMAN, PODMAN_REMOTE)
+    for cmd in runtime_commands:
+        if is_tool(cmd):
+            return cmd
     else:
-        raise Exception("Nor %s nor %s are installed" % (PODMAN, DOCKER))
-    return cmd
+        raise RuntimeError("None of those commands are available: %s", runtime_commands)
 
 
 def get_kubectl_command(target=None, namespace=None):


### PR DESCRIPTION
For NMState performance improvement, we are upgrading our base images to Centos9 (Assisted Service and Assisted Service build).
This PR deals with the Assisted Service build container only.
Assisted Service build images create containers (e.g. Postgres databases) using a container tool. 
Currently assisted-service fully support docker as a container tool. This PR supports using podman as a container tool.
The idea is to expose the host socket to the container and the container uses a thin client to work against the host.
The container detects the right tool by skipper CONTAINER_RUNTIME_COMMAND env parameter (automatically sets by skipper)  or CONTAINER_TOOL (manually sets by the user) and then for podman find the right version.
A podman4 cli client (podman-remote or podman -r) does not have backward compatibility and cannot be used with a podman3 server.
We overcome this by installing two podman-remote versions (3 and 4) and selecting the correct one at runtime.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
