### PR TITLE
NO-ISSUE: Use `go:embed` for ignition templates

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -292,7 +292,8 @@ func main() {
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)
 	mirrorRegistriesBuilder := mirrorregistries.New()
-	ignitionBuilder := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder)
+	ignitionBuilder, err := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder)
+	failOnError(err, "failed to create ignition builder")
 	installConfigBuilder := installcfg.NewInstallConfigBuilder(log.WithField("pkg", "installcfg"), mirrorRegistriesBuilder, providerRegistry)
 
 	var objectHandler = createStorageClient(Options.DeployTarget, Options.Storage, &Options.S3Config,

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -949,7 +949,9 @@ var _ = Describe("IgnitionBuilder", func() {
 			PullSecretSet: false,
 		}, PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"}
 		//cluster.ImageInfo = &models.ImageInfo{}
-		builder = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		var err error
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("with auth enabled", func() {
@@ -1299,7 +1301,9 @@ var _ = Describe("Ignition SSH key building", func() {
 			PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
 		}
 		//cluster.ImageInfo = &models.ImageInfo{}
-		builder = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		var err error
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		Expect(err).ToNot(HaveOccurred())
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 	})
 	Context("when empty or invalid input", func() {
@@ -1355,7 +1359,9 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
 		mockHost = &models.Host{Inventory: hostInventory}
-		builder = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		var err error
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("test custom ignition endpoint", func() {

--- a/internal/ignition/templates.go
+++ b/internal/ignition/templates.go
@@ -1,0 +1,84 @@
+package ignition
+
+import (
+	"bytes"
+	"embed"
+	"encoding/json"
+	"text/template"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+// loadTemplates loads the templates from the embedded 'templates' directory.
+//
+// In addition to the default functions the templates will also have available the 'executeTemplate'
+// and 'toJson' functions.
+func loadTemplates() (result *template.Template, err error) {
+	initial := template.New("")
+	initial.Funcs(template.FuncMap{
+		"executeTemplate": makeExecuteTemplateFunc(initial),
+		"toJson":          toJsonFunc,
+	})
+	_, err = initial.ParseFS(templatesFS, "templates/*")
+	if err != nil {
+		return
+	}
+	result = initial
+	return
+}
+
+// makeExecuteTemplateFunc generates a function that implements the 'executeTemplate' template
+// function. Note that this is not the template function itself, but rather a function that
+// generates it. The reason for that is that the 'executeTemplate' function needs a reference to the
+// initial template so that it can use it to lookup the included template. That reference is not
+// provided the standard template library. To use it first create the template, and then register
+// the 'executeTemplate' function like this:
+//
+//	tmpl := template.New(...)
+//	tmpl.Funcs(template.FuncMap{
+//		"executeTemplate": makeExecuteTemplateFunc(tmpl),
+//		...
+//	})
+//	tmpl.ParseFS(...)
+//
+// Note how the initial template needs to be passed as a parameter.
+//
+// The resulting 'executeTemplate' template funcion is equivalent to the template.ExecuteTemplate
+// method, it receives as parameters the name of the template to execute and the data to pass to it.
+// For example, to execute a 'my.tmpl' template passing it all the same data that was passed to the
+// initial template:
+//
+//	{{ executeTemplate "my.tmpl" . }}
+//
+// The function returns a string containing the result of executing the template, so that it can
+// then be passed to other functions.
+func makeExecuteTemplateFunc(initial *template.Template) func(string, interface{}) (string, error) {
+	return func(name string, data interface{}) (result string, err error) {
+		buffer := &bytes.Buffer{}
+		executed := initial.Lookup(name)
+		err = executed.Execute(buffer, data)
+		if err != nil {
+			return
+		}
+		result = buffer.String()
+		return
+	}
+}
+
+// toJsonFunc is a template function that encodes the given data as JSON. This can be used, for
+// example, to encode as a JSON string the result of executing other function. For example, to
+// create a JSON document with a 'content' field that contains the text of the 'my.tmpl' template:
+//
+//	"content": {{ executeTemplate "my.tmpl" . | toJson }}
+//
+// Note how that the value of that 'content' field doesn't need to sorrounded by quotes, because the
+// 'toJson' function will generate a valid JSON string, including those quotes.
+func toJsonFunc(data interface{}) (result string, err error) {
+	text, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	result = string(text)
+	return
+}

--- a/internal/ignition/templates/agent.service
+++ b/internal/ignition/templates/agent.service
@@ -1,0 +1,23 @@
+[Service]
+Type=simple
+Restart=always
+RestartSec=3
+StartLimitInterval=0
+Environment=HTTP_PROXY={{.HTTPProxy}}
+Environment=http_proxy={{.HTTPProxy}}
+Environment=HTTPS_PROXY={{.HTTPSProxy}}
+Environment=https_proxy={{.HTTPSProxy}}
+Environment=NO_PROXY={{.NoProxy}}
+Environment=no_proxy={{.NoProxy}}{{if .PullSecretToken}}
+Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}{{end}}
+TimeoutStartSec={{.AgentTimeoutStartSec}}
+ExecStartPre=/usr/local/bin/agent-fix-bz1964591 {{.AgentDockerImg}}
+ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin {{.AgentDockerImg}} cp /usr/bin/agent /hostbin
+ExecStart=/usr/local/bin/agent --url {{.ServiceBaseURL}} --infra-env-id {{.infraEnvId}} --agent-version {{.AgentDockerImg}} --insecure={{.SkipCertVerification}}  {{if .HostCACertPath}}--cacert {{.HostCACertPath}}{{end}}
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -1,0 +1,187 @@
+{
+  "ignition": {
+    "version": "3.1.0"{{if .PROXY_SETTINGS}},
+    {{.PROXY_SETTINGS}}{{end}}
+  },
+  "passwd": {
+    "users": [
+      {{.userSshKey}}
+    ]
+  },
+  "systemd": {
+    "units": [{
+      "name": "agent.service",
+      "enabled": {{if .EnableAgentService}}true{{else}}false{{end}},
+      "contents": {{ executeTemplate "agent.service" . | toJson }}
+    },
+    {
+        "name": "selinux.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "selinux.service" . | toJson }}
+    }{{if .OKDBinaries | not}},
+    {
+        "name": "multipathd.service",
+        "enabled": true
+    }{{end}}{{if .StaticNetworkConfig}},
+    {
+        "name": "pre-network-manager-config.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "pre-network-manager-config.service" . | toJson }}
+    }{{end}}{{if .OKDBinaries}},
+    {
+        "name": "okd-overlay.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "okd-overlay.service" . | toJson }}
+    },
+    {
+        "name": "systemd-journal-gatewayd.socket",
+        "enabled": true,
+        "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toJson }}
+    }{{end}}
+    ]
+  },
+  "storage": {
+    "files": [{
+      "overwrite": true,
+      "path": "/usr/local/bin/agent-fix-bz1964591",
+      "mode": 755,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.AGENT_FIX_BZ1964591}}" }
+    },
+    {
+      "overwrite": true,
+      "path": "/etc/motd",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.AGENT_MOTD}}" }
+    }{{if .OKDBinaries | not}},
+    {
+      "overwrite": true,
+      "path": "/etc/multipath.conf",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:text/plain;charset=utf-8;base64,ZGVmYXVsdHMgewogICAgdXNlcl9mcmllbmRseV9uYW1lcyB5ZXMKICAgIGZpbmRfbXVsdGlwYXRocyB5ZXMKICAgIGVuYWJsZV9mb3JlaWduICJeJCIKfQpibGFja2xpc3RfZXhjZXB0aW9ucyB7CiAgICBwcm9wZXJ0eSAiKFNDU0lfSURFTlRffElEX1dXTikiCn0KYmxhY2tsaXN0IHsKfQo=" }
+    }{{end}},
+    {
+      "overwrite": true,
+      "path": "/etc/NetworkManager/conf.d/01-ipv6.conf",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.IPv6_CONF}}" }
+    },
+    {
+        "overwrite": true,
+        "path": "/root/.docker/config.json",
+        "mode": 420,
+        "user": {
+            "name": "root"
+        },
+        "contents": { "source": "data:,{{.PULL_SECRET}}" }
+    },
+    {
+        "overwrite": true,
+        "path": "/root/assisted.te",
+        "mode": 420,
+        "user": {
+            "name": "root"
+        },
+        "contents": { "source": "data:text/plain;base64,{{.SELINUX_POLICY}}" }
+    }{{if .RH_ROOT_CA}},
+    {
+      "overwrite": true,
+      "path": "/etc/pki/ca-trust/source/anchors/rh-it-root-ca.crt",
+      "mode": 420,
+      "user": {
+          "name": "root"
+      },
+      "contents": { "source": "data:,{{.RH_ROOT_CA}}" }
+    }{{end}}{{if .HostCACertPath}},
+    {
+      "path": "{{.HostCACertPath}}",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "{{.ServiceCACertData}}" }
+    }{{end}}{{if .ServiceIPs}},
+    {
+      "path": "/etc/hosts",
+      "mode": 420,
+      "user": {
+        "name": "root"
+      },
+      "append": [{ "source": "{{.ServiceIPs}}" }]
+    }{{end}}{{if .MirrorRegistriesConfig}},
+    {
+      "path": "/etc/containers/registries.conf",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.MirrorRegistriesConfig}}"}
+    },
+    {
+      "path": "/etc/pki/ca-trust/source/anchors/domain.crt",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.MirrorRegistriesCAConfig}}"}
+    }{{end}}{{if .StaticNetworkConfig}},
+    {
+        "path": "/usr/local/bin/pre-network-manager-config.sh",
+        "mode": 493,
+        "overwrite": true,
+        "user": {
+            "name": "root"
+        },
+        "contents": { "source": "data:text/plain;base64,{{.PreNetworkConfigScript}}"}
+    }{{end}}{{range .StaticNetworkConfig}},
+    {
+      "path": "{{.FilePath}}",
+      "mode": 384,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.FileContents}}"}
+    }{{end}}{{if .OKDBinaries}},
+    {
+      "path": "/usr/local/bin/okd-binaries.sh",
+      "mode": 755,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDBinaries}}" }
+    }{{end}}{{if .OKDHoldPivot}},{
+      "path": "/etc/systemd/system/release-image-pivot.service.d/wait-for-okd.conf",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDHoldPivot}}" }
+    }{{end}}{{if .OKDHoldAgent}},
+    {
+      "path": "/etc/systemd/system/agent.service.d/wait-for-okd.conf",
+      "mode": 420,
+      "overwrite": true,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "data:text/plain;base64,{{.OKDHoldAgent}}" }
+    }{{end}}]
+  }
+}

--- a/internal/ignition/templates/node.ign
+++ b/internal/ignition/templates/node.ign
@@ -1,0 +1,18 @@
+{
+  "ignition": {
+    "version": "3.1.0",
+    "config": {
+    "merge": [{
+      "source": "{{.SOURCE}}"{{if .HEADERS}},
+          "httpHeaders": [{{range $k,$v := .HEADERS}}{"name": "{{$k}}", "value": "{{$v}}"}{{end}}]{{end}}
+    }]
+    }{{if .CACERT}},
+          "security": {
+            "tls": {
+        "certificateAuthorities": [{
+          "source": "{{.CACERT}}"
+        }]
+      }
+    }{{end}}
+  }
+}

--- a/internal/ignition/templates/okd-overlay.service
+++ b/internal/ignition/templates/okd-overlay.service
@@ -1,0 +1,10 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/okd-binaries.sh
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/pre-network-manager-config.service
+++ b/internal/ignition/templates/pre-network-manager-config.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Prepare network manager config content
+Before=dracut-initqueue.service
+After=dracut-cmdline.service
+DefaultDependencies=no
+[Service]
+User=root
+Type=oneshot
+TimeoutSec=60
+ExecStart=/bin/bash /usr/local/bin/pre-network-manager-config.sh
+PrivateTmp=true
+RemainAfterExit=no
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/selinux.service
+++ b/internal/ignition/templates/selinux.service
@@ -1,0 +1,8 @@
+[Service]
+Type=oneshot
+ExecStartPre=checkmodule -M -m -o /root/assisted.mod /root/assisted.te
+ExecStartPre=semodule_package -o /root/assisted.pp -m /root/assisted.mod
+ExecStart=semodule -i /root/assisted.pp
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/ignition/templates/systemd-journal-gatewayd.socket
+++ b/internal/ignition/templates/systemd-journal-gatewayd.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description = Fake systemd-journal-gatewayd.socket
+
+[Socket]
+ListenStream = 19531
+Accept = yes
+
+[Install]
+WantedBy = sockets.target


### PR DESCRIPTION
Currently the ignition files are generated from Go templates that are
defined in constants inside the Go code. Those templates also contain
the unit files for the agent and for other systemd units. Changing those
unit files is uncomfortable, because they need to be manually encoded as
a long JSON string. To make those ignition and systemd files easier to
change this patch moves them to external files, using the `embed`
mechanism introduced in Go 1.16.

This patch also introduces to new template functions named
`executeTemplate` and `toJson` that simplify including templates from
other templates. For example, the `agent.service` template is included
from the `discovery.ign` file with this code:

```
"contents": {{ executeTemplate "agent.service" . | toJson }}
```

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Manually verified that the ignition files included in the generated .iso files are exactly the same.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
