### PR TITLE
MGMT-11751: ensure agent-install CRDs exist spoke cluster

### DIFF
--- a/api/v1beta1/hypershiftagentserviceconfig_types.go
+++ b/api/v1beta1/hypershiftagentserviceconfig_types.go
@@ -53,7 +53,7 @@ type HypershiftAgentServiceConfig struct {
 	Status HypershiftAgentServiceConfigStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 // HypershiftAgentServiceConfigList contains a list of HypershiftAgentServiceConfigs
 type HypershiftAgentServiceConfigList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,6 +31,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -64,6 +65,8 @@ func init() {
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 
 	utilruntime.Must(apiregv1.AddToScheme(scheme))
+
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 }
 
 func main() {
@@ -160,6 +163,7 @@ func main() {
 		Scheme:       mgr.GetScheme(),
 		NodeSelector: nodeSelector,
 		Tolerations:  tolerations,
+		Namespace:    ns,
 		SpokeClients: spokeClientCache,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HypershiftAgentServiceConfig")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -202,6 +202,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -474,6 +474,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apiregistration.k8s.io
           resources:
           - apiservices

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -240,6 +241,7 @@ func GetKubeClientSchemes() *runtime.Scheme {
 	utilruntime.Must(apiregv1.AddToScheme(schemes))
 	utilruntime.Must(configv1.Install(schemes))
 	utilruntime.Must(metal3iov1alpha1.AddToScheme(schemes))
+	utilruntime.Must(apiextensionsv1.AddToScheme(schemes))
 	return schemes
 }
 

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
@@ -12,10 +12,14 @@ import (
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -24,6 +28,7 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		ctx                  = context.Background()
 		hr                   *HypershiftAgentServiceConfigReconciler
 		hsc                  *aiv1beta1.HypershiftAgentServiceConfig
+		crd                  *apiextensionsv1.CustomResourceDefinition
 		kubeconfigSecret     *corev1.Secret
 		mockCtrl             *gomock.Controller
 		mockSpokeClient      *spoke_k8s_client.MockSpokeK8sClient
@@ -32,6 +37,7 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 
 	const (
 		testKubeconfigSecretName = "test-secret"
+		testCRDName              = "agent-install"
 	)
 
 	newHypershiftAgentServiceConfigRequest := func(asc *aiv1beta1.HypershiftAgentServiceConfig) ctrl.Request {
@@ -87,6 +93,22 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		}
 	}
 
+	newAgentInstallCRD := func() *apiextensionsv1.CustomResourceDefinition {
+		c := &apiextensionsv1.CustomResourceDefinition{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testCRDName,
+				Labels: map[string]string{
+					fmt.Sprintf("operators.coreos.com/assisted-service-operator.%s", testNamespace): "",
+				},
+			},
+			Spec:   apiextensionsv1.CustomResourceDefinitionSpec{},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{},
+		}
+		c.ResourceVersion = ""
+		return c
+	}
+
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockSpokeClient = spoke_k8s_client.NewMockSpokeK8sClient(mockCtrl)
@@ -94,7 +116,8 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 
 		hsc = newHSCDefault()
 		kubeconfigSecret = newKubeconfigSecret()
-		hr = newHSCTestReconciler(mockSpokeClientCache, hsc, kubeconfigSecret)
+		crd = newAgentInstallCRD()
+		hr = newHSCTestReconciler(mockSpokeClientCache, hsc, kubeconfigSecret, crd)
 	})
 
 	AfterEach(func() {
@@ -103,6 +126,10 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 
 	It("runs without error", func() {
 		mockSpokeClientCache.EXPECT().Get(gomock.Any()).Return(mockSpokeClient, nil)
+		mockSpokeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockSpokeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		crdKey := client.ObjectKeyFromObject(crd)
+		Expect(hr.Client.Get(ctx, crdKey, crd)).To(Succeed())
 		res, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{}))
@@ -137,5 +164,61 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		_, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring("Failed to create client"))
+	})
+
+	It("fails due to missing agent-install CRDs on management cluster", func() {
+		mockSpokeClientCache.EXPECT().Get(gomock.Any()).Return(mockSpokeClient, nil)
+		Expect(hr.Client.Delete(ctx, crd)).To(Succeed())
+		_, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(ContainSubstring("agent-install CRDs are not available"))
+	})
+
+	It("ignores error listing CRD on spoke cluster (warns for failed cleanup)", func() {
+		mockSpokeClientCache.EXPECT().Get(gomock.Any()).Return(mockSpokeClient, nil)
+		mockSpokeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockSpokeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error"))
+		res, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{}))
+	})
+
+	It("successfully creates CRD on spoke cluster", func() {
+		mockSpokeClientCache.EXPECT().Get(gomock.Any()).Return(mockSpokeClient, nil)
+		notFoundError := k8serrors.NewNotFound(schema.GroupResource{Group: "v1", Resource: "CustomResourceDefinition"}, testCRDName)
+		mockSpokeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(notFoundError)
+		mockSpokeClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockSpokeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		res, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal(ctrl.Result{}))
+	})
+
+	It("successfully updates existing CRD on spoke cluster", func() {
+		schemes := GetKubeClientSchemes()
+		spokeCRD := newAgentInstallCRD()
+		fakeSpokeClient := fakeclient.NewClientBuilder().WithScheme(schemes).WithRuntimeObjects(spokeCRD).Build()
+
+		c := crd.DeepCopy()
+		c.Labels["new"] = "label"
+		Expect(hr.Client.Update(ctx, c)).To(Succeed())
+		Expect(hr.syncSpokeAgentInstallCRDs(ctx, fakeSpokeClient)).To(Succeed())
+
+		crdKey := client.ObjectKeyFromObject(crd)
+		spokeCrd := apiextensionsv1.CustomResourceDefinition{}
+		Expect(fakeSpokeClient.Get(ctx, crdKey, &spokeCrd)).To(Succeed())
+		Expect(spokeCrd.Labels["new"]).To(Equal("label"))
+	})
+
+	It("successfully removes redundant CRD from spoke cluster", func() {
+		schemes := GetKubeClientSchemes()
+		crd = newAgentInstallCRD()
+		crd.Name = "redundant"
+		fakeSpokeClient := fakeclient.NewClientBuilder().WithScheme(schemes).WithRuntimeObjects(crd).Build()
+		crdKey := client.ObjectKeyFromObject(crd)
+		spokeCrd := apiextensionsv1.CustomResourceDefinition{}
+		Expect(fakeSpokeClient.Get(ctx, crdKey, &spokeCrd)).To(Succeed())
+		Expect(hr.syncSpokeAgentInstallCRDs(ctx, fakeSpokeClient)).To(Succeed())
+		Expect(fakeSpokeClient.Get(ctx, crdKey, &spokeCrd)).To(Not(Succeed()))
 	})
 })

--- a/internal/spoke_k8s_client/spoke_k8s_client.go
+++ b/internal/spoke_k8s_client/spoke_k8s_client.go
@@ -23,6 +23,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -217,5 +218,6 @@ func GetKubeClientSchemes() *runtime.Scheme {
 	utilruntime.Must(configv1.Install(schemes))
 	utilruntime.Must(metal3iov1alpha1.AddToScheme(schemes))
 	utilruntime.Must(authzv1.AddToScheme(schemes))
+	utilruntime.Must(apiextensionsv1.AddToScheme(schemes))
 	return schemes
 }

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/hypershiftagentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/hypershiftagentserviceconfig_types.go
@@ -22,6 +22,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ConditionType related to our reconcile loop in addition to all the reasons
+// why ConditionStatus could be true or false.
+const (
+	// ReasonSpokeClusterCRDsSyncFailure when agent-install CRDs sync fails on spoke cluster.
+	ReasonSpokeClusterCRDsSyncFailure string = "SpokeClusterCRDsSyncFailure"
+)
+
 // HypershiftAgentServiceConfigSpec defines the desired state of HypershiftAgentServiceConfig.
 type HypershiftAgentServiceConfigSpec struct {
 	AgentServiceConfigSpec `json:",inline"`
@@ -53,7 +60,7 @@ type HypershiftAgentServiceConfig struct {
 	Status HypershiftAgentServiceConfigStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
+// +kubebuilder:object:root=true
 // HypershiftAgentServiceConfigList contains a list of HypershiftAgentServiceConfigs
 type HypershiftAgentServiceConfigList struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
In order to deploy assisted-service on a spoke hypershift cluster, the agent-install CRDs must first exist on it.
Hence, introduced the following flow to ensure each CRD exists (and not stale) on the spoke cluster:
* List the relevant CRDs on the management cluster.
* For each one, create/update on the spoke cluster.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Assignees

/cc @slaviered 
/cc @mhrivnak 
/cc @carbonin 
/cc @filanov 

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
