### PR TITLE
MGMT-11131: Track hosts' registration times

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/host.go
@@ -135,6 +135,10 @@ type Host struct {
 	// progress stages
 	ProgressStages []HostStage `json:"progress_stages" gorm:"-"`
 
+	// The last time the host's agent tried to register in the service.
+	// Format: date-time
+	RegisteredAt strfmt.DateTime `json:"registered_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// requested hostname
 	RequestedHostname string `json:"requested_hostname,omitempty"`
 
@@ -235,6 +239,10 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateProgressStages(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRegisteredAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -507,6 +515,18 @@ func (m *Host) validateProgressStages(formats strfmt.Registry) error {
 			return err
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Host) validateRegisteredAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.RegisteredAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("registered_at", "body", "date-time", m.RegisteredAt.String(), formats); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4462,6 +4462,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 		ID:                       params.NewHostParams.HostID,
 		Href:                     swag.String(url.String()),
 		Kind:                     kind,
+		RegisteredAt:             strfmt.DateTime(time.Now()),
 		CheckedInAt:              strfmt.DateTime(time.Now()),
 		DiscoveryAgentVersion:    params.NewHostParams.DiscoveryAgentVersion,
 		UserName:                 ocm.UserNameFromContext(ctx),

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -77,6 +77,7 @@ func GenerateTestHostByKind(hostID, infraEnvID strfmt.UUID, clusterID *strfmt.UU
 		SuggestedRole:   role,
 		Kind:            swag.String(kind),
 		CheckedInAt:     now,
+		RegisteredAt:    now,
 		StatusUpdatedAt: now,
 		Progress: &models.HostProgressInfo{
 			StageStartedAt: now,
@@ -97,6 +98,7 @@ func GenerateTestHostWithInfraEnv(hostID, infraEnvID strfmt.UUID, state string, 
 		Role:               role,
 		Kind:               swag.String(models.HostKindHost),
 		CheckedInAt:        now,
+		RegisteredAt:       now,
 		StatusUpdatedAt:    now,
 		APIVipConnectivity: GenerateTestAPIVIpConnectivity(""),
 		Connectivity:       GenerateTestConnectivityReport(),
@@ -115,6 +117,7 @@ func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUI
 		Role:              role,
 		Kind:              swag.String(models.HostKindHost),
 		CheckedInAt:       now,
+		RegisteredAt:      now,
 		StatusUpdatedAt:   now,
 		Progress: &models.HostProgressInfo{
 			StageStartedAt: now,

--- a/models/host.go
+++ b/models/host.go
@@ -135,6 +135,10 @@ type Host struct {
 	// progress stages
 	ProgressStages []HostStage `json:"progress_stages" gorm:"-"`
 
+	// The last time the host's agent tried to register in the service.
+	// Format: date-time
+	RegisteredAt strfmt.DateTime `json:"registered_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// requested hostname
 	RequestedHostname string `json:"requested_hostname,omitempty"`
 
@@ -235,6 +239,10 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateProgressStages(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRegisteredAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -507,6 +515,18 @@ func (m *Host) validateProgressStages(formats strfmt.Registry) error {
 			return err
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Host) validateRegisteredAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.RegisteredAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("registered_at", "body", "date-time", m.RegisteredAt.String(), formats); err != nil {
+		return err
 	}
 
 	return nil

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6992,6 +6992,12 @@ func init() {
           },
           "x-go-custom-tag": "gorm:\"-\""
         },
+        "registered_at": {
+          "description": "The last time the host's agent tried to register in the service.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
+        },
         "requested_hostname": {
           "type": "string"
         },
@@ -16319,6 +16325,12 @@ func init() {
             "$ref": "#/definitions/host-stage"
           },
           "x-go-custom-tag": "gorm:\"-\""
+        },
+        "registered_at": {
+          "description": "The last time the host's agent tried to register in the service.",
+          "type": "string",
+          "format": "date-time",
+          "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
         "requested_hostname": {
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4043,6 +4043,11 @@ definitions:
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"
         description: The last time the host's agent communicated with the service.
+      registered_at:
+        type: string
+        format: date-time
+        x-go-custom-tag: gorm:"type:timestamp with time zone"
+        description: The last time the host's agent tried to register in the service.
       discovery_agent_version:
         type: string
       requested_hostname:

--- a/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/vendor/github.com/openshift/assisted-service/models/host.go
@@ -135,6 +135,10 @@ type Host struct {
 	// progress stages
 	ProgressStages []HostStage `json:"progress_stages" gorm:"-"`
 
+	// The last time the host's agent tried to register in the service.
+	// Format: date-time
+	RegisteredAt strfmt.DateTime `json:"registered_at,omitempty" gorm:"type:timestamp with time zone"`
+
 	// requested hostname
 	RequestedHostname string `json:"requested_hostname,omitempty"`
 
@@ -235,6 +239,10 @@ func (m *Host) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateProgressStages(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateRegisteredAt(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -507,6 +515,18 @@ func (m *Host) validateProgressStages(formats strfmt.Registry) error {
 			return err
 		}
 
+	}
+
+	return nil
+}
+
+func (m *Host) validateRegisteredAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.RegisteredAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("registered_at", "body", "date-time", m.RegisteredAt.String(), formats); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This PR introduces a new host property RegisteredAt in order to track
all the registration attemps. This is because an already existing host
can e.g. reboot what would trigger a new registration attempt that
currently is not tracked as a property of the host even though it
triggers an event.

This is going to be helpful as there are scenarios when we want to know
if the host rebooted after the initial registration. With this change it
will be as simple as comparing timestamps of CreatedAt and RegisteredAt.

Contributes-to: [MGMT-11131](https://issues.redhat.com//browse/MGMT-11131)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
