### PR TITLE
MGMT-12423: Additional debug logs when collecting Agents from ACI

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1663,6 +1663,14 @@ func findAgentsByAgentClusterInstall(k8sclient client.Client, ctx context.Contex
 	}
 	log.Debugf("Found %d agents matching ClusterDeployment %s", len(agents), aci.Spec.ClusterDeploymentRef.Name)
 
+	for _, x := range agents {
+		log.Debugf("Agent '%s', dumping below:", x.Name)
+		log.Debugf("Ignition: '%s'", x.Spec.IgnitionConfigOverrides)
+		for _, y := range x.Status.Conditions {
+			log.Debugf("Type: '%s', Status: '%s', Reason: '%s', Message: '%s'", y.Type, y.Status, y.Reason, y.Message)
+		}
+	}
+
 	return agents, nil
 }
 


### PR DESCRIPTION
We are adding additional debug logging to dump the status of all the Agents that belong to a queried AgentClusterInstall. We will dump each Agent's ignition override as well as its conditions. Based on this, we can say if the UnsyncedAgents counter is working properly or not.

Contributes-to: [MGMT-12423](https://issues.redhat.com//browse/MGMT-12423)

/cc @omertuc 