### PR TITLE
[WIP] MGMT-11131: Use host's registration time as key for cache

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -370,7 +370,7 @@ func CanonizeStrings(slice []string) (ret []string) {
 }
 
 func GetHostKey(host *models.Host) string {
-	return host.ID.String() + "@" + host.InfraEnvID.String()
+	return host.ID.String() + "@" + host.InfraEnvID.String() + "@" + host.RegisteredAt.String()
 }
 
 // GetTagFromImageRef returns the tag of the given container image reference. For example, if the


### PR DESCRIPTION
It has been discovered that hosts can get different IP addresses when
they reboot post-discovery. Currently our connectivity validations use
only Host ID and InfraEnv ID as a key and never invalidate the entry.
This causes problems if the host changes its IP address, as the
validation can still rely on the old inventory.

Given that the cache exists inside the validator and is not connected
with the inventory and also the fact that unmarshalling the inventory is
an expensive operation, we decided to additionally use registration
timestamp as a key for the cache.

This limits the exposure to the described issue as with this change
whenever the host reboots it will use a new entry in the cache. Doing so
allows us to avoid redesigning the cache mechanism (the performance hit
for invalidating on every inventory update is too big) while solving the
observed issue.

Please note that if for any reason host changes its IP address without
rebooting or restarting the agent, the wrong cache may still be used.
This has been discussed internally and is at the moment accepted to be a
known issue.

Closes: [MGMT-11131](https://issues.redhat.com//browse/MGMT-11131)

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
