### PR TITLE
MGMT-12318: handle conditions in HASC

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -164,6 +164,8 @@ const (
 	ReasonServiceServiceAccount string = "ServiceServiceAccount"
 	// ReasonNamespaceCreationFailure when there was a failure creating the namespace.
 	ReasonNamespaceCreationFailure string = "NamespaceCreationFailure"
+	// ReasonSpokeClusterCRDsSyncFailure when there was a failure syncing spoke cluster CRDs.
+	ReasonSpokeClusterCRDsSyncFailure string = "SpokeClusterCRDsSyncFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
@@ -164,6 +164,8 @@ const (
 	ReasonServiceServiceAccount string = "ServiceServiceAccount"
 	// ReasonNamespaceCreationFailure when there was a failure creating the namespace.
 	ReasonNamespaceCreationFailure string = "NamespaceCreationFailure"
+	// ReasonSpokeClusterCRDsSyncFailure when there was a failure syncing spoke cluster CRDs.
+	ReasonSpokeClusterCRDsSyncFailure string = "SpokeClusterCRDsSyncFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"


### PR DESCRIPTION
Added conditions handling to HypershiftAgentServiceConfig:
* Extracted conditions in ASC to updateConditions func.
* Extracted StatefulSet condition update to ensureImageServiceStatefulSet func.
* Reused conditions funcs in HASC.
* Added condition update for ReasonSpokeClusterCRDsSyncFailure.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
