### PR TITLE
OKD-90: Support automated extraction of OKD RPMs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -296,7 +296,7 @@ func main() {
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)
 	mirrorRegistriesBuilder := mirrorregistries.New()
-	ignitionBuilder, err := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder)
+	ignitionBuilder, err := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder, releaseHandler, versionHandler)
 	failOnError(err, "failed to create ignition builder")
 	installConfigBuilder := installcfg.NewInstallConfigBuilder(log.WithField("pkg", "installcfg"), mirrorRegistriesBuilder, providerRegistry)
 

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -110,6 +110,21 @@ func (mr *MockReleaseMockRecorder) GetMustGatherImage(log, releaseImage, release
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImage", reflect.TypeOf((*MockRelease)(nil).GetMustGatherImage), log, releaseImage, releaseImageMirror, pullSecret)
 }
 
+// GetOKDRPMSImage mocks base method.
+func (m *MockRelease) GetOKDRPMSImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOKDRPMSImage", log, releaseImage, releaseImageMirror, pullSecret)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOKDRPMSImage indicates an expected call of GetOKDRPMSImage.
+func (mr *MockReleaseMockRecorder) GetOKDRPMSImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOKDRPMSImage", reflect.TypeOf((*MockRelease)(nil).GetOKDRPMSImage), log, releaseImage, releaseImageMirror, pullSecret)
+}
+
 // GetOpenshiftVersion mocks base method.
 func (m *MockRelease) GetOpenshiftVersion(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -23,6 +23,7 @@ const (
 	mcoImageName         = "machine-config-operator"
 	ironicAgentImageName = "ironic-agent"
 	mustGatherImageName  = "must-gather"
+	okdRPMSImageName     = "okd-rpms"
 	DefaultTries         = 5
 	DefaltRetryDelay     = time.Second * 5
 )
@@ -36,6 +37,7 @@ type Config struct {
 type Release interface {
 	GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
+	GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
@@ -81,6 +83,11 @@ func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, relea
 // Else gets it from the source releaseImage
 func (r *release) GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
 	return r.getImageByName(log, ironicAgentImageName, releaseImage, releaseImageMirror, pullSecret)
+}
+
+// GetOKDRPMSImage gets okd RPMS image URL from the release image or releaseImageMirror, if provided.
+func (r *release) GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
+	return r.getImageByName(log, okdRPMSImageName, releaseImage, releaseImageMirror, pullSecret)
 }
 
 // GetMustGatherImage gets must-gather image URL from the release image or releaseImageMirror, if provided.


### PR DESCRIPTION
If payload has `okd-rpms` image Assisted Service should automatically apply OKD Ignition overrides. This would enable us to add OKD payload to AI without additional configuration option

## List all the issues related to this PR

- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->

## What environments does this code impact?

- [x] Cloud

## How was this code tested?

- [x] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
