### PR TITLE
NO-ISSUE: add initialDelaySeconds for readiness probe

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -138,6 +138,12 @@ parameters:
 - name: ENABLE_UPGRADE_AGENT
   value: "false"
   required: false
+- name: READINESS_PROBE_INITIAL_DELAY_SECONDS
+  value: "15"
+  required: false
+- name: LIVENESS_PROBE_INITIAL_DELAY_SECONDS
+  value: "30"
+  required: false
 apiVersion: v1
 kind: Template
 metadata:
@@ -176,11 +182,12 @@ objects:
               httpGet:
                 path: /health
                 port: 8090
-              initialDelaySeconds: 30
+              initialDelaySeconds: ${{LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
             readinessProbe:
               httpGet:
                 path: /ready
                 port: 8090
+              initialDelaySeconds: ${{READINESS_PROBE_INITIAL_DELAY_SECONDS}}
             env:
               - name: AWS_SECRET_ACCESS_KEY
                 valueFrom:


### PR DESCRIPTION
This PR is introducing `initialDealySeconds` parameter for readiness probe.
Startup usually takes around 10s, which normally produces 2 messages of readiness probe failed.
This is not an issue, but it makes people think there might be a problem with readiness as the message looks like this:

`Warning  Unhealthy       18m (x3 over 18m)  kubelet            Readiness probe failed: Get "http://10.129.24.18:8090/ready": dial tcp 10.129.24.18:8090: connect: connection refused`

These errors ocurred at the start of the pod, but it looks like it failed 3 times in the last 18m - which is technically correct but it all happened in the first 20s.

This PR aims at reducing this kind of messages. The downside of this is that we will always wait 15s from startup before the pod being ready in the best case scenario, as for now the best case scenario sets the pod ready after ~11s from startup, although if it fails the 10s probe (which it happens often enough) can lead to 20s effective startup time.

This PR also parametrizes the fields for easy tuning in the feature (for example if startup will take more time in the future)

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
