### PR TITLE
Bug-2107617:  Attempted 240 node cluster with MCE / Assisted-installer and ended up with 187 node cluster

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -764,7 +764,8 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, clusterID strfmt.UU
 	} else {
 		totalPercentage = int64(common.ProgressWeightInstallingStage * float64(installingStagePercentage))
 		if cluster.Progress != nil {
-			totalPercentage += int64(common.ProgressWeightPreparingForInstallationStage * float64(cluster.Progress.PreparingForInstallationStagePercentage))
+			totalPercentage += int64(common.ProgressWeightPreparingForInstallationStage*float64(cluster.Progress.PreparingForInstallationStagePercentage) +
+				common.ProgressWeightFinalizingStage*float64(cluster.Progress.FinalizingStagePercentage))
 		}
 	}
 	updates := map[string]interface{}{
@@ -778,7 +779,7 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, clusterID strfmt.UU
 func (m *Manager) UpdateFinalizingProgress(ctx context.Context, db *gorm.DB, clusterID strfmt.UUID) error {
 	log := logutil.FromContext(ctx, m.log)
 
-	cluster, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+	cluster, err := common.GetClusterFromDB(common.LoadTableFromDB(db, common.MonitoredOperatorsTable), clusterID, common.SkipEagerLoading)
 	if err != nil {
 		log.WithError(err).Error("Failed to get cluster from DB")
 		return err

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -339,20 +339,22 @@ var _ = Describe("Progress bar test", func() {
 		})
 
 		tests := []struct {
-			name             string
-			clusterStatus    string
-			hostStatus       string
-			progress         models.ClusterProgressInfo
-			installStartTime strfmt.DateTime
-			expected         [3]int
+			name                  string
+			clusterStatus         string
+			hostStatus            string
+			progress              models.ClusterProgressInfo
+			installStartTime      strfmt.DateTime
+			expected              [3]int
+			expectedClusterStatus string
 		}{
 			{
-				name:             "preparing-for-installation --> installing should set the progress to 10%",
-				clusterStatus:    models.ClusterStatusPreparingForInstallation,
-				hostStatus:       models.HostStatusPreparingSuccessful,
-				progress:         models.ClusterProgressInfo{},
-				installStartTime: strfmt.DateTime(time.Time{}),
-				expected:         [3]int{100, 0, 0},
+				name:                  "preparing-for-installation --> installing should set the progress to 10%",
+				clusterStatus:         models.ClusterStatusPreparingForInstallation,
+				hostStatus:            models.HostStatusPreparingSuccessful,
+				progress:              models.ClusterProgressInfo{},
+				installStartTime:      strfmt.DateTime(time.Time{}),
+				expected:              [3]int{100, 0, 0},
+				expectedClusterStatus: models.ClusterStatusInstalling,
 			},
 			{
 				name:             "installing-pending-user-action --> installing should not change the progress",
@@ -361,7 +363,8 @@ var _ = Describe("Progress bar test", func() {
 				installStartTime: strfmt.DateTime(time.Now()),
 				progress: models.ClusterProgressInfo{PreparingForInstallationStagePercentage: 100,
 					InstallingStagePercentage: 80, FinalizingStagePercentage: 0, TotalPercentage: 66},
-				expected: [3]int{100, 80, 0},
+				expected:              [3]int{100, 80, 0},
+				expectedClusterStatus: models.ClusterStatusFinalizing,
 			},
 		}
 
@@ -400,7 +403,7 @@ var _ = Describe("Progress bar test", func() {
 				By(fmt.Sprintf("test progress from state %s to installing", t.clusterStatus))
 				cAfterRefresh, err := clusterApi.RefreshStatus(ctx, &c, db)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(*cAfterRefresh.Status).To(Equal(models.ClusterStatusInstalling))
+				Expect(*cAfterRefresh.Status).To(Equal(t.expectedClusterStatus))
 
 				expectProgressToBe(cAfterRefresh, t.expected[0], t.expected[1], t.expected[2])
 			})

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -345,6 +345,18 @@ func (th *transitionHandler) IsInstalling(sw stateswitch.StateSwitch, args state
 	return th.enoughMastersAndWorkers(sCluster, installingStatuses), nil
 }
 
+//check if we should stay in installing state
+func (th *transitionHandler) areAllHostsDone(sw stateswitch.StateSwitch, _ stateswitch.TransitionArgs) (bool, error) {
+	sCluster, _ := sw.(*stateCluster)
+	doneStatuses := []string{models.HostStatusInstalled, models.HostStatusError}
+	for _, h := range sCluster.cluster.Hosts {
+		if !funk.ContainsString(doneStatuses, swag.StringValue(h.Status)) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 //check if we should move to installing-pending-user-action state
 func (th *transitionHandler) IsInstallingPendingUserAction(
 	sw stateswitch.StateSwitch,

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -3367,19 +3367,19 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 
 var _ = Describe("Refresh Cluster - Installing Cases", func() {
 	var (
-		ctx                                     = context.Background()
-		db                                      *gorm.DB
-		clusterId, hid1, hid2, hid3, hid4, hid5 strfmt.UUID
-		cluster                                 common.Cluster
-		clusterApi                              *Manager
-		mockEvents                              *eventsapi.MockHandler
-		mockHostAPI                             *host.MockAPI
-		mockMetric                              *metrics.MockAPI
-		mockS3Api                               *s3wrapper.MockAPI
-		mockAccountsMgmt                        *ocm.MockOCMAccountsMgmt
-		operatorsManager                        *operators.Manager
-		ctrl                                    *gomock.Controller
-		dbName                                  string
+		ctx                                           = context.Background()
+		db                                            *gorm.DB
+		clusterId, hid1, hid2, hid3, hid4, hid5, hid6 strfmt.UUID
+		cluster                                       common.Cluster
+		clusterApi                                    *Manager
+		mockEvents                                    *eventsapi.MockHandler
+		mockHostAPI                                   *host.MockAPI
+		mockMetric                                    *metrics.MockAPI
+		mockS3Api                                     *s3wrapper.MockAPI
+		mockAccountsMgmt                              *ocm.MockOCMAccountsMgmt
+		operatorsManager                              *operators.Manager
+		ctrl                                          *gomock.Controller
+		dbName                                        string
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
@@ -3405,6 +3405,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		hid3 = strfmt.UUID(uuid.New().String())
 		hid4 = strfmt.UUID(uuid.New().String())
 		hid5 = strfmt.UUID(uuid.New().String())
+		hid6 = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 	Context("All transitions", func() {
@@ -3462,6 +3463,21 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					{ID: &hid3, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
 					{ID: &hid4, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
 					{ID: &hid5, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+				},
+				statusInfoChecker: makeValueChecker(statusInfoInstallingPendingUserAction),
+			},
+			{
+				name:          "finalizing to installing-pending-user-action",
+				srcState:      models.ClusterStatusFinalizing,
+				srcStatusInfo: statusInfoFinalizing,
+				dstState:      models.ClusterStatusInstallingPendingUserAction,
+				hosts: []models.Host{
+					{ID: &hid1, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid2, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid3, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid4, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid5, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid6, Status: swag.String(models.HostStatusInstallingPendingUserAction), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
 				},
 				statusInfoChecker: makeValueChecker(statusInfoInstallingPendingUserAction),
 			},
@@ -3549,6 +3565,36 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					{ID: &hid5, Status: swag.String(models.HostStatusInstalling), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
 				},
 				statusInfoChecker: makeValueChecker(statusInfoInstalling),
+			},
+			{
+				name:          "installing-pending-user-action to finalizing",
+				srcState:      models.ClusterStatusInstallingPendingUserAction,
+				srcStatusInfo: statusInfoInstallingPendingUserAction,
+				dstState:      models.ClusterStatusFinalizing,
+				hosts: []models.Host{
+					{ID: &hid1, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid2, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid3, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid4, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid5, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid6, Status: swag.String(models.HostStatusInstallingInProgress), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+				},
+				statusInfoChecker: makeValueChecker(statusInfoFinalizing),
+			},
+			{
+				name:          "installing-pending-user-action to finalizing (2)",
+				srcState:      models.ClusterStatusInstallingPendingUserAction,
+				srcStatusInfo: statusInfoInstallingPendingUserAction,
+				dstState:      models.ClusterStatusFinalizing,
+				hosts: []models.Host{
+					{ID: &hid1, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid2, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid3, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleMaster},
+					{ID: &hid4, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid5, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+					{ID: &hid6, Status: swag.String(models.HostStatusInstalled), Inventory: common.GenerateTestDefaultInventory(), Role: models.HostRoleWorker},
+				},
+				statusInfoChecker: makeValueChecker(statusInfoFinalizing),
 			},
 			{
 				name:          "installing to finalizing",
@@ -3707,7 +3753,8 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 						eventstest.WithNameMatcher(eventgen.ClusterStatusUpdatedEventName),
 						eventstest.WithClusterIdMatcher(clusterId.String()))).AnyTimes()
 				}
-				if t.srcState == models.ClusterStatusFinalizing && !t.requiresAMSUpdate && !t.installationTimeout {
+				if t.srcState == models.ClusterStatusFinalizing && !t.requiresAMSUpdate && !t.installationTimeout &&
+					funk.ContainsString([]string{models.ClusterStatusInstalled, models.ClusterStatusFinalizing}, t.dstState) {
 					mockS3Api.EXPECT().DoesObjectExist(ctx, fmt.Sprintf("%s/%s", cluster.ID, constants.Kubeconfig)).Return(false, nil)
 				}
 				reportInstallationCompleteStatuses := []string{models.ClusterStatusInstalled, models.ClusterStatusError, models.ClusterStatusInstallingPendingUserAction}


### PR DESCRIPTION


In order to move cluster to finalizing, 3 masters and 2 workers have to
be installed.  The others are still may not be installed yet.
If the cluster installation is complete (operators are up and kubeconfig
in place) but some nodes have not completed installation, these hosts
will never move to installed because they depend on the controller to
report the stage.
The controller stops running if cluster is not in installation status.
This means that these hosts will eventually move to error on timeout.
This change ensures that cluster can move from finalizing to insllled
only if all its hosts are either installed, or in error.
This change also enables transition from finalizing to
pending-user-action if there is a host in pending-user-action while the
cluster is finalizing. The cluster will move back to finalizing when the
host moves back to installing status.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
