### PR TITLE
Bug 2099929: Detach BMH using dedicated function

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -908,10 +908,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 	// cluster.
 	bmhAnnotations := bmh.ObjectMeta.GetAnnotations()
 	if _, ok := bmhAnnotations[BMH_DETACHED_ANNOTATION]; !ok {
-		if bmh.ObjectMeta.Annotations == nil {
-			bmh.ObjectMeta.Annotations = make(map[string]string)
-		}
-		bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
+		detachBMH(log, bmh, agent)
 		return reconcileComplete{dirty: true}
 	}
 	return reconcileComplete{}


### PR DESCRIPTION
This commit changes the way we add `detached` annotation to the BMH.
Instead of doing it always manually, we now call a helper function
responsible for logging this action and taking care of handling empty
annotations.

Contributes-to: Bug-2099929

/cc @flaper87 
/cc @omertuc 