### PR TITLE
Change importing of Ansible's nth-host function

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -153,7 +153,7 @@ function nth_ip() {
   network=$1
   idx=$2
 
-  python -c "from ansible_collections.ansible.netcommon.plugins.filter import ipaddr; print(ipaddr.nthhost('"$network"', $idx))"
+  python -c "from ansible_collections.ansible.utils.plugins.filter import nthhost; print(nthhost.nthhost('"$network"', $idx))"
 }
 
 function retry() {


### PR DESCRIPTION
Since bump of Ansible to v5.9.0
(https://github.com/openshift-metal3/dev-scripts/pull/1407) we no longer
have the function
``ansible_collections.ansible.netcommon.plugins.filter.ipaddr`` but rather
it's placed at
``ansible_collections.ansible.utils.plugins.filter.nthhost``.

Otherwise, we get the following warning:
```
++ python -c 'from ansible_collections.ansible.netcommon.plugins.filter import ipaddr; print(ipaddr.nthhost('\''192.168.111.0/24'\'', 85))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'ipaddr' from 'ansible_collections.ansible.netcommon.plugins.filter' (/usr/local/lib/python3.9/site-packages/ansible_collections/ansible/netcommon/plugins/filter/__init__.py)
```
and the ``SPOKE_API_VIP`` and ``SPOKE_INGRESS_VIP`` are set to empty values that are required for multi-node installations.

(see https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-master-edge-e2e-ai-operator-ztp-ipv4v6-3masters-ocp-410-periodic/1548488805265182720 for example)

I'm not sure why it only been printed as a warning, but that's another issue that should be investigated and resolved (so that next time we'll get a better presentation of the issue)

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @mkowalski 
/cc @eranco74 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
