### PR TITLE
MGMT-11642: Add Host Bind/Unbind Events

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -519,6 +519,25 @@ x-events:
     cluster_id: UUID_PTR
     host_name: string
 
+- name: host_bind_succeeded
+  message: "Host {host_name}: Successfully bound to cluster {cluster_id}"
+  event_type: host
+  severity: "info"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    cluster_id: UUID_PTR
+    host_name: string
+
+- name: host_unbind_succeeded
+  message: "Host {host_name}: Successfully unbound from cluster"
+  event_type: host
+  severity: "info"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    host_name: string
+
 - name: generate_image_format_failed
   message: "Failed to generate image: error formatting ignition file"
   event_type: infra_env
@@ -567,6 +586,25 @@ x-events:
     host_id: UUID
     infra_env_id: UUID
     cluster_id: UUID_PTR
+    message: string
+
+- name: host_bind_failed
+  message: "Failed to bind host {host_id} to cluster {cluster_id}: {message}"
+  event_type: host
+  severity: "error"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    cluster_id: UUID_PTR
+    message: string
+
+- name: host_unbind_failed
+  message: "Failed to unbind host {host_id} to cluster: {message}"
+  event_type: host
+  severity: "error"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
     message: string
 
 - name: inactive_clusters_deregistered

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5091,8 +5091,10 @@ func (b *bareMetalInventory) V2UpdateHostInstallProgressInternal(ctx context.Con
 func (b *bareMetalInventory) BindHost(ctx context.Context, params installer.BindHostParams) middleware.Responder {
 	h, err := b.BindHostInternal(ctx, params)
 	if err != nil {
+		eventgen.SendHostBindFailedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, params.BindHostParams.ClusterID, err.Error())
 		return common.GenerateErrorResponder(err)
 	}
+	eventgen.SendHostBindSucceededEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, params.BindHostParams.ClusterID, hostutil.GetHostnameForMsg(&h.Host))
 	return installer.NewBindHostOK().WithPayload(&h.Host)
 }
 
@@ -5198,8 +5200,10 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 func (b *bareMetalInventory) UnbindHost(ctx context.Context, params installer.UnbindHostParams) middleware.Responder {
 	h, err := b.UnbindHostInternal(ctx, params, false)
 	if err != nil {
+		eventgen.SendHostUnbindFailedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, err.Error())
 		return common.GenerateErrorResponder(err)
 	}
+	eventgen.SendHostUnbindSucceededEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, hostutil.GetHostnameForMsg(&h.Host))
 	return installer.NewUnbindHostOK().WithPayload(&h.Host)
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -12826,7 +12826,7 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -12844,6 +12844,11 @@ var _ = Describe("BindHost", func() {
 			InfraEnvID:     "12345",
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(params.InfraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		response := bm.BindHost(ctx, params)
 		verifyApiError(response, http.StatusNotFound)
 	})
@@ -12855,6 +12860,11 @@ var _ = Describe("BindHost", func() {
 			InfraEnvID:     infraEnvID,
 			BindHostParams: &models.BindHostParams{ClusterID: &badClusterID},
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		response := bm.BindHost(ctx, params)
 		verifyApiError(response, http.StatusBadRequest)
 	})
@@ -12868,6 +12878,11 @@ var _ = Describe("BindHost", func() {
 		var hostObj models.Host
 		Expect(db.First(&hostObj, "id = ?", hostID).Error).ShouldNot(HaveOccurred())
 		Expect(db.Model(&hostObj).Update("cluster_id", "some_cluster").Error).ShouldNot(HaveOccurred())
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		response := bm.BindHost(ctx, params)
 		verifyApiError(response, http.StatusConflict)
 	})
@@ -12879,6 +12894,11 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		err := errors.Errorf("Cluster is in wrong state")
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(err).Times(1)
 		response := bm.BindHost(ctx, params)
 		verifyApiError(response, http.StatusConflict)
@@ -12891,6 +12911,11 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		err := errors.Errorf("Transition failed")
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any()).Return(err).Times(1)
 		response := bm.BindHost(ctx, params)
@@ -12919,11 +12944,11 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
-			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
-		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
+		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any()).Times(0)
 		response := bm.BindHost(ctx, params)
 		verifyApiErrorString(response, http.StatusBadRequest, "doesn't match")
 	})
@@ -12952,7 +12977,7 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -12981,7 +13006,7 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -13000,12 +13025,12 @@ var _ = Describe("BindHost", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
-		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
 		response := bm.BindHost(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.BindHostOK{}))
@@ -13038,6 +13063,11 @@ var _ = Describe("BindHost", func() {
 			InfraEnvID:     infraEnvID,
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
 		mockClusterApi.EXPECT().AcceptRegistration(gomock.Any()).Return(nil).Times(1)
 		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockHostApi.EXPECT().BindHost(ctx, gomock.Any(), clusterID, gomock.Any())
@@ -13118,7 +13148,7 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -13140,7 +13170,7 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 			BindHostParams: &models.BindHostParams{ClusterID: &clusterID},
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostBindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -13167,7 +13197,11 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 
 		payload.Username = userName2
 		authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
-
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockOcmAuthz.EXPECT().AccessReview(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -13185,7 +13219,11 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 		payload.Username = userName2
 		payload.Organization = "another_org"
 		authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
-
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostBindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockOcmAuthz.EXPECT().AccessReview(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
@@ -13228,7 +13266,7 @@ var _ = Describe("UnbindHost", func() {
 			InfraEnvID: infraEnvID,
 		}
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
-			eventstest.WithNameMatcher(eventgen.HostRegistrationFailedEventName),
+			eventstest.WithNameMatcher(eventgen.HostUnbindSucceededEventName),
 			eventstest.WithHostIdMatcher(params.HostID.String()),
 			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
 			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
@@ -13243,6 +13281,11 @@ var _ = Describe("UnbindHost", func() {
 			HostID:     hostID,
 			InfraEnvID: "12345",
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostUnbindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(params.InfraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		response := bm.UnbindHost(ctx, params)
 		verifyApiError(response, http.StatusNotFound)
 	})
@@ -13252,6 +13295,11 @@ var _ = Describe("UnbindHost", func() {
 			HostID:     hostID,
 			InfraEnvID: infraEnvID,
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostUnbindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		var hostObj models.Host
 		Expect(db.First(&hostObj, "id = ?", hostID).Error).ShouldNot(HaveOccurred())
 		Expect(db.Model(&hostObj).Update("cluster_id", nil).Error).ShouldNot(HaveOccurred())
@@ -13264,6 +13312,11 @@ var _ = Describe("UnbindHost", func() {
 			HostID:     hostID,
 			InfraEnvID: infraEnvID,
 		}
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostUnbindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		var infraEnvObj models.InfraEnv
 		Expect(db.First(&infraEnvObj, "id = ?", infraEnvID).Error).ShouldNot(HaveOccurred())
 		Expect(db.Model(&infraEnvObj).Update("cluster_id", clusterID).Error).ShouldNot(HaveOccurred())
@@ -13277,6 +13330,11 @@ var _ = Describe("UnbindHost", func() {
 			InfraEnvID: infraEnvID,
 		}
 		err := errors.Errorf("Transition failed")
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostUnbindFailedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityError)))
 		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false).Return(err).Times(1)
 		response := bm.UnbindHost(ctx, params)
 		verifyApiError(response, http.StatusInternalServerError)

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -4866,6 +4866,188 @@ func (e *HostRegistrationSucceededEvent) FormatMessage() string {
 }
 
 //
+// Event host_bind_succeeded
+//
+type HostBindSucceededEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
+    HostName string
+}
+
+var HostBindSucceededEventName string = "host_bind_succeeded"
+
+func NewHostBindSucceededEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,
+) *HostBindSucceededEvent {
+    return &HostBindSucceededEvent{
+        eventName: HostBindSucceededEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
+        HostName: hostName,
+    }
+}
+
+func SendHostBindSucceededEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,) {
+    ev := NewHostBindSucceededEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        hostName,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostBindSucceededEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,
+    eventTime time.Time) {
+    ev := NewHostBindSucceededEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        hostName,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostBindSucceededEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostBindSucceededEvent) GetSeverity() string {
+    return "info"
+}
+func (e *HostBindSucceededEvent) GetClusterId() *strfmt.UUID {
+    return e.ClusterId
+}
+func (e *HostBindSucceededEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostBindSucceededEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostBindSucceededEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+        "{host_name}", fmt.Sprint(e.HostName),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostBindSucceededEvent) FormatMessage() string {
+    s := "Host {host_name}: Successfully bound to cluster {cluster_id}"
+    return e.format(&s)
+}
+
+//
+// Event host_unbind_succeeded
+//
+type HostUnbindSucceededEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    HostName string
+}
+
+var HostUnbindSucceededEventName string = "host_unbind_succeeded"
+
+func NewHostUnbindSucceededEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,
+) *HostUnbindSucceededEvent {
+    return &HostUnbindSucceededEvent{
+        eventName: HostUnbindSucceededEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        HostName: hostName,
+    }
+}
+
+func SendHostUnbindSucceededEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,) {
+    ev := NewHostUnbindSucceededEvent(
+        hostId,
+        infraEnvId,
+        hostName,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostUnbindSucceededEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,
+    eventTime time.Time) {
+    ev := NewHostUnbindSucceededEvent(
+        hostId,
+        infraEnvId,
+        hostName,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostUnbindSucceededEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostUnbindSucceededEvent) GetSeverity() string {
+    return "info"
+}
+func (e *HostUnbindSucceededEvent) GetClusterId() *strfmt.UUID {
+    return nil
+}
+func (e *HostUnbindSucceededEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostUnbindSucceededEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostUnbindSucceededEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{host_name}", fmt.Sprint(e.HostName),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostUnbindSucceededEvent) FormatMessage() string {
+    s := "Host {host_name}: Successfully unbound from cluster"
+    return e.format(&s)
+}
+
+//
 // Event generate_image_format_failed
 //
 type GenerateImageFormatFailedEvent struct {
@@ -5340,6 +5522,188 @@ func (e *HostRegistrationFailedEvent) format(message *string) string {
 
 func (e *HostRegistrationFailedEvent) FormatMessage() string {
     s := "{message}"
+    return e.format(&s)
+}
+
+//
+// Event host_bind_failed
+//
+type HostBindFailedEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
+    Message string
+}
+
+var HostBindFailedEventName string = "host_bind_failed"
+
+func NewHostBindFailedEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,
+) *HostBindFailedEvent {
+    return &HostBindFailedEvent{
+        eventName: HostBindFailedEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
+        Message: message,
+    }
+}
+
+func SendHostBindFailedEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,) {
+    ev := NewHostBindFailedEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        message,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostBindFailedEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,
+    eventTime time.Time) {
+    ev := NewHostBindFailedEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        message,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostBindFailedEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostBindFailedEvent) GetSeverity() string {
+    return "error"
+}
+func (e *HostBindFailedEvent) GetClusterId() *strfmt.UUID {
+    return e.ClusterId
+}
+func (e *HostBindFailedEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostBindFailedEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostBindFailedEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+        "{message}", fmt.Sprint(e.Message),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostBindFailedEvent) FormatMessage() string {
+    s := "Failed to bind host {host_id} to cluster {cluster_id}: {message}"
+    return e.format(&s)
+}
+
+//
+// Event host_unbind_failed
+//
+type HostUnbindFailedEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    Message string
+}
+
+var HostUnbindFailedEventName string = "host_unbind_failed"
+
+func NewHostUnbindFailedEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,
+) *HostUnbindFailedEvent {
+    return &HostUnbindFailedEvent{
+        eventName: HostUnbindFailedEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        Message: message,
+    }
+}
+
+func SendHostUnbindFailedEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,) {
+    ev := NewHostUnbindFailedEvent(
+        hostId,
+        infraEnvId,
+        message,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostUnbindFailedEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,
+    eventTime time.Time) {
+    ev := NewHostUnbindFailedEvent(
+        hostId,
+        infraEnvId,
+        message,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostUnbindFailedEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostUnbindFailedEvent) GetSeverity() string {
+    return "error"
+}
+func (e *HostUnbindFailedEvent) GetClusterId() *strfmt.UUID {
+    return nil
+}
+func (e *HostUnbindFailedEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostUnbindFailedEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostUnbindFailedEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{message}", fmt.Sprint(e.Message),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostUnbindFailedEvent) FormatMessage() string {
+    s := "Failed to unbind host {host_id} to cluster: {message}"
     return e.format(&s)
 }
 


### PR DESCRIPTION
[MGMT-11642](https://issues.redhat.com/browse/MGMT-11642)
Adds host bind/unbind events and correct the unit tests to expect these new
events where appropriate.

Previously, these unit tests incorrectly expected events which was not caught
by ginkgo. When ginkgo is upgraded to v2, these unit tests will correctly fail. The 
original event expected `HostRegistrationFailedEvent` did not match the test or
flow.

Bind/Unbind hosts should trigger an event, since binding/unbinding is different from
registering/unregistering.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR
[MGMT-11642](https://issues.redhat.com/browse/MGMT-11642)

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin @nmagnezi @filanov 