### PR TITLE
MGMT-12423: Add debug logs for counting unsynced agents

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -577,6 +577,7 @@ func (r *ClusterDeploymentsReconciler) isReadyForInstallation(ctx context.Contex
 	}
 
 	unsyncedHosts := getNumOfUnsyncedAgents(agents)
+	log.Debugf("Calculating installation readiness, found %d unsynced agents out of total of %d agents", unsyncedHosts, len(agents))
 	expectedHosts := clusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents +
 		clusterInstall.Spec.ProvisionRequirements.WorkerAgents
 	return approvedHosts == expectedHosts && registered == approvedHosts && unsyncedHosts == 0, nil
@@ -1580,6 +1581,7 @@ func (r *ClusterDeploymentsReconciler) updateStatus(ctx context.Context, log log
 					return ctrl.Result{Requeue: true}, nil
 				}
 				unsyncedHosts = getNumOfUnsyncedAgents(agents)
+				log.Debugf("Updating ACI conditions, found %d unsynced agents out of total of %d agents", unsyncedHosts, len(agents))
 			}
 			clusterRequirementsMet(clusterInstall, status, registeredHosts, approvedHosts, unsyncedHosts)
 			clusterValidated(clusterInstall, status, c)
@@ -1664,6 +1666,7 @@ func findAgentsByAgentClusterInstall(k8sclient client.Client, ctx context.Contex
 			agents = append(agents, agent)
 		}
 	}
+	log.Debugf("Found %d agents matching ClusterDeployment %s", len(agents), aci.Spec.ClusterDeploymentRef.Name)
 
 	return agents, nil
 }


### PR DESCRIPTION
In order to make it easier to debug race conditions in the KubeAPI, this PR adds additional debug logs that will be returning results of the intermediate steps that lead to marking cluster as `UnsyncedAgents` or `UnapprovedAgents`.

Contributes-to: [MGMT-12423](https://issues.redhat.com//browse/MGMT-12423)

/cc @omertuc 