### PR TITLE
MGMT-11020: revert usage of 4.10 catalog for 4.11 ZTP jobs

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -21,35 +21,6 @@ function install_lso() {
   retry -- oc annotate project openshift-local-storage openshift.io/node-selector='' --overwrite=true
 
   catalog_source_name="redhat-operators"
-
-  OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
-  echo "This is the cluster version $OC_VERSION_MAJOR_MINOR"
-  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.11" ]]; then
-      echo  "Creating redhat-operators-v4-10 catalog to be used in LSO subscription"
-      # LSO has not been published to the 4.11 redhat-operators catalog, so
-      # it cannot be installed on OpenShift 4.11. Until this is resolved,
-      # we explicitly install the 4.10 catalog as redhat-operators-v4-10
-      # and then subscribe to the LSO version from the 4.10 rather than the 4.11 catalog.
-      # TODO: Remove this once LSO is published to the 4.11 catalog.
-      catalog_source_name="redhat-operators-v4-10"
-      tee << EOCR >(oc apply -f -)
-kind: CatalogSource
-apiVersion: operators.coreos.com/v1alpha1
-metadata:
-  name: redhat-operators-v4-10
-  namespace: openshift-marketplace
-spec:
-  displayName: Red Hat Operators v4.10
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.10
-  priority: -100
-  publisher: Red Hat
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 10m0s
-EOCR
-  fi
-
   if [ "${DISCONNECTED}" = true ]; then
     if ! which opm; then
         install_opm


### PR DESCRIPTION
A couple of months ago we didn't have LSO available in 4.11 catalog of redhat-operators index
This reverts https://github.com/openshift/assisted-service/pull/4060 as we should now have it in place.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

TBD

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
