### PR TITLE
MGMT-12398: Regression fix: Move host stage to "Done" only when not in KubeAPI mode.

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -601,11 +601,11 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 			swag.StringValue(h.Status), models.HostStatusError, statusInfo)
 	case models.HostStageRebooting:
 		if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost {
-			infoMessage := statusInfo
+			infoMessage := statusInfoRebootingDay2
 			stage := models.HostStageDone
-			if !m.kubeApiEnabled {
+			if m.kubeApiEnabled {
 				// in case kubeApiEnabled the agent controller will keep updating the host stage until the installation is complete
-				infoMessage = statusInfoRebootingDay2
+				infoMessage = statusInfo
 				stage = models.HostStageRebooting
 			}
 			_, err = hostutil.UpdateHostProgress(ctx, logutil.FromContext(ctx, m.log), m.db, m.eventsHandler, h.InfraEnvID, *h.ID,


### PR DESCRIPTION
A recent regression caused the host stage to be prematurely moved to "Done" when the installation is in KubeAPI mode. This change aims to fix that by setting the correct status.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
I used aicli to create a hub/spoke setup and proceeded to use KubeAPI to add a Day2 node to a spoke. 
Prior to this fix, the CSR's of the node would not be signed. 
After this fix, the CSRs are signed correctly and the node joined the cluster successfully.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
