### PR TITLE
Bug 2076333: Add UnsyncedAgents error in ClusterDeployment and ACI

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -25,6 +25,8 @@ const (
 	ClusterInsufficientAgentsMsg     string = "The cluster currently requires %d agents but only %d have registered"
 	ClusterUnapprovedAgentsReason    string = "UnapprovedAgents"
 	ClusterUnapprovedAgentsMsg       string = "The installation is pending on the approval of %d agents"
+	ClusterUnsyncedAgentsReason      string = "UnsyncedAgents"
+	ClusterUnsyncedAgentsMsg         string = "The cluster currently has %d agents with spec error"
 	ClusterAdditionalAgentsReason    string = "AdditionalAgents"
 	ClusterAdditionalAgentsMsg       string = "The cluster currently requires exactly %d agents but have %d registered"
 

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -587,9 +587,16 @@ func (r *ClusterDeploymentsReconciler) isReadyForInstallation(ctx context.Contex
 		return false, err
 	}
 
+	agents, err := findAgentsByAgentClusterInstall(r.Client, ctx, log, clusterInstall)
+	if err != nil {
+		log.WithError(err).Error("failed to fetch ACI's agents")
+		return false, err
+	}
+
+	unsyncedHosts := getNumOfUnsyncedAgents(agents)
 	expectedHosts := clusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents +
 		clusterInstall.Spec.ProvisionRequirements.WorkerAgents
-	return approvedHosts == expectedHosts && registered == approvedHosts, nil
+	return approvedHosts == expectedHosts && registered == approvedHosts && unsyncedHosts == 0, nil
 }
 
 func isSupportedPlatform(cluster *hivev1.ClusterDeployment) bool {
@@ -1471,15 +1478,21 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 			if err != nil {
 				return ctrl.Result{Requeue: true}, nil
 			}
-			var registeredHosts, approvedHosts int
+			var registeredHosts, approvedHosts, unsyncedHosts int
 			if status == models.ClusterStatusReady {
 				registeredHosts, approvedHosts, err = r.getNumOfClusterAgents(c)
 				if err != nil {
 					log.WithError(err).Error("failed to fetch cluster's agents")
 					return ctrl.Result{Requeue: true}, nil
 				}
+				agents, err := findAgentsByAgentClusterInstall(r.Client, ctx, log, clusterInstall)
+				if err != nil {
+					log.WithError(err).Error("failed to fetch ACI's agents")
+					return ctrl.Result{Requeue: true}, nil
+				}
+				unsyncedHosts = getNumOfUnsyncedAgents(agents)
 			}
-			clusterRequirementsMet(clusterInstall, status, registeredHosts, approvedHosts)
+			clusterRequirementsMet(clusterInstall, status, registeredHosts, approvedHosts, unsyncedHosts)
 			clusterValidated(clusterInstall, status, c)
 			clusterCompleted(clusterInstall, status, swag.StringValue(c.StatusInfo), c.MonitoredOperators)
 			clusterFailed(clusterInstall, status, swag.StringValue(c.StatusInfo))
@@ -1538,6 +1551,48 @@ func (r *ClusterDeploymentsReconciler) getNumOfClusterAgents(c *common.Cluster) 
 	return r.Installer.GetKnownHostApprovedCounts(*c.ID)
 }
 
+// Finds the agents related to provided AgentClusterInstall
+//
+// The AgentClusterInstall <-> Agent relation is one-to-many.
+// Thsi function returns all Agents whose ClusterDeploymentName name
+// matches the ClusterDeploymentRef name in the provided ACI.
+func findAgentsByAgentClusterInstall(k8sclient client.Client, ctx context.Context, log logrus.FieldLogger, aci *hiveext.AgentClusterInstall) ([]aiv1beta1.Agent, error) {
+	agentList := aiv1beta1.AgentList{}
+	agents := []aiv1beta1.Agent{}
+	err := k8sclient.List(ctx, &agentList, client.MatchingLabels{aiv1beta1.Group + "/clusterdeployment-namespace": aci.Namespace})
+
+	if err != nil {
+		return agents, err
+	}
+
+	for _, agent := range agentList.Items {
+		if agent.Spec.ClusterDeploymentName == nil {
+			continue
+		}
+		if agent.Spec.ClusterDeploymentName.Name != aci.Spec.ClusterDeploymentRef.Name {
+			continue
+		} else {
+			agents = append(agents, agent)
+		}
+	}
+
+	return agents, nil
+}
+
+func getNumOfUnsyncedAgents(agents []aiv1beta1.Agent) int {
+	num := 0
+	for _, agent := range agents {
+		for _, cond := range agent.Status.Conditions {
+			if cond.Type == aiv1beta1.SpecSyncedCondition && cond.Status == corev1.ConditionFalse {
+				num = num + 1
+				continue
+			}
+		}
+	}
+
+	return num
+}
+
 // clusterSpecSynced is updating the Cluster SpecSynced Condition.
 func clusterSpecSynced(cluster *hiveext.AgentClusterInstall, syncErr error) {
 	var condStatus corev1.ConditionStatus
@@ -1565,7 +1620,7 @@ func clusterSpecSynced(cluster *hiveext.AgentClusterInstall, syncErr error) {
 	})
 }
 
-func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status string, registeredHosts, approvedHosts int) {
+func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status string, registeredHosts, approvedHosts, unsyncedHosts int) {
 	var condStatus corev1.ConditionStatus
 	var reason string
 	var msg string
@@ -1578,6 +1633,10 @@ func clusterRequirementsMet(clusterInstall *hiveext.AgentClusterInstall, status 
 			condStatus = corev1.ConditionFalse
 			reason = hiveext.ClusterInsufficientAgentsReason
 			msg = fmt.Sprintf(hiveext.ClusterInsufficientAgentsMsg, expectedHosts, approvedHosts)
+		} else if unsyncedHosts != 0 {
+			condStatus = corev1.ConditionFalse
+			reason = hiveext.ClusterUnsyncedAgentsReason
+			msg = fmt.Sprintf(hiveext.ClusterUnsyncedAgentsMsg, unsyncedHosts)
 		} else if approvedHosts < expectedHosts {
 			condStatus = corev1.ConditionFalse
 			reason = hiveext.ClusterUnapprovedAgentsReason

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1497,39 +1497,82 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
 		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
 		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
 		infraEnvKey := types.NamespacedName{
 			Namespace: Options.Namespace,
 			Name:      infraNsName.Name,
 		}
 		infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
 		configureLocalAgentClient(infraEnv.ID.String())
-		host := registerNode(ctx, *infraEnv.ID, "hostname1", defaultCIDRv4)
-		key := types.NamespacedName{
-			Namespace: Options.Namespace,
-			Name:      host.ID.String(),
+		hosts := make([]*models.Host, 0)
+		ips := hostutil.GenerateIPv4Addresses(3, defaultCIDRv4)
+		for i := 0; i < 3; i++ {
+			hostname := fmt.Sprintf("h%d", i)
+			host := registerNode(ctx, *infraEnv.ID, hostname, ips[i])
+			hosts = append(hosts, host)
+		}
+		for _, host := range hosts {
+			checkAgentCondition(ctx, host.ID.String(), v1beta1.ValidatedCondition, v1beta1.ValidationsFailingReason)
+			hostkey := types.NamespacedName{
+				Namespace: Options.Namespace,
+				Name:      host.ID.String(),
+			}
+			agent := getAgentCRD(ctx, kubeClient, hostkey)
+			Expect(agent.Status.ValidationsInfo).ToNot(BeNil())
+		}
+		generateFullMeshConnectivity(ctx, ips[0], hosts...)
+		for _, h := range hosts {
+			generateDomainResolution(ctx, h, clusterDeploymentSpec.ClusterName, "hive.example.com")
 		}
 
-		h, err := common.GetHostFromDB(db, infraEnv.ID.String(), host.ID.String())
-		Expect(err).To(BeNil())
-		Expect(h.IgnitionConfigOverrides).To(BeEmpty())
-
 		By("Invalid ignition config - invalid json")
-		Eventually(func() error {
-			agent := getAgentCRD(ctx, kubeClient, key)
-			agent.Spec.IgnitionConfigOverrides = badIgnitionConfigOverride
-			return kubeClient.Update(ctx, agent)
-		}, "30s", "10s").Should(BeNil())
-
-		Eventually(func() bool {
-			condition := conditionsv1.FindStatusCondition(getAgentCRD(ctx, kubeClient, key).Status.Conditions, v1beta1.SpecSyncedCondition)
-			if condition != nil {
-				return strings.Contains(condition.Message, "error parsing ignition: config is not valid")
+		for _, host := range hosts {
+			hostkey := types.NamespacedName{
+				Namespace: Options.Namespace,
+				Name:      host.ID.String(),
 			}
-			return false
-		}, "15s", "2s").Should(Equal(true))
-		h, err = common.GetHostFromDB(db, infraEnv.ID.String(), host.ID.String())
-		Expect(err).To(BeNil())
-		Expect(h.IgnitionConfigOverrides).To(BeEmpty())
+
+			h, err := common.GetHostFromDB(db, infraEnv.ID.String(), host.ID.String())
+			Expect(err).To(BeNil())
+			Expect(h.IgnitionConfigOverrides).To(BeEmpty())
+
+			Eventually(func() error {
+				agent := getAgentCRD(ctx, kubeClient, hostkey)
+				agent.Spec.IgnitionConfigOverrides = badIgnitionConfigOverride
+				return kubeClient.Update(ctx, agent)
+			}, "30s", "10s").Should(BeNil())
+
+			Eventually(func() bool {
+				condition := conditionsv1.FindStatusCondition(getAgentCRD(ctx, kubeClient, hostkey).Status.Conditions, v1beta1.SpecSyncedCondition)
+				if condition != nil {
+					return strings.Contains(condition.Message, "error parsing ignition: config is not valid")
+				}
+				return false
+			}, "15s", "2s").Should(Equal(true))
+
+			h, err = common.GetHostFromDB(db, infraEnv.ID.String(), host.ID.String())
+			Expect(err).To(BeNil())
+			Expect(h.IgnitionConfigOverrides).To(BeEmpty())
+		}
+
+		By("Approve Agents")
+		for _, host := range hosts {
+			hostkey := types.NamespacedName{
+				Namespace: Options.Namespace,
+				Name:      host.ID.String(),
+			}
+			Eventually(func() error {
+				agent := getAgentCRD(ctx, kubeClient, hostkey)
+				agent.Spec.Approved = true
+				return kubeClient.Update(ctx, agent)
+			}, "30s", "10s").Should(BeNil())
+		}
+
+		By("Verify cluster condition UnsyncedAgent")
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterUnsyncedAgentsReason)
 	})
 
 	It("deploy clusterDeployment with agent and update installer args", func() {

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -25,6 +25,8 @@ const (
 	ClusterInsufficientAgentsMsg     string = "The cluster currently requires %d agents but only %d have registered"
 	ClusterUnapprovedAgentsReason    string = "UnapprovedAgents"
 	ClusterUnapprovedAgentsMsg       string = "The installation is pending on the approval of %d agents"
+	ClusterUnsyncedAgentsReason      string = "UnsyncedAgents"
+	ClusterUnsyncedAgentsMsg         string = "The cluster currently has %d agents with spec error"
 	ClusterAdditionalAgentsReason    string = "AdditionalAgents"
 	ClusterAdditionalAgentsMsg       string = "The cluster currently requires exactly %d agents but have %d registered"
 


### PR DESCRIPTION
This PR adds a new "UnsyncedAgents" condition for marking clusters where
at least one of Agents has SpecSynced failure. Currently if this happens
we are showing a misleading error "UnapprovedAgents" coming from the
fact that data in the DB is not in sync with K8s CRs.

Contributes-to: [MGMTBUGSM-307](https://issues.redhat.com//browse/MGMTBUGSM-307)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
