### PR TITLE
MGMT-11736: refactor ASC reconciler

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -142,13 +142,15 @@ func main() {
 	spokeClientCache := controllers.NewSpokeClientCache(spokeClientFactory)
 
 	if err = (&controllers.AgentServiceConfigReconciler{
-		Client:       mgr.GetClient(),
-		Log:          log,
-		Scheme:       mgr.GetScheme(),
-		Recorder:     mgr.GetEventRecorderFor("agentserviceconfig-controller"),
-		Namespace:    ns,
-		NodeSelector: nodeSelector,
-		Tolerations:  tolerations,
+		AgentServiceConfigReconcileContext: controllers.AgentServiceConfigReconcileContext{
+			Client:       mgr.GetClient(),
+			Log:          log,
+			Scheme:       mgr.GetScheme(),
+			NodeSelector: nodeSelector,
+			Tolerations:  tolerations,
+			Recorder:     mgr.GetEventRecorderFor("agentserviceconfig-controller"),
+		},
+		Namespace: ns,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentServiceConfig")
 		os.Exit(1)


### PR DESCRIPTION
First installment of refactoring ASC reconciler so code can be shared between the HypershiftAgentServiceConfig and the existing ASC.

Existing State:
----------------------
1. Component functions (function that returns the k8s artifacts required for deployment) assume default pre-configured namespace.
2. Component functions receive reference to AgentServiceConfig type.
3. Component functions are members of the AgentServiceConfigReconciler.

Changes:
-----------------
1. Component functions accept namespace as parameter. The calling function now passes the above pre-configured namespace (r.Namespace)  as a parameter.
2.  Define a state object ASC which holds the state of the reconciler and the common part of the configuration. This allows inversion of control in the component functions where all the state they need is injected to them.
3. Move Component functions to a package scope. These functions can now be shared also by the new HypershiftASC reconciler.

Next Changes
--------------------
Change the main reconcile function to run as a template with components, finalizers and cleanup functions created at initialization time so this main logic loop can be shared as well.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

<!--
Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
this PR directly to someone.
-->

/cc @
/cc @

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
