### PR TITLE
NO-ISSUE: https://red.ht/assisted doc should link to the actual hosted installer

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,3 +1,7 @@
+# Assisted Installer
+
+Assisted Installer is available at https://console.redhat.com/openshift/assisted-installer
+
 # User Guide
 
 Welcome to the Openshift Assisted Service User Guide.


### PR DESCRIPTION
Right now https://red.ht/assisted redirects to a doc that is mostly just
screenshots and explanations, with no link to the actual product. This
commit fixes that

## List all the issues related to this PR

- [x] Documentation

## What environments does this code impact?

- [x] None

## How was this code tested?

- [x] No tests needed

## Assignees

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md