### PR TITLE
Bug 2112321: Stop reconcile loop after changing CR inside BMAC

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -437,7 +437,7 @@ func detachBMH(log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost, agent *a
 	bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
 	log.Infof("Added detached annotation to agent \n %v", agent)
 
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 }
 
 func shouldSkipDetach(log logrus.FieldLogger, bmh *bmh_v1alpha1.BareMetalHost, agent *aiv1beta1.Agent) bool {
@@ -595,7 +595,7 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 
 	bmh.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION] = string(bytes)
 	log.Debugf("Agent Inventory reconciled to BMH \n %v \n %v", agent, bmh)
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 
 }
 
@@ -909,7 +909,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 	bmhAnnotations := bmh.ObjectMeta.GetAnnotations()
 	if _, ok := bmhAnnotations[BMH_DETACHED_ANNOTATION]; !ok {
 		detachBMH(log, bmh, agent)
-		return reconcileComplete{dirty: true}
+		return reconcileComplete{dirty: true, stop: true}
 	}
 	return reconcileComplete{}
 }
@@ -1203,7 +1203,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 		bmh.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES] = ignitionWithMCSCert
 	}
 	log.Info("MCS certificate injected")
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 }
 
 func (r *BMACReconciler) createIgnitionWithMCSCert(ctx context.Context, log logrus.FieldLogger, spokeClient client.Client) (string, string, error) {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -897,12 +897,14 @@ var _ = Describe("bmac reconcile", func() {
 
 		Context("when agent role worker and cluster deployment is set", func() {
 			It("should set spoke BMH", func() {
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_HARDWARE_DETAILS_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
@@ -965,9 +967,11 @@ var _ = Describe("bmac reconcile", func() {
 			})
 
 			It("validate label on Secrets", func() {
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				secret := &corev1.Secret{}
 				By("Checking if the secret has the custom label")
@@ -1057,12 +1061,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1078,12 +1084,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1099,12 +1107,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1155,12 +1165,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1168,7 +1180,7 @@ var _ = Describe("bmac reconcile", func() {
 				infraEnv.Status = v1beta1.InfraEnvStatus{ISODownloadURL: "http://go.find.it"}
 				Expect(c.Update(ctx, infraEnv)).To(BeNil())
 
-				result, err = bmhr.Reconcile(ctx, newBMHRequest(host))
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
 				Expect(err).To(BeNil())
 				Expect(result).To(Equal(ctrl.Result{}))
 


### PR DESCRIPTION
This PR fixes the issue where returning `reconcileComplete{dirty: true}`
does not stop the reconciliation loop what leads to unexpected races and
objects being modified multiple times.

Closes: Bug-2112321

/cc @flaper87 
/cc @omertuc 