### PR TITLE
MGMT-12063: Fix update cluster UMN when platform is different from baremetal/none

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1694,6 +1694,18 @@ func checkPlatformWrongParamsInput(platform *models.Platform, userManagedNetwork
 	return nil
 }
 
+func doesPlatformDifferentThanBaremetalOrNone(platform *models.Platform, cluster *common.Cluster) bool {
+	if platform != nil && *platform.Type != models.PlatformTypeBaremetal && *platform.Type != models.PlatformTypeNone {
+		return true
+	}
+
+	if platform == nil && *cluster.Platform.Type != models.PlatformTypeBaremetal && *cluster.Platform.Type != models.PlatformTypeNone {
+		return true
+	}
+
+	return false
+}
+
 func getActualUpdateClusterPlatformParams(platform *models.Platform, userManagedNetworking *bool, cluster *common.Cluster) (*models.Platform, *bool, error) {
 	if platform == nil && userManagedNetworking == nil {
 		return nil, nil, nil
@@ -1703,7 +1715,7 @@ func getActualUpdateClusterPlatformParams(platform *models.Platform, userManaged
 		return nil, nil, err
 	}
 
-	if platform != nil && *platform.Type != models.PlatformTypeBaremetal && *platform.Type != models.PlatformTypeNone {
+	if doesPlatformDifferentThanBaremetalOrNone(platform, cluster) {
 		return platform, userManagedNetworking, nil
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5164,6 +5164,111 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 				})
 
+				It("Update UMN=true and vphsere platform while cluster platform already set to none - success", func() {
+					mockClusterUpdateSuccess(2, 0)
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							UserManagedNetworking: swag.Bool(true),
+							VipDhcpAllocation:     swag.Bool(false),
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							NetworkType:           swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+						},
+					})
+
+					Expect(reply2).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+				})
+
+				It("Update UMN=false and vphsere platform while cluster platform already set to none - success", func() {
+					mockClusterUpdateSuccess(2, 0)
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							UserManagedNetworking: swag.Bool(false),
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							NetworkType:           swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+						},
+					})
+
+					Expect(reply2).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(false))
+					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+				})
+
+				It("Update UMN=false and vphsere platform while cluster platform already set to baremetal - success", func() {
+					mockClusterUpdateSuccess(1, 0)
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							UserManagedNetworking: swag.Bool(false),
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							NetworkType:           swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+						},
+					})
+
+					Expect(reply2).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(false))
+					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+				})
+
+				It("Update UMN=true and vphsere platform while cluster platform already set to baremetal - success", func() {
+					mockClusterUpdateSuccess(1, 0)
+
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							UserManagedNetworking: swag.Bool(true),
+							VipDhcpAllocation:     swag.Bool(false),
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							NetworkType:           swag.String(models.ClusterNetworkTypeOpenShiftSDN),
+						},
+					})
+
+					Expect(reply2).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+				})
+
 				It("Update UMN=true - success", func() {
 					mockSuccess()
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)


### PR DESCRIPTION
We missed a case when first we have (creating or creating + updating) cluster with platform different than baremetal/none and next updating the cluster UMN to with sone value (true or false)

Issue: https://issues.redhat.com/browse/MGMT-12063


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eranco74 
/cc @gamli75 