### PR TITLE
NO-ISSUE: Rename misleading network utility function

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -398,7 +398,7 @@ func (m *Manager) GetMasterNodesIds(ctx context.Context, c *common.Cluster, db *
 }
 
 func (m *Manager) tryAssignMachineCidrDHCPMode(cluster *common.Cluster) error {
-	networks := network.GetClusterNetworks(cluster.Hosts, m.log)
+	networks := network.GetInventoryNetworks(cluster.Hosts, m.log)
 	if len(networks) == 1 {
 		/*
 		 * Auto assign machine network CIDR is relevant if there is only single host network.  Otherwise the user
@@ -437,7 +437,7 @@ func (m *Manager) tryAssignMachineCidrSNO(cluster *common.Cluster) error {
 	}
 	if reflect.DeepEqual(clusterFamilies, serviceFamilies) {
 		var pendingCidrs []string
-		cidrsByFamily, err := network.GetClusterNetworksByFamily(cluster.Hosts, m.log)
+		cidrsByFamily, err := network.GetInventoryNetworksByFamily(cluster.Hosts, m.log)
 		if err != nil {
 			return err
 		}
@@ -1062,7 +1062,7 @@ func (m *Manager) setConnectivityMajorityGroupsForClusterInternal(cluster *commo
 		return hosts[i].ID.String() < hosts[j].ID.String()
 	})
 	majorityGroups := make(map[string][]strfmt.UUID)
-	for _, cidr := range network.GetClusterNetworks(hosts, m.log) {
+	for _, cidr := range network.GetInventoryNetworks(hosts, m.log) {
 		majorityGroup, err := network.CreateL2MajorityGroup(cidr, hosts)
 		if err != nil {
 			m.log.WithError(err).Warnf("Create majority group for %s", cidr)

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -243,7 +243,7 @@ func GetPrimaryMachineCidrForUserManagedNetwork(cluster *common.Cluster, log log
 		return ""
 	}
 
-	networks := GetClusterNetworks([]*models.Host{bootstrap}, log)
+	networks := GetInventoryNetworks([]*models.Host{bootstrap}, log)
 	if len(networks) > 0 {
 		// if there is ipv4 network, return it or return the first one
 		for _, network := range networks {
@@ -269,7 +269,7 @@ func GetMachineNetworksFromBoostrapHost(cluster *common.Cluster, log logrus.Fiel
 		return []*models.MachineNetwork{}
 	}
 
-	networks := GetClusterNetworks([]*models.Host{bootstrap}, log)
+	networks := GetInventoryNetworks([]*models.Host{bootstrap}, log)
 	var v4net, v6net string
 	res := []*models.MachineNetwork{}
 	if len(networks) > 0 {
@@ -311,7 +311,7 @@ func GetIpForSingleNodeInstallation(cluster *common.Cluster, log logrus.FieldLog
 	return hostIp, nil
 }
 
-func GetClusterNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
+func GetInventoryNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
 	var err error
 	cidrs := make(map[string]bool)
 	for _, h := range hosts {
@@ -351,8 +351,8 @@ func GetClusterNetworks(hosts []*models.Host, log logrus.FieldLogger) []string {
 	return ret
 }
 
-func GetClusterNetworksByFamily(hosts []*models.Host, log logrus.FieldLogger) (map[AddressFamily][]string, error) {
-	networks := GetClusterNetworks(hosts, log)
+func GetInventoryNetworksByFamily(hosts []*models.Host, log logrus.FieldLogger) (map[AddressFamily][]string, error) {
+	networks := GetInventoryNetworks(hosts, log)
 	ret := make(map[AddressFamily][]string)
 	for _, n := range networks {
 		family, err := CidrToAddressFamily(n)

--- a/internal/network/machine_network_cidr_test.go
+++ b/internal/network/machine_network_cidr_test.go
@@ -229,7 +229,7 @@ var _ = Describe("inventory", func() {
 		})
 	})
 
-	Context("GetClusterNetworks", func() {
+	Context("GetInventoryNetworks", func() {
 
 		var log logrus.FieldLogger
 
@@ -238,12 +238,12 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("No hosts", func() {
-			nets := GetClusterNetworks(createHosts(), log)
+			nets := GetInventoryNetworks(createHosts(), log)
 			Expect(nets).To(BeEmpty())
 		})
 
 		It("Empty inventory", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				"",
 				createInventory(createInterface("2.2.3.10/24"))), log)
 			Expect(nets).To(HaveLen(1))
@@ -251,7 +251,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("Corrupted inventory", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				"{\"interfaces:}",
 				createInventory(createInterface("1.2.3.5/28"))), log)
 			Expect(nets).To(HaveLen(1))
@@ -259,7 +259,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("No interfaces", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(createInterface("10.2.3.20/24")),
 				createInventory()), log)
 			Expect(nets).To(HaveLen(1))
@@ -267,7 +267,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("IPv4 only", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(createInterface("10.2.3.20/24", "1.2.3.4/28")),
 				createInventory(createInterface("198.2.3.10/28"))), log)
 			Expect(nets).To(HaveLen(3))
@@ -275,7 +275,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("IPv6 only", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(addIPv6Addresses(createInterface(), "2001:db8::a1/120")),
 				createInventory(addIPv6Addresses(createInterface(), "fe80:5054::4/120", "2002:db8::a1/120"))), log)
 			Expect(nets).To(HaveLen(3))
@@ -283,7 +283,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("Dual stack", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(addIPv6Addresses(createInterface("1.2.3.4/28"), "2001:db8::a1/120")),
 				createInventory(addIPv6Addresses(createInterface("10.2.3.20/24"), "fe80:5054::4/120"))), log)
 			Expect(nets).To(HaveLen(4))
@@ -291,7 +291,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("Invalid CIDR", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(addIPv6Addresses(createInterface("1.2.260.4/28"), "2001:db8::a1/120")),
 				createInventory(addIPv6Addresses(createInterface("10.2.3.20/24"), "fe80:5054::4"))), log)
 			Expect(nets).To(HaveLen(2))
@@ -299,7 +299,7 @@ var _ = Describe("inventory", func() {
 		})
 
 		It("Same CIDR", func() {
-			nets := GetClusterNetworks(createHosts(
+			nets := GetInventoryNetworks(createHosts(
 				createInventory(addIPv6Addresses(createInterface("1.2.3.4/28"), "2001:db8::a1/120")),
 				createInventory(addIPv6Addresses(createInterface("1.2.3.10/28"), "2001:db8::5/120"))), log)
 			Expect(nets).To(HaveLen(2))


### PR DESCRIPTION
This PR renames the function `GetClusterNetworks` to `GetInventoryNetworks` in order to remove confusion about what Cluster Network is.

The logic of the function goes over the inventory of all discovered hosts and returns all the CIDRs that have been found.

On the other hand, Cluster Network in the OpenShift universe is a network that is used for Pods to talk with each other and is not related at all to the physical network where Nodes belong to.

In order to remove a confusion (because we already have `GetClusterNetworkCidrs` which does something completely different than `GetClusterNetworks`) we are renaming it and use Inventory Networks.

/cc @nmagnezi 