### PR TITLE
MGMT-11563: Allow org-based filtering for multiarch images

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -289,7 +289,7 @@ func main() {
 	extracterHandler := oc.NewExtracter(&executer.CommonExecuter{},
 		oc.Config{MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay})
 	versionHandler, err := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler,
-		Options.Versions, osImagesArray, releaseImagesArray, mustGatherVersionsMap, Options.ReleaseImageMirror)
+		Options.Versions, osImagesArray, releaseImagesArray, mustGatherVersionsMap, Options.ReleaseImageMirror, authzHandler)
 	failOnError(err, "failed to create Versions handler")
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -463,6 +463,11 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	if len(releaseImage.CPUArchitectures) > 1 {
 		log.Infof("Setting cluster as multi-arch because of the release image (requested was %s)", cpuArchitecture)
 		cpuArchitecture = common.MultiCPUArchitecture
+		// (MGMT-11859) Additional check here ensures that the customer cannot just guess a version
+		//              with multiarch in order to get access to that release payload.
+		if err = b.versionsHandler.ValidateAccessToMultiarch(ctx, b.authzHandler); err != nil {
+			return nil, err
+		}
 	}
 
 	if kubeKey == nil {

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -11,6 +11,7 @@ import (
 	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
+	auth "github.com/openshift/assisted-service/pkg/auth"
 	versions0 "github.com/openshift/assisted-service/restapi/operations/versions"
 )
 
@@ -196,4 +197,18 @@ func (m *MockHandler) V2ListSupportedOpenshiftVersions(arg0 context.Context, arg
 func (mr *MockHandlerMockRecorder) V2ListSupportedOpenshiftVersions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2ListSupportedOpenshiftVersions", reflect.TypeOf((*MockHandler)(nil).V2ListSupportedOpenshiftVersions), arg0, arg1)
+}
+
+// ValidateAccessToMultiarch mocks base method.
+func (m *MockHandler) ValidateAccessToMultiarch(arg0 context.Context, arg1 auth.Authorizer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateAccessToMultiarch", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateAccessToMultiarch indicates an expected call of ValidateAccessToMultiarch.
+func (mr *MockHandlerMockRecorder) ValidateAccessToMultiarch(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAccessToMultiarch", reflect.TypeOf((*MockHandler)(nil).ValidateAccessToMultiarch), arg0, arg1)
 }

--- a/pkg/ocm/utils.go
+++ b/pkg/ocm/utils.go
@@ -16,6 +16,7 @@ const (
 	AMSActionUpdate            string = "update"
 	AMSActionDelete            string = "delete"
 	BareMetalCapabilityName    string = "bare_metal_installer_admin"
+	MultiarchCapabilityName    string = "bare_metal_installer_multiarch"
 	AccountCapabilityType      string = "Account"
 	OrganizationCapabilityType string = "Organization"
 	Subscription               string = "Subscription"

--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -30,12 +30,14 @@ var db *gorm.DB
 var log *logrus.Logger
 var wiremock *WireMock
 var kubeClient k8sclient.Client
-var openshiftVersion string = "4.6"
+var openshiftVersion string = "4.8"
 var snoVersion string = "4.8"
 var multiarchOpenshiftVersion string = "4.11.0-multi"
+var pullSecret = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}" // #nosec
 
 var (
 	agentBMClient             *client.AssistedInstall
+	agent2BMClient            *client.AssistedInstall
 	badAgentBMClient          *client.AssistedInstall
 	userBMClient              *client.AssistedInstall
 	user2BMClient             *client.AssistedInstall
@@ -119,6 +121,7 @@ func init() {
 	unallowedUserClientCfg := clientcfg(auth.UserAuthHeaderWriter("bearer " + Options.TestTokenUnallowed))
 	editclusterClientCfg := clientcfg(auth.UserAuthHeaderWriter("bearer " + Options.TestTokenClusterEditor))
 	agentClientCfg := clientcfg(auth.AgentAuthHeaderWriter(FakePS))
+	agent2ClientCfg := clientcfg(auth.AgentAuthHeaderWriter(FakePS2))
 	badAgentClientCfg := clientcfg(auth.AgentAuthHeaderWriter(WrongPullSecret))
 	userBMClient = client.New(userClientCfg)
 	user2BMClient = client.New(userClientCfg2)
@@ -126,6 +129,7 @@ func init() {
 	unallowedUserBMClient = client.New(unallowedUserClientCfg)
 	editclusterUserBMClient = client.New(editclusterClientCfg)
 	agentBMClient = client.New(agentClientCfg)
+	agent2BMClient = client.New(agent2ClientCfg)
 	badAgentBMClient = client.New(badAgentClientCfg)
 
 	db, err = gorm.Open(postgres.Open(fmt.Sprintf("host=%s port=%s user=admin database=installer password=admin sslmode=disable",

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -29,7 +29,6 @@ import (
 const (
 	sshPublicKey                            = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC50TuHS7aYci+U+5PLe/aW/I6maBi9PBDucLje6C6gtArfjy7udWA1DCSIQd+DkHhi57/s+PmvEjzfAfzqo+L+/8/O2l2seR1pPhHDxMR/rSyo/6rZP6KIL8HwFqXHHpDUM4tLXdgwKAe1LxBevLt/yNl8kOiHJESUSl+2QSf8z4SIbo/frDD8OwOvtfKBEG4WCb8zEsEuIPNF/Vo/UxPtS9pPTecEsWKDHR67yFjjamoyLvAzMAJotYgyMoxm8PTyCgEzHk3s3S4iO956d6KVOEJVXnTVhAxrtLuubjskd7N4hVN7h2s4Z584wYLKYhrIBL0EViihOMzY4mH3YE4KZusfIx6oMcggKX9b3NHm0la7cj2zg0r6zjUn6ZCP4gXM99e5q4auc0OEfoSfQwofGi3WmxkG3tEozCB8Zz0wGbi2CzR8zlcF+BNV5I2LESlLzjPY5B4dvv5zjxsYoz94p3rUhKnnPM2zTx1kkilDK5C5fC1k9l/I/r5Qk4ebLQU= oscohen@localhost.localdomain"
 	pullSecretName                          = "pull-secret"
-	pullSecret                              = "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dXNlcjpwYXNzd29yZAo=\",\"email\":\"r@r.com\"}}}"
 	defaultWaitForHostStateTimeout          = 20 * time.Second
 	defaultWaitForClusterStateTimeout       = 40 * time.Second
 	defaultWaitForMachineNetworkCIDRTimeout = 40 * time.Second

--- a/subsystem/versions_test.go
+++ b/subsystem/versions_test.go
@@ -2,10 +2,12 @@ package subsystem
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/versions"
+	"github.com/openshift/assisted-service/models"
 )
 
 var _ = Describe("[minimal-set]test versions", func() {
@@ -22,4 +24,37 @@ var _ = Describe("[minimal-set]test versions", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(len(reply.GetPayload())).To(BeNumerically(">=", 1))
 	})
+
+	Context("organization based functionality", func() {
+		BeforeEach(func() {
+			if !Options.FeatureGate {
+				Skip("organization based functionality access is disabled")
+			}
+		})
+		It("Doesn't have multiarch capability", func() {
+			reply, err := userBMClient.Versions.V2ListSupportedOpenshiftVersions(context.Background(), &versions.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(hasMultiarch(reply.GetPayload())).Should(BeFalse())
+		})
+		It("Has multiarch capability", func() {
+			// (MGMT-11859) This test relies on the fact that multiarch release images have
+			//              "-multi" suffix when presented via SupportedOpenshiftVersions API.
+			//              As soon as we collapse single- and multiarch releases, the contract
+			//              defined by "func hasMultiarch()" will not be valid anymore.
+			reply, err := user2BMClient.Versions.V2ListSupportedOpenshiftVersions(context.Background(), &versions.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(hasMultiarch(reply.GetPayload())).Should(BeTrue())
+		})
+	})
 })
+
+func hasMultiarch(versions models.OpenshiftVersions) bool {
+	hasMultiarch := false
+	for _, version := range versions {
+		if strings.HasSuffix(*version.DisplayName, "-multi") {
+			hasMultiarch = true
+			break
+		}
+	}
+	return hasMultiarch
+}

--- a/subsystem/wiremock_stubs.go
+++ b/subsystem/wiremock_stubs.go
@@ -195,6 +195,12 @@ func (w *WireMock) createStubsForCapabilityReview() error {
 	if _, err := w.createStubBareMetalCapabilityReview(fakePayloadClusterEditor, false); err != nil {
 		return err
 	}
+	if _, err := w.createStubMultiarchCapabilityReview(fakePayloadUsername, OrgId1, false); err != nil {
+		return err
+	}
+	if _, err := w.createStubMultiarchCapabilityReview(fakePayloadUsername2, OrgId2, true); err != nil {
+		return err
+	}
 	if _, err := w.createStubAccountsMgmt(fakePayloadUsername, OrgId1); err != nil {
 		return err
 	}
@@ -468,6 +474,31 @@ func (w *WireMock) createStubBareMetalCapabilityReview(username string, result b
 		Result: strconv.FormatBool(result),
 	}
 
+	return w.addCapabilityReviewStub(capabilityRequest, capabilityResponse)
+}
+
+func (w *WireMock) createStubMultiarchCapabilityReview(username string, orgId string, result bool) (string, error) {
+	type CapabilityRequest struct {
+		Name     string `json:"capability"`
+		Type     string `json:"type"`
+		Username string `json:"account_username"`
+		Org      string `json:"organization_id"`
+	}
+
+	type CapabilityResponse struct {
+		Result string `json:"result"`
+	}
+
+	capabilityRequest := CapabilityRequest{
+		Name:     ocm.MultiarchCapabilityName,
+		Type:     ocm.OrganizationCapabilityType,
+		Username: username,
+		Org:      orgId,
+	}
+
+	capabilityResponse := CapabilityResponse{
+		Result: strconv.FormatBool(result),
+	}
 	return w.addCapabilityReviewStub(capabilityRequest, capabilityResponse)
 }
 


### PR DESCRIPTION
Contributes-to: [MGMT-11563](https://issues.redhat.com//browse/MGMT-11563)
Contributes-to: [MGMT-11859](https://issues.redhat.com//browse/MGMT-11859)
Implements: https://github.com/openshift/assisted-service/pull/3744
Implements-enhancement: saas-per-organization-feature-access

/cc @nmagnezi 
/cc @danielerez 