### PR TITLE
Fix oc-ingress installation method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ deploy-ocm-secret: deploy-namespace
 		--target "$(TARGET)" --apply-manifest $(APPLY_MANIFEST)
 
 deploy-image-service: deploy-namespace
-	python3 ./tools/deploy_image_service.py --namespace "$(NAMESPACE)" --apply-manifest $(APPLY_MANIFEST)
+	python3 ./tools/deploy_image_service.py --namespace "$(NAMESPACE)" --apply-manifest $(APPLY_MANIFEST) --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)"
 
 deploy-inventory-service-file: deploy-namespace
 	python3 ./tools/deploy_inventory_service.py --target "$(TARGET)" --domain "$(INGRESS_DOMAIN)" --namespace "$(NAMESPACE)" \


### PR DESCRIPTION
Seems like we've never passed ``TARGET`` and ``INGRESS_DOMAIN" variables to the image-service deployment script, breaking the deployment when we actually needed to connect to the services.

This led to failing of PSI installations, where they cannot access the image-service URL.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @lalon4 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
