### PR TITLE
AGENT-231: Agentbasedinstaller register extra manifests

### DIFF
--- a/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
+++ b/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus/hooks/test"
-
-	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/client/manifests"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus/hooks/test"
 )
 
 type registerCase struct {

--- a/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
+++ b/cmd/agentbasedinstaller/agentbasedinstaller_suite_test.go
@@ -1,0 +1,147 @@
+package agentbasedinstaller
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"testing/fstest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+	"github.com/openshift/assisted-service/client/manifests"
+	"github.com/openshift/assisted-service/models"
+)
+
+type registerCase struct {
+	files       []string
+	clientError string
+
+	expectedFilesSent int
+	expectedError     string
+}
+
+var _ = DescribeTable(
+	"Register",
+	func(tc registerCase) {
+		fakeLogger, _ := test.NewNullLogger()
+
+		clusterID := strfmt.UUID("e679ea3f-3b85-40e0-8dc9-82fd6945d9b2")
+		fakeCluster := &models.Cluster{
+			ID: &clusterID,
+		}
+
+		fakeFileSystem := fstest.MapFS{}
+		for _, f := range tc.files {
+			fakeFileSystem[f] = &fstest.MapFile{Data: []byte(f)}
+		}
+
+		fakeTransport := NewMockTransport()
+		if tc.clientError != "" {
+			fakeTransport.SetError(tc.clientError)
+		}
+
+		fakeClient := manifests.New(fakeTransport, nil, nil)
+
+		err := RegisterExtraManifests(fakeFileSystem, context.TODO(), fakeLogger, fakeClient, fakeCluster)
+		if tc.expectedError == "" {
+			Expect(err).ShouldNot(HaveOccurred())
+
+			received := fakeTransport.FilesReceived()
+			Expect(len(received)).To(Equal(tc.expectedFilesSent))
+
+			for fileName, fileContent := range received {
+
+				found := false
+				for _, f := range tc.files {
+					if f == fileName {
+						content, decodeErr := base64.StdEncoding.DecodeString(fileContent)
+						Expect(decodeErr).ShouldNot(HaveOccurred())
+						Expect(f).To(Equal(string(content)))
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue())
+			}
+		} else {
+			Expect(tc.expectedError).To(Equal(err.Error()))
+		}
+	},
+	Entry("only-manifests", registerCase{
+		files: []string{
+			"config-map-1.yaml",
+			"config-map-2.yaml",
+		},
+		expectedFilesSent: 2,
+	}),
+	Entry("get-only-yaml-files", registerCase{
+		files: []string{
+			"config-map-1.yaml",
+			"unwanted.exe",
+			"config-map-2.yml",
+		},
+		expectedFilesSent: 2,
+	}),
+	Entry("no-files", registerCase{
+		files:             []string{},
+		expectedFilesSent: 0,
+	}),
+	Entry("client-error", registerCase{
+		files: []string{
+			"config-map-1.yaml",
+			"unwanted.exe",
+			"config-map-2.yml",
+		},
+		clientError:       "client-error",
+		expectedError:     "client-error",
+		expectedFilesSent: 0,
+	}),
+)
+
+func TestAgentbasedinstaller(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Agentbasedinstaller Suite")
+}
+
+type mockTransport struct {
+	filesReceived map[string]string
+	result        manifests.V2CreateClusterManifestCreated
+	err           error
+}
+
+func NewMockTransport() *mockTransport {
+	return &mockTransport{
+		filesReceived: make(map[string]string),
+		result:        manifests.V2CreateClusterManifestCreated{},
+	}
+}
+
+func (m *mockTransport) Submit(op *runtime.ClientOperation) (interface{}, error) {
+
+	params, _ := op.Params.(*manifests.V2CreateClusterManifestParams)
+	m.filesReceived[*params.CreateManifestParams.FileName] = *params.CreateManifestParams.Content
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &m.result, nil
+}
+
+func (m *mockTransport) SetResult(res manifests.V2CreateClusterManifestCreated) {
+	m.result = res
+}
+
+func (m *mockTransport) SetError(errMsg string) {
+	m.err = errors.New(errMsg)
+}
+
+func (m *mockTransport) FilesReceived() map[string]string {
+	return m.filesReceived
+}

--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -109,23 +109,23 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 
 	pullSecret, err := agentbasedinstaller.GetPullSecret(RegisterOptions.PullSecretFile)
 	if err != nil {
-		log.Fatal(err.Error(), "Failed to get pull secret")
+		log.Fatal("Failed to get pull secret: ", err.Error())
 	}
 
 	modelsCluster, err := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
 		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
 	if err != nil {
-		log.Fatal(err, "Failed to register cluster with assisted-service")
+		log.Fatal("Failed to register cluster with assisted-service: ", err)
 	}
 
 	modelsInfraEnv, err := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,
 		modelsCluster, RegisterOptions.InfraEnvFile, RegisterOptions.NMStateConfigFile, RegisterOptions.ImageTypeISO)
 	if err != nil {
-		log.Fatal(err, "Failed to register infraenv with assisted-service")
+		log.Fatal("Failed to register infraenv with assisted-service: ", err)
 	}
 	err = agentbasedinstaller.RegisterExtraManifests(os.DirFS(RegisterOptions.ExtraManifests), ctx, log, bmInventory.Manifests, modelsCluster)
 	if err != nil {
-		log.Fatal(err, "Failed to register extra manifests with assisted-service")
+		log.Fatal("Failed to register extra manifests with assisted-service: ", err)
 	}
 
 	return modelsInfraEnv.ID.String()

--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -123,8 +123,7 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 	if err != nil {
 		log.Fatal(err, "Failed to register infraenv with assisted-service")
 	}
-
-	err = agentbasedinstaller.RegisterExtraManifests(ctx, log, bmInventory, modelsCluster, RegisterOptions.ExtraManifests)
+	err = agentbasedinstaller.RegisterExtraManifests(os.DirFS(RegisterOptions.ExtraManifests), ctx, log, bmInventory.Manifests, modelsCluster)
 	if err != nil {
 		log.Fatal(err, "Failed to register extra manifests with assisted-service")
 	}

--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/openshift/assisted-service/client"
 	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const failureOutputPath = "/var/run/agent-installer/host-config-failures"
@@ -55,6 +54,7 @@ var RegisterOptions struct {
 	NMStateConfigFile       string `envconfig:"NMSTATE_CONFIG_FILE" default:"/manifests/nmstateconfig.yaml"`
 	ImageTypeISO            string `envconfig:"IMAGE_TYPE_ISO" default:"full-iso"`
 	ReleaseImageMirror      string `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
+	ExtraManifests          string `envconfig:"EXTRA_MANIFESTS_PATH" default:"/extra-manifests"`
 }
 
 var ConfigureOptions struct {
@@ -107,34 +107,29 @@ func register(ctx context.Context, log *log.Logger, bmInventory *client.Assisted
 		log.Fatal(err.Error())
 	}
 
-	var secret corev1.Secret
-	if secretErr := agentbasedinstaller.GetFileData(RegisterOptions.PullSecretFile, &secret); secretErr != nil {
-		log.Fatal(secretErr.Error())
+	pullSecret, err := agentbasedinstaller.GetPullSecret(RegisterOptions.PullSecretFile)
+	if err != nil {
+		log.Fatal(err.Error(), "Failed to get pull secret")
 	}
-	pullSecret := secret.StringData[".dockerconfigjson"]
 
-	log.Info("Registering cluster")
-
-	modelsCluster, registerClusterErr := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
+	modelsCluster, err := agentbasedinstaller.RegisterCluster(ctx, log, bmInventory, pullSecret,
 		RegisterOptions.ClusterDeploymentFile, RegisterOptions.AgentClusterInstallFile, RegisterOptions.ClusterImageSetFile, RegisterOptions.ReleaseImageMirror)
-	if registerClusterErr != nil {
-		log.Fatal("Failed to register cluster with assisted-service: ", registerClusterErr)
+	if err != nil {
+		log.Fatal(err, "Failed to register cluster with assisted-service")
 	}
 
-	log.Info("Registered cluster with id: " + modelsCluster.ID.String())
-
-	log.Info("Registering infraenv")
-
-	modelsInfraEnv, registerInfraEnvErr := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,
+	modelsInfraEnv, err := agentbasedinstaller.RegisterInfraEnv(ctx, log, bmInventory, pullSecret,
 		modelsCluster, RegisterOptions.InfraEnvFile, RegisterOptions.NMStateConfigFile, RegisterOptions.ImageTypeISO)
-	if registerInfraEnvErr != nil {
-		log.Fatal("Failed to register infraenv with assisted-service: ", registerInfraEnvErr)
+	if err != nil {
+		log.Fatal(err, "Failed to register infraenv with assisted-service")
 	}
 
-	infraEnvID := modelsInfraEnv.ID.String()
-	log.Info("Registered infraenv with id: " + infraEnvID)
+	err = agentbasedinstaller.RegisterExtraManifests(ctx, log, bmInventory, modelsCluster, RegisterOptions.ExtraManifests)
+	if err != nil {
+		log.Fatal(err, "Failed to register extra manifests with assisted-service")
+	}
 
-	return infraEnvID
+	return modelsInfraEnv.ID.String()
 }
 
 func configure(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall) {

--- a/cmd/agentbasedinstaller/host_config.go
+++ b/cmd/agentbasedinstaller/host_config.go
@@ -62,7 +62,7 @@ func applyHostConfig(ctx context.Context, log *log.Logger, bmInventory *client.A
 	inventory := &models.Inventory{}
 	err := inventory.UnmarshalBinary([]byte(host.Inventory))
 	if err != nil {
-		return fmt.Errorf("Failed to unmarshal host inventory: %w", err)
+		return fmt.Errorf("failed to unmarshal host inventory: %w", err)
 	}
 
 	config := hostConfigs.findHostConfig(*host.ID, inventory)
@@ -109,7 +109,7 @@ func applyHostConfig(ctx context.Context, log *log.Logger, bmInventory *client.A
 				inventory: inventory,
 			}
 		}
-		return fmt.Errorf("Failed to update Host: %w", err)
+		return fmt.Errorf("failed to update Host: %w", err)
 	}
 	return nil
 }
@@ -165,7 +165,7 @@ func LoadHostConfigs(hostConfigDir string) (HostConfigs, error) {
 			log.Infof("No host configuration directory found %s", hostConfigDir)
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to read config directory %s: %w", hostConfigDir, err)
+		return nil, fmt.Errorf("failed to read config directory %s: %w", hostConfigDir, err)
 	}
 
 	for _, e := range entries {
@@ -181,7 +181,7 @@ func LoadHostConfigs(hostConfigDir string) (HostConfigs, error) {
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read MAC Addresses file: %w", err)
+			return nil, fmt.Errorf("failed to read MAC Addresses file: %w", err)
 		}
 
 		lines := strings.Split(string(macs), "\n")
@@ -214,12 +214,12 @@ func (hc hostConfig) RootDeviceHints() (*bmh_v1alpha1.RootDeviceHints, error) {
 			log.Info("No root device hints file found for host")
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to read Root Device Hints file: %w", err)
+		return nil, fmt.Errorf("failed to read Root Device Hints file: %w", err)
 	}
 
 	rdh := &bmh_v1alpha1.RootDeviceHints{}
 	if err := yaml.UnmarshalStrict(hintData, rdh); err != nil {
-		return nil, fmt.Errorf("Failed to parse Root Device Hints file: %w", err)
+		return nil, fmt.Errorf("failed to parse Root Device Hints file: %w", err)
 	}
 	log.Info("Read root device hints file")
 	return rdh, nil
@@ -232,7 +232,7 @@ func (hc hostConfig) Role() (*string, error) {
 			log.Info("No role file found for host")
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to read role file: %w", err)
+		return nil, fmt.Errorf("failed to read role file: %w", err)
 	}
 
 	role := strings.TrimSpace(string(roleData))

--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -131,7 +131,8 @@ func RegisterExtraManifests(fsys fs.FS, ctx context.Context, log *log.Logger, cl
 
 	extraManifestsFolder := "openshift"
 
-	for _, extraManifestFileName := range extras {
+	for _, f := range extras {
+		extraManifestFileName := f
 		bytes, err := fs.ReadFile(fsys, extraManifestFileName)
 		if err != nil {
 			return err
@@ -148,7 +149,7 @@ func RegisterExtraManifests(fsys fs.FS, ctx context.Context, log *log.Logger, cl
 
 		_, err = client.V2CreateClusterManifest(ctx, params)
 		if err != nil {
-			return err
+			return errorutil.GetAssistedError(err)
 		}
 	}
 


### PR DESCRIPTION
This patch extends the `register` command of the agent based installer cli by adding the possibility to register extra manifests for the cluster to be installed.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed


[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
