### PR TITLE
MGMT-8890: Create validator for RHCOS and OCP versions

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3984,8 +3984,6 @@ func validateProxySettings(httpProxy, httpsProxy, noProxy, ocpVersion *string) e
 // the architecture specifically requested by the InfraEnv. We don't need to explicitly validate if
 // the OS image exists because if not, this will be detected by the function generating the ISO.
 func validateArchitectureAndVersion(v versions.Handler, c *common.Cluster, cpuArch, ocpVersion string) error {
-	var err error
-
 	// For late-binding we don't know the cluster yet
 	if c == nil {
 		return nil
@@ -3998,8 +3996,7 @@ func validateArchitectureAndVersion(v versions.Handler, c *common.Cluster, cpuAr
 			return errors.Errorf("Specified CPU architecture (%s) doesn't match the cluster (%s)", cpuArch, c.CPUArchitecture)
 		}
 	} else {
-		_, err = v.GetReleaseImage(ocpVersion, cpuArch)
-		if err != nil {
+		if err := v.ValidateReleaseImageForRHCOS(ocpVersion, cpuArch); err != nil {
 			return err
 		}
 	}

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6300,11 +6300,10 @@ var _ = Describe("infraEnvs", func() {
 			err := db.Create(&cluster).Error
 			Expect(err).ShouldNot(HaveOccurred())
 
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(
-				nil, errors.Errorf("The requested CPU architecture (chocobomb-architecture) isn't specified in release images list")).Times(1)
+			mockVersions.EXPECT().ValidateReleaseImageForRHCOS(gomock.Any(), gomock.Any()).Return(
+				errors.Errorf("chocobomb-architecture is a nonsense architecture")).Times(1)
 			mockEvents.EXPECT().SendInfraEnvEvent(ctx, eventstest.NewEventMatcher(
-				eventstest.WithNameMatcher(eventgen.InfraEnvRegistrationFailedEventName),
-				eventstest.WithMessageContainsMatcher("The requested CPU architecture (chocobomb-architecture) isn't specified in release images list"))).Times(1)
+				eventstest.WithNameMatcher(eventgen.InfraEnvRegistrationFailedEventName))).Times(1)
 
 			reply := bm.RegisterInfraEnv(ctx, installer.RegisterInfraEnvParams{
 				InfraenvCreateParams: &models.InfraEnvCreateParams{

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -212,3 +212,17 @@ func (mr *MockHandlerMockRecorder) ValidateAccessToMultiarch(arg0, arg1 interfac
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAccessToMultiarch", reflect.TypeOf((*MockHandler)(nil).ValidateAccessToMultiarch), arg0, arg1)
 }
+
+// ValidateReleaseImageForRHCOS mocks base method.
+func (m *MockHandler) ValidateReleaseImageForRHCOS(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateReleaseImageForRHCOS", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateReleaseImageForRHCOS indicates an expected call of ValidateReleaseImageForRHCOS.
+func (mr *MockHandlerMockRecorder) ValidateReleaseImageForRHCOS(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateReleaseImageForRHCOS", reflect.TypeOf((*MockHandler)(nil).ValidateReleaseImageForRHCOS), arg0, arg1)
+}

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -456,6 +456,6 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 
 		Expect(err).To(HaveOccurred())
 		actual := err.(*installer.RegisterInfraEnvBadRequest)
-		Expect(*actual.Payload.Reason).To(ContainSubstring("The requested CPU architecture (fake-chocobomb-architecture) isn't specified in release images list"))
+		Expect(*actual.Payload.Reason).To(ContainSubstring("does not have a matching OpenShift release image"))
 	})
 })

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1534,7 +1534,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		deployInfraEnvCRD(ctx, kubeClient, infraEnvFake.Name, infraEnvSpec)
 
 		checkInfraEnvCondition(ctx, infraEnvFake, v1beta1.ImageCreatedCondition,
-			"Failed to create image: The requested CPU architecture (fake) isn't specified in release images list")
+			"does not have a matching OpenShift release image")
 
 		By("fail to deploy infraenv with PowerPC architecture")
 		infraEnvSpec.CpuArchitecture = common.PowerCPUArchitecture


### PR DESCRIPTION
This PR creates the `ValidateReleaseImageForRHCOS` function responsible for validating whether a specified RHCOS version has a matching OCP release available, as otherwise it makes no sense to create such an InfraEnv as it would be effectively unusable until a valid OCP version appears.

This has been discovered only after multi-arch clusters got the validation between InfraEnv (i.e. RHCOS image) and OCP release. With the ability to perform weak matching we don't need to align RHCOS image to the z-stream of OCP, so e.g. we can offer `4.12.0-ec.3-multi` to be served by `4.12` RHCOS (without that change we need to label RHCOS explicitly as `4.12.0-ec.3-multi`).

Single-arch clusters are not affected, as for such a cluster InfraEnv does not perform any validation whatsoever.

Closes: Bug-2131396
Closes: [MGMTBUGSM-567](https://issues.redhat.com//browse/MGMTBUGSM-567)
Caused-by: [MGMT-11500](https://issues.redhat.com//browse/MGMT-11500)
Caused-by: #4285
Contributes-to: [MGMT-8890](https://issues.redhat.com//browse/MGMT-8890)
Supersedes: #4464

/cc @carbonin 