### PR TITLE
MGMT-11799: change all 'go get' commands

### DIFF
--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -1,6 +1,6 @@
 ARG SERVICE=quay.io/edge-infrastructure/assisted-service:latest
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS download_dlv
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN GOFLAGS=-mod=mod go install github.com/go-delve/delve/cmd/dlv@v1.9.1
 
 FROM $SERVICE
 ARG DEBUG_SERVICE_PORT=40000

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -60,12 +60,12 @@ function podman_remote() {
 }
 
 function test_tools() {
-  go get github.com/onsi/ginkgo/ginkgo@v1.16.4 \
-      github.com/golang/mock/mockgen@v1.6.0 \
-      github.com/vektra/mockery/.../@v1.1.2 \
-      gotest.tools/gotestsum@v1.6.3 \
-      github.com/axw/gocov/gocov \
-      github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
+  go install github.com/onsi/ginkgo/ginkgo@v1.16.4
+  go install github.com/golang/mock/mockgen@v1.6.0
+  go install github.com/vektra/mockery/v2@v2.12.3
+  go install gotest.tools/gotestsum@v1.6.3
+  go install github.com/axw/gocov/gocov@latest
+  go install github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 }
 
 function assisted_service() {
@@ -93,8 +93,8 @@ function assisted_service() {
   chmod +x operator-sdk_${OS}_${ARCH}
   install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
 
-  go get golang.org/x/tools/cmd/goimports@v0.1.5 \
-        sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
+  go install golang.org/x/tools/cmd/goimports@v0.1.5
+  go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
 
   python3 -m venv ${VIRTUAL_ENV:-/opt/venv}
   python3 -m pip install --upgrade pip

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -28,12 +28,7 @@ volumes:
   - /var/lib/libvirt/:/var/lib/libvirt/
   - /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt
 
-  # podman - sharing the podman.socket between the host and the skipper container
-  # should be part of skipper implementation. https://github.com/Stratoscale/skipper/issues/153
-  # root user
-  - /run/podman/podman.sock:/run/podman/podman.sock
-  # other users
-  # - $XDG_RUNTIME_DIR/podman/podman.sock:/run/podman/podman.sock
+  - $(podman info --format "{{.Host.RemoteSocket.Path}}" || echo "$XDG_RUNTIME_DIR/podman/podman.sock"):/run/podman/podman.sock
 env_file:
   - skipper.env
 env:


### PR DESCRIPTION
Since they have the tendency to change existing runtime dependencies, this changes all occurrences of 'go get' to 'go install' for wherever we want to just install a testing-related dependency.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

If someone has an env with ``docker`` installed, I'd like to see if ``skipper make update-minimal-debug`` works for him/her!
Basically I want to make sure we use a default podman sock address if ``podman`` command doesn't exist. The resulting "default" value isn't important, as either way it's unused when using ``docker``, just that it should not crash.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
