### PR TITLE
MGMT-12389: Add feature usage for dual-stack VIPs

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2471,6 +2471,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.V2UpdateCluste
 
 	b.setUsage(vipDhcpAllocation, usage.VipDhcpAllocationUsage, nil, usages)
 	b.setUsage(network.CheckIfClusterIsDualStack(cluster), usage.DualStackUsage, nil, usages)
+	b.setUsage(len(cluster.APIVips) > 1, usage.DualStackVipsUsage, nil, usages)
 	return nil
 }
 
@@ -2546,6 +2547,7 @@ func (b *bareMetalInventory) setDefaultUsage(cluster *models.Cluster) error {
 	b.setOperatorsUsage(olmOperators, []*models.MonitoredOperator{}, usages)
 	b.setNetworkTypeUsage(cluster.NetworkType, usages)
 	b.setUsage(network.CheckIfClusterModelIsDualStack(cluster), usage.DualStackUsage, nil, usages)
+	b.setUsage(len(cluster.APIVips) > 1, usage.DualStackVipsUsage, nil, usages)
 	b.setDiskEncryptionUsage(cluster, cluster.DiskEncryption, usages)
 	b.setUsage(cluster.Tags != "", usage.ClusterTags, nil, usages)
 	b.setUsage(cluster.Hyperthreading != models.ClusterHyperthreadingNone, usage.HyperthreadingUsage,

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -53,4 +53,6 @@ const (
 	HyperthreadingUsage string = "Hyperthreading"
 	// Usage of discovery kernel arguments
 	DiscoveryKernelArgumentsUsage = "discovery kernel arguments"
+	// Cluster uses dual-stack VIPs
+	DualStackVipsUsage string = "Dual-stack VIPs"
 )


### PR DESCRIPTION
This commit adds a feature flag for marking clusters that use dual-stack VIPs. This enables us to collect statistics about usage of this feature. The flag is independent from the usage of dual-stack networking, as it is still possible to have a dual-stack cluster that uses only a single pair of VIPs. For this reason it's desired to track separately `DualStackUsage` and `DualStackVipsUsage`.

Contributes-to: [MGMT-12389](https://issues.redhat.com//browse/MGMT-12389)
Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi 