### PR TITLE
MGMT-11266: nutanix: remove worker MachineSet too

### DIFF
--- a/internal/provider/nutanix/ignition.go
+++ b/internal/provider/nutanix/ignition.go
@@ -26,6 +26,15 @@ func (p nutanixProvider) PostCreateManifestsHook(_ *common.Cluster, _ *[]string,
 		return fmt.Errorf("error deleting master machine: %w", err)
 	}
 
+	// Delete machine-set
+	p.Log.Info("Deleting machine set manifest")
+	files, _ = filepath.Glob(path.Join(workDir, "openshift", "*_openshift-cluster-api_worker-machineset-*.yaml"))
+	err = p.deleteAllFiles(files)
+
+	if err != nil {
+		return fmt.Errorf("error deleting machineset: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Worker machineset needs to be removed so that MachineAPI operator would not go degraded due to placeholder credentials on install