### PR TITLE
MGMT-11426: Assisted-service should publish event for failing validations

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -64,13 +64,14 @@ x-events:
     cluster_id: UUID
 
 - name: cluster_validation_failed
-  message: "Cluster validation '{validation_id}' that used to succeed is now failing"
+  message: "Cluster validation '{validation_id}' {failure_message}"
   event_type: cluster
   severity: "warning"
   properties:
     cluster_id: UUID
     validation_id: string
     validation_msg: string
+    failure_message: string
 
 - name: cluster_validation_fixed
   message: "Cluster validation '{validation_id}' is now fixed"
@@ -347,7 +348,7 @@ x-events:
     error: string
 
 - name: host_validation_failed
-  message: "Host {host_name}: validation '{validation_id}' that used to succeed is now failing"
+  message: "Host {host_name}: validation '{validation_id}' {failure_message}"
   event_type: host
   severity: "warning"
   properties:
@@ -356,6 +357,7 @@ x-events:
     cluster_id: UUID_PTR
     host_name: string
     validation_id: string
+    failure_message: string
 
 - name: host_validation_fixed
   message: "Host {host_name}: validation '{validation_id}' is now fixed"

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -264,10 +264,12 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, c *common.C
 		for _, v := range vRes {
 			if previousStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
 				if v.Status == ValidationFailure && previousStatus != ValidationFailure {
+					failureMessage := "failed"
 					if previousStatus == ValidationSuccess {
+						failureMessage = "that used to succeed is now failing"
 						m.metricAPI.ClusterValidationChanged(models.ClusterValidationID(v.ID))
 					}
-					eventgen.SendClusterValidationFailedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
+					eventgen.SendClusterValidationFailedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message, failureMessage)
 				} else if v.Status == ValidationSuccess && previousStatus == ValidationFailure {
 					eventgen.SendClusterValidationFixedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
 				} else if v.Status != previousStatus {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -262,15 +262,17 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, c *common.C
 	newValidationRes, currentValidationRes ValidationsStatus) {
 	for vCategory, vRes := range newValidationRes {
 		for _, v := range vRes {
-			if currentStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
-				if v.Status == ValidationFailure && currentStatus == ValidationSuccess {
-					m.metricAPI.ClusterValidationChanged(models.ClusterValidationID(v.ID))
+			if previousStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
+				if v.Status == ValidationFailure && previousStatus != ValidationFailure {
+					if previousStatus == ValidationSuccess {
+						m.metricAPI.ClusterValidationChanged(models.ClusterValidationID(v.ID))
+					}
 					eventgen.SendClusterValidationFailedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
-				} else if v.Status == ValidationSuccess && currentStatus == ValidationFailure {
+				} else if v.Status == ValidationSuccess && previousStatus == ValidationFailure {
 					eventgen.SendClusterValidationFixedEvent(ctx, m.eventsHandler, *c.ID, v.ID.String(), v.Message)
-				} else if v.Status != currentStatus {
+				} else if v.Status != previousStatus {
 					msg := fmt.Sprintf("Cluster %s: validation '%s' status changed from %s to %s",
-						*c.ID, v.ID.String(), currentStatus, v.Status)
+						*c.ID, v.ID.String(), previousStatus, v.Status)
 					m.eventsHandler.NotifyInternalEvent(ctx, c.ID, nil, nil, msg)
 				}
 			}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -3188,9 +3188,19 @@ var _ = Describe("Validation metrics and events", func() {
 	})
 
 	It("Test reportValidationStatusChanged", func() {
+
+		// Pending -> Success
 		mockEvents.EXPECT().NotifyInternalEvent(ctx, c.ID, nil, nil, gomock.Any())
 		currentValidationRes := generateTestValidationResult(ValidationPending)
 		newValidationRes := generateTestValidationResult(ValidationSuccess)
+		m.reportValidationStatusChanged(ctx, c, newValidationRes, currentValidationRes)
+
+		// Pending -> Failure
+		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.ClusterValidationFailedEventName),
+			eventstest.WithClusterIdMatcher(c.ID.String())))
+		currentValidationRes = generateTestValidationResult(ValidationPending)
+		newValidationRes = generateTestValidationResult(ValidationFailure)
 		m.reportValidationStatusChanged(ctx, c, newValidationRes, currentValidationRes)
 
 		mockEvents.EXPECT().SendClusterEvent(ctx, eventstest.NewEventMatcher(

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -615,6 +615,7 @@ type ClusterValidationFailedEvent struct {
     ClusterId strfmt.UUID
     ValidationId string
     ValidationMsg string
+    FailureMessage string
 }
 
 var ClusterValidationFailedEventName string = "cluster_validation_failed"
@@ -623,12 +624,14 @@ func NewClusterValidationFailedEvent(
     clusterId strfmt.UUID,
     validationId string,
     validationMsg string,
+    failureMessage string,
 ) *ClusterValidationFailedEvent {
     return &ClusterValidationFailedEvent{
         eventName: ClusterValidationFailedEventName,
         ClusterId: clusterId,
         ValidationId: validationId,
         ValidationMsg: validationMsg,
+        FailureMessage: failureMessage,
     }
 }
 
@@ -637,11 +640,13 @@ func SendClusterValidationFailedEvent(
     eventsHandler eventsapi.Sender,
     clusterId strfmt.UUID,
     validationId string,
-    validationMsg string,) {
+    validationMsg string,
+    failureMessage string,) {
     ev := NewClusterValidationFailedEvent(
         clusterId,
         validationId,
         validationMsg,
+        failureMessage,
     )
     eventsHandler.SendClusterEvent(ctx, ev)
 }
@@ -652,11 +657,13 @@ func SendClusterValidationFailedEventAtTime(
     clusterId strfmt.UUID,
     validationId string,
     validationMsg string,
+    failureMessage string,
     eventTime time.Time) {
     ev := NewClusterValidationFailedEvent(
         clusterId,
         validationId,
         validationMsg,
+        failureMessage,
     )
     eventsHandler.SendClusterEventAtTime(ctx, ev, eventTime)
 }
@@ -679,12 +686,13 @@ func (e *ClusterValidationFailedEvent) format(message *string) string {
         "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{validation_id}", fmt.Sprint(e.ValidationId),
         "{validation_msg}", fmt.Sprint(e.ValidationMsg),
+        "{failure_message}", fmt.Sprint(e.FailureMessage),
     )
     return r.Replace(*message)
 }
 
 func (e *ClusterValidationFailedEvent) FormatMessage() string {
-    s := "Cluster validation '{validation_id}' that used to succeed is now failing"
+    s := "Cluster validation '{validation_id}' {failure_message}"
     return e.format(&s)
 }
 
@@ -3242,6 +3250,7 @@ type HostValidationFailedEvent struct {
     ClusterId *strfmt.UUID
     HostName string
     ValidationId string
+    FailureMessage string
 }
 
 var HostValidationFailedEventName string = "host_validation_failed"
@@ -3252,6 +3261,7 @@ func NewHostValidationFailedEvent(
     clusterId *strfmt.UUID,
     hostName string,
     validationId string,
+    failureMessage string,
 ) *HostValidationFailedEvent {
     return &HostValidationFailedEvent{
         eventName: HostValidationFailedEventName,
@@ -3260,6 +3270,7 @@ func NewHostValidationFailedEvent(
         ClusterId: clusterId,
         HostName: hostName,
         ValidationId: validationId,
+        FailureMessage: failureMessage,
     }
 }
 
@@ -3270,13 +3281,15 @@ func SendHostValidationFailedEvent(
     infraEnvId strfmt.UUID,
     clusterId *strfmt.UUID,
     hostName string,
-    validationId string,) {
+    validationId string,
+    failureMessage string,) {
     ev := NewHostValidationFailedEvent(
         hostId,
         infraEnvId,
         clusterId,
         hostName,
         validationId,
+        failureMessage,
     )
     eventsHandler.SendHostEvent(ctx, ev)
 }
@@ -3289,6 +3302,7 @@ func SendHostValidationFailedEventAtTime(
     clusterId *strfmt.UUID,
     hostName string,
     validationId string,
+    failureMessage string,
     eventTime time.Time) {
     ev := NewHostValidationFailedEvent(
         hostId,
@@ -3296,6 +3310,7 @@ func SendHostValidationFailedEventAtTime(
         clusterId,
         hostName,
         validationId,
+        failureMessage,
     )
     eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
 }
@@ -3326,12 +3341,13 @@ func (e *HostValidationFailedEvent) format(message *string) string {
         "{cluster_id}", fmt.Sprint(e.ClusterId),
         "{host_name}", fmt.Sprint(e.HostName),
         "{validation_id}", fmt.Sprint(e.ValidationId),
+        "{failure_message}", fmt.Sprint(e.FailureMessage),
     )
     return r.Replace(*message)
 }
 
 func (e *HostValidationFailedEvent) FormatMessage() string {
-    s := "Host {host_name}: validation '{validation_id}' that used to succeed is now failing"
+    s := "Host {host_name}: validation '{validation_id}' {failure_message}"
     return e.format(&s)
 }
 

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1049,11 +1049,13 @@ func (m *Manager) reportValidationStatusChanged(ctx context.Context, vc *validat
 			if previousStatus, ok := m.getValidationStatus(currentValidationRes, vCategory, v.ID); ok {
 				if v.Status == ValidationFailure && previousStatus != ValidationFailure {
 					log.Errorf("Host %s: validation '%s' changed from %s to %s", hostutil.GetHostnameForMsg(h), v.ID, v.Status, previousStatus)
+					failureMessage := "failed"
 					if previousStatus == ValidationSuccess {
 						m.metricApi.HostValidationChanged(models.HostValidationID(v.ID))
+						failureMessage = "that used to succeed is now failing"
 					}
 					eventgen.SendHostValidationFailedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, h.ClusterID,
-						hostutil.GetHostnameForMsg(h), v.ID.String())
+						hostutil.GetHostnameForMsg(h), v.ID.String(), failureMessage)
 				} else if v.Status == ValidationSuccess && previousStatus == ValidationFailure {
 					log.Infof("Host %s: validation '%s' is now fixed", hostutil.GetHostnameForMsg(h), v.ID)
 					eventgen.SendHostValidationFixedEvent(ctx, m.eventsHandler, *h.ID, h.InfraEnvID, h.ClusterID,

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -3076,7 +3076,10 @@ var _ = Describe("Validation metrics and events", func() {
 		newValidationRes := generateTestValidationResult(ValidationSuccess)
 		// Pending -> Failure
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
-		mockEvents.EXPECT().NotifyInternalEvent(ctx, h.ClusterID, h.ID, &h.InfraEnvID, gomock.Any())
+		mockEvents.EXPECT().SendHostEvent(ctx, eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostValidationFailedEventName),
+			eventstest.WithHostIdMatcher(h.ID.String()),
+			eventstest.WithInfraEnvIdMatcher(h.InfraEnvID.String())))
 		newValidationRes = generateTestValidationResult(ValidationFailure)
 		m.reportValidationStatusChanged(ctx, vc, h, newValidationRes, currentValidationRes)
 	})

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -209,7 +209,7 @@ func assertHostValidationEvent(ctx context.Context, clusterID strfmt.UUID, hostN
 	var eventExist bool
 	var eventMsg string
 	if isFailure {
-		eventMsg = fmt.Sprintf("Host %v: validation '%v' failed", hostName, validationID)
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' that used to succeed is now failing", hostName, validationID)
 	} else {
 		eventMsg = fmt.Sprintf("Host %v: validation '%v' is now fixed", hostName, validationID)
 	}

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -209,7 +209,7 @@ func assertHostValidationEvent(ctx context.Context, clusterID strfmt.UUID, hostN
 	var eventExist bool
 	var eventMsg string
 	if isFailure {
-		eventMsg = fmt.Sprintf("Host %v: validation '%v' that used to succeed is now failing", hostName, validationID)
+		eventMsg = fmt.Sprintf("Host %v: validation '%v' failed", hostName, validationID)
 	} else {
 		eventMsg = fmt.Sprintf("Host %v: validation '%v' is now fixed", hostName, validationID)
 	}


### PR DESCRIPTION
Updated both cluster and host monitors to send an event for every failing validation regardless of the previous validation status (unless it was already failing...)
The monitor will send validation status changed metrics only in case it moved from success to failure,
keeping this logic for the metrics since thats what what the metrics name implys e.g. assisted_installer_cluster_validation_failed_after_success_before_installation

Update Host/ClusterValidationFailedEvent message string to be more generic

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? the change should be visible in the events tab

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-11426
- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @omertuc 
/cc @tsorya 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
