### PR TITLE
MGMT-11035: Allow noProxy wildcard for infraEnv, regardless of OCP version

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3798,10 +3798,7 @@ func validateProxySettings(httpProxy, httpsProxy, noProxy, ocpVersion *string) e
 		}
 	}
 	if noProxy != nil && *noProxy != "" {
-		if ocpVersion == nil {
-			return errors.Errorf("Cannot validate NoProxy: Unknown OpenShift version")
-		}
-		if err := validations.ValidateNoProxyFormat(*noProxy, *ocpVersion); err != nil {
+		if err := validations.ValidateNoProxyFormat(*noProxy, swag.StringValue(ocpVersion)); err != nil {
 			return err
 		}
 	}
@@ -4153,7 +4150,7 @@ func (b *bareMetalInventory) validateInfraEnvCreateParams(ctx context.Context, p
 	if params.InfraenvCreateParams.Proxy != nil {
 		if err = validateProxySettings(params.InfraenvCreateParams.Proxy.HTTPProxy,
 			params.InfraenvCreateParams.Proxy.HTTPSProxy,
-			params.InfraenvCreateParams.Proxy.NoProxy, &params.InfraenvCreateParams.OpenshiftVersion); err != nil {
+			params.InfraenvCreateParams.Proxy.NoProxy, nil); err != nil {
 			return err
 		}
 	}
@@ -4348,7 +4345,7 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 	if params.InfraEnvUpdateParams.Proxy != nil {
 		if err = validateProxySettings(params.InfraEnvUpdateParams.Proxy.HTTPProxy,
 			params.InfraEnvUpdateParams.Proxy.HTTPSProxy,
-			params.InfraEnvUpdateParams.Proxy.NoProxy, &infraEnv.OpenshiftVersion); err != nil {
+			params.InfraEnvUpdateParams.Proxy.NoProxy, nil); err != nil {
 			log.WithError(err).Errorf("Failed to validate Proxy settings")
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -245,50 +245,82 @@ var _ = Describe("Cluster name validation", func() {
 var _ = Describe("URL validations", func() {
 
 	Context("test no-proxy", func() {
-		It("domain name", func() {
-			err := ValidateNoProxyFormat("domain.com", "4.7.0")
-			Expect(err).Should(BeNil())
+
+		Context("test no-proxy with ocpVersion 4.7.0", func() {
+			It("domain name", func() {
+				err := ValidateNoProxyFormat("domain.com", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("domain starts with . for all sub-domains", func() {
+				err := ValidateNoProxyFormat(".domain.com", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("CIDR", func() {
+				err := ValidateNoProxyFormat("10.9.0.0/16", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("IP Address", func() {
+				err := ValidateNoProxyFormat("10.9.8.7", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("multiple entries", func() {
+				err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
+				err := ValidateNoProxyFormat("*", "4.7.0")
+				Expect(err).ShouldNot(BeNil())
+				Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in release: 4.7.0"))
+			})
+			It("'*,domain.com' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "4.7.0")
+				Expect(err).ShouldNot(BeNil())
+				Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in release: 4.7.0"))
+			})
 		})
-		It("domain starts with . for all sub-domains", func() {
-			err := ValidateNoProxyFormat(".domain.com", "4.7.0")
-			Expect(err).Should(BeNil())
+		Context("test no-proxy with ocpVersion 4.8.0", func() {
+			It("'*' bypass proxy for all destinations FC version", func() {
+				err := ValidateNoProxyFormat("*", "4.8.0-fc.7")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations release version", func() {
+				err := ValidateNoProxyFormat("*", "4.8.0")
+				Expect(err).Should(BeNil())
+			})
+			It("invalid format", func() {
+				err := ValidateNoProxyFormat("...", "4.8.0-fc.7")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("invalid format of a single value", func() {
+				err := ValidateNoProxyFormat("domain.com,...", "4.8.0-fc.7")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("A use of asterisk", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "4.8.0-fc.7")
+				Expect(err).Should(BeNil())
+			})
 		})
-		It("CIDR", func() {
-			err := ValidateNoProxyFormat("10.9.0.0/16", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("IP Address", func() {
-			err := ValidateNoProxyFormat("10.9.8.7", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("multiple entries", func() {
-			err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations FC version", func() {
-			err := ValidateNoProxyFormat("*", "4.8.0-fc.7")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations release version", func() {
-			err := ValidateNoProxyFormat("*", "4.8.0")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
-			err := ValidateNoProxyFormat("*", "4.7.0")
-			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in this release"))
-		})
-		It("invalid format", func() {
-			err := ValidateNoProxyFormat("...", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
-		})
-		It("invalid format of a single value", func() {
-			err := ValidateNoProxyFormat("domain.com,...", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
-		})
-		It("invalid use of asterisk", func() {
-			err := ValidateNoProxyFormat("*,domain.com", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
+		Context("test no-proxy with no ocpVersion (InfraEnv)", func() {
+			It("'*' bypass proxy for all destinations FC version", func() {
+				err := ValidateNoProxyFormat("*", "")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations release version", func() {
+				err := ValidateNoProxyFormat("*", "")
+				Expect(err).Should(BeNil())
+			})
+			It("invalid format", func() {
+				err := ValidateNoProxyFormat("...", "")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("invalid format of a single value", func() {
+				err := ValidateNoProxyFormat("domain.com,...", "")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("A use of asterisk", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "")
+				Expect(err).Should(BeNil())
+			})
 		})
 	})
 })

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -217,13 +217,17 @@ func ValidateClusterNameFormat(name string) error {
 // prefaced with '.' to include all subdomains of that domain.
 // Use '*' to bypass proxy for all destinations in OCP 4.8 or later.
 func ValidateNoProxyFormat(noProxy string, ocpVersion string) error {
-	if noProxy == "*" {
+	// TODO MGMT-11401: Remove noProxy wildcard validation when OCP 4.8 gets deprecated.
+	if strings.Contains(noProxy, "*") {
+		if ocpVersion == "" { // a case where ValidateNoProxyFormat got called for InfraEnv
+			return nil
+		}
 		if wildcardSupported, err := common.VersionGreaterOrEqual(ocpVersion, "4.8.0-fc.4"); err != nil {
 			return err
 		} else if wildcardSupported {
 			return nil
 		}
-		return errors.Errorf("Sorry, no-proxy value '*' is not supported in this release")
+		return errors.Errorf("Sorry, no-proxy value '*' is not supported in release: %s", ocpVersion)
 	}
 
 	return validations.ValidateNoProxyFormat(noProxy)

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -2627,6 +2627,47 @@ spec:
 		})
 	})
 
+	Context("NoProxy with Wildcard", func() {
+
+		It("OpenshiftVersion does not support NoProxy wildcard", func() {
+			_, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					BaseDNSDomain:        "example.com",
+					ClusterNetworks:      []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+					ServiceNetworks:      []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+					Name:                 swag.String("sno-cluster"),
+					OpenshiftVersion:     swag.String("4.8.0-fc.1"),
+					NoProxy:              swag.String("*"),
+					PullSecret:           swag.String(pullSecret),
+					SSHPublicKey:         sshPublicKey,
+					VipDhcpAllocation:    swag.Bool(false),
+					NetworkType:          swag.String("OVNKubernetes"),
+					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("OpenshiftVersion does support NoProxy wildcard", func() {
+			_, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					BaseDNSDomain:        "example.com",
+					ClusterNetworks:      []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+					ServiceNetworks:      []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+					Name:                 swag.String("sno-cluster"),
+					OpenshiftVersion:     swag.String("4.8.0-fc.5"),
+					NoProxy:              swag.String("*"),
+					PullSecret:           swag.String(pullSecret),
+					SSHPublicKey:         sshPublicKey,
+					VipDhcpAllocation:    swag.Bool(false),
+					NetworkType:          swag.String("OVNKubernetes"),
+					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	It("install cluster requirement", func() {
 		clusterID := *cluster.ID
 		waitForClusterState(ctx, clusterID, models.ClusterStatusPendingForInput, defaultWaitForClusterStateTimeout,

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -75,6 +75,19 @@ var _ = Describe("Infra_Env", func() {
 		infraEnv = resp.Payload
 	}
 
+	It("update infra env with NoProxy wildcard", func() {
+		updateParams := &installer.UpdateInfraEnvParams{
+			InfraEnvID: infraEnvID,
+			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+				Proxy: &models.Proxy{NoProxy: swag.String("*")},
+			},
+		}
+		res, err := userBMClient.Installer.UpdateInfraEnv(ctx, updateParams)
+		Expect(err).NotTo(HaveOccurred())
+		updateInfraEnv := res.Payload
+		Expect(swag.StringValue(updateInfraEnv.Proxy.NoProxy)).To(Equal("*"))
+	})
+
 	It("download full-iso image success", func() {
 		getInfraEnv()
 		downloadIso(ctx, infraEnv.DownloadURL)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -2284,6 +2284,72 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}, "1m", "10s").Should(BeTrue())
 	})
 
+	It("fail to deploy clusterDeployment with NoProxy wildcard - OpenshiftVersion does not support NoProxy wildcard", func() {
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+
+		By("new deployment with NoProxy")
+		aciSpec.Proxy = &hiveext.Proxy{HTTPProxy: "", HTTPSProxy: "", NoProxy: "*"}
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterInputErrorReason)
+	})
+
+	It("deploy clusterDeployment with NoProxy wildcard - OpenshiftVersion does support NoProxy wildcard", func() {
+		noProxy := "*"
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		clusterKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterName,
+		}
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+
+		By("new deployment with NoProxy")
+		aciSpec.Proxy = &hiveext.Proxy{HTTPProxy: "", HTTPSProxy: "", NoProxy: "*"}
+		imageSetRef4_10 := &hivev1.ClusterImageSetReference{
+			Name: "openshift-v4.10.0",
+		}
+		aciSpec.ImageSetRef = imageSetRef4_10
+		deployClusterImageSetCRD(ctx, kubeClient, aciSpec.ImageSetRef)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterSpecSyncedCondition, hiveext.ClusterSyncedOkReason)
+
+		Eventually(func() bool {
+			c := getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
+			return c.NoProxy == noProxy
+		}, "1m", "10s").Should(BeTrue())
+	})
+
+	It("deploy infraEnv with NoProxy wildcard", func() {
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+
+		infraEnvSpec.Proxy = &v1beta1.Proxy{
+			NoProxy: "*",
+		}
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		infraEnvKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		// InfraEnv Reconcile takes longer, since it needs to generate the image.
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
+		infraEnvKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
+		Expect(infraEnv.Generated).Should(Equal(true))
+		By("Validate NoProxy settings.", func() {
+			Expect(swag.StringValue(infraEnv.Proxy.NoProxy)).Should(Equal("*"))
+		})
+	})
+
 	It("deploy clusterDeployment with install config override", func() {
 		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
 		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)


### PR DESCRIPTION
Changed introduced here:
1. Check OCP version only if a wildcard got detected in cluster noProxy settings.
2. Never for OCP version for infraEnv noProxy settings.
3. wildcard detection should catch all cases. It will now include cases
where '*' is listed alongside other elements.
4. The 'no-proxy value '*' is not supported' will now include the OCP release version.
where '*' is listed alongside other elements.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
