### PR TITLE
fix python syntax of string comparison

### DIFF
--- a/tools/deploy_route53.py
+++ b/tools/deploy_route53.py
@@ -9,7 +9,7 @@ deploy_options = deployment_options.load_deployment_options(parser)
 
 
 def deploy_secret():
-    if deploy_options.secret is "":
+    if deploy_options.secret == "":
         return
 
     # Renderized secret with specified secret


### PR DESCRIPTION
Newer versions of Python have the following behavior:
```
In [1]: if "asd" is "asd":
   ...:     print("qwe")
<>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
<ipython-input-1-20a61c98179a>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if "asd" is "asd":
qwe
```

So to remove the warning we should change to the right syntax.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eliorerz 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
