### PR TITLE
MGMT-10819: Ensure the preprovisioningimage arch matches the infraenv

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -49,6 +50,8 @@ import (
 )
 
 type imageConditionReason string
+
+const archMismatchReason = "InfraEnvArchMismatch"
 
 // PreprovisioningImage reconciles a AgentClusterInstall object
 type PreprovisioningImageReconciler struct {
@@ -105,11 +108,21 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		log.WithError(err).Error("failed to get corresponding infraEnv")
 		return ctrl.Result{}, err
 	}
-
 	if infraEnv == nil {
 		log.Info("failed to find infraEnv for image")
 		return ctrl.Result{}, nil
 	}
+
+	if infraEnv.Spec.CpuArchitecture != image.Spec.Architecture {
+		log.Infof("Image arch %s does not match infraEnv arch %s", image.Spec.Architecture, infraEnv.Spec.CpuArchitecture)
+		setMismatchedArchCondition(image, infraEnv.Spec.CpuArchitecture)
+		err = r.Status().Update(ctx, image)
+		if err != nil {
+			log.WithError(err).Error("failed to update status")
+		}
+		return ctrl.Result{}, err
+	}
+
 	if !IronicAgentEnabled(log, infraEnv) {
 		return r.AddIronicAgentToInfraEnv(ctx, log, infraEnv)
 	}
@@ -218,6 +231,17 @@ func setCoolDownCondition(image *metal3_v1alpha1.PreprovisioningImage) {
 func setUnsupportedFormatCondition(image *metal3_v1alpha1.PreprovisioningImage) {
 	message := "Unsupported image format"
 	reason := imageConditionReason(strcase.ToCamel(message))
+	setImageCondition(image.GetGeneration(), &image.Status,
+		metal3_v1alpha1.ConditionImageReady, metav1.ConditionFalse,
+		reason, message)
+	setImageCondition(image.GetGeneration(), &image.Status,
+		metal3_v1alpha1.ConditionImageError, metav1.ConditionTrue,
+		reason, message)
+}
+
+func setMismatchedArchCondition(image *metal3_v1alpha1.PreprovisioningImage, infraArch string) {
+	message := fmt.Sprintf("PreprovisioningImage CPU architecture (%s) does not match InfraEnv CPU architecture (%s)", image.Spec.Architecture, infraArch)
+	reason := imageConditionReason(archMismatchReason)
 	setImageCondition(image.GetGeneration(), &image.Status,
 		metal3_v1alpha1.ConditionImageReady, metav1.ConditionFalse,
 		reason, message)

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -288,6 +288,29 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
 		})
 
+		It("sets a failure condition when the infraEnv arch doesn't match the preprovisioningimage", func() {
+			infraEnv.Spec.CpuArchitecture = "aarch64"
+			Expect(c.Create(ctx, infraEnv)).To(BeNil())
+
+			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(ctrl.Result{}))
+
+			key := types.NamespacedName{
+				Namespace: testNamespace,
+				Name:      "testPPI",
+			}
+			Expect(c.Get(ctx, key, ppi)).To(BeNil())
+			readyCondition := meta.FindStatusCondition(ppi.Status.Conditions, string(metal3_v1alpha1.ConditionImageReady))
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCondition.Message).To(ContainSubstring("does not match InfraEnv CPU architecture"))
+			Expect(readyCondition.Reason).To(Equal(archMismatchReason))
+			errorCondition := meta.FindStatusCondition(ppi.Status.Conditions, string(metal3_v1alpha1.ConditionImageError))
+			Expect(errorCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errorCondition.Message).To(ContainSubstring("does not match InfraEnv CPU architecture"))
+			Expect(errorCondition.Reason).To(Equal(archMismatchReason))
+		})
+
 		It("doesn't fail when the infraEnv image has not been created yet", func() {
 			infraEnv.Status = aiv1beta1.InfraEnvStatus{}
 			infraEnv.ObjectMeta.Annotations = map[string]string{EnableIronicAgentAnnotation: "true"}


### PR DESCRIPTION
If the architectures don't match the controller now sets an error condition. The user can change the infraenv arch to resolve the issue.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-10819

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Set the arch incorrectly on an infraenv linked to a preprovisioning image and observe the conditions.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
