### PR TITLE
MGMT-11447: Improve ignition downloadable (day2 API connectivity check) validation message

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/api_vip_connectivity_response.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/api_vip_connectivity_response.go
@@ -15,17 +15,21 @@ import (
 // APIVipConnectivityResponse The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.
 // Note - the name "API VIP connectivity" is old and misleading and is preserved for backwards compatibility.
 //
-//
 // swagger:model api_vip_connectivity_response
 type APIVipConnectivityResponse struct {
 
+	// The error that occurred while downloading the worker ignition file, ignored when is_success is true
+	DownloadError string `json:"download_error,omitempty"`
+
 	// Ignition file fetched from the target cluster's API machine config server.
 	// This ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.
-	//
 	Ignition string `json:"ignition,omitempty"`
 
-	// Whether the agent was able to contact the API of the target cluster or not
+	// Whether the agent was able to download the ignition or not
 	IsSuccess bool `json:"is_success,omitempty"`
+
+	// This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request
+	URL string `json:"url,omitempty"`
 }
 
 // Validate validates this api vip connectivity response

--- a/models/api_vip_connectivity_response.go
+++ b/models/api_vip_connectivity_response.go
@@ -15,17 +15,21 @@ import (
 // APIVipConnectivityResponse The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.
 // Note - the name "API VIP connectivity" is old and misleading and is preserved for backwards compatibility.
 //
-//
 // swagger:model api_vip_connectivity_response
 type APIVipConnectivityResponse struct {
 
+	// The error that occurred while downloading the worker ignition file, ignored when is_success is true
+	DownloadError string `json:"download_error,omitempty"`
+
 	// Ignition file fetched from the target cluster's API machine config server.
 	// This ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.
-	//
 	Ignition string `json:"ignition,omitempty"`
 
-	// Whether the agent was able to contact the API of the target cluster or not
+	// Whether the agent was able to download the ignition or not
 	IsSuccess bool `json:"is_success,omitempty"`
+
+	// This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request
+	URL string `json:"url,omitempty"`
 }
 
 // Validate validates this api vip connectivity response

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5221,16 +5221,24 @@ func init() {
       }
     },
     "api_vip_connectivity_response": {
-      "description": "The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.\nNote - the name \"API VIP connectivity\" is old and misleading and is preserved for backwards compatibility.\n",
+      "description": "The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.\nNote - the name \"API VIP connectivity\" is old and misleading and is preserved for backwards compatibility.",
       "type": "object",
       "properties": {
+        "download_error": {
+          "description": "The error that occurred while downloading the worker ignition file, ignored when is_success is true",
+          "type": "string"
+        },
         "ignition": {
-          "description": "Ignition file fetched from the target cluster's API machine config server.\nThis ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.\n",
+          "description": "Ignition file fetched from the target cluster's API machine config server.\nThis ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.",
           "type": "string"
         },
         "is_success": {
-          "description": "Whether the agent was able to contact the API of the target cluster or not",
+          "description": "Whether the agent was able to download the ignition or not",
           "type": "boolean"
+        },
+        "url": {
+          "description": "This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request",
+          "type": "string"
         }
       }
     },
@@ -14615,16 +14623,24 @@ func init() {
       }
     },
     "api_vip_connectivity_response": {
-      "description": "The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.\nNote - the name \"API VIP connectivity\" is old and misleading and is preserved for backwards compatibility.\n",
+      "description": "The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.\nNote - the name \"API VIP connectivity\" is old and misleading and is preserved for backwards compatibility.",
       "type": "object",
       "properties": {
+        "download_error": {
+          "description": "The error that occurred while downloading the worker ignition file, ignored when is_success is true",
+          "type": "string"
+        },
         "ignition": {
-          "description": "Ignition file fetched from the target cluster's API machine config server.\nThis ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.\n",
+          "description": "Ignition file fetched from the target cluster's API machine config server.\nThis ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.",
           "type": "string"
         },
         "is_success": {
-          "description": "Whether the agent was able to contact the API of the target cluster or not",
+          "description": "Whether the agent was able to download the ignition or not",
           "type": "boolean"
+        },
+        "url": {
+          "description": "This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request",
+          "type": "string"
         }
       }
     },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5482,16 +5482,22 @@ definitions:
 
   api_vip_connectivity_response:
     type: object
-    description: |
+    description: |-
       The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.
       Note - the name "API VIP connectivity" is old and misleading and is preserved for backwards compatibility.
     properties:
       is_success:
         type: boolean
-        description: Whether the agent was able to contact the API of the target cluster or not
+        description: Whether the agent was able to download the ignition or not
+      url:
+        type: string
+        description: This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request
+      download_error:
+        type: string
+        description: The error that occurred while downloading the worker ignition file, ignored when is_success is true
       ignition:
         type: string
-        description: |
+        description: |-
           Ignition file fetched from the target cluster's API machine config server.
           This ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.
 

--- a/vendor/github.com/openshift/assisted-service/models/api_vip_connectivity_response.go
+++ b/vendor/github.com/openshift/assisted-service/models/api_vip_connectivity_response.go
@@ -15,17 +15,21 @@ import (
 // APIVipConnectivityResponse The response from the day-2 agent's attempt to download the worker ignition file from the API machine config server of the target cluster.
 // Note - the name "API VIP connectivity" is old and misleading and is preserved for backwards compatibility.
 //
-//
 // swagger:model api_vip_connectivity_response
 type APIVipConnectivityResponse struct {
 
+	// The error that occurred while downloading the worker ignition file, ignored when is_success is true
+	DownloadError string `json:"download_error,omitempty"`
+
 	// Ignition file fetched from the target cluster's API machine config server.
 	// This ignition file may be incomplete as almost all files / systemd units are removed from it by the agent in order to save space.
-	//
 	Ignition string `json:"ignition,omitempty"`
 
-	// Whether the agent was able to contact the API of the target cluster or not
+	// Whether the agent was able to download the ignition or not
 	IsSuccess bool `json:"is_success,omitempty"`
+
+	// This parameter mirrors the url parameter of the corresponding api_vip_connectivity_request
+	URL string `json:"url,omitempty"`
 }
 
 // Validate validates this api vip connectivity response


### PR DESCRIPTION
The current message (constructed by the UI) is "API IP connectivity
failure - To continue installation, configure your DNS or alternatively
<a>Update cluster with API IP</a>"

There are multiple issues with the current message:

1) The title says "API IP connectivity failure". This is not technically
   correct. The issue is reaching the API in general. It doesn't
   necessarily have anything to do with an "IP address".

2) The suggestion to "configure your DNS or Update cluster with API IP"
   is misleading - it seems to imply that if the user chooses to not
   configure their DNS, they can simply "update the cluster with API IP"
   and everything will work fine. This is not necessarily correct -
   none-platform clusters require the user to configure DNS, regardless
   of whether they provide us with the IP address of their cluster or
   not. The worker will simply not be able to join without it.

3) "update the cluster with API IP" needs rewording. "Updating a
   cluster" doesn't mean much to someone without internal AI developer
   perspective. It's extra confusing in day-2 because they already have
   a cluster. The concept of a "cluster" that the message is referring
   to is unknown to the user - us reusing the day-1 internal "cluster"
   entity for adding day-2 workers is merely an implementation detail
   and not something they user should be aware of, yet this message
   expects them to be aware of it. When read superficially by a user,
   this message seems to imply they have to make some change to their
   actual cluster, and it's confusing, because they don't.

To solve this we're gonna make the backend build most of the message.

1) The title should instead say "API connectivity failure"
- This will be done as part of the UI PR

2) The message should be more verbose about what actually happened:
   "This host has failed to contact the cluster's API at <API URL> with
   the following error: <error>. Please ensure the host can reach the
   API", and to that the UI will add to that something like
   "Alternatively, set a different API hostname <link>" which will allow
   lead the users to change the hostname setting dialog

It's important to include the entire URL in the message because we're
trying to contact the API at a very specific port number, and this is a
port number that's likely to be blocked by a firewall, so they user
should be aware of it. It's also important to include the entire URL
because the API domain name is something the UI crafts without user
interaction, when importing the cluster from OCM, so it's possible that
it's not even correct - the user needs to see it.

The agent will be separately improved to provide the service with both
the URL it tried to contact (which it itself will get from the service,
but we include it in the response anyway in case it changed and the
agent didn't get a chance to try the new URL yet) and the agent will
also include the error message it encountered when attempting to
download the ignition from the API - DNS error, connection refused,
whatever - the user should not be forced to SSH and watch agent logs to
figure out what went wrong.

Also changed the validation to be a `ValidationError` whenever the
service fails to deserialize the agent response, instead of a
"ValidationFailure".

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    Unit tests
- [ ] No tests needed

## Assignees

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md