### PR TITLE
MGMT-8578: Use host's role when generating day2 ignition

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -756,7 +756,7 @@ func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context
 		return errors.Wrapf(err, "Failed to create ignition string for cluster %s, host %s", cluster.ID, host.ID)
 	}
 
-	fileName := fmt.Sprintf("%s/worker-%s.ign", cluster.ID, host.ID)
+	fileName := fmt.Sprintf("%s/%s-%s.ign", cluster.ID, common.GetEffectiveRole(host), host.ID)
 	log.Infof("Uploading ignition file <%s>", fileName)
 	err = b.objectHandler.Upload(ctx, fullIgnition, fileName)
 	if err != nil {

--- a/internal/host/hostcommands/api_vip_connectivity_check_cmd.go
+++ b/internal/host/hostcommands/api_vip_connectivity_check_cmd.go
@@ -77,7 +77,7 @@ func getIngnitionEndPoint(cluster *common.Cluster, host *models.Host) (string, e
 	if addressPart == "" {
 		addressPart = cluster.APIVip
 	}
-	poolName := "worker"
+	poolName := string(common.GetEffectiveRole(host))
 	if host.MachineConfigPoolName != "" {
 		poolName = host.MachineConfigPoolName
 	}


### PR DESCRIPTION
Currently whenever we generate a day2 ignition file, we hardcode
`worker` in the filename. In order to enable day2 master nodes, we want
the filename to reflect the effective role of the host. This PR
implements the change without changing the current behaviour for adding
a worker node.

Contributes-to: [MGMT-8578](https://issues.redhat.com//browse/MGMT-8578)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @ori-amizur 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
