### PR TITLE
MGMT-11443: Add API to retrieve Network Manager Config Files

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5342,6 +5342,21 @@ func (b *bareMetalInventory) V2DownloadInfraEnvFiles(ctx context.Context, params
 			return common.GenerateErrorResponder(err)
 		}
 		filename = fmt.Sprintf("%s-%s", params.InfraEnvID, params.FileName)
+	case "static-network-config":
+		if infraEnv.StaticNetworkConfig != "" {
+			netFiles, err := b.staticNetworkConfig.GenerateStaticNetworkConfigData(ctx, infraEnv.StaticNetworkConfig)
+			if err != nil {
+				b.log.WithError(err).Errorf("Failed to create static network config data")
+				return common.GenerateErrorResponder(err)
+			}
+			buffer, err := staticnetworkconfig.GenerateStaticNetworkConfigArchive(netFiles)
+			if err != nil {
+				b.log.WithError(err).Errorf("Failed to create static network config archive")
+				return common.GenerateErrorResponder(err)
+			}
+			content = buffer.String()
+			filename = fmt.Sprintf("%s-%s.tar", params.InfraEnvID, params.FileName)
+		}
 	default:
 		return common.NewApiError(http.StatusBadRequest, fmt.Errorf("unknown file type for download: %s", params.FileName))
 	}

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -2,6 +2,7 @@ package staticnetworkconfig
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -102,3 +103,53 @@ var _ = Describe("StaticNetworkConfig", func() {
 		Expect(formattedOutput).To(Equal(""))
 	})
 })
+
+var _ = Describe("StaticNetworkConfig.GenerateStaticNetworkConfigArchive", func() {
+	It("successfully produces an archive with one host data", func() {
+		data := []StaticNetworkConfigData{
+			{
+				FilePath:     "host1",
+				FileContents: "static network config data of first host",
+			},
+		}
+		archiveBytes, err := GenerateStaticNetworkConfigArchive(data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archiveBytes).ToNot(BeNil())
+		checkArchiveString(archiveBytes.String(), data)
+	})
+	It("successfully produces an archive when file contents is empty", func() {
+		data := []StaticNetworkConfigData{
+			{
+				FilePath: "host1",
+			},
+		}
+		archiveBytes, err := GenerateStaticNetworkConfigArchive(data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archiveBytes).ToNot(BeNil())
+		checkArchiveString(archiveBytes.String(), data)
+	})
+	It("successfully produces an archive with multiple hosts' data", func() {
+		data := []StaticNetworkConfigData{
+			{
+				FilePath:     "host1",
+				FileContents: "static network config data of first host",
+			},
+			{
+				FilePath:     "host2",
+				FileContents: "static network config data of second host",
+			},
+		}
+		archiveBytes, err := GenerateStaticNetworkConfigArchive(data)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(archiveBytes).ToNot(BeNil())
+		checkArchiveString(archiveBytes.String(), data)
+	})
+})
+
+func checkArchiveString(archiveString string, allData []StaticNetworkConfigData) {
+	for _, data := range allData {
+		Expect(archiveString).To(ContainSubstring("tar"))
+		Expect(archiveString).To(ContainSubstring(filepath.Join("/etc/assisted/network", data.FilePath)))
+		Expect(archiveString).To(ContainSubstring(data.FileContents))
+	}
+}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3240,7 +3240,8 @@ func init() {
           {
             "enum": [
               "discovery.ign",
-              "ipxe-script"
+              "ipxe-script",
+              "static-network-config"
             ],
             "type": "string",
             "description": "The file to be downloaded.",
@@ -12579,7 +12580,8 @@ func init() {
           {
             "enum": [
               "discovery.ign",
-              "ipxe-script"
+              "ipxe-script",
+              "static-network-config"
             ],
             "type": "string",
             "description": "The file to be downloaded.",

--- a/restapi/operations/installer/v2_download_infra_env_files_parameters.go
+++ b/restapi/operations/installer/v2_download_infra_env_files_parameters.go
@@ -157,7 +157,7 @@ func (o *V2DownloadInfraEnvFilesParams) bindFileName(rawData []string, hasKey bo
 // validateFileName carries on validations for parameter FileName
 func (o *V2DownloadInfraEnvFilesParams) validateFileName(formats strfmt.Registry) error {
 
-	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"discovery.ign", "ipxe-script"}, true); err != nil {
+	if err := validate.EnumCase("file_name", "query", o.FileName, []interface{}{"discovery.ign", "ipxe-script", "static-network-config"}, true); err != nil {
 		return err
 	}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1635,7 +1635,7 @@ paths:
           name: file_name
           description: The file to be downloaded.
           type: string
-          enum: [discovery.ign, ipxe-script]
+          enum: [discovery.ign, ipxe-script, static-network-config]
           required: true
         - in: query
           name: mac


### PR DESCRIPTION
[MGMT-11443](https://issues.redhat.com/browse/MGMT-11443)
Adds an API to get the network manager config files at the endpoint `/v2/infra-envs/<infra-env-id>/downloads/files?file_name=static-network-config`

Returns a tar archive of the network config files for this infra-env.

WIP: Still need to add unit tests
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR
[MGMT-11443](https://issues.redhat.com/browse/MGMT-11443)

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 