### PR TITLE
MGMT-10868: Fix duplicate `-latebinding` suffix in ZTP latebinding scripts

### DIFF
--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -74,7 +74,7 @@ PATCH
 
   # Apply this patch to our Day2 agents.
   for agentHostName in $(cat "${REMOTE_BAREMETALHOSTS_FILE}"  | jq '.[].name' --raw-output) ; do
-    agentName=$(oc get agents -n ${SPOKE_NAMESPACE} -ojson | jq ".items[] | select(.spec.hostname==\"${agentHostName}\")).metadata.name" --raw-output)
+    agentName=$(oc get agents -n ${SPOKE_NAMESPACE} -ojson | jq ".items[] | select(.spec.hostname==\"${agentHostName}\").metadata.name" --raw-output)
     oc patch agent -n ${SPOKE_NAMESPACE} ${agentName} -p "${agentPatch}" --type=merge
   done
 

--- a/deploy/operator/ztp/infraEnv-latebinding.j2
+++ b/deploy/operator/ztp/infraEnv-latebinding.j2
@@ -3,7 +3,7 @@
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
-  name: '{{ infraenv_name }}-latebinding'
+  name: '{{ infraenv_name }}'
   namespace: '{{ spoke_namespace }}'
 spec:
   pullSecretRef:


### PR DESCRIPTION
While rehearsing 400e890fbaa096253a63fa14f2dae0d99dcda7ac in https://github.com/openshift/release/pull/29787 we encountered this failure:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29787/rehearse-29787-periodic-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-operator-ztp-sno-day2-workers-latbnd-prdc/1542833980045266944

You can see the infra-env being created is mistakenly called
`assisted-infra-env-latebinding-latebinding` rather than
`assisted-infra-env-latebinding`:

```
time="2022-07-01T13:52:56Z" level=info msg="Register infraenv: assisted-infra-env-latebinding-latebinding with id ffa05b80-7f23-4b48-bf68-0fe4d700888f" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).RegisterInfraEnvInternal" file="/go/src/github.com/openshift/origin/internal/bminventory/inventory.go:3882" cluster_id=ffa05b80-7f23-4b48-bf68-0fe4d700888f go-id=609 pkg=Inventory request_id=ecf9cef5-1fa0-4743-ab56-7362895aa028
```

This commit should fix that.

Also fixed jq syntax error. You can see it fail here:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/4058/pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted-operator-ztp-sno-day2-workers-latbnd/1542937647599587328

```
++ jq '.items[] | select(.spec.hostname=="ostest-extraworker-1")).metadata.name' --raw-output
jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
.items[] | select(.spec.hostname=="ostest-extraworker-1")).metadata.name
jq: 1 compile error
```


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    - Waiting for it to merge to we can rehearse it again
- [ ] No tests needed

## Assignees

/cc @paul-maidment
/cc @osherdp

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md