### PR TITLE
MGMT-12001: Update getIronicIP to include latest CBO changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,7 @@ import (
 	"github.com/openshift/assisted-service/pkg/staticnetworkconfig"
 	"github.com/openshift/assisted-service/pkg/thread"
 	"github.com/openshift/assisted-service/restapi"
+	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"go.elastic.co/apm/module/apmhttp"
@@ -511,7 +512,12 @@ func main() {
 
 	go func() {
 		if Options.EnableKubeAPI {
+			clientConfig := ctrl.GetConfigOrDie()
+			osClient := osclientset.NewForConfigOrDie(clientConfig)
+			kubeClient := kubernetes.NewForConfigOrDie(clientConfig)
 			bmoUtils := controllers.NewBMOUtils(ctrlMgr.GetAPIReader(),
+				osClient,
+				kubeClient,
 				log.WithField("pkg", "baremetal_operator_utils"),
 				Options.EnableKubeAPI)
 			useConvergedFlow := Options.AllowConvergedFlow && bmoUtils.ConvergedFlowAvailable()


### PR DESCRIPTION
Roughly the diff in `provisionin/utils.go` from CBO here: https://github.com/openshift/cluster-baremetal-operator/compare/2ca8a8a...01f7f55

This is the backup plan if cluster-baremetal-operator doesn't update their dependencies in time for our release.

Related to https://github.com/openshift/cluster-baremetal-operator/pull/305

Workaround for https://issues.redhat.com/browse/MGMT-12001

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed an image with this change into a dev-scripts environment and saw the ironic URL get built into the infraenv ignition config.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
