### PR TITLE
MGMT-11153: Add cluster tags support

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -239,6 +239,9 @@ type Cluster struct {
 	// Format: date-time
 	StatusUpdatedAt strfmt.DateTime `json:"status_updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags string `json:"tags,omitempty"`
+
 	// All hosts associated to this cluster.
 	TotalHostCount int64 `json:"total_host_count,omitempty" gorm:"-"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -122,6 +122,9 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -43,4 +43,6 @@ const (
 	IgnitionConfigOverrideUsage string = "Ignition Config Override"
 	// Usage of static network config
 	StaticNetworkConfigUsage string = "Static Network Config"
+	// Usage of cluster tags feature
+	ClusterTags string = "Cluster Tags"
 )

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -239,6 +239,9 @@ type Cluster struct {
 	// Format: date-time
 	StatusUpdatedAt strfmt.DateTime `json:"status_updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags string `json:"tags,omitempty"`
+
 	// All hosts associated to this cluster.
 	TotalHostCount int64 `json:"total_host_count,omitempty" gorm:"-"`
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -122,6 +122,9 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -148,3 +148,18 @@ func ValidateNoProxyFormat(noProxy string) error {
 	}
 	return nil
 }
+
+func ValidateTags(tags string) error {
+	if tags == "" {
+		return nil
+	}
+	if !AllStrings(strings.Split(tags, ","), IsValidTag) {
+		return errors.Errorf("Invalid format for Tags: %s. Tags should be a comma-separated list (e.g. tag1,tag2,tag3).", tags)
+	}
+	return nil
+}
+
+func IsValidTag(tag string) bool {
+	tagRegex := `^\w+( \w+)*$` // word characters and whitespace
+	return regexp.MustCompile(tagRegex).MatchString(tag)
+}

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -319,6 +319,73 @@ var _ = Describe("ValidateHostname", func() {
 	}
 })
 
+var _ = Describe("ValidateTags", func() {
+	tests := []struct {
+		tags  string
+		valid bool
+	}{
+		{
+			tags:  "tag1,tag2,tag3",
+			valid: true,
+		},
+		{
+			tags:  "tag 1,tag 2,tag 3",
+			valid: true,
+		},
+		{
+			tags:  "tag1,tag 2",
+			valid: true,
+		},
+		{
+			tags:  "tag1",
+			valid: true,
+		},
+		{
+			tags:  "",
+			valid: true,
+		},
+		{
+			tags:  "tag1 , tag2",
+			valid: false,
+		},
+		{
+			tags:  " tag1 , tag2 ",
+			valid: false,
+		},
+		{
+			tags:  "tag1 ,tag2",
+			valid: false,
+		},
+		{
+			tags:  "tag1, tag2",
+			valid: false,
+		},
+		{
+			tags:  ",",
+			valid: false,
+		},
+		{
+			tags:  ",,",
+			valid: false,
+		},
+		{
+			tags:  "tag,,",
+			valid: false,
+		},
+	}
+	for _, t := range tests {
+		t := t
+		It(fmt.Sprintf("Cluster Tags: \"%s\"", t.tags), func() {
+			err := ValidateTags(t.tags)
+			if t.valid {
+				Expect(err).ToNot(HaveOccurred())
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		})
+	}
+})
+
 func TestCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cluster validations tests")

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5611,6 +5611,10 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
+          "type": "string"
+        },
         "total_host_count": {
           "description": "All hosts associated to this cluster.",
           "type": "integer",
@@ -5823,6 +5827,11 @@ func init() {
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string"
+        },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
+          "type": "string",
+          "x-nullable": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -9097,6 +9106,11 @@ func init() {
         },
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
           "type": "string",
           "x-nullable": true
         },
@@ -14966,6 +14980,10 @@ func init() {
           "format": "date-time",
           "x-go-custom-tag": "gorm:\"type:timestamp with time zone\""
         },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
+          "type": "string"
+        },
         "total_host_count": {
           "description": "All hosts associated to this cluster.",
           "type": "integer",
@@ -15178,6 +15196,11 @@ func init() {
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
           "type": "string"
+        },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
+          "type": "string",
+          "x-nullable": true
         },
         "user_managed_networking": {
           "description": "Indicate if the networking is managed by the user.",
@@ -18345,6 +18368,11 @@ func init() {
         },
         "ssh_public_key": {
           "description": "SSH public key for debugging OpenShift nodes.",
+          "type": "string",
+          "x-nullable": true
+        },
+        "tags": {
+          "description": "A comma-separated list of tags that are associated to the cluster.",
           "type": "string",
           "x-nullable": true
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4312,6 +4312,10 @@ definitions:
         type: object
         $ref: '#/definitions/ignition-endpoint'
         description: Explicit ignition endpoint overrides the default ignition endpoint.
+      tags:
+        type: string
+        description: A comma-separated list of tags that are associated to the cluster.
+        x-nullable: true
 
   host-update-params:
     type: object
@@ -4477,6 +4481,10 @@ definitions:
         type: object
         $ref: '#/definitions/ignition-endpoint'
         description: Explicit ignition endpoint overrides the default ignition endpoint.
+      tags:
+        type: string
+        description: A comma-separated list of tags that are associated to the cluster.
+        x-nullable: true
 
   import-cluster-params:
     type: object
@@ -4817,6 +4825,9 @@ definitions:
           considered imported. Imported clusters usually lack a lot of
           information and are filled with default values that don't necessarily
           reflect the actual cluster they represent
+      tags:
+        type: string
+        description: A comma-separated list of tags that are associated to the cluster.
 
   ignition-endpoint:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -239,6 +239,9 @@ type Cluster struct {
 	// Format: date-time
 	StatusUpdatedAt strfmt.DateTime `json:"status_updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags string `json:"tags,omitempty"`
+
 	// All hosts associated to this cluster.
 	TotalHostCount int64 `json:"total_host_count,omitempty" gorm:"-"`
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -122,6 +122,9 @@ type ClusterCreateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -111,6 +111,9 @@ type V2ClusterUpdateParams struct {
 	// SSH public key for debugging OpenShift nodes.
 	SSHPublicKey *string `json:"ssh_public_key,omitempty"`
 
+	// A comma-separated list of tags that are associated to the cluster.
+	Tags *string `json:"tags,omitempty"`
+
 	// Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 


### PR DESCRIPTION
Introduced 'tags' support for clusters:
* Added tags property to Cluster entity.
* Support add/update tags in RegisterCluster/UpdateCluster API.
* The tags property in cluster is a comma-separated list of free-text strings.
* It is validated to support tags consist of word characters (a-zA-Z0-9_) and inner whitespaces.
E.g. "tags": "tag1,tag 2,tag3"
* When tags are set for clusters, the feature usage is enabled (for monitoring).

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @avishayt 
/cc @filanov 
/cc @romfreiman
/cc @rccrdpccl  

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
