### PR TITLE
MGMT-12167: Make possible to mirror an index referenced by digest

### DIFF
--- a/deploy/operator/mirror_utils.sh
+++ b/deploy/operator/mirror_utils.sh
@@ -21,7 +21,12 @@ function mirror_package() {
 
   catalog_source_name="${5}"
 
-  local_registry_index_tag="${local_registry}/olm-index/${remote_index##*/}"
+  # If the remote index is referenced using name and tag, use "name:tag" for the local image.
+  # If the remote index is referenced using a digest, use "name:digest" for the local image.
+  local_index_name=${remote_index##*/}
+  local_index_name="${local_index_name/@*:/:}"
+
+  local_registry_index_tag="${local_registry}/olm-index/${local_index_name}"
   local_registry_image_tag="${local_registry}/olm"
 
   opm index prune \


### PR DESCRIPTION
Use the digest of the remote image to name the mirrored image locally.
e.g.: `quay.io/me/index@sha256:a02f...` will become
`mylocalregistry/olm-index/index:a02f...` locally.

x-ref: https://github.com/openshift/release/pull/32685
