### PR TITLE
MGMT-12552: Day-2 agent stuck with status_info rebooting although the node is already part of the cluster

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -984,7 +984,7 @@ func (m *Manager) GetStagesByRole(h *models.Host, isSNO bool) []models.HostStage
 	stages := FindMatchingStages(h.Role, h.Bootstrap, isSNO)
 
 	// for day2 hosts, rebooting stage is considered as the last state as we don't have any way to follow up on it further.
-	if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost && len(stages) > 0 {
+	if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost && len(stages) > 0 && !m.kubeApiEnabled {
 		rebootingIndex := m.IndexOfStage(models.HostStageRebooting, stages)
 		stages = stages[:rebootingIndex+1]
 	}


### PR DESCRIPTION
Allow post reboot stages for day-2 workers
These stages are valid now that https://github.com/openshift/assisted-service/pull/4610 merged

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? kube-api
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-12552

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
