### PR TITLE
MGMT-8890: Handle registries.conf without any mirrors correctly

### DIFF
--- a/pkg/mirrorregistries/generator.go
+++ b/pkg/mirrorregistries/generator.go
@@ -2,7 +2,7 @@ package mirrorregistries
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/pelletier/go-toml"
@@ -17,10 +17,15 @@ type MirrorRegistriesConfigBuilder interface {
 }
 
 type mirrorRegistriesConfigBuilder struct {
+	MirrorRegistriesConfigPath      string
+	MirrorRegistriesCertificatePath string
 }
 
 func New() MirrorRegistriesConfigBuilder {
-	return &mirrorRegistriesConfigBuilder{}
+	return &mirrorRegistriesConfigBuilder{
+		MirrorRegistriesConfigPath:      common.MirrorRegistriesConfigPath,
+		MirrorRegistriesCertificatePath: common.MirrorRegistriesCertificatePath,
+	}
 }
 
 type RegistriesConf struct {
@@ -28,26 +33,40 @@ type RegistriesConf struct {
 	Mirror   string
 }
 
+// We consider mirror registries to be configured if the following conditions are all met
+//   * CA bundle file (e.g. /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem) exists
+//   * registry configuration file (e.g. /etc/containers/registries.conf) exists
+//   * registry configuration contains "[[registry]]" section
 func (m *mirrorRegistriesConfigBuilder) IsMirrorRegistriesConfigured() bool {
 	_, err := m.GetMirrorCA()
 	if err != nil {
 		return false
 	}
-	_, err = m.GetMirrorRegistries()
-	return err == nil
+	contents, err := m.GetMirrorRegistries()
+	if err != nil {
+		return false
+	}
+
+	tomlTree, err := toml.Load(string(contents))
+	if err != nil {
+		return false
+	}
+
+	_, ok := tomlTree.Get("registry").([]*toml.Tree)
+	return ok
 }
 
 // return error if the path is actually an empty dir, which will indicate that
 // the mirror registries are not configured.
 // empty dir is due to the way we mao configmap in the assisted-service pod
 func (m *mirrorRegistriesConfigBuilder) GetMirrorCA() ([]byte, error) {
-	return readFile(common.MirrorRegistriesCertificatePath)
+	return os.ReadFile(m.MirrorRegistriesCertificatePath)
 }
 
 // returns error if the file is not present, which will also indicate that
 // mirror registries are not confgiured
 func (m *mirrorRegistriesConfigBuilder) GetMirrorRegistries() ([]byte, error) {
-	return readFile(common.MirrorRegistriesConfigPath)
+	return os.ReadFile(m.MirrorRegistriesConfigPath)
 }
 
 func (m *mirrorRegistriesConfigBuilder) ExtractLocationMirrorDataFromRegistries() ([]RegistriesConf, error) {
@@ -66,28 +85,24 @@ func extractLocationMirrorDataFromRegistries(registriesConfToml string) ([]Regis
 
 	registriesTree, ok := tomlTree.Get("registry").([]*toml.Tree)
 	if !ok {
-		return nil, fmt.Errorf("Failed to cast registry key to toml Tree")
+		return nil, fmt.Errorf("failed to cast registry key to toml Tree, registriesConfToml: %s", registriesConfToml)
 	}
 	registriesConfList := make([]RegistriesConf, len(registriesTree))
 	for i, registryTree := range registriesTree {
 		location, ok := registryTree.Get("location").(string)
 		if !ok {
-			return nil, fmt.Errorf("Failed to cast location key to string")
+			return nil, fmt.Errorf("failed to cast location key to string, registriesConfToml: %s", registriesConfToml)
 		}
 		mirrorTree, ok := registryTree.Get("mirror").([]*toml.Tree)
 		if !ok {
-			return nil, fmt.Errorf("Failed to cast mirror key to toml Tree")
+			return nil, fmt.Errorf("failed to cast mirror key to toml Tree, registriesConfToml: %s", registriesConfToml)
 		}
 		mirror, ok := mirrorTree[0].Get("location").(string)
 		if !ok {
-			return nil, fmt.Errorf("Failed to cast mirror location key to string")
+			return nil, fmt.Errorf("failed to cast mirror location key to string, registriesConfToml: %s", registriesConfToml)
 		}
 		registriesConfList[i] = RegistriesConf{Location: location, Mirror: mirror}
 	}
 
 	return registriesConfList, nil
-}
-
-func readFile(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
 }

--- a/pkg/mirrorregistries/generator_test.go
+++ b/pkg/mirrorregistries/generator_test.go
@@ -1,7 +1,7 @@
 package mirrorregistries
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -10,54 +10,121 @@ import (
 
 func TestMirrorRegistriesConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "MirrorRegistriesConfig Suite")
+	RunSpecs(t, "MirrorRegistries Suite")
 }
 
-var _ = Describe("MirrorRegistriesConfig", func() {
-
-	var (
-		expectedExtractList  = []RegistriesConf{{"location1", "mirror_location1"}, {"location2", "mirror_location2"}, {"location3", "mirror_location3"}}
-		expectedFormatOutput = `unqualified-search-registries = ["registry1", "registry2", "registry3"]
-
-[[registry]]
-  location = "location1"
-  mirror-by-digest-only = false
-  prefix = "prefix1"
-
-  [[registry.mirror]]
-    location = "mirror_location1"
+var (
+	expectedExtractList  = []RegistriesConf{{"location1", "mirror_location1"}, {"location2", "mirror_location2"}, {"location3", "mirror_location3"}}
+	configWithGarbage    = `?;,!`
+	configWithoutMirrors = `unqualified-search-registries = ["registry1", "registry2", "registry3"]`
+	configWithMirrors    = `unqualified-search-registries = ["registry1", "registry2", "registry3"]
 
 [[registry]]
-  location = "location2"
-  mirror-by-digest-only = false
-  prefix = "prefix1"
+location = "location1"
+mirror-by-digest-only = false
+prefix = "prefix1"
 
-  [[registry.mirror]]
-    location = "mirror_location2"
+[[registry.mirror]]
+location = "mirror_location1"
 
 [[registry]]
-  location = "location3"
-  mirror-by-digest-only = false
-  prefix = "prefix1"
+location = "location2"
+mirror-by-digest-only = false
+prefix = "prefix1"
 
-  [[registry.mirror]]
-    location = "mirror_location3"
+[[registry.mirror]]
+location = "mirror_location2"
+
+[[registry]]
+location = "location3"
+mirror-by-digest-only = false
+prefix = "prefix1"
+
+[[registry.mirror]]
+location = "mirror_location3"
 `
-	)
+)
 
-	It("extract data from registries config", func() {
-		dataList, err := extractLocationMirrorDataFromRegistries(expectedFormatOutput)
+var _ = Describe("extractLocationMirrorDataFromRegistries", func() {
+	It("extracts data from registry config with mirrors", func() {
+		dataList, err := extractLocationMirrorDataFromRegistries(configWithMirrors)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(dataList).Should(Equal(expectedExtractList))
 	})
 
-	It("test get CA contents", func() {
-		file, err := ioutil.TempFile("", "ca.crt")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = file.WriteString("some ca data")
-		Expect(err).NotTo(HaveOccurred())
-		contents, err := readFile(file.Name())
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).Should(Equal("some ca data"))
+	It("fails to extract data from registry config without mirrors", func() {
+		_, err := extractLocationMirrorDataFromRegistries(configWithoutMirrors)
+		Expect(err.Error()).Should(Equal("failed to cast registry key to toml Tree, registriesConfToml: unqualified-search-registries = [\"registry1\", \"registry2\", \"registry3\"]"))
+	})
+
+	It("fails to extract data from registry config with garbage", func() {
+		_, err := extractLocationMirrorDataFromRegistries(configWithGarbage)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("fails to extract data from empty config", func() {
+		_, err := extractLocationMirrorDataFromRegistries("")
+		Expect(err.Error()).Should(Equal("failed to cast registry key to toml Tree, registriesConfToml: "))
+	})
+
+})
+
+var _ = Describe("IsMirrorRegistriesConfigured", func() {
+	It("returns false when CA and registry.conf don't exist", func() {
+		m := mirrorRegistriesConfigBuilder{
+			MirrorRegistriesConfigPath:      "/tmp/this-file-for-sure-does-not-exist",
+			MirrorRegistriesCertificatePath: "/tmp/this-file-for-sure-does-not-exist",
+		}
+		res := m.IsMirrorRegistriesConfigured()
+		Expect(res).Should(Equal(false))
+	})
+
+	Context("with registry and CA temp files", func() {
+		var (
+			tempRegistriesFile *os.File
+			tempCAFile         *os.File
+			m                  mirrorRegistriesConfigBuilder
+			err                error
+		)
+
+		BeforeEach(func() {
+			tempRegistriesFile, err = os.CreateTemp(os.TempDir(), "registries.*.conf")
+			Expect(err).NotTo(HaveOccurred())
+
+			tempCAFile, err = os.CreateTemp(os.TempDir(), "ca.*.crt")
+			Expect(err).NotTo(HaveOccurred())
+			_, _ = tempCAFile.WriteString("some random CA certificate")
+
+			m = mirrorRegistriesConfigBuilder{
+				MirrorRegistriesConfigPath:      tempRegistriesFile.Name(),
+				MirrorRegistriesCertificatePath: tempCAFile.Name(),
+			}
+		})
+
+		AfterEach(func() {
+			os.Remove(tempRegistriesFile.Name())
+			os.Remove(tempCAFile.Name())
+		})
+
+		It("returns false when CA exists and registry.conf has no mirrors", func() {
+			_, _ = tempRegistriesFile.WriteString(configWithoutMirrors)
+
+			res := m.IsMirrorRegistriesConfigured()
+			Expect(res).Should(Equal(false))
+		})
+
+		It("returns false when CA exists and registry.conf has garbage", func() {
+			_, _ = tempRegistriesFile.WriteString(configWithGarbage)
+
+			res := m.IsMirrorRegistriesConfigured()
+			Expect(res).Should(Equal(false))
+		})
+
+		It("returns true when CA exists and registry.conf has mirrors", func() {
+			_, _ = tempRegistriesFile.WriteString(configWithMirrors)
+
+			res := m.IsMirrorRegistriesConfigured()
+			Expect(res).Should(Equal(true))
+		})
 	})
 })


### PR DESCRIPTION
Currently the code assumes that existence of registries.conf file means
there are always registry mirrors configured. It has been observed that
the default file has no `[[registry]]` section but is still a correct
file. For such a scenario we want to proceed as the file did not exist
instead of failing.

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)

/cc @carbonin 
/cc @danielerez 