### PR TITLE
MGMT-10844: Add virtual interface metrics for SaaS

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -252,30 +252,29 @@ func GenerateTestDefaultInventory() string {
 	return string(b)
 }
 
-func GenerateTestInventoryWithVirtualInterface() string {
+func generateInterfaces(amount int, intfType string) []*models.Interface {
+	interfaces := make([]*models.Interface, amount)
+	for i := 0; i < amount; i++ {
+		intf := models.Interface{
+			Name: fmt.Sprintf("eth%d", i),
+			IPV4Addresses: []string{
+				fmt.Sprintf("192.%d.2.0/24", i),
+			},
+			IPV6Addresses: []string{
+				fmt.Sprintf("2001:db%d::/32", i),
+			},
+			Type: intfType,
+		}
+		interfaces[i] = &intf
+	}
+	return interfaces
+}
+
+func GenerateTestInventoryWithVirtualInterface(physicalInterfaces, virtualInterfaces int) string {
+	interfaces := generateInterfaces(physicalInterfaces, "physical")
+	interfaces = append(interfaces, generateInterfaces(virtualInterfaces, "device")...)
 	inventory := &models.Inventory{
-		Interfaces: []*models.Interface{
-			{
-				Name: "eth0",
-				IPV4Addresses: []string{
-					"192.0.2.0/24",
-				},
-				IPV6Addresses: []string{
-					"2001:db8::/32",
-				},
-				Type: "physical",
-			},
-			{
-				Name: "cni1",
-				IPV4Addresses: []string{
-					"198.51.100.0/24",
-				},
-				IPV6Addresses: []string{
-					"2001:db8::/32",
-				},
-				Type: "device",
-			},
-		},
+		Interfaces: interfaces,
 		Disks: []*models.Disk{
 			TestDefaultConfig.Disks,
 		},


### PR DESCRIPTION
[MGMT-10844](https://issues.redhat.com/browse/MGMT-10844)
As part of epic [MGMT-10087](https://issues.redhat.com/browse/MGMT-10087)
Virtual interface data per host and per cluster are available
in the SaaS environment, even if the feature is not enabled.

This PR records the virtual interfaces each host/cluster has and
exposes it as a metric. The data will help determine if this is a
viable feature we can enable in SaaS by allowing us to predict
performance/scalability and allowing us to see any patterns/common
interfaces.

**Note**: These metrics only cover the first two data points listed in this
[document](https://docs.google.com/document/d/1eFNcEHGv14iR50Z7cSN8lQuyQx4JaPVc4uaIbGvPdgI/edit?usp=sharing) since the rest require enabling the feature. (See Caveats under 
each data point type)
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

1. Deployed this image with assisted-test-infra, made sure `ENABLE_VIRTUAL_INTERFACES` is set to `false` in the configmap, and ran `make deploy_nodes` to create a cluster
2. Get the metrics for this cluster to make sure metrics were set
    ```
    $ curl "${ASSISTED_SERVICE_URL}/api/assisted-install/v2/events?categories=metrics&cluster_id=${CLUSTER_ID}" | jq '.[] | select(.message | contains("interfaces"))'
      {
        "cluster_id": "c28283b0-3ddf-45c3-a1f5-b31a8dcf7c98",
        "event_time": "2022-07-05T17:28:18.218Z",
        "host_id": "2c5557d6-447e-4611-bc55-be6b0b267c8f",
        "message": "nic.virtual_interfaces",
        "props": "{\"count\":2,\"types\":[\"device\",\"bridge\"]}",
        "severity": "info"
      },
      {
        "cluster_id": "c28283b0-3ddf-45c3-a1f5-b31a8dcf7c98",
        "event_time": "2022-07-05T17:28:18.219Z",
        "host_id": "2c5557d6-447e-4611-bc55-be6b0b267c8f",
        "message": "nic.physical_interfaces",
        "props": "{\"count\":2}",
        "severity": "info"
      }
    ```

3. Checked interface of a host to make sure no virtual interfaces were stored
    ```
    $ curl "${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} | jq -r '.hosts[0].inventory' | jq '.interfaces[].type'
    "physical"
    "physical"
    ```
## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @avishayt 
/cc @gamli75 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
