### PR TITLE
MGMT-8890: Update openshift-versions API call to return all archs

### DIFF
--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -75,9 +75,9 @@ var defaultReleaseImages = models.ReleaseImages{
 		// in order to make sure the change in MGMT-11494 is backwards-compatible.
 		CPUArchitecture:  swag.String("fake-architecture-chocobomb"),
 		CPUArchitectures: []string{},
-		OpenshiftVersion: swag.String("4.11.1"),
-		URL:              swag.String("release_4.11.1"),
-		Version:          swag.String("4.11.1-fake-chocobomb"),
+		OpenshiftVersion: swag.String("4.11.2"),
+		URL:              swag.String("release_4.11.2"),
+		Version:          swag.String("4.11.2-fake-chocobomb"),
 	},
 	&models.ReleaseImage{
 		CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
@@ -212,7 +212,7 @@ var _ = Describe("list versions", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		}
 
-		It("get_defaults", func() {
+		It("get_defaults from data directory", func() {
 			readDefaultOsImages()
 			readDefaultReleaseImages()
 
@@ -225,16 +225,22 @@ var _ = Describe("list versions", func() {
 			for _, releaseImage := range *releaseImages {
 				key := *releaseImage.OpenshiftVersion
 				version := val.Payload[key]
-				architecture := *releaseImage.CPUArchitecture
-				if architecture == "" {
-					architecture = common.CPUArchitecture
+				architectures := releaseImage.CPUArchitectures
+				if len(architectures) == 0 {
+					architectures = []string{*releaseImage.CPUArchitecture}
 				}
-				if architecture == common.CPUArchitecture {
-					Expect(version.Default).Should(Equal(releaseImage.Default))
+				for _, architecture := range architectures {
+					if architecture == "" {
+						architecture = common.CPUArchitecture
+					}
+
+					if architecture == common.CPUArchitecture {
+						Expect(version.Default).Should(Equal(releaseImage.Default))
+					}
+					Expect(version.CPUArchitectures).Should(ContainElement(architecture))
+					Expect(version.DisplayName).Should(Equal(releaseImage.Version))
+					Expect(version.SupportLevel).Should(Equal(h.getSupportLevel(*releaseImage)))
 				}
-				Expect(version.CPUArchitectures).Should(ContainElement(architecture))
-				Expect(version.DisplayName).Should(Equal(releaseImage.Version))
-				Expect(version.SupportLevel).Should(Equal(h.getSupportLevel(*releaseImage)))
 			}
 		})
 
@@ -269,6 +275,73 @@ var _ = Describe("list versions", func() {
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
 			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
 			Expect(val.Payload).Should(BeEmpty())
+		})
+
+		It("release image without cpu_architectures field", func() {
+			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{
+				// This image uses a syntax with missing "cpu_architectures". It is crafted
+				// in order to make sure the change in MGMT-11494 is backwards-compatible.
+				&models.ReleaseImage{
+					CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+					CPUArchitectures: []string{},
+					OpenshiftVersion: swag.String("4.11.1"),
+					URL:              swag.String("release_4.11.1"),
+					Version:          swag.String("4.11.1-chocobomb-for-test"),
+				},
+				&models.ReleaseImage{
+					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+					CPUArchitectures: []string{},
+					OpenshiftVersion: swag.String("4.11.1"),
+					URL:              swag.String("release_4.11.1"),
+					Default:          true,
+					Version:          swag.String("4.11.1-chocobomb-for-test"),
+				},
+			}, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+
+			version := val.Payload["4.11.1"]
+			Expect(version.CPUArchitectures).Should(ContainElement(common.ARM64CPUArchitecture))
+			Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
+			Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
+			Expect(version.Default).Should(Equal(true))
+		})
+
+		It("single-arch and multi-arch for the same version", func() {
+			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{
+				// Those images provide the same architecture using single-arch as well as multi-arch
+				// release images. This is to test if in this scenario we don't return duplicated
+				// entries in the supported architectures list.
+				&models.ReleaseImage{
+					CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+					CPUArchitectures: []string{common.ARM64CPUArchitecture},
+					OpenshiftVersion: swag.String("4.11.1"),
+					URL:              swag.String("release_4.11.1"),
+					Version:          swag.String("4.11.1-chocobomb-for-test"),
+				},
+				&models.ReleaseImage{
+					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
+					OpenshiftVersion: swag.String("4.11.1"),
+					URL:              swag.String("release_4.11.1"),
+					Default:          true,
+					Version:          swag.String("4.11.1-chocobomb-for-test"),
+				},
+			}, nil, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+
+			version := val.Payload["4.11.1"]
+			Expect(version.CPUArchitectures).Should(ContainElement(common.ARM64CPUArchitecture))
+			Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
+			Expect(version.CPUArchitectures).Should(ContainElement(common.PowerCPUArchitecture))
+			Expect(len(version.CPUArchitectures)).Should(Equal(3))
+			Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
+			Expect(version.Default).Should(Equal(true))
 		})
 	})
 
@@ -421,10 +494,10 @@ var _ = Describe("list versions", func() {
 
 		Context("for single-arch release image", func() {
 			It("gets successfuly image with old syntax", func() {
-				releaseImage, err = h.GetReleaseImage("4.11.1", "fake-architecture-chocobomb")
+				releaseImage, err = h.GetReleaseImage("4.11.2", "fake-architecture-chocobomb")
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
-				Expect(*releaseImage.Version).Should(Equal("4.11.1-fake-chocobomb"))
+				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.2"))
+				Expect(*releaseImage.Version).Should(Equal("4.11.2-fake-chocobomb"))
 			})
 
 			It("gets successfuly image with new syntax", func() {


### PR DESCRIPTION
This PR modifies the openshift-versions API call so that for multiarch
release images it unpacks the supported architectures. This is required
so that instead of response containing

```
"4.11":{"cpu_architectures":["multi"]
```

we get a list of architectures from this image. With the current
behaviour it is effectively impossible to query the service about
possible architectures that are supported. This PR removes the
limitation.

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)
Closes: [MGMT-11758](https://issues.redhat.com//browse/MGMT-11758)

/cc @carbonin
/cc @danielerez