### PR TITLE
MGMT-11035: Allow noProxy wildcard for infraEnv, regardless of OCP version

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3934,10 +3934,7 @@ func validateProxySettings(httpProxy, httpsProxy, noProxy, ocpVersion *string) e
 		}
 	}
 	if noProxy != nil && *noProxy != "" {
-		if ocpVersion == nil {
-			return errors.Errorf("Cannot validate NoProxy: Unknown OpenShift version")
-		}
-		if err := validations.ValidateNoProxyFormat(*noProxy, *ocpVersion); err != nil {
+		if err := validations.ValidateNoProxyFormat(*noProxy, swag.StringValue(ocpVersion)); err != nil {
 			return err
 		}
 	}
@@ -4141,7 +4138,7 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 	if params.InfraenvCreateParams.Proxy != nil {
 		if err = validateProxySettings(params.InfraenvCreateParams.Proxy.HTTPProxy,
 			params.InfraenvCreateParams.Proxy.HTTPSProxy,
-			params.InfraenvCreateParams.Proxy.NoProxy, &params.InfraenvCreateParams.OpenshiftVersion); err != nil {
+			params.InfraenvCreateParams.Proxy.NoProxy, nil); err != nil {
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}
 	}
@@ -4378,7 +4375,7 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 		return nil, common.NewApiError(http.StatusNotFound, err)
 	}
 
-	if params, err = b.validateAndUpdateInfraEnvProxyParams(ctx, &params, infraEnv.OpenshiftVersion); err != nil {
+	if params, err = b.validateAndUpdateInfraEnvProxyParams(ctx, &params, ""); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3172,13 +3172,17 @@ var _ = Describe("cluster", func() {
 			Expect(actual.Payload.SchedulableMasters).To(Equal(swag.Bool(true)))
 		})
 
-		Context("Update Proxy", func() {
-			//const emptyProxyHash = "d41d8cd98f00b204e9800998ecf8427e"
+		Context("Set and Update Cluster Proxy", func() {
+
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
 				err := db.Create(&common.Cluster{
 					Cluster: models.Cluster{
-						ID: &clusterID,
+						ID:               &clusterID,
+						OpenshiftVersion: "4.8.0-fc.4",
+						HTTPProxy:        "http://proxy.proxy",
+						HTTPSProxy:       "https://proxy.proxy",
+						NoProxy:          "*",
 					}}).Error
 				Expect(err).ShouldNot(HaveOccurred())
 				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
@@ -3206,6 +3210,20 @@ var _ = Describe("cluster", func() {
 					eventstest.WithNameMatcher(eventgen.ProxySettingsChangedEventName),
 					eventstest.WithClusterIdMatcher(clusterID.String())))
 				_ = updateCluster("http://proxy.proxy", "", "proxy.proxy")
+			})
+
+			It("set a valid noProxy wildcard", func() {
+				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+					eventstest.WithNameMatcher(eventgen.ProxySettingsChangedEventName),
+					eventstest.WithClusterIdMatcher(clusterID.String())))
+				_ = updateCluster("", "", "*")
+			})
+
+			It("set a valid noProxy wildcard comma-delimited", func() {
+				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+					eventstest.WithNameMatcher(eventgen.ProxySettingsChangedEventName),
+					eventstest.WithClusterIdMatcher(clusterID.String())))
+				_ = updateCluster("", "", "*,example.com")
 			})
 		})
 
@@ -4351,6 +4369,54 @@ var _ = Describe("cluster", func() {
 					Expect(dbMachineNetworks).To(HaveLen(len(machineNetworks) * 2))
 				})
 			})
+		})
+	})
+
+	Context("OpenshiftVersion does not support wildcard", func() {
+
+		It("Fail to create Cluster with a wildcard noProxy", func() {
+			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+				eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
+				eventstest.WithMessageContainsMatcher("Sorry, no-proxy value '*' is not supported in release: 4.8.0-fc.1"),
+				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
+
+			reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					Name:             swag.String("some-cluster-name"),
+					OpenshiftVersion: swag.String("4.8.0-fc.1"),
+					NoProxy:          swag.String("*"),
+					PullSecret:       swag.String(`{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"`),
+				},
+			})
+
+			Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+			Expect(reply.(*common.ApiErrorResponse).StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+			Expect(reply.(*common.ApiErrorResponse).Error()).To(Equal("Sorry, no-proxy value '*' is not supported in release: 4.8.0-fc.1"))
+		})
+
+		It("Fail to update Cluster with a wildcard noProxy", func() {
+			clusterID = strfmt.UUID(uuid.New().String())
+			err := db.Create(&common.Cluster{
+				Cluster: models.Cluster{
+					ID:               &clusterID,
+					OpenshiftVersion: "4.8.0-fc.1",
+					HTTPProxy:        "http://proxy.proxy",
+					HTTPSProxy:       "https://proxy.proxy",
+					NoProxy:          "foo.com",
+				}}).Error
+			Expect(err).ShouldNot(HaveOccurred())
+
+			reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+				ClusterID: clusterID,
+				ClusterUpdateParams: &models.V2ClusterUpdateParams{
+					HTTPProxy:  swag.String(""),
+					HTTPSProxy: swag.String(""),
+					NoProxy:    swag.String("*"),
+				},
+			})
+			Expect(reply).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
+			Expect(reply.(*common.ApiErrorResponse).StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+			Expect(reply.(*common.ApiErrorResponse).Error()).To(Equal("Sorry, no-proxy value '*' is not supported in release: 4.8.0-fc.1"))
 		})
 	})
 
@@ -7129,6 +7195,10 @@ var _ = Describe("infraEnvs", func() {
 
 			It("set a valid proxy", func() {
 				_ = updateInfraEnv("http://proxy.proxy", "", "proxy.proxy")
+			})
+
+			It("set a valid noProxy wildcard", func() {
+				_ = updateInfraEnv("", "", "*")
 			})
 		})
 

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -243,50 +243,82 @@ var _ = Describe("Cluster name validation", func() {
 var _ = Describe("URL validations", func() {
 
 	Context("test no-proxy", func() {
-		It("domain name", func() {
-			err := ValidateNoProxyFormat("domain.com", "4.7.0")
-			Expect(err).Should(BeNil())
+
+		Context("test no-proxy with ocpVersion 4.7.0", func() {
+			It("domain name", func() {
+				err := ValidateNoProxyFormat("domain.com", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("domain starts with . for all sub-domains", func() {
+				err := ValidateNoProxyFormat(".domain.com", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("CIDR", func() {
+				err := ValidateNoProxyFormat("10.9.0.0/16", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("IP Address", func() {
+				err := ValidateNoProxyFormat("10.9.8.7", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("multiple entries", func() {
+				err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7", "4.7.0")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
+				err := ValidateNoProxyFormat("*", "4.7.0")
+				Expect(err).ShouldNot(BeNil())
+				Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in release: 4.7.0"))
+			})
+			It("'*,domain.com' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "4.7.0")
+				Expect(err).ShouldNot(BeNil())
+				Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in release: 4.7.0"))
+			})
 		})
-		It("domain starts with . for all sub-domains", func() {
-			err := ValidateNoProxyFormat(".domain.com", "4.7.0")
-			Expect(err).Should(BeNil())
+		Context("test no-proxy with ocpVersion 4.8.0", func() {
+			It("'*' bypass proxy for all destinations FC version", func() {
+				err := ValidateNoProxyFormat("*", "4.8.0-fc.7")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations release version", func() {
+				err := ValidateNoProxyFormat("*", "4.8.0")
+				Expect(err).Should(BeNil())
+			})
+			It("invalid format", func() {
+				err := ValidateNoProxyFormat("...", "4.8.0-fc.7")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("invalid format of a single value", func() {
+				err := ValidateNoProxyFormat("domain.com,...", "4.8.0-fc.7")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("A use of asterisk", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "4.8.0-fc.7")
+				Expect(err).Should(BeNil())
+			})
 		})
-		It("CIDR", func() {
-			err := ValidateNoProxyFormat("10.9.0.0/16", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("IP Address", func() {
-			err := ValidateNoProxyFormat("10.9.8.7", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("multiple entries", func() {
-			err := ValidateNoProxyFormat("domain.com,10.9.0.0/16,.otherdomain.com,10.9.8.7", "4.7.0")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations FC version", func() {
-			err := ValidateNoProxyFormat("*", "4.8.0-fc.7")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations release version", func() {
-			err := ValidateNoProxyFormat("*", "4.8.0")
-			Expect(err).Should(BeNil())
-		})
-		It("'*' bypass proxy for all destinations not supported pre-4.8.0-fc.4", func() {
-			err := ValidateNoProxyFormat("*", "4.7.0")
-			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("Sorry, no-proxy value '*' is not supported in this release"))
-		})
-		It("invalid format", func() {
-			err := ValidateNoProxyFormat("...", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
-		})
-		It("invalid format of a single value", func() {
-			err := ValidateNoProxyFormat("domain.com,...", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
-		})
-		It("invalid use of asterisk", func() {
-			err := ValidateNoProxyFormat("*,domain.com", "4.8.0-fc.7")
-			Expect(err).ShouldNot(BeNil())
+		Context("test no-proxy with no ocpVersion (InfraEnv)", func() {
+			It("'*' bypass proxy for all destinations FC version", func() {
+				err := ValidateNoProxyFormat("*", "")
+				Expect(err).Should(BeNil())
+			})
+			It("'*' bypass proxy for all destinations release version", func() {
+				err := ValidateNoProxyFormat("*", "")
+				Expect(err).Should(BeNil())
+			})
+			It("invalid format", func() {
+				err := ValidateNoProxyFormat("...", "")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("invalid format of a single value", func() {
+				err := ValidateNoProxyFormat("domain.com,...", "")
+				Expect(err).ShouldNot(BeNil())
+			})
+			It("A use of asterisk", func() {
+				err := ValidateNoProxyFormat("*,domain.com", "")
+				Expect(err).Should(BeNil())
+			})
 		})
 	})
 })

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -213,13 +213,17 @@ func ValidateClusterNameFormat(name string) error {
 // prefaced with '.' to include all subdomains of that domain.
 // Use '*' to bypass proxy for all destinations in OCP 4.8 or later.
 func ValidateNoProxyFormat(noProxy string, ocpVersion string) error {
-	if noProxy == "*" {
+	// TODO MGMT-11401: Remove noProxy wildcard validation when OCP 4.8 gets deprecated.
+	if strings.Contains(noProxy, "*") {
+		if ocpVersion == "" { // a case where ValidateNoProxyFormat got called for InfraEnv
+			return nil
+		}
 		if wildcardSupported, err := common.VersionGreaterOrEqual(ocpVersion, "4.8.0-fc.4"); err != nil {
 			return err
 		} else if wildcardSupported {
 			return nil
 		}
-		return errors.Errorf("Sorry, no-proxy value '*' is not supported in this release")
+		return errors.Errorf("Sorry, no-proxy value '*' is not supported in release: %s", ocpVersion)
 	}
 
 	return validations.ValidateNoProxyFormat(noProxy)

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -2708,6 +2708,47 @@ spec:
 		})
 	})
 
+	Context("NoProxy with Wildcard", func() {
+
+		It("OpenshiftVersion does not support NoProxy wildcard", func() {
+			_, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					BaseDNSDomain:        "example.com",
+					ClusterNetworks:      []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+					ServiceNetworks:      []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+					Name:                 swag.String("sno-cluster"),
+					OpenshiftVersion:     swag.String("4.8.0-fc.1"),
+					NoProxy:              swag.String("*"),
+					PullSecret:           swag.String(pullSecret),
+					SSHPublicKey:         sshPublicKey,
+					VipDhcpAllocation:    swag.Bool(false),
+					NetworkType:          swag.String("OVNKubernetes"),
+					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+				},
+			})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("OpenshiftVersion does support NoProxy wildcard", func() {
+			_, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
+				NewClusterParams: &models.ClusterCreateParams{
+					BaseDNSDomain:        "example.com",
+					ClusterNetworks:      []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+					ServiceNetworks:      []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+					Name:                 swag.String("sno-cluster"),
+					OpenshiftVersion:     swag.String("4.8.0-fc.5"),
+					NoProxy:              swag.String("*"),
+					PullSecret:           swag.String(pullSecret),
+					SSHPublicKey:         sshPublicKey,
+					VipDhcpAllocation:    swag.Bool(false),
+					NetworkType:          swag.String("OVNKubernetes"),
+					HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	It("install cluster requirement", func() {
 		clusterID := *cluster.ID
 		waitForClusterState(ctx, clusterID, models.ClusterStatusPendingForInput, defaultWaitForClusterStateTimeout,

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -73,6 +73,19 @@ var _ = Describe("Infra_Env", func() {
 		infraEnv = resp.Payload
 	}
 
+	It("update infra env with NoProxy wildcard", func() {
+		updateParams := &installer.UpdateInfraEnvParams{
+			InfraEnvID: infraEnvID,
+			InfraEnvUpdateParams: &models.InfraEnvUpdateParams{
+				Proxy: &models.Proxy{NoProxy: swag.String("*")},
+			},
+		}
+		res, err := userBMClient.Installer.UpdateInfraEnv(ctx, updateParams)
+		Expect(err).NotTo(HaveOccurred())
+		updateInfraEnv := res.Payload
+		Expect(swag.StringValue(updateInfraEnv.Proxy.NoProxy)).To(Equal("*"))
+	})
+
 	It("download full-iso image success", func() {
 		getInfraEnv()
 		downloadIso(ctx, infraEnv.DownloadURL)


### PR DESCRIPTION
Changed introduced here:
1. Check OCP version only if a wildcard got detected in cluster noProxy settings.
2. Never for OCP version for infraEnv noProxy settings.
3. wildcard detection should catch all cases. It will now include cases
4. The 'no-proxy value '*' is not supported' will now include the OCP release version.
where '*' is listed alongside other elements.

Conflicts:
	internal/bminventory/inventory.go

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
