### PR TITLE
MGMT-11362: Set api vip and not dnsname for day2 cluster (transform) for bm platform

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1323,7 +1323,7 @@ func (m *Manager) TransformClusterToDay2(ctx context.Context, cluster *common.Cl
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
 
-	apiVipDnsname := fmt.Sprintf("api.%s.%s", cluster.Name, cluster.BaseDNSDomain)
+	apiVipDnsname := common.GetConvertedClusterAPIVipDNSName(cluster)
 	dbReply := db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).
 		Updates(map[string]interface{}{
 			"status":           swag.String(models.ClusterStatusAddingHosts),

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2905,82 +2905,124 @@ var _ = Describe("Transform day1 cluster to a day2 cluster", func() {
 	})
 
 	tests := []struct {
-		name          string
-		clusterStatus string
-		clusterKind   string
-		errorExpected bool
+		name               string
+		clusterStatus      string
+		clusterKind        string
+		errorExpected      bool
+		userManagedNetwork bool
+		apiVip             string
 	}{
 		{
-			name:          "successfully transform day1 cluster to a day2 cluster - status installed",
-			clusterStatus: models.ClusterStatusInstalled,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: false,
+			name:               "successfully transform day1 cluster to a day2 cluster - status installed - user managed network true",
+			clusterStatus:      models.ClusterStatusInstalled,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      false,
+			userManagedNetwork: true,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - kind AddHostsCluster",
-			clusterStatus: models.ClusterStatusInstalled,
-			clusterKind:   models.ClusterKindAddHostsCluster,
-			errorExpected: true,
+			name:               "successfully transform day1 cluster to a day2 cluster - status installed - api vip is not set",
+			clusterStatus:      models.ClusterStatusInstalled,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      false,
+			userManagedNetwork: false,
+			apiVip:             "",
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status insufficient",
-			clusterStatus: models.ClusterStatusInsufficient,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "successfully transform day1 cluster to a day2 cluster - status installed",
+			clusterStatus:      models.ClusterStatusInstalled,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      false,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status ready",
-			clusterStatus: models.ClusterStatusReady,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - kind AddHostsCluster",
+			clusterStatus:      models.ClusterStatusInstalled,
+			clusterKind:        models.ClusterKindAddHostsCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status error",
-			clusterStatus: models.ClusterStatusError,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status insufficient",
+			clusterStatus:      models.ClusterStatusInsufficient,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - preparing-for-installation",
-			clusterStatus: models.ClusterStatusPreparingForInstallation,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status ready",
+			clusterStatus:      models.ClusterStatusReady,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status pending-for-input",
-			clusterStatus: models.ClusterStatusPendingForInput,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status error",
+			clusterStatus:      models.ClusterStatusError,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status installing",
-			clusterStatus: models.ClusterStatusInstalling,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - preparing-for-installation",
+			clusterStatus:      models.ClusterStatusPreparingForInstallation,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status finalizing",
-			clusterStatus: models.ClusterStatusFinalizing,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status pending-for-input",
+			clusterStatus:      models.ClusterStatusPendingForInput,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status adding-hosts",
-			clusterStatus: models.ClusterStatusAddingHosts,
-			clusterKind:   models.ClusterKindAddHostsCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status installing",
+			clusterStatus:      models.ClusterStatusInstalling,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status cancelled",
-			clusterStatus: models.ClusterStatusCancelled,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status finalizing",
+			clusterStatus:      models.ClusterStatusFinalizing,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 		{
-			name:          "fail to transform day1 cluster to a day2 cluster - status installing-pending-user-action",
-			clusterStatus: models.ClusterStatusInstallingPendingUserAction,
-			clusterKind:   models.ClusterKindCluster,
-			errorExpected: true,
+			name:               "fail to transform day1 cluster to a day2 cluster - status adding-hosts",
+			clusterStatus:      models.ClusterStatusAddingHosts,
+			clusterKind:        models.ClusterKindAddHostsCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
+		},
+		{
+			name:               "fail to transform day1 cluster to a day2 cluster - status cancelled",
+			clusterStatus:      models.ClusterStatusCancelled,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
+		},
+		{
+			name:               "fail to transform day1 cluster to a day2 cluster - status installing-pending-user-action",
+			clusterStatus:      models.ClusterStatusInstallingPendingUserAction,
+			clusterKind:        models.ClusterKindCluster,
+			errorExpected:      true,
+			userManagedNetwork: false,
+			apiVip:             common.TestIPv4Networking.APIVip,
 		},
 	}
 
@@ -2989,15 +3031,16 @@ var _ = Describe("Transform day1 cluster to a day2 cluster", func() {
 		It(t.name, func() {
 			id := strfmt.UUID(uuid.New().String())
 			cluster := &common.Cluster{Cluster: models.Cluster{
-				ID:               &id,
-				Kind:             swag.String(t.clusterKind),
-				OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
-				Status:           swag.String(t.clusterStatus),
-				MachineNetworks:  common.TestIPv4Networking.MachineNetworks,
-				APIVip:           common.TestIPv4Networking.APIVip,
-				IngressVip:       common.TestIPv4Networking.IngressVip,
-				BaseDNSDomain:    "test.com",
-				PullSecretSet:    true,
+				ID:                    &id,
+				Kind:                  swag.String(t.clusterKind),
+				OpenshiftVersion:      common.TestDefaultConfig.OpenShiftVersion,
+				Status:                swag.String(t.clusterStatus),
+				MachineNetworks:       common.TestIPv4Networking.MachineNetworks,
+				APIVip:                t.apiVip,
+				IngressVip:            common.TestIPv4Networking.IngressVip,
+				BaseDNSDomain:         "test.com",
+				PullSecretSet:         true,
+				UserManagedNetworking: swag.Bool(t.userManagedNetwork),
 			}}
 			Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
 			err1 := clusterApi.TransformClusterToDay2(ctx, cluster, db)
@@ -3007,8 +3050,13 @@ var _ = Describe("Transform day1 cluster to a day2 cluster", func() {
 				Expect(db.Take(&c, "id = ?", cluster.ID.String()).Error).ToNot(HaveOccurred())
 				Expect(c.Kind).To(Equal(swag.String(models.ClusterKindAddHostsCluster)))
 				Expect(c.Status).To(Equal(swag.String(models.ClusterStatusAddingHosts)))
-				apiVipDnsname := fmt.Sprintf("api.%s.%s", c.Name, c.BaseDNSDomain)
-				Expect(c.APIVipDNSName).To(Equal(swag.String(apiVipDnsname)))
+				if t.apiVip == "" || t.userManagedNetwork {
+					apiVipDnsname := fmt.Sprintf("api.%s.%s", c.Name, c.BaseDNSDomain)
+					Expect(c.APIVipDNSName).To(Equal(swag.String(apiVipDnsname)))
+				} else {
+					Expect(c.APIVipDNSName).To(Equal(swag.String(cluster.APIVip)))
+				}
+
 			}
 
 		})

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -393,6 +393,15 @@ func GetTagFromImageRef(ref string) string {
 	}
 }
 
+func GetConvertedClusterAPIVipDNSName(c *Cluster) string {
+	// In case cluster that isn't configured with user-managed-networking
+	// and api vip is set we should set api vip as APIVipDNSName
+	if !swag.BoolValue(c.Cluster.UserManagedNetworking) && c.Cluster.APIVip != "" {
+		return c.Cluster.APIVip
+	}
+	return fmt.Sprintf("api.%s.%s", c.Cluster.Name, c.Cluster.BaseDNSDomain)
+}
+
 func GetAPIHostname(c *Cluster) string {
 	// Despite the confusing name of this parameter, in day-2 scenarios where
 	// this function is used it could either be a DNS domain name that points


### PR DESCRIPTION
[MGMT-11362](https://issues.redhat.com//browse/MGMT-11362): Set api vip and not dnsname for day2 cluster (transform) for bm platform
We see cases where user are not able to manage dns inside their org and
they are stuck with trying to add hosts. We know that in BM case there
is no need to set dns name if we can set api vip.
Changing tranform to day2 logic to set vip in case it can

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
