### PR TITLE
NO-ISSUE: Remove unused `RegisterInstalledOCPHost` and its associated transition

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -93,7 +93,6 @@ type API interface {
 	// Register a new host
 	RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB) error
 	UnRegisterHost(ctx context.Context, hostID, infraEnvID string) error
-	RegisterInstalledOCPHost(ctx context.Context, h *models.Host, db *gorm.DB) error
 	HandleInstallationFailure(ctx context.Context, h *models.Host) error
 	HandleMediaDisconnected(ctx context.Context, h *models.Host) error
 	HandleReclaimBootArtifactDownload(ctx context.Context, h *models.Host) error
@@ -231,13 +230,6 @@ func (m *Manager) RegisterHost(ctx context.Context, h *models.Host, db *gorm.DB)
 		ctx:                   ctx,
 		discoveryAgentVersion: h.DiscoveryAgentVersion,
 		db:                    db,
-	})
-}
-
-func (m *Manager) RegisterInstalledOCPHost(ctx context.Context, h *models.Host, db *gorm.DB) error {
-	return m.sm.Run(TransitionTypeRegisterInstalledHost, newStateHost(h), &TransitionArgsRegisterInstalledHost{
-		ctx: ctx,
-		db:  db,
 	})
 }
 

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -397,20 +397,6 @@ func (mr *MockAPIMockRecorder) RegisterHost(arg0, arg1, arg2 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHost", reflect.TypeOf((*MockAPI)(nil).RegisterHost), arg0, arg1, arg2)
 }
 
-// RegisterInstalledOCPHost mocks base method.
-func (m *MockAPI) RegisterInstalledOCPHost(arg0 context.Context, arg1 *models.Host, arg2 *gorm.DB) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterInstalledOCPHost", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RegisterInstalledOCPHost indicates an expected call of RegisterInstalledOCPHost.
-func (mr *MockAPIMockRecorder) RegisterInstalledOCPHost(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterInstalledOCPHost", reflect.TypeOf((*MockAPI)(nil).RegisterInstalledOCPHost), arg0, arg1, arg2)
-}
-
 // ReportValidationFailedMetrics mocks base method.
 func (m *MockAPI) ReportValidationFailedMetrics(arg0 context.Context, arg1 *models.Host, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -395,20 +395,6 @@ func (mr *MockTransitionHandlerMockRecorder) PostRegisterHost(sw, args interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRegisterHost", reflect.TypeOf((*MockTransitionHandler)(nil).PostRegisterHost), sw, args)
 }
 
-// PostRegisterInstalledHost mocks base method.
-func (m *MockTransitionHandler) PostRegisterInstalledHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostRegisterInstalledHost", sw, args)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PostRegisterInstalledHost indicates an expected call of PostRegisterInstalledHost.
-func (mr *MockTransitionHandlerMockRecorder) PostRegisterInstalledHost(sw, args interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRegisterInstalledHost", reflect.TypeOf((*MockTransitionHandler)(nil).PostRegisterInstalledHost), sw, args)
-}
-
 // PostResetHost mocks base method.
 func (m *MockTransitionHandler) PostResetHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -14,7 +14,6 @@ const (
 	TransitionTypeResettingPendingUserAction = "ResettingPendingUserAction"
 	TransitionTypeRefresh                    = "RefreshHost"
 	TransitionTypeMediaDisconnect            = "MediaDisconnect"
-	TransitionTypeRegisterInstalledHost      = "RegisterInstalledHost"
 	TransitionTypeBindHost                   = "BindHost"
 	TransitionTypeUnbindHost                 = "UnbindHost"
 	TransitionTypeReclaimHost                = "ReclaimHost"
@@ -108,16 +107,6 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 			stateswitch.State(models.HostStatusError),
 		},
 		DestinationState: stateswitch.State(models.HostStatusError),
-	})
-
-	// Register host
-	sm.AddTransition(stateswitch.TransitionRule{
-		TransitionType: TransitionTypeRegisterInstalledHost,
-		SourceStates: []stateswitch.State{
-			"",
-		},
-		DestinationState: stateswitch.State(models.HostStatusInstalled),
-		PostTransition:   th.PostRegisterInstalledHost,
 	})
 
 	// Installation failure

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -57,7 +57,6 @@ type TransitionHandler interface {
 	PostRegisterDuringInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
 	PostRegisterDuringReboot(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
 	PostRegisterHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
-	PostRegisterInstalledHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
 	PostResetHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
 	PostResettingPendingUserAction(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
 	PostUnbindHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error
@@ -199,33 +198,6 @@ func (th *transitionHandler) PostRegisterDuringReboot(sw stateswitch.StateSwitch
 
 	messages = append(messages, fmt.Sprintf("(%s, %s)", installationDisk.Name, common.GetDeviceIdentifier(installationDisk)))
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost, strings.Join(messages, " "))
-}
-
-///////////////////////////////////////////////////////////////////////////
-// Register Installed host
-//////////////////////////////////////////////////////////////////////////
-
-type TransitionArgsRegisterInstalledHost struct {
-	ctx context.Context
-	db  *gorm.DB
-}
-
-func (th *transitionHandler) PostRegisterInstalledHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
-	sHost, ok := sw.(*stateHost)
-	if !ok {
-		return errors.New("PostRegisterInstalledHost incompatible type of StateSwitch")
-	}
-	params, ok := args.(*TransitionArgsRegisterInstalledHost)
-	if !ok {
-		return errors.New("PostRegisterInstalledHost invalid argument")
-	}
-
-	log := logutil.FromContext(params.ctx, th.log)
-
-	sHost.host.StatusUpdatedAt = strfmt.DateTime(time.Now())
-	sHost.host.StatusInfo = swag.String(statusInfoDiscovering)
-	log.Infof("Register installed host %s cluster %s", sHost.host.ID.String(), sHost.host.ClusterID)
-	return params.db.Create(sHost.host).Error
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -642,44 +642,6 @@ var _ = Describe("HostInstallationFailed", func() {
 	})
 })
 
-var _ = Describe("RegisterInstalledOCPHost", func() {
-	var (
-		ctx                           = context.Background()
-		hapi                          API
-		db                            *gorm.DB
-		hostId, clusterId, infraEnvId strfmt.UUID
-		host                          models.Host
-		ctrl                          *gomock.Controller
-		mockMetric                    *metrics.MockAPI
-		mockEvents                    *eventsapi.MockHandler
-		dbName                        string
-	)
-
-	BeforeEach(func() {
-		db, dbName = common.PrepareTestDB()
-		ctrl = gomock.NewController(GinkgoT())
-		mockMetric = metrics.NewMockAPI(ctrl)
-		mockEvents = eventsapi.NewMockHandler(ctrl)
-		mockHwValidator := hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
-		hapi = NewManager(common.GetTestLog(), db, mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, operatorsManager, nil, false, nil)
-		hostId = strfmt.UUID(uuid.New().String())
-		clusterId = strfmt.UUID(uuid.New().String())
-		infraEnvId = strfmt.UUID(uuid.New().String())
-		host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, "")
-	})
-
-	It("register_installed_host", func() {
-		Expect(hapi.RegisterInstalledOCPHost(ctx, &host, db)).ShouldNot(HaveOccurred())
-		h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
-		Expect(swag.StringValue(h.Status)).Should(Equal(models.HostStatusInstalled))
-	})
-
-	AfterEach(func() {
-		common.DeleteTestDB(db, dbName)
-	})
-})
-
 var _ = Describe("Cancel host installation", func() {
 	var (
 		ctx                           = context.Background()


### PR DESCRIPTION
This function is not called, its purpose is not entirely clear at this
point, so it should be removed to simplify the state machine.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md