### PR TITLE
MGMT-9023: Add hyperthreading feature usage

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2203,6 +2203,11 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 		}
 	}
 
+	if params.ClusterUpdateParams.Hyperthreading != nil {
+		b.setUsage(*params.ClusterUpdateParams.Hyperthreading != models.ClusterHyperthreadingNone, usage.HyperthreadingUsage,
+			&map[string]interface{}{"hyperthreading_enabled": *params.ClusterUpdateParams.Hyperthreading}, usages)
+	}
+
 	if len(updates) > 0 {
 		updates["trigger_monitor_timestamp"] = time.Now()
 		err = db.Model(&common.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(updates).Error
@@ -2524,6 +2529,8 @@ func (b *bareMetalInventory) setDefaultUsage(cluster *models.Cluster) error {
 	b.setUsage(network.CheckIfClusterModelIsDualStack(cluster), usage.DualStackUsage, nil, usages)
 	b.setDiskEncryptionUsage(cluster, cluster.DiskEncryption, usages)
 	b.setUsage(cluster.Tags != "", usage.ClusterTags, nil, usages)
+	b.setUsage(cluster.Hyperthreading != models.ClusterHyperthreadingNone, usage.HyperthreadingUsage,
+		&map[string]interface{}{"hyperthreading_enabled": cluster.Hyperthreading}, usages)
 	//write all the usages to the cluster object
 	err := b.providerRegistry.SetPlatformUsages(common.PlatformTypeValue(cluster.Platform.Type), usages, b.usageApi)
 	if err != nil {

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -49,4 +49,6 @@ const (
 	LVM string = "LVM"
 	// Nutanix integration
 	NutanixIntegration string = "Nutanix integration"
+	// Usage of hyperthreading
+	HyperthreadingUsage string = "Hyperthreading"
 )

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1290,7 +1290,8 @@ var _ = Describe("cluster install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			log.Infof("usage after create: %s\n", getReply.Payload.FeatureUsage)
 			verifyUsageSet(getReply.Payload.FeatureUsage,
-				models.Usage{Name: usage.HighAvailabilityModeUsage})
+				models.Usage{Name: usage.HighAvailabilityModeUsage},
+				models.Usage{Name: usage.HyperthreadingUsage, Data: map[string]interface{}{"hyperthreading_enabled": models.ClusterHyperthreadingAll}})
 			verifyUsageNotSet(getReply.Payload.FeatureUsage,
 				strings.ToUpper("console"),
 				usage.VipDhcpAllocationUsage,
@@ -1313,6 +1314,7 @@ var _ = Describe("cluster install", func() {
 			no_proxy := "a.redhat.com"
 			ovn := "OVNKubernetes"
 			hostname := "h1"
+			hyperthreading := "none"
 			_, err = userBMClient.Installer.V2UpdateHost(ctx, &installer.V2UpdateHostParams{
 				HostUpdateParams: &models.HostUpdateParams{
 					HostName: &hostname,
@@ -1330,6 +1332,7 @@ var _ = Describe("cluster install", func() {
 					NoProxy:               &no_proxy,
 					NetworkType:           &ovn,
 					UserManagedNetworking: swag.Bool(false),
+					Hyperthreading:        &hyperthreading,
 				},
 				ClusterID: clusterID,
 			})
@@ -1338,7 +1341,8 @@ var _ = Describe("cluster install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			verifyUsageNotSet(getReply.Payload.FeatureUsage,
 				usage.SDNNetworkTypeUsage,
-				usage.DualStackUsage)
+				usage.DualStackUsage,
+				usage.HyperthreadingUsage)
 			verifyUsageSet(getReply.Payload.FeatureUsage,
 				models.Usage{Name: usage.OVNNetworkTypeUsage},
 				models.Usage{


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9023
The hyperthreading feature usage will appear like
this:
````
  "Hyperthreading": {
    "data": {
      "hyperthreading_enabled": "all"
    },
    "id": "HYPERTHREADING",
    "name": "Hyperthreading"
  },
````

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Test steps:
1. Deploy assisted-service with these changes and created a cluster
2. Get the cluster's feature usage to see the default setting was applied
    ````
    $ curl ${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} | jq -r '.feature_usage' | jq '.Hyperthreading'
      "Hyperthreading": {
        "data": {
          "enabled": "all"
        },
        "id": "HYPERTHREADING",
        "name": "Hyperthreading"
      }
    ````
3. Patch the cluster to not use hyperthreading
    ````
    $ curl ${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} -X PATCH -H "Content-Type: application/json" -d '{"hyperthreading":"none"}'
    ````
5. Get the cluster's feature usage to see the feature usage was removed
    ````
    $ curl ${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} | jq -r '.feature_usage' | jq '.Hyperthreading'
    null
    ````
7. Patch the cluster to only use hyperthreading on masters
    ````
    $ curl ${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} -X PATCH -H "Content-Type: application/json" -d '{"hyperthreading":"masters"}'
    ````
9. Get the cluster's feature usage to see the feature usage only set it to masters
    ````
    $ curl ${ASSISTED_SERVICE_URL}/api/assisted-install/v2/clusters/${CLUSTER_ID} | jq -r '.feature_usage' | jq '.Hyperthreading'
      "Hyperthreading": {
        "data": {
          "enabled": "masters"
        },
        "id": "HYPERTHREADING",
        "name": "Hyperthreading"
      }
    ````

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests) - added subsystem test check

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 
