### PR TITLE
MGMT-11878: Extend validator unit-tests to contain IPv6 URLs

### DIFF
--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -18,6 +18,7 @@ var _ = Describe("URL validations", func() {
 			{"http://username:pswd@proxy.com", ""},
 			{"http://10.9.8.7:123", ""},
 			{"http://username:pswd@10.9.8.7:123", ""},
+			{"http://[1080:0:0:0:8:800:200C:417A]:8888", ""},
 			{
 				"https://proxy.com:3128",
 				"The URL scheme must be http; https is currently not supported: 'https://proxy.com:3128'",
@@ -75,6 +76,8 @@ var _ = Describe("URL validations", func() {
 			{"https://ignition.org:3128/config", ""},
 			{"http://10.9.8.7:123", ""},
 			{"http://10.9.8.7:123/config", ""},
+			{"http://[1080::8:800:200c:417a]:123", ""},
+			{"http://[1080::8:800:200c:417a]:123/config", ""},
 			{"", "The URL scheme must be http(s) and specified in the URL: ''"},
 			{
 				"://!@#$!@#$",


### PR DESCRIPTION
/cc @paul-maidment 