### PR TITLE
MGMT-12066: Fix installation failed to start when UMN is enabled

### DIFF
--- a/internal/provider/vsphere/installConfig.go
+++ b/internal/provider/vsphere/installConfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/installcfg"
+	"github.com/openshift/assisted-service/internal/provider"
 )
 
 func setPlatformValues(platform *installcfg.VsphereInstallConfigPlatform) {
@@ -33,6 +34,11 @@ func (p vsphereProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerCon
 
 		vsPlatform.APIVIP = cluster.APIVip
 		vsPlatform.IngressVIP = cluster.IngressVip
+	} else {
+		cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
+		if cluster.NetworkType != nil {
+			cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
+		}
 	}
 
 	setPlatformValues(vsPlatform)


### PR DESCRIPTION
Starting installation when platform=vsphere and UMN enabled it immediately returning from preparing-for-installation to ready state (returning to the `Review and create` tab).
From the service log it seems that one of the CIDRs is empty:
`error="invalid CIDR address: "`
It seems that the machine_networks on the install-config was empty. This PR configuring the networking properly. 

Task: https://issues.redhat.com/browse/MGMT-12063

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @tsorya 
/cc @gamli75 
