### PR TITLE
MGMT-8578: Framework for day2 master CI ZTP jobs

### DIFF
--- a/deploy/operator/ztp/add-remote-nodes-playbook.yaml
+++ b/deploy/operator/ztp/add-remote-nodes-playbook.yaml
@@ -11,6 +11,7 @@
     - pull_secret_name: "{{ lookup('env', 'ASSISTED_PULLSECRET_NAME') }}"
     - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
     - day2: "true"
+    - day2_masters: "{{ lookup('env', 'DAY2_MASTERS') }}"
     - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
 
   tasks:

--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -10,6 +10,7 @@ source "${__dir}/../utils.sh"
 export REMOTE_BAREMETALHOSTS_FILE="${REMOTE_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/remote_baremetalhosts.json}"
 
 export DAY2_LATE_BINDING=${DAY2_LATE_BINDING:-}
+export DAY2_MASTERS=${DAY2_MASTERS:-}
 
 # If performing late binding then we need to generate an infraenv for this.
 # Generation is handled within "add-remote-nodes-playbook"

--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -40,6 +40,9 @@ metadata:
 {% if baremetalhosts_ignition_override|string | length > 0 %}
     bmac.agent-install.openshift.io/ignition-config-overrides: '{{ baremetalhosts_ignition_override | tojson }}'
 {% endif %}
+{% if day2_masters is defined and day2_masters|string == "True" %}
+    bmac.agent-install.openshift.io/role: master
+{% endif %}
 spec:
   online: true
   bootMACAddress: '{{ host["ports"][0]["address"] }}'


### PR DESCRIPTION
This commit adds an ability to add BMHs for day2 nodes with the explicit role annotation. With this, we are able to easily control from the CI whether nodes will be installed with master or autoassing (i.e. worker) role.

Contributes-to: [MGMT-8578](https://issues.redhat.com//browse/MGMT-8578)
Contributes-to: [MGMT-12143](https://issues.redhat.com//browse/MGMT-12143)