### PR TITLE
NO-ISSUE: Revert legacy security context for disconnected CI

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -46,25 +46,6 @@ function mirror_package() {
 
   oc apply -f "${manifests_dir}/imageContentSourcePolicy.yaml"
 
-  # Modify openshift-marketplace namespace in order to allow workaround the new pod security
-  # admissions. Details are described in https://access.redhat.com/articles/6977554 and they
-  # are used to allow `securityContextConfig: legacy` stanza in the CatalogSource definition.
-  cat > "${manifests_dir}/namespaceHotfix.yaml" << EOF
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    security.openshift.io/scc.podSecurityLabelSync: "false"
-    openshift.io/cluster-monitoring: "true"
-    pod-security.kubernetes.io/enforce: baseline
-  name: openshift-marketplace
-EOF
-
-  echo "Applied hotfix for marketplace namespace:"
-  cat "${manifests_dir}/namespaceHotfix.yaml"
-
-  oc apply -f "${manifests_dir}/namespaceHotfix.yaml"
-
   cat > "${manifests_dir}/catalogSource.yaml" << EOF
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
@@ -76,8 +57,6 @@ spec:
   image: ${local_registry_index_tag}
   displayName: Mirror index for package ${package} from ${remote_index}
   publisher: Local
-  grpcPodConfig:
-    securityContextConfig: legacy
   updateStrategy:
     registryPoll:
       interval: 30m


### PR DESCRIPTION
[OLM-2695](https://issues.redhat.com//browse/OLM-2695) is fixing the issue with openshift-* namespace labelling. Based on the fix, our workaround is no longer needed.

Contributes-to: [MGMT-12248](https://issues.redhat.com//browse/MGMT-12248)

/cc @vrutkovs 
/test edge-e2e-ai-operator-ztp-disconnected