### PR TITLE
Refactor the versions handler into a proper cache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -548,6 +548,7 @@ func main() {
 				ServiceBaseURL:    Options.BMConfig.ServiceBaseURL,
 				PullSecretHandler: controllers.NewPullSecretHandler(cluster_client, cluster_reader, bm),
 				AuthType:          Options.Auth.AuthType,
+				VersionsHandler:   versionHandler,
 			}).SetupWithManager(ctrlMgr), "unable to create controller ClusterDeployment")
 
 			failOnError((&controllers.AgentReconciler{

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -162,7 +162,6 @@ type InstallerInternals interface {
 	UpdateClusterInstallConfigInternal(ctx context.Context, params installer.V2UpdateClusterInstallConfigParams) (*common.Cluster, error)
 	CancelInstallationInternal(ctx context.Context, params installer.V2CancelInstallationParams) (*common.Cluster, error)
 	TransformClusterToDay2Internal(ctx context.Context, clusterID strfmt.UUID) (*common.Cluster, error)
-	AddReleaseImage(ctx context.Context, releaseImageUrl, pullSecret, ocpReleaseVersion string, cpuArchitectures []string) (*models.ReleaseImage, error)
 	GetClusterSupportedPlatformsInternal(ctx context.Context, params installer.GetClusterSupportedPlatformsParams) (*[]models.PlatformType, error)
 	V2UpdateHostInternal(ctx context.Context, params installer.V2UpdateHostParams, interactivity Interactivity) (*common.Host, error)
 	GetInfraEnvByKubeKey(key types.NamespacedName) (*common.InfraEnv, error)
@@ -4157,28 +4156,6 @@ func (b *bareMetalInventory) V2ResetHostValidation(ctx context.Context, params i
 		return common.GenerateErrorResponder(err)
 	}
 	return installer.NewV2ResetHostValidationOK()
-}
-
-func (b *bareMetalInventory) AddReleaseImage(ctx context.Context, releaseImageUrl, pullSecret, ocpReleaseVersion string, cpuArchitectures []string) (*models.ReleaseImage, error) {
-	log := logutil.FromContext(ctx, b.log)
-
-	// Create a new OpenshiftVersion and add it to versions cache
-	debugTemplate := fmt.Sprintf("Creating OpenShiftVersion from release image %s", releaseImageUrl)
-	if ocpReleaseVersion != "" {
-		debugTemplate = fmt.Sprintf(debugTemplate+" for version %s", ocpReleaseVersion)
-	}
-	if cpuArchitectures != nil {
-		debugTemplate = fmt.Sprintf(debugTemplate+" for architectures: %s", cpuArchitectures)
-	}
-	log.Debug(debugTemplate)
-
-	releaseImage, err := b.versionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, ocpReleaseVersion, cpuArchitectures)
-	if err != nil {
-		log.WithError(err).Errorf("Failed to add OCP version for release image: %s", releaseImageUrl)
-		return nil, err
-	}
-
-	return releaseImage, nil
 }
 
 func (b *bareMetalInventory) DeregisterInfraEnv(ctx context.Context, params installer.DeregisterInfraEnvParams) middleware.Responder {

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -491,8 +491,8 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 
-	releaseImage, err := b.versionsHandler.GetReleaseImage(
-		swag.StringValue(params.NewClusterParams.OpenshiftVersion), cpuArchitecture)
+	releaseImage, err := b.versionsHandler.GetReleaseImage(ctx, swag.StringValue(params.NewClusterParams.OpenshiftVersion),
+		cpuArchitecture, swag.StringValue(params.NewClusterParams.PullSecret))
 	if err != nil {
 		err = errors.Wrapf(err, "Openshift version %s for CPU architecture %s is not supported",
 			swag.StringValue(params.NewClusterParams.OpenshiftVersion), cpuArchitecture)
@@ -1651,7 +1651,7 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 		return errors.Wrapf(err, "failed to get install config for cluster %s", cluster.ID)
 	}
 
-	releaseImage, err := b.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion, cluster.CPUArchitecture)
+	releaseImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
 	if err != nil {
 		msg := fmt.Sprintf("failed to get OpenshiftVersion for cluster %s with openshift version %s", cluster.ID, cluster.OpenshiftVersion)
 		log.WithError(err).Errorf(msg)
@@ -1660,7 +1660,7 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 
 	installerReleaseImageOverride := ""
 	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster.CPUArchitecture, cluster.OpenshiftVersion, cluster.Platform.Type) {
-		defaultArchImage, err := b.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion, common.DefaultCPUArchitecture)
+		defaultArchImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, common.DefaultCPUArchitecture, cluster.PullSecret)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get image for installer image override "+
 				"for cluster %s with openshift version %s and %s arch", cluster.ID, cluster.OpenshiftVersion, cluster.CPUArchitecture)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -199,7 +199,7 @@ func toMac(macStr string) *strfmt.MAC {
 
 func mockClusterRegisterSteps() {
 	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+	mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 	mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
@@ -296,7 +296,7 @@ func getDefaultClusterCreateParams() *models.ClusterCreateParams {
 
 func mockGenerateInstallConfigSuccess(mockGenerator *generator.MockISOInstallConfigGenerator, mockVersions *versions.MockHandler) {
 	if mockGenerator != nil {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockGenerator.EXPECT().GenerateInstallConfig(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	}
 }
@@ -2670,7 +2670,7 @@ var _ = Describe("cluster", func() {
 						eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
 						eventstest.WithMessageContainsMatcher("error"),
 						eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
-					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().GetOperatorByName(newOperatorName).Return(nil, errors.Errorf("error")).Times(1)
 
@@ -2685,7 +2685,7 @@ var _ = Describe("cluster", func() {
 				})
 
 				It("should return error when both cnv and lvm operator enabled", func() {
-					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
 						DoAndReturn(func(commonCluster *common.Cluster, operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
@@ -5213,8 +5213,8 @@ var _ = Describe("cluster", func() {
 				URL: swag.String("quay.io/openshift-release-dev/ocp-release:4.6.16-aarch64"),
 			}
 			mockGetInstallConfigSuccess(mockInstallConfigBuilder)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.ARM64CPUArchitecture).Return(armRelease, nil).Times(1)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.DefaultCPUArchitecture).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture, gomock.Any()).Return(armRelease, nil).Times(1)
+			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.DefaultCPUArchitecture, gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 			mockGenerator.EXPECT().GenerateInstallConfig(gomock.Any(), gomock.Any(), gomock.Any(), *armRelease.URL, *common.TestDefaultConfig.ReleaseImage.URL).Return(nil).Times(1)
 
 			mockClusterPrepareForInstallationSuccess(mockClusterApi)
@@ -5274,8 +5274,8 @@ var _ = Describe("cluster", func() {
 				URL: swag.String("quay.io/openshift-release-dev/ocp-release:4.6.16-aarch64"),
 			}
 			mockGetInstallConfigSuccess(mockInstallConfigBuilder)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.ARM64CPUArchitecture).Return(armRelease, nil).Times(1)
-			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), common.DefaultCPUArchitecture).Return(nil, errors.Errorf("Dummy")).Times(1)
+			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.ARM64CPUArchitecture, gomock.Any()).Return(armRelease, nil).Times(1)
+			mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), common.DefaultCPUArchitecture, gomock.Any()).Return(nil, errors.Errorf("Dummy")).Times(1)
 
 			mockClusterPrepareForInstallationSuccess(mockClusterApi)
 			mockHostPrepareForRefresh(mockHostApi)
@@ -11869,7 +11869,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			Version:          &openShiftVersionWithMaintenanceSupportLevel,
 			SupportLevel:     models.OpenshiftVersionSupportLevelMaintenance,
 		}
-		mockVersions.EXPECT().GetReleaseImage(*releaseImage.OpenshiftVersion, *releaseImage.CPUArchitecture).Return(releaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(ctx, *releaseImage.OpenshiftVersion, *releaseImage.CPUArchitecture, *clusterParams.PullSecret).Return(releaseImage, nil).Times(1)
 		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
 			NewClusterParams: clusterParams,
 		})
@@ -12602,7 +12602,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.PullSecret = swag.String("")
@@ -12617,7 +12617,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
 			eventstest.WithMessageContainsMatcher("Openshift version 999 for CPU architecture x86_64 is not supported: OpenShift Version is not supported"),
 			eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("OpenShift Version is not supported")).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("OpenShift Version is not supported")).Times(1)
 
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.OpenshiftVersion = swag.String("999")
@@ -12677,7 +12677,7 @@ var _ = Describe("TestRegisterCluster", func() {
 
 	It("Register cluster with arm64 CPU architecture as multiarch if multiarch release image used", func() {
 		mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
 			CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
 			CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
 			OpenshiftVersion: swag.String("4.11.1"),
@@ -12882,7 +12882,7 @@ var _ = Describe("TestRegisterCluster", func() {
 
 			It("Register a cluster with multi CPU architecture - success", func() {
 				mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
+				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
 					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
 					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
 					OpenshiftVersion: swag.String("its-just-a-mock"),
@@ -12912,7 +12912,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			})
 
 			It("Register a cluster with multi CPU architecture - fail with no capability", func() {
-				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
+				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
 					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
 					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
 					OpenshiftVersion: swag.String("its-just-a-mock"),

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -15251,42 +15251,6 @@ var _ = Describe("GetCredentials", func() {
 	})
 })
 
-var _ = Describe("AddReleaseImage", func() {
-	var (
-		cfg          = Config{}
-		ctx          = context.Background()
-		bm           *bareMetalInventory
-		db           *gorm.DB
-		dbName       string
-		pullSecret   = "test_pull_secret"
-		releaseImage = "releaseImage"
-	)
-
-	BeforeEach(func() {
-		db, dbName = common.PrepareTestDB()
-		bm = createInventory(db, cfg)
-	})
-
-	AfterEach(func() {
-		common.DeleteTestDB(db, dbName)
-	})
-
-	It("successfully added version", func() {
-		mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
-
-		image, err := bm.AddReleaseImage(ctx, releaseImage, pullSecret, "", nil)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(image).Should(Equal(common.TestDefaultConfig.ReleaseImage))
-	})
-
-	It("failed to added version", func() {
-		mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).Times(1)
-
-		_, err := bm.AddReleaseImage(ctx, releaseImage, pullSecret, "", nil)
-		Expect(err).Should(HaveOccurred())
-	})
-})
-
 var _ = Describe("Platform tests", func() {
 
 	var (

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -40,21 +40,6 @@ func (m *MockInstallerInternals) EXPECT() *MockInstallerInternalsMockRecorder {
 	return m.recorder
 }
 
-// AddReleaseImage mocks base method.
-func (m *MockInstallerInternals) AddReleaseImage(arg0 context.Context, arg1, arg2, arg3 string, arg4 []string) (*models.ReleaseImage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddReleaseImage", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(*models.ReleaseImage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AddReleaseImage indicates an expected call of AddReleaseImage.
-func (mr *MockInstallerInternalsMockRecorder) AddReleaseImage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReleaseImage", reflect.TypeOf((*MockInstallerInternals)(nil).AddReleaseImage), arg0, arg1, arg2, arg3, arg4)
-}
-
 // BindHostInternal mocks base method.
 func (m *MockInstallerInternals) BindHostInternal(arg0 context.Context, arg1 installer.BindHostParams) (*common.Host, error) {
 	m.ctrl.T.Helper()

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1328,7 +1328,7 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 
 	// before creating the cluster the source of truth is the
 	// release image url from the ClusterImageSetRef
-	releaseImage, err := r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+	releaseImage, err := r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret)
 	if err != nil {
 		log.Error(err)
 		errMsg := "failed to add release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid (error: %s)."

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -43,6 +43,7 @@ import (
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -93,7 +94,8 @@ type ClusterDeploymentsReconciler struct {
 	Manifests        manifestsapi.ClusterManifestsInternals
 	ServiceBaseURL   string
 	PullSecretHandler
-	AuthType auth.AuthType
+	AuthType        auth.AuthType
+	VersionsHandler versions.Handler
 }
 
 const minimalOpenShiftVersionForDefaultNetworkTypeOVNKubernetes = "4.12.0-0.0"
@@ -1336,13 +1338,11 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 	if cluster == nil {
 		// before creating the cluster the source of truth is the
 		// release image url from the ClusterImageSetRef
-		releaseImage, err = r.Installer.AddReleaseImage(ctx,
-			releaseImageUrl, pullSecret, "", nil)
+		releaseImage, err = r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 	} else {
 		// If the cluster is already created, take the Release Version
 		// ane architecture from the version calculated by the BE.
-		releaseImage, err = r.Installer.AddReleaseImage(ctx,
-			releaseImageUrl, pullSecret, cluster.OpenshiftVersion, []string{cluster.CPUArchitecture})
+		releaseImage, err = r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, cluster.OpenshiftVersion, []string{cluster.CPUArchitecture})
 	}
 
 	if err != nil {

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -376,13 +376,6 @@ func (r *ClusterDeploymentsReconciler) installDay1(ctx context.Context, log logr
 			return ctrl.Result{Requeue: true, RequeueAfter: longerRequeueAfterOnError}, nil
 		}
 
-		// Ensure release image exists in versions cache
-		_, err = r.addReleaseImage(ctx, log, clusterInstall.Spec, pullSecret, cluster)
-		if err != nil {
-			log.WithError(err)
-			return r.updateStatus(ctx, log, clusterInstall, cluster, err)
-		}
-
 		log.Infof("Installing clusterDeployment %s %s", clusterDeployment.Name, clusterDeployment.Namespace)
 		var ic *common.Cluster
 		ic, err = r.Installer.InstallClusterInternal(ctx, installer.V2InstallClusterParams{

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1238,7 +1238,7 @@ func (r *ClusterDeploymentsReconciler) createNewCluster(
 		return r.updateStatus(ctx, log, clusterInstall, nil, err)
 	}
 
-	releaseImage, err := r.addReleaseImage(ctx, log, clusterInstall.Spec, pullSecret, nil)
+	releaseImage, err := r.addReleaseImage(ctx, log, clusterInstall.Spec, pullSecret)
 
 	if err != nil {
 		log.WithError(err)
@@ -1315,8 +1315,7 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 	ctx context.Context,
 	log logrus.FieldLogger,
 	spec hiveext.AgentClusterInstallSpec,
-	pullSecret string,
-	cluster *common.Cluster) (*models.ReleaseImage, error) {
+	pullSecret string) (*models.ReleaseImage, error) {
 
 	var err error
 
@@ -1327,17 +1326,9 @@ func (r *ClusterDeploymentsReconciler) addReleaseImage(
 		return nil, err
 	}
 
-	var releaseImage *models.ReleaseImage
-	if cluster == nil {
-		// before creating the cluster the source of truth is the
-		// release image url from the ClusterImageSetRef
-		releaseImage, err = r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-	} else {
-		// If the cluster is already created, take the Release Version
-		// ane architecture from the version calculated by the BE.
-		releaseImage, err = r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, cluster.OpenshiftVersion, []string{cluster.CPUArchitecture})
-	}
-
+	// before creating the cluster the source of truth is the
+	// release image url from the ClusterImageSetRef
+	releaseImage, err := r.VersionsHandler.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 	if err != nil {
 		log.Error(err)
 		errMsg := "failed to add release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid (error: %s)."

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -292,7 +292,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -312,7 +312,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HTTPSProxy)).To(Equal(httpsProxy))
 						Expect(swag.StringValue(params.NewClusterParams.NoProxy)).To(Equal(noProxy))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -328,7 +328,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -367,7 +367,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*armReleaseImage.Version))
 						Expect(params.NewClusterParams.CPUArchitecture).To(Equal(CpuArchitectureArm))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -400,7 +400,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTang))
 						Expect(params.NewClusterParams.DiskEncryption.TangServers).To(Equal(tangServersConfig))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -420,7 +420,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(ocpReleaseVersion))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace,
@@ -440,7 +440,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HighAvailabilityMode)).
 							To(Equal(HighAvailabilityModeNone))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -460,7 +460,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.BoolValue(params.NewClusterParams.UserManagedNetworking)).
 							To(BeTrue())
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -544,7 +544,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("fail to get openshift version when trying to create a cluster", func() {
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
 				mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -576,7 +576,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -1205,7 +1205,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			simulateACIDeletionWithFinalizer(ctx, c, aci)
 			request := newClusterDeploymentRequest(cd)

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1282,7 +1282,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
@@ -1314,7 +1313,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
 
 			installClusterReply := &common.Cluster{
@@ -1384,7 +1382,6 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			cvoMsg := fmt.Sprintf(". Cluster version status: %s, message: %s", models.OperatorStatusProgressing, cvoStatusInfo)
 			expectedMsg := fmt.Sprintf("%s %s%s", hiveext.ClusterInstallationInProgressMsg, *installClusterReply.StatusInfo, cvoMsg)
@@ -1406,7 +1403,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 			oper := make([]*models.MonitoredOperator, 1)
@@ -1691,7 +1687,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(expectedErr))
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
@@ -2035,7 +2030,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:         backEndCluster.ID,
@@ -2061,7 +2055,6 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("Update manifests - no manifests", func() {
-
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:         backEndCluster.ID,
@@ -2071,7 +2064,6 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil).Times(1)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 			By("no manifests")
@@ -2109,7 +2101,6 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
@@ -2164,7 +2155,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:         backEndCluster.ID,
@@ -2307,63 +2297,6 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionTrue))
 		})
 
-		It("getReleaseImage failed due to an invalid ImageSetRef - should not requeue", func() {
-			backEndCluster.Status = swag.String(models.ClusterStatusReady)
-			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-
-			aci.Spec.ImageSetRef.Name = "invalid"
-			Expect(c.Update(ctx, aci)).Should(BeNil())
-
-			request := newClusterDeploymentRequest(cluster)
-			result, err := cr.Reconcile(ctx, request)
-			Expect(err).To(BeNil())
-			Expect(result.Requeue).To(BeFalse())
-
-			aci = getTestClusterInstall()
-			expectedErr := fmt.Sprintf("failed to get cluster image set %s", aci.Spec.ImageSetRef.Name)
-			expectedState := fmt.Sprintf("%s %s", hiveext.ClusterBackendErrorMsg, expectedErr)
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterBackendErrorReason))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Message).To(ContainSubstring(expectedState))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Reason).To(Equal(hiveext.ClusterReadyReason))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Message).To(Equal(hiveext.ClusterReadyMsg))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionTrue))
-		})
-
-		It("AddReleaseImage failed before installation - should not requeue", func() {
-			backEndCluster.Status = swag.String(models.ClusterStatusReady)
-			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
-			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
-			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
-			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-
-			errMsg := "No OS images are available"
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(errMsg))
-
-			request := newClusterDeploymentRequest(cluster)
-			result, err := cr.Reconcile(ctx, request)
-			Expect(err).To(BeNil())
-			Expect(result.Requeue).To(BeFalse())
-
-			aci = getTestClusterInstall()
-			expectedErr := fmt.Sprintf("failed to add release image '%s'. Please ensure the releaseImage field in ClusterImageSet '%s' is valid (error: %s).",
-				releaseImageUrl, imageSetName, errMsg)
-			expectedState := fmt.Sprintf("%s %s", hiveext.ClusterBackendErrorMsg, expectedErr)
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Reason).To(Equal(hiveext.ClusterBackendErrorReason))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Status).To(Equal(corev1.ConditionFalse))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterSpecSyncedCondition).Message).To(ContainSubstring(expectedState))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Reason).To(Equal(hiveext.ClusterReadyReason))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Message).To(Equal(hiveext.ClusterReadyMsg))
-			Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionTrue))
-		})
-
 		It("install cluster with API VIP and Ingress VIP", func() {
 			backEndCluster.Status = swag.String(models.ClusterStatusReady)
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(1)
@@ -2372,7 +2305,6 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
 
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -292,7 +292,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -312,7 +312,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HTTPSProxy)).To(Equal(httpsProxy))
 						Expect(swag.StringValue(params.NewClusterParams.NoProxy)).To(Equal(noProxy))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -328,7 +328,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -367,7 +367,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*armReleaseImage.Version))
 						Expect(params.NewClusterParams.CPUArchitecture).To(Equal(CpuArchitectureArm))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -400,7 +400,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTang))
 						Expect(params.NewClusterParams.DiskEncryption.TangServers).To(Equal(tangServersConfig))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -420,7 +420,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(ocpReleaseVersion))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace,
@@ -440,7 +440,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HighAvailabilityMode)).
 							To(Equal(HighAvailabilityModeNone))
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -460,7 +460,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.BoolValue(params.NewClusterParams.UserManagedNetworking)).
 							To(BeTrue())
 					}).Return(clusterReply, nil)
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -544,7 +544,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("fail to get openshift version when trying to create a cluster", func() {
-				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
+				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
 				mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -576,7 +576,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -1205,7 +1205,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
-			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			simulateACIDeletionWithFinalizer(ctx, c, aci)
 			request := newClusterDeploymentRequest(cd)

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -169,6 +170,7 @@ var _ = Describe("cluster reconcile", func() {
 		mockHostApi                    *host.MockAPI
 		mockManifestsApi               *manifestsapi.MockClusterManifestsInternals
 		mockCRDEventsHandler           *MockCRDEventsHandler
+		mockVersions                   *versions.MockHandler
 		defaultClusterSpec             hivev1.ClusterDeploymentSpec
 		clusterName                    = "test-cluster"
 		agentClusterInstallName        = "test-cluster-aci"
@@ -228,6 +230,7 @@ var _ = Describe("cluster reconcile", func() {
 		mockHostApi = host.NewMockAPI(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 		mockManifestsApi = manifestsapi.NewMockClusterManifestsInternals(mockCtrl)
+		mockVersions = versions.NewMockHandler(mockCtrl)
 		cr = &ClusterDeploymentsReconciler{
 			Client:            c,
 			APIReader:         c,
@@ -239,6 +242,7 @@ var _ = Describe("cluster reconcile", func() {
 			CRDEventsHandler:  mockCRDEventsHandler,
 			Manifests:         mockManifestsApi,
 			PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
+			VersionsHandler:   mockVersions,
 		}
 	})
 
@@ -288,7 +292,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -308,7 +312,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HTTPSProxy)).To(Equal(httpsProxy))
 						Expect(swag.StringValue(params.NewClusterParams.NoProxy)).To(Equal(noProxy))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -324,7 +328,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -363,7 +367,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*armReleaseImage.Version))
 						Expect(params.NewClusterParams.CPUArchitecture).To(Equal(CpuArchitectureArm))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(armReleaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -396,7 +400,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.DiskEncryption.Mode)).To(Equal(models.DiskEncryptionModeTang))
 						Expect(params.NewClusterParams.DiskEncryption.TangServers).To(Equal(tangServersConfig))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -416,7 +420,7 @@ var _ = Describe("cluster reconcile", func() {
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(ocpReleaseVersion))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace,
@@ -436,7 +440,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.StringValue(params.NewClusterParams.HighAvailabilityMode)).
 							To(Equal(HighAvailabilityModeNone))
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -456,7 +460,7 @@ var _ = Describe("cluster reconcile", func() {
 						Expect(swag.BoolValue(params.NewClusterParams.UserManagedNetworking)).
 							To(BeTrue())
 					}).Return(clusterReply, nil)
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 				mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -540,7 +544,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("fail to get openshift version when trying to create a cluster", func() {
-				mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
+				mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
 				mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 				cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
@@ -572,7 +576,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -1099,6 +1103,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockHostApi = host.NewMockAPI(mockCtrl)
 			mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 			mockManifestsApi = manifestsapi.NewMockClusterManifestsInternals(mockCtrl)
+			mockVersions = versions.NewMockHandler(mockCtrl)
 			cr = &ClusterDeploymentsReconciler{
 				Client:            c,
 				APIReader:         c,
@@ -1110,6 +1115,7 @@ var _ = Describe("cluster reconcile", func() {
 				CRDEventsHandler:  mockCRDEventsHandler,
 				Manifests:         mockManifestsApi,
 				PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
+				VersionsHandler:   mockVersions,
 			}
 			Expect(c.Create(ctx, cd)).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
@@ -1199,7 +1205,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 			mockInstallerInternal.EXPECT().DeregisterClusterInternal(gomock.Any(), gomock.Any()).Return(nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			simulateACIDeletionWithFinalizer(ctx, c, aci)
 			request := newClusterDeploymentRequest(cd)
@@ -1276,7 +1282,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
@@ -1308,7 +1314,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
 
 			installClusterReply := &common.Cluster{
@@ -1378,7 +1384,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			cvoMsg := fmt.Sprintf(". Cluster version status: %s, message: %s", models.OperatorStatusProgressing, cvoStatusInfo)
 			expectedMsg := fmt.Sprintf("%s %s%s", hiveext.ClusterInstallationInProgressMsg, *installClusterReply.StatusInfo, cvoMsg)
@@ -1400,7 +1406,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 			oper := make([]*models.MonitoredOperator, 1)
@@ -1685,7 +1691,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(expectedErr))
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
@@ -2029,7 +2035,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:         backEndCluster.ID,
@@ -2065,7 +2071,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil).Times(1)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 
 			By("no manifests")
@@ -2103,7 +2109,7 @@ var _ = Describe("cluster reconcile", func() {
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
 				Return(installClusterReply, nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
@@ -2158,7 +2164,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:         backEndCluster.ID,
@@ -2339,7 +2345,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 
 			errMsg := "No OS images are available"
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(errMsg))
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New(errMsg))
 
 			request := newClusterDeploymentRequest(cluster)
 			result, err := cr.Reconcile(ctx, request)
@@ -2366,7 +2372,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockInstallerInternal.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
+			mockVersions.EXPECT().AddReleaseImage(gomock.Any(), gomock.Any(), backEndCluster.OpenshiftVersion, []string{backEndCluster.CPUArchitecture}).Return(releaseImage, nil)
 
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -206,19 +206,6 @@ func generatePassword(length int) (string, error) {
 	return string(password), nil
 }
 
-func getReleaseImage(ctx context.Context, c client.Client, imageSetName string) (string, error) {
-	clusterImageSet := &hivev1.ClusterImageSet{}
-	key := types.NamespacedName{
-		Namespace: "",
-		Name:      imageSetName,
-	}
-	if err := c.Get(ctx, key, clusterImageSet); err != nil {
-		return "", errors.Wrapf(err, "failed to get cluster image set %s", key.Name)
-	}
-
-	return clusterImageSet.Spec.ReleaseImage, nil
-}
-
 func addRequestIdIfNeeded(ctx context.Context) context.Context {
 	ctxWithReqID := ctx
 	if requestid.FromContext(ctx) == "" {

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -430,7 +430,7 @@ func (r *PreprovisioningImageReconciler) getIronicAgentImageByRelease(ctx contex
 		return "", fmt.Errorf("Openshift version (%s) is lower than the minimal version for the converged flow (%s)", cluster.OpenshiftVersion, MinimalVersionForConvergedFlow)
 	}
 
-	releaseImage, err := r.VersionsHandler.GetReleaseImage(cluster.OpenshiftVersion, infraEnv.CPUArchitecture)
+	releaseImage, err := r.VersionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.PullSecret)
 	if err != nil {
 		return "", err
 	}

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -303,10 +303,11 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			ironicAgentImage := "ironic-image:4.12.0"
 			backendInfraEnv.OpenshiftVersion = "4.12.0-test.release"
 			backendInfraEnv.CPUArchitecture = "x86_64"
+			backendInfraEnv.PullSecret = "mypullsecret"
 			backendCluster := common.Cluster{Cluster: models.Cluster{ID: &clusterID, OpenshiftVersion: "4.12"}}
 			mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: clusterID}).Return(&backendCluster, nil)
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-			mockVersionHandler.EXPECT().GetReleaseImage(backendCluster.OpenshiftVersion, backendInfraEnv.CPUArchitecture).Return(&models.ReleaseImage{URL: &openshiftRelaseImage}, nil)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), backendCluster.OpenshiftVersion, backendInfraEnv.CPUArchitecture, backendInfraEnv.PullSecret).Return(&models.ReleaseImage{URL: &openshiftRelaseImage}, nil)
 			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), openshiftRelaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {

--- a/internal/host/hostcommands/container_image_availability_cmd_test.go
+++ b/internal/host/hostcommands/container_image_availability_cmd_test.go
@@ -55,7 +55,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 
@@ -75,7 +75,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_release_image_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
 		Expect(err).To(HaveOccurred())
@@ -83,7 +83,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_mco_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("err")).Times(1)
 
 		step, err := cmd.GetSteps(ctx, &host)
@@ -92,7 +92,7 @@ var _ = Describe("container_image_availability_cmd", func() {
 	})
 
 	It("get_step_get_must_gather_failure", func() {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("err")).Times(1)
 
@@ -127,12 +127,12 @@ var _ = Describe("get images", func() {
 
 	It("get_step_get_all_images", func() {
 		mco := "image-mco"
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mco, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 		release := common.TestDefaultConfig.ReleaseImageUrl
 		expected := []string{release, mco, defaultMustGatherVersion["ocp"]}
-		images, err := cmd.getImages(cluster)
+		images, err := cmd.getImages(context.Background(), cluster)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(images).To(Equal(expected))
 	})

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -116,7 +116,7 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 
 	// those flags are not used on day2 installation
 	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
-		releaseImage, err := i.versionsHandler.GetReleaseImage(cluster.OpenshiftVersion, cluster.CPUArchitecture)
+		releaseImage, err := i.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, cluster.CPUArchitecture, cluster.PullSecret)
 		if err != nil {
 			return "", err
 		}

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -79,7 +79,7 @@ var _ = Describe("installcmd", func() {
 	})
 
 	mockGetReleaseImage := func(times int) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(times)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(times)
 	}
 
 	mockImages := func(times int) {
@@ -362,7 +362,7 @@ var _ = Describe("installcmd arguments", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockRelease = oc.NewMockRelease(ctrl)
 		mockVersions = versions.NewMockHandler(ctrl)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).AnyTimes()
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).AnyTimes()
 		mockImages()
 	})
 

--- a/internal/host/hostcommands/instruction_manager_test.go
+++ b/internal/host/hostcommands/instruction_manager_test.go
@@ -510,7 +510,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	ExpectWithOffset(1, swag.StringValue(h.Status)).Should(Equal(state))
 	if funk.Contains(expectedStepTypes, models.StepTypeInstall) {
 		mockValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/disk/by-id/wwn-sda").Times(1)
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockRelease.EXPECT().GetMCOImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMCOImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
@@ -527,7 +527,7 @@ func checkStepsByState(state string, host *models.Host, db *gorm.DB, mockEvents 
 	}
 
 	if funk.Contains(expectedStepTypes, models.StepTypeContainerImageAvailability) {
-		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
 		mockVersions.EXPECT().GetMustGatherImages(gomock.Any(), gomock.Any(), gomock.Any()).Return(defaultMustGatherVersion, nil).Times(1)
 	}
 	stepsReply, stepsErr := instMng.GetNextSteps(ctx, &h.Host)

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1457,7 +1457,7 @@ func (ib *ignitionBuilder) shouldAppendOKDFiles(ctx context.Context, infraEnv *c
 		return cfg.OKDRPMsImage, true
 	}
 	// Check if selected payload contains `okd-rpms` image
-	releaseImage, err := ib.versionHandler.GetReleaseImage(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
+	releaseImage, err := ib.versionHandler.GetReleaseImage(ctx, infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.PullSecret)
 	if err != nil {
 		ib.log.Warnf("unable to find release image for %s/%s", infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
 		return "", false

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1018,7 +1018,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		It("ignition_file_contains_pull_secret_token", func() {
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 			Expect(err).Should(BeNil())
@@ -1030,7 +1030,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 			// Try with bundle
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(2)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(2)
 			infraEnv.AdditionalTrustBundle = magicString
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).Should(BeNil())
@@ -1047,7 +1047,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("auth_disabled_no_pull_secret_token", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeNone, "")
 
 		Expect(err).Should(BeNil())
@@ -1058,7 +1058,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1069,7 +1069,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, true, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1080,7 +1080,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("enabled_cert_verification", func() {
 		config := IgnitionConfig{SkipCertVerification: false}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1090,7 +1090,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("disabled_cert_verification", func() {
 		config := IgnitionConfig{SkipCertVerification: true}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1099,7 +1099,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("cert_verification_enabled_by_default", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1117,7 +1117,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1135,7 +1135,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1144,7 +1144,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition v3.1 spec by default", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1157,7 +1157,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	// TODO(deprecate-ignition-3.1.0)
 	It("produces a valid ignition v3.1 spec with overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1168,7 +1168,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1181,7 +1181,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition spec with internal overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1194,7 +1194,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		ironicIgn := `{ "ignition": { "version": "3.2.0" }, "storage": { "files": [ { "group": { }, "overwrite": false, "path": "/etc/ironic-python-agent.conf", "user": { }, "contents": { "source": "data:text/plain,%0A%5BDEFAULT%5D%0Aapi_url%20%3D%20https%3A%2F%2Fironic.redhat.com%3A6385%0Ainspection_callback_url%20%3D%20https%3A%2F%2Fironic.redhat.com%3A5050%2Fv1%2Fcontinue%0Ainsecure%20%3D%20True%0A%0Acollect_lldp%20%3D%20True%0Aenable_vlan_interfaces%20%3D%20all%0Ainspection_collectors%20%3D%20default%2Cextra-hardware%2Clogs%0Ainspection_dhcp_all_interfaces%20%3D%20True%0A", "verification": { } }, "mode": 420 } ] }, "systemd": { "units": [ { "contents": "[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull some-ironic-image --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp\" --name ironic-agent somce-ironic-image\n[Install]\nWantedBy=multi-user.target\n", "enabled": true, "name": "ironic-agent.service" } ] } }`
 		infraEnv.IgnitionConfigOverride = ironicIgn
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(text).Should(ContainSubstring("ironic-agent.service"))
@@ -1210,7 +1210,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition spec with v3.2 overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1222,7 +1222,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1236,7 +1236,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("fails when given overrides with an incompatible version", func() {
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "2.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		_, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 		Expect(err).To(HaveOccurred())
@@ -1278,7 +1278,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			URL:              &okdNewImageURL,
 			Version:          &okdNewImageVersion,
 		}
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
 		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("quay.io/foo/bar:okd-rpms", nil)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
@@ -1289,7 +1289,7 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("multipath configured for non-okd", func() {
 		config := IgnitionConfig{}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1318,7 +1318,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1336,7 +1336,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1353,7 +1353,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		It("Will include static network config for minimal iso type in infraenv if overridden in call to FormatDiscoveryIgnitionFile", func() {
 			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(gomock.Any(), formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
@@ -1375,7 +1375,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1397,7 +1397,7 @@ var _ = Describe("IgnitionBuilder", func() {
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(true).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return([]byte("some ca config"), nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorRegistries().Return([]byte("some mirror registries config"), nil).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1443,7 +1443,7 @@ var _ = Describe("Ignition SSH key building", func() {
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
 		mockOcRelease = oc.NewMockRelease(ctrl)
 		mockVersionHandler = versions.NewMockHandler(ctrl)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		infraEnv = common.InfraEnv{
 			InfraEnv: models.InfraEnv{
 				ID:            &infraEnvID,
@@ -2059,13 +2059,13 @@ var _ = Describe("OKD overrides", func() {
 	})
 
 	It("OKD_RPMS config option unset", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(ocpImage, nil).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(ocpImage, nil).Times(1)
 		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 		checkOKDFiles(text, err, false)
 	})
 	It("OKD_RPMS config option not set, OKD release has no RPM image", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdOldImage, nil).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(okdOldImage, nil).Times(1)
 		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 		checkOKDFiles(text, err, false)
@@ -2075,7 +2075,7 @@ var _ = Describe("OKD overrides", func() {
 		checkOKDFiles(text, err, true)
 	})
 	It("OKD_RPMS config option not set, RPM image present in release payload", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
 		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("quay.io/foo/bar:okd-rpms", nil)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 		checkOKDFiles(text, err, true)

--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -108,7 +108,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 		err = json.Unmarshal(bytes, releaseImages)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, *releaseImages, nil, "")
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, *releaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 		return versionsHandler
 	}
@@ -182,7 +182,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 
 	It("missing release images", func() {
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, models.ReleaseImages{}, nil, "")
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, models.ReleaseImages{}, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
@@ -206,7 +206,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 		}
 
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -232,7 +232,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 			},
 		}
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -276,7 +276,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 			},
 		}
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -331,7 +331,7 @@ var _ = Describe("Test list versions with capability restrictions", func() {
 
 		osImages, err := NewOSImages(defaultOsImages)
 		Expect(err).ShouldNot(HaveOccurred())
-		versionsHandler, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "")
+		versionsHandler, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		return NewAPIHandler(common.GetTestLog(), Versions{}, authzHandler, versionsHandler, osImages)

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -35,21 +35,6 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
-// AddReleaseImage mocks base method.
-func (m *MockHandler) AddReleaseImage(arg0, arg1 string) (*models.ReleaseImage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddReleaseImage", arg0, arg1)
-	ret0, _ := ret[0].(*models.ReleaseImage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AddReleaseImage indicates an expected call of AddReleaseImage.
-func (mr *MockHandlerMockRecorder) AddReleaseImage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReleaseImage", reflect.TypeOf((*MockHandler)(nil).AddReleaseImage), arg0, arg1)
-}
-
 // GetDefaultReleaseImage mocks base method.
 func (m *MockHandler) GetDefaultReleaseImage(arg0 string) (*models.ReleaseImage, error) {
 	m.ctrl.T.Helper()
@@ -93,6 +78,21 @@ func (m *MockHandler) GetReleaseImage(arg0 context.Context, arg1, arg2, arg3 str
 func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0, arg1, arg2, arg3)
+}
+
+// GetReleaseImageByURL mocks base method.
+func (m *MockHandler) GetReleaseImageByURL(arg0 context.Context, arg1, arg2 string) (*models.ReleaseImage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReleaseImageByURL", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*models.ReleaseImage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReleaseImageByURL indicates an expected call of GetReleaseImageByURL.
+func (mr *MockHandlerMockRecorder) GetReleaseImageByURL(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImageByURL", reflect.TypeOf((*MockHandler)(nil).GetReleaseImageByURL), arg0, arg1, arg2)
 }
 
 // ValidateReleaseImageForRHCOS mocks base method.

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -36,18 +36,18 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // AddReleaseImage mocks base method.
-func (m *MockHandler) AddReleaseImage(arg0, arg1, arg2 string, arg3 []string) (*models.ReleaseImage, error) {
+func (m *MockHandler) AddReleaseImage(arg0, arg1 string) (*models.ReleaseImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddReleaseImage", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "AddReleaseImage", arg0, arg1)
 	ret0, _ := ret[0].(*models.ReleaseImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddReleaseImage indicates an expected call of AddReleaseImage.
-func (mr *MockHandlerMockRecorder) AddReleaseImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) AddReleaseImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReleaseImage", reflect.TypeOf((*MockHandler)(nil).AddReleaseImage), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReleaseImage", reflect.TypeOf((*MockHandler)(nil).AddReleaseImage), arg0, arg1)
 }
 
 // GetDefaultReleaseImage mocks base method.

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -5,6 +5,7 @@
 package versions
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -80,18 +81,18 @@ func (mr *MockHandlerMockRecorder) GetMustGatherImages(arg0, arg1, arg2 interfac
 }
 
 // GetReleaseImage mocks base method.
-func (m *MockHandler) GetReleaseImage(arg0, arg1 string) (*models.ReleaseImage, error) {
+func (m *MockHandler) GetReleaseImage(arg0 context.Context, arg1, arg2, arg3 string) (*models.ReleaseImage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReleaseImage", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetReleaseImage", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*models.ReleaseImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetReleaseImage indicates an expected call of GetReleaseImage.
-func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0, arg1, arg2, arg3)
 }
 
 // ValidateReleaseImageForRHCOS mocks base method.

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -490,7 +490,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImage.CPUArchitecture).Should(Equal(cpuArchitecture))
@@ -498,18 +498,6 @@ var _ = Describe("AddReleaseImage", func() {
 			Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
 			Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
 			Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
-		})
-
-		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture})
-			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, cpuArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(cpuArchitecture))
-			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture}))
 		})
 
 		It("when release image already exists", func() {
@@ -523,7 +511,7 @@ var _ = Describe("AddReleaseImage", func() {
 			})
 			Expect(releaseImageFromCache).ShouldNot(BeNil())
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			releaseImage, err := h.GetReleaseImage(ctx, existingOcpVersion, cpuArchitecture, pullSecret)
@@ -538,7 +526,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			_, err := h.AddReleaseImage("invalidRelease", pullSecret, "", nil)
+			_, err := h.AddReleaseImage("invalidRelease", pullSecret)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("No OS images are available for version %s and architecture %s", ocpVersion, cpuArchitecture)))
 		})
@@ -551,7 +539,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
 
-			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImage.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
@@ -559,35 +547,6 @@ var _ = Describe("AddReleaseImage", func() {
 			Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
 			Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
 			Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
-		})
-
-		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture, common.ARM64CPUArchitecture})
-			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, common.MultiCPUArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
-			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
-		})
-
-		It("added successfuly and recalculated using specified ocpReleaseVersion and 'multiarch' cpuArchitecture", func() {
-			mockRelease.EXPECT().GetOpenshiftVersion(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-			mockRelease.EXPECT().GetReleaseArchitecture(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
-
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{common.MultiCPUArchitecture})
-			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, common.MultiCPUArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
-			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
 		})
 
 		It("when release image already exists", func() {
@@ -601,7 +560,7 @@ var _ = Describe("AddReleaseImage", func() {
 			})
 			Expect(releaseImageFromCache).ShouldNot(BeNil())
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Query for multi-arch release image using generic multiarch
@@ -623,48 +582,24 @@ var _ = Describe("AddReleaseImage", func() {
 		})
 	})
 
-	Context("with failing OCP version extraction", func() {
-		It("using default syntax", func() {
-			mockRelease.EXPECT().GetOpenshiftVersion(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
-			mockRelease.EXPECT().GetReleaseArchitecture(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
+	It("fails when the version extraction fails", func() {
+		mockRelease.EXPECT().GetOpenshiftVersion(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
+		mockRelease.EXPECT().GetReleaseArchitecture(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("using specified cpuArchitectures", func() {
-			mockRelease.EXPECT().GetOpenshiftVersion(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
-			mockRelease.EXPECT().GetReleaseArchitecture(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", []string{cpuArchitecture})
-			Expect(err).Should(HaveOccurred())
-		})
+		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+		Expect(err).Should(HaveOccurred())
 	})
 
-	Context("with failing architecture extraction", func() {
-		It("using default syntax", func() {
-			mockRelease.EXPECT().GetOpenshiftVersion(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-			mockRelease.EXPECT().GetReleaseArchitecture(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
+	It("fails when the arch extraction fails", func() {
+		mockRelease.EXPECT().GetOpenshiftVersion(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+		mockRelease.EXPECT().GetReleaseArchitecture(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-			Expect(err).Should(HaveOccurred())
-		})
-
-		It("using specified ocpReleaseVersion", func() {
-			mockRelease.EXPECT().GetOpenshiftVersion(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-			mockRelease.EXPECT().GetReleaseArchitecture(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
-
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, nil)
-			Expect(err).Should(HaveOccurred())
-		})
+		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("keep support level from cache", func() {
@@ -673,7 +608,7 @@ var _ = Describe("AddReleaseImage", func() {
 		mockRelease.EXPECT().GetReleaseArchitecture(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = h.GetReleaseImage(ctx, customOcpVersion, cpuArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -1,6 +1,7 @@
 package versions
 
 import (
+	context "context"
 	"fmt"
 	"testing"
 
@@ -11,8 +12,14 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestHandler_ListComponentVersions(t *testing.T) {
@@ -95,7 +102,7 @@ var defaultReleaseImages = models.ReleaseImages{
 		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
 		CPUArchitectures: []string{common.X86CPUArchitecture},
 		OpenshiftVersion: swag.String("4.10.2"),
-		URL:              swag.String("release_4.10.1"),
+		URL:              swag.String("release_4.10.2"),
 		Version:          swag.String("4.10.1-candidate"),
 	},
 	&models.ReleaseImage{
@@ -131,45 +138,55 @@ var defaultReleaseImages = models.ReleaseImages{
 
 var _ = Describe("GetReleaseImage", func() {
 	var (
-		h        *handler
-		osImages OSImages
+		h           *handler
+		osImages    OSImages
+		ctx         = context.Background()
+		pullSecret  = "mypullsecret"
+		ctrl        *gomock.Controller
+		mockRelease *oc.MockRelease
 	)
 
 	BeforeEach(func() {
 		var err error
 		osImages, err = NewOSImages(defaultOsImages)
 		Expect(err).ShouldNot(HaveOccurred())
-		h, err = NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "")
+		ctrl = gomock.NewController(GinkgoT())
+		mockRelease = oc.NewMockRelease(ctrl)
+		h, err = NewHandler(common.GetTestLog(), mockRelease, osImages, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
 	It("unsupported openshiftVersion", func() {
-		releaseImage, err := h.GetReleaseImage("unsupported", common.TestDefaultConfig.CPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "unsupported", common.TestDefaultConfig.CPUArchitecture, pullSecret)
 		Expect(err).Should(HaveOccurred())
 		Expect(releaseImage).Should(BeNil())
 	})
 
 	It("unsupported cpuArchitecture", func() {
-		releaseImage, err := h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
+		releaseImage, err := h.GetReleaseImage(ctx, common.TestDefaultConfig.OpenShiftVersion, "unsupported", pullSecret)
 		Expect(err).Should(HaveOccurred())
 		Expect(releaseImage).Should(BeNil())
 		Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
 	})
 
 	It("empty openshiftVersion", func() {
-		releaseImage, err := h.GetReleaseImage("", common.TestDefaultConfig.CPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "", common.TestDefaultConfig.CPUArchitecture, pullSecret)
 		Expect(err).Should(HaveOccurred())
 		Expect(releaseImage).Should(BeNil())
 	})
 
 	It("empty cpuArchitecture", func() {
-		releaseImage, err := h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "")
+		releaseImage, err := h.GetReleaseImage(ctx, common.TestDefaultConfig.OpenShiftVersion, "", pullSecret)
 		Expect(err).Should(HaveOccurred())
 		Expect(releaseImage).Should(BeNil())
 	})
 
 	It("fetch release image by major.minor", func() {
-		releaseImage, err := h.GetReleaseImage("4.9", common.DefaultCPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "4.9", common.DefaultCPUArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
 		Expect(*releaseImage.Version).Should(Equal("4.9-candidate"))
@@ -178,9 +195,9 @@ var _ = Describe("GetReleaseImage", func() {
 	It("get from ReleaseImages", func() {
 		for _, key := range osImages.GetOpenshiftVersions() {
 			for _, architecture := range osImages.GetCPUArchitectures(key) {
-				releaseImage, err := h.GetReleaseImage(key, architecture)
+				releaseImage, err := h.GetReleaseImage(ctx, key, architecture, pullSecret)
 				if err != nil {
-					releaseImage, err = h.GetReleaseImage(key, common.MultiCPUArchitecture)
+					releaseImage, err = h.GetReleaseImage(ctx, key, common.MultiCPUArchitecture, pullSecret)
 					Expect(err).ShouldNot(HaveOccurred())
 				}
 
@@ -194,31 +211,97 @@ var _ = Describe("GetReleaseImage", func() {
 	})
 
 	It("gets successfuly image with old syntax", func() {
-		releaseImage, err := h.GetReleaseImage("4.11.2", "fake-architecture-chocobomb")
+		releaseImage, err := h.GetReleaseImage(ctx, "4.11.2", "fake-architecture-chocobomb", pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.2"))
 		Expect(*releaseImage.Version).Should(Equal("4.11.2-fake-chocobomb"))
 	})
 
 	It("gets successfuly image with new syntax", func() {
-		releaseImage, err := h.GetReleaseImage("4.10.1", common.X86CPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "4.10.1", common.X86CPUArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.10.1"))
 		Expect(*releaseImage.Version).Should(Equal("4.10.1-candidate"))
 	})
 
 	It("gets successfuly image using generic multiarch query", func() {
-		releaseImage, err := h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "4.11.1", common.MultiCPUArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
 		Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
 	})
 
 	It("gets successfuly image using sub-architecture", func() {
-		releaseImage, err := h.GetReleaseImage("4.11.1", common.PowerCPUArchitecture)
+		releaseImage, err := h.GetReleaseImage(ctx, "4.11.1", common.PowerCPUArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
 		Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
+	})
+
+	Context("with a kube client", func() {
+		var (
+			client client.Client
+		)
+		BeforeEach(func() {
+			schemes := runtime.NewScheme()
+			utilruntime.Must(hivev1.AddToScheme(schemes))
+			client = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
+			h.kubeClient = client
+		})
+
+		It("returns no image when no clusterimageset matches", func() {
+			image, err := h.GetReleaseImage(ctx, "4.20.0", common.X86CPUArchitecture, pullSecret)
+			Expect(err).To(HaveOccurred())
+			Expect(image).To(BeNil())
+		})
+
+		It("returns an existing image from the cache", func() {
+			image, err := h.GetReleaseImage(ctx, "4.11.1", common.X86CPUArchitecture, pullSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(image.URL).To(HaveValue(Equal("release_4.11.1")))
+		})
+
+		It("adds a release to the cache from a clusterimageset when no image in the cache matches", func() {
+			releaseImageURL := "example.com/openshift-release-dev/ocp-release:4.11.999"
+			cis := &hivev1.ClusterImageSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-release"},
+				Spec:       hivev1.ClusterImageSetSpec{ReleaseImage: releaseImageURL},
+			}
+			Expect(client.Create(ctx, cis)).To(Succeed())
+
+			mockRelease.EXPECT().GetOpenshiftVersion(gomock.Any(), releaseImageURL, "", pullSecret).Return("4.11.999", nil).Times(1)
+			mockRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), releaseImageURL, "", pullSecret).Return([]string{common.X86CPUArchitecture}, nil).Times(1)
+
+			image, err := h.GetReleaseImage(ctx, "4.11.999", common.X86CPUArchitecture, pullSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(image.URL).To(HaveValue(Equal(releaseImageURL)))
+			image, err = h.GetReleaseImage(ctx, "4.11.999", common.X86CPUArchitecture, pullSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(image.URL).To(HaveValue(Equal(releaseImageURL)))
+		})
+
+		It("doesn't re-add existing releases", func() {
+			for _, rel := range defaultReleaseImages {
+				cis := &hivev1.ClusterImageSet{
+					ObjectMeta: metav1.ObjectMeta{Name: *rel.URL},
+					Spec:       hivev1.ClusterImageSetSpec{ReleaseImage: *rel.URL},
+				}
+				Expect(client.Create(ctx, cis)).To(Succeed())
+			}
+			releaseImageURL := "example.com/openshift-release-dev/ocp-release:4.11.999"
+			cis := &hivev1.ClusterImageSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-release"},
+				Spec:       hivev1.ClusterImageSetSpec{ReleaseImage: releaseImageURL},
+			}
+			Expect(client.Create(ctx, cis)).To(Succeed())
+
+			mockRelease.EXPECT().GetOpenshiftVersion(gomock.Any(), releaseImageURL, "", pullSecret).Return("4.11.999", nil).Times(1)
+			mockRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), releaseImageURL, "", pullSecret).Return([]string{common.X86CPUArchitecture}, nil).Times(1)
+
+			image, err := h.GetReleaseImage(ctx, "4.11.999", common.X86CPUArchitecture, pullSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(image.URL).To(HaveValue(Equal(releaseImageURL)))
+		})
 	})
 })
 
@@ -246,7 +329,7 @@ var _ = Describe("ValidateReleaseImageForRHCOS", func() {
 		}
 		osImages, err := NewOSImages(defaultOsImages)
 		Expect(err).ShouldNot(HaveOccurred())
-		h, err = NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		h, err = NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -285,7 +368,7 @@ var _ = Describe("GetDefaultReleaseImage", func() {
 	})
 
 	It("Default release image exists", func() {
-		h, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "")
+		h, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		releaseImage, err := h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
@@ -296,7 +379,7 @@ var _ = Describe("GetDefaultReleaseImage", func() {
 	})
 
 	It("Missing default release image", func() {
-		h, err := NewHandler(common.GetTestLog(), nil, osImages, models.ReleaseImages{}, nil, "")
+		h, err := NewHandler(common.GetTestLog(), nil, osImages, models.ReleaseImages{}, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
@@ -327,7 +410,7 @@ var _ = Describe("GetMustGatherImages", func() {
 		var err error
 		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
-		h, err = NewHandler(common.GetTestLog(), mockRelease, nil, defaultReleaseImages, mustgatherImages, mirror)
+		h, err = NewHandler(common.GetTestLog(), mockRelease, nil, defaultReleaseImages, mustgatherImages, mirror, nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -383,6 +466,7 @@ var _ = Describe("AddReleaseImage", func() {
 		releaseImageUrl    = "releaseImage"
 		customOcpVersion   = "4.8.0"
 		existingOcpVersion = "4.9.1"
+		ctx                = context.Background()
 	)
 
 	BeforeEach(func() {
@@ -391,7 +475,7 @@ var _ = Describe("AddReleaseImage", func() {
 
 		osImages, err := NewOSImages(defaultOsImages)
 		Expect(err).ShouldNot(HaveOccurred())
-		h, err = NewHandler(common.GetTestLog(), mockRelease, osImages, defaultReleaseImages, nil, "")
+		h, err = NewHandler(common.GetTestLog(), mockRelease, osImages, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -419,7 +503,7 @@ var _ = Describe("AddReleaseImage", func() {
 		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
 			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, cpuArchitecture)
+			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, cpuArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
@@ -442,7 +526,7 @@ var _ = Describe("AddReleaseImage", func() {
 			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			releaseImage, err := h.GetReleaseImage(existingOcpVersion, cpuArchitecture)
+			releaseImage, err := h.GetReleaseImage(ctx, existingOcpVersion, cpuArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
 		})
@@ -480,7 +564,7 @@ var _ = Describe("AddReleaseImage", func() {
 		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
 			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture, common.ARM64CPUArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
+			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, common.MultiCPUArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
@@ -497,7 +581,7 @@ var _ = Describe("AddReleaseImage", func() {
 
 			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{common.MultiCPUArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
-			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
+			releaseImageFromCache, err := h.GetReleaseImage(ctx, customOcpVersion, common.MultiCPUArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
@@ -521,20 +605,20 @@ var _ = Describe("AddReleaseImage", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Query for multi-arch release image using generic multiarch
-			releaseImage, err := h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
+			releaseImage, err := h.GetReleaseImage(ctx, "4.11.1", common.MultiCPUArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
 
 			// Query for multi-arch release image using specific arch
-			releaseImage, err = h.GetReleaseImage("4.11.1", common.X86CPUArchitecture)
+			releaseImage, err = h.GetReleaseImage(ctx, "4.11.1", common.X86CPUArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
-			releaseImage, err = h.GetReleaseImage("4.11.1", common.ARM64CPUArchitecture)
+			releaseImage, err = h.GetReleaseImage(ctx, "4.11.1", common.ARM64CPUArchitecture, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
 
 			// Query for non-existing architecture
-			_, err = h.GetReleaseImage("4.11.1", "architecture-chocobomb")
+			_, err = h.GetReleaseImage(ctx, "4.11.1", "architecture-chocobomb", pullSecret)
 			Expect(err.Error()).Should(Equal("The requested CPU architecture (architecture-chocobomb) isn't specified in release images list"))
 		})
 	})
@@ -591,14 +675,14 @@ var _ = Describe("AddReleaseImage", func() {
 
 		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
-		_, err = h.GetReleaseImage(customOcpVersion, cpuArchitecture)
+		_, err = h.GetReleaseImage(ctx, customOcpVersion, cpuArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })
 
 var _ = Describe("NewHandler", func() {
 	validateNewHandler := func(releaseImages models.ReleaseImages) error {
-		_, err := NewHandler(common.GetTestLog(), nil, nil, releaseImages, nil, "")
+		_, err := NewHandler(common.GetTestLog(), nil, nil, releaseImages, nil, "", nil)
 		return err
 	}
 

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -456,7 +456,7 @@ var _ = Describe("GetMustGatherImages", func() {
 	})
 })
 
-var _ = Describe("AddReleaseImage", func() {
+var _ = Describe("GetReleaseImageByURL", func() {
 	var (
 		h                  *handler
 		ctrl               *gomock.Controller
@@ -490,7 +490,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+			releaseImage, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImage.CPUArchitecture).Should(Equal(cpuArchitecture))
@@ -511,7 +511,7 @@ var _ = Describe("AddReleaseImage", func() {
 			})
 			Expect(releaseImageFromCache).ShouldNot(BeNil())
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+			_, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			releaseImage, err := h.GetReleaseImage(ctx, existingOcpVersion, cpuArchitecture, pullSecret)
@@ -526,7 +526,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			_, err := h.AddReleaseImage("invalidRelease", pullSecret)
+			_, err := h.GetReleaseImageByURL(ctx, "invalidRelease", pullSecret)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(Equal(fmt.Sprintf("No OS images are available for version %s and architecture %s", ocpVersion, cpuArchitecture)))
 		})
@@ -539,7 +539,7 @@ var _ = Describe("AddReleaseImage", func() {
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
 
-			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+			releaseImage, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(*releaseImage.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
@@ -560,7 +560,7 @@ var _ = Describe("AddReleaseImage", func() {
 			})
 			Expect(releaseImageFromCache).ShouldNot(BeNil())
 
-			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+			_, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Query for multi-arch release image using generic multiarch
@@ -588,7 +588,7 @@ var _ = Describe("AddReleaseImage", func() {
 		mockRelease.EXPECT().GetReleaseArchitecture(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+		_, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 		Expect(err).Should(HaveOccurred())
 	})
 
@@ -598,7 +598,7 @@ var _ = Describe("AddReleaseImage", func() {
 		mockRelease.EXPECT().GetReleaseArchitecture(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
 
-		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+		_, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 		Expect(err).Should(HaveOccurred())
 	})
 
@@ -608,7 +608,7 @@ var _ = Describe("AddReleaseImage", func() {
 		mockRelease.EXPECT().GetReleaseArchitecture(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret)
+		_, err := h.GetReleaseImageByURL(ctx, releaseImageUrl, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		_, err = h.GetReleaseImage(ctx, customOcpVersion, cpuArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
As it is today the versions handler does too much and doesn't function well as a cache when we need to add release images from `ClusterImageSets`.

This has caused a few issues such as https://issues.redhat.com/browse/MGMT-8279 and https://issues.redhat.com/browse/MGMT-11956. The solution to these has been to add the release image from more places, but that means the issue will continue to occur.

Additionally the way the cluster deployment controller added to the cache, but the main inventory code read from it was going to make it difficult to separate out the controllers from the API in the future.

This effort began by splitting unrelated functionality off of the existing `versions.Handler` interface.
Really it did several unrelated things that are split into new structs/interfaces:
1. Track and cache a list of release images (`versions.Handler`)
2. ~~Track OS images (`versions.OSImages`)~~ - https://github.com/openshift/assisted-service/pull/4737
3. ~~Implement API controllers for serving currently used container images and release versions (`versions.apiHandler`)~~ - https://github.com/openshift/assisted-service/pull/4728
4. ~~Check authorization for multiarch release images~~ - https://github.com/openshift/assisted-service/pull/4630

This PR implements a better caching mechanism where the versions cache handles refreshing itself from the kubeAPI when a `get` operation misses. This means that we don't have to rely on a controller to specifically add an image just before we install to ensure it will be present when the install actually runs while also not increasing the amount of times we query for `ClusterImageSets`.

Each commit in this PR is individually reviewable (I recommend looking at them individually and setting up the diff viewer to ignore whitespace changes).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

1. Deployed assisted with kube-api
2. Created an SNO cluster without late-binding (infraenv, agentclusterinstall, clusterdeployment, clusterimageset, pullsecret)
3. Deleted the assisted-service pod (to ensure release image cache was empty)
4. Booted and approved an agent
5. Installed cluster

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
