### PR TITLE
NO-ISSUE: Stream events

### DIFF
--- a/internal/controller/controllers/controller_event_wrapper.go
+++ b/internal/controller/controllers/controller_event_wrapper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
+	"github.com/openshift/assisted-service/internal/streaming"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
@@ -59,6 +60,10 @@ func (c *controllerEventsWrapper) V2AddMetricsEvent(ctx context.Context, cluster
 
 func (c *controllerEventsWrapper) V2GetEvents(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, categories ...string) ([]*common.Event, error) {
 	return c.events.V2GetEvents(ctx, clusterID, hostID, infraEnvID, categories...)
+}
+
+func (c *controllerEventsWrapper) V2GetEventStream(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, categories ...string) (streaming.Stream[*common.Event], error) {
+	return c.events.V2GetEventStream(ctx, clusterID, hostID, infraEnvID, categories...)
 }
 
 func (c *controllerEventsWrapper) SendClusterEvent(ctx context.Context, event eventsapi.ClusterEvent) {

--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/streaming"
 	"github.com/openshift/assisted-service/models"
 )
 
@@ -40,6 +41,7 @@ type Sender interface {
 type Handler interface {
 	Sender
 	V2GetEvents(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, categories ...string) ([]*common.Event, error)
+	V2GetEventStream(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, categories ...string) (streaming.Stream[*common.Event], error)
 }
 
 var DefaultEventCategories = []string{

--- a/internal/migrations/2022120400000_create_open_cursor_function.go
+++ b/internal/migrations/2022120400000_create_open_cursor_function.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+const createOpenCursorFunctionID = "20221204000000"
+
+const createOpenCursorFunctionSQL = `
+create or replace function open_cursor(ref refcursor, query text) returns void as '
+begin
+	open ref for execute query;
+end;
+' language plpgsql
+`
+
+const dropOpenCursorFunctionSQL = `
+drop function if exists open_cursor(ref refcursor, query text);
+`
+
+func createOpenCursorFunction() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		return tx.Exec(createOpenCursorFunctionSQL).Error
+	}
+	rollback := func(tx *gorm.DB) error {
+		return tx.Exec(dropOpenCursorFunctionSQL).Error
+	}
+	return &gormigrate.Migration{
+		ID:       createOpenCursorFunctionID,
+		Migrate:  migrate,
+		Rollback: rollback,
+	}
+}

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -41,6 +41,7 @@ func post() []*gormigrate.Migration {
 		dropClusterIgnitionOverrides(),
 		multipleVips(),
 		renameKernelArguments(),
+		createOpenCursorFunction(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })

--- a/internal/streaming/query.go
+++ b/internal/streaming/query.go
@@ -1,0 +1,184 @@
+package streaming
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// QueryBuilder contains the data and logic needed to build a query stream. Don't create instances
+// of this directly, use the NewQuery function instead.
+type QueryBuilder[R any] struct {
+	db      *sql.DB
+	text    string
+	fetch   int
+	scanner func(*sql.Rows) (R, error)
+}
+
+// Query is a stream that returns the results of a SQL query. Don't create instances of this
+// directly, use the NewQuery function instead.
+type Query[R any] struct {
+	db      *sql.DB
+	tx      *sql.Tx
+	text    string
+	fetch   int
+	scanner func(*sql.Rows) (R, error)
+	cursor  string
+	buffer  []R
+	eos     bool
+}
+
+// NewQuery creats a builder that can then be used to create a query stream.
+func NewQuery[R any]() *QueryBuilder[R] {
+	return &QueryBuilder[R]{
+		fetch: 1,
+	}
+}
+
+// DB sets the database handle that will be used to execute the query. This is mandatory.
+func (b *QueryBuilder[R]) DB(value *sql.DB) *QueryBuilder[R] {
+	b.db = value
+	return b
+}
+
+// Text sets the SQL text of the query. This is mandatory.
+func (b *QueryBuilder[R]) Text(value string) *QueryBuilder[R] {
+	b.text = value
+	return b
+}
+
+// Fetch sets the number of rows that will be fetched from the database each time that new rows
+// are needed. The default is to retrieve one row each time. It is usually desirable to fetch
+// multiple rows each time, but it requires more memory.
+func (b *QueryBuilder[R]) Fetch(value int) *QueryBuilder[R] {
+	b.fetch = value
+	return b
+}
+
+// Scanner is the function that will be used to convert a rows into items. This is mandatory.
+func (b *QueryBuilder[R]) Scanner(value func(*sql.Rows) (R, error)) *QueryBuilder[R] {
+	b.scanner = value
+	return b
+}
+
+// Build uses the information stored in the builder to configure and create a query stream.
+func (b *QueryBuilder[R]) Build() (result *Query[R], err error) {
+	// Check parameters:
+	if b.db == nil {
+		err = errors.New("database handle is mandatory")
+		return
+	}
+	if b.text == "" {
+		err = errors.New("text is mandatory")
+		return
+	}
+	if b.scanner == nil {
+		err = errors.New("scanner is mandatory")
+		return
+	}
+	if b.fetch < 1 {
+		err = fmt.Errorf(
+			"fetch count should be greater or equal than one, but it is %d",
+			b.fetch,
+		)
+		return
+	}
+
+	// Create and populate the object:
+	result = &Query[R]{
+		db:      b.db,
+		text:    b.text,
+		fetch:   b.fetch,
+		scanner: b.scanner,
+	}
+	return
+}
+
+func (s *Query[R]) Next(ctx context.Context) (row R, err error) {
+	// Always remember to close the transaction in case of error, including the end of the
+	// stream. These transactions are read only, so it is OK to always roll them back.
+	defer func() {
+		if err != nil && s.tx != nil {
+			s.tx.Rollback()
+			s.tx = nil
+		}
+	}()
+
+	// Exit if we have already reached the end of the stream:
+	if s.eos {
+		err = EOS
+		return
+	}
+
+	// Stop if the context is canceled:
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+		return
+	default:
+	}
+
+	// Start the transaction if needed:
+	if s.tx == nil {
+		s.tx, err = s.db.BeginTx(ctx, &sql.TxOptions{
+			ReadOnly: true,
+		})
+		if err != nil {
+			return
+		}
+	}
+
+	// Open the cursor if needed:
+	if s.cursor == "" {
+		s.cursor = uuid.New().String()
+		_, err = s.tx.ExecContext(
+			ctx,
+			`select open_cursor($1, $2)`,
+			s.cursor,
+			s.text,
+		)
+		if err != nil {
+			return
+		}
+	}
+
+	// If the current buffer hasn't been exahusted then return the first item from it:
+	if len(s.buffer) > 0 {
+		row = s.buffer[0]
+		s.buffer = s.buffer[1:]
+		return
+	}
+
+	// Fill the buffer:
+	rows, err := s.tx.QueryContext(
+		ctx,
+		fmt.Sprintf(`fetch %d from "%s"`, s.fetch, s.cursor),
+	)
+	if err != nil {
+		return
+	}
+	s.buffer = nil
+	for rows.Next() {
+		var tmp R
+		tmp, err = s.scanner(rows)
+		if err != nil {
+			return
+		}
+		s.buffer = append(s.buffer, tmp)
+	}
+
+	// If at this point the buffer is empty then there are no more rows:
+	if len(s.buffer) == 0 {
+		s.eos = true
+		err = EOS
+		return
+	}
+
+	// Return the first row from the buffer:
+	row = s.buffer[0]
+	s.buffer = s.buffer[1:]
+	return
+}

--- a/internal/streaming/responder.go
+++ b/internal/streaming/responder.go
@@ -1,0 +1,173 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+	jsoniter "github.com/json-iterator/go"
+)
+
+// ResponderBuilder contains the data and logic needed to build a new streaming respnder. Don't
+// create instances of this directly, use the NewResponder function instead.
+type ResponderBuilder[I any] struct {
+	source Stream[I]
+	flush  int
+	ctx    context.Context
+}
+
+// Responder is an responder that takes items from a stream and writes then to the response as
+// items of a JSON array. Don't create instances of this directly, use the NewResponder function
+// instead.
+type Responder[I any] struct {
+	source Stream[I]
+	flush  int
+	ctx    context.Context
+}
+
+// NewResponder creates a builder that can then be used to configure and create a streaming
+// responder.
+func NewResponder[I any]() *ResponderBuilder[I] {
+	return &ResponderBuilder[I]{}
+}
+
+// Source sets the stream that the responder will consume. This is mandatory.
+func (b *ResponderBuilder[I]) Source(value Stream[I]) *ResponderBuilder[I] {
+	b.source = value
+	return b
+}
+
+// Flush sets how many items are written before explicitly flushing the writer. Small values reduce
+// performance, as there will be more writes and buffers will be used less efficiently, but it can
+// be convenient when the client needs or wants to process results one by one as soon as they
+// arrive. The default value is zero which means that the writer will never be explicitly flushed.
+// It may be flushed anyhow when the underlying buffers are filled.
+//
+// Note that flushing requires the response writer to support the http.Flusher interface. If it
+// doesn't implement it then this flag will be ignored.
+func (b *ResponderBuilder[I]) Flush(value int) *ResponderBuilder[I] {
+	b.flush = value
+	return b
+}
+
+// Context sets the context that the responder will use. The default is to use a new
+// background context.
+func (b *ResponderBuilder[I]) Context(value context.Context) *ResponderBuilder[I] {
+	b.ctx = value
+	return b
+}
+
+// Build uses the data stored in the builder to create a new streaming respnder.
+func (b *ResponderBuilder[I]) Build() (result *Responder[I], err error) {
+	// Check parameters:
+	if b.source == nil {
+		err = errors.New("stream is mandatory")
+		return
+	}
+	if b.flush < 0 {
+		err = fmt.Errorf(
+			"flush must be greater or equal than zero, but it is %d",
+			b.flush,
+		)
+	}
+
+	// Set default values:
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Create and populate the object:
+	result = &Responder[I]{
+		source: b.source,
+		flush:  b.flush,
+		ctx:    ctx,
+	}
+	return
+}
+
+// WriteResponse is the implementation of the responder interface. Note that this implementation
+// ignores the producer; it always writes JSON.
+func (r *Responder[I]) WriteResponse(w http.ResponseWriter, _ runtime.Producer) {
+	// Get the context:
+	ctx := r.ctx
+
+	// Get the flusher:
+	flusher, _ := w.(http.Flusher)
+
+	// Create the JSON stream:
+	stream := jsoniter.NewStream(jsoniter.ConfigDefault, w, 4096)
+
+	// Get items from the source stream and write them to the JSON stream:
+	r.sendArrayStart(stream)
+	first := true
+	count := r.flush
+	for {
+		item, err := r.source.Next(ctx)
+		if errors.Is(err, EOS) {
+			r.sendArrayEnd(stream)
+			return
+		}
+		if !first {
+			r.sendMore(stream)
+		}
+		r.sendItem(stream, item)
+		if r.flush > 0 {
+			count--
+			if count == 0 {
+				err = stream.Flush()
+				if err != nil {
+					panic(err)
+				}
+				if flusher != nil {
+					flusher.Flush()
+				}
+				count = r.flush
+			}
+		}
+		first = false
+	}
+}
+
+func (r *Responder[I]) sendArrayStart(stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	if stream.Error != nil {
+		panic(stream.Error)
+	}
+	r.sendLineBreak(stream)
+}
+
+func (r *Responder[I]) sendArrayEnd(stream *jsoniter.Stream) {
+	r.sendLineBreak(stream)
+	stream.WriteArrayEnd()
+	if stream.Error != nil {
+		panic(stream.Error)
+	}
+	r.sendLineBreak(stream)
+}
+
+func (r *Responder[I]) sendMore(stream *jsoniter.Stream) {
+	stream.WriteMore()
+	if stream.Error != nil {
+		panic(stream.Error)
+	}
+	r.sendLineBreak(stream)
+}
+
+func (h *Responder[I]) sendItem(stream *jsoniter.Stream, item I) {
+	stream.WriteVal(item)
+	if stream.Error != nil {
+		panic(stream.Error)
+	}
+}
+
+func (h *Responder[I]) sendLineBreak(stream *jsoniter.Stream) {
+	stream.Write(lineBreak)
+	if stream.Error != nil {
+		panic(stream.Error)
+	}
+}
+
+var lineBreak = []byte("\n")

--- a/internal/streaming/stream.go
+++ b/internal/streaming/stream.go
@@ -1,0 +1,194 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Stream represents a stream of items.
+type Stream[I any] interface {
+	// Next resturns the next item from the stream. Returns the EOS error if there are
+	// no more items. Other errors may also be returned. For example, if the stream is backed
+	// by a database table the database connection may fail and generate an error.
+	Next(ctx context.Context) (item I, err error)
+}
+
+// Sizer is an interface that can optionally be implemented by streams that know what is their
+// size. Some functions, for example the Slice function that builds an slice from a stream, can
+// take advantage of this to allocate the required space in advance.
+type Sizer interface {
+	// Returns the number of items still available in the stream.
+	Size(ctx context.Context) (size int, err error)
+}
+
+// EOS is the error returned by by the Next method of streams when there are no more items
+// in the stream.
+var EOS = errors.New("EOS")
+
+// StreamFunc creates an implementation of the Stream interface using the given function.
+type StreamFunc[I any] func(context.Context) (I, error)
+
+func (f StreamFunc[I]) Next(ctx context.Context) (item I, err error) {
+	return f(ctx)
+}
+
+// Pour creates a stream that contains the items in the given slice.
+func Pour[I any](slice []I) Stream[I] {
+	return &pourStream[I]{
+		slice: slice,
+	}
+}
+
+// pourStream is the implementation of the streams returned by the Pour function.
+type pourStream[I any] struct {
+	slice []I
+}
+
+func (s *pourStream[I]) Next(ctx context.Context) (item I, err error) {
+	if len(s.slice) > 0 {
+		item = s.slice[0]
+		s.slice = s.slice[1:]
+	} else {
+		s.slice = nil
+		err = EOS
+	}
+	return
+}
+
+func (s *pourStream[I]) Size(ctx context.Context) (size int, err error) {
+	size = len(s.slice)
+	return
+}
+
+// Collect collects all the items in the given stream and returns an slice containing them.
+func Collect[I any](ctx context.Context, stream Stream[I]) (slice []I, err error) {
+	// If we know the size of the stream we can create the slice with the reuquired capacity
+	// in advance and avoid the reallocations that will otherwise be done as items are added.
+	var buffer []I
+	sizer, ok := stream.(Sizer)
+	if ok {
+		var size int
+		size, err = sizer.Size(ctx)
+		if err != nil {
+			return
+		}
+		if size > 0 {
+			buffer = make([]I, 0, size)
+		}
+	}
+
+	// Collect the items of the stream remembering to stop if the context is canceled:
+	for {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			return
+		default:
+		}
+		var item I
+		item, err = stream.Next(ctx)
+		if errors.Is(err, EOS) {
+			slice = buffer
+			return
+		}
+		if err != nil {
+			return
+		}
+		buffer = append(buffer, item)
+	}
+}
+
+// Mapper is a function that transofms one object into another.
+type Mapper[F, T any] func(context.Context, F) (T, error)
+
+// Map creates a stream that contains the result of transforming the objects of the given stream
+// with a mapper. Note that the actual calls to the mapper will not happen when this function is
+// called, they will happen only when the stream is eventually consumed.
+func Map[F, T any](source Stream[F], mapper Mapper[F, T]) Stream[T] {
+	return &mapStream[F, T]{
+		source: source,
+		mapper: mapper,
+	}
+}
+
+// mapStream is the implementation of the streams returned by the Map function.
+type mapStream[F, T any] struct {
+	source Stream[F]
+	mapper Mapper[F, T]
+}
+
+func (s *mapStream[F, T]) Next(ctx context.Context) (item T, err error) {
+	tmp, err := s.source.Next(ctx)
+	if err != nil {
+		return
+	}
+	item, err = s.mapper(ctx, tmp)
+	return
+}
+
+// Selector is a function that filters element of a stream.
+type Selector[I any] func(context.Context, I) (bool, error)
+
+// Select creates a new stream that only contains the items of the source stream that return true
+// for the given selector. Note that the actual calls to the select will not happen when this
+// function is called, they will happen only when the stream is eventually consumed.
+func Select[I any](source Stream[I], selector Selector[I]) Stream[I] {
+	return &selectStream[I]{
+		source:   source,
+		selector: selector,
+	}
+}
+
+// selectStream is the implementation of streams returned by the Select function.
+type selectStream[I any] struct {
+	source   Stream[I]
+	selector Selector[I]
+}
+
+func (s *selectStream[I]) Next(ctx context.Context) (item I, err error) {
+	for {
+		var tmp I
+		tmp, err = s.source.Next(ctx)
+		if err != nil {
+			return
+		}
+		var ok bool
+		ok, err = s.selector(ctx, tmp)
+		if err != nil {
+			return
+		}
+		if ok {
+			item = tmp
+			return
+		}
+	}
+}
+
+// Delay creates a new stream that returns the same items than the given source, but with an
+// additional delay for each item. This is intended for tests and there is usually no reason
+// to use in production code.
+func Delay[I any](source Stream[I], delay time.Duration) Stream[I] {
+	return &delayStream[I]{
+		source: source,
+		delay:  delay,
+	}
+}
+
+// delayStream is the implementation of streams returned by the Delay function.
+type delayStream[I any] struct {
+	source Stream[I]
+	delay  time.Duration
+}
+
+func (s *delayStream[I]) Next(ctx context.Context) (item I, err error) {
+	item, err = s.source.Next(ctx)
+	if err != nil {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(s.delay):
+	}
+	return
+}


### PR DESCRIPTION
This patch changes the events endpoint so that it send results using an streaming approach. Currently this endpoint retrieves all the results from the database in a list in memory, then it transforms that list of database objects into API objects using a another list, and finally it renders the list as JSON and sends it to the client. Instead of that this patch changes the endpoint so that as soon as the first result arrives from the database it is sent to the client, and so on for the rest of the results. This changes the space complexity of the operation from O(n) to O(1).

Before the change, with the service otherwise idle, for a host with 500000 events the resident set increased approximately 850 MiB.

After the change, in the same conditions, it increased 16 MiB.

I think there is still room for improvement in the database side, as we could fetch rows block by block using a cursor.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
