### PR TITLE
MGMT-11056: Additional stages when adding workers with k8s API

### DIFF
--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -518,6 +518,21 @@ func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostIgnitionInternal(arg0,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2UpdateHostIgnitionInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2UpdateHostIgnitionInternal), arg0, arg1)
 }
 
+// V2UpdateHostInstallProgressInternal mocks base method.
+func (m *MockInstallerInternals) V2UpdateHostInstallProgressInternal(arg0 context.Context, arg1 installer.V2UpdateHostInstallProgressParams) (*common.Host, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "V2UpdateHostInstallProgressInternal", arg0, arg1)
+	ret0, _ := ret[0].(*common.Host)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// V2UpdateHostInstallProgressInternal indicates an expected call of V2UpdateHostInstallProgressInternal.
+func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostInstallProgressInternal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2UpdateHostInstallProgressInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2UpdateHostInstallProgressInternal), arg0, arg1)
+}
+
 // V2UpdateHostInstallerArgsInternal mocks base method.
 func (m *MockInstallerInternals) V2UpdateHostInstallerArgsInternal(arg0 context.Context, arg1 installer.V2UpdateHostInstallerArgsParams) (*models.Host, error) {
 	m.ctrl.T.Helper()

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -636,12 +636,15 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 	case models.HostStageRebooting:
 		if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost {
 			infoMessage := statusInfo
+			stage := models.HostStageDone
 			if !m.kubeApiEnabled {
+				// in case kubeApiEnabled the agent controller will keep updating the host stage until the installation is complete
 				infoMessage = statusInfoRebootingDay2
+				stage = models.HostStageRebooting
 			}
 			_, err = hostutil.UpdateHostProgress(ctx, logutil.FromContext(ctx, m.log), m.db, m.eventsHandler, h.InfraEnvID, *h.ID,
 				swag.StringValue(h.Status), models.HostStatusAddedToExistingCluster, infoMessage,
-				h.Progress.CurrentStage, models.HostStageDone, progress.ProgressInfo, extra...)
+				h.Progress.CurrentStage, stage, progress.ProgressInfo, extra...)
 			break
 		}
 		fallthrough


### PR DESCRIPTION
When adding a worker to an existing cluster we move straight from Rebooting to Done.  However,  with the k8s API we have the kubeconfig and can determine the stages more accurately.

### This PR adds to the following changes:
1. If kubeAPIEnabled, do not move the Agent to Done, leave it in Rebooting.
2. If the agent-controller sees:
    a. a ready node for that host, move the Agent to Done
    b. a non-ready node for that host, move the Agent to Joined

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? yes, with the infrastructure-operator
- Any logs, screenshots, etc that can help with the review process? nope

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-11047

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @carbonin 
/cc @nmagnezi 
/cc @ori-amizur 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
