### PR TITLE
NO-ISSUE: add unauthenticatedRegistries to HASC on deploy

### DIFF
--- a/deploy/operator/hypershift/deploy_hypershift_cluster.sh
+++ b/deploy/operator/hypershift/deploy_hypershift_cluster.sh
@@ -50,10 +50,6 @@ oc get namespace "${HYPERSHIFT_AGENT_NS}" || oc create namespace "${HYPERSHIFT_A
 # We need a storage for etcd of the hosted cluster
 oc patch storageclass assisted-service -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
-# Update assisted-service-operator Subscription to ignore validating pull-secret against non-auth registries
-oc -n $ASSISTED_NAMESPACE patch subscription assisted-service-operator --type merge \
-    -p '{"spec":{"config":{"env":[{"name":"PUBLIC_CONTAINER_REGISTRIES","value":"'${PUBLIC_CONTAINER_REGISTRIES}'"}]}}}'
-
 echo "Installing HyperShift using upstream image"
 hypershift install --hypershift-image $HYPERSHIFT_IMAGE --namespace hypershift
 wait_for_pods "hypershift"

--- a/deploy/operator/hypershift/playbooks/hasc-playbook.yaml
+++ b/deploy/operator/hypershift/playbooks/hasc-playbook.yaml
@@ -6,6 +6,7 @@
   vars:
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
     - spoke_kubeconfig_secret: "{{ lookup('env', 'SPOKE_KUBECONFIG_SECRET') }}"
+    - unauthenticatedRegistries: "{{ lookup('env', 'PUBLIC_CONTAINER_REGISTRIES') }}"
 
   tasks:
   - name: create directory for generated resources

--- a/deploy/operator/hypershift/playbooks/templates/hasc.j2
+++ b/deploy/operator/hypershift/playbooks/templates/hasc.j2
@@ -24,3 +24,8 @@ spec:
   resources:
    requests:
     storage: 10Gi
+ unauthenticatedRegistries:
+{% set registries = unauthenticatedRegistries.split(',') %}
+{% for registry in registries %}
+ - {{ registry }}
+{% endfor %}


### PR DESCRIPTION
The 'e2e-ai-operator-ztp-hypershift-zero-nodes' CI [job](https://github.com/openshift/release/blob/4721a60662841beeaf592d9e5a377a04d88d5e76/ci-operator/step-registry/assisted/baremetal/operator/hypershift/assisted-baremetal-operator-hypershift-commands.sh#L5-L6) depends on 'assisted-common-setup-prepare' which sets the [PUBLIC_CONTAINER_REGISTRIES](https://github.com/openshift/release/blob/323c572130449387ba5d338ed81e03d57b7e8039/ci-operator/step-registry/assisted/common/setup/prepare/assisted-common-setup-prepare-commands.sh#L91) var. E.g. it includes the ci registry as 'registry.build04.ci.openshift.org'.

On deploy_hypershift_cluster.sh [script](https://github.com/openshift/assisted-service/blob/0493e129a277f8ede5249006140c8aaea1ae1b14/deploy/operator/hypershift/deploy_hypershift_cluster.sh#L25), we use this variable in order to [propagate](https://github.com/openshift/assisted-service/blob/46d509057c9870ce0177a69177e61eddd5214e72/internal/controller/controllers/agentserviceconfig_controller.go#L1079) in AgentServiceConfigReconciler.
This is required for creating an InfraEnv using an image for the CI registry.

Since 'unauthenticatedRegistries' has been recentley introduced in https://github.com/openshift/assisted-service/pull/4552, PUBLIC_CONTAINER_REGISTRIES env var is no longer read on ASC controller. Thus, setting 'UnauthenticatedRegistries' property in HASC CR as required instead.
Which should fix the 'hypershift-zero-nodes' CI job.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
