### PR TITLE
Bug 2116549: SNO dnsmasq should use the managed nm resolv.conf

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -79,6 +79,15 @@ const snoDnsmasqConf = `
 address=/apps.{{.CLUSTER_NAME}}.{{.DNS_DOMAIN}}/{{.HOST_IP}}
 address=/api-int.{{.CLUSTER_NAME}}.{{.DNS_DOMAIN}}/{{.HOST_IP}}
 address=/api.{{.CLUSTER_NAME}}.{{.DNS_DOMAIN}}/{{.HOST_IP}}
+
+# Configure dnsmasq to use /run/NetworkManager/resolv.conf as its
+# resolv-file instead of /etc/resolv.conf. This way it uses a file
+# that's stable and doesn't change by our forcedns dispatcher script,
+# and also it uses a file that doesn't contain the node's own IP address.
+# We do this to alleviate https://bugzilla.redhat.com/show_bug.cgi?id=2116549
+# but we should keep it regardless, even after that bug is fixed, because
+# it's more correct.
+resolv-file=/run/NetworkManager/resolv.conf
 `
 
 const unmanagedResolvConf = `


### PR DESCRIPTION
# Background

NetworkManager stores its generated `resolv.conf` configuration in
`/run/NetworkManager/resolv.conf`. Since we use the `rc-manager=unmanaged`
config, it means NetworkManager only generates the above file, but
doesn't copy it to `/etc/resolv.conf`.

We use a network-manager dispatcher script we call `forcedns` to copy
`/run/NetworkManager/resolv.conf` to `/etc/resolv.conf`, but before we
do that, we also append the node's IP address to that file as a
nameserver. This is done to make the pods on the node use the dnsmasq
DNS server as their DNS server, and this way they can resolve the
API/Internal API/Ingress domains that we hard-code into the dnsmasq's
configuration.

# Issue

There's an OCP/RHCOS 4.11 bug that's still under investigation where
dnsmasq's CPU usage gets stuck at 100%. We have reasons to believe it
has something to do with us modifying/moving the `/etc/resolv.conf` file
while dnsmasq is using it. Also we suspect newer versions of `dnsmasq`
may not like the node's own IP address appearing in the
`/etc/resolv.conf` file.

# Proposed solution

Configure dnsmasq to use `/run/NetworkManager/resolv.conf` as its
`resolv-file` instead of `/etc/resolv.conf`. This way it uses a file
that's stable and doesn't change, and also it uses a file that doesn't
contain the node's own IP address.

# Note

The dnsmasq bug is under investigation and would have to be fixed in
dnsmasq itself in order to fix existing clusters that may want to
upgrade to 4.11. This PR / solution would alleviate the issue for newly
installed Assisted clusters.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
    - Will wait for people who can reproduce the issue to confirm this helps
- [ ] No tests needed

## Assignees

/cc @tsorya
/cc @celebdor

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md