### PR TITLE
Remove reviewers listing from PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -43,21 +43,10 @@ how this code was tested. Here are some questions that may be worth answering:
 - [ ] Manual (Elaborate on how it was tested)
 - [x] No tests needed
 
-## Assignees
-
-<!--
-Please, add one or two reviewers that could help review this PR. Use `/assign` if you want to assign
-this PR directly to someone.
--->
-
-/cc @
-/cc @
-
 ## Checklist
 
 - [ ] Title and description added to both, commit and PR.
 - [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
-- [ ] Reviewers have been listed
 - [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
 - [ ] Does this change include unit-tests (note that code changes require unit-tests)
 


### PR DESCRIPTION
Since draft mode enables us to start off with no reviewers being mentioned, we can remove that part now.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Assignees

/cc @flaper87 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] Reviewers have been listed
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
