### PR TITLE
Bug 2112817: Stop reconcile loop after changing CR inside BMAC

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -445,7 +445,7 @@ func (r *BMACReconciler) addBMHDetachedAnnotationIfAgentHasStartedInstallation(c
 	bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
 	log.Infof("Added detached annotation to agent \n %v", agent)
 
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 }
 
 // Reconcile BMH's HardwareDetails using the agent's inventory
@@ -558,7 +558,7 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 
 	bmh.ObjectMeta.Annotations[BMH_HARDWARE_DETAILS_ANNOTATION] = string(bytes)
 	log.Debugf("Agent Inventory reconciled to BMH \n %v \n %v", agent, bmh)
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 
 }
 
@@ -857,7 +857,7 @@ func (r *BMACReconciler) reconcileSpokeBMH(ctx context.Context, log logrus.Field
 			bmh.ObjectMeta.Annotations = make(map[string]string)
 		}
 		bmh.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION] = "assisted-service-controller"
-		return reconcileComplete{dirty: true}
+		return reconcileComplete{dirty: true, stop: true}
 	}
 	return reconcileComplete{}
 }
@@ -1194,7 +1194,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 		bmh.ObjectMeta.Annotations[BMH_AGENT_IGNITION_CONFIG_OVERRIDES] = ignitionWithMCSCert
 	}
 	log.Info("MCS certificate injected")
-	return reconcileComplete{dirty: true}
+	return reconcileComplete{dirty: true, stop: true}
 }
 
 func (r *BMACReconciler) createIgnitionWithMCSCert(ctx context.Context, log logrus.FieldLogger, spokeClient client.Client) (string, string, error) {

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -895,12 +895,14 @@ var _ = Describe("bmac reconcile", func() {
 
 		Context("when agent role worker and cluster deployment is set", func() {
 			It("should set spoke BMH", func() {
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_HARDWARE_DETAILS_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
@@ -963,9 +965,11 @@ var _ = Describe("bmac reconcile", func() {
 			})
 
 			It("validate label on Secrets", func() {
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				secret := &corev1.Secret{}
 				By("Checking if the secret has the custom label")
@@ -1055,12 +1059,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1076,12 +1082,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1097,12 +1105,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1153,12 +1163,14 @@ var _ = Describe("bmac reconcile", func() {
 				}
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
-				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
-				Expect(err).To(BeNil())
-				Expect(result).To(Equal(ctrl.Result{}))
+				for range [3]int{} {
+					result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+					Expect(err).To(BeNil())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
 
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
-				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
@@ -1166,7 +1178,7 @@ var _ = Describe("bmac reconcile", func() {
 				infraEnv.Status = v1beta1.InfraEnvStatus{ISODownloadURL: "http://go.find.it"}
 				Expect(c.Update(ctx, infraEnv)).To(BeNil())
 
-				result, err = bmhr.Reconcile(ctx, newBMHRequest(host))
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
 				Expect(err).To(BeNil())
 				Expect(result).To(Equal(ctrl.Result{}))
 


### PR DESCRIPTION
This PR fixes the issue where returning `reconcileComplete{dirty: true}`
does not stop the reconciliation loop what leads to unexpected races and
objects being modified multiple times.

Cherry-picks: #4201
Closes: Bug-2112817

/cc @flaper87 