### PR TITLE
MGMT-10739: Reclaim agents on unbind

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,6 +147,7 @@ var Options struct {
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
 	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"` // set to true once https://bugzilla.redhat.com/show_bug.cgi?id=2089683 is resolved
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
+	EnableHostReclaim              bool `envconfig:"ENABLE_HOST_RECLAIM" default:"false"`
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
 	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`
@@ -557,6 +558,8 @@ func main() {
 				AuthType:                   Options.Auth.AuthType,
 				SpokeK8sClientFactory:      spoke_k8s_client.NewSpokeK8sClientFactory(log),
 				ApproveCsrsRequeueDuration: Options.ApproveCsrsRequeueDuration,
+				EnableHostReclaim:          Options.EnableHostReclaim,
+				AgentContainerImage:        Options.BMConfig.AgentDockerImg,
 			}).SetupWithManager(ctrlMgr), "unable to create controller Agent")
 
 			failOnError((&controllers.BMACReconciler{

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -12417,7 +12417,7 @@ var _ = Describe("BindHost", func() {
 		}
 		mockAccountsMgmt.EXPECT().GetSubscription(ctx, gomock.Any()).Return(&amgmtv1.Subscription{}, nil)
 		mockClusterApi.EXPECT().DeregisterCluster(ctx, gomock.Any())
-		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any()).Times(1)
+		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false).Times(1)
 		response = bm.V2DeregisterCluster(ctx, deregisterParams)
 		Expect(response).To(BeAssignableToTypeOf(&installer.V2DeregisterClusterNoContent{}))
 	})
@@ -12451,7 +12451,7 @@ var _ = Describe("BindHost", func() {
 		}
 		mockAccountsMgmt.EXPECT().GetSubscription(ctx, gomock.Any()).Return(&amgmtv1.Subscription{}, nil)
 		mockClusterApi.EXPECT().DeregisterCluster(ctx, gomock.Any())
-		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any()).Times(1)
+		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false).Times(1)
 		mockHostApi.EXPECT().UnRegisterHost(ctx, host2ID.String(), infraEnv2ID.String()).Return(nil).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.HostDeregisteredEventName),
@@ -12629,7 +12629,7 @@ var _ = Describe("UnbindHost", func() {
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
-		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any())
+		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		response := bm.UnbindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.UnbindHostOK{}))
@@ -12674,7 +12674,7 @@ var _ = Describe("UnbindHost", func() {
 			InfraEnvID: infraEnvID,
 		}
 		err := errors.Errorf("Transition failed")
-		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any()).Return(err).Times(1)
+		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false).Return(err).Times(1)
 		response := bm.UnbindHost(ctx, params)
 		verifyApiError(response, http.StatusInternalServerError)
 	})

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -369,18 +369,18 @@ func (mr *MockInstallerInternalsMockRecorder) TransformClusterToDay2Internal(arg
 }
 
 // UnbindHostInternal mocks base method.
-func (m *MockInstallerInternals) UnbindHostInternal(arg0 context.Context, arg1 installer.UnbindHostParams) (*common.Host, error) {
+func (m *MockInstallerInternals) UnbindHostInternal(arg0 context.Context, arg1 installer.UnbindHostParams, arg2 bool) (*common.Host, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnbindHostInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "UnbindHostInternal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*common.Host)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnbindHostInternal indicates an expected call of UnbindHostInternal.
-func (mr *MockInstallerInternalsMockRecorder) UnbindHostInternal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInstallerInternalsMockRecorder) UnbindHostInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UnbindHostInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UnbindHostInternal), arg0, arg1, arg2)
 }
 
 // UpdateClusterInstallConfigInternal mocks base method.

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -339,10 +339,11 @@ func (r *AgentReconciler) tryApproveDay2CSRs(ctx context.Context, agent *aiv1bet
 }
 
 func (r *AgentReconciler) unbindHost(ctx context.Context, log logrus.FieldLogger, agent, origAgent *aiv1beta1.Agent, h *common.Host) (ctrl.Result, error) {
-	host, err2 := r.Installer.UnbindHostInternal(ctx, installer.UnbindHostParams{
+	params := installer.UnbindHostParams{
 		HostID:     *h.ID,
 		InfraEnvID: h.InfraEnvID,
-	})
+	}
+	host, err2 := r.Installer.UnbindHostInternal(ctx, params, false)
 	if err2 != nil {
 		return r.updateStatus(ctx, log, agent, origAgent, &h.Host, nil, err2, !IsUserError(err2))
 	}

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/openshift/assisted-service/api/common"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
@@ -84,6 +85,9 @@ type AgentReconciler struct {
 	AuthType                   auth.AuthType
 	SpokeK8sClientFactory      spoke_k8s_client.SpokeK8sClientFactory
 	ApproveCsrsRequeueDuration time.Duration
+	EnableHostReclaim          bool
+	AgentContainerImage        string
+	reclaimer                  *agentReclaimer
 }
 
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch;create;update;patch;delete
@@ -342,15 +346,96 @@ func (r *AgentReconciler) tryApproveDay2CSRs(ctx context.Context, agent *aiv1bet
 	return !shouldApproveMoreCSRs
 }
 
+func (r *AgentReconciler) bmhExists(ctx context.Context, agent *aiv1beta1.Agent) (bool, error) {
+	bmhName, ok := agent.ObjectMeta.Labels[AGENT_BMH_LABEL]
+	if !ok {
+		return false, nil
+	}
+
+	bmhKey := types.NamespacedName{
+		Name:      bmhName,
+		Namespace: agent.Namespace,
+	}
+	if err := r.Client.Get(ctx, bmhKey, &bmh_v1alpha1.BareMetalHost{}); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	return true, nil
+}
+
+func (r *AgentReconciler) shouldReclaimOnUnbind(ctx context.Context, agent *aiv1beta1.Agent, clusterRef *aiv1beta1.ClusterReference) bool {
+	if !r.EnableHostReclaim {
+		return false
+	}
+
+	// default to not attempting to reclaim as that's the safer route
+	if foundBMH, err := r.bmhExists(ctx, agent); err != nil || foundBMH {
+		if err != nil {
+			r.Log.WithError(err).Warnf("failed to determine if BMH exists for agent")
+		}
+		return false
+	}
+	return true
+}
+
+func (r *AgentReconciler) runReclaimAgent(ctx context.Context, agent *aiv1beta1.Agent, clusterRef *aiv1beta1.ClusterReference, host *common.Host) error {
+	if !r.EnableHostReclaim {
+		return errors.Errorf("host reclaim disabled")
+	}
+
+	client, err := r.spokeKubeClient(ctx, clusterRef)
+	if err != nil {
+		r.Log.WithError(err).Warnf("failed to create spoke kube client")
+		return err
+	}
+
+	hostname := getAgentHostname(agent)
+	r.Log.Infof("Starting agent pod for reclaim on node %s", hostname)
+	if err := ensureSpokeNamespace(ctx, client); err != nil {
+		return err
+	}
+	if err := r.reclaimer.ensureSpokeAgentSecret(ctx, client, host.InfraEnvID.String()); err != nil {
+		return err
+	}
+	if err := r.reclaimer.ensureSpokeAgentCertCM(ctx, client); err != nil {
+		return err
+	}
+	return r.reclaimer.createNextStepRunnerPod(ctx, client, hostname, host.InfraEnvID.String(), host.ID.String())
+}
+
 func (r *AgentReconciler) unbindHost(ctx context.Context, log logrus.FieldLogger, agent, origAgent *aiv1beta1.Agent, h *common.Host) (ctrl.Result, error) {
+	var reclaim bool
+
+	if r.EnableHostReclaim {
+		// log and don't reclaim if anything fails here
+		cluster, err := r.Installer.GetClusterInternal(ctx, installer.V2GetClusterParams{ClusterID: *h.ClusterID})
+		if err != nil || cluster.KubeKeyName == "" || cluster.KubeKeyNamespace == "" {
+			if err != nil {
+				r.Log.WithError(err).Warnf("failed to get cluster %s, not attempting reclaim", h.ClusterID)
+			} else {
+				r.Log.Warnf("cluster %s missing kube key (%s/%s), not attempting reclaim", h.ClusterID, cluster.KubeKeyNamespace, cluster.KubeKeyName)
+			}
+		} else {
+			clusterRef := &aiv1beta1.ClusterReference{Namespace: cluster.KubeKeyNamespace, Name: cluster.KubeKeyName}
+			reclaim = r.shouldReclaimOnUnbind(ctx, origAgent, clusterRef)
+			if reclaim {
+				if err := r.runReclaimAgent(ctx, agent, clusterRef, h); err != nil {
+					r.Log.WithError(err).Warn("failed to start agent on spoke cluster to reclaim")
+					reclaim = false
+				}
+			}
+		}
+	}
+
 	params := installer.UnbindHostParams{
 		HostID:     *h.ID,
 		InfraEnvID: h.InfraEnvID,
 	}
-	host, err2 := r.Installer.UnbindHostInternal(ctx, params, false)
-	if err2 != nil {
-		return r.updateStatus(ctx, log, agent, origAgent, &h.Host, nil, err2, !IsUserError(err2))
+	host, err := r.Installer.UnbindHostInternal(ctx, params, reclaim)
+	if err != nil {
+		return r.updateStatus(ctx, log, agent, origAgent, &h.Host, nil, err, !IsUserError(err))
 	}
+
 	return r.updateStatus(ctx, log, agent, origAgent, &host.Host, h.ClusterID, nil, true)
 }
 
@@ -1257,6 +1342,11 @@ func (r *AgentReconciler) setInfraEnvNameLabel(ctx context.Context, log logrus.F
 }
 
 func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	var err error
+	r.reclaimer, err = newAgentReclaimer()
+	if err != nil {
+		return err
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&aiv1beta1.Agent{}).
 		Watches(&source.Channel{Source: r.CRDEventsHandler.GetAgentUpdates()},

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -687,7 +687,7 @@ var _ = Describe("agent reconcile", func() {
 		Expect(c.Create(ctx, clusterDeployment)).To(BeNil())
 
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil)
-		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any()).Return(commonHost, nil)
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
 		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
 		Expect(c.Create(ctx, host)).To(BeNil())
 
@@ -727,7 +727,7 @@ var _ = Describe("agent reconcile", func() {
 
 		errString := "failed to find host in infraEnv"
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
-		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any()).Return(commonHost, common.NewApiError(http.StatusNotFound, errors.New(errString)))
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, common.NewApiError(http.StatusNotFound, errors.New(errString)))
 		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
 
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
@@ -859,7 +859,7 @@ var _ = Describe("agent reconcile", func() {
 
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(targetBECluster, nil)
-		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any()).Return(commonHost, nil)
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
 		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
 		Expect(c.Create(ctx, host)).To(BeNil())
 

--- a/internal/controller/controllers/agent_reclaimer.go
+++ b/internal/controller/controllers/agent_reclaimer.go
@@ -1,0 +1,210 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/pkg/auth"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	spokeReclaimNamespaceName = "assisted-installer"
+	spokeReclaimCMName        = "reclaim-config"
+)
+
+type reclaimConfig struct {
+	AgentContainerImage  string        `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
+	AuthType             auth.AuthType `envconfig:"AUTH_TYPE" default:""`
+	ServiceBaseURL       string        `envconfig:"SERVICE_BASE_URL"`
+	ServiceCACertPath    string        `envconfig:"SERVICE_CA_CERT_PATH" default:""`
+	SkipCertVerification bool          `envconfig:"SKIP_CERT_VERIFICATION" default:"false"`
+}
+
+type agentReclaimer struct {
+	reclaimConfig
+}
+
+func newAgentReclaimer() (*agentReclaimer, error) {
+	config := reclaimConfig{}
+
+	if err := envconfig.Process("", &config); err != nil {
+		return nil, errors.Wrapf(err, "failed to populate reclaimConfig")
+	}
+
+	return &agentReclaimer{reclaimConfig: config}, nil
+}
+
+func ensureSpokeNamespace(ctx context.Context, c client.Client) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spokeReclaimNamespaceName}}
+	if err := c.Get(ctx, types.NamespacedName{Name: ns.Name}, ns); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to get namespace %s", spokeReclaimNamespaceName)
+		}
+		if err := c.Create(ctx, ns); err != nil {
+			return errors.Wrapf(err, "failed to create namespace %s", spokeReclaimNamespaceName)
+		}
+	}
+
+	return nil
+}
+
+func spokeReclaimSecretName(infraEnvID string) string {
+	return fmt.Sprintf("reclaim-%s-token", infraEnvID)
+}
+
+func (r *agentReclaimer) ensureSpokeAgentSecret(ctx context.Context, c client.Client, infraEnvID string) error {
+	authToken := ""
+	if r.AuthType == auth.TypeLocal {
+		var err error
+		authToken, err = gencrypto.LocalJWT(infraEnvID, gencrypto.InfraEnvKey)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create local JWT for infraEnv %s", infraEnvID)
+		}
+	}
+
+	key := types.NamespacedName{
+		Name:      spokeReclaimSecretName(infraEnvID),
+		Namespace: spokeReclaimNamespaceName,
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	err := c.Get(ctx, key, secret)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to get secret %s/%s", key.Namespace, key.Name)
+	}
+
+	if k8serrors.IsNotFound(err) {
+		secret.Data = map[string][]byte{"auth-token": []byte(authToken)}
+		if err := c.Create(ctx, secret); err != nil {
+			return errors.Wrapf(err, "failed to create secret %s", spokeReclaimNamespaceName)
+		}
+	}
+
+	return nil
+}
+
+func (r *agentReclaimer) ensureSpokeAgentCertCM(ctx context.Context, c client.Client) error {
+	if r.ServiceCACertPath == "" {
+		return nil
+	}
+
+	key := types.NamespacedName{
+		Name:      spokeReclaimCMName,
+		Namespace: spokeReclaimNamespaceName,
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+	}
+
+	err := c.Get(ctx, key, cm)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to get secret %s/%s", key.Namespace, key.Name)
+	}
+
+	if k8serrors.IsNotFound(err) {
+		data, err := os.ReadFile(r.ServiceCACertPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to read service ca cert")
+		}
+		cm.Data = map[string]string{filepath.Base(common.HostCACertPath): string(data)}
+		if err := c.Create(ctx, cm); err != nil {
+			return errors.Wrapf(err, "failed to create secret %s", spokeReclaimNamespaceName)
+		}
+	}
+
+	return nil
+}
+
+func (r *agentReclaimer) createNextStepRunnerPod(ctx context.Context, c client.Client, nodeName string, infraEnvID string, hostID string) error {
+	node := &corev1.Node{}
+	if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		return errors.Wrapf(err, "failed to find node %s", nodeName)
+	}
+
+	cliArgs := []string{
+		fmt.Sprintf("-url=%s", r.ServiceBaseURL),
+		fmt.Sprintf("-infra-env-id=%s", infraEnvID),
+		fmt.Sprintf("-host-id=%s", hostID),
+		fmt.Sprintf("-agent-version=%s", r.AgentContainerImage),
+		fmt.Sprintf("-insecure=%t", r.SkipCertVerification),
+		"-with-stdout-logging=true",
+	}
+	volumes := []corev1.Volume{{
+		Name: "host",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/",
+			},
+		},
+	}}
+	volumeMounts := []corev1.VolumeMount{{Name: "host", MountPath: "/host"}}
+
+	if r.ServiceCACertPath != "" {
+		cliArgs = append(cliArgs, fmt.Sprintf("-cacert=%s", common.HostCACertPath))
+		volumes = append(volumes, corev1.Volume{
+			Name: "ca-cert",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: spokeReclaimCMName,
+					},
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "ca-cert",
+			MountPath: filepath.Dir(common.HostCACertPath),
+		})
+	}
+
+	podName := fmt.Sprintf("%s-reclaim", nodeName)
+	var privileged bool = true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: spokeReclaimNamespaceName,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node.Name,
+			Volumes:  volumes,
+			Containers: []corev1.Container{{
+				Name:            podName,
+				Image:           r.AgentContainerImage,
+				Command:         []string{"next_step_runner"},
+				Args:            cliArgs,
+				SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+				VolumeMounts:    volumeMounts,
+				Env: []corev1.EnvVar{{
+					Name: "PULL_SECRET_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "auth-token",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: spokeReclaimSecretName(infraEnvID),
+						},
+					}},
+				}},
+			}},
+		},
+	}
+
+	return c.Create(ctx, pod)
+}

--- a/internal/controller/controllers/agent_reclaimer_test.go
+++ b/internal/controller/controllers/agent_reclaimer_test.go
@@ -1,0 +1,279 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/gencrypto"
+	"github.com/openshift/assisted-service/pkg/auth"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = It("newAgentReclaimer pulls config from env vars", func() {
+	image := "registry.example.com/agent:latest"
+	authType := auth.TypeLocal
+	serviceURL := "https://assisted.example.com"
+	certPath := "/etc/some/path/cert.crt"
+	skipVerify := "true"
+
+	os.Setenv("AGENT_DOCKER_IMAGE", image)
+	os.Setenv("AUTH_TYPE", string(authType))
+	os.Setenv("SERVICE_BASE_URL", serviceURL)
+	os.Setenv("SERVICE_CA_CERT_PATH", certPath)
+	os.Setenv("SKIP_CERT_VERIFICATION", skipVerify)
+
+	r, err := newAgentReclaimer()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(r.AgentContainerImage).To(Equal(image))
+	Expect(r.AuthType).To(Equal(authType))
+	Expect(r.ServiceBaseURL).To(Equal(serviceURL))
+	Expect(r.ServiceCACertPath).To(Equal(certPath))
+	Expect(r.SkipCertVerification).To(BeTrue())
+})
+
+var _ = Context("with a fake client", func() {
+	var (
+		c               client.Client
+		ctx             = context.Background()
+		agentImage      = "registry.example.com/assisted-installer/agent:latest"
+		assistedBaseURL = "https://assisted.example.com"
+		reclaimer       *agentReclaimer
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		reclaimer = &agentReclaimer{reclaimConfig{
+			AgentContainerImage: agentImage,
+			ServiceBaseURL:      assistedBaseURL,
+		}}
+	})
+
+	Describe("ensureSpokeNamespace", func() {
+		It("creates the namespace", func() {
+			Expect(ensureSpokeNamespace(ctx, c)).To(Succeed())
+
+			key := types.NamespacedName{Name: spokeReclaimNamespaceName}
+			Expect(c.Get(ctx, key, &corev1.Namespace{})).To(Succeed())
+		})
+
+		It("succeeds if the namespace already exists", func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: spokeReclaimNamespaceName}}
+			Expect(c.Create(ctx, ns)).To(Succeed())
+
+			Expect(ensureSpokeNamespace(ctx, c)).To(Succeed())
+		})
+	})
+
+	Describe("ensureSpokeAgentSecret", func() {
+		var infraEnvID string
+		BeforeEach(func() {
+			infraEnvID = uuid.New().String()
+		})
+
+		It("creates the secret with an empty value with none auth", func() {
+			reclaimer.AuthType = auth.TypeNone
+			Expect(reclaimer.ensureSpokeAgentSecret(ctx, c, infraEnvID)).To(Succeed())
+
+			key := types.NamespacedName{
+				Name:      fmt.Sprintf("reclaim-%s-token", infraEnvID),
+				Namespace: spokeReclaimNamespaceName,
+			}
+			secret := &corev1.Secret{}
+			Expect(c.Get(ctx, key, secret)).To(Succeed())
+			tok, ok := secret.Data["auth-token"]
+			Expect(ok).To(BeTrue(), "secret should have auth-token key")
+			Expect(tok).To(BeEmpty())
+		})
+
+		It("creates a token with local auth", func() {
+			_, priv, err := gencrypto.ECDSAKeyPairPEM()
+			Expect(err).NotTo(HaveOccurred())
+			os.Setenv("EC_PRIVATE_KEY_PEM", priv)
+			defer os.Unsetenv("EC_PROVATE_KEY_PEM")
+
+			reclaimer.AuthType = auth.TypeLocal
+			Expect(reclaimer.ensureSpokeAgentSecret(ctx, c, infraEnvID)).To(Succeed())
+
+			key := types.NamespacedName{
+				Name:      fmt.Sprintf("reclaim-%s-token", infraEnvID),
+				Namespace: spokeReclaimNamespaceName,
+			}
+			secret := &corev1.Secret{}
+			Expect(c.Get(ctx, key, secret)).To(Succeed())
+			tok, ok := secret.Data["auth-token"]
+			Expect(ok).To(BeTrue(), "secret should have auth-token key")
+			Expect(tok).NotTo(BeEmpty())
+		})
+
+		It("succeeds if the secret already exists", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("reclaim-%s-token", infraEnvID),
+					Namespace: spokeReclaimNamespaceName,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{"auth-token": []byte("")},
+			}
+			Expect(c.Create(ctx, secret)).To(Succeed())
+
+			reclaimer.AuthType = auth.TypeNone
+			Expect(reclaimer.ensureSpokeAgentSecret(ctx, c, infraEnvID)).To(Succeed())
+		})
+
+		It("creates a second secret if one exists for a different infra-env", func() {
+			reclaimer.AuthType = auth.TypeNone
+			Expect(reclaimer.ensureSpokeAgentSecret(ctx, c, infraEnvID)).To(Succeed())
+
+			otherInfraEnvID := uuid.New().String()
+			Expect(reclaimer.ensureSpokeAgentSecret(ctx, c, otherInfraEnvID)).To(Succeed())
+
+			key := types.NamespacedName{
+				Name:      fmt.Sprintf("reclaim-%s-token", infraEnvID),
+				Namespace: spokeReclaimNamespaceName,
+			}
+			Expect(c.Get(ctx, key, &corev1.Secret{})).To(Succeed())
+			key.Name = fmt.Sprintf("reclaim-%s-token", otherInfraEnvID)
+			Expect(c.Get(ctx, key, &corev1.Secret{})).To(Succeed())
+		})
+	})
+
+	Describe("ensureSpokeAgentCertCM", func() {
+		It("creates the configmap if a cert path is set", func() {
+			certFile, err := os.CreateTemp("", "reclaim-cert-file")
+			Expect(err).NotTo(HaveOccurred())
+			fileName := certFile.Name()
+			defer os.Remove(fileName)
+
+			content := "some cert content here"
+			_, err = certFile.WriteString(content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(certFile.Sync()).To(Succeed())
+
+			reclaimer.ServiceCACertPath = fileName
+			Expect(reclaimer.ensureSpokeAgentCertCM(ctx, c)).To(Succeed())
+
+			key := types.NamespacedName{
+				Name:      spokeReclaimCMName,
+				Namespace: spokeReclaimNamespaceName,
+			}
+			cm := &corev1.ConfigMap{}
+			Expect(c.Get(ctx, key, cm)).To(Succeed())
+			cmContent, ok := cm.Data["service-ca-cert.crt"]
+			Expect(ok).To(BeTrue(), "config map should include CA cert file key")
+			Expect(cmContent).To(Equal(content))
+		})
+
+		It("does not create a configmap when no cert path is set", func() {
+			Expect(reclaimer.ensureSpokeAgentCertCM(ctx, c)).To(Succeed())
+			key := types.NamespacedName{
+				Name:      spokeReclaimCMName,
+				Namespace: spokeReclaimNamespaceName,
+			}
+			err := c.Get(ctx, key, &corev1.ConfigMap{})
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("succeeds when the configmap already exists", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      spokeReclaimCMName,
+					Namespace: spokeReclaimNamespaceName,
+				},
+				Data: map[string]string{"service-ca-cert.crt": "some cert data"},
+			}
+			Expect(c.Create(ctx, cm)).To(Succeed())
+
+			Expect(reclaimer.ensureSpokeAgentCertCM(ctx, c)).To(Succeed())
+		})
+	})
+
+	Describe("createNextStepRunnerPod", func() {
+		var (
+			nodeName   = "node.example.com"
+			podName    = "node.example.com-reclaim"
+			infraEnvID string
+			hostID     string
+		)
+
+		BeforeEach(func() {
+			infraEnvID = uuid.New().String()
+			hostID = uuid.New().String()
+		})
+
+		withANode := func(hostname string) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: hostname},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeHostName, Address: hostname},
+					},
+				},
+			}
+			Expect(c.Create(ctx, node)).To(Succeed())
+		}
+
+		It("creates a pod correctly on the spoke node", func() {
+			withANode(nodeName)
+			Expect(reclaimer.createNextStepRunnerPod(ctx, c, nodeName, infraEnvID, hostID)).To(Succeed())
+
+			pod := &corev1.Pod{}
+			podNsName := types.NamespacedName{
+				Name:      podName,
+				Namespace: spokeReclaimNamespaceName,
+			}
+			Expect(c.Get(ctx, podNsName, pod)).To(Succeed())
+
+			Expect(pod.Spec.NodeName).To(Equal(nodeName))
+			container := pod.Spec.Containers[0]
+			Expect(container.Image).To(Equal(agentImage))
+			Expect(container.SecurityContext.Privileged).To(HaveValue(Equal(true)))
+			Expect(container.Command).To(Equal([]string{"next_step_runner"}))
+
+			// no cacert should be provided by default
+			Expect(container.Args).NotTo(ContainElement(ContainSubstring("-cacert")))
+		})
+
+		It("adds cert configuration when CA cert path is set", func() {
+			withANode(nodeName)
+			reclaimer.ServiceCACertPath = "/etc/assisted/cert.crt"
+			Expect(reclaimer.createNextStepRunnerPod(ctx, c, nodeName, infraEnvID, hostID)).To(Succeed())
+
+			pod := &corev1.Pod{}
+			podNsName := types.NamespacedName{
+				Name:      podName,
+				Namespace: spokeReclaimNamespaceName,
+			}
+			Expect(c.Get(ctx, podNsName, pod)).To(Succeed())
+
+			Expect(pod.Spec.Containers[0].Args).To(ContainElement("-cacert=/etc/assisted-service/service-ca-cert.crt"))
+			foundVolume := false
+			for _, vol := range pod.Spec.Volumes {
+				if vol.Name == "ca-cert" && vol.VolumeSource.ConfigMap.LocalObjectReference.Name == spokeReclaimCMName {
+					foundVolume = true
+				}
+			}
+			Expect(foundVolume).To(BeTrue(), "Pod should have ca-cert volume")
+			foundMount := false
+			for _, mount := range pod.Spec.Containers[0].VolumeMounts {
+				if mount.Name == "ca-cert" && mount.MountPath == "/etc/assisted-service" {
+					foundMount = true
+				}
+			}
+			Expect(foundMount).To(BeTrue(), "Pod should have ca-cert volume mount")
+		})
+
+		It("fails when the node doesn't exist", func() {
+			Expect(reclaimer.createNextStepRunnerPod(ctx, c, nodeName, infraEnvID, hostID)).ToNot(Succeed())
+		})
+	})
+})

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1855,7 +1855,7 @@ var _ = Describe("Unbind host", func() {
 					host.Kind = t.kind
 				}
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
-				t.validation(hapi.UnbindHost(ctx, &host, db))
+				t.validation(hapi.UnbindHost(ctx, &host, db, false))
 			})
 		}
 	})

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -496,17 +496,17 @@ func (mr *MockAPIMockRecorder) UnRegisterHost(arg0, arg1, arg2 interface{}) *gom
 }
 
 // UnbindHost mocks base method.
-func (m *MockAPI) UnbindHost(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
+func (m *MockAPI) UnbindHost(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnbindHost", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UnbindHost", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnbindHost indicates an expected call of UnbindHost.
-func (mr *MockAPIMockRecorder) UnbindHost(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) UnbindHost(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHost", reflect.TypeOf((*MockAPI)(nil).UnbindHost), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHost", reflect.TypeOf((*MockAPI)(nil).UnbindHost), arg0, arg1, arg2, arg3)
 }
 
 // UpdateApiVipConnectivityReport mocks base method.

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1107,6 +1107,7 @@ var _ = Describe("Unbind", func() {
 		dstState  string
 		success   bool
 		sendEvent bool
+		reclaim   bool
 	}{
 		{
 			name:      "known to unbinding",
@@ -1114,6 +1115,15 @@ var _ = Describe("Unbind", func() {
 			dstState:  models.HostStatusUnbinding,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
+		},
+		{
+			name:      "known to unbinding - reclaim",
+			srcState:  models.HostStatusKnown,
+			dstState:  models.HostStatusUnbinding,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
 		},
 		{
 			name:      "disconnected to unbinding",
@@ -1121,6 +1131,15 @@ var _ = Describe("Unbind", func() {
 			dstState:  models.HostStatusUnbinding,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
+		},
+		{
+			name:      "disconnected to unbinding - reclaim",
+			srcState:  models.HostStatusDisconnected,
+			dstState:  models.HostStatusUnbinding,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
 		},
 		{
 			name:      "discovering to unbinding",
@@ -1128,6 +1147,15 @@ var _ = Describe("Unbind", func() {
 			dstState:  models.HostStatusUnbinding,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
+		},
+		{
+			name:      "discovering to unbinding - reclaim",
+			srcState:  models.HostStatusDiscovering,
+			dstState:  models.HostStatusUnbinding,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
 		},
 		{
 			name:      "pending-for-input to binding",
@@ -1135,27 +1163,63 @@ var _ = Describe("Unbind", func() {
 			dstState:  models.HostStatusUnbinding,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
 		},
 		{
-			name:      "error to unbinding",
+			name:      "pending-for-input to binding - reclaim",
+			srcState:  models.HostStatusPendingForInput,
+			dstState:  models.HostStatusUnbinding,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
+		},
+		{
+			name:      "error to unbinding-pending-user-action",
 			srcState:  models.HostStatusError,
 			dstState:  models.HostStatusUnbindingPendingUserAction,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
 		},
 		{
-			name:      "cancelled to unbinding",
+			name:      "error to unbinding-pending-user-action - reclaim",
+			srcState:  models.HostStatusError,
+			dstState:  models.HostStatusUnbindingPendingUserAction,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
+		},
+		{
+			name:      "cancelled to unbinding-pending-user-action",
 			srcState:  models.HostStatusCancelled,
 			dstState:  models.HostStatusUnbindingPendingUserAction,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
 		},
 		{
-			name:      "installing to unbinding",
+			name:      "cancelled to unbinding-pending-user-action - reclaim",
+			srcState:  models.HostStatusCancelled,
+			dstState:  models.HostStatusUnbindingPendingUserAction,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
+		},
+		{
+			name:      "installing noop",
 			srcState:  models.HostStatusInstalling,
 			dstState:  models.HostStatusInstalling,
 			success:   false,
 			sendEvent: false,
+			reclaim:   false,
+		},
+		{
+			name:      "installing noop - reclaim",
+			srcState:  models.HostStatusInstalling,
+			dstState:  models.HostStatusInstalling,
+			success:   false,
+			sendEvent: false,
+			reclaim:   true,
 		},
 		{
 			name:      "added-host-to-existing-cluster to unbinding-pending-user-action",
@@ -1163,6 +1227,23 @@ var _ = Describe("Unbind", func() {
 			dstState:  models.HostStatusUnbindingPendingUserAction,
 			success:   true,
 			sendEvent: true,
+			reclaim:   false,
+		},
+		{
+			name:      "added-host-to-existing-cluster to reclaiming",
+			srcState:  models.HostStatusAddedToExistingCluster,
+			dstState:  models.HostStatusReclaiming,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
+		},
+		{
+			name:      "installed to reclaiming",
+			srcState:  models.HostStatusInstalled,
+			dstState:  models.HostStatusReclaiming,
+			success:   true,
+			sendEvent: true,
+			reclaim:   true,
 		},
 	}
 	for i := range tests {
@@ -1215,7 +1296,7 @@ var _ = Describe("Unbind", func() {
 				validation = failure
 				validationState = t.srcState
 			}
-			validation(hapi.UnbindHost(ctx, &host, db), validationState)
+			validation(hapi.UnbindHost(ctx, &host, db, t.reclaim), validationState)
 		})
 	}
 

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -4283,8 +4283,17 @@ var _ = Describe("bmac reconcile flow", func() {
 			Expect(kubeClient.Update(ctx, bmh)).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
+				// expect bmh hardware annotation to be set
 				bmh = getBmhCRD(ctx, kubeClient, bmhNsName)
-				return bmh.ObjectMeta.Annotations != nil && bmh.ObjectMeta.Annotations[controllers.BMH_HARDWARE_DETAILS_ANNOTATION] != ""
+				if bmh.ObjectMeta.Annotations == nil || bmh.ObjectMeta.Annotations[controllers.BMH_HARDWARE_DETAILS_ANNOTATION] == "" {
+					return false
+				}
+				// expect agent bmh reference to be set
+				agent := getAgentCRD(ctx, kubeClient, agentNsName)
+				if agent.Labels == nil || agent.Labels[controllers.AGENT_BMH_LABEL] != bmh.Name {
+					return false
+				}
+				return true
 			}, "60s", "10s").Should(Equal(true))
 		})
 	})

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3252,9 +3252,11 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 		Eventually(agentHasAllLabels, "30s", "1s").Should(Equal(true))
 
-		a := getAgentCRD(ctx, kubeClient, key)
-		delete(a.Labels, v1beta1.InfraEnvNameLabel)
-		Expect(kubeClient.Update(ctx, a)).To(Succeed())
+		Eventually(func() error {
+			a := getAgentCRD(ctx, kubeClient, key)
+			delete(a.Labels, v1beta1.InfraEnvNameLabel)
+			return kubeClient.Update(ctx, a)
+		}, "30s", "2s").Should(Succeed())
 		Eventually(agentHasAllLabels, "30s", "1s").Should(Equal(true))
 
 		By("Approve Agent")


### PR DESCRIPTION
Run a pod on the spoke node when the agent associated with that node is unbound.
This agent will boot the host back into the discovery image, allowing it to be reused from the same infraEnv.

This is only done when the agent does not have an associated BareMetalHost.

This PR also adds a feature flag for all of this that will prevent us from moving to `HostStatusReclaiming` even if the BMH isn't present. This is added so that the feature can be worked on incrementally. Without this we would need all the agent commands to be implemented before this could be merged.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-10739

Part of the implementation for the [Automatically Return Agents to InfraEnv enhancement](https://github.com/openshift/assisted-service/blob/6b8401d3b0f0ceea5a837f33c17b9b1cd5ec52a3/docs/enhancements/auto-return-agent-to-infra-env.md)

~~Built on https://github.com/openshift/assisted-service/pull/4139~~ Merged

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Ran this version of assisted-service in the hub cluster of a dev-scripts setup.
This allowed the hub cluster and the spokes to exist on the same libvirt network.

Created an SNO spoke and added 2 workers as a day-2 install step.
Unbound a worker and observed the pod get started on the spoke node.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @danielerez 
/cc @ori-amizur 
/cc @CrystalChun 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) TODO
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?