### PR TITLE
Remove useless getReleaseImage function

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1311,14 +1311,6 @@ func (r *ClusterDeploymentsReconciler) createNewDay2Cluster(
 	return r.updateStatus(ctx, log, clusterInstall, c, err)
 }
 
-func (r *ClusterDeploymentsReconciler) getReleaseImage(ctx context.Context, spec hiveext.AgentClusterInstallSpec) (string, error) {
-	releaseImage, err := getReleaseImage(ctx, r.Client, spec.ImageSetRef.Name)
-	if err != nil {
-		return "", err
-	}
-	return releaseImage, nil
-}
-
 func (r *ClusterDeploymentsReconciler) addReleaseImage(
 	ctx context.Context,
 	log logrus.FieldLogger,
@@ -1330,7 +1322,7 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 
 	// retrieve the release image url from the associated
 	// ClusterImageSetRef
-	releaseImageUrl, err := r.getReleaseImage(ctx, spec)
+	releaseImageUrl, err := getReleaseImage(ctx, r.Client, spec.ImageSetRef.Name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

cc @danielerez 