### PR TITLE
NO-ISSUE: annotate lso namespace instead of project

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -18,7 +18,7 @@ function print_help() {
 function install_lso() {
   oc adm new-project openshift-local-storage || true
 
-  retry -- oc annotate project openshift-local-storage openshift.io/node-selector='' --overwrite=true
+  retry -- oc annotate namespace openshift-local-storage openshift.io/node-selector='' --overwrite=true
 
   catalog_source_name="redhat-operators"
 


### PR DESCRIPTION
The annotation on project is currently failing with:
```
$ oc annotate project openshift-local-storage openshift.io/node-selector="" --overwrite=true
The Project "openshift-local-storage" is invalid:
* metadata.namespace: Invalid value: "openshift-local-storage": field is immutable
* metadata.namespace: Forbidden: not allowed on this type
```

while the annotation on the namespace seems to work:
```
$ oc annotate namespace openshift-local-storage openshift.io/node-selector="" --overwrite=true
namespace/openshift-local-storage annotated
```
