### PR TITLE
MGMT-12402: Add url auth for getting a single infra-env

### DIFF
--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2982,6 +2982,15 @@ func init() {
           },
           {
             "agentAuth": []
+          },
+          {
+            "urlAuth": []
+          },
+          {
+            "imageAuth": []
+          },
+          {
+            "imageURLAuth": []
           }
         ],
         "description": "Retrieves the details of the infra-env.",
@@ -12342,6 +12351,15 @@ func init() {
           },
           {
             "agentAuth": []
+          },
+          {
+            "urlAuth": []
+          },
+          {
+            "imageAuth": []
+          },
+          {
+            "imageURLAuth": []
           }
         ],
         "description": "Retrieves the details of the infra-env.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -520,6 +520,9 @@ paths:
       security:
         - userAuth: [admin, read-only-admin, user]
         - agentAuth: []
+        - urlAuth: []
+        - imageAuth: []
+        - imageURLAuth: []
       description: Retrieves the details of the infra-env.
       operationId: GetInfraEnv
       parameters:


### PR DESCRIPTION
This is required for the image service to query an infra env to get any kernel arg overrides for the discovery image.

https://issues.redhat.com/browse/MGMT-12402

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
