### PR TITLE
MGMT-8890: Unit test to ensure compatibility of release images

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -43,6 +43,7 @@ const (
 	X86CPUArchitecture     = "x86_64"
 	DefaultCPUArchitecture = X86CPUArchitecture
 	ARM64CPUArchitecture   = "arm64"
+	PowerCPUArchitecture   = "ppc64le"
 	MultiCPUArchitecture   = "multiarch"
 )
 


### PR DESCRIPTION
This PR adds a set of explicit unit tests to ensure that extending
release image with `cpu_architectures` didn't break compatibility with
images using `cpu_architecture` and ignoring the old fields.

This tests adds explicit coverage for the following two scenarios:

1) image containing `cpu_architecture` and missing `cpu_architectures`
2) image containing both `cpu_architecture` and `cpu_architectures`

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)
Contributes-to: [MGMT-11494](https://issues.redhat.com//browse/MGMT-11494)