### PR TITLE
NO-ISSUE: Improve error reporting in ephemeral installer client

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -118,7 +118,7 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 	modelsCluster, registerClusterErr := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
 		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
 	if registerClusterErr != nil {
-		log.Fatal(registerClusterErr, "Failed to register cluster with assisted-service")
+		log.Fatal("Failed to register cluster with assisted-service: ", registerClusterErr)
 	}
 
 	log.Info("Registered cluster with id: " + modelsCluster.ID.String())
@@ -128,7 +128,7 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 	modelsInfraEnv, registerInfraEnvErr := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,
 		modelsCluster, RegisterOptions.InfraEnvFile, RegisterOptions.NMStateConfigFile, RegisterOptions.ImageTypeISO)
 	if registerInfraEnvErr != nil {
-		log.Fatal(registerInfraEnvErr, "Failed to register infraenv with assisted-service")
+		log.Fatal("Failed to register infraenv with assisted-service: ", registerInfraEnvErr)
 	}
 
 	infraEnvID := modelsInfraEnv.ID.String()

--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -23,7 +23,7 @@ import (
 func ApplyHostConfigs(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall, hostConfigs HostConfigs, infraEnvID strfmt.UUID) ([]Failure, error) {
 	hostList, err := bmInventory.Installer.V2ListHosts(ctx, installer.NewV2ListHostsParams().WithInfraEnvID(infraEnvID))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to list hosts: %w", err)
+		return nil, fmt.Errorf("Failed to list hosts: %w", errorutil.GetAssistedError(err))
 	}
 
 	failures := []Failure{}

--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/assisted-service/internal/controller/controllers"
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
+	errorutil "github.com/openshift/assisted-service/pkg/error"
 	"github.com/openshift/assisted-service/pkg/executer"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/pkg/errors"
@@ -49,7 +50,7 @@ func RegisterCluster(ctx context.Context, log *log.Logger, bmInventory *client.A
 	}
 	clusterResult, registerClusterErr := bmInventory.Installer.V2RegisterCluster(ctx, clientClusterParams)
 	if registerClusterErr != nil {
-		return nil, registerClusterErr
+		return nil, errorutil.GetAssistedError(registerClusterErr)
 	}
 	return clusterResult.Payload, nil
 }
@@ -83,7 +84,7 @@ func RegisterInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.
 	}
 	infraEnvResult, registerInfraEnvErr := bmInventory.Installer.RegisterInfraEnv(ctx, clientInfraEnvParams)
 	if registerInfraEnvErr != nil {
-		return nil, registerInfraEnvErr
+		return nil, errorutil.GetAssistedError(registerInfraEnvErr)
 	}
 	return infraEnvResult.Payload, nil
 }


### PR DESCRIPTION
The errors returned from the API are not especially human-readable, they
print something like:

    [POST /v2/clusters][400] v2RegisterClusterBadRequest  &{Code:0xc00052e790 Href:0xc00052e7a0 ID:0xc00053ed84 Kind:0xc00052e7b0 Reason:0xc00052e7c0}

Passing through GetAssistedError() returns an error that is readable in
the logs, including describing the reason for the failure.