### PR TITLE
MGMT-11973: Fix vSphere platform with enabled user-managed-networking results none platform

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1703,6 +1703,10 @@ func getActualUpdateClusterPlatformParams(platform *models.Platform, userManaged
 		return nil, nil, err
 	}
 
+	if platform != nil && *platform.Type != models.PlatformTypeBaremetal && *platform.Type != models.PlatformTypeNone {
+		return platform, userManagedNetworking, nil
+	}
+
 	if *cluster.Platform.Type == models.PlatformTypeBaremetal {
 		if !swag.BoolValue(userManagedNetworking) && (platform == nil || *platform.Type == models.PlatformTypeBaremetal) {
 			// Platform is already baremetal, nothing to do
@@ -1735,12 +1739,16 @@ func getActualUpdateClusterPlatformParams(platform *models.Platform, userManaged
 		}
 	}
 
-	return platform, userManagedNetworking, nil
+	return nil, nil, common.NewApiError(http.StatusBadRequest, errors.Errorf("Got invalid platform (%s) and/or user-managed-networking (%v)", *platform.Type, userManagedNetworking))
 }
 
 func getActualCreateClusterPlatformParams(platform *models.Platform, userManagedNetworking *bool, highAvailabilityMode *string) (*models.Platform, *bool, error) {
 	if err := checkPlatformWrongParamsInput(platform, userManagedNetworking); err != nil {
 		return nil, nil, err
+	}
+
+	if platform != nil && *platform.Type != models.PlatformTypeBaremetal && *platform.Type != models.PlatformTypeNone {
+		return platform, userManagedNetworking, nil
 	}
 
 	if *highAvailabilityMode == models.ClusterHighAvailabilityModeFull {
@@ -1763,7 +1771,7 @@ func getActualCreateClusterPlatformParams(platform *models.Platform, userManaged
 		return &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)}, swag.Bool(true), nil
 	}
 
-	return platform, userManagedNetworking, nil
+	return nil, nil, common.NewApiError(http.StatusBadRequest, errors.Errorf("Got invalid platform (%s) and/or user-managed-networking (%v)", *platform.Type, userManagedNetworking))
 }
 
 func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params installer.V2UpdateClusterParams, interactivity Interactivity) (*common.Cluster, error) {


### PR DESCRIPTION
Fix changes made on https://github.com/openshift/assisted-service/pull/4158.
One case was missed, if platform (e.g. vsphere) is different than none or baremetal with user-managed-networking enabled it will result none platform instead of the desired platform.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @gamli75 
/cc @vrutkovs 
