### PR TITLE
MGMT-11997: Default to using converged flow for 4.12 hub versions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,7 +147,7 @@ var Options struct {
 	LivenessValidationTimeout      time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
 	ApproveCsrsRequeueDuration     time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
-	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"` // set to true once https://bugzilla.redhat.com/show_bug.cgi?id=2089683 is resolved
+	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"true"`
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
@@ -511,10 +511,7 @@ func main() {
 			bmoUtils := controllers.NewBMOUtils(ctrlMgr.GetAPIReader(),
 				log.WithField("pkg", "baremetal_operator_utils"),
 				Options.EnableKubeAPI)
-			useConvergedFlow := false
-			if Options.AllowConvergedFlow {
-				useConvergedFlow = bmoUtils.ConvergedFlowAvailable()
-			}
+			useConvergedFlow := Options.AllowConvergedFlow && bmoUtils.ConvergedFlowAvailable()
 
 			c := ctrlMgr.GetClient()
 			r := ctrlMgr.GetAPIReader()

--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -173,7 +173,7 @@ See BMAC documentation [here](./baremetal-agent-controller.md).
 ## Bare Metal Operator Integration using the converged flow
 See reference [here](https://github.com/openshift/enhancements/blob/master/enhancements/baremetal/ztp-metal3.md)
 
-In case the Bare Metal Operator on the HUB cluster version is 4.11 or higher, the integration between the BMO and the assisted-service is slightly different.
+In case the Bare Metal Operator on the HUB cluster version is 4.12 or higher, the integration between the BMO and the assisted-service is slightly different.
 The assisted-service will run a Preprovisioning Image Controller that reconciles PreprovisioningImages and:
 - Annotates the InfraEnv for the BareMetalHost with `infraenv.agent-install.openshift.io/enable-ironic-agent="true"`
 - Adds the ironic agent config to the discovery ignition embedded in the InfraEnv ISO
@@ -196,7 +196,8 @@ It will continue to:
 The assisted agent will not reboot the machine at the end of the installation, instead it will stop
 the assisted agent service and let the ironic agent to manage the machine power state
 
-The converged flow is disalbed by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
+The converged flow is enabled by default, but can be disabled by setting the `ALLOW_CONVERGED_FLOW` env to false [here](../operator.md##specifying-environmental-variables-via-configmap)
+
 To set a different default ironicAgent image you can override the following env vars:
 The environment var for the ironicAgent image to be used on X86_64 CPU architecture:
 `IRONIC_AGENT_IMAGE`

--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const MinimalVersionForConvergedFlow = "4.11.0-0.alpha"
+const MinimalVersionForConvergedFlow = "4.12.0-ec.4"
 
 type BMOUtils struct {
 	// The methods of this receiver get called once before the cache is initialized hence we check the API directly

--- a/internal/controller/controllers/bmo_utils_test.go
+++ b/internal/controller/controllers/bmo_utils_test.go
@@ -43,17 +43,17 @@ var _ = Describe("BMOUtils", func() {
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			clusterOperator := CreateCBO("4.11.0")
+			clusterOperator := CreateCBO("4.12.0")
 			Expect(c.Create(context.Background(), clusterOperator)).To(BeNil())
 			Expect(bmoUtils.ConvergedFlowAvailable()).Should(Equal(true))
 		})
-		It("converged flow available with nightly version", func() {
+		It("converged flow available with candidate version", func() {
 			bmoUtils := BMOUtils{
 				c:              c,
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			clusterOperator := CreateCBO("4.11.0-0.nightly-2022-06-21-151125")
+			clusterOperator := CreateCBO("4.12.0-ec.4")
 			Expect(c.Create(context.Background(), clusterOperator)).To(BeNil())
 			Expect(bmoUtils.ConvergedFlowAvailable()).Should(Equal(true))
 		})

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -235,9 +235,9 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		})
 		It("Add the ironic Ignition to the infraEnv using the ironic agent image from the release", func() {
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-			openshiftRelaseImage := "release-image:4.11.0"
-			ironicAgentImage := "ironic-image:4.11.0"
-			backendInfraEnv.OpenshiftVersion = "4.11.0-test.release"
+			openshiftRelaseImage := "release-image:4.12.0"
+			ironicAgentImage := "ironic-image:4.12.0"
+			backendInfraEnv.OpenshiftVersion = "4.12.0-test.release"
 			backendInfraEnv.CPUArchitecture = "x86_64"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 			mockVersionHandler.EXPECT().GetReleaseImage(backendInfraEnv.OpenshiftVersion, backendInfraEnv.CPUArchitecture).Return(&models.ReleaseImage{URL: &openshiftRelaseImage}, nil)


### PR DESCRIPTION
This sets the ALLOW_CONVERGED_FLOW env var to true by default

Additionally this only allows the converged flow to be used
on hub clusters at version 4.12.0-ec.4 or later to ensure that
https://issues.redhat.com/browse/METAL-256 is resolved.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-11997

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
