### PR TITLE
Bug-2106496: Make sure that updateInventory function does not use the  internal DB object.

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -314,14 +314,14 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	}
 
 	if h.ClusterID != nil && h.ClusterID.String() != "" {
-		cluster, err = common.GetClusterFromDB(m.db, *h.ClusterID, common.SkipEagerLoading)
+		cluster, err = common.GetClusterFromDB(db, *h.ClusterID, common.SkipEagerLoading)
 		if err != nil {
 			log.WithError(err).Errorf("not updating inventory - failed to find cluster %s", h.ClusterID.String())
 			return common.NewApiError(http.StatusNotFound, err)
 		}
 	}
 
-	infraEnv, err := common.GetInfraEnvFromDB(m.db, h.InfraEnvID)
+	infraEnv, err := common.GetInfraEnvFromDB(db, h.InfraEnvID)
 	if err != nil {
 		log.WithError(err).Errorf("not updating inventory - failed to find infra env %s", h.InfraEnvID.String())
 		return common.NewApiError(http.StatusNotFound, err)


### PR DESCRIPTION
The updateInventory function in the host package is called with db
object parameter.  This may be a transactional object.  If it is, direct
use of the internal db object cause a new db connection to be requested
from the db connection pool.  If all the connections in the db
connection pool are in use, then this function will wait.  Since this
goroutine is holding a transaction, this may result in complete halt of
all database operations.
Changed to use only the db object received as parameter.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @carbonin 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
