### PR TITLE
MGMT-12782: Regression test for nil inventory in subsystem

### DIFF
--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -509,4 +509,9 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 		actual := err.(*installer.RegisterInfraEnvBadRequest)
 		Expect(*actual.Payload.Reason).To(ContainSubstring("does not have a matching OpenShift release image"))
 	})
+
+	It("Service should continue to function if inventory is nil", func() {
+		
+	})
+
 })


### PR DESCRIPTION
Recent issues such as the rollback of MGMT-11506 have highlighted a need to regression test for scenarios where a host inventory is nil. This PR introduces some testing in this area to ensure that the service stays up (as opposed to crashing) when nil inventory is presented.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [X] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
