### PR TITLE
MGMT-11161: fix rootfs access in PSI installations

### DIFF
--- a/deploy/assisted-installer-ingress.yaml
+++ b/deploy/assisted-installer-ingress.yaml
@@ -31,6 +31,13 @@ spec:
                 name: assisted-image-service
                 port:
                   number: 8080
+          - path: "/boot-artifacts"
+            pathType: Prefix
+            backend:
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080
           - path: "/health"
             pathType: Prefix
             backend:


### PR DESCRIPTION
Seems like we did not route access to '/boot-artifacts' endpoint of the
assisted-image-service. This PR adds this kind of route so that we can
make the flow of minimal-iso that requires it.

Without it, we're getting the following error when booting the hosts:
![image (8)](https://user-images.githubusercontent.com/7492909/178982438-666a283f-682b-4a37-8a77-405ebc6c2fd5.png)

The downloaded file is basically a "500" HTML output in PSI environment, because this route does not exist.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] PSI
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eliorerz 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
