### PR TITLE
NO-ISSUE: Fix command syntax for getting postgres size

### DIFF
--- a/tools/pvc_size_utils.py
+++ b/tools/pvc_size_utils.py
@@ -89,7 +89,7 @@ def extract_requested_size_from_yaml_docs(name, docs):
 def get_current_size_if_exist(target, namespace, pvc_name):
     kubectl_cmd = utils.get_kubectl_command(target, namespace)
 
-    jsonpath = ".spec.resources.requests.storage"
+    jsonpath = "{.spec.resources.requests.storage}"
 
     command = shlex.split(kubectl_cmd) + [
         "get",
@@ -119,7 +119,7 @@ def get_current_size_if_exist(target, namespace, pvc_name):
             f"failed to get {jsonpath} of pvc {pvc_name}: empty output"
         )
 
-    return stdout
+    return stdout.strip('"')
 
 
 def determine_which_size_to_deploy(req, cur=None):


### PR DESCRIPTION
The kubectl command was missing curly braces. The output would be: `".spec.resources.requests.storage"`, causing the rest of the script to error out.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested): 
    - deployed subystem tests and `make deploy-service-for-subsystem-test` passed successfully. 
    - Also added the following into `tools/pvc_size_utils.py` and ran `$ python3 tools/pvc_size_utils.py` to make sure the output was correct.
    ```
    if __name__ == "__main__":
        size = get_current_size_if_exist(target="local", namespace="assisted-installer", pvc_name="postgres-pv-claim")
        print(size)
    ```
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @omertuc @adriengentil 