### PR TITLE
document process for using assisted installer in a disconnected env

### DIFF
--- a/deploy/podman/README-disconnected.md
+++ b/deploy/podman/README-disconnected.md
@@ -14,7 +14,7 @@ If you do not have a web server to host the ISO and a container registry availab
 
 ## Identify a Container Registry and Mirror Contents
 
-You will need to have a container registry available in the disconnected environment to house all the container images that are required to complete an OpenShift install. See [Mirroring image for a disconnected installation](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-installation-images.html) for how to mirror the required images. 
+You will need to have a container registry available in the disconnected environment to house all the container images that are required to complete an OpenShift install. See [Mirroring image for a disconnected installation](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-installation-images.html) or [Mirroring image for a disconnected installation using the oc-mirror plug-in](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-disconnected.html) for how to mirror the required images. 
 
 If you do not have a container registry available you, instructions for installing a container registry and mirroring the contents into that registry can be found in [Creating a mirror registry with mirror registry for Red Hat OpenShift](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-creating-registry.html).
 
@@ -146,6 +146,28 @@ $ sed -i "s/BASE64_ENCODED_REGISTRY_CONF/$(cat registry.conf.b64)/" discovery-ig
 $ sed -i "s/BASE64_ENCODED_LOCAL_REGISTRY_CRT/$(cat quay.crt.b64)/" discovery-ignition.json
 ```
 
+You will apply this file as a part of the [Build/Deploy a Cluster](#builddeploy-a-cluster) in the next section.
+
 ## Build/Deploy a Cluster
 
-At this point, you can now follow standard Assisted Installer workflows to create a cluster. However you will need to ensure that you also apply the "ignition_config_override" created in the [Ignition Config Override](#ignition-config-override) section.
+At this point, you can now follow standard Assisted Installer workflows to create a cluster. Keep in mind that you will need to add your mirror registry certificate to the install_config as and _additionalTrustBundle_ well as add the _imageContentSources_ that define your mirror registry. The process that you use to do this will vary based on if you are using the Assisted Installer Web UI, via all api calls, or using [aicli](https://github.com/karmab/aicli).
+
+### Using the Assisted Installer GUI
+
+You can use the Assisted Installer web UI to set up the initial cluster settings, but you will need to customize the cluster using the API in order to patch the ignition_config to use the internal mirror resources. Instructions for creating a cluster through the UI can be found in the [Assisted Installer User Guide](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/README.md). Once the cluster is configured (but PRIOR to downloading the ISO file), follow the steps below [Patching the Cluster Definition](#patching-the-cluster-definition).
+
+### Using AICLI
+
+The [aicli](https://github.com/karmab/aicli) tool is a tool that can be used to deploy OpenShift clusters using the Assisted Installer service from the command line. This is a community supported tool, and is NOT a part of the OpenShift project. 
+
+### Using the API
+
+#### Creating the Cluster
+
+Follow the instructions [rest api getting started](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/rest-api-getting-started.md) to create your cluster. 
+
+#### Patching the Cluster Definition
+
+Then use the instructions [Install Customization - Discovery Ignition](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/install-customization.md#discovery-ignition) to apply the discovery-ignition.json file created in the [Ignition Config Override](#ignition-config-override)
+
+Then use the instructions [Install Customization - Install Config](https://github.com/openshift/assisted-service/blob/master/docs/user-guide/install-customization.md#install-config) to apply the _additionalTrustBundle_ and _imageContentSources_ to the OpenShift install_config.yaml.

--- a/deploy/podman/README-disconnected.md
+++ b/deploy/podman/README-disconnected.md
@@ -1,0 +1,151 @@
+# Deploy with podman in disconnected Environment
+
+These instructions detail how to deploy the assisted installer service in a disconnected or air-gaped environment with no Internet connectivity available. By default the assisted installer assumes that Internet connectivity is available for pulling container images and boot ISO files. This document will cover how to setup and configure the assisted installer to run in a disconnected environment with no access to the Internet.
+
+## Requirements
+
+* A server with at least 8GB of RAM and 2+ vCPU
+* A container registry to mirror an OpenShift release
+* A web server to hold the Red Hat CoreOS (RHCOS) boot ISO
+
+Make sure you have [podman](https://podman.io) version 3.3+ installed. If you must use an older version of podman, reference the [previous documentation and procedure](https://github.com/openshift/assisted-service/tree/v2.0.11#deploy-without-a-kubernetes-cluster) to avoid a [podman bug](https://github.com/containers/podman/issues/9609).
+
+If you do not have a web server to host the ISO and a container registry available you can co-locate all these services on the same host that you run the Assisted Installer from. This host will be referred to as the "assisted installer host" in the rest of the document.
+
+## Identify a Container Registry and Mirror Contents
+
+You will need to have a container registry available in the disconnected environment to house all the container images that are required to complete an OpenShift install. See [Mirroring image for a disconnected installation](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-installation-images.html) for how to mirror the required images. 
+
+If you do not have a container registry available you, instructions for installing a container registry and mirroring the contents into that registry can be found in [Creating a mirror registry with mirror registry for Red Hat OpenShift](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-creating-registry.html).
+
+Once you have mirrored the OpenShift container images, as well as the [Operator Hub catalog](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog_installing-mirroring-installation-images), you will need to mirror in additional container images that are used by the Assisted Installer as they are not mirrored by the standard mirror process. Once you have completed the mirroring of the OpenShift images as well as the Operator Catalog images run the following commands to mirror in the Assisted Installer containers.
+
+### Mirror assisted-installer agents
+
+```shell
+$ podman pull quay.io/edge-infrastructure/assisted-installer-agent:latest
+$ podman pull quay.io/edge-infrastructure/assisted-installer:latest
+$ podman pull quay.io/edge-infrastructure/assisted-installer-controller:latest
+$ podman tag quay.io/edge-infrastructure/assisted-installer-agent:latest <container image registry server:port>/edge-infrastructure/assisted-installer-agent:latest
+$ podman tag quay.io/edge-infrastructure/assisted-installer:latest <container image registry server:port>/edge-infrastructure/assisted-installer:latest
+$ podman tag quay.io/edge-infrastructure/assisted-installer-controller:latest <container image registry server:port>/edge-infrastructure/assisted-installer-controller:latest
+$ podman push <container image registry server:port>/edge-infrastructure/assisted-installer-agent:latest
+$ podman push <container image registry server:port>/edge-infrastructure/assisted-installer:latest
+$ podman push <container image registry server:port>/edge-infrastructure/assisted-installer-controller:latest
+```
+
+## Identify a Web Server for ISO mirroring
+
+You will need to have a Web server available within your disconnected environment. The Assisted Installer requires a URL to retrieve the RHCOS ISO from on the fly. If you have an existing web server available in your disconnected environment you can use that to host this file. Otherwise, this section will detail some steps for a Fedora/RHEL box.
+
+We need to host the RHCOS image required for booting. We will use NGINX to handle this for us. First get a copy of the RHCOS images and place them in /usr/share/nginx/html... 
+
+```shell
+$ sudo dnf install -y nginx
+$ sudo mkdir -p /usr/share/nginx/html/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16
+$ cd /usr/share/nginx/html/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16
+$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
+$ sudo wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/sha256sum.txt
+```
+
+If you installed a web server on the assisted installer host, you will need to configure the firewall:
+
+```shell
+$ sudo firewall-cmd --permanent --add-port={80/tcp,443/tcp}
+$ sudo firewall-cmd --reload
+$ sudo systemctl enable nginx --now
+```
+
+## Running the Assisted Installer via podman
+
+You will need to configure multiple files to properly use the Assisted Installer in a disconnected environment. You will need to gather up the following information before proceeding:
+
+* signing cert for your container image registry
+* host name for your container image registry
+* hostname or IP address for the web server hosting the RHCOS ISO file (if not using the assisted installer host)
+
+### Install the Assisted Installer Service
+
+Start by creating a directory for the assistedInstaller and copy the `pod-persistent-disconnected.yml` and `configmap-disconnected.yml` files from this Git repo directory into the assistedInstaller directory:
+
+```shell
+$ mkdir ~/assistedInstaller
+$ cp pod-persistent-disconnected.yml configmap-disconnected.yml ~/assistedInstaller
+```
+
+2. Create a registry.conf file and change all "\<container image registry server:port\>" entries to point to your assisted installer host name
+
+```conf
+unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
+[[registry]]
+   prefix = ""
+   location = "quay.io/openshift-release-dev/ocp-release"
+   mirror-by-digest-only = true
+   [[registry.mirror]]
+   location = "<container image registry server:port>/ocp4/openshift4"
+[[registry]]
+   prefix = ""
+   location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+   mirror-by-digest-only = true
+   [[registry.mirror]]
+   location = "<container image registry server:port>/ocp4/openshift4"
+```
+
+3. Edit `configmap-disconnected.yml` and update the following values to point to the IP address of the assisted installer host:
+
+* IMAGE_SERVICE_BASE_URL - http://<IP address of assisted installer host>:8888
+* SERVICE_BASE_URL - http://<IP address of assisted installer host>:8090
+
+4. Edit the "RELEASE_IMAGES" section. Replace "quay.io/openshift-release-dev/ocp-release:4.10.22-x86_64" with the "Update Image" from the [Identify a Container Registry and Mirror Contents](#identify-a-container-registry-and-mirror-contents) steps.
+
+'[{"openshift_version":"4.10","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift-release-dev/ocp-release:4.10.22-x86_64","version":"4.10.22","default":true}]'
+
+5. Edit the "OS_IMAGES" section, and be sure to update the host IP address to match your assisted install host:
+
+'[{"openshift_version":"4.10","cpu_architecture":"x86_64","url":"http://172.16.35.23/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso","version":"410.84.202205191234-0"}]'
+
+6. Update the tls-ca-bundle.pem file with the contents of your container image registry rootCA. (If you are using the OpenShift Mirror Registry you can find this in the `quay-rootCA/rootCA.pem` file in the root directory for the mirror registry install.)  
+
+7. Update the registries.conf section with the contents of the registries.conf file you created in step 2. 
+
+8. Update "AGENT_DOCKER_IMAGE" to point to your mirror copy of the assisted-installer-agent, for example "\<container image registry server:port\>/edge-infrastructure/assisted-installer-agent:latest"
+
+9. Update "CONTROLLER_IMAGE" to point to your mirror copy of the assisted-installer-agent, for example "\<container image registry server:port\>/edge-infrastructure/assisted-installer-controller:latest"
+
+10. Update "INSTALLER_IMAGE" to point to your mirror copy of the assisted-installer-agent, for example "\<container image registry server:port\>/edge-infrastructure/assisted-installer:latest"
+
+11. Save the file
+
+12. Run the AssistedInstaller 
+```shell
+$ podman play kube --configmap configmap-disconnected.yml pod-persistent-disconnected.yml
+# startup can be slower when the VM is not connected to the internet
+$ sudo firewall-cmd --permanent --add-port={8090/tcp,8080/tcp,8888/tcp}
+$ sudo firewall-cmd --reload
+```
+
+The assisted installer is now available at http://<your host ip address>:8080
+
+## Additional Configuration required for Cluster Deployment
+
+### Ignition Config Override
+
+We need to create a "ignition_config_override" that will allow the assisted install boot CD to use the container image mirror. You will need to have the registry.conf file that we created previously and you will need the certificate for the Image Registry if it is using a self-signed certificate. Create a file called `discovery-ignition.json` with the following contents:
+
+discovery-ignition.json.template
+```json
+{"ignition_config_override": "{\"ignition\": {\"version\": \"3.1.0\"}, \"storage\": {\"files\": [{\"path\": \"/etc/containers/registries.conf\", \"mode\": 420, \"overwrite\": true, \"user\": { \"name\": \"root\"},\"contents\": {\"source\": \"data:text/plain;base64,BASE64_ENCODED_REGISTRY_CONF\"}}, {\"path\": \"/etc/pki/ca-trust/source/anchors/domain.crt\", \"mode\": 420, \"overwrite\": true, \"user\": { \"name\": \"root\"}, \"contents\": {\"source\":\"data:text/plain;base64,BASE64_ENCODED_LOCAL_REGISTRY_CRT\"}}]}}"}
+```
+
+Now create base64 encoded versions of the registry.conf you created in [Install Assisted Installer](#install-the-assisted-installer-service) and the root CA for the image registry and update our discovery-ignition.json file:
+
+```shell
+$ base64 -w0 registry.conf > registry.conf.b64
+$ base64 -w0 /u01/quay/quay-rootCA/rootCA.pem  > quay.crt.b64
+$ sed -i "s/BASE64_ENCODED_REGISTRY_CONF/$(cat registry.conf.b64)/" discovery-ignition.json
+$ sed -i "s/BASE64_ENCODED_LOCAL_REGISTRY_CRT/$(cat quay.crt.b64)/" discovery-ignition.json
+```
+
+## Build/Deploy a Cluster
+
+At this point, you can now follow standard Assisted Installer workflows to create a cluster. However you will need to ensure that you also apply the "ignition_config_override" created in the [Ignition Config Override](#ignition-config-override) section.

--- a/deploy/podman/README-disconnected.md
+++ b/deploy/podman/README-disconnected.md
@@ -169,7 +169,21 @@ You can use the Assisted Installer web UI to set up the initial cluster settings
 
 ### Using AICLI
 
-The [aicli](https://github.com/karmab/aicli) tool is a tool that can be used to deploy OpenShift clusters using the Assisted Installer service from the command line. This is a community supported tool, and is NOT a part of the OpenShift project. 
+The [aicli](https://github.com/karmab/aicli) tool is a tool that can be used to deploy OpenShift clusters using the Assisted Installer service from the command line. This is a community supported tool, and is NOT a part of the OpenShift project. See the [How to use](https://github.com/karmab/aicli/blob/main/doc/index.md#how-to-use) section of the aicli tool on how to create a cluster using this tool. You will need to add the following additional sections in the parameters file in order to point to the mirror registry:
+
+```
+disconnected_url: <server name or IP address for assisted installer host>:8443
+installconfig:
+    additionalTrustBundle: |
+      -----BEGIN CERTIFICATE-----
+      <contents of your signing certificate>
+      -----END CERTIFICATE-----
+    imageContentSources:
+      <the values here are based on the output from the OpenShift mirror command>
+ignition_config_override: <contents of the discovery-ignition.json file created earlier>
+```
+
+The values for the imageContentSources will be based on the output of the OpenShift mirror command that you used. See the "imageContentSourcePolicy.yaml" file that is generated after the successful creation of a mirror for the exact information that should go here.
 
 ### Using the API
 

--- a/deploy/podman/configmap-disconnected.yml
+++ b/deploy/podman/configmap-disconnected.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  ASSISTED_SERVICE_HOST: 127.0.0.1:8090
+  ASSISTED_SERVICE_SCHEME: http
+  AUTH_TYPE: none
+  DB_HOST: 127.0.0.1
+  DB_NAME: installer
+  DB_PASS: admin
+  DB_PORT: "5432"
+  DB_USER: admin
+  DEPLOY_TARGET: onprem
+  DISK_ENCRYPTION_SUPPORT: "true"
+  DUMMY_IGNITION: "false"
+  ENABLE_SINGLE_NODE_DNSMASQ: "true"
+  HW_VALIDATOR_REQUIREMENTS: '[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":100,"installation_disk_speed_threshold_ms":10}}]'
+  IMAGE_SERVICE_BASE_URL: http://<IP address of assisted installer host>:8888
+  IPV6_SUPPORT: "true"
+  ISO_IMAGE_TYPE: "full-iso"
+  LISTEN_PORT: "8888"
+  NTP_DEFAULT_SERVER: ""
+  OS_IMAGES: '[{"openshift_version":"4.10","cpu_architecture":"x86_64","url":"http://<IP address of iso mirror>/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso","version":"410.84.202205191234-0"}]'
+  POSTGRESQL_DATABASE: installer
+  POSTGRESQL_PASSWORD: admin
+  POSTGRESQL_USER: admin
+  PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
+  RELEASE_IMAGES: '[{"openshift_version":"4.10","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"<container image registry server:port>/ocp4/openshift4:4.10.22-x86_64","version":"4.10.22","default":true}]'
+  SERVICE_BASE_URL: http://<IP address of assisted installer host>:8090
+  STORAGE: filesystem
+  ENABLE_UPGRADE_AGENT: "false"
+  AGENT_DOCKER_IMAGE: "<container image registry server:port>/edge-infrastructure/assisted-installer-agent:latest"
+  CONTROLLER_IMAGE: "<container image registry server:port>/edge-infrastructure/assisted-installer-controller:latest"
+  INSTALLER_IMAGE: "<container image registry server:port>/edge-infrastructure/assisted-installer:latest"
+
+  registries.conf: |
+    unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
+    [[registry]]
+        prefix = ""
+        location = "quay.io/openshift-release-dev/ocp-release"
+        mirror-by-digest-only = true
+        [[registry.mirror]]
+        location = "<container image registry server:port>/ocp4/openshift4"
+    [[registry]]
+        prefix = ""
+        location = "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+        mirror-by-digest-only = true
+        [[registry.mirror]]
+        location = "<container image registry server:port>/ocp4/openshift4"
+  tls-ca-bundle.pem: |
+    -----BEGIN CERTIFICATE-----
+    <your cert goes here>
+    -----END CERTIFICATE-----

--- a/deploy/podman/pod-persistent-disconnected.yml
+++ b/deploy/podman/pod-persistent-disconnected.yml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: assisted-installer
+  name: assisted-installer
+spec:
+  containers:
+  - args:
+    - run-postgresql
+    image: quay.io/centos7/postgresql-12-centos7:latest
+    name: db
+    envFrom:
+    - configMapRef:
+        name: config
+    volumeMounts:
+      - mountPath: /var/lib/pgsql
+        name: pg-data
+  - image: quay.io/edge-infrastructure/assisted-installer-ui:latest
+    name: ui
+    ports:
+    - hostPort: 8080
+    envFrom:
+    - configMapRef:
+        name: config
+  - image: quay.io/edge-infrastructure/assisted-image-service:latest
+    name: image-service
+    ports:
+    - hostPort: 8888
+    envFrom:
+    - configMapRef:
+        name: config
+  - image: quay.io/edge-infrastructure/assisted-service:latest
+    name: service
+    ports:
+    - hostPort: 8090
+    envFrom:
+    - configMapRef:
+        name: config
+    volumeMounts:
+      - mountPath: /data
+        name: ai-data
+      - mountPath: /etc/containers
+        name: mirror-registry-config
+      - mountPath: /etc/pki/ca-trust/extracted/pem
+        subPath: tls-ca-bundle.pem
+        name: mirror-registry-config
+  restartPolicy: Never
+  volumes:
+    - name: ai-data
+      persistentVolumeClaim:
+        claimName: ai-service-data
+    - name: pg-data
+      persistentVolumeClaim:
+        claimName: ai-db-data
+    - name: mirror-registry-config
+      configMap:
+        name: config
+        deafultMode: 420
+        items:
+          - key: registries.conf
+            path: registries.conf
+          - key: tls-ca-bundle.pem
+            path: tls-ca-bundle.pem


### PR DESCRIPTION
NO-ISSUE: Adding documentation on how to use the Assisted Installer in a disconnected mode.

In working on a Proof of Concept, I needed the ability to use the Assisted Installer in a fully disconnected/air-gaped environment. The README and associated yaml are the results of this POC, which allowed for using the Assisted Installer in a fully disconnected environment, leveraging a container image registry and mirror of the RHCOS ISO. This is a documentation/process update only.

Signed-off-by: Mark DeNeve <xphyr@users.noreply.github.com>

## List all the issues related to this PR

- [x] Documentation

## What environments does this code impact?

- [x] None

## How was this code tested?

- [x] Manual (Elaborate on how it was tested)

I have tested this documentation against two different environments to ensure that there were no steps missed.

## Assignees

/cc @romfreiman 
/cc @mhrivnak 

## Checklist

- [x ] Title and description added to both, commit and PR.
- [x ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x ] Reviewers have been listed
- [x ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

