### PR TITLE
MGMT-8890: Add OS image validator to openshift-versions API call

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -109,6 +109,13 @@ func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params o
 				arch = common.DefaultCPUArchitecture
 			}
 
+			// In order to mark a specific version and architecture as supported we do not
+			// only need to have an available release image, but we need RHCOS image as well.
+			if _, err := h.GetOsImage(key, arch); err != nil {
+				h.log.Debugf("Marking architecture %s for version %s as not available because no matching OS image found", arch, key)
+				continue
+			}
+
 			openshiftVersion, exists := openshiftVersions[key]
 			if !exists {
 				openshiftVersion = models.OpenshiftVersion{


### PR DESCRIPTION
With this commit we are changing behaviour of the "openshift-versions"
API call so that it returns only versions and architectures if there is
a matching release image as well as RHCOS image.

This is in order to cover a scenario when a multi-arch release image is
used by the service, but available OS images do not contain every
architecture that is provided by the release. For such a scenario we
only want to mark availability for those combinations that have a
coverage in both release as well as RHCOS image.

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)
Closes: [MGMT-11780](https://issues.redhat.com//browse/MGMT-11780)

/cc @danielerez 