### PR TITLE
MGMT-12616: Reject register after install

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2832,7 +2832,7 @@ func readConfiguredAgentImage(fullName string, tagOnly bool) string {
 func returnRegisterHostTransitionError(
 	defaultCode int32,
 	err error) middleware.Responder {
-	if isRegisterHostForbiddenDueWrongBootOrder(err) {
+	if isRegisterHostForbidden(err) {
 		return installer.NewV2RegisterHostForbidden().WithPayload(
 			&models.InfraError{
 				Code:    swag.Int32(http.StatusForbidden),
@@ -2842,7 +2842,7 @@ func returnRegisterHostTransitionError(
 	return common.NewApiError(defaultCode, err)
 }
 
-func isRegisterHostForbiddenDueWrongBootOrder(err error) bool {
+func isRegisterHostForbidden(err error) bool {
 	if serr, ok := err.(*common.ApiErrorResponse); ok {
 		return serr.StatusCode() == http.StatusForbidden
 	}

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -353,6 +353,20 @@ func (mr *MockTransitionHandlerMockRecorder) PostRefreshReclaimTimeout(sw, args 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRefreshReclaimTimeout", reflect.TypeOf((*MockTransitionHandler)(nil).PostRefreshReclaimTimeout), sw, args)
 }
 
+// PostRegisterAfterInstallation mocks base method.
+func (m *MockTransitionHandler) PostRegisterAfterInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostRegisterAfterInstallation", sw, args)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PostRegisterAfterInstallation indicates an expected call of PostRegisterAfterInstallation.
+func (mr *MockTransitionHandlerMockRecorder) PostRegisterAfterInstallation(sw, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRegisterAfterInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).PostRegisterAfterInstallation), sw, args)
+}
+
 // PostRegisterDuringInstallation mocks base method.
 func (m *MockTransitionHandler) PostRegisterDuringInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 	m.ctrl.T.Helper()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -108,6 +108,18 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		DestinationState: stateswitch.State(models.HostStatusError),
 	})
 
+	// A host may boot from the installation ISO after the cluster has been installed. In that
+	// case we want to ask the host to go away, as otherwise it will flood the log and the
+	// events.
+	sm.AddTransition(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRegisterHost,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusInstalled),
+		},
+		DestinationState: stateswitch.State(models.HostStatusInstalled),
+		PostTransition:   th.PostRegisterAfterInstallation,
+	})
+
 	// Installation failure
 	sm.AddTransition(stateswitch.TransitionRule{
 		TransitionType: TransitionTypeHostInstallationFailed,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -123,7 +123,7 @@ var _ = Describe("RegisterHost", func() {
 		Expect(h.DiscoveryAgentVersion).To(Equal("v1.0.1"))
 	})
 
-	Context("register during installation", func() {
+	Context("register during or after installation", func() {
 		tests := []struct {
 			name                  string
 			progressStage         models.HostStage
@@ -153,6 +153,15 @@ var _ = Describe("RegisterHost", func() {
 				progressStage:         models.HostStageRebooting,
 				srcState:              models.HostStatusInstallingPendingUserAction,
 				dstState:              models.HostStatusInstallingPendingUserAction,
+				errorCode:             http.StatusForbidden,
+				expectedEventInfo:     "",
+				expectedNilStatusInfo: true,
+			},
+			{
+				name:                  "pending-user-action",
+				progressStage:         models.HostStageDone,
+				srcState:              models.HostStatusInstalled,
+				dstState:              models.HostStatusInstalled,
 				errorCode:             http.StatusForbidden,
 				expectedEventInfo:     "",
 				expectedNilStatusInfo: true,


### PR DESCRIPTION
This patch changes the service so that it returns a 403 error response when an agent tries to register when the cluster is already installed, as otherwise the agent will keep trying to register and spam both the log and the events.

Related: https://issues.redhat.com/browse/MGMT-12616
Related: https://issues.redhat.com/browse/MGMT-2359
Related: https://issues.redhat.com/browse/MGMT-1041

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested manuall installing a cluster and then rebooting one of the nodes with the installation ISO.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
