### PR TITLE
NO-ISSUE: Add shell debug for libvirt_disks.sh

### DIFF
--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -3,6 +3,8 @@
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source ${__dir}/utils.sh
 
+set -x
+
 function print_help() {
     echo "Usage: DISKS=\$(echo sd{b..f}) bash ${0} (create|destroy|print_help)"
 }


### PR DESCRIPTION
This change enable the shell debug in `libvirt_disks.sh` in order to
investigate why ztp jobs fail from time to time with the following
error:

```
[2022-09-22 11:23:24] Creating libvirt disks and attaching them...
[2022-09-22 11:23:24] Formatting '/tmp/ostest_worker_0-sdb.img', fmt=raw size=53687091200
[2022-09-22 11:23:24] error: Failed to attach disk
[2022-09-22 11:23:24] error: Requested operation is not valid: Domain already contains a disk with that address
```

https://search.ci.openshift.org/?search=Domain+already+contains+a+disk+with+that+address&maxAge=168h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job
