### PR TITLE
MGMT-11642: Add Host Bind/Unbind Events (#4490)

### DIFF
--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -505,6 +505,25 @@ x-events:
     cluster_id: UUID_PTR
     host_name: string
 
+- name: host_bind_succeeded
+  message: "Host {host_name}: Successfully bound to cluster {cluster_id}"
+  event_type: host
+  severity: "info"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    cluster_id: UUID_PTR
+    host_name: string
+
+- name: host_unbind_succeeded
+  message: "Host {host_name}: Successfully unbound from cluster"
+  event_type: host
+  severity: "info"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    host_name: string
+
 - name: generate_image_format_failed
   message: "Failed to generate image: error formatting ignition file"
   event_type: infra_env
@@ -553,6 +572,25 @@ x-events:
     host_id: UUID
     infra_env_id: UUID
     cluster_id: UUID_PTR
+    message: string
+
+- name: host_bind_failed
+  message: "Failed to bind host {host_id} to cluster {cluster_id}: {message}"
+  event_type: host
+  severity: "error"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
+    cluster_id: UUID_PTR
+    message: string
+
+- name: host_unbind_failed
+  message: "Failed to unbind host {host_id} to cluster: {message}"
+  event_type: host
+  severity: "error"
+  properties:
+    host_id: UUID
+    infra_env_id: UUID
     message: string
 
 - name: inactive_clusters_deregistered

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4872,8 +4872,10 @@ func (b *bareMetalInventory) V2UpdateHostInstallProgress(ctx context.Context, pa
 func (b *bareMetalInventory) BindHost(ctx context.Context, params installer.BindHostParams) middleware.Responder {
 	h, err := b.BindHostInternal(ctx, params)
 	if err != nil {
+		eventgen.SendHostBindFailedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, params.BindHostParams.ClusterID, err.Error())
 		return common.GenerateErrorResponder(err)
 	}
+	eventgen.SendHostBindSucceededEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, params.BindHostParams.ClusterID, hostutil.GetHostnameForMsg(&h.Host))
 	return installer.NewBindHostOK().WithPayload(&h.Host)
 }
 
@@ -4979,8 +4981,10 @@ func (b *bareMetalInventory) UnbindHostInternal(ctx context.Context, params inst
 func (b *bareMetalInventory) UnbindHost(ctx context.Context, params installer.UnbindHostParams) middleware.Responder {
 	h, err := b.UnbindHostInternal(ctx, params)
 	if err != nil {
+		eventgen.SendHostUnbindFailedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, err.Error())
 		return common.GenerateErrorResponder(err)
 	}
+	eventgen.SendHostUnbindSucceededEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID, hostutil.GetHostnameForMsg(&h.Host))
 	return installer.NewUnbindHostOK().WithPayload(&h.Host)
 }
 

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -4739,6 +4739,188 @@ func (e *HostRegistrationSucceededEvent) FormatMessage() string {
 }
 
 //
+// Event host_bind_succeeded
+//
+type HostBindSucceededEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
+    HostName string
+}
+
+var HostBindSucceededEventName string = "host_bind_succeeded"
+
+func NewHostBindSucceededEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,
+) *HostBindSucceededEvent {
+    return &HostBindSucceededEvent{
+        eventName: HostBindSucceededEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
+        HostName: hostName,
+    }
+}
+
+func SendHostBindSucceededEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,) {
+    ev := NewHostBindSucceededEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        hostName,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostBindSucceededEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    hostName string,
+    eventTime time.Time) {
+    ev := NewHostBindSucceededEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        hostName,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostBindSucceededEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostBindSucceededEvent) GetSeverity() string {
+    return "info"
+}
+func (e *HostBindSucceededEvent) GetClusterId() *strfmt.UUID {
+    return e.ClusterId
+}
+func (e *HostBindSucceededEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostBindSucceededEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostBindSucceededEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+        "{host_name}", fmt.Sprint(e.HostName),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostBindSucceededEvent) FormatMessage() string {
+    s := "Host {host_name}: Successfully bound to cluster {cluster_id}"
+    return e.format(&s)
+}
+
+//
+// Event host_unbind_succeeded
+//
+type HostUnbindSucceededEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    HostName string
+}
+
+var HostUnbindSucceededEventName string = "host_unbind_succeeded"
+
+func NewHostUnbindSucceededEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,
+) *HostUnbindSucceededEvent {
+    return &HostUnbindSucceededEvent{
+        eventName: HostUnbindSucceededEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        HostName: hostName,
+    }
+}
+
+func SendHostUnbindSucceededEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,) {
+    ev := NewHostUnbindSucceededEvent(
+        hostId,
+        infraEnvId,
+        hostName,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostUnbindSucceededEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    hostName string,
+    eventTime time.Time) {
+    ev := NewHostUnbindSucceededEvent(
+        hostId,
+        infraEnvId,
+        hostName,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostUnbindSucceededEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostUnbindSucceededEvent) GetSeverity() string {
+    return "info"
+}
+func (e *HostUnbindSucceededEvent) GetClusterId() *strfmt.UUID {
+    return nil
+}
+func (e *HostUnbindSucceededEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostUnbindSucceededEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostUnbindSucceededEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{host_name}", fmt.Sprint(e.HostName),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostUnbindSucceededEvent) FormatMessage() string {
+    s := "Host {host_name}: Successfully unbound from cluster"
+    return e.format(&s)
+}
+
+//
 // Event generate_image_format_failed
 //
 type GenerateImageFormatFailedEvent struct {
@@ -5213,6 +5395,188 @@ func (e *HostRegistrationFailedEvent) format(message *string) string {
 
 func (e *HostRegistrationFailedEvent) FormatMessage() string {
     s := "{message}"
+    return e.format(&s)
+}
+
+//
+// Event host_bind_failed
+//
+type HostBindFailedEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    ClusterId *strfmt.UUID
+    Message string
+}
+
+var HostBindFailedEventName string = "host_bind_failed"
+
+func NewHostBindFailedEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,
+) *HostBindFailedEvent {
+    return &HostBindFailedEvent{
+        eventName: HostBindFailedEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        ClusterId: clusterId,
+        Message: message,
+    }
+}
+
+func SendHostBindFailedEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,) {
+    ev := NewHostBindFailedEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        message,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostBindFailedEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    clusterId *strfmt.UUID,
+    message string,
+    eventTime time.Time) {
+    ev := NewHostBindFailedEvent(
+        hostId,
+        infraEnvId,
+        clusterId,
+        message,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostBindFailedEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostBindFailedEvent) GetSeverity() string {
+    return "error"
+}
+func (e *HostBindFailedEvent) GetClusterId() *strfmt.UUID {
+    return e.ClusterId
+}
+func (e *HostBindFailedEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostBindFailedEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostBindFailedEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+        "{message}", fmt.Sprint(e.Message),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostBindFailedEvent) FormatMessage() string {
+    s := "Failed to bind host {host_id} to cluster {cluster_id}: {message}"
+    return e.format(&s)
+}
+
+//
+// Event host_unbind_failed
+//
+type HostUnbindFailedEvent struct {
+    eventName string
+    HostId strfmt.UUID
+    InfraEnvId strfmt.UUID
+    Message string
+}
+
+var HostUnbindFailedEventName string = "host_unbind_failed"
+
+func NewHostUnbindFailedEvent(
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,
+) *HostUnbindFailedEvent {
+    return &HostUnbindFailedEvent{
+        eventName: HostUnbindFailedEventName,
+        HostId: hostId,
+        InfraEnvId: infraEnvId,
+        Message: message,
+    }
+}
+
+func SendHostUnbindFailedEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,) {
+    ev := NewHostUnbindFailedEvent(
+        hostId,
+        infraEnvId,
+        message,
+    )
+    eventsHandler.SendHostEvent(ctx, ev)
+}
+
+func SendHostUnbindFailedEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    hostId strfmt.UUID,
+    infraEnvId strfmt.UUID,
+    message string,
+    eventTime time.Time) {
+    ev := NewHostUnbindFailedEvent(
+        hostId,
+        infraEnvId,
+        message,
+    )
+    eventsHandler.SendHostEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *HostUnbindFailedEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *HostUnbindFailedEvent) GetSeverity() string {
+    return "error"
+}
+func (e *HostUnbindFailedEvent) GetClusterId() *strfmt.UUID {
+    return nil
+}
+func (e *HostUnbindFailedEvent) GetHostId() strfmt.UUID {
+    return e.HostId
+}
+func (e *HostUnbindFailedEvent) GetInfraEnvId() strfmt.UUID {
+    return e.InfraEnvId
+}
+
+
+
+func (e *HostUnbindFailedEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{host_id}", fmt.Sprint(e.HostId),
+        "{infra_env_id}", fmt.Sprint(e.InfraEnvId),
+        "{message}", fmt.Sprint(e.Message),
+    )
+    return r.Replace(*message)
+}
+
+func (e *HostUnbindFailedEvent) FormatMessage() string {
+    s := "Failed to unbind host {host_id} to cluster: {message}"
     return e.format(&s)
 }
 


### PR DESCRIPTION
Backport of PR
https://github.com/openshift/assisted-service/pull/4490

* [MGMT-11642](https://issues.redhat.com//browse/MGMT-11642): Add Host Bind/Unbind Event

Added a new host bind/unbind event since host
registration refers to a host registering to an
infra env whereas binding is related to a cluster.

* [MGMT-11642](https://issues.redhat.com//browse/MGMT-11642): Call Host Bind/Unbind Events

Call host bind/unbind events where appropriate.

* [MGMT-11642](https://issues.redhat.com//browse/MGMT-11642): Fix unit test by expecting the correct events

https://issues.redhat.com/browse/MGMT-11642
Previously, these unit tests still passed even though the expected mock events were either missing, incorrect, or not called.

Once ginkgo is upgraded, these tests will fail because ginkgo will actually check that these expected event calls happened.

This commit corrects a few incorrectly called events and adds expected event calls where needed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin @omertuc @filanov 