### PR TITLE
MGMT-12471: Don't wait for console if it is disabled

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/infraenv"
+	installcfgdata "github.com/openshift/assisted-service/internal/installcfg"
 	installcfg "github.com/openshift/assisted-service/internal/installcfg/builder"
 	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/manifests"
@@ -64,6 +65,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
+	"gopkg.in/yaml.v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -125,6 +127,7 @@ type Config struct {
 
 const minimalOpenShiftVersionForSingleNode = "4.8.0-0.0"
 const minimalOpenShiftVersionForDefaultNetworkTypeOVNKubernetes = "4.12.0-0.0"
+const minimalOpenShiftVersionForConsoleCapability = "4.12.0-0.0"
 
 type Interactivity bool
 
@@ -1578,11 +1581,19 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 		log.WithError(err).Errorf("failed to set install config overrides feature usage for cluster %s", params.ClusterID)
 	}
 
+	cluster.InstallConfigOverrides = params.InstallConfigParams
 	err = tx.Model(&common.Cluster{}).Where(query, params.ClusterID).Update("install_config_overrides", params.InstallConfigParams).Error
 	if err != nil {
 		log.WithError(err).Errorf("failed to update install config overrides")
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
+
+	err = b.updateMonitoredOperators(tx, cluster)
+	if err != nil {
+		log.WithError(err).Error("failed to update monitored operators")
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
+	}
+
 	err = tx.Commit().Error
 	if err != nil {
 		log.Error(err)
@@ -1591,6 +1602,7 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 	txSuccess = true
 	eventgen.SendInstallConfigAppliedEvent(ctx, b.eventsHandler, params.ClusterID)
 	log.Infof("Custom install config was applied to cluster %s", params.ClusterID)
+
 	return cluster, nil
 }
 
@@ -6128,4 +6140,89 @@ func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version s
 		common.PlatformTypeValue(platform) == models.PlatformTypeBaremetal &&
 		featuresupport.IsFeatureSupported(version,
 			models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTUREWITHCLUSTERMANAGEDNETWORKING)
+}
+
+// updateMonitoredOperators checks the content of the installer configuration and updates the list
+// of monitored operators accordingly. For example, if the installer configuration uses the
+// capabilities mechanism to disable the console then the console operator is removed from the list
+// of monitored operators.
+func (b *bareMetalInventory) updateMonitoredOperators(tx *gorm.DB, cluster *common.Cluster) error {
+	// Get the complete installer configuration, including the overrides:
+	installConfigData, err := b.installConfigBuilder.GetInstallConfig(cluster, nil, "")
+	if err != nil {
+		return err
+	}
+	var installConfig installcfgdata.InstallerConfigBaremetal
+	err = yaml.Unmarshal(installConfigData, &installConfig)
+	if err != nil {
+		return err
+	}
+
+	// Since version 4.12 it is possible to disable the console via the capabilities section of
+	// the installer configuration. The way to do it is to set the base capability set to `None`
+	// and then explicitly list all the enabled capabilities.
+	consoleEnabled := true
+	logFields := logrus.Fields{
+		"cluster_id":      cluster.ID,
+		"cluster_version": cluster.OpenshiftVersion,
+		"minimal_version": minimalOpenShiftVersionForConsoleCapability,
+	}
+	consoleCapabilitySupported, err := common.VersionGreaterOrEqual(
+		cluster.OpenshiftVersion,
+		minimalOpenShiftVersionForConsoleCapability,
+	)
+	if err != nil {
+		return err
+	}
+	if consoleCapabilitySupported {
+		capabilities := installConfig.Capabilities
+		if capabilities != nil {
+			logFields["baseline_capability_set"] = capabilities.BaselineCapabilitySet
+			logFields["additional_enabled_capabilities"] = capabilities.AdditionalEnabledCapabilities
+			if capabilities.BaselineCapabilitySet == "None" {
+				consoleEnabled = false
+				for _, capability := range capabilities.AdditionalEnabledCapabilities {
+					if capability == "Console" {
+						consoleEnabled = true
+						break
+					}
+				}
+			}
+		}
+		if consoleEnabled {
+			b.log.WithFields(logFields).Info(
+				"Console is enabled because the cluster version supports the " +
+					"capability and it has been explicitly enabled by " +
+					"the user",
+			)
+		} else {
+			b.log.WithFields(logFields).Info(
+				"Console is disabled because the cluster version supports the " +
+					"capability and it hasn't been explicitly enabled by " +
+					"the user",
+			)
+		}
+	} else {
+		consoleEnabled = true
+		b.log.WithFields(logFields).Info(
+			"Console is enabled because the cluster version doesn't support " +
+				"the capability",
+		)
+	}
+
+	// Add or remove the console operator to the list of monitored operators:
+	consoleOperator := operators.OperatorConsole
+	consoleOperator.ClusterID = *cluster.ID
+	if consoleEnabled {
+		b.log.WithFields(logFields).Info(
+			"Adding the console to the set of monitored operators",
+		)
+		err = tx.FirstOrCreate(&consoleOperator).Error
+	} else {
+		b.log.WithFields(logFields).Info(
+			"Removing the console from the set of monitored operators",
+		)
+		err = tx.Delete(&consoleOperator).Error
+	}
+	return err
 }


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manually creating a cluster with the console disabled and waiting for the installation to complete.

```shell
$ cat > disable-console.json <<.
{
  "capabilities": {
    "baselineCapabilitySet": "None",
    "additionalEnabledCapabilities": [
      "baremetal"
    ]
  }
}
.

$ cat disable-console.json | jq -sR > disable-console.patch

$ ocm patch /api/assisted-install/v2/clusters/.../install-config --body disable-console.patch
```

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
