### PR TITLE
MGMT-9354: Define agent labels as variables

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -59,9 +59,16 @@ import (
 )
 
 const (
-	AgentFinalizerName   = "agent." + aiv1beta1.Group + "/ai-deprovision"
-	BaseLabelPrefix      = aiv1beta1.Group + "/"
-	InventoryLabelPrefix = "inventory." + BaseLabelPrefix
+	AgentFinalizerName                   = "agent." + aiv1beta1.Group + "/ai-deprovision"
+	BaseLabelPrefix                      = aiv1beta1.Group + "/"
+	InventoryLabelPrefix                 = "inventory." + BaseLabelPrefix
+	AgentLabelHasNonrotationalDisk       = InventoryLabelPrefix + "storage-hasnonrotationaldisk"
+	AgentLabelCpuArchitecture            = InventoryLabelPrefix + "cpu-architecture"
+	AgentLabelCpuVirtEnabled             = InventoryLabelPrefix + "cpu-virtenabled"
+	AgentLabelHostManufacturer           = InventoryLabelPrefix + "host-manufacturer"
+	AgentLabelHostProductName            = InventoryLabelPrefix + "host-productname"
+	AgentLabelHostIsVirtual              = InventoryLabelPrefix + "host-isvirtual"
+	AgentLabelClusterDeploymentNamespace = BaseLabelPrefix + "clusterdeployment-namespace"
 )
 
 // AgentReconciler reconciles a Agent object
@@ -1001,18 +1008,18 @@ func (r *AgentReconciler) updateLabels(log logrus.FieldLogger, ctx context.Conte
 
 	changed := false
 	changed = setAgentAnnotation(log, agent, InventoryLabelPrefix+"version", "0.1") || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"storage-hasnonrotationaldisk", strconv.FormatBool(hasSSD)) || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"cpu-architecture", inventory.Cpu.Architecture) || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"cpu-virtenabled", strconv.FormatBool(hasVirt)) || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"host-manufacturer", inventory.SystemVendor.Manufacturer) || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"host-productname", inventory.SystemVendor.ProductName) || changed
-	changed = setAgentLabel(log, agent, InventoryLabelPrefix+"host-isvirtual", strconv.FormatBool(inventory.SystemVendor.Virtual)) || changed
+	changed = setAgentLabel(log, agent, AgentLabelHasNonrotationalDisk, strconv.FormatBool(hasSSD)) || changed
+	changed = setAgentLabel(log, agent, AgentLabelCpuArchitecture, inventory.Cpu.Architecture) || changed
+	changed = setAgentLabel(log, agent, AgentLabelCpuVirtEnabled, strconv.FormatBool(hasVirt)) || changed
+	changed = setAgentLabel(log, agent, AgentLabelHostManufacturer, inventory.SystemVendor.Manufacturer) || changed
+	changed = setAgentLabel(log, agent, AgentLabelHostProductName, inventory.SystemVendor.ProductName) || changed
+	changed = setAgentLabel(log, agent, AgentLabelHostIsVirtual, strconv.FormatBool(inventory.SystemVendor.Virtual)) || changed
 
 	namespace := ""
 	if agent.Spec.ClusterDeploymentName != nil {
 		namespace = agent.Spec.ClusterDeploymentName.Namespace
 	}
-	changed = setAgentLabel(log, agent, BaseLabelPrefix+"clusterdeployment-namespace", namespace) || changed
+	changed = setAgentLabel(log, agent, AgentLabelClusterDeploymentNamespace, namespace) || changed
 
 	if changed {
 		if err := r.Update(ctx, agent); err != nil {

--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -65,7 +65,6 @@ type BMACReconciler struct {
 
 const (
 	AGENT_BMH_LABEL                     = "agent-install.openshift.io/bmh"
-	AGENT_CD_LABEL                      = "agent-install.openshift.io/clusterdeployment-namespace"
 	BMH_AGENT_ROLE                      = "bmac.agent-install.openshift.io/role"
 	BMH_AGENT_HOSTNAME                  = "bmac.agent-install.openshift.io/hostname"
 	BMH_AGENT_MACHINE_CONFIG_POOL       = "bmac.agent-install.openshift.io/machine-config-pool"
@@ -969,7 +968,7 @@ func (r *BMACReconciler) findInstallationDiskID(devices []aiv1beta1.HostDisk, hi
 // matches this ClusterDeployment's name.
 func (r *BMACReconciler) findAgentsByClusterDeployment(ctx context.Context, clusterDeployment *hivev1.ClusterDeployment) []*aiv1beta1.Agent {
 	agentList := aiv1beta1.AgentList{}
-	err := r.Client.List(ctx, &agentList, client.MatchingLabels{AGENT_CD_LABEL: clusterDeployment.Namespace})
+	err := r.Client.List(ctx, &agentList, client.MatchingLabels{AgentLabelClusterDeploymentNamespace: clusterDeployment.Namespace})
 	if err != nil {
 		return []*aiv1beta1.Agent{}
 	}

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -1445,7 +1445,7 @@ func newAgentWithClusterReference(name string, namespace string, ipv4address str
 	}
 	agent.Spec.ClusterDeploymentName = &v1beta1.ClusterReference{Name: clusterName, Namespace: namespace}
 	agent.ObjectMeta.Labels = make(map[string]string)
-	agent.ObjectMeta.Labels[AGENT_CD_LABEL] = namespace
+	agent.ObjectMeta.Labels[AgentLabelClusterDeploymentNamespace] = namespace
 	if agentBMHLabel != "" {
 		agent.ObjectMeta.Labels[AGENT_BMH_LABEL] = agentBMHLabel
 	}

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1592,7 +1592,7 @@ func (r *ClusterDeploymentsReconciler) getNumOfClusterAgents(c *common.Cluster) 
 func findAgentsByAgentClusterInstall(k8sclient client.Client, ctx context.Context, log logrus.FieldLogger, aci *hiveext.AgentClusterInstall) ([]aiv1beta1.Agent, error) {
 	agentList := aiv1beta1.AgentList{}
 	agents := []aiv1beta1.Agent{}
-	err := k8sclient.List(ctx, &agentList, client.MatchingLabels{aiv1beta1.Group + "/clusterdeployment-namespace": aci.Namespace})
+	err := k8sclient.List(ctx, &agentList, client.MatchingLabels{AgentLabelClusterDeploymentNamespace: aci.Namespace})
 
 	if err != nil {
 		return agents, err


### PR DESCRIPTION
Define agent labels as variables

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @eranco74 
/cc @mkowalski 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
