### PR TITLE
NO-ISSUE: Don't log whole ignition for InfraEnv

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -999,7 +999,8 @@ func (b *bareMetalInventory) createAndUploadNewImage(ctx context.Context, log lo
 
 func (b *bareMetalInventory) getIgnitionConfigForLogging(ctx context.Context, infraEnv *common.InfraEnv, log logrus.FieldLogger, imageType models.ImageType) string {
 	ignitionConfigForLogging, _ := b.IgnitionBuilder.FormatDiscoveryIgnitionFile(ctx, infraEnv, b.IgnitionConfig, true, b.authHandler.AuthType())
-	log.Infof("Generated infra env <%s> image with ignition config %s", infraEnv.ID, ignitionConfigForLogging)
+	log.Infof("Generated infra env <%s> image with ignition config", infraEnv.ID)
+	log.Debugf("Ignition for infra env <%s>: %s", infraEnv.ID, ignitionConfigForLogging)
 	var msgDetails []string
 
 	httpProxy, _, _ := common.GetProxyConfigs(infraEnv.Proxy)


### PR DESCRIPTION
This commit changes the log level from INFO to DEBUG for the content of
the ignition placed inside ISO generated for a specific InfraEnv. This
is so that when using a default log level we don't print the whole
content but only the message indicating that the generation has
happened.

/cc @omertuc 