### PR TITLE
Bug 2099929: Allow CI ZTP job with ignition override

### DIFF
--- a/deploy/operator/ztp/add-remote-nodes-playbook.yaml
+++ b/deploy/operator/ztp/add-remote-nodes-playbook.yaml
@@ -11,9 +11,10 @@
     - pull_secret_name: "{{ lookup('env', 'ASSISTED_PULLSECRET_NAME') }}"
     - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
     - day2: "true"
-  
+    - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
+
   tasks:
-  - name: optional-latebinding 
+  - name: optional-latebinding
     block:
     - name: write the infraEnv crd
       template:
@@ -22,7 +23,7 @@
     - name: apply infraenvs with oc
       ansible.builtin.command: "oc apply -f generated/day2-latebinding-infraenv.yaml"
     when: cluster_deployment_name == ""
-  - name: generate-crds-and-apply 
+  - name: generate-crds-and-apply
     block:
     - name: create directory for generated CRDs
       file:

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -30,6 +30,7 @@
     - assisted_stop_after_agent_discovery: "{{ lookup('env', 'ASSISTED_STOP_AFTER_AGENT_DISCOVERY') }}"
     - user_managed_networking: "{{ lookup('env', 'USER_MANAGED_NETWORKING') }}"
     - day2: "false"
+    - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
 
   tasks:
   - name: create directory for generated CRDs

--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -37,6 +37,9 @@ metadata:
     infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
   annotations:
     bmac.agent-install.openshift.io/hostname: '{{ host["name"] }}'
+{% if baremetalhosts_ignition_override|string | length > 0 %}
+    bmac.agent-install.openshift.io/ignition-config-overrides: '{{ baremetalhosts_ignition_override | tojson }}'
+{% endif %}
 spec:
   online: true
   bootMACAddress: '{{ host["ports"][0]["address"] }}'


### PR DESCRIPTION
This PR adds the possibility to have CI ZTP job create BMH definitions
containing ignition override.

Please note the override here is very opinionated and crafted based on
one of the most problematic we have encountered till now. It's hardcoded
here so that we don't need to carry it around o/release. Given that the
sole use of jinja templates here is our CI and the default disables it,
it carries no risk.

Contributes-to: Bug-2099929
Contributes-to: [MGMTBUGSM-447](https://issues.redhat.com//browse/MGMTBUGSM-447)

/cc @omertuc 