### PR TITLE
MGMT-12588: fix attach-disk failure

### DIFF
--- a/deploy/operator/libvirt_disks.sh
+++ b/deploy/operator/libvirt_disks.sh
@@ -18,6 +18,7 @@ function create() {
 
     echo "Creating libvirt disks and attaching them..."
     for node in ${NODES}; do
+        possible_targets=(sd{b..z})
         for disk in ${DISKS}; do
             img_path="/tmp/${node}-${disk}.img"
             if [ ! -f "${img_path}" ]; then
@@ -26,15 +27,30 @@ function create() {
                 echo "Image ${img_path} already existing. Skipping creation"
             fi
 
-            node_disks=$(virsh domblklist "${node}" | awk '{print $1}')
-            if [[ ! "${node_disks}" =~ "${disk}" ]]; then
+            if virsh domblklist "${node}" | grep -q "${img_path}"; then
+                echo "Image ${img_path} is already attached to ${node}. Skipping attachment"
+                continue
+            fi
+
+            failed=true
+            while [ "${#possible_targets[@]}" -gt 0 ]; do
+                target="${possible_targets[0]}" # get the first element
+                possible_targets=("${possible_targets[@]:1}") # remove the first element
+
                 # Libvirt cannot guarantee the device name on the guest OS (It's controlled by udev)
                 # In order to make an absolute expected destination, we provide a WWN
                 # that could be derived from the disk name.
-                # The disk would be available as a link on /dev/disk/by-id/wwn-.
-                virsh attach-disk "${node}" "${img_path}" "${disk}" --wwn "$(disk_to_wwn ${disk})"
-            else
-                echo "Disk ${disk} is already attached to ${node}. Skipping attachment"
+                # The disk would be available as a link on /dev/disk/by-id/wwn-.}}
+                # https://bugzilla.redhat.com/show_bug.cgi?id=693372
+                if virsh attach-disk "${node}" "${img_path}" "${target}" --wwn "$(disk_to_wwn ${disk})"; then
+                    failed=false
+                    break
+                fi
+            done
+
+            if ${failed}; then
+                echo "Failed to attach image ${img_path} to node ${node}."
+                exit 1
             fi
         done
     done
@@ -47,12 +63,12 @@ function destroy() {
 
     for node in ${NODES}; do
         for disk in ${DISKS}; do
-            node_disks=$(virsh domblklist "${node}" | awk '{print $1}')
-            if [[ "${node_disks}" =~ "${disk}" ]]; then
+            img_path="/tmp/${node}-${disk}.img"
+
+            if virsh domblklist "${node}" | grep -q "${img_path}"; then
                 virsh detach-disk "${node}" "${disk}" || true
             fi
 
-            img_path="/tmp/${node}-${disk}.img"
             if [ -f "${img_path}" ]; then
                 rm -rf "${img_path}"
             fi


### PR DESCRIPTION
The target disk given to `virsh attach-disk` is a hint for the guest OS. Sometimes, the target disk collides a disk already mounted in the guest OS (e.g.: a target `sdb` will be seen as `/dev/sda` in the guest OS) and `virsh attach-disk` fails with `error: Requested operation is not valid: Domain already contains a disk with that address`. This issue is one cause of flakiness for ZTP jobs.

This change tries to attach the first target available for a given disk name. The target as no impact on the reachability of the disk on the guest OS because later we use the wwn which is derived from the disk name.

Example of flaky job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-installer/580/pull-ci-openshift-assisted-installer-master-edge-e2e-ai-operator-ztp/1592525947402194944