### PR TITLE
WIP: internal/network/manifests_generator: Move Scheduler manifest to do-schedule-to-masters.yaml

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -120,14 +120,7 @@ func IsImportedCluster(cluster *Cluster) bool {
 }
 
 func AreMastersSchedulable(cluster *Cluster) bool {
-	// If the topology forces schedulable masters (i.e. there are no workers),
-	// SchedulableMastersForcedTrue will be true, but also it will be enabled
-	// by default in the installer. Since overriding it currently causes a
-	// failure due to a conflict starting with 4.12, we prefer to avoid it. We
-	// only need to override the installer when the user has set
-	// SchedulableMasters explicitly and that is not already the default in the
-	// installer.
-	return !swag.BoolValue(cluster.SchedulableMastersForcedTrue) && swag.BoolValue(cluster.SchedulableMasters)
+	return swag.BoolValue(cluster.SchedulableMastersForcedTrue) || swag.BoolValue(cluster.SchedulableMasters)
 }
 
 func GetEffectiveRole(host *models.Host) models.HostRole {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -253,8 +253,8 @@ var _ = Describe("Test AreMastersSchedulable", func() {
 		}{
 			{schedulableMastersForcedTrue: false, schedulableMasters: false, expectedSchedulableMasters: false},
 			{schedulableMastersForcedTrue: false, schedulableMasters: true, expectedSchedulableMasters: true},
-			{schedulableMastersForcedTrue: true, schedulableMasters: false, expectedSchedulableMasters: false}, // Handled by installer
-			{schedulableMastersForcedTrue: true, schedulableMasters: true, expectedSchedulableMasters: false},  // Handled by installer
+			{schedulableMastersForcedTrue: true, schedulableMasters: false, expectedSchedulableMasters: true},
+			{schedulableMastersForcedTrue: true, schedulableMasters: true, expectedSchedulableMasters: true},
 		} {
 			test := test
 			It(fmt.Sprintf("schedulableMastersForcedTrue=%v schedulableMasters=%v AreMastersSchedulable? %v", test.schedulableMastersForcedTrue, test.schedulableMasters, test.expectedSchedulableMasters), func() {

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -152,6 +152,8 @@ apiVersion: config.openshift.io/v1
 kind: Scheduler
 metadata:
   name: cluster
+  annotations:
+    wking: if you see this, the assisted-installer opinion won
 spec:
   mastersSchedulable: true
   policy:
@@ -214,7 +216,7 @@ func (m *ManifestsGenerator) AddChronyManifest(ctx context.Context, log logrus.F
 
 func (m *ManifestsGenerator) AddSchedulableMastersManifest(ctx context.Context, log logrus.FieldLogger, cluster *common.Cluster) error {
 	content := []byte(schedulableMastersManifest)
-	schedulableMastersManifestFile := "50-schedulable_masters.yaml"
+	schedulableMastersManifestFile := "do-schedule-to-masters.yaml"
 	err := m.createManifests(ctx, cluster, schedulableMastersManifestFile, content)
 	if err != nil {
 		return err


### PR DESCRIPTION
To see if that causes us to sort later than the installer's cluster-scheduler-02-config.yml, and have our opinions get ignored.