### PR TITLE
NO-ISSUE: log build version

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -16,7 +16,7 @@ RUN cd /assisted-service/build && python3 ../tools/client_package_initializer.py
 # Build binaries
 FROM quay.io/centos/centos:stream8 as builder
 
-RUN dnf install -y gcc && dnf clean all
+RUN dnf install -y gcc git && dnf clean all
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.18 /usr/local/go /usr/local/go
 
 ENV GOROOT=/usr/local/go
@@ -33,10 +33,10 @@ RUN go mod download
 
 COPY . /assisted-service/
 
-RUN CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service cmd/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-operator cmd/operator/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-admission cmd/webadmission/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/agent-installer-client cmd/agentbasedinstaller/client/main.go
+RUN cd cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service
+RUN cd ./cmd/operator && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-operator
+RUN cd ./cmd/webadmission && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-admission
+RUN cd ./cmd/agentbasedinstaller/client && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/agent-installer-client
 
 # Create final image
 FROM quay.io/centos/centos:stream8

--- a/Dockerfile.assisted-service.ocp
+++ b/Dockerfile.assisted-service.ocp
@@ -6,10 +6,11 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS 
 WORKDIR /src
 COPY . .
 
-RUN CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service cmd/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-operator cmd/operator/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-admission cmd/webadmission/main.go
-RUN CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/agent-installer-client cmd/agentbasedinstaller/client/main.go
+RUN dnf install -y git && dnf clean all
+RUN cd cmd && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service
+RUN cd ./cmd/operator && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-operator
+RUN cd ./cmd/webadmission && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/assisted-service-admission
+RUN cd ./cmd/agentbasedinstaller/client && CGO_ENABLED=0 GOFLAGS="" GO111MODULE=on go build -o /build/agent-installer-client
 
 
 FROM registry.ci.openshift.org/ocp/4.12:cli AS oc-image

--- a/Makefile
+++ b/Makefile
@@ -208,10 +208,10 @@ build-in-docker:
 
 build-assisted-service:
 	# We need the CGO_ENABLED for the go-sqlite library build.
-	CGO_ENABLED=1 go build $(DEBUG_ARGS) -o $(BUILD_FOLDER)/assisted-service cmd/main.go
+	cd ./cmd && CGO_ENABLED=1 go build $(DEBUG_ARGS) -o $(BUILD_FOLDER)/assisted-service
 
 build-assisted-service-operator:
-	CGO_ENABLED=0 go build $(DEBUG_ARGS) -o $(BUILD_FOLDER)/assisted-service-operator cmd/operator/main.go
+	cd ./cmd/operator && CGO_ENABLED=0 go build $(DEBUG_ARGS) -o $(BUILD_FOLDER)/assisted-service-operator
 
 build-minimal: $(BUILD_FOLDER)
 	$(MAKE) -j build-assisted-service build-assisted-service-operator

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -200,6 +200,7 @@ func main() {
 		err = Options.HostConfig.Complete()
 	}
 	log := InitLogs()
+	log.Infof("Starting assisted-service version: %s", versions.GetRevision())
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -585,4 +586,20 @@ func (h *handler) validateVersions() error {
 	}
 
 	return nil
+}
+
+// GetRevision returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+func GetRevision() string {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "<unknown>"
+	}
+
+	for _, setting := range buildInfo.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return "<unknown>"
 }


### PR DESCRIPTION
Go 1.18 adds some commit information to the binary automatically when running go build.
* This requires building the package without file patterns This PR adds the git commit to the output logs.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? check the service logs

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
