### PR TITLE
Update discovery.ign to fix incorrect file modes

### DIFF
--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -44,7 +44,7 @@
     "files": [{
       "overwrite": true,
       "path": "/usr/local/bin/agent-fix-bz1964591",
-      "mode": 755,
+      "mode": 493,
       "user": {
           "name": "root"
       },
@@ -159,7 +159,7 @@
     }{{end}}{{if .OKDBinaries}},
     {
       "path": "/usr/local/bin/okd-binaries.sh",
-      "mode": 755,
+      "mode": 493,
       "overwrite": true,
       "user": {
         "name": "root"


### PR DESCRIPTION
Fix the modes of scripts to their proper decimal representation.

This addresses issue #4310
