### PR TITLE
MGMT-10973 - kube-api imported clusters should be considered imported

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -148,7 +148,7 @@ type InstallerInternals interface {
 	GetCredentialsInternal(ctx context.Context, params installer.V2GetCredentialsParams) (*models.Credentials, error)
 	V2DownloadClusterFilesInternal(ctx context.Context, params installer.V2DownloadClusterFilesParams) (io.ReadCloser, int64, error)
 	V2DownloadClusterCredentialsInternal(ctx context.Context, params installer.V2DownloadClusterCredentialsParams) (io.ReadCloser, int64, error)
-	V2ImportClusterInternal(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID, params installer.V2ImportClusterParams, imported bool) (*common.Cluster, error)
+	V2ImportClusterInternal(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID, params installer.V2ImportClusterParams) (*common.Cluster, error)
 	InstallSingleDay2HostInternal(ctx context.Context, clusterId strfmt.UUID, infraEnvId strfmt.UUID, hostId strfmt.UUID) error
 	UpdateClusterInstallConfigInternal(ctx context.Context, params installer.V2UpdateClusterInstallConfigParams) (*common.Cluster, error)
 	CancelInstallationInternal(ctx context.Context, params installer.V2CancelInstallationParams) (*common.Cluster, error)
@@ -708,7 +708,7 @@ func importedClusterBaseDomain(hostname string) (string, string) {
 }
 
 func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID,
-	params installer.V2ImportClusterParams, imported bool) (*common.Cluster, error) {
+	params installer.V2ImportClusterParams) (*common.Cluster, error) {
 	url := installer.V2GetClusterURL{ClusterID: *id}
 
 	log := logutil.FromContext(ctx, b.log).WithField(ctxparams.ClusterId, id)
@@ -753,7 +753,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		HostNetworks:       []*models.HostNetwork{},
 		Hosts:              []*models.Host{},
 		Platform:           &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
-		Imported:           &imported,
+		Imported:           swag.Bool(true),
 	},
 		KubeKeyName:      kubeKey.Name,
 		KubeKeyNamespace: kubeKey.Namespace,

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -469,7 +469,7 @@ func (b *bareMetalInventory) V2ListFeatureSupportLevels(ctx context.Context, par
 
 func (b *bareMetalInventory) V2ImportCluster(ctx context.Context, params installer.V2ImportClusterParams) middleware.Responder {
 	id := strfmt.UUID(uuid.New().String())
-	c, err := b.V2ImportClusterInternal(ctx, nil, &id, params, true)
+	c, err := b.V2ImportClusterInternal(ctx, nil, &id, params)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -474,18 +474,18 @@ func (mr *MockInstallerInternalsMockRecorder) V2DownloadClusterFilesInternal(arg
 }
 
 // V2ImportClusterInternal mocks base method.
-func (m *MockInstallerInternals) V2ImportClusterInternal(arg0 context.Context, arg1 *types.NamespacedName, arg2 *strfmt.UUID, arg3 installer.V2ImportClusterParams, arg4 bool) (*common.Cluster, error) {
+func (m *MockInstallerInternals) V2ImportClusterInternal(arg0 context.Context, arg1 *types.NamespacedName, arg2 *strfmt.UUID, arg3 installer.V2ImportClusterParams) (*common.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2ImportClusterInternal", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "V2ImportClusterInternal", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*common.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // V2ImportClusterInternal indicates an expected call of V2ImportClusterInternal.
-func (mr *MockInstallerInternalsMockRecorder) V2ImportClusterInternal(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockInstallerInternalsMockRecorder) V2ImportClusterInternal(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2ImportClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2ImportClusterInternal), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2ImportClusterInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2ImportClusterInternal), arg0, arg1, arg2, arg3)
 }
 
 // V2UpdateHostIgnitionInternal mocks base method.

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1239,14 +1239,9 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 		clusterParams.OpenshiftClusterID = &cid
 	}
 
-	// TODO: Remove this once CAPI tests are fixed to create the right DNS entries.
-	// For now we set it to false because CAPI tests don't have the right DNS entries
-	// and it will cause DNS validations to be disabled. This is just a temporary hack.
-	imported := false
-
 	c, err := r.Installer.V2ImportClusterInternal(ctx, &key, &id, installer.V2ImportClusterParams{
 		NewImportClusterParams: clusterParams,
-	}, imported)
+	})
 	if err != nil {
 		log.WithError(err).Error("failed to create day2 cluster")
 	}

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -522,7 +522,7 @@ var _ = Describe("cluster reconcile", func() {
 				cluster.Spec.Installed = true
 				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
 
-				mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
 				aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, getDefaultSNOAgentClusterInstallSpec(clusterName), cluster)
 				aci.Spec.ImageSetRef = nil
@@ -2973,12 +2973,12 @@ var _ = Describe("cluster reconcile", func() {
 			}
 
 			V2ImportClusterInternal := func(ctx context.Context, kubeKey *types.NamespacedName, id *strfmt.UUID,
-				params installer.V2ImportClusterParams, imported bool) (*common.Cluster, error) {
+				params installer.V2ImportClusterParams) (*common.Cluster, error) {
 				Expect(string(*params.NewImportClusterParams.OpenshiftClusterID)).To(Equal(cid))
 				return clusterReply, nil
 			}
 			mockInstallerInternal.EXPECT().
-				V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(V2ImportClusterInternal)
 
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
@@ -2993,7 +2993,7 @@ var _ = Describe("cluster reconcile", func() {
 
 		It("failure creating cluster", func() {
 			mockInstallerInternal.EXPECT().
-				V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf("failed to import cluster"))
 
 			request := newClusterDeploymentRequest(cluster)


### PR DESCRIPTION
As part of 564650feca372064314282d98d6fd9c6ee69bd2c we pretended
imported kube-api clusters are not imported, which is wrong, just
to disable DNS validations because those validations were causing
issues in the CAPI CI and we had to merge the PR quickly because
it was needed for a SaaS release.

This commit reverts that hack. We expect the capi CI to fail, but
at-least now we can fix it without hurrying to get it merged for
a release.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eranco74

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md