### PR TITLE
MGMT-12300: Fix nil pointer exception with v2uploadLogs

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -390,7 +390,9 @@ func (b *bareMetalInventory) v2uploadLogs(ctx context.Context, params installer.
 
 	defer func() {
 		// Closing file and removing all temporary files created by Multipart
-		params.Upfile.Close()
+		if params.Upfile != nil {
+			params.Upfile.Close()
+		}
 		params.HTTPRequest.Body.Close()
 		err := params.HTTPRequest.MultipartForm.RemoveAll()
 		if err != nil {

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -150,6 +150,12 @@ func (c *S3Client) CreateBucket() error {
 
 func (c *S3Client) uploadStream(ctx context.Context, reader io.Reader, objectName, bucket string, uploader s3manageriface.UploaderAPI) error {
 	log := logutil.FromContext(ctx, c.log)
+	if reader == nil {
+		err := errors.Errorf("Upfile log may not be nil. Cannot upload %s to bucket %s", objectName, bucket)
+		log.Error(err)
+		return err
+	}
+
 	_, err := uploader.Upload(&s3manager.UploadInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(objectName),

--- a/pkg/s3wrapper/client_test.go
+++ b/pkg/s3wrapper/client_test.go
@@ -3,6 +3,7 @@ package s3wrapper
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"time"
@@ -108,6 +109,13 @@ var _ = Describe("s3client", func() {
 		called := false
 		client.handleObject(ctx, log, &obj, now, deleteTime, func(ctx context.Context, log logrus.FieldLogger, objectName string) { called = true })
 		Expect(called).To(Equal(false))
+	})
+
+	It("fail UploadStream with nil reader", func() {
+		objectName := "fakeObjectName"
+		err := client.UploadStream(ctx, nil, objectName)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(Equal(fmt.Sprintf("Upfile log may not be nil. Cannot upload %s to bucket %s", objectName, bucket)))
 	})
 
 	Describe("createBucket", func() {


### PR DESCRIPTION
Using curl to upload a file without providing an `upfile` parameter leads to a nil pointer exception. This fix adds a check for nil before:
1. The attempt to upload the file via `s3client`.
2. The cleanup done with `params.Upfile.Close()`

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
