### PR TITLE
MGMT-11753: moving CI Dockerfiles to the repo

### DIFF
--- a/ci-images/Dockerfile.base
+++ b/ci-images/Dockerfile.base
@@ -1,0 +1,19 @@
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf install -y git unzip make gcc which nmstate-devel
+
+COPY --from=registry.ci.openshift.org/openshift/release:golang-1.17 /usr/local/go /usr/local/go
+
+ENV GOPATH=/go
+ENV GOROOT=/usr/local/go
+ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+
+COPY . /assisted-service/
+WORKDIR /assisted-service/
+
+RUN go mod vendor
+
+RUN chmod 775 -R $GOPATH && chmod 775 -R $(go env GOROOT) && chmod 775 -R /assisted-service/ && \
+    mkdir /.cache && chmod 775 -R /.cache

--- a/ci-images/Dockerfile.code-generation
+++ b/ci-images/Dockerfile.code-generation
@@ -1,0 +1,22 @@
+FROM base
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY --from=quay.io/goswagger/swagger:v0.28.0 /usr/bin/swagger /usr/bin/goswagger
+
+RUN cd / && /assisted-service/hack/setup_env.sh spectral && \
+    /assisted-service/hack/setup_env.sh jq && \
+    /assisted-service/hack/setup_env.sh kustomize && \
+    go install github.com/golang/mock/mockgen@v1.5.0 && \
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 && \
+    go install golang.org/x/tools/cmd/goimports@v0.1.5 && \
+    chmod 775 -R $GOPATH
+
+RUN curl --retry 5 -L https://github.com/operator-framework/operator-sdk/releases/download/v1.10.1/operator-sdk_linux_amd64 --output /tmp/operator-sdk_linux_amd64 && \
+    chmod +x /tmp/operator-sdk_linux_amd64 && \
+    install /tmp/operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
+
+RUN python3 -m venv ${VIRTUAL_ENV} && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install -r /assisted-service/dev-requirements.txt

--- a/ci-images/Dockerfile.lint
+++ b/ci-images/Dockerfile.lint
@@ -1,0 +1,3 @@
+FROM base
+
+COPY --from=quay.io/app-sre/golangci-lint:v1.37.1 /usr/bin/golangci-lint /usr/bin/golangci-lint

--- a/ci-images/Dockerfile.subsystem
+++ b/ci-images/Dockerfile.subsystem
@@ -1,0 +1,6 @@
+FROM base
+
+COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin/kubectl /usr/bin/
+
+RUN make build-openshift-ci-test-bin
+RUN go mod vendor

--- a/ci-images/Dockerfile.unit-tests
+++ b/ci-images/Dockerfile.unit-tests
@@ -1,0 +1,5 @@
+FROM base
+
+RUN dnf install -y postgresql-server
+
+RUN cd / && /assisted-service/hack/setup_env.sh test_tools


### PR DESCRIPTION
In order to be able to do quick fixes with less rehearse jobs and to spot duplicated code, we should have all CI-related images inside the repository (currently it's configured ad-hoc in the ``openshift/release`` repo).

This mainly copies the Dockerfiles to this repo without any significant changes.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
