### PR TITLE
MGMT-12318: improve condition message of missing secret

### DIFF
--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
@@ -238,7 +238,7 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		_, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring(
-			fmt.Sprintf("Failed to get '%s' secret in '%s' namespace",
+			fmt.Sprintf("Failed to get '%s' secret in '%s' namespace (check `kubeconfigSecretRef` property)",
 				hsc.Spec.KubeconfigSecretRef.Name, testNamespace)))
 		assertReconcileCompletedCondition(corev1.ConditionFalse, aiv1beta1.ReasonKubeconfigSecretFetchFailure)
 	})
@@ -252,7 +252,10 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		}
 		asc.initHASC(hr, hsc)
 		Expect(hr.Client.Create(ctx, secret)).To(Succeed())
-		_, err := hr.createSpokeClient(ctx, secret.Name, asc)
+		Expect(hr.Client.Update(ctx, hsc)).To(Succeed())
+		mockSpokeClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockSpokeClient.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		_, err := hr.Reconcile(ctx, newHypershiftAgentServiceConfigRequest(hsc))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(ContainSubstring(
 			fmt.Sprintf("Secret '%s' does not contain '%s' key value",


### PR DESCRIPTION
Condition message for missing kubeconfig secret should contain concise informat of the error. Thus, logging the internal error and expose a clear message.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
