### PR TITLE
MGMT-11700: Validate storage requirements

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -195,7 +195,7 @@ spec:
   - ReadWriteOnce
   resources:
    requests:
-    storage: 8Gi
+    storage: 10Gi
 
 $(mirror_config)
 EOCR

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bombsimon/logrusr/v3 v3.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
@@ -120,7 +121,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/analysis v0.21.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -250,7 +250,10 @@ github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/blizzy78/varnamelen v0.6.1/go.mod h1:zy2Eic4qWqjrxa60jG34cfL0VXcSwzUrIx68eJPb4Q8=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bombsimon/logrusr/v3 v3.0.0 h1:tcAoLfuAhKP9npBxWzSdpsvKPQt1XV02nSf2lZA82TQ=
+github.com/bombsimon/logrusr/v3 v3.0.0/go.mod h1:PksPPgSFEL2I52pla2glgCyyd2OqOHAnFF5E+g8Ixco=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -641,6 +644,8 @@ github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
+github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/hashicorp/go-version"
@@ -97,6 +98,10 @@ var (
 	databasePort         = intstr.Parse("5432")
 	imageHandlerPort     = intstr.Parse("8080")
 	imageHandlerHTTPPort = intstr.Parse("8081")
+
+	minDatabaseStorage   = resource.MustParse("1Gi")
+	minFilesystemStorage = resource.MustParse("1Gi")
+	minImageStorage      = resource.MustParse("10Gi")
 )
 
 type AgentServiceConfigReconcileContext struct {
@@ -250,6 +255,48 @@ func (r *AgentServiceConfigReconciler) Reconcile(origCtx context.Context, req ct
 		}
 
 		return ctrl.Result{}, nil
+	}
+
+	// Validate the storage configuration. If that returns warnings then generate the
+	// corresponding events. If it returns errors then update the conditions and stop the
+	// reconciliation.
+	warnings, failures, err := r.validateStorage(ctx, log, instance)
+	if err != nil {
+		log.WithError(err).Error("Failed to validate storage configuration")
+		return ctrl.Result{Requeue: true}, err
+	}
+	for _, warning := range warnings {
+		r.Recorder.Event(instance, "Warning", aiv1beta1.ReasonStorageFailure, warning)
+	}
+	if len(failures) > 0 {
+		log.Error("Storage configuration isn't valid")
+		conditionsv1.SetStatusConditionNoHeartbeat(
+			&instance.Status.Conditions, conditionsv1.Condition{
+				Type:    aiv1beta1.ConditionReconcileCompleted,
+				Status:  corev1.ConditionFalse,
+				Reason:  aiv1beta1.ReasonStorageFailure,
+				Message: fmt.Sprintf("%s.", strings.Join(failures, ". ")),
+			},
+		)
+		err = r.Status().Update(ctx, instance)
+		if err != nil {
+			log.WithError(err).Error("Failed to update status")
+			return ctrl.Result{Requeue: true}, err
+		}
+		return ctrl.Result{}, err
+	}
+
+	// If we are here then the storage configuration validation succeeded, so we may need to
+	// remove a previous failure condition:
+	condition := conditionsv1.FindStatusCondition(
+		instance.Status.Conditions,
+		aiv1beta1.ConditionReconcileCompleted,
+	)
+	if condition != nil && condition.Reason == aiv1beta1.ReasonStorageFailure {
+		conditionsv1.RemoveStatusCondition(
+			&instance.Status.Conditions,
+			aiv1beta1.ConditionReconcileCompleted,
+		)
 	}
 
 	for _, component := range []component{
@@ -2276,4 +2323,94 @@ func getImageService(ctx context.Context, log logrus.FieldLogger, asc ASC) strin
 		return ""
 	}
 	return imageServiceURL
+}
+
+// validateStorage checks that the sizes of the storage volumes for the database, the file system
+// and the images are acceptable.
+//
+// Returns two slices of strings containing warnings and failures. Warnings are intended for
+// creation of events. Failures are intended for reporting in conditions, and for stopping the
+// reconciliation.
+//
+// If a volume size is smaller than the minimum it will generate a warning. It will generate an
+// error only if the corresponding persistent volume claim (or the stateful set for the image
+// storage) has not been created yet. This is for backwards compatility, to prevent breaking
+// environments that were created before this validation was introduced. Those environments may be
+// working correctly even if the size was smaller that the minimum, because they aren't consuming
+// that space or because the actual volume was larger then the initial request.
+func (r *AgentServiceConfigReconciler) validateStorage(ctx context.Context, log logrus.FieldLogger,
+	instance *aiv1beta1.AgentServiceConfig) (warnings, failures []string, err error) {
+
+	// Check the size of the database storage:
+	databaseStorage := instance.Spec.DatabaseStorage.Resources.Requests.Storage()
+	if databaseStorage.Cmp(minDatabaseStorage) < 0 {
+		message := fmt.Sprintf(
+			"Database storage %s is too small, it must be at least %s",
+			databaseStorage, &minDatabaseStorage,
+		)
+		warnings = append(warnings, message)
+		key := client.ObjectKey{
+			Namespace: r.Namespace,
+			Name:      databaseName,
+		}
+		var tmp corev1.PersistentVolumeClaim
+		err = r.Get(ctx, key, &tmp)
+		if errors.IsNotFound(err) {
+			err = nil
+			failures = append(failures, message)
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	// Check the size of the filesystem storage:
+	filesystemStorage := instance.Spec.FileSystemStorage.Resources.Requests.Storage()
+	if filesystemStorage.Cmp(minFilesystemStorage) < 0 {
+		message := fmt.Sprintf(
+			"Filesystem storage %s is too small, it must be at least %s",
+			filesystemStorage, &minFilesystemStorage,
+		)
+		warnings = append(warnings, message)
+		key := client.ObjectKey{
+			Namespace: r.Namespace,
+			Name:      serviceName,
+		}
+		var tmp corev1.PersistentVolumeClaim
+		err = r.Get(ctx, key, &tmp)
+		if errors.IsNotFound(err) {
+			failures = append(failures, message)
+			err = nil
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	// Check the size of the image storage:
+	if instance.Spec.ImageStorage != nil {
+		imageStorage := instance.Spec.ImageStorage.Resources.Requests.Storage()
+		if imageStorage.Cmp(minImageStorage) < 0 {
+			message := fmt.Sprintf(
+				"Image storage %s is too small, it must be at least %s",
+				imageStorage, &minImageStorage,
+			)
+			warnings = append(warnings, message)
+			key := client.ObjectKey{
+				Namespace: r.Namespace,
+				Name:      imageServiceName,
+			}
+			var tmp appsv1.StatefulSet
+			err = r.Get(ctx, key, &tmp)
+			if errors.IsNotFound(err) {
+				err = nil
+				failures = append(failures, message)
+			}
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
 }

--- a/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
@@ -1,0 +1,431 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/internal/testing"
+	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Agent service config controller storage validation", func() {
+	var (
+		ctx        context.Context
+		cluster    *testing.FakeCluster
+		client     clnt.Client
+		subject    *aiv1beta1.AgentServiceConfig
+		key        clnt.ObjectKey
+		request    ctrl.Request
+		reconciler *AgentServiceConfigReconciler
+	)
+
+	BeforeEach(func() {
+		// Create a context for the test:
+		ctx = context.Background()
+
+		// Create the fake cluster:
+		cluster = testing.NewFakeCluster().
+			Logger(logger).
+			Build()
+
+		// Create the client:
+		client = cluster.Client()
+
+		// Create the default object to be reconciled, with a storage configuration that
+		// passes all validations. Specific tests will later adapt these settings as needed.
+		subject = &aiv1beta1.AgentServiceConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "agent",
+			},
+			Spec: aiv1beta1.AgentServiceConfigSpec{
+				DatabaseStorage: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Ti"),
+						},
+					},
+				},
+				FileSystemStorage: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Ti"),
+						},
+					},
+				},
+				ImageStorage: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteOnce,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Ti"),
+						},
+					},
+				},
+			},
+		}
+		key = clnt.ObjectKeyFromObject(subject)
+		request = ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Name: subject.Name,
+			},
+		}
+
+		// Create the reconciler:
+		reconciler = &AgentServiceConfigReconciler{
+			AgentServiceConfigReconcileContext: AgentServiceConfigReconcileContext{
+				Client:   client,
+				Scheme:   cluster.Scheme(),
+				Log:      logrusLogger,
+				Recorder: cluster.Recorder(),
+			},
+			Namespace: "assisted-installer",
+		}
+	})
+
+	AfterEach(func() {
+		cluster.Stop()
+	})
+
+	When("Objects haven't been created", func() {
+		It("Rejects small database storage", func() {
+			subject.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(aiv1beta1.ReasonStorageFailure))
+				g.Expect(condition.Message).To(ContainSubstring(
+					"Database storage 1Mi is too small",
+				))
+			}).Should(Succeed())
+		})
+
+		It("Rejects small filesystem storage", func() {
+			subject.Spec.FileSystemStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(aiv1beta1.ReasonStorageFailure))
+				g.Expect(condition.Message).To(ContainSubstring(
+					"Filesystem storage 1Mi is too small",
+				))
+			}).Should(Succeed())
+		})
+
+		It("Rejects small image storage", func() {
+			subject.Spec.ImageStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(aiv1beta1.ReasonStorageFailure))
+				g.Expect(condition.Message).To(ContainSubstring(
+					"Image storage 1Mi is too small",
+				))
+			}).Should(Succeed())
+		})
+
+		It("Rejects small database and filesystem storage (two failures)", func() {
+			subject.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			subject.Spec.FileSystemStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(aiv1beta1.ReasonStorageFailure))
+				g.Expect(condition.Message).To(ContainSubstring(
+					"Database storage 1Mi is too small",
+				))
+				g.Expect(condition.Message).To(ContainSubstring(
+					"Filesystem storage 1Mi is too small",
+				))
+			}).Should(Succeed())
+		})
+
+		It("Accepts large database storage", func() {
+			subject.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Pi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts large filesystem storage", func() {
+			subject.Spec.FileSystemStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Pi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts large image storage", func() {
+			subject.Spec.ImageStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Pi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts unspecified image storage (it is optional)", func() {
+			subject.Spec.ImageStorage = nil
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Resumes reconciling when configration is fixed", func() {
+			By("Creating invalid configuration")
+			subject.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Mi"),
+			}
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err = reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(aiv1beta1.ReasonStorageFailure))
+			}).Should(Succeed())
+
+			By("Fixing configuration")
+			patched := subject.DeepCopy()
+			patched.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Pi"),
+			}
+			err = client.Patch(ctx, patched, clnt.MergeFrom(subject))
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+	})
+
+	When("Objects have been created before", func() {
+		BeforeEach(func() {
+			// Run the reconciler once so that it succeeds and therefore it creates the
+			// objects, in particular the persistent volume claims and the stateful set
+			// for the image service, as that is what we are interested on in this case.
+			err := client.Create(ctx, subject)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts small database storage", func() {
+			patched := subject.DeepCopy()
+			patched.Spec.DatabaseStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1M"),
+			}
+			err := client.Patch(ctx, patched, clnt.MergeFrom(subject))
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts small filesystem storage", func() {
+			patched := subject.DeepCopy()
+			patched.Spec.FileSystemStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1M"),
+			}
+			err := client.Patch(ctx, patched, clnt.MergeFrom(subject))
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts small image storage", func() {
+			patched := subject.DeepCopy()
+			patched.Spec.ImageStorage.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1M"),
+			}
+			err := client.Patch(ctx, patched, clnt.MergeFrom(subject))
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+
+		It("Accepts unspecified image storage (it is optional)", func() {
+			patched := subject.DeepCopy()
+			patched.Spec.ImageStorage = nil
+			err := client.Patch(ctx, patched, clnt.MergeFrom(subject))
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, request)
+				g.Expect(err).ToNot(HaveOccurred())
+				err = client.Get(ctx, key, subject)
+				g.Expect(err).ToNot(HaveOccurred())
+				condition := conditionsv1.FindStatusCondition(
+					subject.Status.Conditions,
+					aiv1beta1.ConditionReconcileCompleted,
+				)
+				g.Expect(condition).ToNot(BeNil())
+				g.Expect(condition.Status).To(Equal(corev1.ConditionTrue))
+			}).Should(Succeed())
+		})
+	})
+})

--- a/internal/controller/controllers/controllers_suite_test.go
+++ b/internal/controller/controllers/controllers_suite_test.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"testing"
 
+	"github.com/bombsimon/logrusr/v3"
+	"github.com/go-logr/logr"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,10 +13,12 @@ import (
 	"github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/common"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -37,6 +41,22 @@ func TestControllers(t *testing.T) {
 	defer common.TerminateDBTest()
 	RunSpecs(t, "controllers tests")
 }
+
+var (
+	logrusLogger *logrus.Logger
+	logger       logr.Logger
+)
+
+var _ = BeforeSuite(func() {
+	// Configure the Kubernetes and controller-runtime libraries so that they write log messages
+	// to the Ginkgo writer, this way those messages are automatically associated to the right
+	// test.
+	logrusLogger = logrus.New()
+	logrusLogger.Out = GinkgoWriter
+	logger = logrusr.New(logrusLogger)
+	klog.SetLogger(logger)
+	ctrl.SetLogger(logger)
+})
 
 func newSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
 	secret := &corev1.Secret{

--- a/internal/testing/fake_cluster.go
+++ b/internal/testing/fake_cluster.go
@@ -1,0 +1,224 @@
+package testing
+
+import (
+	"context"
+
+	"github.com/bombsimon/logrusr/v3"
+	"github.com/go-logr/logr"
+	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
+	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	wtch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// FakeClusterBuilder contains the data and logic needed to create a fake OpenShift cluster that can
+// be used to test our controllers.
+type FakeClusterBuilder struct {
+	logger logr.Logger
+}
+
+// FakeCluster is a fake OpenShift cluster.
+type FakeCluster struct {
+	logger   logr.Logger
+	scheme   *runtime.Scheme
+	client   clnt.WithWatch
+	watches  []wtch.Interface
+	recorder *record.FakeRecorder
+}
+
+// NewFakeCluster creates a builder that can then be used to configure and create a fake cluster.
+func NewFakeCluster() *FakeClusterBuilder {
+	return &FakeClusterBuilder{}
+}
+
+// Logger sets the logger that the fake cluster will use to write messages. The default is a logger
+// that writes to the Ginkgo writer.
+func (b *FakeClusterBuilder) Logger(value logr.Logger) *FakeClusterBuilder {
+	b.logger = value
+	return b
+}
+
+// Build uses the data stored in the builder to create a new fake cluster. Remember to call the Stop
+// method once the fake cluster is no longer needed.
+func (b *FakeClusterBuilder) Build() *FakeCluster {
+	// Prepare the logger:
+	if b.logger.GetSink() == nil {
+		tmp := logrus.New()
+		tmp.Out = GinkgoWriter
+		b.logger = logrusr.New(tmp)
+	}
+
+	// Prepare the scheme:
+	adders := []func(*runtime.Scheme) error{
+		aiv1beta1.AddToScheme,
+		apiextensionsv1.AddToScheme,
+		apiregv1.AddToScheme,
+		bmh_v1alpha1.AddToScheme,
+		configv1.Install,
+		corev1.AddToScheme,
+		hiveext.AddToScheme,
+		hivev1.AddToScheme,
+		machinev1beta1.AddToScheme,
+		metal3iov1alpha1.AddToScheme,
+		monitoringv1.AddToScheme,
+		routev1.Install,
+		scheme.AddToScheme,
+	}
+	scheme := runtime.NewScheme()
+	for _, adder := range adders {
+		err := adder(scheme)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	// Create the client:
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Create the objects that are needed by all the tests:
+	b.createIngressConfig(client)
+
+	// Create the object:
+	c := &FakeCluster{
+		logger: b.logger,
+		scheme: scheme,
+		client: client,
+	}
+
+	// Create the watches that simulate controllers:
+	c.watches = append(c.watches, c.watchRoutes())
+	c.watches = append(c.watches, c.watchStatefulSets())
+
+	// Start the goroutine that drains events:
+	c.recorder = record.NewFakeRecorder(0)
+	go c.drainEvents()
+
+	return c
+}
+
+// createIngressConfig creates the configmap of the ingress controller. This is needed because some
+// of our reconcilers check that it exists. Note that it needs just to exist, the content is not
+// relevant.
+func (b *FakeClusterBuilder) createIngressConfig(client clnt.Client) {
+	err := client.Create(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-config-managed",
+			Name:      "default-ingress-cert",
+		},
+	})
+	Expect(err).ToNot(HaveOccurred())
+}
+
+// watchRoutes creates the watch that simulates the OpenShift route controller, so that routes will
+// have host names assigned.
+func (c *FakeCluster) watchRoutes() wtch.Interface {
+	watch, err := c.client.Watch(context.Background(), &routev1.RouteList{})
+	Expect(err).ToNot(HaveOccurred())
+	go func() {
+		defer GinkgoRecover()
+		for event := range watch.ResultChan() {
+			switch event.Type {
+			case wtch.Added:
+				object, ok := event.Object.(*routev1.Route)
+				Expect(ok).To(BeTrue())
+				if object.Spec.Host == "" {
+					object.Spec.Host = object.Name
+					err = c.client.Update(context.Background(), object)
+					Expect(err).ToNot(HaveOccurred())
+					c.logger.Info(
+						"Updated route",
+						"namesapce", object.Namespace,
+						"name", object.Name,
+						"host", object.Spec.Host,
+					)
+				}
+			}
+		}
+	}()
+	return watch
+}
+
+// watchStatefulSets creates the watch that simulates the stateful set controller, so that stateful
+// sets will have the actual number of replicas equal to the specified number of replicas.
+func (c *FakeCluster) watchStatefulSets() wtch.Interface {
+	watch, err := c.client.Watch(context.Background(), &appsv1.StatefulSetList{})
+	Expect(err).ToNot(HaveOccurred())
+	go func() {
+		defer GinkgoRecover()
+		for event := range watch.ResultChan() {
+			switch event.Type {
+			case wtch.Added:
+				object, ok := event.Object.(*appsv1.StatefulSet)
+				Expect(ok).To(BeTrue())
+				replicas := *object.Spec.Replicas
+				object.Status.Replicas = replicas
+				object.Status.ReadyReplicas = replicas
+				object.Status.CurrentReplicas = replicas
+				object.Status.UpdatedReplicas = replicas
+				err = c.client.Update(context.Background(), object)
+				Expect(err).ToNot(HaveOccurred())
+				c.logger.Info(
+					"Updated stateful set",
+					"namespace", object.Namespace,
+					"name", object.Name,
+					"replicas", replicas,
+				)
+			}
+		}
+	}()
+	return watch
+}
+
+// drainEvents drains the events channel, as otherwise the tests will hang when the capacity of the
+// events channel is exahusted.
+func (c *FakeCluster) drainEvents() {
+	for event := range c.recorder.Events {
+		c.logger.Info(
+			"Drained event",
+			"event", event,
+		)
+	}
+}
+
+// Scheme returns the scheme of the fake cluster.
+func (c *FakeCluster) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+// Client returns a controller runtime client that can be used to interact with the fake cluster.
+func (c *FakeCluster) Client() clnt.Client {
+	return c.client
+}
+
+// Recorder returns the event recorder of the fake cluster.
+func (c *FakeCluster) Recorder() record.EventRecorder {
+	return c.recorder
+}
+
+// Stop stops the fake cluster and releases all the resources that it was using.
+func (c *FakeCluster) Stop() {
+	// Stop the watches:
+	for _, watch := range c.watches {
+		watch.Stop()
+	}
+
+	// Stop event draining:
+	close(c.recorder.Events)
+}

--- a/vendor/github.com/bombsimon/logrusr/v3/.gitignore
+++ b/vendor/github.com/bombsimon/logrusr/v3/.gitignore
@@ -1,0 +1,81 @@
+
+# Created by https://www.gitignore.io/api/vim,macOS,IntelliJ+allb,go
+# Edit at https://www.gitignore.io/?templates=vim,macOS,IntelliJ+allb,go
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+#!! ERROR: intellij+allb is undefined. Use list command to see defined gitignore types !!#
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+# End of https://www.gitignore.io/api/vim,macOS,IntelliJ+allb,go

--- a/vendor/github.com/bombsimon/logrusr/v3/LICENSE
+++ b/vendor/github.com/bombsimon/logrusr/v3/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Simon Sawert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/bombsimon/logrusr/v3/README.md
+++ b/vendor/github.com/bombsimon/logrusr/v3/README.md
@@ -1,0 +1,34 @@
+# Logrusr
+
+[![GitHub Actions](https://github.com/bombsimon/logrusr/actions/workflows/go.yml/badge.svg)](https://github.com/bombsimon/logrusr/actions/workflows/go.yml)
+[![Coverage Status](https://coveralls.io/repos/github/bombsimon/logrusr/badge.svg?branch=main)](https://coveralls.io/github/bombsimon/logrusr?branch=main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bombsimon/logrusr)](https://goreportcard.com/report/github.com/bombsimon/logrusr)
+
+A [logr](https://github.com/go-logr/logr) implementation using
+[logrus](https://github.com/sirupsen/logrus).
+
+## Usage
+
+```go
+import (
+    "github.com/bombsimon/logrusr/v3"
+    "github.com/go-logr/logr"
+    "github.com/sirupsen/logrus"
+)
+
+func main() {
+    logrusLog := logrus.New()
+    log := logrusr.New(logrusLog)
+
+    log = log.WithName("MyName").WithValues("user", "you")
+    log.Info("Logr in action!", "the answer", 42)
+}
+```
+
+For more details, see [example](example/main.go).
+
+## Implementation details
+
+The New method takes a `logrus.FieldLogger` interface as input which means
+this works with both `logrus.Logger` and `logrus.Entry`. This is currently a
+quite naive implementation in early state. Use with caution.

--- a/vendor/github.com/bombsimon/logrusr/v3/logrusr.go
+++ b/vendor/github.com/bombsimon/logrusr/v3/logrusr.go
@@ -1,0 +1,231 @@
+package logrusr
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+// According to the specification of the Logger interface calling the InfoLogger
+// directly on the logger should be the same as calling them on V(0). Since
+// logrus level 0 is PanicLevel and Infolevel doesn't start until V(4) we use
+// this constant to be able to calculate what V(n) values should mean.
+const logrusDiffToInfo = 4
+
+// FormatFunc is the function to format log values with for non primitive data.
+// By default, this is empty and the data will be JSON marshaled.
+type FormatFunc func(interface{}) string
+
+// Option is options to give when construction a logrusr logger.
+type Option func(l *logrusr)
+
+// WithFormatter will set the FormatFunc to use.
+func WithFormatter(f FormatFunc) Option {
+	return func(l *logrusr) {
+		l.defaultFormatter = f
+	}
+}
+
+// WithReportCaller will enable reporting of the caller.
+func WithReportCaller() Option {
+	return func(l *logrusr) {
+		l.reportCaller = true
+	}
+}
+
+// WithName will set an initial name instead of having to call `WithName` on the
+// logger itself after constructing it.
+func WithName(name ...string) Option {
+	return func(l *logrusr) {
+		l.name = name
+
+		l.logger = l.logger.WithField(
+			"logger", strings.Join(l.name, "."),
+		)
+	}
+}
+
+type logrusr struct {
+	name             []string
+	depth            int
+	reportCaller     bool
+	logger           *logrus.Entry
+	defaultFormatter FormatFunc
+}
+
+// New will return a new logr.Logger created from a logrus.FieldLogger.
+func New(l logrus.FieldLogger, opts ...Option) logr.Logger {
+	// Immediately convert the FieldLogger to an Entry so we don't have to type
+	// cast and can use methods that exist on the Entry but not the FieldLogger
+	// interface.
+	logger := &logrusr{
+		depth:  0,
+		logger: l.WithFields(logrus.Fields{}),
+	}
+
+	for _, o := range opts {
+		o(logger)
+	}
+
+	return logr.New(logger)
+}
+
+// Init receives optional information about the library.
+func (l *logrusr) Init(ri logr.RuntimeInfo) {
+	l.depth = ri.CallDepth
+}
+
+// Enabled tests whether this Logger is enabled. It will return true if the
+// logrus.Logger has a level set to logrus.InfoLevel or higher (Warn/Panic).
+// According to the documentation, level V(0) should be equivalent as calling
+// Info() directly on the logger. To ensure this the constant `logrusDiffToInfo`
+// will be added to all passed values so that V(0) creates a logger with level
+// logrus.InfoLevel and V(2) would create a logger with level logrus.TraceLevel.
+// This menas that if logrus is  set to logrus.InfoLevel or **higher** this
+// method will return true, otherwise false.
+func (l *logrusr) Enabled(level int) bool {
+	// logrus.InfoLevel has value 4 so if the level on the logger is set to 0 we
+	// should only be seen as enabled if the logrus logger has a severity of
+	// info or higher.
+	return l.logger.Logger.IsLevelEnabled(logrus.Level(level + logrusDiffToInfo))
+}
+
+// Info logs info messages if the logger is enabled, that is if the level on the
+// logger is set to logrus.InfoLevel or less.
+func (l *logrusr) Info(level int, msg string, keysAndValues ...interface{}) {
+	log := l.logger
+	if c := l.caller(); c != "" {
+		log = log.WithField("caller", c)
+	}
+
+	log.
+		WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...)).
+		Log(logrus.Level(level+logrusDiffToInfo), msg)
+}
+
+// Error logs error messages. Since the log will be written with `Error` level
+// it won't show if the severity of the underlying logrus logger is less than
+// Error.
+func (l *logrusr) Error(err error, msg string, keysAndValues ...interface{}) {
+	log := l.logger
+	if c := l.caller(); c != "" {
+		log = log.WithField("caller", c)
+	}
+
+	log.
+		WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...)).
+		WithError(err).
+		Error(msg)
+}
+
+// WithValues returns a new logger with additional key/values pairs. This is
+// equivalent to logrus WithFields() but takes a list of even arguments
+// (key/value pairs) instead of a map as input. If an odd number of arguments
+// are sent all values will be discarded.
+func (l *logrusr) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	newLogger := l.copyLogger()
+	newLogger.logger = newLogger.logger.WithFields(
+		listToLogrusFields(l.defaultFormatter, keysAndValues...),
+	)
+
+	return newLogger
+}
+
+// WithName is a part of the Logger interface. This will set the key "logger" as
+// a logrus field to identify the instance.
+func (l *logrusr) WithName(name string) logr.LogSink {
+	newLogger := l.copyLogger()
+	newLogger.name = append(newLogger.name, name)
+
+	newLogger.logger = newLogger.logger.WithField(
+		"logger", strings.Join(newLogger.name, "."),
+	)
+
+	return newLogger
+}
+
+// listToLogrusFields converts a list of arbitrary length to key/value paris.
+func listToLogrusFields(formatter func(interface{}) string, keysAndValues ...interface{}) logrus.Fields {
+	f := make(logrus.Fields)
+
+	// Skip all fields if it's not an even length list.
+	if len(keysAndValues)%2 != 0 {
+		return f
+	}
+
+	for i := 0; i < len(keysAndValues); i += 2 {
+		k, v := keysAndValues[i], keysAndValues[i+1]
+
+		if s, ok := k.(string); ok {
+			// Try to avoid marshaling known types.
+			switch vVal := v.(type) {
+			case int, int8, int16, int32, int64,
+				uint, uint8, uint16, uint32, uint64,
+				float32, float64, complex64, complex128,
+				string, bool:
+				f[s] = vVal
+
+			case []byte:
+				f[s] = string(vVal)
+
+			default:
+				if formatter != nil {
+					f[s] = formatter(v)
+				} else {
+					j, _ := json.Marshal(vVal)
+					f[s] = string(j)
+				}
+			}
+		}
+	}
+
+	return f
+}
+
+// copyLogger copies the logger creating a new slice of the name but preserving
+// the formatter and actual logrus logger.
+func (l *logrusr) copyLogger() *logrusr {
+	newLogger := &logrusr{
+		name:             make([]string, len(l.name)),
+		depth:            l.depth,
+		reportCaller:     l.reportCaller,
+		logger:           l.logger.Dup(),
+		defaultFormatter: l.defaultFormatter,
+	}
+
+	copy(newLogger.name, l.name)
+
+	return newLogger
+}
+
+// WithCallDepth implements the optional WithCallDepth to offset the call stack
+// when reporting caller.
+func (l *logrusr) WithCallDepth(depth int) logr.LogSink {
+	newLogger := l.copyLogger()
+	newLogger.depth = depth
+
+	return newLogger
+}
+
+// caller will return the caller of the logging method.
+func (l *logrusr) caller() string {
+	// Check if we should even report the caller.
+	if !l.reportCaller {
+		return ""
+	}
+
+	// +1 for this frame.
+	// +1 for frame calling here (Info/Error)
+	// +1 for logr frame
+	_, file, line, ok := runtime.Caller(l.depth + 3)
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("%s:%d", filepath.Base(file), line)
+}

--- a/vendor/github.com/go-logr/logr/README.md
+++ b/vendor/github.com/go-logr/logr/README.md
@@ -105,14 +105,18 @@ with higher verbosity means more (and less important) logs will be generated.
 There are implementations for the following logging libraries:
 
 - **a function** (can bridge to non-structured libraries): [funcr](https://github.com/go-logr/logr/tree/master/funcr)
+- **a testing.T** (for use in Go tests, with JSON-like output): [testr](https://github.com/go-logr/logr/tree/master/testr)
 - **github.com/google/glog**: [glogr](https://github.com/go-logr/glogr)
 - **k8s.io/klog** (for Kubernetes): [klogr](https://git.k8s.io/klog/klogr)
+- **a testing.T** (with klog-like text output): [ktesting](https://git.k8s.io/klog/ktesting)
 - **go.uber.org/zap**: [zapr](https://github.com/go-logr/zapr)
 - **log** (the Go standard library logger): [stdr](https://github.com/go-logr/stdr)
 - **github.com/sirupsen/logrus**: [logrusr](https://github.com/bombsimon/logrusr)
 - **github.com/wojas/genericr**: [genericr](https://github.com/wojas/genericr) (makes it easy to implement your own backend)
 - **logfmt** (Heroku style [logging](https://www.brandur.org/logfmt)): [logfmtr](https://github.com/iand/logfmtr)
 - **github.com/rs/zerolog**: [zerologr](https://github.com/go-logr/zerologr)
+- **github.com/go-kit/log**: [gokitlogr](https://github.com/tonglil/gokitlogr) (also compatible with github.com/go-kit/kit/log since v0.12.0)
+- **bytes.Buffer** (writing to a buffer): [bufrlogr](https://github.com/tonglil/buflogr) (useful for ensuring values were logged, like during testing)
 
 ## FAQ
 

--- a/vendor/github.com/go-logr/logr/logr.go
+++ b/vendor/github.com/go-logr/logr/logr.go
@@ -115,6 +115,15 @@ limitations under the License.
 // may be any Go value, but how the value is formatted is determined by the
 // LogSink implementation.
 //
+// Logger instances are meant to be passed around by value. Code that receives
+// such a value can call its methods without having to check whether the
+// instance is ready for use.
+//
+// Calling methods with the null logger (Logger{}) as instance will crash
+// because it has no LogSink. Therefore this null logger should never be passed
+// around. For cases where passing a logger is optional, a pointer to Logger
+// should be used.
+//
 // Key Naming Conventions
 //
 // Keys are not strictly required to conform to any specification or regex, but

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,6 +109,9 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver/v4 v4.0.0
 ## explicit; go 1.14
 github.com/blang/semver/v4
+# github.com/bombsimon/logrusr/v3 v3.0.0
+## explicit; go 1.17
+github.com/bombsimon/logrusr/v3
 # github.com/buger/jsonparser v1.1.1
 ## explicit; go 1.13
 github.com/buger/jsonparser
@@ -239,7 +242,7 @@ github.com/ghodss/yaml
 # github.com/go-gormigrate/gormigrate/v2 v2.0.1
 ## explicit; go 1.17
 github.com/go-gormigrate/gormigrate/v2
-# github.com/go-logr/logr v1.2.2
+# github.com/go-logr/logr v1.2.3
 ## explicit; go 1.16
 github.com/go-logr/logr
 # github.com/go-logr/zapr v1.2.0


### PR DESCRIPTION
Currently when the user creates an instance of the _AgentConfigService_
object the sizes of the volumes aren't validated. This patch changes the
controller so that it validates these sizes.

To avoid potential issues with environments that were created before
this change the validation will not generate an error and stop
reconciliation if the corresponding persistent volume claims and
stateful set have already been created.

Related: https://issues.redhat.com/browse/MGMT-11700

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manually deploying the operator and trying to create _AgentServiceConfig_ objects with incorrect sizes.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
