### PR TITLE
MGMT-11335: Handle agent reclaim step replies

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2851,6 +2851,10 @@ func (b *bareMetalInventory) handleReplyError(params installer.V2PostStepReplyPa
 
 	case models.StepTypeTangConnectivityCheck:
 		return b.hostApi.UpdateTangConnectivityReport(ctx, h, params.Reply.Error)
+
+	case models.StepTypeDownloadBootArtifacts:
+		log.Errorf("Failed to download boot artifacts to reclaim host %s, output: %s, error: %s", h.ID, params.Reply.Output, params.Reply.Error)
+		return b.hostApi.HandleReclaimFailure(ctx, h)
 	}
 	return nil
 }
@@ -3090,6 +3094,8 @@ func handleReplyByType(params installer.V2PostStepReplyParams, b *bareMetalInven
 		err = b.updateDomainNameResolutionResponse(ctx, &host, stepReply)
 	case models.StepTypeUpgradeAgent:
 		err = b.processUpgradeAgentResponse(ctx, &host, stepReply)
+	case models.StepTypeDownloadBootArtifacts:
+		err = b.hostApi.HandleReclaimBootArtifactDownload(ctx, &host)
 	}
 	return err
 }

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -96,6 +96,8 @@ type API interface {
 	RegisterInstalledOCPHost(ctx context.Context, h *models.Host, db *gorm.DB) error
 	HandleInstallationFailure(ctx context.Context, h *models.Host) error
 	HandleMediaDisconnected(ctx context.Context, h *models.Host) error
+	HandleReclaimBootArtifactDownload(ctx context.Context, h *models.Host) error
+	HandleReclaimFailure(ctx context.Context, h *models.Host) error
 	UpdateInstallProgress(ctx context.Context, h *models.Host, progress *models.HostProgress) error
 	RefreshStatus(ctx context.Context, h *models.Host, db *gorm.DB) error
 	SetBootstrap(ctx context.Context, h *models.Host, isbootstrap bool, db *gorm.DB) error
@@ -1397,4 +1399,12 @@ func (m *Manager) HostWithCollectedLogsExists(clusterId strfmt.UUID) (bool, erro
 
 func (m *Manager) GetKnownApprovedHosts(clusterId strfmt.UUID) (hosts []*common.Host, err error) {
 	return common.GetHostsFromDBWhere(m.db, "cluster_id = ? and status = ? and approved = TRUE", clusterId.String(), models.HostStatusKnown)
+}
+
+func (m *Manager) HandleReclaimBootArtifactDownload(ctx context.Context, h *models.Host) error {
+	return m.sm.Run(TransitionTypeRebootingForReclaim, newStateHost(h), &TransitionArgsReclaimHost{ctx: ctx, db: m.db})
+}
+
+func (m *Manager) HandleReclaimFailure(ctx context.Context, h *models.Host) error {
+	return m.sm.Run(TransitionTypeReclaimFailed, newStateHost(h), &TransitionArgsUnbindHost{ctx: ctx, db: m.db})
 }

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -201,6 +201,34 @@ func (mr *MockAPIMockRecorder) HandleMediaDisconnected(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleMediaDisconnected", reflect.TypeOf((*MockAPI)(nil).HandleMediaDisconnected), arg0, arg1)
 }
 
+// HandleReclaimBootArtifactDownload mocks base method.
+func (m *MockAPI) HandleReclaimBootArtifactDownload(arg0 context.Context, arg1 *models.Host) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleReclaimBootArtifactDownload", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleReclaimBootArtifactDownload indicates an expected call of HandleReclaimBootArtifactDownload.
+func (mr *MockAPIMockRecorder) HandleReclaimBootArtifactDownload(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleReclaimBootArtifactDownload", reflect.TypeOf((*MockAPI)(nil).HandleReclaimBootArtifactDownload), arg0, arg1)
+}
+
+// HandleReclaimFailure mocks base method.
+func (m *MockAPI) HandleReclaimFailure(arg0 context.Context, arg1 *models.Host) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleReclaimFailure", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleReclaimFailure indicates an expected call of HandleReclaimFailure.
+func (mr *MockAPIMockRecorder) HandleReclaimFailure(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleReclaimFailure", reflect.TypeOf((*MockAPI)(nil).HandleReclaimFailure), arg0, arg1)
+}
+
 // HostMonitoring mocks base method.
 func (m *MockAPI) HostMonitoring() {
 	m.ctrl.T.Helper()

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -422,7 +422,7 @@ func (th *transitionHandler) PostReclaim(sw stateswitch.StateSwitch, args states
 		return errors.New("PostReclaim invalid argument")
 	}
 
-	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, statusInfoRebootingForReclaim, nil)
+	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, statusInfoRebootingForReclaim)
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -548,6 +548,13 @@ var _ = Describe("RegisterHost", func() {
 				newHost:     false,
 				eventRaised: true,
 			},
+			{
+				name:        "reclaiming-rebooting to discovering-unbound",
+				srcState:    models.HostStatusReclaimingRebooting,
+				dstState:    models.HostStatusDiscoveringUnbound,
+				newHost:     false,
+				eventRaised: true,
+			},
 		}
 		for i := range tests {
 			t := tests[i]


### PR DESCRIPTION
Adds handling for agent step replies for the `download-boot-artifacts` step type.

A successful response transitions the host from `Reclaiming` to `ReclaimingRebooting` a failure transitions the host to `UnbindingPendingUserAction`

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-11335

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Rebased this PR onto https://github.com/openshift/assisted-service/pull/4117 and manually posted the agent response.
Saw the agent progress into `ReclaimingRebooting` then into `Known` after I manually booted the machine from the discovery ISO.

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nmagnezi 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
