### PR TITLE
MGMT-11309: clean up prom metrics to enable meaningful alerts

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -541,7 +541,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	}
 
 	success = true
-	b.metricApi.ClusterRegistered(cluster.OpenshiftVersion, *cluster.ID, cluster.EmailDomain)
+	b.metricApi.ClusterRegistered()
 	return b.GetClusterInternal(ctx, installer.V2GetClusterParams{ClusterID: *cluster.ID})
 }
 
@@ -784,7 +784,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	b.metricApi.ClusterRegistered("", *newCluster.ID, newCluster.EmailDomain)
+	b.metricApi.ClusterRegistered()
 	return &newCluster, nil
 }
 
@@ -2938,7 +2938,7 @@ func (b *bareMetalInventory) processDiskSpeedCheckResponse(ctx context.Context, 
 	}
 
 	if exitCode == 0 {
-		b.metricApi.DiskSyncDuration(*h.ID, diskPerfCheckResponse.Path, diskPerfCheckResponse.IoSyncDuration)
+		b.metricApi.DiskSyncDuration(diskPerfCheckResponse.IoSyncDuration)
 
 		thresholdMs, err := b.getInstallationDiskSpeedThresholdMs(ctx, h)
 		if err != nil {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -134,7 +134,7 @@ func mockClusterRegisterSteps() {
 
 func mockClusterRegisterSuccess(withEvents bool) {
 	mockClusterRegisterSteps()
-	mockMetric.EXPECT().ClusterRegistered(common.TestDefaultConfig.ReleaseVersion, gomock.Any(), gomock.Any()).Times(1)
+	mockMetric.EXPECT().ClusterRegistered().Times(1)
 
 	if withEvents {
 		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
@@ -1326,7 +1326,7 @@ var _ = Describe("PostStepReply", func() {
 
 		It("Disk speed success", func() {
 			mockHostApi.EXPECT().SetDiskSpeed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetric.EXPECT().DiskSyncDuration(gomock.Any()).Times(1)
 			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(10), nil).Times(1)
 			params := makeStepReply(*clusterId, *hostId, "/dev/sda", 5, 0)
 			reply := bm.V2PostStepReply(ctx, params)
@@ -1759,7 +1759,7 @@ var _ = Describe("v2PostStepReply", func() {
 
 		It("Disk speed success", func() {
 			mockHostApi.EXPECT().SetDiskSpeed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			mockMetric.EXPECT().DiskSyncDuration(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockMetric.EXPECT().DiskSyncDuration(gomock.Any()).Times(1)
 			mockHwValidator.EXPECT().GetInstallationDiskSpeedThresholdMs(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(10), nil).Times(1)
 			params := makeStepReply(*clusterId, *hostId, "/dev/sda", 5, 0)
 			reply := bm.V2PostStepReply(ctx, params)
@@ -9968,7 +9968,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 			},
 		}
 		mockClusterApi.EXPECT().RegisterAddHostsCluster(ctx, gomock.Any()).Return(nil).Times(1)
-		mockMetric.EXPECT().ClusterRegistered("", gomock.Any(), "Unknown").Times(1)
+		mockMetric.EXPECT().ClusterRegistered().Times(1)
 		res := bm.V2ImportCluster(ctx, params)
 		actual := res.(*installer.V2ImportClusterCreated)
 
@@ -9995,7 +9995,7 @@ var _ = Describe("Register AddHostsCluster test", func() {
 			},
 		}
 		mockClusterApi.EXPECT().RegisterAddHostsCluster(ctx, gomock.Any()).Return(nil).Times(1)
-		mockMetric.EXPECT().ClusterRegistered("", gomock.Any(), "Unknown").Times(1)
+		mockMetric.EXPECT().ClusterRegistered().Times(1)
 		res := bm.V2ImportCluster(ctx, params)
 		actual := res.(*installer.V2ImportClusterCreated)
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -251,7 +251,7 @@ func (m *Manager) reportValidationFailedMetrics(ctx context.Context, c *common.C
 	for _, vRes := range validationRes {
 		for _, v := range vRes {
 			if v.Status == ValidationFailure {
-				m.metricAPI.ClusterValidationFailed(ocpVersion, emailDomain, models.ClusterValidationID(v.ID))
+				m.metricAPI.ClusterValidationFailed(models.ClusterValidationID(v.ID))
 			}
 		}
 	}
@@ -264,7 +264,7 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, c *common.C
 		for _, v := range vRes {
 			if currentStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
 				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
-					m.metricAPI.ClusterValidationChanged(c.OpenshiftVersion, c.EmailDomain, models.ClusterValidationID(v.ID))
+					m.metricAPI.ClusterValidationChanged(models.ClusterValidationID(v.ID))
 					eventgen.SendClusterValidationFailedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
 				}
 				if v.Status == ValidationSuccess && currentStatus == ValidationFailure {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -3131,7 +3131,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	It("Test DeregisterCluster", func() {
 		mockHost.EXPECT().ReportValidationFailedMetrics(ctx, gomock.Any(), openshiftVersion, emailDomain)
-		mockMetric.EXPECT().ClusterValidationFailed(openshiftVersion, emailDomain, models.ClusterValidationIDSufficientMastersCount)
+		mockMetric.EXPECT().ClusterValidationFailed(models.ClusterValidationIDSufficientMastersCount)
 		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.ClusterDeregisteredEventName),
 			eventstest.WithClusterIdMatcher(c.ID.String())))
@@ -3148,7 +3148,7 @@ var _ = Describe("Validation metrics and events", func() {
 		Expect(err).ToNot(HaveOccurred())
 		m.reportValidationStatusChanged(ctx, c, newValidationRes, currentValidationRes)
 
-		mockMetric.EXPECT().ClusterValidationChanged(openshiftVersion, emailDomain, models.ClusterValidationIDSufficientMastersCount)
+		mockMetric.EXPECT().ClusterValidationChanged(models.ClusterValidationIDSufficientMastersCount)
 		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
 			eventstest.WithClusterIdMatcher(c.ID.String())))
 

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -331,8 +331,7 @@ var _ = Describe("Progress bar test", func() {
 			mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 			mockDnsApi.EXPECT().CreateDNSRecordSets(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			mockOperatorApi.EXPECT().ValidateCluster(gomock.Any(), gomock.Any()).Return([]api.ValidationResult{}, nil).AnyTimes()
-			mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any()).AnyTimes()
-			mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), 1, gomock.Any()).AnyTimes()
+			mockMetric.EXPECT().InstallationStarted().AnyTimes()
 			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 				eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
 				eventstest.WithClusterIdMatcher(clusterId.String())))

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -570,8 +569,7 @@ func (th *transitionHandler) InstallCluster(sw stateswitch.StateSwitch, args sta
 		return err
 	}
 	// send metric and event that installation process has been started
-	params.metricApi.InstallationStarted(cluster.OpenshiftVersion, *cluster.ID, cluster.EmailDomain, strconv.FormatBool(swag.BoolValue(cluster.UserManagedNetworking)))
-	params.metricApi.ClusterHostInstallationCount(cluster.EmailDomain, len(cluster.Hosts), cluster.OpenshiftVersion)
+	params.metricApi.InstallationStarted()
 	return nil
 }
 

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -1826,9 +1826,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 			case models.ClusterStatusInsufficient:
 				mockHostAPIIsRequireUserActionResetFalse()
 			case models.ClusterStatusInstalling:
-				nonDisabled := len(t.hosts)
-				mockMetric.EXPECT().InstallationStarted(gomock.Any(), clusterId, gomock.Any(), gomock.Any()).Times(1)
-				mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), nonDisabled, gomock.Any()).Times(1)
+				mockMetric.EXPECT().InstallationStarted().Times(1)
 			}
 			Expect(cluster.ValidationsInfo).To(BeEmpty())
 			clusterAfterRefresh, err := clusterApi.RefreshStatus(ctx, &cluster, db)
@@ -4441,8 +4439,7 @@ var _ = Describe("Single node", func() {
 					cluster.Cluster.StatusUpdatedAt = strfmt.DateTime(time.Now())
 					cluster.InstallationPreparationCompletionStatus = common.InstallationPreparationSucceeded
 
-					mockMetric.EXPECT().InstallationStarted(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-					mockMetric.EXPECT().ClusterHostInstallationCount(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+					mockMetric.EXPECT().InstallationStarted().Times(1)
 
 				}
 				Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1032,7 +1032,7 @@ func (m *Manager) ReportValidationFailedMetrics(ctx context.Context, h *models.H
 	for _, vRes := range validationRes {
 		for _, v := range vRes {
 			if v.Status == ValidationFailure {
-				m.metricApi.HostValidationFailed(ocpVersion, emailDomain, models.HostValidationID(v.ID))
+				m.metricApi.HostValidationFailed(models.HostValidationID(v.ID))
 			}
 		}
 	}
@@ -1047,11 +1047,7 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 			if currentStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
 				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
 					log.Errorf("Host %s: validation '%s' that used to succeed is now failing", hostutil.GetHostnameForMsg(h), v.ID)
-					if vc.cluster != nil {
-						m.metricApi.HostValidationChanged(vc.cluster.OpenshiftVersion, vc.cluster.EmailDomain, models.HostValidationID(v.ID))
-					} else if vc.infraEnv != nil {
-						m.metricApi.HostValidationChanged(vc.infraEnv.OpenshiftVersion, vc.infraEnv.EmailDomain, models.HostValidationID(v.ID))
-					}
+					m.metricApi.HostValidationChanged(models.HostValidationID(v.ID))
 					eventgen.SendHostValidationFailedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, h.ClusterID,
 						hostutil.GetHostnameForMsg(h), v.ID.String())
 				}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -3036,7 +3036,7 @@ var _ = Describe("Validation metrics and events", func() {
 
 	It("Test ReportValidationFailedMetrics", func() {
 
-		mockMetric.EXPECT().HostValidationFailed(openshiftVersion, emailDomain, models.HostValidationIDHasMinCPUCores)
+		mockMetric.EXPECT().HostValidationFailed(models.HostValidationIDHasMinCPUCores)
 
 		err := m.ReportValidationFailedMetrics(ctx, h, openshiftVersion, emailDomain)
 		Expect(err).ToNot(HaveOccurred())
@@ -3056,7 +3056,7 @@ var _ = Describe("Validation metrics and events", func() {
 		Expect(err).ToNot(HaveOccurred())
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
 
-		mockMetric.EXPECT().HostValidationChanged(openshiftVersion, emailDomain, models.HostValidationIDHasMinCPUCores)
+		mockMetric.EXPECT().HostValidationChanged(models.HostValidationIDHasMinCPUCores)
 		mockEvents.EXPECT().SendHostEvent(ctx, eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.HostValidationFailedEventName),
 			eventstest.WithHostIdMatcher(h.ID.String()),
@@ -3081,7 +3081,7 @@ var _ = Describe("Validation metrics and events", func() {
 		Expect(err).ToNot(HaveOccurred())
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
 
-		mockMetric.EXPECT().HostValidationChanged(openshiftVersion, emailDomain, models.HostValidationIDHasMinCPUCores)
+		mockMetric.EXPECT().HostValidationChanged(models.HostValidationIDHasMinCPUCores)
 		mockEvents.EXPECT().SendHostEvent(ctx, eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.HostValidationFailedEventName),
 			eventstest.WithHostIdMatcher(h.ID.String()),

--- a/internal/metrics/mock_metrics_manager_api.go
+++ b/internal/metrics/mock_metrics_manager_api.go
@@ -37,18 +37,6 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// ClusterHostInstallationCount mocks base method.
-func (m *MockAPI) ClusterHostInstallationCount(emailDomain string, hostCount int, clusterVersion string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterHostInstallationCount", emailDomain, hostCount, clusterVersion)
-}
-
-// ClusterHostInstallationCount indicates an expected call of ClusterHostInstallationCount.
-func (mr *MockAPIMockRecorder) ClusterHostInstallationCount(emailDomain, hostCount, clusterVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterHostInstallationCount", reflect.TypeOf((*MockAPI)(nil).ClusterHostInstallationCount), emailDomain, hostCount, clusterVersion)
-}
-
 // ClusterInstallationFinished mocks base method.
 func (m *MockAPI) ClusterInstallationFinished(ctx context.Context, result, prevState, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime) {
 	m.ctrl.T.Helper()
@@ -62,51 +50,51 @@ func (mr *MockAPIMockRecorder) ClusterInstallationFinished(ctx, result, prevStat
 }
 
 // ClusterRegistered mocks base method.
-func (m *MockAPI) ClusterRegistered(clusterVersion string, clusterID strfmt.UUID, emailDomain string) {
+func (m *MockAPI) ClusterRegistered() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterRegistered", clusterVersion, clusterID, emailDomain)
+	m.ctrl.Call(m, "ClusterRegistered")
 }
 
 // ClusterRegistered indicates an expected call of ClusterRegistered.
-func (mr *MockAPIMockRecorder) ClusterRegistered(clusterVersion, clusterID, emailDomain interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ClusterRegistered() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterRegistered", reflect.TypeOf((*MockAPI)(nil).ClusterRegistered), clusterVersion, clusterID, emailDomain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterRegistered", reflect.TypeOf((*MockAPI)(nil).ClusterRegistered))
 }
 
 // ClusterValidationChanged mocks base method.
-func (m *MockAPI) ClusterValidationChanged(clusterVersion, emailDomain string, clusterValidationType models.ClusterValidationID) {
+func (m *MockAPI) ClusterValidationChanged(clusterValidationType models.ClusterValidationID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterValidationChanged", clusterVersion, emailDomain, clusterValidationType)
+	m.ctrl.Call(m, "ClusterValidationChanged", clusterValidationType)
 }
 
 // ClusterValidationChanged indicates an expected call of ClusterValidationChanged.
-func (mr *MockAPIMockRecorder) ClusterValidationChanged(clusterVersion, emailDomain, clusterValidationType interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ClusterValidationChanged(clusterValidationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterValidationChanged", reflect.TypeOf((*MockAPI)(nil).ClusterValidationChanged), clusterVersion, emailDomain, clusterValidationType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterValidationChanged", reflect.TypeOf((*MockAPI)(nil).ClusterValidationChanged), clusterValidationType)
 }
 
 // ClusterValidationFailed mocks base method.
-func (m *MockAPI) ClusterValidationFailed(clusterVersion, emailDomain string, clusterValidationType models.ClusterValidationID) {
+func (m *MockAPI) ClusterValidationFailed(clusterValidationType models.ClusterValidationID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClusterValidationFailed", clusterVersion, emailDomain, clusterValidationType)
+	m.ctrl.Call(m, "ClusterValidationFailed", clusterValidationType)
 }
 
 // ClusterValidationFailed indicates an expected call of ClusterValidationFailed.
-func (mr *MockAPIMockRecorder) ClusterValidationFailed(clusterVersion, emailDomain, clusterValidationType interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) ClusterValidationFailed(clusterValidationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterValidationFailed", reflect.TypeOf((*MockAPI)(nil).ClusterValidationFailed), clusterVersion, emailDomain, clusterValidationType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterValidationFailed", reflect.TypeOf((*MockAPI)(nil).ClusterValidationFailed), clusterValidationType)
 }
 
 // DiskSyncDuration mocks base method.
-func (m *MockAPI) DiskSyncDuration(hostID strfmt.UUID, diskPath string, syncDuration int64) {
+func (m *MockAPI) DiskSyncDuration(syncDuration int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DiskSyncDuration", hostID, diskPath, syncDuration)
+	m.ctrl.Call(m, "DiskSyncDuration", syncDuration)
 }
 
 // DiskSyncDuration indicates an expected call of DiskSyncDuration.
-func (mr *MockAPIMockRecorder) DiskSyncDuration(hostID, diskPath, syncDuration interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) DiskSyncDuration(syncDuration interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), hostID, diskPath, syncDuration)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskSyncDuration", reflect.TypeOf((*MockAPI)(nil).DiskSyncDuration), syncDuration)
 }
 
 // Duration mocks base method.
@@ -134,27 +122,27 @@ func (mr *MockAPIMockRecorder) FileSystemUsage(usageInPercentage interface{}) *g
 }
 
 // HostValidationChanged mocks base method.
-func (m *MockAPI) HostValidationChanged(clusterVersion, emailDomain string, hostValidationType models.HostValidationID) {
+func (m *MockAPI) HostValidationChanged(hostValidationType models.HostValidationID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HostValidationChanged", clusterVersion, emailDomain, hostValidationType)
+	m.ctrl.Call(m, "HostValidationChanged", hostValidationType)
 }
 
 // HostValidationChanged indicates an expected call of HostValidationChanged.
-func (mr *MockAPIMockRecorder) HostValidationChanged(clusterVersion, emailDomain, hostValidationType interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) HostValidationChanged(hostValidationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationChanged", reflect.TypeOf((*MockAPI)(nil).HostValidationChanged), clusterVersion, emailDomain, hostValidationType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationChanged", reflect.TypeOf((*MockAPI)(nil).HostValidationChanged), hostValidationType)
 }
 
 // HostValidationFailed mocks base method.
-func (m *MockAPI) HostValidationFailed(clusterVersion, emailDomain string, hostValidationType models.HostValidationID) {
+func (m *MockAPI) HostValidationFailed(hostValidationType models.HostValidationID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HostValidationFailed", clusterVersion, emailDomain, hostValidationType)
+	m.ctrl.Call(m, "HostValidationFailed", hostValidationType)
 }
 
 // HostValidationFailed indicates an expected call of HostValidationFailed.
-func (mr *MockAPIMockRecorder) HostValidationFailed(clusterVersion, emailDomain, hostValidationType interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) HostValidationFailed(hostValidationType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationFailed", reflect.TypeOf((*MockAPI)(nil).HostValidationFailed), clusterVersion, emailDomain, hostValidationType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostValidationFailed", reflect.TypeOf((*MockAPI)(nil).HostValidationFailed), hostValidationType)
 }
 
 // ImagePullStatus mocks base method.
@@ -170,15 +158,15 @@ func (mr *MockAPIMockRecorder) ImagePullStatus(imageName, resultStatus, download
 }
 
 // InstallationStarted mocks base method.
-func (m *MockAPI) InstallationStarted(clusterVersion string, clusterID strfmt.UUID, emailDomain, userManagedNetworking string) {
+func (m *MockAPI) InstallationStarted() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "InstallationStarted", clusterVersion, clusterID, emailDomain, userManagedNetworking)
+	m.ctrl.Call(m, "InstallationStarted")
 }
 
 // InstallationStarted indicates an expected call of InstallationStarted.
-func (mr *MockAPIMockRecorder) InstallationStarted(clusterVersion, clusterID, emailDomain, userManagedNetworking interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) InstallationStarted() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallationStarted", reflect.TypeOf((*MockAPI)(nil).InstallationStarted), clusterVersion, clusterID, emailDomain, userManagedNetworking)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallationStarted", reflect.TypeOf((*MockAPI)(nil).InstallationStarted))
 }
 
 // MonitoredClusterCount mocks base method.


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

This PR aims to reduce number of unnecessary labels for exported prometheus metrics.
The reason is that we want to be able to alert if our statistics (elasticsearch) falls behind (clusters, events, etc) compared to the service itself.
Once this gets merged, we will add a follow-up PR that will only add exporting event count, to enable comparison between the two systems with the most meaningful stat.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @gamli75 
/cc @osherdp 
/cc @jhernand 

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] Reviewers have been listed
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
