### PR TITLE
MGMT-10816: Returning the actual resulting cluster platform

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -291,7 +291,8 @@ func (b *bareMetalInventory) updatePullSecret(pullSecret string, log logrus.Fiel
 	return pullSecret, nil
 }
 
-func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, params installer.V2RegisterClusterParams) installer.V2RegisterClusterParams {
+func (b *bareMetalInventory) setDefaultRegisterClusterParams(ctx context.Context, params installer.V2RegisterClusterParams) (installer.V2RegisterClusterParams, error) {
+	log := logutil.FromContext(ctx, b.log)
 	if params.NewClusterParams.ClusterNetworks == nil {
 		params.NewClusterParams.ClusterNetworks = []*models.ClusterNetwork{
 			{Cidr: models.Subnet(b.Config.DefaultClusterNetworkCidr), HostPrefix: b.Config.DefaultClusterNetworkHostPrefix},
@@ -309,20 +310,27 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 	if params.NewClusterParams.VipDhcpAllocation == nil {
 		params.NewClusterParams.VipDhcpAllocation = swag.Bool(false)
 	}
-	if params.NewClusterParams.UserManagedNetworking == nil {
-		params.NewClusterParams.UserManagedNetworking = swag.Bool(false)
-	}
 	if params.NewClusterParams.Hyperthreading == nil {
 		params.NewClusterParams.Hyperthreading = swag.String(models.ClusterHyperthreadingAll)
 	}
 	if params.NewClusterParams.SchedulableMasters == nil {
 		params.NewClusterParams.SchedulableMasters = swag.Bool(false)
 	}
-	if params.NewClusterParams.Platform == nil {
-		params.NewClusterParams.Platform = &models.Platform{
-			Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
-		}
+	if params.NewClusterParams.HighAvailabilityMode == nil {
+		params.NewClusterParams.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
 	}
+
+	log.Infof("Verifying cluster platform and user-managed-networking, got platform=%v and userManagedNetworking=%v", params.NewClusterParams.Platform, params.NewClusterParams.UserManagedNetworking)
+	platform, userManagedNetworking, err := getActualCreateClusterPlatformParams(params.NewClusterParams.Platform, params.NewClusterParams.UserManagedNetworking, params.NewClusterParams.HighAvailabilityMode)
+	if err != nil {
+		log.Error(err)
+		return params, err
+	}
+
+	params.NewClusterParams.Platform = platform
+	params.NewClusterParams.UserManagedNetworking = userManagedNetworking
+	log.Infof("Cluster high-availability-mode is set to %v, setting platform type to %v and user-managed-networking to %v", params.NewClusterParams.HighAvailabilityMode, platform, userManagedNetworking)
+
 	if params.NewClusterParams.AdditionalNtpSource == nil {
 		params.NewClusterParams.AdditionalNtpSource = &b.Config.DefaultNTPSource
 	}
@@ -333,7 +341,7 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(_ context.Context, 
 		}
 	}
 
-	return params
+	return params, nil
 }
 
 func (b *bareMetalInventory) validateRegisterClusterInternalParams(params *installer.V2RegisterClusterParams, log logrus.FieldLogger) error {
@@ -421,11 +429,15 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	if err = validations.ValidateDualStackNetworks(params.NewClusterParams, false); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
-	if err = b.validateRegisterClusterInternalParams(&params, log); err != nil {
+
+	params, err = b.setDefaultRegisterClusterParams(ctx, params)
+	if err != nil {
 		return nil, err
 	}
 
-	params = b.setDefaultRegisterClusterParams(ctx, params)
+	if err = b.validateRegisterClusterInternalParams(&params, log); err != nil {
+		return nil, err
+	}
 
 	cpuArchitecture, err := b.getNewClusterCPUArchitecture(params.NewClusterParams)
 	if err != nil {
@@ -1668,6 +1680,93 @@ func (b *bareMetalInventory) UpdateClusterNonInteractive(ctx context.Context, pa
 	return b.v2UpdateClusterInternal(ctx, params, NonInteractive)
 }
 
+func checkPlatformWrongParamsInput(platform *models.Platform, userManagedNetworking *bool) error {
+	if platform != nil && userManagedNetworking != nil {
+		userManagedNetworkingStatus := "enabled"
+		if !*userManagedNetworking {
+			userManagedNetworkingStatus = "disabled"
+		}
+
+		if (!*userManagedNetworking && *platform.Type == models.PlatformTypeNone) || (*userManagedNetworking && models.PlatformTypeBaremetal == *platform.Type) {
+			return common.NewApiError(http.StatusBadRequest, errors.Errorf("Can't set %s platform with user-managed-networking %s", *platform.Type, userManagedNetworkingStatus))
+		}
+	}
+
+	return nil
+}
+
+func getActualUpdateClusterPlatformParams(platform *models.Platform, userManagedNetworking *bool, cluster *common.Cluster) (*models.Platform, *bool, error) {
+	if platform == nil && userManagedNetworking == nil {
+		return nil, nil, nil
+	}
+
+	if err := checkPlatformWrongParamsInput(platform, userManagedNetworking); err != nil {
+		return nil, nil, err
+	}
+
+	if *cluster.Platform.Type == models.PlatformTypeBaremetal {
+		if !swag.BoolValue(userManagedNetworking) && (platform == nil || *platform.Type == models.PlatformTypeBaremetal) {
+			// Platform is already baremetal, nothing to do
+			return nil, nil, nil
+		}
+
+		if (platform != nil && *platform.Type == models.PlatformTypeNone) || (swag.BoolValue(userManagedNetworking) && platform == nil) {
+			return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)}, swag.Bool(true), nil
+		}
+	} else if *cluster.Platform.Type == models.PlatformTypeNone {
+		if (userManagedNetworking == nil || *userManagedNetworking) && (platform == nil || *platform.Type == models.PlatformTypeNone) {
+			// Platform is already none, nothing to do
+			return nil, nil, nil
+		}
+
+		if *cluster.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			if !swag.BoolValue(userManagedNetworking) || (platform != nil && *platform.Type != models.PlatformTypeNone) {
+				return nil, nil, common.NewApiError(http.StatusBadRequest, errors.New("disabling User Managed Networking or setting platform different than none platform is not allowed in single node Openshift"))
+			}
+		}
+
+		if !swag.BoolValue(userManagedNetworking) {
+			if platform == nil || *platform.Type == models.PlatformTypeBaremetal {
+				if cluster.CPUArchitecture != common.X86CPUArchitecture && !featuresupport.IsFeatureSupported(cluster.OpenshiftVersion, models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTUREWITHCLUSTERMANAGEDNETWORKING) {
+					return nil, nil, common.NewApiError(http.StatusBadRequest, errors.New("disabling User Managed Networking or setting Bare-Metal platform is not allowed for clusters with non-x86_64 CPU architecture"))
+				}
+
+				return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)}, swag.Bool(false), nil
+			}
+		}
+	}
+
+	return platform, userManagedNetworking, nil
+}
+
+func getActualCreateClusterPlatformParams(platform *models.Platform, userManagedNetworking *bool, highAvailabilityMode *string) (*models.Platform, *bool, error) {
+	if err := checkPlatformWrongParamsInput(platform, userManagedNetworking); err != nil {
+		return nil, nil, err
+	}
+
+	if *highAvailabilityMode == models.ClusterHighAvailabilityModeFull {
+		if (platform == nil || *platform.Type == models.PlatformTypeBaremetal) && !swag.BoolValue(userManagedNetworking) {
+			return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)}, swag.Bool(false), nil
+		}
+
+		if swag.BoolValue(userManagedNetworking) || (platform != nil && *platform.Type == models.PlatformTypeNone) {
+			return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)}, swag.Bool(true), nil
+		}
+	} else { // *highAvailabilityMode == models.ClusterHighAvailabilityModeNone
+		if platform != nil && *platform.Type == models.PlatformTypeBaremetal {
+			return nil, nil, common.NewApiError(http.StatusBadRequest, errors.Errorf("Can't set %s platform on single node OpenShift", *platform.Type))
+		}
+
+		if userManagedNetworking != nil && !*userManagedNetworking {
+			return nil, nil, common.NewApiError(http.StatusBadRequest, errors.New("Can't disable user-managed-networking on single node OpenShift"))
+		}
+
+		return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)}, swag.Bool(true), nil
+	}
+
+	return platform, userManagedNetworking, nil
+}
+
 func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params installer.V2UpdateClusterParams, interactivity Interactivity) (*common.Cluster, error) {
 	log := logutil.FromContext(ctx, b.log)
 	var cluster *common.Cluster
@@ -1719,6 +1818,18 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 		log.WithError(err).Errorf("cluster %s can't be updated in current state", params.ClusterID)
 		return nil, common.NewApiError(http.StatusConflict, err)
 	}
+
+	log.Infof("Current cluster platform is set to %v and user-managed-networking is set to %v", cluster.Platform, cluster.UserManagedNetworking)
+	log.Infof("Verifying cluster platform and user-managed-networking, got platform=%v and userManagedNetworking=%v", params.ClusterUpdateParams.Platform, params.ClusterUpdateParams.UserManagedNetworking)
+	platform, userManagedNetworking, err := getActualUpdateClusterPlatformParams(params.ClusterUpdateParams.Platform, params.ClusterUpdateParams.UserManagedNetworking, cluster)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	params.ClusterUpdateParams.Platform = platform
+	params.ClusterUpdateParams.UserManagedNetworking = userManagedNetworking
+	log.Infof("Platform verification completed, setting platform type to %v and user-managed-networking to %v", platform, userManagedNetworking)
 
 	if err = b.v2NoneHaModeClusterUpdateValidations(cluster, params); err != nil {
 		log.WithError(err).Warnf("Unsupported update params in none ha mode")

--- a/internal/provider/baremetal/base.go
+++ b/internal/provider/baremetal/base.go
@@ -8,19 +8,21 @@ import (
 
 //
 type baremetalProvider struct {
-	Log logrus.FieldLogger
+	Log  logrus.FieldLogger
+	name models.PlatformType
 }
 
 // NewBaremetalProvider creates a new baremetal provider.
-func NewBaremetalProvider(log logrus.FieldLogger) provider.Provider {
+func NewBaremetalProvider(log logrus.FieldLogger, name models.PlatformType) provider.Provider {
 	return &baremetalProvider{
-		Log: log,
+		Log:  log,
+		name: name,
 	}
 }
 
 // Name returns the name of the provider
 func (p *baremetalProvider) Name() models.PlatformType {
-	return models.PlatformTypeBaremetal
+	return p.name
 }
 
 func (p *baremetalProvider) IsHostSupported(_ *models.Host) (bool, error) {

--- a/internal/provider/registry/registry.go
+++ b/internal/provider/registry/registry.go
@@ -161,6 +161,7 @@ func InitProviderRegistry(log logrus.FieldLogger) ProviderRegistry {
 	providerRegistry := NewProviderRegistry()
 	providerRegistry.Register(ovirt.NewOvirtProvider(log, nil))
 	providerRegistry.Register(vsphere.NewVsphereProvider(log))
-	providerRegistry.Register(baremetal.NewBaremetalProvider(log))
+	providerRegistry.Register(baremetal.NewBaremetalProvider(log, models.PlatformTypeBaremetal))
+	providerRegistry.Register(baremetal.NewBaremetalProvider(log, models.PlatformTypeNone))
 	return providerRegistry
 }

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -147,16 +147,16 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, bmInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(len(platforms)).Should(Equal(2))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
 	})
 	It("single vsphere host", func() {
 		hosts := make([]*models.Host, 0)
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere}
+		Expect(len(platforms)).Should(Equal(3))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("5 vsphere hosts - 3 masters, 2 workers", func() {
@@ -168,8 +168,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere}
+		Expect(len(platforms)).Should(Equal(3))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("2 vsphere hosts 1 generic host", func() {
@@ -179,8 +179,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(len(platforms)).Should(Equal(2))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
 	})
 	It("3 vsphere masters 2 generic workers", func() {
 		hosts := make([]*models.Host, 0)
@@ -191,16 +191,16 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, bmInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(len(platforms)).Should(Equal(2))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
 	})
 	It("single ovirt host", func() {
 		hosts := make([]*models.Host, 0)
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, ovirtInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeOvirt}
+		Expect(len(platforms)).Should(Equal(3))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeOvirt, models.PlatformTypeNone}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("5 ovirt hosts - 3 masters, 2 workers", func() {
@@ -212,8 +212,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, ovirtInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeOvirt}
+		Expect(len(platforms)).Should(Equal(3))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeOvirt, models.PlatformTypeNone}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("2 ovirt hosts 1 generic host", func() {
@@ -223,8 +223,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, ovirtInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(len(platforms)).Should(Equal(2))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
 	})
 	It("3 ovirt masters 2 generic workers", func() {
 		hosts := make([]*models.Host, 0)
@@ -235,8 +235,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, bmInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(1))
-		Expect(platforms[0]).Should(Equal(models.PlatformTypeBaremetal))
+		Expect(len(platforms)).Should(Equal(2))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
 	})
 	It("host with an invalid inventory", func() {
 		hosts := make([]*models.Host, 0)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3234,7 +3234,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}, "30s", "1s").Should(Equal(aciSNOSpec.IngressVIP))
 
 		By("verify platform type status")
-		checkPlatformStatus(ctx, installkey, "", hiveext.BareMetalPlatformType, swag.Bool(true))
+		checkPlatformStatus(ctx, installkey, "", hiveext.NonePlatformType, swag.Bool(true))
 
 		By("Verify Agent labels")
 		labels[v1beta1.InfraEnvNameLabel] = infraNsName.Name


### PR DESCRIPTION
- Make `none platform` as a valid platform
- When setting `UserManagedNetworking` (on cluster creation and on cluster update), if `UserManagedNetworking=true && Platform.Type == "baremetal"` than `cluster.Platform.Type` is set to `"none"`
- Allow creating and updating cluster with `Platform.Type = none`  
- `GetSupportedProvidersByHosts` returns also `none` platform alongside `baremetal`

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @eranco74 
/cc @avishayt 
/cc @gamli75  
