### PR TITLE
MGMT-10734: Add host states and transitions for reclaim

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/host.go
@@ -151,7 +151,7 @@ type Host struct {
 
 	// status
 	// Required: true
-	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound]
+	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound reclaiming reclaiming-rebooting]
 	Status *string `json:"status"`
 
 	// status info
@@ -554,7 +554,7 @@ var hostTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound","reclaiming","reclaiming-rebooting"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -641,6 +641,12 @@ const (
 
 	// HostStatusDiscoveringUnbound captures enum value "discovering-unbound"
 	HostStatusDiscoveringUnbound string = "discovering-unbound"
+
+	// HostStatusReclaiming captures enum value "reclaiming"
+	HostStatusReclaiming string = "reclaiming"
+
+	// HostStatusReclaimingRebooting captures enum value "reclaiming-rebooting"
+	HostStatusReclaimingRebooting string = "reclaiming-rebooting"
 )
 
 // prop value enum

--- a/internal/host/pool_host_statemachine.go
+++ b/internal/host/pool_host_statemachine.go
@@ -27,6 +27,7 @@ func NewPoolHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler)
 			stateswitch.State(models.HostStatusKnownUnbound),
 			stateswitch.State(models.HostStatusUnbinding),
 			stateswitch.State(models.HostStatusUnbindingPendingUserAction),
+			stateswitch.State(models.HostStatusReclaimingRebooting),
 		},
 		DestinationState: stateswitch.State(models.HostStatusDiscoveringUnbound),
 		PostTransition:   th.PostRegisterHost,

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -17,6 +17,7 @@ const (
 	TransitionTypeRegisterInstalledHost      = "RegisterInstalledHost"
 	TransitionTypeBindHost                   = "BindHost"
 	TransitionTypeUnbindHost                 = "UnbindHost"
+	TransitionTypeReclaimHost                = "ReclaimHost"
 )
 
 // func NewHostStateMachine(th *transitionHandler) stateswitch.StateMachine {
@@ -251,6 +252,16 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th *transitionHandler) sta
 			stateswitch.State(models.HostStatusCancelled),
 		},
 		DestinationState: stateswitch.State(models.HostStatusUnbindingPendingUserAction),
+		PostTransition:   th.PostUnbindHost,
+	})
+
+	// Reclaim host
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeReclaimHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalled),
+		},
+		DestinationState: stateswitch.State(models.HostStatusReclaiming),
 		PostTransition:   th.PostUnbindHost,
 	})
 

--- a/models/host.go
+++ b/models/host.go
@@ -151,7 +151,7 @@ type Host struct {
 
 	// status
 	// Required: true
-	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound]
+	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound reclaiming reclaiming-rebooting]
 	Status *string `json:"status"`
 
 	// status info
@@ -554,7 +554,7 @@ var hostTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound","reclaiming","reclaiming-rebooting"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -641,6 +641,12 @@ const (
 
 	// HostStatusDiscoveringUnbound captures enum value "discovering-unbound"
 	HostStatusDiscoveringUnbound string = "discovering-unbound"
+
+	// HostStatusReclaiming captures enum value "reclaiming"
+	HostStatusReclaiming string = "reclaiming"
+
+	// HostStatusReclaimingRebooting captures enum value "reclaiming-rebooting"
+	HostStatusReclaimingRebooting string = "reclaiming-rebooting"
 )
 
 // prop value enum

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7012,7 +7012,9 @@ func init() {
             "disconnected-unbound",
             "insufficient-unbound",
             "disabled-unbound",
-            "discovering-unbound"
+            "discovering-unbound",
+            "reclaiming",
+            "reclaiming-rebooting"
           ]
         },
         "status_info": {
@@ -16186,7 +16188,9 @@ func init() {
             "disconnected-unbound",
             "insufficient-unbound",
             "disabled-unbound",
-            "discovering-unbound"
+            "discovering-unbound",
+            "reclaiming",
+            "reclaiming-rebooting"
           ]
         },
         "status_info": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3921,6 +3921,8 @@ definitions:
           - insufficient-unbound
           - disabled-unbound
           - discovering-unbound
+          - reclaiming
+          - reclaiming-rebooting
       status_info:
         type: string
         x-go-custom-tag: gorm:"type:varchar(2048)"

--- a/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/vendor/github.com/openshift/assisted-service/models/host.go
@@ -151,7 +151,7 @@ type Host struct {
 
 	// status
 	// Required: true
-	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound]
+	// Enum: [discovering known disconnected insufficient disabled preparing-for-installation preparing-failed preparing-successful pending-for-input installing installing-in-progress installing-pending-user-action resetting-pending-user-action installed error resetting added-to-existing-cluster cancelled binding unbinding unbinding-pending-user-action known-unbound disconnected-unbound insufficient-unbound disabled-unbound discovering-unbound reclaiming reclaiming-rebooting]
 	Status *string `json:"status"`
 
 	// status info
@@ -554,7 +554,7 @@ var hostTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["discovering","known","disconnected","insufficient","disabled","preparing-for-installation","preparing-failed","preparing-successful","pending-for-input","installing","installing-in-progress","installing-pending-user-action","resetting-pending-user-action","installed","error","resetting","added-to-existing-cluster","cancelled","binding","unbinding","unbinding-pending-user-action","known-unbound","disconnected-unbound","insufficient-unbound","disabled-unbound","discovering-unbound","reclaiming","reclaiming-rebooting"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -641,6 +641,12 @@ const (
 
 	// HostStatusDiscoveringUnbound captures enum value "discovering-unbound"
 	HostStatusDiscoveringUnbound string = "discovering-unbound"
+
+	// HostStatusReclaiming captures enum value "reclaiming"
+	HostStatusReclaiming string = "reclaiming"
+
+	// HostStatusReclaimingRebooting captures enum value "reclaiming-rebooting"
+	HostStatusReclaimingRebooting string = "reclaiming-rebooting"
 )
 
 // prop value enum


### PR DESCRIPTION
Adds the statemachine transitions and new states in order to implement
the following diagram:

```
                   -----------------------
                   | HostStatusInstalled |
                   -----------------------
                             |
                      User unbinds agent
                             |
     Kube API and no BMH     |   REST API, Kube API with BMH, or other machine management
          -------------------+-------------------
          |                                     |
          V                                     V
-----------------------------            ----------------------------
| TransitionTypeReclaimHost |            | TransitionTypeUnbindHost |
-----------------------------            ----------------------------
            |                                               |
            V                                               |
  ------------------------                                  |
  | HostStatusReclaiming |                                  |
  ------------------------                                  |
                |                                           |
       Agent posts step reply                               |
                |                                           |
       ---------+----------------------------------         |
       |                                          |         |
    Success                                    Failure      |
       |                                          |         |
       V                                          |         |
-------------------------------------             |         |
| HostStatusReclaimingPendingReboot |------       |         |
-------------------------------------     |       |         |
                |                         |       |         |
  ------------------------------       Timeout    |         |
  | TransitionTypeRegisterHost |          |       |         |
  ------------------------------          |       |         |
                |                         |       |         |
                V                         V       V         V
--------------------------------  ----------------------------------------
| HostStatusDiscoveringUnbound |  | HostStatusUnbindingPendingUserAction |
--------------------------------  ----------------------------------------
              ^                                       |
              |       ------------------------------  |
              --------| TransitionTypeRegisterHost |---
                      ------------------------------

```

Specifically I'm looking for input on the names of these states in this patch. This doesn't actually make any of the transitions happen yet.

## List all the issues related to this PR

Related to the enhancement in https://github.com/openshift/assisted-service/pull/3849
Part 1 of https://issues.redhat.com/browse/MGMT-10734

The next PR will add the code to push the hosts through these new states when required.

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

This code is just adding states and transitions, no functional changes were added.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @filanov 
/cc @nmagnezi 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
