### PR TITLE
Disable converged flow by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,7 +147,7 @@ var Options struct {
 	LivenessValidationTimeout      time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
 	ApproveCsrsRequeueDuration     time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
-	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"true"`
+	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"`
 	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer

--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -196,7 +196,7 @@ It will continue to:
 The assisted agent will not reboot the machine at the end of the installation, instead it will stop
 the assisted agent service and let the ironic agent to manage the machine power state
 
-The converged flow is enabled by default, but can be disabled by setting the `ALLOW_CONVERGED_FLOW` env to false [here](../operator.md##specifying-environmental-variables-via-configmap)
+The converged flow is disalbed by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
 
 To set a different default ironicAgent image you can override the following env vars:
 The environment var for the ironicAgent image to be used on X86_64 CPU architecture:


### PR DESCRIPTION
Having this on by default without also having a good way to detect what ironic agent image should be used for every use case would not be a good experience. Leaving it opt-in for now allows users who need it for BIOS configuration to use it while also not disrupting disconnected users who would need to all of a sudden mirror additional images.

When 4.13 releases and includes multi-arch images in every case, we should be able to detect a suitable ironic agent image from the hub release image and instruct disconnected users to mirror that.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-11997

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

cc @eranco74 @filanov @trewest 