### PR TITLE
MGMT-12294: Run subsystem with deterministic openshift version

### DIFF
--- a/subsystem/subsystem_suite_test.go
+++ b/subsystem/subsystem_suite_test.go
@@ -158,12 +158,14 @@ func init() {
 		}
 	}
 
-	// Test on first openshift version. We can't test on latest because quay.io/openshift-release-dev/ocp-release-nightly
-	// is not public, so we would have to add PULL_SECRET env var as mandatory to access the quay.
+	// Use the default openshift version
 	if reply, err := userBMClient.Versions.V2ListSupportedOpenshiftVersions(context.Background(),
 		&versions.V2ListSupportedOpenshiftVersionsParams{}); err == nil {
-		for openshiftVersion = range reply.GetPayload() {
-			break
+		for openshiftVersionString, openshiftVersionStruct := range reply.GetPayload() {
+			if openshiftVersionStruct.Default {
+				openshiftVersion = openshiftVersionString
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
Currently, the openshift version which is used in the the subsystem tests is set to the first version in the payload of an API call that retrieves the supported openshift versions. This API call response is not guaranteed to be ordered in a specific way, which causes nondeterministic subsystem tests. I changed the openshift version to the default one.  
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
