### PR TITLE
MGMT-11750: ensure namespace exists on spoke cluster (HASC)

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -160,6 +160,10 @@ const (
 	ReasonWebHookServiceAccountFailure string = "ReasonWebHookServiceAccountFailure"
 	// ReasonWebHookAPIServiceFailure when there was a failure related to the webhook's API service.
 	ReasonWebHookAPIServiceFailure string = "ReasonWebHookAPIServiceFailure"
+	// ReasonServiceServiceAccount when there was a failure configuring/deploying the assisted-service service-account.
+	ReasonServiceServiceAccount string = "ServiceServiceAccount"
+	// ReasonNamespaceCreationFailure when there was a failure creating the namespace.
+	ReasonNamespaceCreationFailure string = "NamespaceCreationFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -168,6 +168,12 @@ rules:
 - apiGroups:
   - agent-install.openshift.io
   resources:
+  - hypershiftagentserviceconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
   - hypershiftagentserviceconfigs/status
   verbs:
   - get

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -440,6 +440,12 @@ spec:
         - apiGroups:
           - agent-install.openshift.io
           resources:
+          - hypershiftagentserviceconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - agent-install.openshift.io
+          resources:
           - hypershiftagentserviceconfigs/status
           verbs:
           - get

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
@@ -160,6 +160,10 @@ const (
 	ReasonWebHookServiceAccountFailure string = "ReasonWebHookServiceAccountFailure"
 	// ReasonWebHookAPIServiceFailure when there was a failure related to the webhook's API service.
 	ReasonWebHookAPIServiceFailure string = "ReasonWebHookAPIServiceFailure"
+	// ReasonServiceServiceAccount when there was a failure configuring/deploying the assisted-service service-account.
+	ReasonServiceServiceAccount string = "ServiceServiceAccount"
+	// ReasonNamespaceCreationFailure when there was a failure creating the namespace.
+	ReasonNamespaceCreationFailure string = "NamespaceCreationFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"


### PR DESCRIPTION
 This PR handles the following:
 * Create namespace on spoke cluster to ensure it exists (the namespace of HASC resource).
 * Create assisted-service service-account on both hub and spoke clusters.
 * Restore client on AgentServiceConfigReconcileContext upon finishing reconcile (as there's a single context).

Note: to avoid switching the client property between hub and spoke, client should be extracted from AgentServiceConfigReconcileContext. That way, we could avoid sharing it and just pass it as needed.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
