### PR TITLE
AGENT-271: Make generation of kubeadmin-password optional

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/url"
 	"os"
@@ -437,7 +438,8 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 
 	// move all files into the working directory
 	err = os.Rename(filepath.Join(g.workDir, "auth/kubeadmin-password"), filepath.Join(g.workDir, "kubeadmin-password"))
-	if err != nil {
+	// Ephemeral agent-based installer does not generate a kubeadmin-password
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 	// after installation completes, a new kubeconfig will be created and made

--- a/pkg/s3wrapper/filesystem.go
+++ b/pkg/s3wrapper/filesystem.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path"
@@ -73,6 +74,10 @@ func (f *FSClient) UploadFile(ctx context.Context, filePath, objectName string) 
 	log := logutil.FromContext(ctx, f.log)
 	file, err := os.Open(filePath)
 	if err != nil {
+		// Ephemeral agent-based installer does not generate a kubeadmin-password
+		if errors.Is(err, fs.ErrNotExist) && filepath.Base(objectName) == "kubeadmin-password" {
+			return nil
+		}
 		err = errors.Wrapf(err, "Unable to open file %s for upload", filePath)
 		log.Error(err)
 		return err


### PR DESCRIPTION
In the automated flow of the ephemeral installer, we generate the kubeadmin password at the same time as the ISO. To avoid having to store the password in the ISO, we pass only the hash. When running the installer to create the bootstrap ignition, it reads this hash and therefore does not create a kubeadmin-password file.

To allow this, do not fail when the kubeadmin-password file does not exist.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [X] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
