### PR TITLE
MGMT-12552: Day-2 agent stuck with status_info rebooting although the node is already part of the cluster

### DIFF
--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1967,7 +1967,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 				ClusterID:  &sId,
 				Kind:       swag.String(models.HostKindAddToExistingClusterHost),
 				Inventory:  generateInventory(),
-				Status:     swag.String(models.HostStatusAddedToExistingCluster),
+				Status:     swag.String(models.HostStatusInstalling),
 				Progress: &models.HostProgressInfo{
 					CurrentStage: models.HostStageRebooting,
 				},
@@ -2017,6 +2017,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 		clusterInstall      *hiveext.AgentClusterInstall
 		updateProgressStage bool
 		getNodeCount        int
+		isDay1Host          bool
 	}{
 		{
 			name:                "Not day 2 host - do nothing",
@@ -2028,6 +2029,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
 			getNodeCount:        0,
+			isDay1Host:          true,
 		},
 		{
 			name:                "No matching node - No csrs",
@@ -2035,7 +2037,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			csrs:                &certificatesv1.CertificateSigningRequestList{},
 			nodeError:           &notFoundError{},
 			expectedResult:      ctrl.Result{RequeueAfter: time.Minute},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageRebooting,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
@@ -2068,7 +2070,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageJoined,
 			clusterInstall:      newAciNoUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2099,7 +2101,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			},
 			approveExpected:     false,
 			expectedResult:      ctrl.Result{},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageDone,
 			clusterInstall:      newAciNoUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2133,7 +2135,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageJoined,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2167,7 +2169,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageJoined,
 			clusterInstall:      newAciNoUserManagedNetworkingWithSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2197,7 +2199,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageRebooting,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
@@ -2226,7 +2228,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageJoined,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2257,7 +2259,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			csrs:                serverCsrs(),
 			approveExpected:     true,
 			expectedResult:      ctrl.Result{},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageDone,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2273,7 +2275,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageRebooting,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
@@ -2289,7 +2291,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageRebooting,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
@@ -2318,7 +2320,7 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			expectedResult: ctrl.Result{
 				RequeueAfter: time.Minute,
 			},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageJoined,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: true,
@@ -2326,11 +2328,22 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 		},
 		{
 			name:                "Already done",
-			createClient:        true,
+			createClient:        false,
 			hostInitialStage:    models.HostStageDone,
 			expectedResult:      ctrl.Result{},
-			expectedStatus:      models.HostStatusAddedToExistingCluster,
+			expectedStatus:      models.HostStatusInstalling,
 			expectedStage:       models.HostStageDone,
+			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
+			updateProgressStage: false,
+			getNodeCount:        0,
+		},
+		{
+			name:                "Not rebooting yet - do nothing",
+			createClient:        false,
+			hostInitialStage:    models.HostStageWritingImageToDisk,
+			expectedResult:      ctrl.Result{},
+			expectedStatus:      models.HostStatusInstalling,
+			expectedStage:       models.HostStageWritingImageToDisk,
 			clusterInstall:      newAciWithUserManagedNetworkingNoSNO("test-cluster-aci", testNamespace),
 			updateProgressStage: false,
 			getNodeCount:        0,
@@ -2346,6 +2359,9 @@ VU1eS0RiS/Lz6HwRs2mATNY5FrpZOgdM3cI=
 			agentSpec := v1beta1.AgentSpec{ClusterDeploymentName: &v1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace}}
 			if t.hostname != "" {
 				agentSpec.Hostname = t.hostname
+			}
+			if t.isDay1Host {
+				commonHost.Kind = swag.String(models.HostKindHost)
 			}
 			host := newAgent(hostId.String(), testNamespace, agentSpec)
 			host.Spec.Approved = true


### PR DESCRIPTION
The following applies to kube-API only:
The host UpdateInstallProgress will not update day-2 hosts to HostStatusAddedToExistingCluster if the host stage is Rebooting. The host UpdateInstallProgress will update day-2 hosts to HostStatusAddedToExistingCluster if the host stage is Done The agent controller will keep updateing day-2 agents if the agent stage is Rebooting, Configuring or Joined.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? kube-api
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-12552

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
