### PR TITLE
MGMT-10997: Use label filtering when listing Agents via K8s API

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -65,6 +65,7 @@ type BMACReconciler struct {
 
 const (
 	AGENT_BMH_LABEL                     = "agent-install.openshift.io/bmh"
+	AGENT_CD_LABEL                      = "agent-install.openshift.io/clusterdeployment-namespace"
 	BMH_AGENT_ROLE                      = "bmac.agent-install.openshift.io/role"
 	BMH_AGENT_HOSTNAME                  = "bmac.agent-install.openshift.io/hostname"
 	BMH_AGENT_MACHINE_CONFIG_POOL       = "bmac.agent-install.openshift.io/machine-config-pool"
@@ -933,7 +934,7 @@ func (r *BMACReconciler) findInstallationDiskID(devices []aiv1beta1.HostDisk, hi
 // matches this ClusterDeployment's name.
 func (r *BMACReconciler) findAgentsByClusterDeployment(ctx context.Context, clusterDeployment *hivev1.ClusterDeployment) []*aiv1beta1.Agent {
 	agentList := aiv1beta1.AgentList{}
-	err := r.Client.List(ctx, &agentList)
+	err := r.Client.List(ctx, &agentList, client.MatchingLabels{AGENT_CD_LABEL: clusterDeployment.Namespace})
 	if err != nil {
 		return []*aiv1beta1.Agent{}
 	}

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -1384,8 +1384,9 @@ func newAgentWithClusterReference(name string, namespace string, ipv4address str
 		},
 	}
 	agent.Spec.ClusterDeploymentName = &v1beta1.ClusterReference{Name: clusterName, Namespace: namespace}
+	agent.ObjectMeta.Labels = make(map[string]string)
+	agent.ObjectMeta.Labels[AGENT_CD_LABEL] = namespace
 	if agentBMHLabel != "" {
-		agent.ObjectMeta.Labels = make(map[string]string)
 		agent.ObjectMeta.Labels[AGENT_BMH_LABEL] = agentBMHLabel
 	}
 	agent.ObjectMeta.CreationTimestamp.Time = creationTime


### PR DESCRIPTION
This commit optimizes a call that lists all the Agents existing in the
Hub cluster. Given that we now have each Agent labeled by the
ClusterDeployment's namespace, we can ask K8s API `List()` call to
immediately filter returned resources instead of manually iterating over
all of them.

Closes: MGMG-10997

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @avishayt 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
