### PR TITLE
Bug 2099929: Print merged ignition for day2

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1453,6 +1453,7 @@ func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert 
 			return []byte(""), errors.Wrapf(err, "Failed to apply ignition override for host %s", host.ID)
 		}
 		ib.log.Infof("Applied ignition override for host %s", host.ID)
+		ib.log.Debugf("Ignition override for day2 host %s: %s", host.ID, overrides)
 	}
 
 	res, err := SetHostnameForNodeIgnition([]byte(overrides), host)
@@ -1460,6 +1461,7 @@ func (ib *ignitionBuilder) FormatSecondDayWorkerIgnitionFile(url string, caCert 
 		return []byte(""), errors.Wrapf(err, "Failed to set hostname in ignition for host %s", host.ID)
 	}
 
+	ib.log.Debugf("Final ignition for day2 host %s: %s", host.ID, string(res))
 	return res, nil
 }
 


### PR DESCRIPTION
With this PR, whenever a day2 ignition override is applies, we will
print it to the debug log. This is in order to make debugging easier as
currently the overrides are stored in BareMetalHost and Agent CRs, but
the final state (and what's pulled by the host) is the file in S3. With
this log we'll get an output of what's closer to the final ignition that
the host will apply.

In any case for day2 host we will print the rendered ignition just
before it's stored in S3 so that debug logs from the service contain all
the required content.

Contributes-to: [MGMTBUGSM-447](https://issues.redhat.com//browse/MGMTBUGSM-447)

/cc @omertuc 