### PR TITLE
MGMT-10852: auto-assign races

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -420,9 +420,6 @@ var _ = Describe("RegisterHost", func() {
 				test.availability, test.expectedRole), func() {
 				cluster := createClusterWithAvailability(db, models.ClusterStatusInsufficient, test.availability)
 				infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
-				if test.availability == models.ClusterHighAvailabilityModeFull {
-					mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-				}
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -471,7 +468,6 @@ var _ = Describe("RegisterHost", func() {
 		infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -609,9 +605,6 @@ var _ = Describe("v2RegisterHost", func() {
 				test.availability, test.expectedRole), func() {
 				cluster := createClusterWithAvailability(db, models.ClusterStatusInsufficient, test.availability)
 				infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
-				if test.availability == models.ClusterHighAvailabilityModeFull {
-					mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-				}
 
 				mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 				mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
@@ -660,7 +653,6 @@ var _ = Describe("v2RegisterHost", func() {
 		infraEnv := createInfraEnv(db, *cluster.ID, *cluster.ID)
 		expectedErrMsg := "some-internal-error"
 
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().RegisterHost(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -2813,12 +2805,6 @@ var _ = Describe("cluster", func() {
 								}).Times(1)
 						}
 
-						noChangedOperators := test.updateOperators == nil ||
-							(len(test.updateOperators) == 0 && len(test.originalOperators) == len(test.expectedOperators))
-						if !noChangedOperators {
-							mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-						}
-
 						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 							ClusterID: clusterID,
 							ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -2842,7 +2828,6 @@ var _ = Describe("cluster", func() {
 
 				// Update
 				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSuccess()
 
 				newOperatorName := testOLMOperators[1].Name
@@ -4837,7 +4822,6 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							mockGetOperatorByName(updateOperator.Name)
 						}
 						if test.updateOperators != nil {
-							mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 							mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any()).
 								DoAndReturn(func(operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
 									return operators, nil
@@ -4867,7 +4851,6 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 
 				// Update
 				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
-				mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 				mockSuccess()
 				newOperatorName := testOLMOperators[1].Name
 
@@ -12267,7 +12250,6 @@ var _ = Describe("BindHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
@@ -12377,7 +12359,6 @@ var _ = Describe("BindHost", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
@@ -12412,7 +12393,6 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
@@ -12497,7 +12477,6 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		payload.Username = userName1
@@ -12520,7 +12499,6 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().ResetAutoAssignRoles(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		payload.Username = userName2

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -529,21 +529,6 @@ func (mr *MockAPIMockRecorder) RegisterCluster(ctx, c interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCluster", reflect.TypeOf((*MockAPI)(nil).RegisterCluster), ctx, c)
 }
 
-// ResetAutoAssignRoles mocks base method.
-func (m *MockAPI) ResetAutoAssignRoles(ctx context.Context, c *common.Cluster, db *gorm.DB) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResetAutoAssignRoles", ctx, c, db)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResetAutoAssignRoles indicates an expected call of ResetAutoAssignRoles.
-func (mr *MockAPIMockRecorder) ResetAutoAssignRoles(ctx, c, db interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetAutoAssignRoles", reflect.TypeOf((*MockAPI)(nil).ResetAutoAssignRoles), ctx, c, db)
-}
-
 // ResetCluster mocks base method.
 func (m *MockAPI) ResetCluster(ctx context.Context, c *common.Cluster, reason string, db *gorm.DB) *common.ApiErrorResponse {
 	m.ctrl.T.Helper()

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -341,6 +341,21 @@ func GetInfraEnvFromDBWhere(db *gorm.DB, where ...interface{}) (*InfraEnv, error
 	return &infraEnv, nil
 }
 
+func ResetAutoAssignRoles(db *gorm.DB, onClusters interface{}) (int, error) {
+	if db == nil {
+		return 0, nil
+	}
+
+	reply := db.Model(&models.Host{}).Where("role = ?", models.HostRoleAutoAssign).
+		Where("cluster_id in (?)", onClusters).
+		Update("suggested_role", models.HostRoleAutoAssign)
+
+	if err := reply.Error; err != nil {
+		return 0, err
+	}
+	return int(reply.RowsAffected), nil
+}
+
 func ToModelsHosts(hosts []*Host) []*models.Host {
 	ret := make([]*models.Host, 0)
 	for _, h := range hosts {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -433,11 +433,14 @@ func (m *Manager) refreshRoleInternal(ctx context.Context, h *models.Host, db *g
 	var suggestedRole models.HostRole
 	var err error
 	if m.Config.EnableAutoAssign || forceRefresh {
-		//because of possible hw changes, suggested role should be calculated
-		//periodically even if the suggested role is already set
+		//because of possible hw changes, or new host being registered
+		//suggested role should be calculated periodically even if the
+		//suggested role is already set
 		if h.Role == models.HostRoleAutoAssign &&
 			funk.ContainsString(hostStatusesBeforeInstallation[:], *h.Status) {
-			if suggestedRole, err = m.autoRoleSelection(ctx, h, db); err == nil {
+			host := *h //must have a defensive copy becuase selectRole changes the host object
+			if suggestedRole, err = m.selectRole(ctx, &host, db); err == nil {
+				m.log.Debugf("calculated role for host %s is %s (original suggested = %s)", hostutil.GetHostnameForMsg(h), suggestedRole, h.SuggestedRole)
 				if h.SuggestedRole != suggestedRole {
 					if err = updateRole(m.log, h, h.Role, suggestedRole, db, string(h.Role)); err == nil {
 						h.SuggestedRole = suggestedRole
@@ -1106,13 +1109,6 @@ func (m *Manager) AutoAssignRole(ctx context.Context, h *models.Host, db *gorm.D
 	}
 
 	return false, nil
-}
-
-func (m *Manager) autoRoleSelection(ctx context.Context, host *models.Host, db *gorm.DB) (models.HostRole, error) {
-	h := *host
-
-	suggestedRole, err := m.selectRole(ctx, &h, db)
-	return suggestedRole, err
 }
 
 // This function recommends a role for a given host based on these criteria:

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1087,10 +1087,9 @@ var _ = Describe("cluster install", func() {
 		waitForClusterState(ctx, clusterID, models.ClusterStatusReady, defaultWaitForClusterStateTimeout,
 			IgnoreStateInfo)
 
-		//TODO: uncomment when the falkyness in assignment is solved
-		//By("expect h4 and h5 to be auto-assigned as masters")
-		//Expect(getSuggestedRole(*h4.ID)).Should(Equal(models.HostRoleMaster))
-		//Expect(getSuggestedRole(*h5.ID)).Should(Equal(models.HostRoleMaster))
+		By("expect h4 and h5 to be auto-assigned as masters")
+		Expect(getSuggestedRole(*h4.ID)).Should(Equal(models.HostRoleMaster))
+		Expect(getSuggestedRole(*h5.ID)).Should(Equal(models.HostRoleMaster))
 
 		By("add hosts with worker inventory expect the cluster to be ready")
 		h6 := &registerHost(*infraEnvID).Host
@@ -1122,9 +1121,8 @@ var _ = Describe("cluster install", func() {
 		}
 		Expect(getHostRole(*h1.ID)).Should(Equal(models.HostRoleWorker))
 		Expect(getHostRole(*h6.ID)).Should(Equal(models.HostRoleWorker))
-		//TODO: uncomment after the falkiness is solved
-		//Expect(getHostRole(*h4.ID)).Should(Equal(models.HostRoleMaster))
-		//Expect(getHostRole(*h5.ID)).Should(Equal(models.HostRoleMaster))
+		Expect(getHostRole(*h4.ID)).Should(Equal(models.HostRoleMaster))
+		Expect(getHostRole(*h5.ID)).Should(Equal(models.HostRoleMaster))
 		getReply, err := userBMClient.Installer.V2GetCluster(ctx, &installer.V2GetClusterParams{ClusterID: clusterID})
 		Expect(err).NotTo(HaveOccurred())
 		mastersCount := 0
@@ -1147,7 +1145,6 @@ var _ = Describe("cluster install", func() {
 
 	//TODO: stabilize this test
 	It("auto-assign_with_cnv_operator", func() {
-		Skip("Test is flaky, and needs extra work for its stabilization")
 		By("register 3 hosts all with master hw information and virtualization, cluster expected to be ready")
 		clusterID := *cluster.ID
 		ips := hostutil.GenerateIPv4Addresses(6, defaultCIDRv4)
@@ -1157,7 +1154,7 @@ var _ = Describe("cluster install", func() {
 			hwInventory := getDefaultInventory(ips[i])
 			hwInventory.CPU.Flags = []string{"vmx"}
 			hosts[i] = &registerHost(*infraEnvID).Host
-			generateEssentialHostStepsWithInventory(ctx, hosts[i], fmt.Sprintf("HHH_h%d", i+1), hwInventory)
+			generateEssentialHostStepsWithInventory(ctx, hosts[i], fmt.Sprintf("hhh%d", i+1), hwInventory)
 		}
 		updateVipParams(ctx, clusterID)
 		generateFullMeshConnectivity(ctx, ips[0], hosts[0], hosts[1], hosts[2])
@@ -1171,7 +1168,7 @@ var _ = Describe("cluster install", func() {
 			minHwInventory := getMinimalMasterInventory(ips[i])
 			minHwInventory.CPU.Flags = []string{"vmx"}
 			hosts[i] = &registerHost(*infraEnvID).Host
-			generateEssentialHostStepsWithInventory(ctx, hosts[i], fmt.Sprintf("HHH_h%d", i+1), minHwInventory)
+			generateEssentialHostStepsWithInventory(ctx, hosts[i], fmt.Sprintf("hhh%d", i+1), minHwInventory)
 		}
 		generateFullMeshConnectivity(ctx, ips[0], hosts...)
 		waitForHostState(ctx, models.HostStatusKnown, defaultWaitForHostStateTimeout, hosts...)


### PR DESCRIPTION
A race between resetting the host roles on registration time and calculating the hosts' roles in the monitor has been identified in the CI.

The monitor loop would have picked up the cluster and hosts. Then, a context switch woud have ocuured. During that time, a the new host would have registered, and the roles resetted. 

Once the monitor took control again, it kept calucalting the roles only on the subset of hosts in its memory.

In the next monitoring round, it did read the new host - but since there were three masters assigned already,  it assigned that new host to server as worker, making the reset inefectual.

The fix eliminates the race by putting the reset and the re-calculation in the same thread. 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
