### PR TITLE
NO-ISSUE: Abstract how to get spoke kubeconfig from ClusterReference and add tests

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -281,16 +281,17 @@ func (r *AgentReconciler) approveAIHostsCSRs(clients spoke_k8s_client.SpokeK8sCl
 }
 
 func (r *AgentReconciler) spokeKubeClient(ctx context.Context, clusterRef *aiv1beta1.ClusterReference) (spoke_k8s_client.SpokeK8sClient, error) {
-	adminKubeConfigSecretName := fmt.Sprintf(adminKubeConfigStringTemplate, clusterRef.Name)
 	clusterDeployment := &hivev1.ClusterDeployment{}
 	cdKey := types.NamespacedName{
 		Namespace: clusterRef.Namespace,
 		Name:      clusterRef.Name,
 	}
 	err := r.Get(ctx, cdKey, clusterDeployment)
-	if err == nil {
-		adminKubeConfigSecretName = getClusterDeploymentAdminKubeConfigSecretName(clusterDeployment)
+	if err != nil {
+		// set this so it can be used by the following call
+		clusterDeployment.Name = cdKey.Name
 	}
+	adminKubeConfigSecretName := getClusterDeploymentAdminKubeConfigSecretName(clusterDeployment)
 
 	namespacedName := types.NamespacedName{
 		Namespace: clusterRef.Namespace,

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -3519,7 +3519,7 @@ var _ = Describe("selectClusterNetworkType", func() {
 	}
 })
 
-var _ = Describe("Getting ClusterDeployment admin kubeconfig secret name", func() {
+var _ = Describe("getClusterDeploymentAdminKubeConfigSecretName", func() {
 	var (
 		clusterName             = "test-cluster"
 		agentClusterInstallName = "test-cluster-aci"
@@ -3532,20 +3532,16 @@ var _ = Describe("Getting ClusterDeployment admin kubeconfig secret name", func(
 		defaultClusterSpec = getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName)
 		cd = newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 	})
-	Context("ClusterMetadata.AdminKubeconfigSecretRef.Name is not present", func() {
-		It("can make secret name from template", func() {
-			Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(fmt.Sprintf(adminKubeConfigStringTemplate, cd.Name)))
-		})
+	It("can make secret name from template when ClusterMetadata.AdminKubeconfigSecretRef.Name is not present", func() {
+		Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(fmt.Sprintf(adminKubeConfigStringTemplate, cd.Name)))
 	})
-	Context("ClusterMetadata.AdminKubeconfigSecretRef.Name is present", func() {
-		It("can extract the secret from ClusterDeployment", func() {
-			cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
-				AdminKubeconfigSecretRef: corev1.LocalObjectReference{
-					Name: adminSecretName,
-				},
-			}
-			Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(adminSecretName))
-		})
+	It("can extract secret name from ClusterDeployment when ClusterMetadata.AdminKubeconfigSecretRef.Name is present", func() {
+		cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+			AdminKubeconfigSecretRef: corev1.LocalObjectReference{
+				Name: adminSecretName,
+			},
+		}
+		Expect(getClusterDeploymentAdminKubeConfigSecretName(cd)).To(Equal(adminSecretName))
 	})
 })
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->
Abstract the way that we're getting the spoke Admin KubeConfig name
This way it can be reused if needed and we can also run some tests against it

/cc @carbonin

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Unit tests
- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
