### PR TITLE
NO-ISSUE: Use legacy security context for disconnected CI

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -46,6 +46,25 @@ function mirror_package() {
 
   oc apply -f "${manifests_dir}/imageContentSourcePolicy.yaml"
 
+  # Modify openshift-marketplace namespace in order to allow workaround the new pod security
+  # admissions. Details are described in https://access.redhat.com/articles/6977554 and they
+  # are used to allow `securityContextConfig: legacy` stanza in the CatalogSource definition.
+  cat > "${manifests_dir}/namespaceHotfix.yaml" << EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: baseline
+  name: openshift-marketplace
+EOF
+
+  echo "Applied hotfix for marketplace namespace:"
+  cat "${manifests_dir}/namespaceHotfix.yaml"
+
+  oc apply -f "${manifests_dir}/namespaceHotfix.yaml"
+
   cat > "${manifests_dir}/catalogSource.yaml" << EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -57,6 +76,8 @@ spec:
   image: ${local_registry_index_tag}
   displayName: Mirror index for package ${package} from ${remote_index}
   publisher: Local
+  grpcPodConfig:
+    securityContextConfig: legacy
   updateStrategy:
     registryPoll:
       interval: 30m

--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -23,7 +23,7 @@ function install_lso() {
   catalog_source_name="redhat-operators"
 
   OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
-  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.12" ]]; then
+  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.12" && "${DISCONNECTED}" != true ]]; then
       # LSO has not been published to the 4.12 redhat-operators catalog, so
       # it cannot be installed on OpenShift 4.12. Until this is resolved,
       # we explicitly install the 4.11 catalog as redhat-operators-v4-11


### PR DESCRIPTION
Starting from OCP 4.12 the CatalogSources are replaced with file-based catalogs. Because of that, our current catalogs are not working when the Hub cluster is OCP 4.12. In order to workaround this we follow the recommendation from https://access.redhat.com/articles/6977554 and use the legacy mode.

/cc @vrutkovs 
/hold