### PR TITLE
NO-ISSUE: Remove host ID from the `serviceLogicClusterHostImagePullStatus` histogram metric

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -754,7 +754,7 @@ func (m *Manager) UpdateImageStatus(ctx context.Context, h *models.Host, newImag
 	} else {
 		common.SetImageStatus(hostImageStatuses, newImageStatus)
 		m.log.Infof("Adding new image status for %s with status %s to host %s", newImageStatus.Name, newImageStatus.Result, h.ID.String())
-		m.metricApi.ImagePullStatus(*h.ID, newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
+		m.metricApi.ImagePullStatus(newImageStatus.Name, string(newImageStatus.Result), newImageStatus.DownloadRate)
 
 		var eventInfo string
 		if newImageStatus.SizeBytes > 0 {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2534,7 +2534,7 @@ var _ = Describe("UpdateImageStatus", func() {
 					eventstest.WithSeverityMatcher(models.EventSeverityInfo),
 					eventstest.WithMessageMatcher(eventMsg))).Times(1)
 
-				mockMetric.EXPECT().ImagePullStatus(hostId, expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
+				mockMetric.EXPECT().ImagePullStatus(expectedImage.Name, string(expectedImage.Result), expectedImage.DownloadRate).Times(1)
 			} else {
 				expectedImage.DownloadRate = t.originalImageStatuses[common.TestDefaultConfig.ImageName].DownloadRate
 				expectedImage.SizeBytes = t.originalImageStatuses[common.TestDefaultConfig.ImageName].SizeBytes
@@ -3199,7 +3199,7 @@ var _ = Describe("ResetHostValidation", func() {
 		m = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, validatorCfg, mockMetric, defaultConfig, nil, nil, nil, false)
 		h = registerTestHost(strfmt.UUID(uuid.New().String()), &clusterId)
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
-		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockMetric.EXPECT().ImagePullStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithHostIdMatcher(h.ID.String()),
 			eventstest.WithInfraEnvIdMatcher(h.InfraEnvID.String()))).AnyTimes()

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -158,15 +158,15 @@ func (mr *MockAPIMockRecorder) HostValidationFailed(clusterVersion, emailDomain,
 }
 
 // ImagePullStatus mocks base method.
-func (m *MockAPI) ImagePullStatus(hostID strfmt.UUID, imageName, resultStatus string, downloadRate float64) {
+func (m *MockAPI) ImagePullStatus(imageName, resultStatus string, downloadRate float64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ImagePullStatus", hostID, imageName, resultStatus, downloadRate)
+	m.ctrl.Call(m, "ImagePullStatus", imageName, resultStatus, downloadRate)
 }
 
 // ImagePullStatus indicates an expected call of ImagePullStatus.
-func (mr *MockAPIMockRecorder) ImagePullStatus(hostID, imageName, resultStatus, downloadRate interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ImagePullStatus(imageName, resultStatus, downloadRate interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), hostID, imageName, resultStatus, downloadRate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePullStatus", reflect.TypeOf((*MockAPI)(nil).ImagePullStatus), imageName, resultStatus, downloadRate)
 }
 
 // InstallationStarted mocks base method.


### PR DESCRIPTION
Creating an entire histogram for every host makes it impossible to query
/ graph this metric over a long period of time, prometheus can't handle
summing that many time-series.

It also doesn't make sense because each host/image pair only really
(most of the time) generates a single data point. This metric should not
include the host ID. Per-host information can be easily obtained through
the corresponding event if needed.

On top of the host ID label causing slowness, the two other labels -
"result" and "image" were used the other way around. The result
("success" or "failure") was being set in the "image" label and the
image pull-spec was being set in the "result" label.

I've swapped them back - but since this is a "metric backwards
incompatible" change I've also renmaed the metric from
`assisted_installer_cluster_host_image_pull_status` to
`assisted_installer_cluster_image_pull_status`

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    - Testing manually that the metric actually has the host-id removed:
```
[root@edge-18 assisted-test-infra]# minikube ssh
                         _             _
            _         _ ( )           ( )
  ___ ___  (_)  ___  (_)| |/')  _   _ | |_      __
/' _ ` _ `\| |/' _ `\| || , <  ( ) ( )| '_`\  /'__`\
| ( ) ( ) || || ( ) || || |\`\ | (_) || |_) )(  ___/
(_) (_) (_)(_)(_) (_)(_)(_) (_)`\___/'(_,__/'`\____)

$ cat <(curl -s http://172.17.0.9:8090/metrics) <(curl -s http://172.17.0.8:8090/metrics) <(curl -s http://172.17.0.12:8090/metrics)  | grep pull | head -20
# HELP service_assisted_installer_cluster_image_pull_status Histogram/sum/count of the images' pull statuses
# TYPE service_assisted_installer_cluster_image_pull_status histogram
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="0.1"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="0.5"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="1"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="5"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="10"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="15"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="20"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="25"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="30"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="35"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="40"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="45"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="50"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success",le="+Inf"} 1
service_assisted_installer_cluster_image_pull_status_sum{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success"} 300.3733005142054
service_assisted_installer_cluster_image_pull_status_count{imageName="quay.io/edge-infrastructure/assisted-installer:latest",result="success"} 1
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/openshift-release-dev/ocp-release:4.10.18-x86_64",result="success",le="0.1"} 0
service_assisted_installer_cluster_image_pull_status_bucket{imageName="quay.io/openshift-release-dev/ocp-release:4.10.18-x86_64",result="success",le="0.5"} 0
$
```
- [ ] No tests needed

## Assignees

/cc @rccrdpccl
/cc @gamli75

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md