### PR TITLE
MGMT-8460: Automatically rename discovered hosts

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -236,6 +236,17 @@ type AgentStatus struct {
 	// ValidationsInfo is a JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
 	// +optional
 	ValidationsInfo common.ValidationsStatus `json:"validationsInfo,omitempty"`
+
+	// Hostname is the name that will be assigned to the host when the cluster is eventually
+	// installed. This will be different to the host name included in the inventory if that is a
+	// forbidden host name (like localhost, localhost4 or localhost6) or if the user has
+	// explicitly requested a different name using the .spec.hostname field.
+	//
+	// When the host name included in the inventory is forbidden and the user hasn't explicitly
+	// requested a different one, this will be calculated from the MAC address of the host. For
+	// example, if the MAC address of the host is A8:CD:16:AE:79:01 then this will be
+	// a8-cd-16-ae-79-01.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 type DebugInfo struct {
@@ -259,7 +270,7 @@ type DebugInfo struct {
 // +kubebuilder:printcolumn:name="Approved",type="boolean",JSONPath=".spec.approved",description="The `Approve` state of the Agent."
 // +kubebuilder:printcolumn:name="Role",type="string",JSONPath=".status.role",description="The role (master/worker) of the Agent."
 // +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".status.progress.currentStage",description="The HostStage of the Agent."
-// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".status.inventory.hostname",description="The hostname of the Agent.",priority=1
+// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".status.hostname",description="The hostname of the Agent.",priority=1
 // +kubebuilder:printcolumn:name="Requested Hostname",type="string",JSONPath=".spec.hostname",description="The requested hostname for the Agent.",priority=1
 
 // Agent is the Schema for the hosts API

--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -34,7 +34,7 @@ spec:
       name: Stage
       type: string
     - description: The hostname of the Agent.
-      jsonPath: .status.inventory.hostname
+      jsonPath: .status.hostname
       name: Hostname
       priority: 1
       type: string
@@ -168,6 +168,18 @@ spec:
                       the Agent
                     type: string
                 type: object
+              hostname:
+                description: "Hostname is the name that will be assigned to the host
+                  when the cluster is eventually installed. This will be different
+                  to the host name included in the inventory if that is a forbidden
+                  host name (like localhost, localhost4 or localhost6) or if the user
+                  has explicitly requested a different name using the .spec.hostname
+                  field. \n When the host name included in the inventory is forbidden
+                  and the user hasn't explicitly requested a different one, this will
+                  be calculated from the MAC address of the host. For example, if
+                  the MAC address of the host is A8:CD:16:AE:79:01 then this will
+                  be a8-cd-16-ae-79-01."
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -656,7 +656,7 @@ spec:
       name: Stage
       type: string
     - description: The hostname of the Agent.
-      jsonPath: .status.inventory.hostname
+      jsonPath: .status.hostname
       name: Hostname
       priority: 1
       type: string
@@ -790,6 +790,18 @@ spec:
                       the Agent
                     type: string
                 type: object
+              hostname:
+                description: "Hostname is the name that will be assigned to the host
+                  when the cluster is eventually installed. This will be different
+                  to the host name included in the inventory if that is a forbidden
+                  host name (like localhost, localhost4 or localhost6) or if the user
+                  has explicitly requested a different name using the .spec.hostname
+                  field. \n When the host name included in the inventory is forbidden
+                  and the user hasn't explicitly requested a different one, this will
+                  be calculated from the MAC address of the host. For example, if
+                  the MAC address of the host is A8:CD:16:AE:79:01 then this will
+                  be a8-cd-16-ae-79-01."
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -32,7 +32,7 @@ spec:
       name: Stage
       type: string
     - description: The hostname of the Agent.
-      jsonPath: .status.inventory.hostname
+      jsonPath: .status.hostname
       name: Hostname
       priority: 1
       type: string
@@ -166,6 +166,18 @@ spec:
                       the Agent
                     type: string
                 type: object
+              hostname:
+                description: "Hostname is the name that will be assigned to the host
+                  when the cluster is eventually installed. This will be different
+                  to the host name included in the inventory if that is a forbidden
+                  host name (like localhost, localhost4 or localhost6) or if the user
+                  has explicitly requested a different name using the .spec.hostname
+                  field. \n When the host name included in the inventory is forbidden
+                  and the user hasn't explicitly requested a different one, this will
+                  be calculated from the MAC address of the host. For example, if
+                  the MAC address of the host is A8:CD:16:AE:79:01 then this will
+                  be a8-cd-16-ae-79-01."
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -519,6 +519,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 	specSynced(agent, syncErr, internal)
 
 	if h != nil && h.Status != nil {
+		agent.Status.Hostname = h.RequestedHostname
 		agent.Status.Bootstrap = h.Bootstrap
 		agent.Status.Role = h.Role
 		if h.SuggestedRole != "" && h.Role == models.HostRoleAutoAssign {

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -302,3 +302,15 @@ func AreServiceNetworksIdentical(n1, n2 []*models.ServiceNetwork) bool {
 func AreClusterNetworksIdentical(n1, n2 []*models.ClusterNetwork) bool {
 	return areListsEquivalent(len(n1), len(n2), func(i, j int) bool { return n1[i].Cidr == n2[j].Cidr && n1[i].HostPrefix == n2[j].HostPrefix })
 }
+
+// IsGlobalCIDR returns a boolean flag indicating if the IP address in the given CIDR is a global
+// one and not a local one like 127.0.0.1 or ::1. Returns an error if the given string can't be
+// parsed as a CIDR.
+func IsGlobalCIDR(cidr string) (result bool, err error) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return
+	}
+	result = ip.IsGlobalUnicast()
+	return
+}

--- a/internal/network/utils_test.go
+++ b/internal/network/utils_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/models"
 )
@@ -689,4 +690,27 @@ var _ = Describe("ArClusterNetworksIdentical", func() {
 			Expect(AreClusterNetworksIdentical(t.n1, t.n2)).To(Equal(t.expectedResult))
 		})
 	}
+})
+
+var _ = Describe("Is global CIDR", func() {
+	DescribeTable(
+		"Returns the expected result",
+		func(address string, expected bool) {
+			actual, err := IsGlobalCIDR(address)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("IPv4 loopback", "127.0.0.1/32", false),
+		Entry("IPv4 global", "192.168.0.1/24", true),
+		Entry("IPv6 loopback", "::1/128", false),
+		Entry("IPv6 global", "5dc8:725d:26ae:1192:d336:54a3:d7c7:23a7/64", true),
+	)
+
+	It("Returns error if address can't be parsed", func() {
+		result, err := IsGlobalCIDR("junk")
+		Expect(err).To(HaveOccurred())
+		message := err.Error()
+		Expect(message).To(ContainSubstring("junk"))
+		Expect(result).To(BeFalse())
+	})
 })

--- a/subsystem/metrics_test.go
+++ b/subsystem/metrics_test.go
@@ -688,12 +688,12 @@ var _ = Describe("Metrics tests", func() {
 			oldFailedMetricCounter := getValidationMetricCounter(string(models.HostValidationIDHostnameValid), hostValidationFailedMetric)
 
 			// create a validation failure
-			// 'localhost' is a forbidden host name
-			generateHWPostStepReply(ctx, h, validHwInfo, "localhost")
+			// 'my host' isn't a valid host name
+			generateHWPostStepReply(ctx, h, validHwInfo, "my host")
 			waitForHostValidationStatus(clusterID, *infraEnvID, *h.ID, "failure", models.HostValidationIDHostnameValid)
 
 			// check generated events
-			assertHostValidationEvent(ctx, clusterID, "localhost", models.HostValidationIDHostnameValid, true)
+			assertHostValidationEvent(ctx, clusterID, "my host", models.HostValidationIDHostnameValid, true)
 
 			// check generated metrics
 			Expect(getValidationMetricCounter(string(models.HostValidationIDHostnameValid), hostValidationChangedMetric)).To(Equal(oldChangedMetricCounter + 1))
@@ -705,8 +705,8 @@ var _ = Describe("Metrics tests", func() {
 
 			// create a validation failure
 			h := &registerHost(*infraEnvID).Host
-			// 'localhost' is a forbidden host name
-			generateHWPostStepReply(ctx, h, validHwInfo, "localhost")
+			// 'my host' isn't a valid host name
+			generateHWPostStepReply(ctx, h, validHwInfo, "my host")
 			waitForHostValidationStatus(clusterID, *infraEnvID, *h.ID, "failure", models.HostValidationIDHostnameValid)
 
 			// create a validation success
@@ -955,7 +955,7 @@ var _ = Describe("Metrics tests", func() {
 			oldFailedMetricCounter := getValidationMetricCounter(string(models.ClusterValidationIDAllHostsAreReadyToInstall), clusterValidationFailedMetric)
 
 			// create a validation failure by causing the a host to not be ready
-			generateHWPostStepReply(ctx, hosts[0], validHwInfo, "localhost")
+			generateHWPostStepReply(ctx, hosts[0], validHwInfo, "my host")
 			waitForHostStateV2(ctx, models.HostStatusInsufficient, defaultWaitForHostStateTimeout, hosts[0])
 
 			waitForClusterValidationStatus(clusterID, "failure", models.ClusterValidationIDAllHostsAreReadyToInstall)

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -236,6 +236,17 @@ type AgentStatus struct {
 	// ValidationsInfo is a JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
 	// +optional
 	ValidationsInfo common.ValidationsStatus `json:"validationsInfo,omitempty"`
+
+	// Hostname is the name that will be assigned to the host when the cluster is eventually
+	// installed. This will be different to the host name included in the inventory if that is a
+	// forbidden host name (like localhost, localhost4 or localhost6) or if the user has
+	// explicitly requested a different name using the .spec.hostname field.
+	//
+	// When the host name included in the inventory is forbidden and the user hasn't explicitly
+	// requested a different one, this will be calculated from the MAC address of the host. For
+	// example, if the MAC address of the host is A8:CD:16:AE:79:01 then this will be
+	// a8-cd-16-ae-79-01.
+	Hostname string `json:"hostname,omitempty"`
 }
 
 type DebugInfo struct {
@@ -259,7 +270,7 @@ type DebugInfo struct {
 // +kubebuilder:printcolumn:name="Approved",type="boolean",JSONPath=".spec.approved",description="The `Approve` state of the Agent."
 // +kubebuilder:printcolumn:name="Role",type="string",JSONPath=".status.role",description="The role (master/worker) of the Agent."
 // +kubebuilder:printcolumn:name="Stage",type="string",JSONPath=".status.progress.currentStage",description="The HostStage of the Agent."
-// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".status.inventory.hostname",description="The hostname of the Agent.",priority=1
+// +kubebuilder:printcolumn:name="Hostname",type="string",JSONPath=".status.hostname",description="The hostname of the Agent.",priority=1
 // +kubebuilder:printcolumn:name="Requested Hostname",type="string",JSONPath=".spec.hostname",description="The requested hostname for the Agent.",priority=1
 
 // Agent is the Schema for the hosts API


### PR DESCRIPTION
Currently host that use a forbidden name like `hostname` need to be manually renamed by users before proceeding to the installation. That isn't convenient for users. To avoid it this patch changes the code so that when the inventory is updated those hosts will be automatically renamed with a name calculated from the MAC address of a network interface card of the host that has a non-local IP address.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manually adding a host with `localhost.localdomain` as the name and
checking that it was automatically renamed.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
