### PR TITLE
NO-ISSUE: Increase compatibility of hacks for different OS

### DIFF
--- a/hack/update_local_image.sh
+++ b/hack/update_local_image.sh
@@ -37,8 +37,8 @@ case "${CLUSTER_CONTEXT}" in
       rpm -ivh minikube-latest.x86_64.rpm
     fi
 
-    eval $(SHELL=${SHELL:-/bin/sh} minikube "$(get_container_runtime_command | sed "s/-remote//")-env") && \
-        make update-${DEBUG_SERVICE:+debug-}minimal
+    make update-${DEBUG_SERVICE:+debug-}minimal
+    minikube image load ${SERVICE}
     ;;
 
   "k3d")


### PR DESCRIPTION
This PR changes the hack script to build the service image in the context of minikube cluster instead of using directly a Podman or Docker runtime.

The rationale for this is the following - Minikube allows selection of driver (aka. where it runs) and runtime (aka. what it runs). It means that we can have a Minikube cluster running in the following combinations:

* in a VM, serving CRI-O API
* in a VM, serving Docker API
* in a container, serving CRI-O API
* in a container, serving Docker API

In order to talk natively using `podman` or `docker` CLI on the host, Minikube cluster must be serving a matching version of the runtime, e.g.

* RHEL host with Podman 4.0 cannot talk to Minikube serving Docker API
* RHEL host with Docker can talk to minikube serving Docker API

Because any kind of mix-and-match is allowed, we have no easy way of picking a working combination because CRI-O/Podman versions can differ, e.g. Minikube serves always Podman 3.4.2 whereas RHEL 8.6 contains already Podman 4.0 client that cannot talk to Minikube's Podman server.

Overall, multitude of combinations causes "escaping from minikube" a non-trivial issue to solve in order to achieve rather unmeasurable result. Because of this, we are dropping the "escape logic" and perform all the actions using API provided directly by Minikube, using it as a layer of abstraction.

/cc @osherdp 
/cc @paul-maidment 