### PR TITLE
MGMT-12317: Add capabilities entries to install-config

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -102,6 +102,15 @@ type MachineNetwork struct {
 	Cidr string `yaml:"cidr"`
 }
 
+type ClusterVersionCapabilitySet string
+
+type ClusterVersionCapability string
+
+type Capabilities struct {
+	BaselineCapabilitySet         ClusterVersionCapabilitySet `yaml:"baselineCapabilitySet,omitempty"`
+	AdditionalEnabledCapabilities []ClusterVersionCapability  `yaml:"additionalEnabledCapabilities,omitempty"`
+}
+
 type InstallerConfigBaremetal struct {
 	APIVersion string `yaml:"apiVersion"`
 	BaseDomain string `yaml:"baseDomain"`
@@ -132,6 +141,7 @@ type InstallerConfigBaremetal struct {
 	SSHKey                string               `yaml:"sshKey"`
 	AdditionalTrustBundle string               `yaml:"additionalTrustBundle,omitempty"`
 	ImageContentSources   []ImageContentSource `yaml:"imageContentSources,omitempty"`
+	Capabilities          *Capabilities        `yaml:"capabilities,omitempty"`
 }
 
 func (c *InstallerConfigBaremetal) Validate() error {


### PR DESCRIPTION
In order to support composible openshift, we need to add capabilities fields to install-config, given that we're not importing from https://github.com/openshift/installer/blob/f7e1ded6aad8c0f32a6bff4f365d4eb775cd2391/pkg/types/installconfig.go#L89-L193

The capabilities feature gets documented by https://github.com/openshift/assisted-service/pull/4213

/cc @omertuc
/cc @mkowalski 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tried to update install-config via API customizing capabilities

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
