### PR TITLE
MGMT-12478: AgentClusterInstall remains in installed state when using ignitionEndpoint

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -760,7 +761,9 @@ func (r *ClusterDeploymentsReconciler) updateIgnitionInUpdateParams(ctx context.
 		ignitionEndpoint, err := r.parseIgnitionEndpoint(ctx, log, clusterInstall.Spec.IgnitionEndpoint)
 		if err == nil {
 			params.IgnitionEndpoint = ignitionEndpoint
-			update = true
+			if cluster.IgnitionEndpoint == nil || !reflect.DeepEqual(cluster.IgnitionEndpoint, ignitionEndpoint) {
+				update = true
+			}
 		} else {
 			log.WithError(err).Errorf("Failed to get and parse ignition ca certificate %s/%s", clusterInstall.Namespace, clusterInstall.Name)
 			return false, errors.Wrap(err, fmt.Sprintf("Failed to get and parse ignition ca certificate %s/%s", clusterInstall.Namespace, clusterInstall.Name))

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -836,6 +837,83 @@ var _ = Describe("cluster reconcile", func() {
 		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstall)).To(BeNil())
 		Expect(clusterInstall.Status.DebugInfo.EventsURL).NotTo(BeEmpty())
 		Expect(clusterInstall.Status.DebugInfo.EventsURL).To(HavePrefix(expectedEventUrlPrefix))
+	})
+
+	It("validate ignitionEndpoint override doesn't trigger clusterUpdate unless required", func() {
+		mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
+		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+		pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
+		Expect(c.Create(ctx, pullSecret)).To(BeNil())
+		imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
+		Expect(c.Create(ctx, imageSet)).To(BeNil())
+
+		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
+		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+		aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cluster)
+		aci.Spec.Networking.ClusterNetwork = []hiveext.ClusterNetworkEntry{}
+		aci.Spec.Networking.ServiceNetwork = []string{}
+
+		sId := strfmt.UUID(uuid.New().String())
+		ignitionURL := "https://fakeurl:8080/config"
+		ignitionCert := []byte("cert...")
+		encodedCertString := base64.StdEncoding.EncodeToString(ignitionCert)
+		backEndCluster := &common.Cluster{
+			Cluster: models.Cluster{
+				ID:               &sId,
+				Name:             clusterName,
+				BaseDNSDomain:    cluster.Spec.BaseDomain,
+				Status:           swag.String(models.ClusterStatusInsufficient),
+				OpenshiftVersion: arbitraryOCPVersion,
+				IgnitionEndpoint: &models.IgnitionEndpoint{CaCertificate: &encodedCertString, URL: &ignitionURL},
+				PullSecretSet:    true,
+				Hyperthreading:   models.ClusterHyperthreadingAll,
+				SSHPublicKey:     "some-key",
+				NetworkType:      swag.String(models.ClusterNetworkTypeOVNKubernetes),
+				APIVip:           aci.Spec.APIVIP,
+				IngressVip:       aci.Spec.IngressVIP,
+			},
+			PullSecret: testPullSecretVal,
+		}
+
+		// caCertificateReference := aci.Spec.IgnitionEndpoint.CaCertificateReference
+		caCertificateData := map[string][]byte{
+			corev1.TLSCertKey: ignitionCert,
+		}
+		caCertificateSecret := newSecret(aci.Namespace, caCertificateSecretName, caCertificateData)
+		Expect(c.Create(ctx, caCertificateSecret)).ShouldNot(HaveOccurred())
+		ignitionEndpoint := &hiveext.IgnitionEndpoint{
+			CaCertificateReference: &hiveext.CaCertificateReference{
+				Namespace: caCertificateSecret.Namespace,
+				Name:      caCertificateSecret.Name,
+			},
+			Url: ignitionURL,
+		}
+		aci.Spec.IgnitionEndpoint = ignitionEndpoint
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+		request := newClusterDeploymentRequest(cluster)
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+
+		By("no changes to the spec - update should not get called")
+		_, err := cr.Reconcile(ctx, request)
+		Expect(err).ShouldNot(HaveOccurred())
+		clusterInstall := &hiveext.AgentClusterInstall{}
+		agentClusterInstallKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      agentClusterInstallName,
+		}
+		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstall)).ShouldNot(HaveOccurred())
+		Expect(clusterInstall.Spec.IgnitionEndpoint).To(Equal(ignitionEndpoint))
+
+		By("ignition override doesn't match")
+		backEndCluster.IgnitionEndpoint.URL = swag.String("https://anotherfakeurl:8080/config")
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
+		mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).Return(backEndCluster, nil)
+		_, err = cr.Reconcile(ctx, request)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(c.Get(ctx, agentClusterInstallKey, clusterInstall)).ShouldNot(HaveOccurred())
+		Expect(clusterInstall.Spec.IgnitionEndpoint.Url).To(Equal(ignitionEndpoint.Url))
+		Expect(FindStatusCondition(clusterInstall.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Status).To(Equal(corev1.ConditionTrue))
+
 	})
 
 	It("validate Logs URL - before and after host log collection", func() {

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -274,7 +274,7 @@ func installAlreadyStarted(conditions []hivev1.ClusterInstallCondition) bool {
 		return false
 	}
 	switch cond.Reason {
-	case hiveext.ClusterInstallationFailedReason, hiveext.ClusterInstalledReason, hiveext.ClusterInstallationInProgressReason:
+	case hiveext.ClusterInstallationFailedReason, hiveext.ClusterInstalledReason, hiveext.ClusterInstallationInProgressReason, hiveext.ClusterAlreadyInstallingReason:
 		return true
 	default:
 		return false


### PR DESCRIPTION
It seems that the ignition endpoint override triggers a call to v2UpdateClusterInternal regardless if an update is required.
The v2UpdateClusterInternal call failes because the cluster is already installing, this result in early termination of the reconcile function.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? kube-api
- Any logs, screenshots, etc that can help with the review process? check the clusterdeployment controller logs and see that you no longer get the update failure errors


## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-12478

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) on the env that reproduced the bug
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
