### PR TITLE
MGMT-8818: clusterdeployments: set HTTPS Ignition URL when finalizing the cluster

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -15253,3 +15253,88 @@ var _ = Describe("GetHostByKubeKey", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("UpdateIgnitionEndpointIfHasMCSCert", func() {
+	var (
+		bm      *bareMetalInventory
+		cfg     Config
+		db      *gorm.DB
+		dbName  string
+		cluster *common.Cluster
+		log     logrus.FieldLogger
+	)
+	const (
+		httpIgnitionEndpointUrl  = "http://api.foo.bar.com:22624/config/custom-pool"
+		httpsIgnitionEndpointUrl = "https://api-int.foo.bar.com:22623/config/custom-pool"
+		masterIgn                = `{
+		  "ignition": {
+		    "config": {
+		      "merge": [
+			{
+			  "source": "https://192.168.126.199:22623/config/master"
+			}
+		      ]
+		    },
+		    "security": {
+		      "tls": {
+			"certificateAuthorities": [
+			  {
+			    "source": "data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFRENDQWZpZ0F3SUJBZ0lJUk90aUgvOC82ckF3RFFZSktvWklodmNOQVFFTEJRQXdKakVTTUJBR0ExVUUKQ3hNSmIzQmxibk5vYVdaME1SQXdEZ1lEVlFRREV3ZHliMjkwTFdOaE1CNFhEVEl3TURreE9ERTVORFV3TVZvWApEVE13TURreE5qRTVORFV3TVZvd0pqRVNNQkFHQTFVRUN4TUpiM0JsYm5Ob2FXWjBNUkF3RGdZRFZRUURFd2R5CmIyOTBMV05oTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE1c1orVWtaaGsxUWQKeFU3cWI3YXArNFczaS9ZWTFzZktURC8ybDVJTjFJeVhPajlSL1N2VG5SOGYvajNJa1JHMWN5ZXR4bnNlNm1aZwpaOW1IRDJMV0srSEFlTTJSYXpuRkEwVmFwOWxVbVRrd3Vza2Z3QzhnMWJUZUVHUlEyQmFId09KekpvdjF4a0ZICmU2TUZCMlcxek1rTWxLTkwycnlzMzRTeVYwczJpNTFmTTJvTEM2SXRvWU91RVVVa2o0dnVUbThPYm5rV0t4ZnAKR1VGMThmNzVYeHJId0tVUEd0U0lYMGxpVGJNM0tiTDY2V2lzWkFIeStoN1g1dnVaaFYzYXhwTVFMdlczQ2xvcQpTaG9zSXY4SWNZbUJxc210d2t1QkN3cWxibEo2T2gzblFrelorVHhQdGhkdWsrZytzaVBUNi9va0JKU2M2cURjClBaNUNyN3FrR3dJREFRQUJvMEl3UURBT0JnTlZIUThCQWY4RUJBTUNBcVF3RHdZRFZSMFRBUUgvQkFVd0F3RUIKL3pBZEJnTlZIUTRFRmdRVWNSbHFHT1g3MWZUUnNmQ0tXSGFuV3NwMFdmRXdEUVlKS29aSWh2Y05BUUVMQlFBRApnZ0VCQU5Xc0pZMDY2RnNYdzFOdXluMEkwNUtuVVdOMFY4NVJVV2drQk9Wd0J5bHluTVRneGYyM3RaY1FsS0U4CjVHMlp4Vzl5NmpBNkwzMHdSNWhOcnBzM2ZFcUhobjg3UEM3L2tWQWlBOWx6NjBwV2ovTE5GU1hobDkyejBGMEIKcGNUQllFc1JNYU0zTFZOK0tZb3Q2cnJiamlXdmxFMU9hS0Q4dnNBdkk5YXVJREtOdTM0R2pTaUJGWXMrelRjSwphUUlTK3UzRHVYMGpVY001aUgrMmwzNGxNR0hlY2tjS1hnUWNXMGJiT28xNXY1Q2ExenJtQ2hIUHUwQ2NhMU1MCjJaM2MxMHVXZnR2OVZnbC9LcEpzSjM3b0phbTN1Mmp6MXN0K3hHby9iTmVSdHpOMjdXQSttaDZ6bXFwRldYKzUKdWFjZUY1SFRWc0FkbmtJWHpwWXBuek5qb0lFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+			  }
+			]
+		      }
+		    },
+		    "version": "3.2.0"
+		  },
+		  "storage": {}
+		}`
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		bm = createInventory(db, cfg)
+		cluster = createClusterWithAvailability(db, models.ClusterStatusReady, models.ClusterCreateParamsHighAvailabilityModeNone)
+		cluster.Name = "foo"
+		cluster.BaseDNSDomain = "bar.com"
+		// this doesn't need to be a VM, but any host works for this test
+		addVMToCluster(cluster, db)
+		log = logrus.New()
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+		ctrl.Finish()
+	})
+
+	It("no ignition overrides for host set", func() {
+		h := cluster.Hosts[0]
+		ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+	})
+
+	It("ignition override has no CA set", func() {
+		h := cluster.Hosts[0]
+		h.IgnitionConfigOverrides = "{}"
+		ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+	})
+
+	It("bm has no k8sclient", func() {
+		h := cluster.Hosts[0]
+		h.IgnitionConfigOverrides = masterIgn
+		bm.k8sClient = nil
+		ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+	})
+
+	It("should use https", func() {
+		h := cluster.Hosts[0]
+		h.IgnitionConfigOverrides = masterIgn
+		ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ignitionEndpointUrl).To(Equal(httpsIgnitionEndpointUrl))
+	})
+})

--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -16,3 +16,9 @@ const InternalAPIClusterSubdomain = "api-int"
 // domain *does* resolve then the validation failed, as it indicates a wildcard configuration that
 // is known to be problematic for OCP
 const DNSWildcardFalseDomainName = "validateNoWildcardDNS"
+
+// HTTPS-backed machine config server port
+const SecureMCSPort = 22623
+
+// Plain http machine config server port
+const InsecureMCSPort = 22624

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/swag"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"github.com/pkg/errors"
@@ -325,7 +326,7 @@ func GetIgnitionEndpoint(cluster *common.Cluster, host *models.Host) (string, er
 		poolName = host.MachineConfigPoolName
 	}
 
-	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", common.GetAPIHostname(cluster), poolName)
+	ignitionEndpointUrl := fmt.Sprintf("http://%s:%d/config/%s", common.GetAPIHostname(cluster), constants.InsecureMCSPort, poolName)
 	if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
 		url, err := url.Parse(*cluster.IgnitionEndpoint.URL)
 		if err != nil {

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1157,6 +1157,14 @@ func setCACertInIgnition(role models.HostRole, path string, workDir string, caCe
 	return nil
 }
 
+func HasCACertInIgnition(contents string) bool {
+	config, err := ParseToLatest([]byte(contents))
+	if err != nil {
+		return false
+	}
+	return len(config.Ignition.Security.TLS.CertificateAuthorities) > 0
+}
+
 func writeHostFiles(hosts []*models.Host, baseFile string, workDir string) error {
 	g := new(errgroup.Group)
 	for i := range hosts {


### PR DESCRIPTION
When possible, fetch MCS certificate from spoke cluster and use it to provision day2 workers via HTTPS Ignition endpoint.

## List all the issues related to this PR

- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->

## What environments does this code impact?

- [x] Operator Managed Deployments

## How was this code tested?

- [x] Waiting for CI to do a full test run

TODO:
* [x] atm the code assumes that if IgnitionOverrides has CA its the CA set by BMH controller (it fetches MCS cert after cluster is transitioned to day 2) and its an operator-backed instance. So, there is at least one usecase where this might have a false-positive case:
* * hub cannot contact spoke cluster and won't add MCS cert to ignition override
* * user has set Ignition override with CA manually

In that case day2 worker would attempt to use HTTPS and fail as Ignition server cannot be contacted using user-provided CA.
Do we consider this usecase likely to happen and serious enough to fix?

Discussed with mko and omer - hub->spoke connection is a requirement on day2, so we can rely on having MCS cert in ignition override. Users are rarely setting host-specific overrides for CA (this would be replaced by a new API later), so it looks like a low-risk assumption to me

* [x] add unit tests
