### PR TITLE
MGMT-11124: remove usage of IMAGE_SERVICE_SCHEME/HOST

### DIFF
--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -51,10 +51,8 @@ items:
                 value: http
               - name: ASSISTED_SERVICE_HOST
                 value: assisted-service:8090
-              - name: IMAGE_SERVICE_SCHEME
-                value: REPLACE_IMAGE_SERVICE_SCHEME
-              - name: IMAGE_SERVICE_HOST
-                value: REPLACE_IMAGE_SERVICE_HOST
+              - name: IMAGE_SERVICE_BASE_URL
+                value: REPLACE_IMAGE_SERVICE_BASE_URL
               - name: ALLOWED_DOMAINS
                 value: "*"
         serviceAccountName: assisted-service

--- a/deploy/podman/configmap.yml
+++ b/deploy/podman/configmap.yml
@@ -17,8 +17,6 @@ data:
   ENABLE_SINGLE_NODE_DNSMASQ: "true"
   HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]'
   IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
-  IMAGE_SERVICE_HOST: 127.0.0.1:8888
-  IMAGE_SERVICE_SCHEME: http
   IPV6_SUPPORT: "true"
   ISO_IMAGE_TYPE: "full-iso"
   LISTEN_PORT: "8888"

--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -17,8 +17,6 @@ data:
   ENABLE_SINGLE_NODE_DNSMASQ: "false"
   HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]'
   IMAGE_SERVICE_BASE_URL: http://127.0.0.1:8888
-  IMAGE_SERVICE_HOST: 127.0.0.1:8888
-  IMAGE_SERVICE_SCHEME: http
   IPV6_SUPPORT: "true"
   ISO_IMAGE_TYPE: "full-iso"
   LISTEN_PORT: "8888"

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -864,17 +864,14 @@ var _ = Describe("reconcileImageServiceStatefulSet", func() {
 		found := &appsv1.StatefulSet{}
 		Expect(ascr.reconcileImageServiceStatefulSet(ctx, log, asc)).To(Succeed())
 		Expect(ascr.Client.Get(ctx, types.NamespacedName{Name: imageServiceName, Namespace: testNamespace}, found)).To(Succeed())
-		var scheme, host string
+		var baseURL string
 		for _, envVar := range found.Spec.Template.Spec.Containers[0].Env {
 			switch envVar.Name {
-			case "IMAGE_SERVICE_SCHEME":
-				scheme = envVar.Value
-			case "IMAGE_SERVICE_HOST":
-				host = envVar.Value
+			case "IMAGE_SERVICE_BASE_URL":
+				baseURL = envVar.Value
 			}
 		}
-		Expect(scheme).To(Equal("https"))
-		Expect(host).To(Equal("my.test.images"))
+		Expect(baseURL).To(Equal("https://my.test.images"))
 	})
 })
 

--- a/tools/deploy_image_service.py
+++ b/tools/deploy_image_service.py
@@ -53,9 +53,7 @@ def main():
                                                                             namespace=deploy_options.namespace,
                                                                             disable_tls=deploy_options.disable_tls,
                                                                             check_connection=True))
-        parsed_url = urlparse(image_service_base_url)
-        raw_data = raw_data.replace('REPLACE_IMAGE_SERVICE_SCHEME', parsed_url.scheme)
-        raw_data = raw_data.replace('REPLACE_IMAGE_SERVICE_HOST', parsed_url.netloc)
+        raw_data = raw_data.replace('REPLACE_IMAGE_SERVICE_BASE_URL', image_service_base_url)
 
         data = yaml.safe_load(raw_data)
         log.info(data)


### PR DESCRIPTION
Following to https://github.com/openshift/assisted-image-service/pull/88 and https://github.com/openshift/assisted-image-service/pull/89, IMAGE_SERVICE_SCHEME and IMAGE_SERVICE_HOST vars are now deprecated. Instead, all deployments should now specify only  IMAGE_SERVICE_BASE_URL.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
