### PR TITLE
NO-ISSUE: Explicitly finish mock controller in ignition tests

### DIFF
--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -992,6 +992,10 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Context("with auth enabled", func() {
 
 		It("ignition_file_fails_missing_Pull_Secret_token", func() {
@@ -1213,7 +1217,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("no multipath for okd", func() {
 		config := IgnitionConfig{OKDRPMsImage: "image"}
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1222,7 +1226,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("multipath configured for non-okd", func() {
 		config := IgnitionConfig{}
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1265,7 +1269,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			Expect(count).Should(Equal(3))
 		})
 		It("Doesn't include static network config for minimal isos", func() {
-			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(gomock.Any(), formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
@@ -1303,7 +1306,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		})
 
 		It("Will not include static network config for full iso type in infraenv if overridden in call to FormatDiscoveryIgnitionFile", func() {
-			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(gomock.Any(), formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
@@ -1363,6 +1365,7 @@ var _ = Describe("Ignition SSH key building", func() {
 			Expect(text).ShouldNot(ContainSubstring(subStr))
 		}
 	}
+
 	BeforeEach(func() {
 		infraEnvID = strfmt.UUID("a64fff36-dcb1-11ea-87d0-0242ac130003")
 		ctrl = gomock.NewController(GinkgoT())
@@ -1381,6 +1384,11 @@ var _ = Describe("Ignition SSH key building", func() {
 		Expect(err).ToNot(HaveOccurred())
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	Context("when empty or invalid input", func() {
 		It("white_space_string should return an empty string", func() {
 			buildIgnitionAndAssertSubString("  \n  \n \t \n  ", false, "sshAuthorizedKeys")
@@ -1437,6 +1445,10 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		var err error
 		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Context("test custom ignition endpoint", func() {


### PR DESCRIPTION
Currently some of the mock controllers in the ignition tests aren't finished. As a result some of the expectations aren't verified, and some of the tests are incorrect. With the introduction of Ginkgo 2 the controllers will be automatically finished, and that will make these tests fail. In order to reduce the size of that migration to Gingo 2 this patch fixes those tests and changes them to explicitly finish the mock controllers.

The patch also brings the `BeforeEach` and `AfterEach` blocks that create the mock controllers closer, so that it will hopefully be harder to forget to add the cleanup code.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
