### PR TITLE
AGENT-374: agent-based-client: Apply installconfig overrides

### DIFF
--- a/docs/hive-integration/crds/agentClusterInstall-with-installconfig-overrides.yaml
+++ b/docs/hive-integration/crds/agentClusterInstall-with-installconfig-overrides.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  annotations:
+    agent-install.openshift.io/install-config-overrides: '{"fips": true}'
+  name: test-agent-cluster-install
+  namespace: spoke-cluster
+spec:
+  apiVIP: 1.2.3.8
+  clusterDeploymentRef:
+    name: test-cluster
+  imageSetRef:
+    name: openshift-v4.8.0
+  ingressVIP: 1.2.3.9
+  platformType: BareMetal
+  networking:
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    serviceNetwork:
+    - 172.30.0.0/16
+  provisionRequirements:
+    controlPlaneAgents: 3
+ #sshPublicKey: ssh-rsa your-public-key-here (optional)
+  # By default, SMT (or hyperthreading) is enabled to increase the performance of your machines' cores. 
+  # Therefore, you can omit this section unless you wish to disable hyperthreading. 
+  # You can disable SMT by setting the parameter value to 'Disabled'. Then, you must disable it in all cluster machines; 
+  # this includes both control plane and compute machines.
+  compute:
+  - hyperthreading: Enabled
+    name: worker
+  controlPlane:
+    hyperthreading: Enabled
+    name: master
+


### PR DESCRIPTION
The annotation was mistakenly ignored. This sets it on the cluster.


It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? agent based installation
- Any logs, screenshots, etc that can help with the review process?

## List all the issues related to this PR

- [ ] New Feature
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] Agent based installation
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed
- [x] No tests performed yet

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
