### PR TITLE
MGMT-8890: InfraEnv to validate content of release image

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -168,16 +168,6 @@ func (h *handler) GetDefaultReleaseImage(cpuArchitecture string) (*models.Releas
 
 // Returns the OsImage entity
 func (h *handler) GetOsImage(openshiftVersion, cpuArchitecture string) (*models.OsImage, error) {
-	// For multiarch clusters we are offloading the validation checking for existing OS image matching the version
-	// and the architecture directly to the InfraEnv. This is because Cluster object on its own cannot know which
-	// architecture is going to be used and we cannot enforce that OS images exist for every architecture from the
-	// multiarch release image.
-	// In the multiarch scenario it's up to the InfraEnv's ISO generation part to detect whether the required
-	// OS image exists or not. This is because we still have InfraEnvs per-architecture and don't allow for multiarch
-	// InfraEnvs. Based on that, it's reasonable to skip the validation for Cluster and let InfraEnv handle it.
-	if cpuArchitecture == common.MultiCPUArchitecture {
-		return nil, nil
-	}
 	if cpuArchitecture == "" {
 		// Empty implies default CPU architecture
 		cpuArchitecture = common.DefaultCPUArchitecture
@@ -283,12 +273,6 @@ func (h *handler) GetReleaseImage(openshiftVersion, cpuArchitecture string) (*mo
 
 // Returns the latest OSImage entity for a specified CPU architecture
 func (h *handler) GetLatestOsImage(cpuArchitecture string) (*models.OsImage, error) {
-	// For multiarch we are not returning any OS image. This is because at this moment there is no multiarch OS image,
-	// therefore a specific architecture has to always be requested. This is handled by the fact that InfraEnv always
-	// specifies an architecture and "multiarch" is valid only as a Cluster property.
-	if cpuArchitecture == common.MultiCPUArchitecture {
-		return nil, nil
-	}
 	var latest *models.OsImage
 	openshiftVersions := h.GetOpenshiftVersions()
 	for _, k := range openshiftVersions {

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -308,7 +308,7 @@ var _ = Describe("list versions", func() {
 			osImage, err = h.GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
 			Expect(err).Should(HaveOccurred())
 			Expect(osImage).Should(BeNil())
-			Expect(err.Error()).To(ContainSubstring("isn't specified"))
+			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
 		})
 
 		It("empty architecture fallback to default", func() {
@@ -317,10 +317,11 @@ var _ = Describe("list versions", func() {
 			Expect(*osImage.CPUArchitecture).Should(Equal(common.DefaultCPUArchitecture))
 		})
 
-		It("multiarch returns empty OS image", func() {
+		It("multiarch returns error", func() {
 			osImage, err = h.GetOsImage("4.11", common.MultiCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).Should(HaveOccurred())
 			Expect(osImage).Should(BeNil())
+			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
 		})
 
 		It("fetch OS image by major.minor", func() {
@@ -390,6 +391,18 @@ var _ = Describe("list versions", func() {
 			Expect(err).Should(HaveOccurred())
 			Expect(releaseImage).Should(BeNil())
 			Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
+		})
+
+		It("empty openshiftVersion", func() {
+			releaseImage, err = h.GetReleaseImage("", common.TestDefaultConfig.CPUArchitecture)
+			Expect(err).Should(HaveOccurred())
+			Expect(releaseImage).Should(BeNil())
+		})
+
+		It("empty cpuArchitecture", func() {
+			releaseImage, err = h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "")
+			Expect(err).Should(HaveOccurred())
+			Expect(releaseImage).Should(BeNil())
 		})
 
 		It("fetch release image by major.minor", func() {
@@ -765,12 +778,13 @@ var _ = Describe("list versions", func() {
 			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
 		})
 
-		It("Empty OS images for multiarch", func() {
+		It("fails to get OS images for multiarch", func() {
 			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			osImage, err = h.GetLatestOsImage(common.MultiCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).Should(HaveOccurred())
 			Expect(osImage).Should(BeNil())
+			Expect(err.Error()).To(ContainSubstring("No OS images are available"))
 		})
 	})
 

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -23,14 +23,23 @@ import (
 )
 
 var registerInfraEnv = func(clusterID *strfmt.UUID, imageType models.ImageType) *models.InfraEnv {
+	return internalRegisterInfraEnv(clusterID, imageType, "", openshiftVersion)
+}
+
+var registerInfraEnvSpecificVersionAndArch = func(clusterID *strfmt.UUID, imageType models.ImageType, cpuArch, ocpVersion string) *models.InfraEnv {
+	return internalRegisterInfraEnv(clusterID, imageType, cpuArch, ocpVersion)
+}
+
+var internalRegisterInfraEnv = func(clusterID *strfmt.UUID, imageType models.ImageType, cpuArch, ocpVersion string) *models.InfraEnv {
 	request, err := userBMClient.Installer.RegisterInfraEnv(context.Background(), &installer.RegisterInfraEnvParams{
 		InfraenvCreateParams: &models.InfraEnvCreateParams{
 			Name:             swag.String("test-infra-env"),
-			OpenshiftVersion: openshiftVersion,
+			OpenshiftVersion: ocpVersion,
 			PullSecret:       swag.String(pullSecret),
 			SSHAuthorizedKey: swag.String(sshPublicKey),
 			ImageType:        imageType,
 			ClusterID:        clusterID,
+			CPUArchitecture:  cpuArch,
 		},
 	})
 

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -32,6 +32,7 @@ var wiremock *WireMock
 var kubeClient k8sclient.Client
 var openshiftVersion string = "4.6"
 var snoVersion string = "4.8"
+var multiarchOpenshiftVersion string = "4.11"
 
 var (
 	agentBMClient             *client.AssistedInstall


### PR DESCRIPTION
This PR adds a logic that ensures we create InfraEnvs that refer to
existing release images. This is in order to prevent the following
scenario

* release image contains architecture [x86_64 ppc64le s390x]
* OS images available for [x86_64 arm64]
* infraenv created for arm64

The current logic for creating the ISO already detects the case when
InfraEnv uses architecture for which no RHCOS image is available.
However a scenario where RHCOS exists but OpenShift release image does
not was not covered till now. Without the change introduced by this PR
the missing release image would be detected only during the
installation. With this change it will happen very early in the
process so that we can prevent the installation from even starting.

Closes: [MGMT-11500](https://issues.redhat.com//browse/MGMT-11500)
Closes: [MGMT-11569](https://issues.redhat.com//browse/MGMT-11569)