### PR TITLE
MGMT-12379: PlatformType is not validated when installing SNO cluster

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -414,6 +414,12 @@ func (b *bareMetalInventory) validateRegisterClusterInternalParams(params *insta
 		}
 	}
 
+	if params.NewClusterParams.Platform != nil {
+		if err := validations.ValidateHighAvailabilityModeWithPlatform(params.NewClusterParams.HighAvailabilityMode, params.NewClusterParams.Platform); err != nil {
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
+	}
+
 	return nil
 }
 
@@ -1792,6 +1798,10 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 	}
 
 	if err = validations.ValidateDiskEncryptionParams(params.ClusterUpdateParams.DiskEncryption, b.DiskEncryptionSupport); err != nil {
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
+	if err = validations.ValidateHighAvailabilityModeWithPlatform(cluster.HighAvailabilityMode, platform); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -523,3 +523,13 @@ func ValidateDiskEncryptionParams(diskEncryptionParams *models.DiskEncryption, D
 	}
 	return nil
 }
+
+func ValidateHighAvailabilityModeWithPlatform(highAvailabilityMode *string, platform *models.Platform) error {
+	if swag.StringValue(highAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
+		if platform != nil && platform.Type != nil && *platform.Type != models.PlatformTypeNone {
+			return errors.Errorf("Single node cluster is not supported alongside %s platform", *platform.Type)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Return bad-request on single-node cluster when setting the platform type to different from none.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 
/cc @eranco74 