### PR TITLE
MGMT-12489: We should validate that inventory is not nil while returning from GetOrUnmarshal in installer cache.

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -173,7 +173,7 @@ func GetHostnameAndEffectiveRoleByHostID(hostId strfmt.UUID, hosts []*models.Hos
 		return "", "", fmt.Errorf("host with ID %s was not found", hostId.String())
 	}
 	inventory, err := inventoryCache.GetOrUnmarshal(host)
-	if err != nil {
+	if err != nil || inventory == nil {
 		return "", "", err
 	}
 	return getRealHostname(host, inventory), common.GetEffectiveRole(host), nil

--- a/internal/host/common_test.go
+++ b/internal/host/common_test.go
@@ -96,4 +96,13 @@ var _ = Describe("GetHostnameAndEffectiveRoleByHostID", func() {
 			})
 		}
 	})
+
+	Context("Inventory is empty string", func() {
+		hostID := strfmt.UUID(uuid.New().String())
+		hosts := []*models.Host{{ID: &hostID, Inventory: "", RequestedHostname: "master"}}
+		inventoryCache := make(InventoryCache)
+		hostname, _, err := GetHostnameAndEffectiveRoleByHostID(hostID, hosts, inventoryCache)
+		Expect(hostname).To(Equal(""))
+		Expect(err).ToNot(HaveOccurred())
+	})
 })

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -558,7 +558,7 @@ func (v *validator) isHostnameUnique(c *validationContext) (ValidationStatus, st
 	for _, h := range c.cluster.Hosts {
 		if h.ID.String() != c.host.ID.String() && h.Inventory != "" {
 			otherInventory, err := c.inventoryCache.GetOrUnmarshal(h)
-			if err != nil {
+			if err != nil || otherInventory == nil {
 				v.log.WithError(err).Warnf("Illegal inventory for host %s", h.ID.String())
 				// It is not our hostname
 				continue
@@ -1662,7 +1662,7 @@ func (v *validator) noSkipMissingDisk(c *validationContext) (ValidationStatus, s
 	// so we don't accidentally erase it under its new ID.
 	for _, skipFormattingDiskID := range common.GetSkippedFormattingDiskIdentifiers(c.host) {
 		inventory, err := c.inventoryCache.GetOrUnmarshal(c.host)
-		if err != nil {
+		if err != nil || inventory == nil {
 			return ValidationError, errorMessage
 		}
 


### PR DESCRIPTION
[MGMT-12489](https://issues.redhat.com//browse/MGMT-12489): We should validate that inventory is not nil while returning from GetOrUnmarshal in installer cache.
Without validation monitor can crash due to null pointer exception in further functions where we provide inventory

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
