### PR TITLE
MGMT-12354: Migrate single VIP values to the new data structure

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -138,13 +138,32 @@ const (
 	ClusterNetworksTable    = "ClusterNetworks"
 	ServiceNetworksTable    = "ServiceNetworks"
 	MachineNetworksTable    = "MachineNetworks"
+	APIVIPsTable            = "APIVips"
+	IngressVIPsTable        = "IngressVips"
 )
 
-var ClusterSubTables = [...]string{HostsTable, MonitoredOperatorsTable, ClusterNetworksTable, ServiceNetworksTable, MachineNetworksTable}
+var ClusterSubTables = [...]string{
+	HostsTable,
+	MonitoredOperatorsTable,
+	ClusterNetworksTable,
+	ServiceNetworksTable,
+	MachineNetworksTable,
+	APIVIPsTable,
+	IngressVIPsTable,
+}
 
 func AutoMigrate(db *gorm.DB) error {
-	return db.AutoMigrate(&models.MonitoredOperator{}, &Host{}, &Cluster{}, &Event{}, &InfraEnv{},
-		&models.ClusterNetwork{}, &models.ServiceNetwork{}, &models.MachineNetwork{})
+	return db.AutoMigrate(&models.MonitoredOperator{},
+		&Host{},
+		&Cluster{},
+		&Event{},
+		&InfraEnv{},
+		&models.ClusterNetwork{},
+		&models.ServiceNetwork{},
+		&models.MachineNetwork{},
+		&models.APIVip{},
+		&models.IngressVip{},
+	)
 }
 
 func LoadTableFromDB(db *gorm.DB, tableName string, conditions ...interface{}) *gorm.DB {

--- a/internal/migrations/20221031103047_multiple_vips.go
+++ b/internal/migrations/20221031103047_multiple_vips.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+func multipleVips() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		dbClusters, err := common.GetClustersFromDBWhere(tx, common.UseEagerLoading, common.IncludeDeletedRecords)
+		if err != nil {
+			return err
+		}
+		for _, cluster := range dbClusters {
+			if cluster.APIVip != "" {
+				apiVIPs := &models.APIVip{
+					ClusterID: *cluster.ID,
+					IP:        models.IP(cluster.APIVip),
+				}
+				if err = tx.Save(apiVIPs).Error; err != nil {
+					return err
+				}
+			}
+			if cluster.IngressVip != "" {
+				ingressVIPs := &models.IngressVip{
+					ClusterID: *cluster.ID,
+					IP:        models.IP(cluster.IngressVip),
+				}
+				if err = tx.Save(ingressVIPs).Error; err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		for _, model := range []interface{}{
+			&models.APIVip{},
+			&models.IngressVip{},
+		} {
+			if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(model).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20221031103047",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/20221031103047_multiple_vips_test.go
+++ b/internal/migrations/20221031103047_multiple_vips_test.go
@@ -1,0 +1,82 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("multipleVips", func() {
+	var (
+		db        *gorm.DB
+		dbName    string
+		clusterID strfmt.UUID
+		cluster   *common.Cluster
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		clusterID = strfmt.UUID(uuid.New().String())
+		cluster = &common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID,
+			},
+		}
+		Expect(db.Save(cluster).Error).ShouldNot(HaveOccurred())
+
+		_, err := common.GetClusterFromDB(db, clusterID, common.UseEagerLoading)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		var value []string
+		db.Raw("UPDATE clusters SET api_vip = ? WHERE id = ? RETURNING id", "192.168.111.10", clusterID).Scan(&value)
+		db.Raw("UPDATE clusters SET ingress_vip = ? WHERE id = ? RETURNING id", "192.168.111.11", clusterID).Scan(&value)
+
+		db.Raw("SELECT api_vip FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("192.168.111.10"))
+		db.Raw("SELECT ingress_vip FROM clusters WHERE id = ?", clusterID).Scan(&value)
+		Expect(value[0]).To(Equal("192.168.111.11"))
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Migrates up", func() {
+		// setup
+		err := migrateTo(db, "20221031103047")
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		var valueStr []string
+		var valueNum []int
+		db.Raw("SELECT COUNT(ip) FROM api_vips WHERE cluster_id = ?", clusterID).Scan(&valueNum)
+		Expect(valueNum[0]).To(Equal(1))
+		db.Raw("SELECT ip FROM api_vips WHERE cluster_id = ?", clusterID).Scan(&valueStr)
+		Expect(valueStr[0]).To(Equal("192.168.111.10"))
+		db.Raw("SELECT COUNT(ip) FROM ingress_vips WHERE cluster_id = ?", clusterID).Scan(&valueNum)
+		Expect(valueNum[0]).To(Equal(1))
+		db.Raw("SELECT ip FROM ingress_vips WHERE cluster_id = ?", clusterID).Scan(&valueStr)
+		Expect(valueStr[0]).To(Equal("192.168.111.11"))
+	})
+
+	It("Migrates down", func() {
+		err := migrateTo(db, "20221031103047")
+		Expect(err).NotTo(HaveOccurred())
+
+		// setup
+		err = gormigrate.New(db, gormigrate.DefaultOptions, post()).RollbackMigration(multipleVips())
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		var valueNum []int
+		db.Raw("SELECT COUNT(ip) FROM api_vips WHERE cluster_id = ?", clusterID).Scan(&valueNum)
+		Expect(valueNum[0]).To(Equal(0))
+		db.Raw("SELECT COUNT(ip) FROM ingress_vips WHERE cluster_id = ?", clusterID).Scan(&valueNum)
+		Expect(valueNum[0]).To(Equal(0))
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -39,6 +39,7 @@ func post() []*gormigrate.Migration {
 		changeStaticConfigFormat(),
 		multipleNetworksCleanup(),
 		dropClusterIgnitionOverrides(),
+		multipleVips(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })


### PR DESCRIPTION
With the new way of storing the data, we need to pre-populate database so that the new tables `api_vips` and `ingress_vips` get the data for all the existing clusters filled.

This PR is resposible for going over all the existing clusters and populating the newly created DB tables with already known IP addresses.

Closes: [MGMT-12354](https://issues.redhat.com//browse/MGMT-12354)
Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi