### PR TITLE
MGMT-11161: Add "/boot-artifacts/" route to ingress-tls

### DIFF
--- a/deploy/assisted-installer-ingress-tls.yaml
+++ b/deploy/assisted-installer-ingress-tls.yaml
@@ -37,6 +37,13 @@ spec:
                 name: assisted-image-service
                 port:
                   number: 8080
+          - path: "/boot-artifacts"
+            pathType: Prefix
+            backend:
+              service:
+                name: assisted-image-service
+                port:
+                  number: 8080
           - path: "/health"
             pathType: Prefix
             backend:


### PR DESCRIPTION
Back in https://github.com/openshift/assisted-service/pull/4134 I've added the ``/boot-artifacts/`` route to the regular ingress yaml that is supposedly not used in PSI installations. This will hopefully do the fix as required.

QE will test those changes, now that they have added the ability to parameterize branches.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eliorerz 
/cc @danielerez 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
