### PR TITLE
MGMT-8357: change 'local' deployment method to 'minikube'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(CONTAINER_COMMAND), docker)
 	CONTAINER_COMMAND = $(shell docker -v 2>/dev/null | cut -f1 -d' ' | tr '[:upper:]' '[:lower:]')
 endif
 
-TARGET := $(or ${TARGET},local)
+TARGET := $(or ${TARGET},minikube)
 KUBECTL=kubectl -n $(NAMESPACE)
 
 define get_service_host_port
@@ -123,7 +123,7 @@ BUNDLE_METADATA_OPTS ?= --channels=$(BUNDLE_CHANNELS) --default-channel=alpha
 # We decided to have an option to change replicas count only while running locally
 # check if SERVICE_REPLICAS_COUNT was set and if yes change default value to required one
 # Default for 1 replica
-REPLICAS_COUNT = $(shell if ! [ "${TARGET}" = "local" ] && ! [ "${TARGET}" = "oc" ];then echo 3; else echo $(or ${SERVICE_REPLICAS_COUNT},1);fi)
+REPLICAS_COUNT = $(shell if [[ "${TARGET}" != @(minikube|kind|oc) ]]; then echo 3; else echo $(or ${SERVICE_REPLICAS_COUNT},1);fi)
 
 ifdef INSTALLATION_TIMEOUT
 	INSTALLATION_TIMEOUT_FLAG = --installation-timeout $(INSTALLATION_TIMEOUT)

--- a/tools/deployment_options.py
+++ b/tools/deployment_options.py
@@ -5,12 +5,14 @@ import requests
 import yaml
 
 
-LOCAL_TARGET = 'local'
+# Deployment options
+MINIKUBE_TARGET = 'minikube'
 INGRESS_REMOTE_TARGET = 'oc-ingress'
-IMAGE_FQDN_TEMPLATE = "quay.io/{}/{}:{}"
 OCP_TARGET = 'ocp'
 OPENSHIFT_TARGET = 'oc'
 KIND_TARGET = 'kind'
+
+IMAGE_FQDN_TEMPLATE = "quay.io/{}/{}:{}"
 
 
 def load_deployment_options(parser=None):
@@ -26,8 +28,8 @@ def load_deployment_options(parser=None):
     parser.add_argument(
         '--target',
         help='Target kubernetes distribution',
-        choices=[LOCAL_TARGET, OPENSHIFT_TARGET, INGRESS_REMOTE_TARGET, OCP_TARGET, KIND_TARGET],
-        default=LOCAL_TARGET
+        choices=[MINIKUBE_TARGET, OPENSHIFT_TARGET, INGRESS_REMOTE_TARGET, OCP_TARGET, KIND_TARGET],
+        default=MINIKUBE_TARGET
     )
     parser.add_argument(
         '--domain',


### PR DESCRIPTION
Since we're gonna (temporarily) have two deployment methods that have different network configuration, we should rename 'local' to 'minikube'. Then assisted-test-infra can pass its value of ``DEPLOY_TARGET`` to what assisted-service calls ``TARGET`` (seems ``DEPLOY_TARGET`` in assisted-service is already used in some other constellation).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment - I'll check the 'kind' flow locally
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
