### PR TITLE
NO-ISSUE: fix CONTAINER_COMMAND for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_FOLDER = $(PWD)/build/$(NAMESPACE)
 ROOT_DIR := $(or ${ROOT_DIR},$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST)))))
 CONTAINER_COMMAND := $(or ${CONTAINER_COMMAND},docker)
 ifeq ($(CONTAINER_COMMAND), docker)
-	CONTAINER_COMMAND = $(shell docker -v > /dev/null 2>&1 | cut -f1 -d' ' | tr '[:upper:]' '[:lower:]')
+	CONTAINER_COMMAND = $(shell docker -v 2>/dev/null | cut -f1 -d' ' | tr '[:upper:]' '[:lower:]')
 endif
 TARGET := $(or ${TARGET},local)
 KUBECTL=kubectl -n $(NAMESPACE)


### PR DESCRIPTION
Following to https://github.com/openshift/assisted-service/pull/4116, in case CONTAINER_COMMAND=docker, the var is always set to empty in Makefile.
Since '/dev/null 2>&1' removes both stderr and stdout, the output is always empty.
Instead, only the stderr should be removed to suppress the error when docker is not available.

I.e.
* $ docker -v 2>/dev/null
  output:
  - (when docker is available) `Docker version...`
  - (when docker isn't available) `empty`
* $ docker -v > /dev/null 2>&1
  output: `always empty`

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @osherdp 
/cc @michaellevy101 

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
