### PR TITLE
MGMT-1107: Make host stage timeouts configurable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,6 +196,9 @@ func maxDuration(dur time.Duration, durations ...time.Duration) time.Duration {
 
 func main() {
 	err := envconfig.Process(common.EnvConfigPrefix, &Options)
+	if err == nil {
+		err = Options.HostConfig.Complete()
+	}
 	log := InitLogs()
 
 	if err != nil {

--- a/internal/host/config.go
+++ b/internal/host/config.go
@@ -1,0 +1,95 @@
+package host
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+)
+
+type Config struct {
+	LogTimeoutConfig
+	EnableAutoReset          bool                    `envconfig:"ENABLE_AUTO_RESET" default:"false"`
+	EnableAutoAssign         bool                    `envconfig:"ENABLE_AUTO_ASSIGN" default:"true"`
+	ResetTimeout             time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
+	MonitorBatchSize         int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
+	DisabledHostvalidations  DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:""` // Which host validations to disable (should not run in preprocess)
+	BootstrapHostMAC         string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
+	MaxHostDisconnectionTime time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
+	EnableVirtualInterfaces  bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
+
+	// hostStageTimeouts contains the values of the host stage timeouts. Don't use this
+	// directly, use the HostStageTimeout method instead.
+	hostStageTimeouts map[models.HostStage]time.Duration `ignored:"true"`
+}
+
+// Complete performs additional processing of the configuration after it has been loaded by the
+// envconfig library. For example, it loads the values of the host stage timeouts from the
+// environment.
+func (c *Config) Complete() error {
+	values := map[models.HostStage]time.Duration{}
+	for stage, value := range hostStageTimeoutDefaults {
+		stageName := strings.ToUpper(strings.ReplaceAll(string(stage), " ", "_"))
+		envName := fmt.Sprintf("HOST_STAGE_%s_TIMEOUT", stageName)
+		envValue, ok := os.LookupEnv(envName)
+		if ok {
+			var err error
+			value, err = time.ParseDuration(envValue)
+			if err != nil {
+				return errors.Wrapf(
+					err,
+					"failed to parse timeout of host stage '%s' from value of "+
+						"environment variable '%s'",
+					stage, envName,
+				)
+			}
+		}
+		values[stage] = value
+	}
+	c.hostStageTimeouts = values
+	return nil
+}
+
+// hostStageTimeoutDefaults contains the built-in default values for the host stage timeouts.
+var hostStageTimeoutDefaults = map[models.HostStage]time.Duration{
+	models.HostStageStartingInstallation:   30 * time.Minute,
+	models.HostStageWaitingForControlPlane: 60 * time.Minute,
+	models.HostStageWaitingForController:   60 * time.Minute,
+	models.HostStageWaitingForBootkube:     60 * time.Minute,
+	models.HostStageInstalling:             60 * time.Minute,
+	models.HostStageJoined:                 60 * time.Minute,
+	models.HostStageWritingImageToDisk:     30 * time.Minute,
+	models.HostStageRebooting:              40 * time.Minute,
+	models.HostStageConfiguring:            60 * time.Minute,
+	models.HostStageWaitingForIgnition:     24 * time.Hour,
+}
+
+// hostStageTimeoutDefault is the default timeout for stages that aren't explicitly enumerated in
+// the map above.
+const hostStageTimeoutDefault = 60 * time.Minute
+
+// HostStageTimeout returns the timeout for the given host stage.
+//
+// If the Complete method of the configuration has been called then then the timeout for a stage
+// will be taken from an environment variable. If that environment variable doesn't exist then it
+// will return a built-in default.
+//
+// The values of the environment variables should use the format used by the time.ParseDuration
+// method.
+//
+// The names of the environment variables will be calculated converting the stage name to upper
+// case, replacing spaces with underscores and adding the `HOST_STAGE_` prefix and the `_TIMEOUT`
+// suffix. For example, for the `Starting installation` stage the name of the environment variable
+// will be `HOST_STAGE_STARTING_INSTALLATION_TIMEOUT`.
+func (c *Config) HostStageTimeout(stage models.HostStage) time.Duration {
+	if c.hostStageTimeouts != nil {
+		value, ok := c.hostStageTimeouts[stage]
+		if ok {
+			return value
+		}
+	}
+	return hostStageTimeoutDefault
+}

--- a/internal/host/config_test.go
+++ b/internal/host/config_test.go
@@ -1,0 +1,102 @@
+package host
+
+import (
+	"os"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("Host stage timeout configuration", func() {
+	DescribeTable(
+		"Takes the value from the environment",
+		func(stage models.HostStage, envName, envValue string, expected time.Duration) {
+			oldValue, ok := os.LookupEnv(envName)
+			if ok {
+				defer os.Setenv(envName, oldValue)
+			} else {
+				defer os.Unsetenv(envName)
+			}
+			os.Setenv(envName, envValue)
+			config := &Config{}
+			err := envconfig.Process("", config)
+			Expect(err).ToNot(HaveOccurred())
+			err = config.Complete()
+			Expect(err).ToNot(HaveOccurred())
+			actual := config.HostStageTimeout(stage)
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"Starting installation",
+			models.HostStageStartingInstallation,
+			"HOST_STAGE_STARTING_INSTALLATION_TIMEOUT",
+			"42s",
+			42*time.Second,
+		),
+		Entry(
+			"Waiting for control plane",
+			models.HostStageWaitingForControlPlane,
+			"HOST_STAGE_WAITING_FOR_CONTROL_PLANE_TIMEOUT",
+			"51m",
+			51*time.Minute,
+		),
+	)
+
+	DescribeTable(
+		"Takes the value from the defaults",
+		func(stage models.HostStage, expected time.Duration) {
+			config := &Config{}
+			err := envconfig.Process("", config)
+			Expect(err).ToNot(HaveOccurred())
+			err = config.Complete()
+			Expect(err).ToNot(HaveOccurred())
+			value := config.HostStageTimeout(stage)
+			Expect(value).To(Equal(expected))
+		},
+		Entry(
+			"Starting installation",
+			models.HostStageStartingInstallation,
+			30*time.Minute,
+		),
+		Entry(
+			"Waiting for control plane",
+			models.HostStageWaitingForControlPlane,
+			60*time.Minute,
+		),
+	)
+
+	It("Fails if environment value isn't valid duration", func() {
+		const (
+			envName  = "HOST_STAGE_STARTING_INSTALLATION_TIMEOUT"
+			envValue = "junk"
+		)
+		oldValue, ok := os.LookupEnv(envName)
+		if ok {
+			defer os.Setenv(envName, oldValue)
+		} else {
+			defer os.Unsetenv(envName)
+		}
+		os.Setenv(envName, envValue)
+		config := &Config{}
+		err := envconfig.Process("", config)
+		Expect(err).ToNot(HaveOccurred())
+		err = config.Complete()
+		Expect(err).To(HaveOccurred())
+		msg := err.Error()
+		Expect(msg).To(ContainSubstring(string(models.HostStageStartingInstallation)))
+		Expect(msg).To(ContainSubstring(envName))
+		Expect(msg).To(ContainSubstring(envValue))
+	})
+
+	It("Uses the default for unknown stages", func() {
+		config := &Config{}
+		err := envconfig.Process("", config)
+		Expect(err).ToNot(HaveOccurred())
+		value := config.HostStageTimeout(models.HostStage("Doing something"))
+		Expect(value).To(Equal(60 * time.Minute))
+	})
+})

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -34,20 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var InstallationProgressTimeout = map[models.HostStage]time.Duration{
-	models.HostStageStartingInstallation:   30 * time.Minute,
-	models.HostStageWaitingForControlPlane: 60 * time.Minute,
-	models.HostStageWaitingForController:   60 * time.Minute,
-	models.HostStageWaitingForBootkube:     60 * time.Minute,
-	models.HostStageInstalling:             60 * time.Minute,
-	models.HostStageJoined:                 60 * time.Minute,
-	models.HostStageWritingImageToDisk:     30 * time.Minute,
-	models.HostStageRebooting:              40 * time.Minute,
-	models.HostStageConfiguring:            60 * time.Minute,
-	models.HostStageWaitingForIgnition:     24 * time.Hour,
-	"DEFAULT":                              60 * time.Minute,
-}
-
 const singleNodeRebootTimeout = 80 * time.Minute
 
 var WrongBootOrderIgnoreTimeoutStages = []models.HostStage{
@@ -73,18 +59,6 @@ const (
 type LogTimeoutConfig struct {
 	LogCollectionTimeout time.Duration `envconfig:"HOST_LOG_COLLECTION_TIMEOUT" default:"10m"`
 	LogPendingTimeout    time.Duration `envconfig:"HOST_LOG_PENDING_TIMEOUT" default:"2m"`
-}
-
-type Config struct {
-	LogTimeoutConfig
-	EnableAutoReset          bool                    `envconfig:"ENABLE_AUTO_RESET" default:"false"`
-	EnableAutoAssign         bool                    `envconfig:"ENABLE_AUTO_ASSIGN" default:"true"`
-	ResetTimeout             time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`
-	MonitorBatchSize         int                     `envconfig:"HOST_MONITOR_BATCH_SIZE" default:"100"`
-	DisabledHostvalidations  DisabledHostValidations `envconfig:"DISABLED_HOST_VALIDATIONS" default:""` // Which host validations to disable (should not run in preprocess)
-	BootstrapHostMAC         string                  `envconfig:"BOOTSTRAP_HOST_MAC" default:""`        // For ephemeral installer to ensure the bootstrap for the (single) cluster lands on the same host as assisted-service
-	MaxHostDisconnectionTime time.Duration           `envconfig:"HOST_MAX_DISCONNECTION_TIME" default:"3m"`
-	EnableVirtualInterfaces  bool                    `envconfig:"ENABLE_VIRTUAL_INTERFACES" default:"false"`
 }
 
 //go:generate mockgen --build_flags=--mod=mod -package=host -aux_files=github.com/openshift/assisted-service/internal/host/hostcommands=instruction_manager.go -destination=mock_host_api.go . API

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -40,7 +40,12 @@ import (
 var (
 	defaultHwInfo                  = "default hw info" // invalid hw info used only for tests
 	defaultDisabledHostValidations = DisabledHostValidations{}
-	defaultConfig                  = &Config{
+	defaultConfig                  *Config
+	defaultNTPSources              = []*models.NtpSource{common.TestNTPSourceSynced}
+)
+
+var _ = BeforeEach(func() {
+	defaultConfig = &Config{
 		ResetTimeout:             3 * time.Minute,
 		EnableAutoReset:          true,
 		EnableAutoAssign:         true,
@@ -48,8 +53,9 @@ var (
 		DisabledHostvalidations:  defaultDisabledHostValidations,
 		MaxHostDisconnectionTime: MaxHostDisconnectionTime,
 	}
-	defaultNTPSources = []*models.NtpSource{common.TestNTPSourceSynced}
-)
+	err := defaultConfig.Complete()
+	Expect(err).ToNot(HaveOccurred())
+})
 
 var _ = Describe("update_role", func() {
 	var (

--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -618,10 +618,7 @@ func (th *transitionHandler) HasInstallationInProgressTimedOut(sw stateswitch.St
 	if !ok {
 		return false, errors.New("HasInstallationInProgressTimedOut incompatible type of StateSwitch")
 	}
-	maxDuration, ok := InstallationProgressTimeout[sHost.host.Progress.CurrentStage]
-	if !ok {
-		maxDuration = InstallationProgressTimeout["DEFAULT"]
-	}
+	maxDuration := th.config.HostStageTimeout(sHost.host.Progress.CurrentStage)
 	if sHost.host.Progress.CurrentStage == models.HostStageRebooting {
 		if hostutil.IsSingleNode(th.log, th.db, sHost.host) {
 			// use extended reboot timeout for SNO
@@ -653,7 +650,8 @@ func (th *transitionHandler) PostRefreshHost(reason string) stateswitch.PostTran
 			template = statusInfoInstallationInProgressWritingImageToDiskTimedOut
 		}
 		template = strings.Replace(template, "$STAGE", string(sHost.host.Progress.CurrentStage), 1)
-		template = strings.Replace(template, "$MAX_TIME", InstallationProgressTimeout[sHost.host.Progress.CurrentStage].String(), 1)
+		maxTime := th.config.HostStageTimeout(sHost.host.Progress.CurrentStage)
+		template = strings.Replace(template, "$MAX_TIME", maxTime.String(), 1)
 		if strings.Contains(template, "$INSTALLATION_DISK") {
 			var installationDisk *models.Disk
 			installationDisk, err = hostutil.GetHostInstallationDisk(sHost.host)

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1472,7 +1472,7 @@ var _ = Describe("Refresh Host", func() {
 				if t.expectTimeout {
 					Expect(prevStageUpdatedAt).Should(Equal(currStageUpdateAt))
 					Expect(swag.StringValue(resultHost.Status)).Should(Equal(models.HostStatusError))
-					Expect(swag.StringValue(resultHost.StatusInfo)).Should(Equal(formatProgressTimedOutInfo(t.stage)))
+					Expect(swag.StringValue(resultHost.StatusInfo)).Should(Equal(formatProgressTimedOutInfo(defaultConfig, t.stage)))
 				} else {
 					if funk.Contains(WrongBootOrderIgnoreTimeoutStages, t.stage) {
 						Expect(prevStageUpdatedAt).ShouldNot(Equal(currStageUpdateAt))
@@ -1922,7 +1922,7 @@ var _ = Describe("Refresh Host", func() {
 								Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(statusInfo))
 							} else {
 								Expect(swag.StringValue(resultHost.Status)).To(Equal(models.HostStatusError))
-								info := formatProgressTimedOutInfo(stage)
+								info := formatProgressTimedOutInfo(defaultConfig, stage)
 								Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(info))
 							}
 						}
@@ -1975,10 +1975,10 @@ var _ = Describe("Refresh Host", func() {
 			var resultHost models.Host
 			Expect(db.Take(&resultHost, "id = ? and cluster_id = ?", hostId.String(), clusterId.String()).Error).ToNot(HaveOccurred())
 
-			info := formatProgressTimedOutInfo(models.HostStageWaitingForControlPlane)
+			info := formatProgressTimedOutInfo(defaultConfig, models.HostStageWaitingForControlPlane)
 			Expect(swag.StringValue(resultMaster.StatusInfo)).To(Equal(info))
 
-			info = formatProgressTimedOutInfo(models.HostStageConfiguring)
+			info = formatProgressTimedOutInfo(defaultConfig, models.HostStageConfiguring)
 			Expect(swag.StringValue(resultHost.StatusInfo)).To(Equal(info))
 		})
 
@@ -6031,8 +6031,8 @@ func mockPreflightInfraEnvHardwareRequirements(mockHwValidator *hardware.MockVal
 		}, nil)
 }
 
-func formatProgressTimedOutInfo(stage models.HostStage) string {
-	timeFormat := InstallationProgressTimeout[stage].String()
+func formatProgressTimedOutInfo(config *Config, stage models.HostStage) string {
+	timeFormat := config.HostStageTimeout(stage).String()
 	statusInfo := statusInfoInstallationInProgressTimedOut
 	if stage == models.HostStageWritingImageToDisk {
 		statusInfo = statusInfoInstallationInProgressWritingImageToDiskTimedOut


### PR DESCRIPTION
Currently the host stage timeouts are hardcoded and can't be configured. This patch makes them configurable via environment variables. The names of these environment variables will be calculated from the name of the stage. For example:

- _Starting installation_ - `HOST_STAGE_STARTING_INSTALLATION_TIMEOUT`
- _Waiting for control plane_ - `HOST_STAGE_WAITING_FOR_CONTROL_PLANE_TIMEOUT`

The values of these environment variables will be strings acceptable by the `time.ParseDuration` function, for example `42s` or `51m`.

Related: https://issues.redhat.com/browse/MGMT-11075

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
