### PR TITLE
WIP Software RAID support

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -243,6 +243,9 @@ func (m *Disk) UnmarshalBinary(b []byte) error {
 // swagger:model DiskInstallationEligibility
 type DiskInstallationEligibility struct {
 
+	// Warnings for why this disk is not recommended for installation.
+	EligibilityWarnings []string `json:"eligibility_warnings"`
+
 	// Whether the disk is eligible for installation or not.
 	Eligible bool `json:"eligible,omitempty"`
 

--- a/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -55,6 +55,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -62,7 +65,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -36,6 +36,20 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 	return m.recorder
 }
 
+// DiskEligibilityWarnings mocks base method.
+func (m *MockValidator) DiskEligibilityWarnings(disk *models.Disk) []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiskEligibilityWarnings", disk)
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// DiskEligibilityWarnings indicates an expected call of DiskEligibilityWarnings.
+func (mr *MockValidatorMockRecorder) DiskEligibilityWarnings(disk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskEligibilityWarnings", reflect.TypeOf((*MockValidator)(nil).DiskEligibilityWarnings), disk)
+}
+
 // DiskIsEligible mocks base method.
 func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, infraEnv *common.InfraEnv, cluster *common.Cluster, host *models.Host, allDisks []*models.Disk) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/internal/hardware/validator.go
+++ b/internal/hardware/validator.go
@@ -412,7 +412,7 @@ func (v *validator) getOCPRequirementsForVersion(openshiftVersion string) (*mode
 }
 
 func (v *validator) getValidDeviceStorageTypes() []string {
-	return []string{string(models.DriveTypeHDD), string(models.DriveTypeSSD), string(models.DriveTypeMultipath), string(models.DriveTypeFC)}
+	return []string{string(models.DriveTypeHDD), string(models.DriveTypeSSD), string(models.DriveTypeMultipath), string(models.DriveTypeFC), string(models.DriveTypeRAID)}
 }
 
 func compileDiskReasonTemplate(template string, wildcards ...interface{}) *regexp.Regexp {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -236,6 +236,7 @@ func (m *Manager) populateDisksEligibility(ctx context.Context, inventory *model
 			// for backwards compatibility, pretend that the agent has decided that this disk is eligible
 			disk.InstallationEligibility.Eligible = true
 			disk.InstallationEligibility.NotEligibleReasons = make([]string, 0)
+			disk.InstallationEligibility.EligibilityWarnings = make([]string, 0)
 		}
 
 		// Append to the existing reasons already filled in by the agent
@@ -243,7 +244,9 @@ func (m *Manager) populateDisksEligibility(ctx context.Context, inventory *model
 		if err != nil {
 			return err
 		}
+
 		disk.InstallationEligibility.NotEligibleReasons = reasons
+		disk.InstallationEligibility.EligibilityWarnings = m.hwValidator.DiskEligibilityWarnings(disk)
 
 		disk.InstallationEligibility.Eligible = len(disk.InstallationEligibility.NotEligibleReasons) == 0
 	}

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1142,6 +1142,7 @@ var _ = Describe("UpdateInventory", func() {
 				host = hostutil.GenerateTestHost(hostId, infraEnvId, clusterId, models.HostStatusDiscovering)
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
 				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
@@ -1204,6 +1205,7 @@ var _ = Describe("UpdateInventory", func() {
 			test := test
 			It(test.testName, func() {
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(append(test.agentReasons, test.serviceReasons...), nil)
+				mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 
 				testInventory := models.Inventory{Disks: []*models.Disk{
 					{InstallationEligibility: models.DiskInstallationEligibility{
@@ -1275,6 +1277,7 @@ var _ = Describe("UpdateInventory", func() {
 				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(inventory.Disks)
 				if test.expectMatch {
 					mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
@@ -1309,6 +1312,7 @@ var _ = Describe("UpdateInventory", func() {
 		})
 		It("Happy flow", func() {
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			)
@@ -1356,7 +1360,7 @@ var _ = Describe("UpdateInventory", func() {
 			host.InstallationDiskPath = ""
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-
+			mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 		})
 
 		It("Make sure UpdateInventory updates the db", func() {
@@ -1372,6 +1376,7 @@ var _ = Describe("UpdateInventory", func() {
 
 			// Now make sure it gets removed if the disk is no longer in the inventory
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{},
 			)
@@ -1395,6 +1400,7 @@ var _ = Describe("UpdateInventory", func() {
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			)
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).ToNot(HaveOccurred())
 			h = hostutil.GetHostFromDB(hostId, infraEnvId, db)
 			Expect(h.InstallationDiskPath).To(Equal(diskPath))
@@ -1416,6 +1422,7 @@ var _ = Describe("UpdateInventory", func() {
 			host.InstallationDiskPath = ""
 			Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 			mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			mockValidator.EXPECT().DiskEligibilityWarnings(gomock.Any())
 			mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(
 				[]*models.Disk{{ID: diskId, Name: diskName}},
 			).AnyTimes()

--- a/models/disk.go
+++ b/models/disk.go
@@ -243,6 +243,9 @@ func (m *Disk) UnmarshalBinary(b []byte) error {
 // swagger:model DiskInstallationEligibility
 type DiskInstallationEligibility struct {
 
+	// Warnings for why this disk is not recommended for installation.
+	EligibilityWarnings []string `json:"eligibility_warnings"`
+
 	// Whether the disk is eligible for installation or not.
 	Eligible bool `json:"eligible,omitempty"`
 

--- a/models/drive_type.go
+++ b/models/drive_type.go
@@ -55,6 +55,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -62,7 +65,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6422,6 +6422,13 @@ func init() {
         "installation_eligibility": {
           "type": "object",
           "properties": {
+            "eligibility_warnings": {
+              "description": "Warnings for why this disk is not recommended for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "eligible": {
               "description": "Whether the disk is eligible for installation or not.",
               "type": "boolean"
@@ -14661,6 +14668,13 @@ func init() {
     "DiskInstallationEligibility": {
       "type": "object",
       "properties": {
+        "eligibility_warnings": {
+          "description": "Warnings for why this disk is not recommended for installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "eligible": {
           "description": "Whether the disk is eligible for installation or not.",
           "type": "boolean"
@@ -16038,6 +16052,13 @@ func init() {
         "installation_eligibility": {
           "type": "object",
           "properties": {
+            "eligibility_warnings": {
+              "description": "Warnings for why this disk is not recommended for installation.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "eligible": {
               "description": "Whether the disk is eligible for installation or not.",
               "type": "boolean"

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6702,7 +6702,8 @@ func init() {
         "Multipath",
         "iSCSI",
         "FC",
-        "LVM"
+        "LVM",
+        "RAID"
       ]
     },
     "error": {
@@ -16280,7 +16281,8 @@ func init() {
         "Multipath",
         "iSCSI",
         "FC",
-        "LVM"
+        "LVM",
+        "RAID"
       ]
     },
     "error": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5321,6 +5321,11 @@ definitions:
             description: Reasons for why this disk is not eligible for installation.
             items:
               type: string
+          eligibility_warnings:
+            type: array
+            description: Warnings for why this disk is not recommended for installation.
+            items:
+              type: string
       smart:
         type: string
       io_perf:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5342,6 +5342,7 @@ definitions:
       - iSCSI
       - FC
       - LVM
+      - RAID
 
   io_perf:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -243,6 +243,9 @@ func (m *Disk) UnmarshalBinary(b []byte) error {
 // swagger:model DiskInstallationEligibility
 type DiskInstallationEligibility struct {
 
+	// Warnings for why this disk is not recommended for installation.
+	EligibilityWarnings []string `json:"eligibility_warnings"`
+
 	// Whether the disk is eligible for installation or not.
 	Eligible bool `json:"eligible,omitempty"`
 

--- a/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -55,6 +55,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -62,7 +65,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
The first commit unblocks software RAID devices.

The second commit returns warnings in disk eligibility in the following cases:
1. The disk is removable (a separate PR to assisted-installer-agent now makes it eligible)
2. The disk is FC (we prefer multipath)
3. The disk has holders (which means it's part of an LV, RAID, or multipath)

Also modifies the disk sorting to prevent the default installation disk from being one with warnings.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
