### PR TITLE
MGMT-12522 Fix unit test DB connection failure

### DIFF
--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -114,10 +114,11 @@ var _ = Describe("Ignition endpoint URL generation", func() {
 	var host models.Host
 	var cluster common.Cluster
 	var db *gorm.DB
+	var dbName string
 	var id, clusterID, infraEnvID strfmt.UUID
 
 	BeforeEach(func() {
-		db, _ = common.PrepareTestDB()
+		db, dbName = common.PrepareTestDB()
 
 		id = strfmt.UUID(uuid.New().String())
 		clusterID = strfmt.UUID(uuid.New().String())
@@ -127,6 +128,10 @@ var _ = Describe("Ignition endpoint URL generation", func() {
 		apiVipDNSName := "test.com"
 		cluster = common.Cluster{Cluster: models.Cluster{ID: &clusterID, APIVipDNSName: &apiVipDNSName}}
 		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
 	})
 
 	Context("using GetIgnitionEndpoint function", func() {
@@ -175,5 +180,7 @@ var _ = Describe("Ignition endpoint URL generation", func() {
 
 func TestHostUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
+	common.InitializeDBTest()
+	defer common.TerminateDBTest()
 	RunSpecs(t, "HostUtil Tests")
 }


### PR DESCRIPTION
When running unit tests directly from a directory without skipper sometimes tests will fail if the test start before DB container is ready To avoid that db initialization should try to connect to the DB before starting the test.

In addition fixing hostutil tests to initialize DB in the test preperation


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
