### PR TITLE
MGMT-11596: improve invalid tags format message

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -162,7 +162,9 @@ func ValidateTags(tags string) error {
 		return nil
 	}
 	if !AllStrings(strings.Split(tags, ","), IsValidTag) {
-		return errors.Errorf("Invalid format for Tags: %s. Tags should be a comma-separated list (e.g. tag1,tag2,tag3).", tags)
+		errMsg := "Invalid format for Tags: %s. Tags should be a comma-separated list (e.g. tag1,tag2,tag3). " +
+			"Each tag can consist of the following characters: Alphanumeric (aA-zZ, 0-9), underscore (_) and white-spaces."
+		return errors.Errorf(errMsg, tags)
 	}
 	return nil
 }

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -395,6 +395,9 @@ var _ = Describe("ValidateTags", func() {
 				Expect(err).ToNot(HaveOccurred())
 			} else {
 				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(
+					"Tags should be a comma-separated list (e.g. tag1,tag2,tag3). " +
+						"Each tag can consist of the following characters: Alphanumeric (aA-zZ, 0-9), underscore (_) and white-spaces."))
 			}
 		})
 	}


### PR DESCRIPTION
Added more details to invalid cluster tags format error message. The message should mention  which characters are valid for tags (as described in the [doc](https://github.com/openshift/assisted-service/blob/2343139dee37c5950e159513ff85bba8b3fdb9b2/docs/user-guide/rest-api-cluster-tags.md#L3-L4).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @filanov 
/cc @avishayt 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
