### PR TITLE
MGMT-8357: Support kind hub-cluster for e2e tests

### DIFF
--- a/skipper.yaml
+++ b/skipper.yaml
@@ -5,9 +5,7 @@ containers:
   assisted-service-build: Dockerfile.assisted-service-build
 volumes:
   # programs
-  - /usr/bin/minikube:/usr/bin/minikube
-  - /usr/local/bin/minikube:/usr/local/bin/minikube
-  - /usr/local/bin/k3d:/usr/local/bin/k3d
+  - $(which minikube || echo /usr/local/bin/minikube):/usr/local/bin/minikube
 
   # config
   - $MINIKUBE_HOME:$MINIKUBE_HOME

--- a/tools/deploy_image_service.py
+++ b/tools/deploy_image_service.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import socket
 from urllib.parse import urlparse
 
 import yaml
@@ -47,12 +48,21 @@ def main():
         # Getting IMAGE_SERVICE_BASE_URL variable from environment which should be specified
         # as part of service deployment flow in assisted-test-infra (sets custom hostname and port).
         # Otherwise, fetching the base url from the deployed image-service `service`.
-        image_service_base_url = os.environ.get("IMAGE_SERVICE_BASE_URL", utils.get_service_url(service="assisted-image-service",
-                                                                            target=deploy_options.target,
-                                                                            domain=deploy_options.domain,
-                                                                            namespace=deploy_options.namespace,
-                                                                            disable_tls=deploy_options.disable_tls,
-                                                                            check_connection=True))
+        if deploy_options.target == "kind":
+            image_service_base_url = f"http://{socket.gethostname()}"
+        else:
+            image_service_base_url = os.environ.get(
+                "IMAGE_SERVICE_BASE_URL",
+                utils.get_service_url(
+                    service="assisted-image-service",
+                    target=deploy_options.target,
+                    domain=deploy_options.domain,
+                    namespace=deploy_options.namespace,
+                    disable_tls=deploy_options.disable_tls,
+                    check_connection=True,
+                )
+            )
+
         raw_data = raw_data.replace('REPLACE_IMAGE_SERVICE_BASE_URL', image_service_base_url)
 
         data = yaml.safe_load(raw_data)

--- a/tools/deploy_inventory_service.py
+++ b/tools/deploy_inventory_service.py
@@ -1,4 +1,5 @@
 import os
+import socket
 
 import yaml
 
@@ -59,6 +60,13 @@ def main():
             template = "assisted-installer-ingress-tls.yaml"
 
         deploy_ingress(hostname=hostname, namespace=deploy_options.namespace, template_file=template)
+
+    elif deploy_options.target == "kind":
+        deploy_ingress(
+            hostname=socket.gethostname(),
+            namespace=deploy_options.namespace,
+            template_file="assisted-installer-ingress.yaml",
+        )
 
 
 def deploy_ingress(hostname, namespace, template_file):

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -10,6 +10,7 @@ INGRESS_REMOTE_TARGET = 'oc-ingress'
 IMAGE_FQDN_TEMPLATE = "quay.io/{}/{}:{}"
 OCP_TARGET = 'ocp'
 OPENSHIFT_TARGET = 'oc'
+KIND_TARGET = 'kind'
 
 
 def load_deployment_options(parser=None):
@@ -25,7 +26,7 @@ def load_deployment_options(parser=None):
     parser.add_argument(
         '--target',
         help='Target kubernetes distribution',
-        choices=[LOCAL_TARGET, OPENSHIFT_TARGET, INGRESS_REMOTE_TARGET, OCP_TARGET],
+        choices=[LOCAL_TARGET, OPENSHIFT_TARGET, INGRESS_REMOTE_TARGET, OCP_TARGET, KIND_TARGET],
         default=LOCAL_TARGET
     )
     parser.add_argument(


### PR DESCRIPTION
This change is about:
* Enable running e2e tests via assisted-test-infra when hub-cluster is a
  kind cluster.
* There's another side of this automation in assisted-test-infra
  repository, which depends on this change.
* A bit of cleaning-up, as some stuff on those automation scripts are
  pretty yucky. For example: removing confusing k3d binary mount,
  refactor code to have a less-nested indentation, etc.
* Kind is able to mirror ports from the kubernetes node to the external
  host. We have chosen to mirror 80->80 (I can accept other suggestions
  if anyone rejects that). In addition, we have an ingress-controller,
  meaning we just use <host>:80 to access
  assisted-service/assisted-image-service. This should explain most of
  the changes here. I preferred usage of ingress instead of
  load-balancer services strategies like Metallb to simplify the
  networking architecture and also to make it work smoothly on non-Linux
  machines.

Those things are out of scope:
* Removing 'minikube' code or using 'kind' by default. To make things
  easier we'd like to transition slowly and only remove 'minikube'
  support support when we're fully ready for it.
* As a consequence of point 1, code will still be yucky for now (but I
  do want to continue and simplify it in time. Any easy change in the
  scope of this PR will be accepted gladly.
* Supporting subsystem or debug mode. Those will be considered next.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] Reviewer's test appreciated - I'll need someone with mac to give this whole setup a try
- [x] Waiting for CI to do a full test run - mainly a validation
- [x] Manual (Elaborate on how it was tested) - tested together with the assisted-test-infra code changes
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
