### PR TITLE
MGMT-12592: added webhooks tests to hypershift e2e

### DIFF
--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -164,6 +164,7 @@ function gather_hypershift_data() {
   oc logs --tail=-1 -n "${SPOKE_NAMESPACE}" --selector app=assisted-service -c assisted-service > ${hypershift_dir}/assisted-service.log
   oc logs --tail=-1 -n "${SPOKE_NAMESPACE}" --selector app=assisted-image-service -c assisted-image-service > ${hypershift_dir}/assisted-image-service.log
   oc logs --tail=-1 -n "${SPOKE_NAMESPACE}" --selector app=assisted-service -c postgres > ${hypershift_dir}/postgres.log
+  oc logs --tail=-1 -n "${SPOKE_NAMESPACE}" --selector app=agentinstalladmission > ${hypershift_dir}/agentinstalladmission.log
   oc logs --tail=-1 -n "${SPOKE_NAMESPACE}" --selector control-plane=infrastructure-operator > ${hypershift_dir}/infrastructure-operator.log
 
   hub_dir="${hypershift_dir}/hub_cluster"


### PR DESCRIPTION
Added webhooks test to deploy_hypershift_cluster script:
* positive: successful validation on update of InfraEnv CR
* negative: failed validation on invalid update of InfraEnv CR

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
