### PR TITLE
MGMT-12434: Allow nightly 4.12 builds to use the converged flow

### DIFF
--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const MinimalVersionForConvergedFlow = "4.12.0-ec.4"
+const MinimalVersionForConvergedFlow = "4.12.0-0.alpha"
 
 type BMOUtils struct {
 	// The methods of this receiver get called once before the cache is initialized hence we check the API directly


### PR DESCRIPTION
The previous minimum version ensured that all the bugs associated with the converged flow were fixed, but excluded nightly releases.

It is better to include nightly releases for ease of testing. If versions earlier than ec.4 are used and have issues it should be easy enough to recognize the problem as it would only happen internally.

Resolves https://issues.redhat.com/browse/MGMT-12434

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?
Unit tests should be enough here

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

cc @eranco74 
cc @trewest 
