### PR TITLE
Bug 2106110: Don't set ip=<nic>:dhcp kernel params with static networking

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -256,17 +256,27 @@ func (i *installCmd) getDisksToFormat(ctx context.Context, host *models.Host, in
 func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inventory *models.Inventory, infraEnv *common.InfraEnv, log logrus.FieldLogger) (string, error) {
 
 	var installerArgs []string
+	var err error
+	hasStaticNetwork := (infraEnv != nil && infraEnv.StaticNetworkConfig != "") || cluster.StaticNetworkConfigured
 
 	if host.InstallerArgs != "" {
-		err := json.Unmarshal([]byte(host.InstallerArgs), &installerArgs)
+		err = json.Unmarshal([]byte(host.InstallerArgs), &installerArgs)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	installerArgs, err := appendDHCPArgs(cluster, host, inventory, installerArgs, log)
-	if err != nil {
-		return "", err
+	if !hasStaticNetwork {
+		// The set of ip=<nic>:dhcp kernel arguments should be added only if there is no static
+		// network configured by the user. This is because this parameter will configure RHCOS to
+		// try to obtain IP address from the DHCP server even if we provide a static addressing.
+		// As in majority of cases it's not an issue because of the priorities set in the config
+		// of NetworkManager, in some specific scenarios (e.g. BZ-2106110) this causes machines to
+		// lose their connectivity because priorities get mixed.
+		installerArgs, err = appendDHCPArgs(cluster, host, inventory, installerArgs, log)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	for _, disk := range inventory.Disks {
@@ -275,7 +285,6 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 		}
 	}
 
-	hasStaticNetwork := (infraEnv != nil && infraEnv.StaticNetworkConfig != "") || cluster.StaticNetworkConfigured
 	if hasStaticNetwork && !funk.Contains(installerArgs, "--copy-network") {
 		// network not configured statically or
 		// installer args already contain command for network configuration

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -832,7 +832,7 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args).To(Equal(""))
 	})
-	It("ip=<nic>:dhcp and copy-network added with static config", func() {
+	It("ip=<nic>:dhcp not added and copy-network added with static config", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		infraEnv.StaticNetworkConfig = "something"
 		cluster.ImageInfo.StaticNetworkConfig = "something"
@@ -847,9 +847,9 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","ip=eth1:dhcp","--copy-network"]`))
+		Expect(args).To(Equal(`["--copy-network"]`))
 	})
-	It("ip=<nic>:dhcp added with static config and copy-network set by the user", func() {
+	It("ip=<nic>:dhcp not added with static config and copy-network set by the user", func() {
 		host.InstallerArgs = `["--copy-network"]`
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}
 		infraEnv.StaticNetworkConfig = "something"
@@ -865,7 +865,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--copy-network","--append-karg","ip=eth0:dhcp"]`))
+		Expect(args).To(Equal(`["--copy-network"]`))
 	})
 	It("ip=<nic>:dhcp added when copy-network set by the user without static config", func() {
 		host.InstallerArgs = `["--copy-network"]`


### PR DESCRIPTION
This PR changes the behaviour of logic responsible for appending `ip=<nic>:dhcp` kernel parameters. Those must not be added when static network configuration is used as in some specific cases it causes loss of connectivity due to NetworkManager having to deal with two contradicting configurations (static config created by NMstate and DHCP as requested by kernel parameter).

With this change as soon as we detect that InfraEnv has network configuration provided by the user, we will not add any `ip` kernel param. This is not expected to cause any trouble as the behaviour will be as follows

* with no static configuration, `ip=<nic>:dhcp` will be set on the NIC that is used to provision the server (behaviour like today)
* with static configuration the NIC used to provision the server should have IP address assigned with NMstate

Closes: Bug-2106110
Closes: [MGMTBUGSM-508](https://issues.redhat.com//browse/MGMTBUGSM-508)

/cc @carbonin 