### PR TITLE
MGMT-11129: Only set bootstrap host when it's attached to a cluster

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -327,7 +327,7 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 		return common.NewApiError(http.StatusNotFound, err)
 	}
 
-	if m.Config.BootstrapHostMAC != "" && !h.Bootstrap {
+	if cluster != nil && m.Config.BootstrapHostMAC != "" && !h.Bootstrap {
 		for _, iface := range inventory.Interfaces {
 			if iface.MacAddress == m.Config.BootstrapHostMAC {
 				log.Infof("selected local bootstrap host %s for cluster %s", h.ID, cluster.ID)


### PR DESCRIPTION
[MGMT-11129](https://issues.redhat.com/browse/MGMT-11129)
Initially there wasn't a check to see if the host was attached to a
cluster before setting the bootstrap host. In a scenario like
late-binding, there could be hosts without a cluster, which would
cause a panic.

This checks to make sure the cluster is not nil before executing
the logic to set a bootstrap host.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): created a late-binding cluster and set the BOOTSTRAP_MAC_HOST in the assisted-service configmap to a host that was not the bootstrap host. Ensured that the panic didn't occur
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
