### PR TITLE
[release-ocm-2.5] MGMT-11412: fix flaky installation of golangci-lint

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -2,6 +2,7 @@ FROM quay.io/edge-infrastructure/postgresql-12-centos7:latest
 
 COPY --from=quay.io/goswagger/swagger:v0.28.0 /usr/bin/swagger /usr/bin/goswagger
 COPY --from=quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /opt/swagger-codegen-cli /opt/swagger-codegen-cli
+COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint
 
 ENV GOPATH=/go
 ENV GOROOT=/usr/local/go

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -62,9 +62,6 @@ function assisted_service() {
 
   spectral
 
-  curl --retry 5 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-    | sh -s -- -b $(go env GOPATH)/bin v1.36.0
-
   OS=$(uname | awk '{print tolower($0)}')
   OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.10.1
   curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}


### PR DESCRIPTION
Basically a manual backport of https://github.com/openshift/assisted-service/pull/4077.