### PR TITLE
MGMT-11444 - Wildcard DNS validation should be pending before we have DNS resolutions

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -146,6 +146,14 @@ var DomainResolutions = []*models.DomainResolutionResponseDomain{
 	},
 }
 
+var WildcardResolved = []*models.DomainResolutionResponseDomain{
+	{
+		DomainName:    &WildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
+		IPV6Addresses: []strfmt.IPv6{"1003:db8::40/120"},
+	},
+}
+
 var DomainResolutionNoAPI = []*models.DomainResolutionResponseDomain{
 	{
 		DomainName:    &DomainApps,
@@ -185,6 +193,7 @@ var DomainResolutionAllEmpty = []*models.DomainResolutionResponseDomain{
 var TestDomainNameResolutionsSuccess = &models.DomainResolutionResponse{Resolutions: DomainResolutions}
 var TestDomainResolutionsNoAPI = &models.DomainResolutionResponse{Resolutions: DomainResolutionNoAPI}
 var TestDomainResolutionsAllEmpty = &models.DomainResolutionResponse{Resolutions: DomainResolutionAllEmpty}
+var TestDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: WildcardResolved}
 
 var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "192.168.1.1", Destination: "0.0.0.0"}}
 

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1439,9 +1439,12 @@ func (v *validator) isDNSWildcardNotConfigured(c *validationContext) (Validation
 	if hostutil.IsDay2Host(c.host) {
 		return ValidationSuccess, "DNS wildcard check is not required for day2"
 	}
+	if c.host.DomainNameResolutions == "" {
+		return ValidationPending, "DNS wildcard check cannot be performed yet because the host has not yet performed DNS resolution"
+	}
 	var response *models.DomainResolutionResponse
 	if err := json.Unmarshal([]byte(c.host.DomainNameResolutions), &response); err != nil {
-		return ValidationError, ""
+		return ValidationError, "Error while parsing DNS resolution response"
 	}
 	dnsWildcardName := domainNameToResolve(c, constants.DNSWildcardFalseDomainName)
 


### PR DESCRIPTION
Fixes the following issue and adds test to a feature that previously
didn't have tests:

# Description of the problem:

The IsDNSWildcardNotConfigured validation should be pending before the agent responds with domain resolutions

# How reproducible:

100%

# Steps to reproduce:

1. Boot a host

2. See that IsDNSWildcardNotConfigured is in error

3. Wait for DNS resolutions to arrive from the agent

4. See that IsDNSWildcardNotConfigured is no longer in error

# Actual results:

IsDNSWildcardNotConfigured is in error for a while because it's can't decode the empty non-existing result as JSON

# Expected results:

IsDNSWildcardNotConfigured should never be in error before resolutions, it should be pending instead


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md