### PR TITLE
fixing small documentation error in Patch InfraEnv section

### DIFF
--- a/docs/user-guide/rest-api-getting-started.md
+++ b/docs/user-guide/rest-api-getting-started.md
@@ -96,7 +96,7 @@ curl -X PATCH -H "Content-Type: application/json" \
 * Note: Configure your public SSH key here to gain SSH access to your hosts in the discovery phase (pre-install).
 
 ```bash
-curl -X POST -H "Content-Type: application/json" \
+curl -X PATCH -H "Content-Type: application/json" \
     -d '{"proxy":{"http_proxy":"","https_proxy":"","no_proxy":""},"ssh_authorized_key":"<public_key_here>","pull_secret":"","image_type":"full-iso"}' \
     <HOST>:<PORT>/api/assisted-install/v2/infra-envs/<infra_en_id>
 ```


### PR DESCRIPTION
Signed-off-by: Mark D <xphyr@users.noreply.github.com>

Fixed a small documentation error in the "Patch InfraEnv" section where the curl example was using a "POST" instead of a "PATCH".  Should make the docs more usable.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [X] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
