### PR TITLE
MGMT-12790: add temp migration to delete agnet upgrade events

### DIFF
--- a/internal/migrations/20221201120400_delete_agent_upgrade_events.go
+++ b/internal/migrations/20221201120400_delete_agent_upgrade_events.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/openshift/assisted-service/internal/common"
+	"gorm.io/gorm"
+)
+
+const deleteAgentUpgradeEventsID = "202212011120400"
+
+func deleteAgentUpgradeEvents() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		// temporary migration - will need to switch this code to empty migration
+		// in order to avoid missing migrations in the DB
+		return tx.Where("name = ? or name = ?", "upgrade_agent_started", "upgrade_agent_finished").
+			Delete(&common.Event{}).Error
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID:       deleteAgentUpgradeEventsID,
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/20221201120400_delete_agent_upgrade_events_test.go
+++ b/internal/migrations/20221201120400_delete_agent_upgrade_events_test.go
@@ -1,0 +1,62 @@
+package migrations
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("delete agent upgrade events", func() {
+	var (
+		db     *gorm.DB
+		dbName string
+		gm     *gormigrate.Gormigrate
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, post())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	newEvent := func(name string) *common.Event {
+		clusterID := strfmt.UUID(uuid.New().String())
+		now := strfmt.DateTime(time.Now())
+		hostID := strfmt.UUID(uuid.New().String())
+		return &common.Event{
+			Event: models.Event{
+				ClusterID: &clusterID,
+				EventTime: &now,
+				HostID:    &hostID,
+				Name:      name,
+			},
+		}
+	}
+
+	It("delete only relevant events", func() {
+		Expect(db.Create(newEvent("upgrade_agent_started")).Error).To(BeNil())
+		Expect(db.Create(newEvent("upgrade_agent_started")).Error).To(BeNil())
+		Expect(db.Create(newEvent("upgrade_agent_finished")).Error).To(BeNil())
+		Expect(db.Create(newEvent("host_registration_succeeded")).Error).To(BeNil())
+		Expect(db.Create(newEvent("cluster_logs_uploaded")).Error).To(BeNil())
+
+		Expect(gm.MigrateTo(deleteAgentUpgradeEventsID)).ToNot(HaveOccurred())
+
+		var events []*common.Event
+		Expect(db.Find(&events).Error).To(BeNil())
+		Expect(events).To(HaveLen(2))
+		Expect(db.Find(&events).Where("name = host_registration_succeeded").Error).To(BeNil())
+		Expect(db.Find(&events).Where("name = cluster_logs_uploaded").Error).To(BeNil())
+	})
+
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -41,6 +41,7 @@ func post() []*gormigrate.Migration {
 		dropClusterIgnitionOverrides(),
 		multipleVips(),
 		renameKernelArguments(),
+		deleteAgentUpgradeEvents(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })


### PR DESCRIPTION
Because of a bug in the agent we spam the service with those events create a migration is a fast solution to remove those events Later to avoid problems with the migrations we should make this migration code to be empty migration and edit the code and not to revert it.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] Unit test
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
