### PR TITLE
Bug 2113954: Fix order when merging ignitions

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1191,7 +1191,7 @@ func (r *BMACReconciler) ensureMCSCert(ctx context.Context, log logrus.FieldLogg
 	// User has set ignition via annotation
 	if ok {
 		log.Debug("User has set ignition via annotation")
-		res, err := ignition.MergeIgnitionConfig([]byte(userIgnition), []byte(ignitionWithMCSCert))
+		res, err := ignition.MergeIgnitionConfig([]byte(ignitionWithMCSCert), []byte(userIgnition))
 		if err != nil {
 			log.WithError(err).Errorf("Error while merging the ignitions")
 			return reconcileError{err}

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -411,6 +411,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 	})
 })
 
+// TODO(deprecate-ignition-3.1.0)
 var _ = Describe("createHostIgnitions", func() {
 	const masterIgn = `{
 		  "ignition": {
@@ -813,69 +814,104 @@ var _ = Describe("downloadManifest", func() {
 	})
 })
 
-var _ = Describe("ParseToLatest", func() {
+var _ = Context("with test ignitions", func() {
+	const v30ignition = `{"ignition": {"version": "3.0.0"},"storage": {"files": []}}`
+	const v31ignition = `{"ignition": {"version": "3.1.0"},"storage": {"files": [{"path": "/tmp/chocobomb", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+	const v32ignition = `{"ignition": {"version": "3.2.0"},"storage": {"files": [{"path": "/tmp/chocobomb", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+	const v33ignition = `{"ignition": {"version": "3.3.0"},"storage": {"files": []}}`
 	const v99ignition = `{"ignition": {"version": "9.9.0"},"storage": {"files": []}}`
-	const v32ignition = `{"ignition": {"version": "3.2.0"},"storage": {"files": []}}`
-	const v31ignition = `{"ignition": {"version": "3.1.0"},"storage": {"files": []}}`
-	const v32override = `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+
 	const v31override = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
-	It("parses a v32 config as 3.2.0", func() {
-		config, err := ParseToLatest([]byte(v32ignition))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(config.Ignition.Version).To(Equal("3.2.0"))
+	const v32override = `{"ignition": {"version": "3.2.0"}, "storage": {"disks":[{"device":"/dev/sdb","partitions":[{"label":"root","number":4,"resize":true,"sizeMiB":204800}],"wipeTable":false}],"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 
-		bytes, err := json.Marshal(config)
-		Expect(err).ToNot(HaveOccurred())
-		v32Config, _, err := config_32.Parse(bytes)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
+	Describe("ParseToLatest", func() {
+		It("parses a v32 config as 3.2.0", func() {
+			config, err := ParseToLatest([]byte(v32ignition))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Ignition.Version).To(Equal("3.2.0"))
+
+			bytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			v32Config, _, err := config_32.Parse(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
+		})
+
+		It("parses a v31 config as 3.1.0", func() {
+			config, err := ParseToLatest([]byte(v31ignition))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Ignition.Version).To(Equal("3.1.0"))
+
+			bytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			v31Config, _, err := config_31.Parse(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
+		})
+
+		It("does not parse v99 config", func() {
+			_, err := ParseToLatest([]byte(v99ignition))
+			Expect(err.Error()).To(ContainSubstring("unsupported config version"))
+		})
+
+		It("does not parse v30 config", func() {
+			_, err := ParseToLatest([]byte(v30ignition))
+			Expect(err.Error()).To(ContainSubstring("unsupported config version"))
+		})
+
+		It("does not parse v33 config", func() {
+			_, err := ParseToLatest([]byte(v33ignition))
+			Expect(err.Error()).To(ContainSubstring("unsupported config version"))
+		})
 	})
 
-	It("parses a v31 config as 3.1.0", func() {
-		config, err := ParseToLatest([]byte(v31ignition))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(config.Ignition.Version).To(Equal("3.1.0"))
+	Describe("MergeIgnitionConfig", func() {
+		It("parses a v31 config with v31 override as 3.1.0", func() {
+			merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v31override))
+			Expect(err).ToNot(HaveOccurred())
 
-		bytes, err := json.Marshal(config)
-		Expect(err).ToNot(HaveOccurred())
-		v31Config, _, err := config_31.Parse(bytes)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
-	})
+			config, err := ParseToLatest([]byte(merge))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Ignition.Version).To(Equal("3.1.0"))
 
-	It("parses a v31 config with v31 override as 3.1.0", func() {
-		merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v31override))
-		Expect(err).ToNot(HaveOccurred())
+			bytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			v31Config, _, err := config_31.Parse(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
+		})
 
-		config, err := ParseToLatest([]byte(merge))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(config.Ignition.Version).To(Equal("3.1.0"))
+		It("parses a v31 config with v32 override as 3.2.0", func() {
+			merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v32override))
+			Expect(err).ToNot(HaveOccurred())
 
-		bytes, err := json.Marshal(config)
-		Expect(err).ToNot(HaveOccurred())
-		v31Config, _, err := config_31.Parse(bytes)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
-	})
+			config, err := ParseToLatest([]byte(merge))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Ignition.Version).To(Equal("3.2.0"))
 
-	It("parses a v31 config with v32 override as 3.2.0", func() {
-		merge, err := MergeIgnitionConfig([]byte(v31ignition), []byte(v32override))
-		Expect(err).ToNot(HaveOccurred())
+			bytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			v32Config, _, err := config_32.Parse(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
+		})
 
-		config, err := ParseToLatest([]byte(merge))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(config.Ignition.Version).To(Equal("3.2.0"))
+		// Be aware, this combination is counterintuitive and comes from the fact that MergeStructTranscribe()
+		// is not order-agnostic and prefers the field coming from the override rather from the base.
+		It("parses a v32 config with v31 override as 3.1.0", func() {
+			merge, err := MergeIgnitionConfig([]byte(v32ignition), []byte(v31override))
+			Expect(err).ToNot(HaveOccurred())
 
-		bytes, err := json.Marshal(config)
-		Expect(err).ToNot(HaveOccurred())
-		v32Config, _, err := config_32.Parse(bytes)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(v32Config.Ignition.Version).To(Equal("3.2.0"))
-	})
+			config, err := ParseToLatest([]byte(merge))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(config.Ignition.Version).To(Equal("3.1.0"))
 
-	It("does not parse v99 config", func() {
-		_, err := ParseToLatest([]byte(v99ignition))
-		Expect(err.Error()).To(ContainSubstring("unsupported config version"))
+			bytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			v31Config, _, err := config_31.Parse(bytes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v31Config.Ignition.Version).To(Equal("3.1.0"))
+		})
 	})
 })
 


### PR DESCRIPTION
This PR changes the order of calling ignition merge function in BMAC.
This is because the function is not performing a merge towards the
latest provided ignition but merges towards the ignition version
provided as a second parameter.

Because of this behaviour we have observed cases where user providing
ignition override v3.2.0 was receiving a rendered ignition v3.1.0 with
some data lost (i.e. features introduced in 3.2 and not available in
3.1).

Fixes: Bug-2113954
Fixes: Bug-2099929
Closes: [MGMTBUGSM-447](https://issues.redhat.com//browse/MGMTBUGSM-447)
Closes: [MGMTBUGSM-499](https://issues.redhat.com//browse/MGMTBUGSM-499)

/cc @carbonin 