### PR TITLE
MGMT-11708: install oc from quay.io

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -52,8 +52,7 @@ ARG WORK_DIR=/data
 RUN mkdir $WORK_DIR && chmod 775 $WORK_DIR
 
 # downstream this can be installed as an RPM
-ARG OC_URL=https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.12.0-0.nightly-2022-07-11-054352/openshift-client-linux.tar.gz
-RUN curl --retry 5 -s $OC_URL | tar -xzC /usr/local/bin/ oc
+COPY --from=quay.io/openshift/origin-cli:4.12 /usr/bin/oc /usr/local/bin/
 
 COPY --from=builder /build/assisted-service /assisted-service
 COPY --from=builder /build/assisted-service-operator /assisted-service-operator


### PR DESCRIPTION
We started getting a lot of failures when installing 'oc' as part of assisted-service build:

```
11:31:32 Step 31/41 : RUN curl --retry 5 -s $OC_URL | tar -xzC
   /usr/local/bin/ oc
11:31:32  ---> Running in 344822c28b1b
11:31:32
11:31:32 gzip: stdin: unexpected end of file
11:31:32 tar: Child returned status 1
11:31:32 tar: Error is not recoverable: exiting now
11:31:32 The command '/bin/sh -c curl --retry 5 -s $OC_URL | tar -xzC
   /usr/local/bin/ oc' returned a non-zero code: 2
11:31:33 make: *** [update-minimal] Error 2
11:31:33 Build step 'Execute shell' marked build as failure
11:31:33 Finished: FAILURE
```

It seems to affect builds on both app-sre and dptp platforms.

How reproducible:

On CI systems 100% (see prow and ci.ext.devshift.net), locally I
couldn't produce it.

More concrete examples:
https://ci.ext.devshift.net/job/openshift-assisted-service-gh-build-master/2874/console
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-assisted-service-release-ocm-2.6-images/1560939451792756736

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

TBD

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
