### PR TITLE
OCPBUGS-1482: Don't override schedulableMasters unnecessarily

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -120,7 +120,14 @@ func IsImportedCluster(cluster *Cluster) bool {
 }
 
 func AreMastersSchedulable(cluster *Cluster) bool {
-	return swag.BoolValue(cluster.SchedulableMastersForcedTrue) || swag.BoolValue(cluster.SchedulableMasters)
+	// If the topology forces schedulable masters (i.e. there are no workers),
+	// SchedulableMastersForcedTrue will be true, but also it will be enabled
+	// by default in the installer. Since overriding it currently causes a
+	// failure due to a conflict starting with 4.12, we prefer to avoid it. We
+	// only need to override the installer when the user has set
+	// SchedulableMasters explicitly and that is not already the default in the
+	// installer.
+	return !swag.BoolValue(cluster.SchedulableMastersForcedTrue) && swag.BoolValue(cluster.SchedulableMasters)
 }
 
 func GetEffectiveRole(host *models.Host) models.HostRole {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -253,8 +253,8 @@ var _ = Describe("Test AreMastersSchedulable", func() {
 		}{
 			{schedulableMastersForcedTrue: false, schedulableMasters: false, expectedSchedulableMasters: false},
 			{schedulableMastersForcedTrue: false, schedulableMasters: true, expectedSchedulableMasters: true},
-			{schedulableMastersForcedTrue: true, schedulableMasters: false, expectedSchedulableMasters: true},
-			{schedulableMastersForcedTrue: true, schedulableMasters: true, expectedSchedulableMasters: true},
+			{schedulableMastersForcedTrue: true, schedulableMasters: false, expectedSchedulableMasters: false}, // Handled by installer
+			{schedulableMastersForcedTrue: true, schedulableMasters: true, expectedSchedulableMasters: false},  // Handled by installer
 		} {
 			test := test
 			It(fmt.Sprintf("schedulableMastersForcedTrue=%v schedulableMasters=%v AreMastersSchedulable? %v", test.schedulableMastersForcedTrue, test.schedulableMasters, test.expectedSchedulableMasters), func() {


### PR DESCRIPTION
When generating the Ignition files, the installer already sets schdulableMasters to true when there are no worker nodes (i.e. in the SNO and compact cluster topologies. (See
https://github.com/openshift/installer/pull/2004) Therefore it is unnecessary to override it here (though it may be preferred to avoid a warning log from the installer).

Since https://github.com/openshift/installer/pull/6247, attempting to override the schedulableMasters setting causes installation to fail, because there are two manifests of the same type and name that conflict.

Since we don't need to set this override when the installer would already do it, avoid doing so and triggering the error when the value is determined by the number of hosts rather than explicitly set by the user.

The conflict still needs to be resolved so that the user can enable schedulableMasters, but this at least allows the SNO and compact topologies to install OpenShift 4.12 again.

This partially reverts commit c45f3699d83665a5e27a00939a9ff40907f39111.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

https://issues.redhat.com/browse/OCPBUGS-1482

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
