### PR TITLE
MGMT-11026: Use image tag for metrics

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/containers/image/v5/docker/reference"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/models"
@@ -370,4 +371,20 @@ func CanonizeStrings(slice []string) (ret []string) {
 
 func GetHostKey(host *models.Host) string {
 	return host.ID.String() + "@" + host.InfraEnvID.String()
+}
+
+// GetTagFromImageRef returns the tag of the given container image reference. For example, if the
+// image reference is 'quay.io/my/image:latest' then the result will be 'latest'. If the image
+// reference isn't valid or doesn't contain a tag then the result will be an empty string.
+func GetTagFromImageRef(ref string) string {
+	parsed, err := reference.ParseNamed(ref)
+	if err != nil {
+		return ""
+	}
+	switch typed := parsed.(type) {
+	case reference.Tagged:
+		return typed.Tag()
+	default:
+		return ""
+	}
 }

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/models"
 )
@@ -265,6 +266,22 @@ var _ = Describe("Test AreMastersSchedulable", func() {
 		}
 	})
 })
+
+var _ = DescribeTable(
+	"Get tag from image reference",
+	func(image, expected string) {
+		actual := GetTagFromImageRef(image)
+		Expect(actual).To(Equal(expected))
+	},
+	Entry("Empty", "", ""),
+	Entry("No tag", "quay.io/my/image", ""),
+	Entry("Latest tag", "quay.io/my/image:latest", "latest"),
+	Entry("Numeric tag", "quay.io/my/image:1.2.3", "1.2.3"),
+	Entry("Alphabetic tag", "quay.io/my/image:old", "old"),
+	Entry("Version tag", "quay.io/my/image:v1.2.3", "v1.2.3"),
+	Entry("Digest", "quay.io/image/agent@sha256:e7d2b565a30757833c911cf623b3d834804b21a67fbb37844e0071a08159afa5", ""),
+	Entry("Incorrect", "a:b:c:d", ""),
+)
 
 func createHost(hostRole models.HostRole, state string) *models.Host {
 	hostId := strfmt.UUID(uuid.New().String())

--- a/internal/metrics/suite_test.go
+++ b/internal/metrics/suite_test.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics")
+}
+
+// MetricsServer is an HTTP server configured to return Prometheus metrics. Don't create objects of
+// this type directly, use the MakeMetricsServer function instead.
+type MetricsServer struct {
+	server   *Server
+	registry *prometheus.Registry
+}
+
+// NewMetricsServer creates a metrics server.
+func NewMetricsServer() *MetricsServer {
+	// Create the registry:
+	registry := prometheus.NewPedanticRegistry()
+
+	// Create the server:
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	server := NewServer()
+	server.AppendHandlers(handler.ServeHTTP)
+
+	// Create and populate the object:
+	return &MetricsServer{
+		server:   server,
+		registry: registry,
+	}
+}
+
+// Metrics returns an array of strings containing the metrics available in this server. Each item in
+// this array is a line in the Prometheus exposition format. This is intended to be used together
+// with the MatchLine matcher.
+func (s *MetricsServer) Metrics() []string {
+	response, err := http.Get(s.server.URL() + "/metrics")
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		err = response.Body.Close()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	data, err := ioutil.ReadAll(response.Body)
+	Expect(err).ToNot(HaveOccurred())
+	return strings.Split(string(data), "\n")
+}
+
+// Registry returns the registry that should be used to register metrics for this server.
+func (s *MetricsServer) Registry() prometheus.Registerer {
+	return s.registry
+}
+
+// Close stops the server and releases the resources it uses.
+func (s *MetricsServer) Close() {
+	s.server.Close()
+}
+
+// MatchLine succeeds if actual is an slice of strings that contains at least one items that matches
+// the passed regular expression.
+func MatchLine(regexp string, args ...interface{}) OmegaMatcher {
+	return ContainElement(MatchRegexp(regexp, args...))
+}


### PR DESCRIPTION
Currently the `assisted_installer_host_installation_phase_seconds_...`
metrics contain the agent version in the `discoveryAgentVersion` label, with
values like `v1.0.0-141`. This is copied directly from the
`discovery_agent_version` column of the `hosts` table. But with the
introduction of the agent upgrade feature this column will be changed to
store the full image reference instead of just the version number. That
means that the code that populates the metric labels needs to be changed
to detect if the `discovery_agent_version` is a full image reference,
and in that case extract the version from the tag of the image. That is
what this patch does.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested using the included `_test.go` files.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
