### PR TITLE
NO-ISSUE: Explicitly finish mock controllers in cluster transition tests

### DIFF
--- a/internal/cluster/cluster_suite_test.go
+++ b/internal/cluster/cluster_suite_test.go
@@ -2,7 +2,9 @@ package cluster_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/go-openapi/strfmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
@@ -10,7 +12,22 @@ import (
 
 func TestCluster(t *testing.T) {
 	RegisterFailHandler(Fail)
-	common.InitializeDBTest()
-	defer common.TerminateDBTest()
 	RunSpecs(t, "cluster tests")
 }
+
+var _ = BeforeSuite(func() {
+	// This is needed to prevent issues with non-initialized time stamp columns when the
+	// database is configured for a time zone other than UTC. Without it the result are error
+	// like this:
+	//
+	// ERROR: date/time field value out of range: "0000-12-31T23:45:16.000-00:14" (SQLSTATE 22008)
+	strfmt.NormalizeTimeForMarshal = func(t time.Time) time.Time {
+		return t.UTC()
+	}
+
+	common.InitializeDBTest()
+})
+
+var _ = AfterSuite(func() {
+	common.TerminateDBTest()
+})


### PR DESCRIPTION
Currently some of the mock controllers in the cluster transition tests aren't finished. As a result some of the expectations aren't verified, and some of the tests are incorrect. With the introduction of Ginkgo 2 the controllers will be automatically finished, and that will make these tests fail. In order to reduce the size of that migration to Gingo 2 this patch fixes those tests and changes them to explicitly finish the mock controllers.

The patch also brings the `BeforeEach` and `AfterEach` blocks that create the mock controllers closer, so that it will hopefully be harder to forget to add the cleanup code.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
