### PR TITLE
MGMT-12332: Subsystem tests for discovery kernel arguments

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -37,7 +37,7 @@ type InfraEnvCreateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// Name of the infra-env.
 	// Required: true

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -29,7 +29,7 @@ type InfraEnvUpdateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// proxy
 	Proxy *Proxy `json:"proxy,omitempty" gorm:"embedded;embeddedPrefix:proxy_"`

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -37,7 +37,7 @@ type InfraEnvCreateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// Name of the infra-env.
 	// Required: true

--- a/models/infra_env_update_params.go
+++ b/models/infra_env_update_params.go
@@ -29,7 +29,7 @@ type InfraEnvUpdateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// proxy
 	Proxy *Proxy `json:"proxy,omitempty" gorm:"embedded;embeddedPrefix:proxy_"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8193,7 +8193,8 @@ func init() {
       "type": "array",
       "items": {
         "$ref": "#/definitions/kernel_argument"
-      }
+      },
+      "x-omitempty": false
     },
     "l2-connectivity": {
       "type": "object",
@@ -17727,7 +17728,8 @@ func init() {
       "type": "array",
       "items": {
         "$ref": "#/definitions/kernel_argument"
-      }
+      },
+      "x-omitempty": false
     },
     "l2-connectivity": {
       "type": "object",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6324,6 +6324,7 @@ definitions:
 
   kernel_arguments:
     description: List of kernel arugment objects that define the operations and values to be applied.
+    x-omitempty: false
     type: array
     items:
       $ref: '#/definitions/kernel_argument'

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -37,7 +37,7 @@ type InfraEnvCreateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// Name of the infra-env.
 	// Required: true

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -29,7 +29,7 @@ type InfraEnvUpdateParams struct {
 	ImageType ImageType `json:"image_type,omitempty"`
 
 	// kernel arguments
-	KernelArguments KernelArguments `json:"kernel_arguments,omitempty"`
+	KernelArguments KernelArguments `json:"kernel_arguments"`
 
 	// proxy
 	Proxy *Proxy `json:"proxy,omitempty" gorm:"embedded;embeddedPrefix:proxy_"`


### PR DESCRIPTION
REST API only
This commit also adds "x-omitempty: false" in the swagger for kernel
arguments.  This causes the kernel arguments to always be part of the
infra-env register and update payloads.  This was needed to enable clear
operation on kernel arguments.
When clearing kernel arguments, empty slice is sent to indicate the request to clear them.
This is opposed to null value when the kernel arguments should not be manipulated.
When omitempty is present, empty slice and null slice are ignored and
not sent in the payload.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @filanov 