### PR TITLE
MGMT-11536: refresh cluster after host deletion

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -494,7 +494,7 @@ var _ = Describe("RegisterHost", func() {
 				Expect(h.InfraEnvID).Should(Equal(*infraEnv.ID))
 				return nil
 			}).Times(1)
-		mockHostApi.EXPECT().UnRegisterHost(ctx, hostID.String(), infraEnv.ID.String()).Return(nil).Times(1)
+		mockHostApi.EXPECT().UnRegisterHost(ctx, gomock.Any()).Return(nil).Times(1)
 		mockCRDUtils.EXPECT().CreateAgentCR(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New(expectedErrMsg)).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.HostRegistrationSucceededEventName),
@@ -13732,7 +13732,7 @@ var _ = Describe("BindHost", func() {
 		mockAccountsMgmt.EXPECT().GetSubscription(ctx, gomock.Any()).Return(&amgmtv1.Subscription{}, nil)
 		mockClusterApi.EXPECT().DeregisterCluster(ctx, gomock.Any())
 		mockHostApi.EXPECT().UnbindHost(ctx, gomock.Any(), gomock.Any(), false).Times(1)
-		mockHostApi.EXPECT().UnRegisterHost(ctx, host2ID.String(), infraEnv2ID.String()).Return(nil).Times(1)
+		mockHostApi.EXPECT().UnRegisterHost(ctx, gomock.Any()).Return(nil).Times(1)
 		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.HostDeregisteredEventName),
 			eventstest.WithHostIdMatcher(host2ID.String()),
@@ -13876,6 +13876,52 @@ var _ = Describe("BindHost - with rhsso auth", func() {
 
 		response := bm.BindHost(authCtx, params)
 		verifyApiError(response, http.StatusNotFound)
+	})
+})
+
+var _ = Describe("V2DeregisterHost", func() {
+	var (
+		bm         *bareMetalInventory
+		cfg        Config
+		db         *gorm.DB
+		ctx        = context.Background()
+		clusterID  strfmt.UUID
+		hostID     strfmt.UUID
+		infraEnvID strfmt.UUID
+		dbName     string
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		clusterID = strfmt.UUID(uuid.New().String())
+		hostID = strfmt.UUID(uuid.New().String())
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		bm = createInventory(db, cfg)
+		err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnvID}}).Error
+		Expect(err).ShouldNot(HaveOccurred())
+		err = db.Create(&common.Host{Host: models.Host{ID: &hostID, InfraEnvID: infraEnvID, ClusterID: &clusterID}}).Error
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("refresh cluster after deregister fails silently", func() {
+		params := installer.V2DeregisterHostParams{
+			HostID:     hostID,
+			InfraEnvID: infraEnvID,
+		}
+		mockHostApi.EXPECT().UnRegisterHost(gomock.Any(), gomock.Any()).Return(nil)
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostDeregisteredEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(infraEnvID.String()),
+			eventstest.WithSeverityMatcher(models.EventSeverityInfo)))
+		mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("Bad Refresh Status"))
+		mockClusterApi.EXPECT().RefreshSchedulableMastersForcedTrue(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		response := bm.V2DeregisterHost(ctx, params)
+		Expect(response).To(BeAssignableToTypeOf(&installer.V2DeregisterHostNoContent{}))
 	})
 })
 

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -369,18 +369,18 @@ func (mr *MockInstallerInternalsMockRecorder) TransformClusterToDay2Internal(arg
 }
 
 // UnbindHostInternal mocks base method.
-func (m *MockInstallerInternals) UnbindHostInternal(arg0 context.Context, arg1 installer.UnbindHostParams, arg2 bool) (*common.Host, error) {
+func (m *MockInstallerInternals) UnbindHostInternal(arg0 context.Context, arg1 installer.UnbindHostParams, arg2 bool, arg3 Interactivity) (*common.Host, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnbindHostInternal", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UnbindHostInternal", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*common.Host)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnbindHostInternal indicates an expected call of UnbindHostInternal.
-func (mr *MockInstallerInternalsMockRecorder) UnbindHostInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInstallerInternalsMockRecorder) UnbindHostInternal(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UnbindHostInternal), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).UnbindHostInternal), arg0, arg1, arg2, arg3)
 }
 
 // UpdateClusterInstallConfigInternal mocks base method.
@@ -443,17 +443,17 @@ func (mr *MockInstallerInternalsMockRecorder) UpdateInfraEnvInternal(arg0, arg1,
 }
 
 // V2DeregisterHostInternal mocks base method.
-func (m *MockInstallerInternals) V2DeregisterHostInternal(arg0 context.Context, arg1 installer.V2DeregisterHostParams) error {
+func (m *MockInstallerInternals) V2DeregisterHostInternal(arg0 context.Context, arg1 installer.V2DeregisterHostParams, arg2 Interactivity) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2DeregisterHostInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "V2DeregisterHostInternal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // V2DeregisterHostInternal indicates an expected call of V2DeregisterHostInternal.
-func (mr *MockInstallerInternalsMockRecorder) V2DeregisterHostInternal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInstallerInternalsMockRecorder) V2DeregisterHostInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2DeregisterHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2DeregisterHostInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2DeregisterHostInternal", reflect.TypeOf((*MockInstallerInternals)(nil).V2DeregisterHostInternal), arg0, arg1, arg2)
 }
 
 // V2DownloadClusterCredentialsInternal mocks base method.

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -429,7 +429,7 @@ func (r *AgentReconciler) unbindHost(ctx context.Context, log logrus.FieldLogger
 		HostID:     *h.ID,
 		InfraEnvID: h.InfraEnvID,
 	}
-	host, err := r.Installer.UnbindHostInternal(ctx, params, reclaim)
+	host, err := r.Installer.UnbindHostInternal(ctx, params, reclaim, bminventory.NonInteractive)
 	if err != nil {
 		return r.updateStatus(ctx, log, agent, origAgent, &h.Host, nil, err, !IsUserError(err))
 	}
@@ -478,7 +478,7 @@ func (r *AgentReconciler) deregisterHostIfNeeded(ctx context.Context, log logrus
 		ctx, installer.V2DeregisterHostParams{
 			InfraEnvID: h.InfraEnvID,
 			HostID:     *h.ID,
-		})
+		}, bminventory.NonInteractive)
 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -759,7 +759,7 @@ var _ = Describe("agent reconcile", func() {
 			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DaemonSet{})).Return(nil)
 			mockClient.EXPECT().Update(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), true).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), true, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -769,7 +769,7 @@ var _ = Describe("agent reconcile", func() {
 		It("unbind does not attempt to reclaim if kubeconfig secret is missing", func() {
 			expectDBClusterWithKubeKeys()
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -782,7 +782,7 @@ var _ = Describe("agent reconcile", func() {
 
 			mockClientFactory.EXPECT().CreateFromSecret(gomock.Any()).Return(nil, errors.New("failed to create client"))
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -807,7 +807,7 @@ var _ = Describe("agent reconcile", func() {
 			mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DaemonSet{})).Return(notFoundError)
 			mockClient.EXPECT().Create(gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DaemonSet{})).Return(errors.New("Failed to create DaemonSet"))
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -824,7 +824,7 @@ var _ = Describe("agent reconcile", func() {
 			Expect(c.Delete(ctx, clusterDeployment)).To(Succeed())
 			expectDBClusterWithKubeKeys()
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -834,7 +834,7 @@ var _ = Describe("agent reconcile", func() {
 		It("unbind does not attempt to reclaim if cluster isn't found in DB", func() {
 			mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: sId}).Return(nil, errors.New("some error getting cluster"))
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -844,7 +844,7 @@ var _ = Describe("agent reconcile", func() {
 		It("unbind does not attempt to reclaim if cluster doesn't have kubekeys set", func() {
 			mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: sId}).Return(backEndCluster, nil)
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -868,7 +868,7 @@ var _ = Describe("agent reconcile", func() {
 			Expect(c.Update(ctx, host)).To(Succeed())
 			expectDBClusterWithKubeKeys()
 
-			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+			mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 			result, err := hr.Reconcile(ctx, newHostRequest(host))
 			Expect(err).To(BeNil())
 			Expect(result).To(Equal(ctrl.Result{}))
@@ -899,7 +899,7 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil).AnyTimes()
 		// Return cluster without kube key to skip reclaim
 		mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: sId}).Return(backEndCluster, nil).AnyTimes()
-		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, common.NewApiError(http.StatusNotFound, errors.New(errString)))
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, common.NewApiError(http.StatusNotFound, errors.New(errString)))
 		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
 
 		result, err := hr.Reconcile(ctx, newHostRequest(host))
@@ -1039,7 +1039,7 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(commonHost, nil)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(types.NamespacedName{Name: targetClusterName, Namespace: testNamespace}).Return(targetBECluster, nil)
 		mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: sId}).Return(backEndCluster, nil).AnyTimes()
-		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false).Return(commonHost, nil)
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(commonHost, nil)
 		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
 		Expect(c.Create(ctx, host)).To(BeNil())
 

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -117,7 +117,7 @@ func (u *CRDUtils) CreateAgentCR(ctx context.Context, log logrus.FieldLogger, ho
 				return nil
 			}
 			//delete previous host
-			if err3 := u.hostApi.UnRegisterHost(ctx, h.ID.String(), h.InfraEnvID.String()); err3 != nil {
+			if err3 := u.hostApi.UnRegisterHost(ctx, &h.Host); err3 != nil {
 				return errors.Wrapf(err3, "Failed to UnRegisterHost ID: %s ClusterID: %s", h.ID.String(), h.ClusterID.String())
 			}
 		}

--- a/internal/controller/controllers/crd_utils_test.go
+++ b/internal/controller/controllers/crd_utils_test.go
@@ -224,7 +224,7 @@ var _ = Describe("create agent CR", func() {
 				},
 			}
 			mockHostApi.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&h, nil).Times(1)
-			mockHostApi.EXPECT().UnRegisterHost(ctx, id.String(), infraEnvId.String()).Return(nil).Times(1)
+			mockHostApi.EXPECT().UnRegisterHost(ctx, gomock.Any()).Return(nil).Times(1)
 			mockHostApi.EXPECT().UpdateKubeKeyNS(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			err = crdUtils.CreateAgentCR(ctx, log, hostId, infraEnv2, cluster)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -517,7 +517,7 @@ func (r *InfraEnvReconciler) deregisterInfraEnvWithHosts(ctx context.Context, lo
 				ctx, installer.V2DeregisterHostParams{
 					InfraEnvID: h.InfraEnvID,
 					HostID:     hostId,
-				})
+				}, bminventory.NonInteractive)
 
 			if err != nil {
 				if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -963,7 +963,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		hostId := strfmt.UUID(uuid.New().String())
 		host := &common.Host{Host: models.Host{ID: &hostId, Status: swag.String(models.HostStatusKnownUnbound)}}
 		mockInstallerInternal.EXPECT().GetInfraEnvHostsInternal(gomock.Any(), gomock.Any()).Return([]*common.Host{host}, nil)
-		mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), gomock.Any()).Return(nil)
+		mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockInstallerInternal.EXPECT().DeregisterInfraEnvInternal(gomock.Any(), gomock.Any()).Return(nil)
 		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(BeNil())
@@ -1015,7 +1015,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		mockInstallerInternal.EXPECT().V2DeregisterHostInternal(gomock.Any(), installer.V2DeregisterHostParams{
 			InfraEnvID: *backendInfraEnv.ID,
 			HostID:     hostUnboundId,
-		}).Return(nil)
+		}, bminventory.NonInteractive).Return(nil)
 		res, err = ir.Reconcile(ctx, newInfraEnvRequest(infraEnvImage))
 		Expect(err).To(Not(BeNil()))
 		Expect(res).To(Equal(ctrl.Result{RequeueAfter: longerRequeueAfterOnError}))

--- a/internal/host/mock_host_api.go
+++ b/internal/host/mock_host_api.go
@@ -496,17 +496,17 @@ func (mr *MockAPIMockRecorder) SetUploadLogsAt(arg0, arg1, arg2 interface{}) *go
 }
 
 // UnRegisterHost mocks base method.
-func (m *MockAPI) UnRegisterHost(arg0 context.Context, arg1, arg2 string) error {
+func (m *MockAPI) UnRegisterHost(arg0 context.Context, arg1 *models.Host) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnRegisterHost", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UnRegisterHost", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnRegisterHost indicates an expected call of UnRegisterHost.
-func (mr *MockAPIMockRecorder) UnRegisterHost(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) UnRegisterHost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRegisterHost", reflect.TypeOf((*MockAPI)(nil).UnRegisterHost), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRegisterHost", reflect.TypeOf((*MockAPI)(nil).UnRegisterHost), arg0, arg1)
 }
 
 // UnbindHost mocks base method.

--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -92,7 +92,6 @@ var _ = Describe("[V2ClusterTests]", func() {
 
 		By("verify that the cluster status is updated immediately")
 		c := getCluster(clusterID)
-		log.Info(c.ValidationsInfo)
 		Expect(*c.Status).To(Equal(models.ClusterStatusInsufficient))
 
 		By("verify that the unbound host still retains its name and disks count")
@@ -261,7 +260,6 @@ var _ = Describe("[V2ClusterTests]", func() {
 		}
 		h1 = updateHostV2(ctx, hostReq)
 		c := getCluster(clusterID)
-		log.Info(c.ValidationsInfo)
 		Expect(*c.Status).To(Equal(models.ClusterStatusInsufficient))
 	})
 


### PR DESCRIPTION
When a user deletes a host, the cluster validations do not run immediately. Therefore the UI presents an incorrect view of the validation status. For example, master count validation shows erroneous status.

That may lead to a user starting an installation when the cluster is actually not ready to be installed.

This PR adds a refresh cluster after host deletion so the validation will run before the result is returned to the UI.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
