### PR TITLE
AGENT-325: Support setting network type from AgentClusterInstall

### DIFF
--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -62,6 +62,11 @@ func RegisterCluster(ctx context.Context, log *log.Logger, bmInventory *client.A
 	log.Infof("releaseImage version %s cpuarch %s", releaseImageVersion, releaseImageCPUArch)
 
 	clusterParams := controllers.CreateClusterParams(&cd, &aci, pullSecret, releaseImageVersion, releaseImageCPUArch, nil)
+
+	if aci.Spec.Networking.NetworkType != "" {
+		clusterParams.NetworkType = &aci.Spec.Networking.NetworkType
+	}
+
 	clientClusterParams := &installer.V2RegisterClusterParams{
 		NewClusterParams: clusterParams,
 	}


### PR DESCRIPTION
Currently the network type is unspecified for cluster0. When
unspecified the network type defaults to OpenShiftSDN, even
if the user had specified OVNKubernetes.

We need the cluster to reflect the network type specified in
AgentClusterInstall. The CreateClusterParams for cluster0 now
includes the AgentClusterInstall's NetworkType value.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None
- [x] Agent-based installer

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

A compact cluster was deployed using dev-scripts. dev-scripts was modified to use a custom assisted-service image containing this change and was modified to set the AgentClusterInstall's NetworkType to OVNKubernetes. After the cluster has been installed, I verified that ovn kubernetes was deployed by seeing these pods listed:

```
openshift-ovn-kubernetes                           ovnkube-master-26dpc                                                6/6     Running       0              18h
openshift-ovn-kubernetes                           ovnkube-master-vv7zd                                                6/6     Running       3 (18h ago)    18h
openshift-ovn-kubernetes                           ovnkube-master-xjs2x                                                6/6     Running       3 (18h ago)    18h
openshift-ovn-kubernetes                           ovnkube-node-5gznq                                                  5/5     Running       0              18h
openshift-ovn-kubernetes                           ovnkube-node-dpzbw                                                  5/5     Running       0              18h
openshift-ovn-kubernetes                           ovnkube-node-pj9zr                                                  5/5     Running       0              18h
```

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @lranjbar 
/cc @pawanpinjarkar 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
