### PR TITLE
MGMT-8890: Mark cluster as multi-arch automatically

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -460,6 +460,11 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		swag.StringValue(releaseImage.OpenshiftVersion),
 		swag.StringValue(releaseImage.URL))
 
+	if len(releaseImage.CPUArchitectures) > 1 {
+		log.Infof("Setting cluster as multi-arch because of the release image (requested was %s)", cpuArchitecture)
+		cpuArchitecture = common.MultiCPUArchitecture
+	}
+
 	if kubeKey == nil {
 		kubeKey = &types.NamespacedName{}
 	}

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -328,12 +328,13 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 				OpenshiftVersion: swag.String(multiarchOpenshiftVersion),
 				PullSecret:       swag.String(pullSecret),
 				BaseDNSDomain:    "example.com",
-				CPUArchitecture:  common.MultiCPUArchitecture,
 			},
 		})
 
 		Expect(err).NotTo(HaveOccurred())
 		clusterID = *clusterReq.GetPayload().ID
+		clusterArch := clusterReq.GetPayload().CPUArchitecture
+		Expect(clusterArch).To(Equal(common.MultiCPUArchitecture))
 
 		// standalone x86 infraEnv
 		infraEnv := registerInfraEnv(nil, models.ImageTypeFullIso)


### PR DESCRIPTION
This PR introduces a change that marks all the cluster using multiarch
release image as multiarch clusters. This is in order not to force users
(whether via API or via UI) to manually set that property if based on
the selection of the release image we know that the cluster is able to
consist of multiple architectures.

Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)