### PR TITLE
MGMT-11521: Fix twine upload of assisted-service-client

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ wheel==0.37.1
 retry==0.9.2
 pyyaml==6.0
 jinja2==3.0.3
+packaging==21.3


### PR DESCRIPTION
Somewhere around July 31 2022, the 'publish-python-client' job started failing (see
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-assisted-service-master-edge-publish-python-client/1553847262923198464) with the following error:
```
python3 -m twine upload --skip-existing
"/home/assisted-service/build/ci-op-9xpc88fc/assisted-service-client/dist/*.whl"
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/venv/lib64/python3.9/site-packages/twine/__main__.py", line
22, in <module>
    from twine import cli
  File "/opt/venv/lib64/python3.9/site-packages/twine/cli.py", line 18,
in <module>
    from packaging import requirements
ModuleNotFoundError: No module named 'packaging'
```

Apparently there's some need to install the 'packaging' package now.
This change adds 'packaging' dependency (the problem has been resolved in twine v4.0, but we cannot upgrade because some parts are still built with py3.6 that is incompatible with twine v4.0).

I manually verified the fix and it worked great for me.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @eliorerz 
/cc @gamli75 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
