### PR TITLE
MGMT-9915: Create utility functions to get cluster's VIPs

### DIFF
--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -177,6 +177,34 @@ func GetClusterNetworkCidrs(cluster *common.Cluster) (ret []string) {
 	return
 }
 
+func GetApiVips(cluster *common.Cluster) (ret []string) {
+	ret = funk.Map(cluster.APIVips, func(x *models.APIVip) string { return string(x.IP) }).([]string)
+	return
+}
+
+func GetIngressVips(cluster *common.Cluster) (ret []string) {
+	ret = funk.Map(cluster.IngressVips, func(x *models.IngressVip) string { return string(x.IP) }).([]string)
+	return
+}
+
+func GetApiVipById(cluster *common.Cluster, index int) string {
+	vips := GetApiVips(cluster)
+	if len(vips) <= index {
+		return ""
+	} else {
+		return vips[index]
+	}
+}
+
+func GetIngressVipById(cluster *common.Cluster, index int) string {
+	vips := GetIngressVips(cluster)
+	if len(vips) <= index {
+		return ""
+	} else {
+		return vips[index]
+	}
+}
+
 func CidrToAddressFamily(cidr string) (AddressFamily, error) {
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {


### PR DESCRIPTION
This PR creates a set of utility functions that are returning cluster's VIPs as a simple `[]string` or `string` instead of a custom data structures. This is to make it easier to perform parsing and validations when only the value of the VIP is required and not the whole context it carries.

Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi 