### PR TITLE
Bug 2107715: Add validation for Agent's role

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -138,6 +138,10 @@ func updateRole(log logrus.FieldLogger, h *models.Host, role models.HostRole, su
 	fields := make(map[string]interface{})
 	fields["suggested_role"] = suggestedRole
 	if srcRole != string(role) {
+		if !hostutil.IsRoleValid(role, hostutil.IsDay2Host(h)) {
+			return common.NewApiError(http.StatusBadRequest,
+				errors.Errorf("Requested role (%s) is invalid for host %s from infraEnv %s", role, h.ID, h.InfraEnvID))
+		}
 		fields["role"] = role
 
 		if role == models.HostRoleWorker {

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -96,6 +96,16 @@ func ValidateHostname(hostname string) error {
 	return nil
 }
 
+func IsRoleValid(requestedRole models.HostRole, isDay2Host bool) bool {
+	roleSet := map[models.HostRole]struct{}{models.HostRoleAutoAssign: {}, models.HostRoleBootstrap: {}, models.HostRoleMaster: {}, models.HostRoleWorker: {}}
+	if isDay2Host {
+		roleSet = map[models.HostRole]struct{}{models.HostRoleMaster: {}, models.HostRoleWorker: {}}
+	}
+
+	_, exists := roleSet[requestedRole]
+	return exists
+}
+
 // determineDefaultInstallationDisk considers both the previously set installation disk and the current list of valid
 // disks to determine the current required installation disk.
 //


### PR DESCRIPTION
This PR adds validation for the Agent's role whenever an update is requested. This is in order to prevent configuration where an incorrect role causes the Node to try to download a non-existing ignition file and fail the installation without a clear error returned to the end user.

With this change, as soon as an attempt to set an invalid role is detected, an API error will be returned preventing the change to be applied (in the REST API flow) or causing Agent CR to return a SpecSync error (in the Kube API flow).

Closes: [MGMTBUGSM-473](https://issues.redhat.com//browse/MGMTBUGSM-473)

/cc @omertuc 
