### PR TITLE
NO-ISSUE: added infraenv label to bmh template

### DIFF
--- a/deploy/operator/hypershift/deploy_hypershift_cluster.sh
+++ b/deploy/operator/hypershift/deploy_hypershift_cluster.sh
@@ -106,8 +106,6 @@ export -f wait_for_cmd_amount
 export -f get_agents
 timeout --signal=SIGKILL 20m bash -c "wait_for_cmd_amount 1 30 get_agents" || \
     (echo "Timed-out waiting for agents to be ready" && exit 124)
-agent_name=$(oc --kubeconfig $SPOKE_KUBECONFIG get -n ${SPOKE_NAMESPACE} agent -ojson | jq -r '.items[] | .metadata.name')
-oc --kubeconfig $SPOKE_KUBECONFIG -n $SPOKE_NAMESPACE patch agent $agent_name -p '{"spec":{"approved":true}}' --type merge
 
 
 echo "Waiting until cluster is installed"

--- a/deploy/operator/hypershift/playbooks/bmh-playbook.yaml
+++ b/deploy/operator/hypershift/playbooks/bmh-playbook.yaml
@@ -19,6 +19,7 @@
     - baremetalhosts: "{{ lookup('file', lookup('env', 'EXTRA_BAREMETALHOSTS_FILE')) | from_json }}"
     - iso_download_url: "{{ lookup('env', 'ISO_DOWNLOAD_URL') }}"
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
+    - infraenv_name: "{{ lookup('env', 'ASSISTED_INFRAENV_NAME') }}"
 
   tasks:
   - name: create directory for generated resources

--- a/deploy/operator/hypershift/playbooks/templates/baremetalHost.j2
+++ b/deploy/operator/hypershift/playbooks/templates/baremetalHost.j2
@@ -18,6 +18,8 @@ kind: BareMetalHost
 metadata:
   name: '{{ host["name"] }}'
   namespace: '{{ spoke_namespace }}'
+  labels:
+    infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
   annotations:
     bmac.agent-install.openshift.io/hostname: '{{ host["name"] }}'
 spec:


### PR DESCRIPTION
Added 'infraenvs.agent-install.openshift.io' label to baremetalHost.j2 template. 
This should allow the bmh_agent_controller to approve the agent.
I.e. instead of manually approving the agent in deploy_hypershift_cluster script.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
