### PR TITLE
MGMT-11635: Bad request error when user chooses both LVM and CNV

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -509,8 +509,14 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		if err != nil {
 			return nil, err
 		}
+		err = operators.EnsureLVMAndCNVDoNotClash(*releaseImage.Version, newOLMOperators)
+		if err != nil {
+			log.Error(err)
+			return nil, common.NewApiError(http.StatusBadRequest, err)
+		}
 
 		monitoredOperators = append(monitoredOperators, newOLMOperators...)
+
 	}
 
 	cluster := common.Cluster{
@@ -2647,6 +2653,12 @@ func (b *bareMetalInventory) updateOperatorsData(ctx context.Context, cluster *c
 	updateOLMOperators, err := b.getOLMOperators(params.ClusterUpdateParams.OlmOperators)
 	if err != nil {
 		return err
+	}
+
+	err = operators.EnsureLVMAndCNVDoNotClash(cluster.OpenshiftVersion, updateOLMOperators)
+	if err != nil {
+		log.Error(err)
+		return common.NewApiError(http.StatusBadRequest, err)
 	}
 
 	for _, updatedOperator := range updateOLMOperators {

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -161,6 +161,46 @@ var _ = Describe("Operators manager", func() {
 		)
 	})
 
+	Context("EnsureLVMAndCNVDoNotClash", func() {
+		It("should return error when both cnv and lvm operator enabled before 4.12", func() {
+			monitoredOperators := []*models.MonitoredOperator{
+				{Name: "lvm"},
+				{Name: "lso"},
+				{Name: "odf"},
+				{Name: "cnv"},
+			}
+			err := operators.EnsureLVMAndCNVDoNotClash("4.11.0", monitoredOperators)
+			Expect(err).To(Not(BeNil()))
+		})
+		It("no error when both cnv and lvm operator enabled after 4.12", func() {
+			monitoredOperators := []*models.MonitoredOperator{
+				{Name: "lvm"},
+				{Name: "lso"},
+				{Name: "odf"},
+			}
+			err := operators.EnsureLVMAndCNVDoNotClash("4.12.0-ec.3", monitoredOperators)
+			Expect(err).To(BeNil())
+		})
+		It("lvm operator enabled without cnv before 4.12", func() {
+			monitoredOperators := []*models.MonitoredOperator{
+				{Name: "lvm"},
+				{Name: "lso"},
+				{Name: "odf"},
+			}
+			err := operators.EnsureLVMAndCNVDoNotClash("4.11.0", monitoredOperators)
+			Expect(err).To(BeNil())
+		})
+		It("cnv operator enabled without lvm before 4.12", func() {
+			monitoredOperators := []*models.MonitoredOperator{
+				{Name: "cnv"},
+				{Name: "lso"},
+				{Name: "odf"},
+			}
+			err := operators.EnsureLVMAndCNVDoNotClash("4.11.0", monitoredOperators)
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Context("ValidateCluster", func() {
 		It("should deem operators cluster-valid when none is present", func() {
 			cluster.MonitoredOperators = []*models.MonitoredOperator{}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -662,6 +662,7 @@ var _ = Describe("V2ListClusters", func() {
 				PullSecret:        swag.String(pullSecret),
 				SSHPublicKey:      sshPublicKey,
 				VipDhcpAllocation: swag.Bool(true),
+				NetworkType:       swag.String(models.ClusterCreateParamsNetworkTypeOpenShiftSDN),
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -794,6 +795,7 @@ var _ = Describe("cluster install - DHCP", func() {
 				PullSecret:        swag.String(pullSecret),
 				SSHPublicKey:      sshPublicKey,
 				VipDhcpAllocation: swag.Bool(true),
+				NetworkType:       swag.String(models.ClusterCreateParamsNetworkTypeOpenShiftSDN),
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -1054,14 +1056,13 @@ var _ = Describe("cluster install", func() {
 	BeforeEach(func() {
 		registerClusterReply, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 			NewClusterParams: &models.ClusterCreateParams{
-				BaseDNSDomain:     "example.com",
-				ClusterNetworks:   []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
-				ServiceNetworks:   []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
-				Name:              swag.String("test-cluster"),
-				OpenshiftVersion:  swag.String(openshiftVersion),
-				PullSecret:        swag.String(pullSecret),
-				SSHPublicKey:      sshPublicKey,
-				VipDhcpAllocation: swag.Bool(true),
+				BaseDNSDomain:    "example.com",
+				ClusterNetworks:  []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+				ServiceNetworks:  []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+				Name:             swag.String("test-cluster"),
+				OpenshiftVersion: swag.String(openshiftVersion),
+				PullSecret:       swag.String(pullSecret),
+				SSHPublicKey:     sshPublicKey,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -4057,6 +4058,7 @@ var _ = Describe("disk encryption", func() {
 						Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 					},
 					VipDhcpAllocation: swag.Bool(true),
+					NetworkType:       swag.String(models.ClusterCreateParamsNetworkTypeOpenShiftSDN),
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Operators endpoint tests", func() {
 					PullSecret:        swag.String(pullSecret),
 					SSHPublicKey:      sshPublicKey,
 					VipDhcpAllocation: swag.Bool(true),
+					NetworkType:       swag.String(models.ClusterCreateParamsNetworkTypeOpenShiftSDN),
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
