### PR TITLE
MGMT-10861:  When removing/adding api* and apps records, it takes 5-15 minutes till host/cluster status is updated

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -768,7 +768,11 @@ func (m *Manager) UpdateDomainNameResolution(ctx context.Context, h *models.Host
 		db = m.db
 	}
 	if string(response) != h.DomainNameResolutions {
-		if err := db.Model(h).Update("domain_name_resolutions", string(response)).Error; err != nil {
+		updates := map[string]interface{}{
+			"domain_name_resolutions":   string(response),
+			"trigger_monitor_timestamp": time.Now(),
+		}
+		if err := db.Model(h).Updates(updates).Error; err != nil {
 			return errors.Wrapf(err, "failed to update api_domain_name_resolution to host %s", h.ID.String())
 		}
 	}


### PR DESCRIPTION


In order to make sure that domain name resolution validation is updated
right after the domain resolution result of the host is updated, the
trigger_monitor_timestamp is updated along with the domain resolution.
Setting this field causes the monitor to be triggered.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
