### PR TITLE
MGMT-11563: Fix default label for release image

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -141,10 +141,7 @@ func (h *handler) V2ListSupportedOpenshiftVersions(ctx context.Context, params o
 				if !exists(openshiftVersion.CPUArchitectures, arch) {
 					openshiftVersion.CPUArchitectures = append(openshiftVersion.CPUArchitectures, arch)
 				}
-				if arch == common.DefaultCPUArchitecture {
-					// Default flag is specified on x86 image
-					openshiftVersion.Default = releaseImage.Default
-				}
+				openshiftVersion.Default = releaseImage.Default || openshiftVersion.Default
 				openshiftVersions[key] = openshiftVersion
 			}
 		}


### PR DESCRIPTION
This PR fixes labeling of the default release image in case when x86
single-arch as well as multi-arch are provided. We are now allowing to
set the "default" property on any image for a specific OCP version
without requiring the flag to be present on a particular architecture.

Contributes-to: [MGMT-11563](https://issues.redhat.com//browse/MGMT-11563)

/cc @osherdp 