### PR TITLE
MGMT-11621: Allow subdomains in cluster name

### DIFF
--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -212,12 +212,16 @@ func (m *mockOCMAuthorization) CapabilityReview(ctx context.Context, username, c
 }
 
 var _ = Describe("Cluster name validation", func() {
-	It("success", func() {
+	It("valid", func() {
 		err := ValidateClusterNameFormat("test-1")
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("success - name starts with number", func() {
+	It("valid - starts with number", func() {
 		err := ValidateClusterNameFormat("1-test")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("valid - contains subdomain", func() {
+		err := ValidateClusterNameFormat("test.test")
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("invalid format - special character", func() {
@@ -238,6 +242,14 @@ var _ = Describe("Cluster name validation", func() {
 	})
 	It("invalid format - starts with hyphen", func() {
 		err := ValidateClusterNameFormat("-test")
+		Expect(err).Should(HaveOccurred())
+	})
+	It("invalid format - starts with dot", func() {
+		err := ValidateClusterNameFormat(".test")
+		Expect(err).Should(HaveOccurred())
+	})
+	It("invalid format - contains two dots in a row", func() {
+		err := ValidateClusterNameFormat("test..test")
 		Expect(err).Should(HaveOccurred())
 	})
 })

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -29,7 +29,7 @@ type Config struct {
 }
 
 const (
-	clusterNameRegex    = "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+	clusterNameRegex    = "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*$"
 	CloudOpenShiftCom   = "cloud.openshift.com"
 	sshPublicKeyRegex   = "^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$"
 	dockerHubRegistry   = "docker.io"
@@ -206,7 +206,7 @@ func (v *registryPullSecretValidator) ValidatePullSecret(secret string, username
 func ValidateClusterNameFormat(name string) error {
 	if matched, _ := regexp.MatchString(clusterNameRegex, name); !matched {
 		return errors.Errorf("Cluster name format is not valid: '%s'. "+
-			"Name must consist of lower-case letters, numbers and hyphens. "+
+			"Name must consist of lower-case letters, numbers, hyphens, and periods. "+
 			"It must start and end with either a letter or number.", name)
 	}
 	return nil


### PR DESCRIPTION
[MGMT-11621](https://issues.redhat.com/browse/MGMT-11621)
[MGMT-11614](https://issues.redhat.com/browse/MGMT-11614)
Subdomains are allowed according to RFC 1123, so
this change modifies the regex to  allow cluster
names to have subdomains.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): built image off this change, deployed in test-infra environment, created cluster with name "example.com" and saw it was created successfully
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @nmagnezi 
/cc @jtomasek 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
