### PR TITLE
NO-ISSUE: Return bytes from `executeTemplate` template function

### DIFF
--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -12,12 +12,12 @@
     "units": [{
       "name": "agent.service",
       "enabled": {{if .EnableAgentService}}true{{else}}false{{end}},
-      "contents": {{ executeTemplate "agent.service" . | toJson }}
+      "contents": {{ executeTemplate "agent.service" . | toString | toJson }}
     },
     {
         "name": "selinux.service",
         "enabled": true,
-        "contents": {{ executeTemplate "selinux.service" . | toJson }}
+        "contents": {{ executeTemplate "selinux.service" . | toString | toJson }}
     }{{if .OKDBinaries | not}},
     {
         "name": "multipathd.service",
@@ -26,17 +26,17 @@
     {
         "name": "pre-network-manager-config.service",
         "enabled": true,
-        "contents": {{ executeTemplate "pre-network-manager-config.service" . | toJson }}
+        "contents": {{ executeTemplate "pre-network-manager-config.service" . | toString | toJson }}
     }{{end}}{{if .OKDBinaries}},
     {
         "name": "okd-overlay.service",
         "enabled": true,
-        "contents": {{ executeTemplate "okd-overlay.service" . | toJson }}
+        "contents": {{ executeTemplate "okd-overlay.service" . | toString | toJson }}
     },
     {
         "name": "systemd-journal-gatewayd.socket",
         "enabled": true,
-        "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toJson }}
+        "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toString | toJson }}
     }{{end}}
     ]
   },


### PR DESCRIPTION
Currently the `executeTemplate` template function returns a string,
therefore assuming the result is text. This could make it difficult to
generate binary files. To make that more feasible this patch changes it
so that it returns an array of bytes. The conversion to UTF-8 encoded
strings will be performed by a new `toString` function.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

Tested manually in the development environment.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
