### PR TITLE
MGMT-10991: Add forbidden hostnames to cluster_default_config

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
@@ -35,6 +35,9 @@ type ClusterDefaultConfig struct {
 	// cluster networks ipv4
 	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
 
+	// This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.
+	ForbiddenHostnames []string `json:"forbidden_hostnames"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -331,6 +331,8 @@ func (b *bareMetalInventory) V2GetClusterDefaultConfig(_ context.Context, _ inst
 		{Cidr: models.Subnet(b.Config.DefaultServiceNetworkCidrIPv6)},
 	}
 
+	body.ForbiddenHostnames = append(body.ForbiddenHostnames, hostutil.ForbiddenHostnames...)
+
 	return installer.NewV2GetClusterDefaultConfigOK().WithPayload(body)
 }
 

--- a/models/cluster_default_config.go
+++ b/models/cluster_default_config.go
@@ -35,6 +35,9 @@ type ClusterDefaultConfig struct {
 	// cluster networks ipv4
 	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
 
+	// This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.
+	ForbiddenHostnames []string `json:"forbidden_hostnames"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5949,6 +5949,13 @@ func init() {
             "$ref": "#/definitions/cluster_network"
           }
         },
+        "forbidden_hostnames": {
+          "description": "This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "inactive_deletion_hours": {
           "type": "integer"
         },
@@ -15193,6 +15200,13 @@ func init() {
           "items": {
             "type": "object",
             "$ref": "#/definitions/cluster_network"
+          }
+        },
+        "forbidden_hostnames": {
+          "description": "This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.",
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "inactive_deletion_hours": {

--- a/subsystem/cluster_default_config_test.go
+++ b/subsystem/cluster_default_config_test.go
@@ -36,4 +36,16 @@ var _ = Describe("V2GetClusterDefaultConfig", func() {
 		Expect(res.GetPayload().ClusterNetworksDualstack[1].HostPrefix).To(Equal(int64(64)))
 		Expect(res.GetPayload().ServiceNetworksDualstack[1].Cidr).To(Equal(models.Subnet("fd02::/112")))
 	})
+
+	It("Forbidden hostnames", func() {
+		res, err := userBMClient.Installer.V2GetClusterDefaultConfig(context.Background(), &installer.V2GetClusterDefaultConfigParams{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(res.GetPayload().ForbiddenHostnames)).To(Equal(6))
+		Expect(res.GetPayload().ForbiddenHostnames[0]).To(Equal("localhost"))
+		Expect(res.GetPayload().ForbiddenHostnames[1]).To(Equal("localhost.localdomain"))
+		Expect(res.GetPayload().ForbiddenHostnames[2]).To(Equal("localhost4"))
+		Expect(res.GetPayload().ForbiddenHostnames[3]).To(Equal("localhost4.localdomain4"))
+		Expect(res.GetPayload().ForbiddenHostnames[4]).To(Equal("localhost6"))
+		Expect(res.GetPayload().ForbiddenHostnames[5]).To(Equal("localhost6.localdomain6"))
+	})
 })

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5152,6 +5152,11 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/service_network'
+      forbidden_hostnames:
+        description: This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.
+        type: array
+        items:
+          type: string
 
   infra_error:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_default_config.go
@@ -35,6 +35,9 @@ type ClusterDefaultConfig struct {
 	// cluster networks ipv4
 	ClusterNetworksIPV4 []*ClusterNetwork `json:"cluster_networks_ipv4"`
 
+	// This provides a list of forbidden hostnames. If this list is empty or not present, this implies that the UI should fall back to a hard coded list.
+	ForbiddenHostnames []string `json:"forbidden_hostnames"`
+
 	// inactive deletion hours
 	InactiveDeletionHours int64 `json:"inactive_deletion_hours,omitempty"`
 


### PR DESCRIPTION
Presently, the frontend has no way of determining the forbidden
hostnames as defined by the backend.

This PR makes those hostnames available as part of the
cluster_default_config endpoint.

This is part of the effort being made in epic [MGMT-10990](https://issues.redhat.com//browse/MGMT-10990)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
