### PR TITLE
MGMT-12492: update statusRebootTimeout info message to ask the user to look at the host console.

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -36,7 +36,7 @@ const (
 	statusInfoInstallationInProgressWritingImageToDiskTimedOut = "Host failed to install because its installation stage $STAGE did not sufficiently progress in the last $MAX_TIME."
 	statusInfoHostReadyToBeBound                               = "Host is ready to be bound to a cluster"
 	statusInfoBinding                                          = "Host is waiting to be bound to the cluster"
-	statusRebootTimeout                                        = "Host failed to reboot within timeout, please boot the host from the the OpenShift installation disk $INSTALLATION_DISK. The installation will resume once the host has rebooted"
+	statusRebootTimeout                                        = "Host timed out when pulling ignition. Check the host console and verify that it boots from the OpenShift installation disk $INSTALLATION_DISK and has network access to the cluster API. The installation will resume once the host successfully boots and can access the cluster API"
 	statusInfoUnbinding                                        = "Host is waiting to be unbound from the cluster"
 	statusInfoRebootingDay2                                    = "Host has rebooted and no further updates will be posted. Please check console for progress and to possibly approve pending CSRs"
 	statusInfoRebootingForReclaim                              = "Host is rebooting into the discovery image"


### PR DESCRIPTION
The old message implied that the host failed to boot from the installation disk, but in practice this timeout is mainly a result of misconfigured network, preventing the host from pulling ignition, the new message reflects that.


- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? yes
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no

## List all the issues related to this PR
https://issues.redhat.com/browse/AITRIAGE-4441

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
