### PR TITLE
MGMT-12062: Remove host reclaim feature flag

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,7 +148,6 @@ var Options struct {
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
 	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"` // set to true once https://bugzilla.redhat.com/show_bug.cgi?id=2089683 is resolved
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
-	EnableHostReclaim              bool `envconfig:"ENABLE_HOST_RECLAIM" default:"false"`
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
 	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`
@@ -560,7 +559,6 @@ func main() {
 				AuthType:                   Options.Auth.AuthType,
 				SpokeK8sClientFactory:      spoke_k8s_client.NewSpokeK8sClientFactory(log),
 				ApproveCsrsRequeueDuration: Options.ApproveCsrsRequeueDuration,
-				EnableHostReclaim:          Options.EnableHostReclaim,
 				AgentContainerImage:        Options.BMConfig.AgentDockerImg,
 				HostFSMountDir:             hostFSMountDir,
 			}).SetupWithManager(ctrlMgr), "unable to create controller Agent")


### PR DESCRIPTION
This was needed so that we could merge the work a bit at a time. Now that all the pieces are in place for reclaim to work correctly this can be removed.

This isn't a problem for non-kubeapi deployments as the agent controller is the only place we will ever run the reclaim transition.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-12062

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

cc @CrystalChun 
cc @danielerez 
cc @ori-amizur 
