### PR TITLE
MGMT-10850: Fix misleading message during KubeAPI reboot

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -635,8 +635,12 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 			swag.StringValue(h.Status), models.HostStatusError, statusInfo)
 	case models.HostStageRebooting:
 		if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost {
+			infoMessage := statusInfo
+			if !m.kubeApiEnabled {
+				infoMessage = statusInfoRebootingDay2
+			}
 			_, err = hostutil.UpdateHostProgress(ctx, logutil.FromContext(ctx, m.log), m.db, m.eventsHandler, h.InfraEnvID, *h.ID,
-				swag.StringValue(h.Status), models.HostStatusAddedToExistingCluster, statusInfoRebootingDay2,
+				swag.StringValue(h.Status), models.HostStatusAddedToExistingCluster, infoMessage,
 				h.Progress.CurrentStage, models.HostStageDone, progress.ProgressInfo, extra...)
 			break
 		}


### PR DESCRIPTION
[MGMT-10850](https://issues.redhat.com//browse/MGMT-10850): Fix misleading day 2 reboot message.

Note: This change combines changes made in https://github.com/openshift/assisted-service/pull/3970 that had to be rolled back due to a problem >

There is an epic to solve the underlying issues https://issues.redhat.com/browse/MGMT-11047 however this is complex and will take some time for>
In the meantime, I have patched my original commit so that the host will be moved to "Done" correctly when not using KubeAPI.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees
/cc @tsorya 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
