### PR TITLE
NO-ISSUE: Fix e2e-metal-assisted-operator-ztp-sno-day2-workers CI job

### DIFF
--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -12,7 +12,7 @@ export ASSISTED_INFRAENV_NAME="${ASSISTED_INFRAENV_NAME:-assisted-infra-env}"
 
 # If performing late binding then we need to generate an infraenv for this.
 # Generation is handled within "add-remote-nodes-playbook"
-if [ -z "${DAY2_LATE_BINDING}" ] ; then
+if [ -z "${DAY2_LATE_BINDING:-}" ] ; then
   export LATE_BINDING_ASSISTED_CLUSTER_DEPLOYMENT_NAME=${ASSISTED_CLUSTER_DEPLOYMENT_NAME}
   export ASSISTED_CLUSTER_DEPLOYMENT_NAME=""
   export ASSISTED_INFRAENV_NAME=${ASSISTED_INFRAENV_NAME}-latebinding
@@ -54,7 +54,7 @@ export -f remote_done_agents
 
 # If we are performing late binding then each of the agents needs to have the correct clusterDeploymentRef applied.
 # This needs to happen after the agents are available. They cannot move to "done" until the clusterDeploymentRef is applied.
-if [ -z "${DAY2_LATE_BINDING}" ] ; then
+if [ -z "${DAY2_LATE_BINDING:-}" ] ; then
   clusterDeploymentName=${LATE_BINDING_ASSISTED_CLUSTER_DEPLOYMENT_NAME}
 
   # Generate a patch to assign the correct cluster name.


### PR DESCRIPTION
The job e2e-metal-assisted-operator-ztp-sno-day2-workers currently fails with the following error:
```
./add_day2_remote_nodes.sh: line 15: DAY2_LATE_BINDING: unbound variable
```

This change ensures that the tests don't fail when `DAY2_LATE_BINDING` is not defined

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @paul-maidment 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
