### PR TITLE
MGMT-12318: fix conditions update on ASC

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -144,7 +144,7 @@ type ASC struct {
 	spec *aiv1beta1.AgentServiceConfigSpec
 
 	/* Status part of AgentServiceConfig CRD family */
-	conditions []conditionsv1.Condition
+	conditions *[]conditionsv1.Condition
 }
 
 func (asc *ASC) init(r *AgentServiceConfigReconciler, instance *aiv1beta1.AgentServiceConfig) {
@@ -152,7 +152,7 @@ func (asc *ASC) init(r *AgentServiceConfigReconciler, instance *aiv1beta1.AgentS
 	asc.rec = &r.AgentServiceConfigReconcileContext
 	asc.Object = instance
 	asc.spec = &instance.Spec
-	asc.conditions = instance.Status.Conditions
+	asc.conditions = &instance.Status.Conditions
 }
 
 type NewComponentFn func(context.Context, logrus.FieldLogger, ASC) (client.Object, controllerutil.MutateFn, error)
@@ -406,7 +406,7 @@ func reconcileComponent(ctx context.Context, log *logrus.Entry, asc ASC, compone
 	if err != nil {
 		msg := "Failed to generate definition for " + component.name
 		log.WithError(err).Error(msg)
-		conditionsv1.SetStatusConditionNoHeartbeat(&asc.conditions, conditionsv1.Condition{
+		conditionsv1.SetStatusConditionNoHeartbeat(asc.conditions, conditionsv1.Condition{
 			Type:    aiv1beta1.ConditionReconcileCompleted,
 			Status:  corev1.ConditionFalse,
 			Reason:  component.reason,
@@ -422,7 +422,7 @@ func reconcileComponent(ctx context.Context, log *logrus.Entry, asc ASC, compone
 	if result, err := controllerutil.CreateOrUpdate(ctx, asc.rec.Client, obj, mutateFn); err != nil {
 		msg := "Failed to ensure " + component.name
 		log.WithError(err).Error(msg)
-		conditionsv1.SetStatusConditionNoHeartbeat(&asc.conditions, conditionsv1.Condition{
+		conditionsv1.SetStatusConditionNoHeartbeat(asc.conditions, conditionsv1.Condition{
 			Type:    aiv1beta1.ConditionReconcileCompleted,
 			Status:  corev1.ConditionFalse,
 			Reason:  component.reason,

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -372,6 +372,21 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 		Expect(conditionsv1.FindStatusCondition(instance.Status.Conditions, aiv1beta1.ConditionDeploymentsHealthy).Reason).To(Equal(aiv1beta1.ReasonDeploymentSucceeded))
 	})
 
+	It("should set `ReconcileCompleted` condition to `False` on AgentServiceConfig when reconcileComponent fails", func() {
+		ascr = newTestReconciler(asc)
+		result, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
+
+		Expect(err).NotTo(Succeed())
+		Expect(result).NotTo(Equal(ctrl.Result{}))
+
+		instance := &aiv1beta1.AgentServiceConfig{}
+		err = ascr.Get(ctx, types.NamespacedName{Name: "agent"}, instance)
+		Expect(err).To(BeNil())
+		condition := conditionsv1.FindStatusCondition(instance.Status.Conditions, aiv1beta1.ConditionReconcileCompleted)
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Status).To(Equal(corev1.ConditionFalse))
+	})
+
 	Context("IPXE routes", func() {
 		var (
 			imageServiceStatefulSet *appsv1.StatefulSet

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -64,7 +64,7 @@ func (asc *ASC) initHASC(r *HypershiftAgentServiceConfigReconciler, instance *ai
 	asc.rec = &r.AgentServiceConfigReconcileContext
 	asc.Object = instance
 	asc.spec = &instance.Spec.AgentServiceConfigSpec
-	asc.conditions = instance.Status.Conditions
+	asc.conditions = &instance.Status.Conditions
 }
 
 var assistedServiceRBAC_l0 = []component{


### PR DESCRIPTION
Currently in AgentServiceConfigReconciler -> init: asc.conditions are initialized with a copy of instance.Status.Conditions. Hence, when updating the instance status on reconcileComponent, the conditions are not updated (as instance.Status.Conditions are always empty).

To mitigate the issue, changed conditions property in ASC struct to a pointer. I.e. asc.conditions should keep a pointer to instance.Status.Conditions, so updating asc.conditions would affect the instance.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
