### PR TITLE
bug-2109637: Agent validations out of sync with the host validation

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -266,9 +266,12 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, c *common.C
 				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
 					m.metricAPI.ClusterValidationChanged(models.ClusterValidationID(v.ID))
 					eventgen.SendClusterValidationFailedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
-				}
-				if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
+				} else if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
 					eventgen.SendClusterValidationFixedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
+				} else if v.Status != currentStatus {
+					msg := fmt.Sprintf("Cluster %s: validation '%s' status changed from %s to %s",
+						*c.ID, v.ID.String(), currentStatus, v.Status)
+					m.eventsHandler.NotifyInternalEvent(ctx, c.ID, nil, nil, msg)
 				}
 			}
 		}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -3140,10 +3140,14 @@ var _ = Describe("Validation metrics and events", func() {
 	})
 
 	It("Test reportValidationStatusChanged", func() {
+		mockEvents.EXPECT().NotifyInternalEvent(ctx, c.ID, nil, nil, gomock.Any())
+		currentValidationRes := generateTestValidationResult(ValidationPending)
+		newValidationRes := generateTestValidationResult(ValidationSuccess)
+		m.reportValidationStatusChanged(ctx, c, newValidationRes, currentValidationRes)
+
 		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
 			eventstest.WithClusterIdMatcher(c.ID.String())))
-		newValidationRes := generateTestValidationResult(ValidationSuccess)
-		var currentValidationRes ValidationsStatus
+		newValidationRes = generateTestValidationResult(ValidationSuccess)
 		err := json.Unmarshal([]byte(c.ValidationsInfo), &currentValidationRes)
 		Expect(err).ToNot(HaveOccurred())
 		m.reportValidationStatusChanged(ctx, c, newValidationRes, currentValidationRes)

--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -36,6 +36,15 @@ func (c *controllerEventsWrapper) V2AddEvent(ctx context.Context, clusterID *str
 	}
 }
 
+func (c *controllerEventsWrapper) NotifyInternalEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, msg string) {
+	c.log.Debugf("Notifying internal event %s", msg)
+	if hostID != nil {
+		c.NotifyKubeApiHostEvent(common.StrFmtUUIDVal(infraEnvID), common.StrFmtUUIDVal(hostID))
+	} else {
+		c.NotifyKubeApiClusterEvent(common.StrFmtUUIDVal(clusterID))
+	}
+}
+
 func (c *controllerEventsWrapper) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{}) {
 	//TODO: Remove this when V1 Events endpoint gets removed.
 }

--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -17,6 +17,12 @@ type Sender interface {
 	// Use the prop field to add list of arbitrary key value pairs when additional information is needed (for example: "vendor": "RedHat")
 	AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	V2AddEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{})
+	// Used for events that are not interesting for metrics or for users, but we still
+	// want to raise them for internal notification between systems. e.g. notify kube-api
+	// that a cluster / host validation status changed so the CR conditions messages could
+	// be updated, but the status that changed is trivial (e.g. from pending to success) so it's
+	// not interesting to display to user or to be included in metrics
+	NotifyInternalEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, msg string)
 
 	//Add metric-related event. These events are hidden from the user and has 'metrics' Category field
 	AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})

--- a/internal/events/api/mock_event.go
+++ b/internal/events/api/mock_event.go
@@ -71,6 +71,18 @@ func (mr *MockSenderMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, severi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockSender)(nil).AddMetricsEvent), varargs...)
 }
 
+// NotifyInternalEvent mocks base method.
+func (m *MockSender) NotifyInternalEvent(ctx context.Context, clusterID, hostID, infraEnvID *strfmt.UUID, msg string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyInternalEvent", ctx, clusterID, hostID, infraEnvID, msg)
+}
+
+// NotifyInternalEvent indicates an expected call of NotifyInternalEvent.
+func (mr *MockSenderMockRecorder) NotifyInternalEvent(ctx, clusterID, hostID, infraEnvID, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyInternalEvent", reflect.TypeOf((*MockSender)(nil).NotifyInternalEvent), ctx, clusterID, hostID, infraEnvID, msg)
+}
+
 // SendClusterEvent mocks base method.
 func (m *MockSender) SendClusterEvent(ctx context.Context, event ClusterEvent) {
 	m.ctrl.T.Helper()
@@ -232,6 +244,18 @@ func (mr *MockHandlerMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, sever
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockHandler)(nil).AddMetricsEvent), varargs...)
+}
+
+// NotifyInternalEvent mocks base method.
+func (m *MockHandler) NotifyInternalEvent(ctx context.Context, clusterID, hostID, infraEnvID *strfmt.UUID, msg string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyInternalEvent", ctx, clusterID, hostID, infraEnvID, msg)
+}
+
+// NotifyInternalEvent indicates an expected call of NotifyInternalEvent.
+func (mr *MockHandlerMockRecorder) NotifyInternalEvent(ctx, clusterID, hostID, infraEnvID, msg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyInternalEvent", reflect.TypeOf((*MockHandler)(nil).NotifyInternalEvent), ctx, clusterID, hostID, infraEnvID, msg)
 }
 
 // SendClusterEvent mocks base method.

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -171,6 +171,11 @@ func (e *Events) V2AddEvent(ctx context.Context, clusterID *strfmt.UUID, hostID 
 	e.v2SaveEvent(ctx, clusterID, hostID, infraEnvID, name, models.EventCategoryUser, severity, msg, eventTime, requestID, props...)
 }
 
+func (e *Events) NotifyInternalEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, msg string) {
+	log := logutil.FromContext(ctx, e.log)
+	log.Debugf("Notifying internal event %s, nothing to do", msg)
+}
+
 func (e *Events) V2AddMetricsEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{}) {
 	requestID := requestid.FromContext(ctx)
 	e.v2SaveEvent(ctx, clusterID, hostID, infraEnvID, name, models.EventCategoryMetrics, severity, msg, eventTime, requestID, props...)

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1050,11 +1050,14 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 					m.metricApi.HostValidationChanged(models.HostValidationID(v.ID))
 					eventgen.SendHostValidationFailedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, h.ClusterID,
 						hostutil.GetHostnameForMsg(h), v.ID.String())
-				}
-				if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
+				} else if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
 					log.Infof("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
 					eventgen.SendHostValidationFixedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, h.ClusterID,
 						hostutil.GetHostnameForMsg(h), v.ID.String())
+				} else if v.Status != currentStatus {
+					msg := fmt.Sprintf("Host %s: validation '%s' status changed from %s to %s", hostutil.GetHostnameForMsg(h), v.ID, currentStatus, v.Status)
+					log.Infof(msg)
+					m.eventsHandler.NotifyInternalEvent(ctx, h.ClusterID, h.ID, &h.InfraEnvID, msg)
 				}
 			}
 		}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -3067,6 +3067,20 @@ var _ = Describe("Validation metrics and events", func() {
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
 	})
 
+	It("Test reportValidationStatusChanged from pending", func() {
+
+		// Pending -> Success
+		mockEvents.EXPECT().NotifyInternalEvent(ctx, h.ClusterID, h.ID, &h.InfraEnvID, gomock.Any())
+		vc := generateValidationCtx()
+		currentValidationRes := generateTestValidationResult(ValidationPending)
+		newValidationRes := generateTestValidationResult(ValidationSuccess)
+		// Pending -> Failure
+		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
+		mockEvents.EXPECT().NotifyInternalEvent(ctx, h.ClusterID, h.ID, &h.InfraEnvID, gomock.Any())
+		newValidationRes = generateTestValidationResult(ValidationFailure)
+		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
+	})
+
 	It("Test reportValidationStatusChanged for unbound host", func() {
 
 		mockEvents.EXPECT().SendHostEvent(ctx, eventstest.NewEventMatcher(

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -751,6 +751,7 @@ var _ = Describe("Validations test", func() {
 			h := hostutil.GenerateTestHostByKind(hostID, infraEnvID, &clusterID, models.HostStatusDiscovering, models.HostKindHost, models.HostRoleAutoAssign)
 			h.Inventory = common.GenerateTestInventoryWithTpmVersion(models.InventoryTpmVersionNr20)
 			Expect(db.Create(&h).Error).ShouldNot(HaveOccurred())
+			mockEvents.EXPECT().NotifyInternalEvent(ctx, h.ClusterID, h.ID, &h.InfraEnvID, gomock.Any())
 
 			checkValidation := func(expectedStatus ValidationStatus, expectedMsg string) {
 				h = hostutil.GetHostFromDB(*h.ID, h.InfraEnvID, db).Host


### PR DESCRIPTION
Added NotifyInternalEvent to events Sender intervace

Now when the host/cluster monitor calls reportValidationStatusChanged it will send notification in case the validation status changed.
This notification will trigger reconciliation of the relevant agent
Prior to this commit status changes from Pending to Success/Failure were ignored by reportValidationStatusChanged

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? kube-api
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://bugzilla.redhat.com/show_bug.cgi?id=2109637

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
