### PR TITLE
MGMT-8890: Use "multi" as a keyword for multi-arch OpenShift

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -44,7 +44,7 @@ const (
 	DefaultCPUArchitecture = X86CPUArchitecture
 	ARM64CPUArchitecture   = "arm64"
 	PowerCPUArchitecture   = "ppc64le"
-	MultiCPUArchitecture   = "multiarch"
+	MultiCPUArchitecture   = "multi"
 )
 
 // Configuration to be injected by discovery ignition.  It will cause IPv6 DHCP client identifier to be the same

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1486,7 +1486,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      clusterDeploymentSpec.ClusterName,
 		}
 		cluster := getClusterFromDB(ctx, kubeClient, db, clusterKubeName, waitForReconcileTimeout)
-		Expect(cluster.CPUArchitecture).Should(Equal("multiarch"))
+		Expect(cluster.CPUArchitecture).Should(Equal("multi"))
 
 		By("deploy infraenv with arm64 architecure")
 		infraEnvSpec.CpuArchitecture = "arm64"


### PR DESCRIPTION
This PR changes the value used to mark multiarchitecture OpenShift
clusters from "multiarch" to "multi". This is because the official
version marker is `-multi` so that all the tooling relying on this name
does not have to perform any translation.

An example of the currently performed translation is "amd64" and
"x86_64" that are representing the same architecture in two different
ways. With this change here we will not need to handle "multi" and "multiarch"
as the only used one will be "multi".

The change is safe as there are no clusters created using multiarch
release payload yet.

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)

/cc @carbonin 
/test edge-e2e-ai-operator-ztp-multiarch-sno-ocp-411