### PR TITLE
NO-ISSUE: Update subsystem docs to use minikube with podman

### DIFF
--- a/docs/dev/running-test.md
+++ b/docs/dev/running-test.md
@@ -30,7 +30,7 @@ First we must prepare the minikube cluster -
 # minikube delete
 
 # Clean remains of any networks created by minikube
-podman network rm minikube
+podman network rm minikube || true
 
 # Start minikube with registry addon
 minikube start --driver=podman --addons registry --addons dashboard --force

--- a/docs/dev/running-test.md
+++ b/docs/dev/running-test.md
@@ -29,10 +29,13 @@ First we must prepare the minikube cluster -
 # Optionally delete the existing minikube cluster:
 # minikube delete
 
-minikube start
+# Clean remains of any networks created by minikube
+podman network rm minikube
 
-# Start the minikube container registry and make it accessible locally:
-minikube addons enable registry
+# Start minikube with registry addon
+minikube start --driver=podman --addons registry --addons dashboard --force
+
+# Make the registry addon accessible locally:
 nohup kubectl port-forward svc/registry 5000:80 -n kube-system &>/dev/null &
 export LOCAL_SUBSYSTEM_REGISTRY=localhost:5000
 


### PR DESCRIPTION
This change allows to use the same setup for test-infra and subsystem. As the default minikube tries to use as much of Docker as possible, we want to explicitly point it to use Podman.

/cc @paul-maidment 