### PR TITLE
MGMT-11115: Add setting bootstrap kubelet ip os env for installer generate

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -313,12 +313,24 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 		log.WithError(wrapped).Errorf("GenerateInstallConfig")
 		return wrapped
 	}
+
 	envVars := append(os.Environ(),
 		"OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="+g.releaseImage,
 		"OPENSHIFT_INSTALL_INVOKER="+g.installInvoker,
 	)
 	if g.clusterTLSCertOverrideDir != "" {
 		envVars = append(envVars, "OPENSHIFT_INSTALL_LOAD_CLUSTER_CERTS=true")
+	}
+
+	// setting bootstrap kubelet node ip
+	if !common.IsSingleNodeCluster(g.cluster) {
+		log.Debugf("Adding bootstrap ip to env vars")
+		bootstrapIp, errB := network.GetPrimaryMachineCIDRIP(common.GetBootstrapHost(g.cluster), g.cluster)
+		if errB != nil {
+			log.WithError(errB).Warn("Failed to get bootstrap primary ip for kubelet service update.")
+			return errB
+		}
+		envVars = append(envVars, "OPENSHIFT_INSTALL_BOOTSTRAP_NODE_IP="+bootstrapIp)
 	}
 
 	// write installConfig to install-config.yaml so openshift-install can read it


### PR DESCRIPTION
MGMT-11115: Add setting bootstrap kubelet ip os env for installer generate 
Currently installer has an env variable for bootstrap kubelet ip, it will be change once 
https://github.com/openshift/enhancements/pull/1181 will be done but till then we can set it in assisted-service.
This is second part of a fix for https://bugzilla.redhat.com/show_bug.cgi?id=2070318
This code should be changed after https://github.com/openshift/enhancements/pull/1181 will be accepted.
This is needed as 
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
