### PR TITLE
Bug 2122747: Update json-iterator and reflect2 dependencies to fix panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/iancoleman/strcase v0.1.2
 	github.com/jinzhu/gorm v1.9.12
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,9 @@ github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -821,8 +822,9 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180320133207-05fbef0ca5da/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=


### PR DESCRIPTION
When reading and then subsequently writing a BMH yaml within a bootstrap ignition file we encountered a panic.

This seems to be a rather well known issue with these two module versions and upgrading fixes the problem.

This was fixed in master by cc8f3538 when updating some seemingly unrelated packages, but it seems safer to just updated the required ones rather than also bringing back the prometheus client update.

References:
https://github.com/golang/go/issues/48238
https://github.com/kubernetes/kubernetes/issues/104947

## List all the issues related to this PR

https://bugzilla.redhat.com/show_bug.cgi?id=2122747

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

I found the fix by git bisecting using this rather contrived unit test in `ignition.go` derived from the environment that originally produced the bug report.
Since the actual problem was in an indirect dependency (and I don't fully understand what is broken) I decided it wasn't worth including the test in the fix.

```go
var _ = It("modifyBMHFile doesn't segfault", func() {
	g := &installerGenerator{log: log}

	overwrite := true
	root := "root"
	mode := 420
	contentSource := "data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogbWV0YWwzLmlvL3YxYWxwaGExCmtpbmQ6IEJhcmVNZXRhbEhvc3QKbWV0YWRhdGE6CiAgYW5ub3RhdGlvbnM6CiAgICBiYXJlbWV0YWxob3N0Lm1ldGFsMy5pby9wYXVzZWQ6ICIiCiAgY3JlYXRpb25UaW1lc3RhbXA6IG51bGwKICBuYW1lOiBzcG9rZS1tYXN0ZXItMC0wCiAgbmFtZXNwYWNlOiBvcGVuc2hpZnQtbWFjaGluZS1hcGkKc3BlYzoKICBibWM6CiAgICBhZGRyZXNzOiAiIgogICAgY3JlZGVudGlhbHNOYW1lOiAiIgogIGJvb3RNQUNBZGRyZXNzOiA1Mjo1NDowMDowNjoxMzpiNwogIGJvb3RNb2RlOiBVRUZJCiAgY29uc3VtZXJSZWY6CiAgICBhcGlWZXJzaW9uOiBtYWNoaW5lLm9wZW5zaGlmdC5pby92MWJldGExCiAgICBraW5kOiBNYWNoaW5lCiAgICBuYW1lOiBzcG9rZS0wLXhybmd2LW1hc3Rlci0wCiAgICBuYW1lc3BhY2U6IG9wZW5zaGlmdC1tYWNoaW5lLWFwaQogIGV4dGVybmFsbHlQcm92aXNpb25lZDogdHJ1ZQogIGhhcmR3YXJlUHJvZmlsZTogdW5rbm93bgogIG9ubGluZTogdHJ1ZQpzdGF0dXM6CiAgZXJyb3JDb3VudDogMAogIGVycm9yTWVzc2FnZTogIiIKICBnb29kQ3JlZGVudGlhbHM6IHt9CiAgaGFyZHdhcmVQcm9maWxlOiAiIgogIG9wZXJhdGlvbkhpc3Rvcnk6CiAgICBkZXByb3Zpc2lvbjoKICAgICAgZW5kOiBudWxsCiAgICAgIHN0YXJ0OiBudWxsCiAgICBpbnNwZWN0OgogICAgICBlbmQ6IG51bGwKICAgICAgc3RhcnQ6IG51bGwKICAgIHByb3Zpc2lvbjoKICAgICAgZW5kOiBudWxsCiAgICAgIHN0YXJ0OiBudWxsCiAgICByZWdpc3RlcjoKICAgICAgZW5kOiBudWxsCiAgICAgIHN0YXJ0OiBudWxsCiAgb3BlcmF0aW9uYWxTdGF0dXM6ICIiCiAgcG93ZXJlZE9uOiBmYWxzZQogIHByb3Zpc2lvbmluZzoKICAgIElEOiAiIgogICAgaW1hZ2U6CiAgICAgIHVybDogIiIKICAgIHN0YXRlOiAiIgogIHRyaWVkQ3JlZGVudGlhbHM6IHt9Cg=="

	file := &config_32_types.File{
		Node: config_32_types.Node{
			Overwrite: &overwrite,
			Path:      "/opt/openshift/openshift/99_openshift-cluster-api_hosts-0.yaml",
			User:      config_32_types.NodeUser{Name: &root},
		},
		FileEmbedded1: config_32_types.FileEmbedded1{
			Contents: config_32_types.Resource{Source: &contentSource},
			Mode:     &mode,
		},
	}

	bmh, err := fileToBMH(file)
	Expect(err).ToNot(HaveOccurred())

	inventory := `{"bmc_address":"0.0.0.0","bmc_v6address":"::/0","boot":{"current_boot_mode":"uefi"},"cpu":{"architecture":"x86_64","count":4,"flags":["fpu","vme","de","pse","tsc","msr","pae","mce","cx8","apic","sep","mtrr","pge","mca","cmov","pat","pse36","clflush","mmx","fxsr","sse","sse2","ss","syscall","nx","pdpe1gb","rdtscp","lm","constant_tsc","arch_perfmon","rep_good","nopl","xtopology","cpuid","tsc_known_freq","pni","pclmulqdq","vmx","ssse3","fma","cx16","pdcm","pcid","sse4_1","sse4_2","x2apic","movbe","popcnt","tsc_deadline_timer","aes","xsave","avx","f16c","rdrand","hypervisor","lahf_lm","abm","3dnowprefetch","cpuid_fault","invpcid_single","ssbd","ibrs","ibpb","stibp","ibrs_enhanced","tpr_shadow","vnmi","flexpriority","ept","vpid","ept_ad","fsgsbase","tsc_adjust","bmi1","avx2","smep","bmi2","erms","invpcid","mpx","avx512f","avx512dq","rdseed","adx","smap","clflushopt","clwb","avx512cd","avx512bw","avx512vl","xsaveopt","xsavec","xgetbv1","xsaves","arat","umip","pku","ospke","avx512_vnni","md_clear","arch_capabilities"],"frequency":2095.106,"model_name":"Intel(R) Xeon(R) Gold 5218R CPU @ 2.10GHz"},"disks":[{"by_id":"/dev/disk/by-id/wwn-0x05abcd1bbbf7231f","by_path":"/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0","drive_type":"HDD","hctl":"0:0:0:0","id":"/dev/disk/by-id/wwn-0x05abcd1bbbf7231f","installation_eligibility":{"eligible":true,"not_eligible_reasons":null},"model":"QEMU_HARDDISK","name":"sda","path":"/dev/sda","serial":"05abcd1bbbf7231f","size_bytes":128849018880,"smart":"{\"json_format_version\":[1,0],\"smartctl\":{\"version\":[7,1],\"svn_revision\":\"5049\",\"platform_info\":\"x86_64-linux-4.18.0-305.49.1.el8_4.x86_64\",\"build_info\":\"(local build)\",\"argv\":[\"smartctl\",\"--xall\",\"--json=c\",\"/dev/sda\"],\"exit_status\":4},\"device\":{\"name\":\"/dev/sda\",\"info_name\":\"/dev/sda\",\"type\":\"scsi\",\"protocol\":\"SCSI\"},\"vendor\":\"QEMU\",\"product\":\"QEMU HARDDISK\",\"model_name\":\"QEMU QEMU HARDDISK\",\"revision\":\"2.5+\",\"scsi_version\":\"SPC-3\",\"user_capacity\":{\"blocks\":251658240,\"bytes\":128849018880},\"logical_block_size\":512,\"rotation_rate\":0,\"device_type\":{\"scsi_value\":0,\"name\":\"disk\"},\"local_time\":{\"time_t\":1662726601,\"asctime\":\"Fri Sep  9 12:30:01 2022 UTC\"},\"temperature\":{\"current\":0,\"drive_trip\":0}}","vendor":"QEMU","wwn":"0x05abcd1bbbf7231f"},{"by_path":"/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:1","drive_type":"ODD","hctl":"0:0:0:1","id":"/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:1","installation_eligibility":{"not_eligible_reasons":["Disk is removable","Disk is too small (disk only has 109 MB, but 120 GB are required)","Drive type is ODD, it must be one of HDD, SSD."]},"is_installation_media":true,"model":"QEMU_CD-ROM","name":"sr0","path":"/dev/sr0","removable":true,"serial":"drive-scsi0-0-0-1","size_bytes":108785664,"smart":"{\"json_format_version\":[1,0],\"smartctl\":{\"version\":[7,1],\"svn_revision\":\"5049\",\"platform_info\":\"x86_64-linux-4.18.0-305.49.1.el8_4.x86_64\",\"build_info\":\"(local build)\",\"argv\":[\"smartctl\",\"--xall\",\"--json=c\",\"/dev/sr0\"],\"exit_status\":4},\"device\":{\"name\":\"/dev/sr0\",\"info_name\":\"/dev/sr0\",\"type\":\"scsi\",\"protocol\":\"SCSI\"},\"vendor\":\"QEMU\",\"product\":\"QEMU CD-ROM\",\"model_name\":\"QEMU QEMU CD-ROM\",\"revision\":\"2.5+\",\"scsi_version\":\"SPC-3\",\"user_capacity\":{\"blocks\":53118,\"bytes\":108785664},\"logical_block_size\":2048,\"device_type\":{\"scsi_value\":5,\"name\":\"CD/DVD\"},\"local_time\":{\"time_t\":1662726601,\"asctime\":\"Fri Sep  9 12:30:01 2022 UTC\"},\"temperature\":{\"current\":0,\"drive_trip\":0}}","vendor":"QEMU"}],"gpus":[{"address":"0000:00:02.0"}],"hostname":"localhost","interfaces":[{"flags":["up","broadcast","multicast"],"has_carrier":true,"ipv4_addresses":[],"ipv6_addresses":["fd2e:6f44:5dd8:1::11/64"],"mac_address":"52:54:00:1a:9a:9f","mtu":1500,"name":"enp0s3","product":"0x0001","speed_mbps":-1,"vendor":"0x1af4"}],"memory":{"physical_bytes":17179869184,"physical_bytes_method":"dmidecode","usable_bytes":16782921728},"routes":[{"destination":"10.88.0.0","family":2,"interface":"cni-podman0"},{"destination":"::1","family":10,"interface":"lo"},{"destination":"fd2e:6f44:5dd8:1::","family":10,"interface":"enp0s3"},{"destination":"fe80::","family":10,"interface":"enp0s3"},{"destination":"fe80::","family":10,"interface":"cni-podman0"},{"destination":"::","family":10,"gateway":"fd2e:6f44:5dd8:1::1","interface":"enp0s3"}],"system_vendor":{"manufacturer":"Red Hat","product_name":"KVM","virtual":true},"timestamp":1662726631,"tpm_version":"none"}`

	host := &models.Host{
		Inventory:         inventory,
		RequestedHostname: "spoke-master-0-2",
	}

	Expect(g.modifyBMHFile(file, bmh, host)).To(Succeed())
})
```

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @filanov 
/cc @danielerez 

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
