### PR TITLE
ARMOCP-417: enable arm64 for agent installer

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -67,6 +67,7 @@ type Cluster struct {
 	ControllerLogsStartedAt strfmt.DateTime `json:"controller_logs_started_at,omitempty" gorm:"type:timestamp with time zone"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// The time that this cluster was created.
@@ -304,6 +305,10 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateControllerLogsStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -551,6 +556,60 @@ func (m *Cluster) validateControllerLogsStartedAt(formats strfmt.Registry) error
 	}
 
 	if err := validate.FormatOf("controller_logs_started_at", "body", "date-time", m.ControllerLogsStartedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var clusterTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterTypeCPUArchitecturePropEnum = append(clusterTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCPUArchitectureS390x captures enum value "s390x"
+	ClusterCPUArchitectureS390x string = "s390x"
+
+	// ClusterCPUArchitectureMulti captures enum value "multi"
+	ClusterCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *Cluster) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Cluster) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -47,6 +47,7 @@ type ClusterCreateParams struct {
 	ClusterNetworks []*ClusterNetwork `json:"cluster_networks"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// Installation disks encryption mode and host roles to be applied.
@@ -159,6 +160,10 @@ func (m *ClusterCreateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateClusterNetworks(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -315,6 +320,60 @@ func (m *ClusterCreateParams) validateClusterNetworks(formats strfmt.Registry) e
 			}
 		}
 
+	}
+
+	return nil
+}
+
+var clusterCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterCreateParamsTypeCPUArchitecturePropEnum = append(clusterCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	ClusterCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// ClusterCreateParamsCPUArchitectureMulti captures enum value "multi"
+	ClusterCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ClusterCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ClusterCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
 	}
 
 	return nil

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env.go
@@ -35,6 +35,7 @@ type InfraEnv struct {
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"index"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// created at
@@ -122,6 +123,10 @@ func (m *InfraEnv) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCreatedAt(formats); err != nil {
 		res = append(res, err)
 	}
@@ -174,6 +179,60 @@ func (m *InfraEnv) validateClusterID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvTypeCPUArchitecturePropEnum = append(infraEnvTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnv) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnv) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -34,6 +35,7 @@ type InfraEnvCreateParams struct {
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -74,6 +76,10 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -110,6 +116,60 @@ func (m *InfraEnvCreateParams) validateClusterID(formats strfmt.Registry) error 
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvCreateParamsTypeCPUArchitecturePropEnum = append(infraEnvCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCreateParamsCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnvCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/os_image.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/os_image.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -21,6 +22,7 @@ type OsImage struct {
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// Version of the operating system image
@@ -63,9 +65,52 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var osImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeCPUArchitecturePropEnum = append(osImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageCPUArchitectureX8664 captures enum value "x86_64"
+	OsImageCPUArchitectureX8664 string = "x86_64"
+
+	// OsImageCPUArchitectureAarch64 captures enum value "aarch64"
+	OsImageCPUArchitectureAarch64 string = "aarch64"
+
+	// OsImageCPUArchitectureArm64 captures enum value "arm64"
+	OsImageCPUArchitectureArm64 string = "arm64"
+
+	// OsImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	OsImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// OsImageCPUArchitectureS390x captures enum value "s390x"
+	OsImageCPUArchitectureS390x string = "s390x"
+)
+
+// prop value enum
+func (m *OsImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/release_image.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/release_image.go
@@ -22,6 +22,7 @@ type ReleaseImage struct {
 
 	// (DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// List of CPU architectures provided by the image.
@@ -77,9 +78,55 @@ func (m *ReleaseImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var releaseImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		releaseImageTypeCPUArchitecturePropEnum = append(releaseImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ReleaseImageCPUArchitectureX8664 captures enum value "x86_64"
+	ReleaseImageCPUArchitectureX8664 string = "x86_64"
+
+	// ReleaseImageCPUArchitectureAarch64 captures enum value "aarch64"
+	ReleaseImageCPUArchitectureAarch64 string = "aarch64"
+
+	// ReleaseImageCPUArchitectureArm64 captures enum value "arm64"
+	ReleaseImageCPUArchitectureArm64 string = "arm64"
+
+	// ReleaseImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	ReleaseImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// ReleaseImageCPUArchitectureS390x captures enum value "s390x"
+	ReleaseImageCPUArchitectureS390x string = "s390x"
+
+	// ReleaseImageCPUArchitectureMulti captures enum value "multi"
+	ReleaseImageCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ReleaseImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, releaseImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *ReleaseImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -4291,6 +4292,8 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 	}
 	url := installer.GetInfraEnvURL{InfraEnvID: id}
 
+	params.InfraenvCreateParams.CPUArchitecture = common.NormalizeCPUArchitecture(params.InfraenvCreateParams.CPUArchitecture)
+
 	log = log.WithField(ctxparams.ClusterId, id)
 	log.Infof("Register infraenv: %s with id %s", swag.StringValue(params.InfraenvCreateParams.Name), id)
 
@@ -6129,7 +6132,7 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 // will automatically use the image matching the Hub's architecture.
 func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version string, platform *models.PlatformType) bool {
 	return cpuArchitecture != common.MultiCPUArchitecture &&
-		cpuArchitecture != common.DefaultCPUArchitecture &&
+		cpuArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
 		common.PlatformTypeValue(platform) == models.PlatformTypeBaremetal &&
 		featuresupport.IsFeatureSupported(version,
 			models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTUREWITHCLUSTERMANAGEDNETWORKING)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -42,6 +42,7 @@ const (
 	FamilyIPv4 int32 = 4
 	FamilyIPv6 int32 = 6
 
+	AMD64CPUArchitecture   = "amd64"
 	X86CPUArchitecture     = "x86_64"
 	DefaultCPUArchitecture = X86CPUArchitecture
 	ARM64CPUArchitecture   = "arm64"
@@ -91,6 +92,17 @@ const NMDebugModeConf = `
 [logging]
 domains=ALL:DEBUG
 `
+
+func NormalizeCPUArchitecture(arch string) string {
+	switch arch {
+	case AMD64CPUArchitecture:
+		return X86CPUArchitecture
+	case AARCH64CPUArchitecture:
+		return ARM64CPUArchitecture
+	default:
+		return arch
+	}
+}
 
 func AllStrings(vs []string, f func(string) bool) bool {
 	for _, v := range vs {

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -220,9 +220,8 @@ func (r *release) GetReleaseArchitecture(log logrus.FieldLogger, releaseImage st
 			res, _ := jsonparser.GetString(value, "platform", "architecture")
 
 			// Convert architecture naming to supported values
-			if res == "amd64" {
-				res = common.DefaultCPUArchitecture
-			} else if res == "" {
+			res = common.NormalizeCPUArchitecture(res)
+			if res == "" {
 				return
 			}
 
@@ -245,10 +244,7 @@ func (r *release) GetReleaseArchitecture(log logrus.FieldLogger, releaseImage st
 	}
 
 	// Convert architecture naming to supported values
-	switch architecture {
-	case "amd64":
-		architecture = common.DefaultCPUArchitecture
-	}
+	architecture = common.NormalizeCPUArchitecture(architecture)
 
 	return []string{architecture}, nil
 }

--- a/internal/versions/osimages.go
+++ b/internal/versions/osimages.go
@@ -57,6 +57,11 @@ func (images osImageList) validate() error {
 			if swag.StringValue(osImage.Version) == "" {
 				return errors.Errorf(fmt.Sprintf(missingValueTemplate, "version", key))
 			}
+			// Normalize osImage.CPUArchitecture
+			// TODO: remove this block when AI starts using aarch64 instead of arm64
+			if architecture == common.AARCH64CPUArchitecture {
+				*osImage.CPUArchitecture = common.NormalizeCPUArchitecture(*osImage.CPUArchitecture)
+			}
 		}
 	}
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -305,6 +305,15 @@ func (h *handler) validateVersions() error {
 		if swag.StringValue(release.Version) == "" {
 			return errors.Errorf(fmt.Sprintf(missingValueTemplate, "version"))
 		}
+		// Normalize release.CPUArchitecture and release.CPUArchitectures
+		// TODO: remove this block when AI starts using aarch64 instead of arm64
+		if swag.StringValue(release.CPUArchitecture) == common.MultiCPUArchitecture || swag.StringValue(release.CPUArchitecture) == common.AARCH64CPUArchitecture {
+			*release.CPUArchitecture = common.NormalizeCPUArchitecture(*release.CPUArchitecture)
+			for i := 0; i < len(release.CPUArchitectures); i++ {
+				release.CPUArchitectures[i] = common.NormalizeCPUArchitecture(release.CPUArchitectures[i])
+			}
+
+		}
 	}
 
 	return nil

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -67,6 +67,7 @@ type Cluster struct {
 	ControllerLogsStartedAt strfmt.DateTime `json:"controller_logs_started_at,omitempty" gorm:"type:timestamp with time zone"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// The time that this cluster was created.
@@ -304,6 +305,10 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateControllerLogsStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -551,6 +556,60 @@ func (m *Cluster) validateControllerLogsStartedAt(formats strfmt.Registry) error
 	}
 
 	if err := validate.FormatOf("controller_logs_started_at", "body", "date-time", m.ControllerLogsStartedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var clusterTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterTypeCPUArchitecturePropEnum = append(clusterTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCPUArchitectureS390x captures enum value "s390x"
+	ClusterCPUArchitectureS390x string = "s390x"
+
+	// ClusterCPUArchitectureMulti captures enum value "multi"
+	ClusterCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *Cluster) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Cluster) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -47,6 +47,7 @@ type ClusterCreateParams struct {
 	ClusterNetworks []*ClusterNetwork `json:"cluster_networks"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// Installation disks encryption mode and host roles to be applied.
@@ -159,6 +160,10 @@ func (m *ClusterCreateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateClusterNetworks(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -315,6 +320,60 @@ func (m *ClusterCreateParams) validateClusterNetworks(formats strfmt.Registry) e
 			}
 		}
 
+	}
+
+	return nil
+}
+
+var clusterCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterCreateParamsTypeCPUArchitecturePropEnum = append(clusterCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	ClusterCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// ClusterCreateParamsCPUArchitectureMulti captures enum value "multi"
+	ClusterCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ClusterCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ClusterCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
 	}
 
 	return nil

--- a/models/infra_env.go
+++ b/models/infra_env.go
@@ -35,6 +35,7 @@ type InfraEnv struct {
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"index"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// created at
@@ -122,6 +123,10 @@ func (m *InfraEnv) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCreatedAt(formats); err != nil {
 		res = append(res, err)
 	}
@@ -174,6 +179,60 @@ func (m *InfraEnv) validateClusterID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvTypeCPUArchitecturePropEnum = append(infraEnvTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnv) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnv) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -34,6 +35,7 @@ type InfraEnvCreateParams struct {
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -74,6 +76,10 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -110,6 +116,60 @@ func (m *InfraEnvCreateParams) validateClusterID(formats strfmt.Registry) error 
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvCreateParamsTypeCPUArchitecturePropEnum = append(infraEnvCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCreateParamsCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnvCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/models/os_image.go
+++ b/models/os_image.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -21,6 +22,7 @@ type OsImage struct {
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// Version of the operating system image
@@ -63,9 +65,52 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var osImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeCPUArchitecturePropEnum = append(osImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageCPUArchitectureX8664 captures enum value "x86_64"
+	OsImageCPUArchitectureX8664 string = "x86_64"
+
+	// OsImageCPUArchitectureAarch64 captures enum value "aarch64"
+	OsImageCPUArchitectureAarch64 string = "aarch64"
+
+	// OsImageCPUArchitectureArm64 captures enum value "arm64"
+	OsImageCPUArchitectureArm64 string = "arm64"
+
+	// OsImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	OsImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// OsImageCPUArchitectureS390x captures enum value "s390x"
+	OsImageCPUArchitectureS390x string = "s390x"
+)
+
+// prop value enum
+func (m *OsImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/models/release_image.go
+++ b/models/release_image.go
@@ -22,6 +22,7 @@ type ReleaseImage struct {
 
 	// (DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// List of CPU architectures provided by the image.
@@ -77,9 +78,55 @@ func (m *ReleaseImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var releaseImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		releaseImageTypeCPUArchitecturePropEnum = append(releaseImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ReleaseImageCPUArchitectureX8664 captures enum value "x86_64"
+	ReleaseImageCPUArchitectureX8664 string = "x86_64"
+
+	// ReleaseImageCPUArchitectureAarch64 captures enum value "aarch64"
+	ReleaseImageCPUArchitectureAarch64 string = "aarch64"
+
+	// ReleaseImageCPUArchitectureArm64 captures enum value "arm64"
+	ReleaseImageCPUArchitectureArm64 string = "arm64"
+
+	// ReleaseImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	ReleaseImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// ReleaseImageCPUArchitectureS390x captures enum value "s390x"
+	ReleaseImageCPUArchitectureS390x string = "s390x"
+
+	// ReleaseImageCPUArchitectureMulti captures enum value "multi"
+	ReleaseImageCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ReleaseImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, releaseImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *ReleaseImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5452,6 +5452,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "created_at": {
@@ -5844,6 +5852,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "disk_encryption": {
@@ -7757,6 +7773,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "created_at": {
@@ -7894,6 +7918,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "ignition_config_override": {
@@ -8839,6 +8871,13 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x"
+          ],
           "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
@@ -8965,6 +9004,14 @@ func init() {
           "description": "(DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "cpu_architectures": {
@@ -15232,6 +15279,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "created_at": {
@@ -15624,6 +15679,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "disk_encryption": {
@@ -17456,6 +17519,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "created_at": {
@@ -17594,6 +17665,14 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-nullable": false
         },
         "ignition_config_override": {
@@ -18528,6 +18607,13 @@ func init() {
           "description": "The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x"
+          ],
           "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "openshift_version": {
@@ -18654,6 +18740,14 @@ func init() {
           "description": "(DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).",
           "type": "string",
           "default": "x86_64",
+          "enum": [
+            "x86_64",
+            "aarch64",
+            "arm64",
+            "ppc64le",
+            "s390x",
+            "multi"
+          ],
           "x-go-custom-tag": "gorm:\"default:'x86_64'\""
         },
         "cpu_architectures": {

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -474,7 +474,7 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 			IgnoreStateInfo)
 	})
 
-	It("Fail to register infraenv with missing release image and OS ", func() {
+	It("Fail to register an infraenv with a non-supported CPUArchitecture ", func() {
 		_, err := userBMClient.Installer.RegisterInfraEnv(context.Background(), &installer.RegisterInfraEnvParams{
 			InfraenvCreateParams: &models.InfraEnvCreateParams{
 				Name:             swag.String("test-infra-env"),
@@ -488,7 +488,5 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 		})
 
 		Expect(err).To(HaveOccurred())
-		actual := err.(*installer.RegisterInfraEnvBadRequest)
-		Expect(*actual.Payload.Reason).To(ContainSubstring("does not have a matching OpenShift release image"))
 	})
 })

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4390,6 +4390,8 @@ definitions:
         type: string
         x-nullable: false
         default: 'x86_64'
+        # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi']
         description: The CPU architecture of the image (x86_64/arm64/etc).
       disk_encryption:
         $ref: '#/definitions/disk-encryption'
@@ -4921,6 +4923,8 @@ definitions:
         type: string
         x-nullable: false
         default: 'x86_64'
+         # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi']
         description: The CPU architecture of the image (x86_64/arm64/etc).
       ignition_endpoint:
         $ref: '#/definitions/ignition-endpoint'
@@ -6345,6 +6349,8 @@ definitions:
       cpu_architecture:
         type: string
         default: "x86_64"
+         # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x']
         description: The CPU architecture of the image (x86_64/arm64/etc).
         x-go-custom-tag: gorm:"default:'x86_64'"
       url:
@@ -6373,6 +6379,8 @@ definitions:
       cpu_architecture:
         type: string
         default: "x86_64"
+         # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi']
         description: (DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).
         x-go-custom-tag: gorm:"default:'x86_64'"
       cpu_architectures:
@@ -6566,6 +6574,8 @@ definitions:
         type: string
         x-nullable: false
         default: 'x86_64'
+         # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi']
         description: The CPU architecture of the image (x86_64/arm64/etc).
       kernel_arguments:
         type: string
@@ -6650,6 +6660,8 @@ definitions:
         type: string
         x-nullable: false
         default: 'x86_64'
+         # TODO: remove arm64 when AI moves to using aarch64
+        enum: ['x86_64', 'aarch64', 'arm64','ppc64le','s390x','multi']
         description: The CPU architecture of the image (x86_64/arm64/etc).
       kernel_arguments:
         $ref: '#/definitions/kernel_arguments'

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -67,6 +67,7 @@ type Cluster struct {
 	ControllerLogsStartedAt strfmt.DateTime `json:"controller_logs_started_at,omitempty" gorm:"type:timestamp with time zone"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// The time that this cluster was created.
@@ -304,6 +305,10 @@ func (m *Cluster) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateControllerLogsStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -551,6 +556,60 @@ func (m *Cluster) validateControllerLogsStartedAt(formats strfmt.Registry) error
 	}
 
 	if err := validate.FormatOf("controller_logs_started_at", "body", "date-time", m.ControllerLogsStartedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var clusterTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterTypeCPUArchitecturePropEnum = append(clusterTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCPUArchitectureS390x captures enum value "s390x"
+	ClusterCPUArchitectureS390x string = "s390x"
+
+	// ClusterCPUArchitectureMulti captures enum value "multi"
+	ClusterCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *Cluster) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Cluster) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -47,6 +47,7 @@ type ClusterCreateParams struct {
 	ClusterNetworks []*ClusterNetwork `json:"cluster_networks"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// Installation disks encryption mode and host roles to be applied.
@@ -159,6 +160,10 @@ func (m *ClusterCreateParams) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateClusterNetworks(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateCPUArchitecture(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -315,6 +320,60 @@ func (m *ClusterCreateParams) validateClusterNetworks(formats strfmt.Registry) e
 			}
 		}
 
+	}
+
+	return nil
+}
+
+var clusterCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		clusterCreateParamsTypeCPUArchitecturePropEnum = append(clusterCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ClusterCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	ClusterCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// ClusterCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	ClusterCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// ClusterCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	ClusterCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// ClusterCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	ClusterCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// ClusterCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	ClusterCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// ClusterCreateParamsCPUArchitectureMulti captures enum value "multi"
+	ClusterCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ClusterCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, clusterCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *ClusterCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
 	}
 
 	return nil

--- a/vendor/github.com/openshift/assisted-service/models/infra_env.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env.go
@@ -35,6 +35,7 @@ type InfraEnv struct {
 	ClusterID strfmt.UUID `json:"cluster_id,omitempty" gorm:"index"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// created at
@@ -122,6 +123,10 @@ func (m *InfraEnv) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateCreatedAt(formats); err != nil {
 		res = append(res, err)
 	}
@@ -174,6 +179,60 @@ func (m *InfraEnv) validateClusterID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvTypeCPUArchitecturePropEnum = append(infraEnvTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnv) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnv) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -34,6 +35,7 @@ type InfraEnvCreateParams struct {
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty"`
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture string `json:"cpu_architecture,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -74,6 +76,10 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
+	if err := m.validateCPUArchitecture(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -110,6 +116,60 @@ func (m *InfraEnvCreateParams) validateClusterID(formats strfmt.Registry) error 
 	}
 
 	if err := validate.FormatOf("cluster_id", "body", "uuid", m.ClusterID.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var infraEnvCreateParamsTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		infraEnvCreateParamsTypeCPUArchitecturePropEnum = append(infraEnvCreateParamsTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// InfraEnvCreateParamsCPUArchitectureX8664 captures enum value "x86_64"
+	InfraEnvCreateParamsCPUArchitectureX8664 string = "x86_64"
+
+	// InfraEnvCreateParamsCPUArchitectureAarch64 captures enum value "aarch64"
+	InfraEnvCreateParamsCPUArchitectureAarch64 string = "aarch64"
+
+	// InfraEnvCreateParamsCPUArchitectureArm64 captures enum value "arm64"
+	InfraEnvCreateParamsCPUArchitectureArm64 string = "arm64"
+
+	// InfraEnvCreateParamsCPUArchitecturePpc64le captures enum value "ppc64le"
+	InfraEnvCreateParamsCPUArchitecturePpc64le string = "ppc64le"
+
+	// InfraEnvCreateParamsCPUArchitectureS390x captures enum value "s390x"
+	InfraEnvCreateParamsCPUArchitectureS390x string = "s390x"
+
+	// InfraEnvCreateParamsCPUArchitectureMulti captures enum value "multi"
+	InfraEnvCreateParamsCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *InfraEnvCreateParams) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, infraEnvCreateParamsTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateCPUArchitecture(formats strfmt.Registry) error {
+	if swag.IsZero(m.CPUArchitecture) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/os_image.go
+++ b/vendor/github.com/openshift/assisted-service/models/os_image.go
@@ -7,6 +7,7 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
@@ -21,6 +22,7 @@ type OsImage struct {
 
 	// The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// Version of the operating system image
@@ -63,9 +65,52 @@ func (m *OsImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var osImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		osImageTypeCPUArchitecturePropEnum = append(osImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// OsImageCPUArchitectureX8664 captures enum value "x86_64"
+	OsImageCPUArchitectureX8664 string = "x86_64"
+
+	// OsImageCPUArchitectureAarch64 captures enum value "aarch64"
+	OsImageCPUArchitectureAarch64 string = "aarch64"
+
+	// OsImageCPUArchitectureArm64 captures enum value "arm64"
+	OsImageCPUArchitectureArm64 string = "arm64"
+
+	// OsImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	OsImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// OsImageCPUArchitectureS390x captures enum value "s390x"
+	OsImageCPUArchitectureS390x string = "s390x"
+)
+
+// prop value enum
+func (m *OsImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, osImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *OsImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/release_image.go
+++ b/vendor/github.com/openshift/assisted-service/models/release_image.go
@@ -22,6 +22,7 @@ type ReleaseImage struct {
 
 	// (DEPRECATED) The CPU architecture of the image (x86_64/arm64/etc).
 	// Required: true
+	// Enum: [x86_64 aarch64 arm64 ppc64le s390x multi]
 	CPUArchitecture *string `json:"cpu_architecture" gorm:"default:'x86_64'"`
 
 	// List of CPU architectures provided by the image.
@@ -77,9 +78,55 @@ func (m *ReleaseImage) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
+var releaseImageTypeCPUArchitecturePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["x86_64","aarch64","arm64","ppc64le","s390x","multi"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		releaseImageTypeCPUArchitecturePropEnum = append(releaseImageTypeCPUArchitecturePropEnum, v)
+	}
+}
+
+const (
+
+	// ReleaseImageCPUArchitectureX8664 captures enum value "x86_64"
+	ReleaseImageCPUArchitectureX8664 string = "x86_64"
+
+	// ReleaseImageCPUArchitectureAarch64 captures enum value "aarch64"
+	ReleaseImageCPUArchitectureAarch64 string = "aarch64"
+
+	// ReleaseImageCPUArchitectureArm64 captures enum value "arm64"
+	ReleaseImageCPUArchitectureArm64 string = "arm64"
+
+	// ReleaseImageCPUArchitecturePpc64le captures enum value "ppc64le"
+	ReleaseImageCPUArchitecturePpc64le string = "ppc64le"
+
+	// ReleaseImageCPUArchitectureS390x captures enum value "s390x"
+	ReleaseImageCPUArchitectureS390x string = "s390x"
+
+	// ReleaseImageCPUArchitectureMulti captures enum value "multi"
+	ReleaseImageCPUArchitectureMulti string = "multi"
+)
+
+// prop value enum
+func (m *ReleaseImage) validateCPUArchitectureEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, releaseImageTypeCPUArchitecturePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (m *ReleaseImage) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.Required("cpu_architecture", "body", m.CPUArchitecture); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateCPUArchitectureEnum("cpu_architecture", "body", *m.CPUArchitecture); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Translate arm64-> aarch64 in instances where we reference rhcos (should mirror x86_64 -> amd64 mapping)
In parallel with openshift-installer change for agent installer: https://github.com/openshift/installer/pull/6401
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment (dev-scripts needs additional work to support arm)
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Manually created agent.iso and installed OCP with arm64 BM HW in our RDU2 lab
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
