### PR TITLE
MGMT-11506: Present a more useful validation message for packet loss

### DIFF
--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -5106,10 +5106,10 @@ var _ = Describe("Refresh Host", func() {
 				IPAddressPool:          hostutil.GenerateIPv4Addresses(3, common.IncrementCidrIP(string(common.TestIPv4Networking.MachineNetworks[0].Cidr))),
 				machineNetworks:        common.TestIPv4Networking.MachineNetworks,
 				ipType:                 ipv4,
-				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): Network latency requirements of less than or equals 100.00 ms not met for connectivity between.*Packet loss percentage requirement of equals 0.00% not met for connectivity between.*"),
+				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): A total network latency above the tolerated threshold of 100.00 ms was encountered when performing network latency tests between host((.|\n)*)A total packet loss above the tolerated threshold of 0.00% was encountered when performing connectivity validation between host((.|\n)*)"),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
-					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less than or equals 100.00 ms not met for connectivity between .*? and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
-					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of equals 0.00% not met for connectivity between .*? and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
+					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "A total network latency above the tolerated threshold of 100.00 ms was encountered when performing network latency tests between host ((.|\n)*) and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
+					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "A total packet loss above the tolerated threshold of 0.00% was encountered when performing connectivity validation between host ((.|\n)*) and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
 				}),
 			}, {name: "insufficient with IPv6 and 3 masters with high latency and packet loss",
 				srcState:               models.HostStatusDiscovering,
@@ -5120,10 +5120,10 @@ var _ = Describe("Refresh Host", func() {
 				IPAddressPool:          hostutil.GenerateIPv6Addresses(3, common.IncrementCidrIP(string(common.TestIPv4Networking.MachineNetworks[0].Cidr))),
 				machineNetworks:        common.TestIPv4Networking.MachineNetworks,
 				ipType:                 ipv6,
-				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): Network latency requirements of less than or equals 100.00 ms not met for connectivity between.*Packet loss percentage requirement of equals 0.00% not met for connectivity between.*"),
+				statusInfoChecker:      makeRegexChecker("Host cannot be installed due to following failing validation\\(s\\): A total network latency above the tolerated threshold of 100.00 ms was encountered when performing network latency tests between host((.|\n)*)A total packet loss above the tolerated threshold of 0.00% was encountered when performing connectivity validation between host((.|\n)*)"),
 				validationsChecker: makeJsonChecker(map[validationID]validationCheckResult{
-					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "Network latency requirements of less than or equals 100.00 ms not met for connectivity between .*? and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
-					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "Packet loss percentage requirement of equals 0.00% not met for connectivity between .*? and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
+					HasSufficientNetworkLatencyRequirementForRole: {status: ValidationFailure, messagePattern: "A total network latency above the tolerated threshold of 100.00 ms was encountered when performing network latency tests between host .*? and master-1 \\(200.00 ms\\), master-2 \\(200.00 ms\\)."},
+					HasSufficientPacketLossRequirementForRole:     {status: ValidationFailure, messagePattern: "A total packet loss above the tolerated threshold of 0.00% was encountered when performing connectivity validation between host .*? and master-1 \\(1.00%\\), master-2 \\(1.00%\\)."},
 				}),
 			},
 		}
@@ -5738,15 +5738,6 @@ var _ = Describe("validationResult sort", func() {
 		Expect(validationResults[1].ID.String()).Should(Equal("acb"))
 		Expect(validationResults[2].ID.String()).Should(Equal("bac"))
 		Expect(validationResults[3].ID.String()).Should(Equal("cab"))
-	})
-})
-
-var _ = Describe("Comparison builder", func() {
-	It("should return 'equals' when value is == 0", func() {
-		Expect(comparisonBuilder(0)).To(Equal("equals"))
-	})
-	It("should return 'less than or equals' when value is > 0", func() {
-		Expect(comparisonBuilder(1)).To(Equal("less than or equals"))
 	})
 })
 

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -44,6 +44,8 @@ const (
 	ValidationDisabled              ValidationStatus = "disabled"
 	maxServiceAheadOfHostTimeDiff                    = 20 * time.Minute
 	maxHostAheadOfServiceTimeDiff                    = 1 * time.Hour
+	maxHostTimingMetrics                             = 4
+	maxPingCommandExamples                           = 4
 )
 
 const FailedToFindAction = "failed to find action for step"
@@ -916,41 +918,54 @@ func (v *validator) sufficientOrUnknownInstallationDiskSpeed(c *validationContex
 	return ValidationFailure, "While preparing the previous installation the installation disk speed measurement failed or was found to be insufficient"
 }
 
-func (v *validator) hasSufficientNetworkLatencyRequirementForRole(c *validationContext) (ValidationStatus, string) {
-	if c.infraEnv != nil {
-		return ValidationSuccessSuppressOutput, ""
-	}
-	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.NetworkLatencyThresholdMs == nil || common.GetEffectiveRole(c.host) == models.HostRoleAutoAssign || hostutil.IsDay2Host(c.host) {
-		// Single Node use case || no requirements defined || role is auto assign
-		return ValidationSuccess, "Network latency requirement has been satisfied."
-	}
-	if len(c.host.Connectivity) == 0 {
-		return ValidationPending, "Missing network latency information."
-	}
-	s, hostLatencies, err := v.validateNetworkLatencyForRole(c.host, c.clusterHostRequirements, c.cluster.Hosts, c.inventoryCache)
-	if s == ValidationFailure {
-		if err != nil {
-			return ValidationFailure, fmt.Sprintf("Error while attempting to validate network latency: %s", err)
-		}
-		return ValidationFailure, fmt.Sprintf("Network latency requirements of %s %.2f ms not met for connectivity between %s and%s.", comparisonBuilder(*c.clusterHostRequirements.Total.NetworkLatencyThresholdMs), *c.clusterHostRequirements.Total.NetworkLatencyThresholdMs, c.host.ID, strings.Join(hostLatencies, ","))
-	}
-	if s == ValidationError {
-		return ValidationError, "Parse error while attempting to process the connectivity report"
-	}
-	return ValidationSuccess, "Network latency requirement has been satisfied."
+type hostTimingMetric struct {
+	otherHostName string
+	timingMetric  float64
+	timingSuffix  string
 }
 
-func (v *validator) validateNetworkLatencyForRole(host *models.Host, clusterRoleReqs *models.ClusterHostRequirements, hosts []*models.Host, inventoryCache InventoryCache) (ValidationStatus, []string, error) {
+func (v *validator) summarizeHostTimingMetrics(packetLossInfo []hostTimingMetric, truncateMetrics bool) string {
+	result := []string{}
+	for i, p := range packetLossInfo {
+		//If there a lot of hosts in the cluster, this list could be rather large, so we shorten it
+		if truncateMetrics && i > maxHostTimingMetrics {
+			result = append(result, fmt.Sprintf("%s (%.2f%s) and others...", p.otherHostName, p.timingMetric, p.timingSuffix))
+			break
+		}
+		result = append(result, fmt.Sprintf("%s (%.2f%s)", p.otherHostName, p.timingMetric, p.timingSuffix))
+	}
+	return strings.Join(result, ", ")
+}
+
+type thresholdTestType int
+
+const (
+	thresholdTestL3AverageRTTMs thresholdTestType = 0
+	thresholdTestL3PacketLoss   thresholdTestType = 1
+)
+
+func (v *validator) thresholdExceededTest(testType thresholdTestType, host *models.Host, clusterRoleReqs *models.ClusterHostRequirements, hosts []*models.Host, inventoryCache InventoryCache) (ValidationStatus, []hostTimingMetric, error) {
+
 	connectivityReport, err := hostutil.UnmarshalConnectivityReport(host.Connectivity)
 	if err != nil {
 		v.log.Errorf("Unable to unmarshall host connectivity for %s:%s", host.ID, err)
 		return ValidationError, nil, nil
 	}
 	failedHostIPs := map[string]struct{}{}
-	failedHostLatencies := []string{}
+	failedHostMetrics := []hostTimingMetric{}
 	for _, r := range connectivityReport.RemoteHosts {
 		for _, l3 := range r.L3Connectivity {
-			if l3.AverageRTTMs > *clusterRoleReqs.Total.NetworkLatencyThresholdMs {
+
+			var hostHasExceededThreshold bool
+			switch testType {
+			case thresholdTestL3AverageRTTMs:
+				hostHasExceededThreshold = l3.AverageRTTMs > *clusterRoleReqs.Total.NetworkLatencyThresholdMs
+			case thresholdTestL3PacketLoss:
+				hostHasExceededThreshold = l3.PacketLossPercentage > *clusterRoleReqs.Total.PacketLossPercentage
+			default:
+				return ValidationError, nil, fmt.Errorf("unexpected testType")
+			}
+			if hostHasExceededThreshold {
 				if _, ok := failedHostIPs[l3.RemoteIPAddress]; !ok {
 					hostname, role, err := GetHostnameAndEffectiveRoleByHostID(r.HostID, hosts, inventoryCache)
 					if err != nil {
@@ -959,31 +974,28 @@ func (v *validator) validateNetworkLatencyForRole(host *models.Host, clusterRole
 					}
 					if role == common.GetEffectiveRole(host) {
 						failedHostIPs[l3.RemoteIPAddress] = struct{}{}
-						failedHostLatencies = append(failedHostLatencies, fmt.Sprintf(" %s (%.2f ms)", hostname, l3.AverageRTTMs))
+						switch testType {
+						case thresholdTestL3AverageRTTMs:
+							failedHostMetrics = append(failedHostMetrics, hostTimingMetric{otherHostName: hostname, timingMetric: l3.AverageRTTMs, timingSuffix: " ms"})
+						case thresholdTestL3PacketLoss:
+							failedHostMetrics = append(failedHostMetrics, hostTimingMetric{otherHostName: hostname, timingMetric: l3.PacketLossPercentage, timingSuffix: "%"})
+						}
 					}
 				}
 			}
 		}
 	}
-	if len(failedHostLatencies) > 0 {
-		return ValidationFailure, failedHostLatencies, nil
+	if len(failedHostMetrics) > 0 {
+		return ValidationFailure, failedHostMetrics, nil
 	}
 	return ValidationSuccess, nil, nil
-}
 
-const (
-	lessThanOr = "less than or"
-	equals     = "equals"
-)
-
-func comparisonBuilder(value float64) string {
-	if value > 0 {
-		return fmt.Sprintf("%s %s", lessThanOr, equals)
-	}
-	return equals
 }
 
 func (v *validator) hasSufficientPacketLossRequirementForRole(c *validationContext) (ValidationStatus, string) {
+	if c.inventory == nil {
+		return ValidationPending, "The inventory is not available yet."
+	}
 	if c.infraEnv != nil {
 		return ValidationSuccessSuppressOutput, ""
 	}
@@ -994,7 +1006,7 @@ func (v *validator) hasSufficientPacketLossRequirementForRole(c *validationConte
 	if len(c.host.Connectivity) == 0 {
 		return ValidationPending, "Missing packet loss information."
 	}
-	status, hostPacketLoss, err := v.validatePacketLossForRole(c.host, c.clusterHostRequirements, c.cluster.Hosts, c.inventoryCache)
+	status, hostMetrics, err := v.thresholdExceededTest(thresholdTestL3PacketLoss, c.host, c.clusterHostRequirements, c.cluster.Hosts, c.inventoryCache)
 	if err != nil {
 		return status, fmt.Sprintf("Error while attempting to validate packet loss validation: %s", err)
 	}
@@ -1003,43 +1015,123 @@ func (v *validator) hasSufficientPacketLossRequirementForRole(c *validationConte
 	case ValidationSuccess:
 		return status, "Packet loss requirement has been satisfied."
 	case ValidationFailure:
-
-		return status, fmt.Sprintf("Packet loss percentage requirement of %s %.2f%% not met for connectivity between %s and%s.", comparisonBuilder(*c.clusterHostRequirements.Total.PacketLossPercentage), *c.clusterHostRequirements.Total.PacketLossPercentage, c.host.ID, strings.Join(hostPacketLoss, ","))
+		// When logging, make sure the full timing metrics are logged.
+		fullHostTimingMetrics := v.summarizeHostTimingMetrics(hostMetrics, false)
+		v.log.Error(fmt.Sprintf(`A total packet loss above the tolerated threshold of %.2f%% was encountered when performing connectivity validation between host %s and %s\n`,
+			*c.clusterHostRequirements.Total.PacketLossPercentage,
+			c.host.ID,
+			fullHostTimingMetrics,
+		))
+		// For the advisory message, a truncated summary of the timing metrics.
+		shortHostTimingMetrics := v.summarizeHostTimingMetrics(hostMetrics, true)
+		packetLossAdvisoryMessage := fmt.Sprintf(`A total packet loss above the tolerated threshold of %.2f%% was encountered when performing connectivity validation between host %s and %s\n`,
+			*c.clusterHostRequirements.Total.PacketLossPercentage,
+			c.host.ID,
+			shortHostTimingMetrics,
+		)
+		packetLossAdvisoryMessage += v.generatePacketLossAdvisoryMessageForHost(c)
+		return status, packetLossAdvisoryMessage
 	case ValidationError:
 		return status, "Parse error while attempting to process the connectivity report"
 	}
 	return status, fmt.Sprintf("Unexpected status %s", status)
 }
 
-func (v *validator) validatePacketLossForRole(host *models.Host, clusterRoleReqs *models.ClusterHostRequirements, hosts []*models.Host, inventoryCache InventoryCache) (ValidationStatus, []string, error) {
-	connectivityReport, err := hostutil.UnmarshalConnectivityReport(host.Connectivity)
-	if err != nil {
-		v.log.Errorf("Unable to unmarshall host connectivity for %s:%s", host.ID, err)
-		return ValidationError, nil, nil
+func (v *validator) generatePingCommand(c *validationContext, interfaceName string, addresses []string) string {
+	var message string
+
+	for i, address := range addresses {
+		//If there a lot of hosts in the cluster, this list could be rather large, so we shorten it
+		if i > maxPingCommandExamples {
+			message += "etc... \n"
+			break
+		}
+		// This command must be kept in sync with the agent repo https://github.com/openshift/assisted-installer-agent/blob/a35f7c36951313f6a6948a190ca6b56d1472516b/src/connectivity_check/connectivity_check.go#L87
+		message += fmt.Sprintf("ping -c 10 -W 3 -q -I %s %s\n", interfaceName, address)
 	}
-	failedHostIPs := map[string]struct{}{}
-	failedHostPacketLoss := []string{}
-	for _, r := range connectivityReport.RemoteHosts {
-		for _, l3 := range r.L3Connectivity {
-			if l3.PacketLossPercentage > *clusterRoleReqs.Total.PacketLossPercentage {
-				if _, ok := failedHostIPs[l3.RemoteIPAddress]; !ok {
-					hostname, role, err := GetHostnameAndEffectiveRoleByHostID(r.HostID, hosts, inventoryCache)
-					if err != nil {
-						v.log.Error(err)
-						return ValidationFailure, nil, err
-					}
-					if role == common.GetEffectiveRole(host) {
-						failedHostIPs[l3.RemoteIPAddress] = struct{}{}
-						failedHostPacketLoss = append(failedHostPacketLoss, fmt.Sprintf(" %s (%.2f%%)", hostname, l3.PacketLossPercentage))
-					}
-				}
-			}
+
+	return message
+}
+
+func (v *validator) generatePingCommandAdvisoryForInventory(c *validationContext, inventory *models.Inventory) string {
+	var message string
+	hostName := getRealHostname(c.host, inventory)
+	if len(inventory.Interfaces) > 0 {
+		message += fmt.Sprintf("2: Please try the following commands on the host %s to investigate the packet loss further\n\n", hostName)
+		for _, intf := range inventory.Interfaces {
+			message += v.generatePingCommand(c, intf.Name, intf.IPV4Addresses)
 		}
 	}
-	if len(failedHostPacketLoss) > 0 {
-		return ValidationFailure, failedHostPacketLoss, nil
+	return message
+}
+
+func (v *validator) generatePacketLossAdvisoryMessageForHost(c *validationContext) string {
+	message := "Actions:\n"
+	message += "1: Check if there are multiple devices on the same L2 network, if so then use the built-in nmstate-based advanced networking configuration to create a bond or disable all but one of the interfaces.\n"
+
+	inventory, err := c.inventoryCache.GetOrUnmarshal(c.host)
+	if err != nil {
+		v.log.WithError(err).Warnf("Could not parse inventory of host %s\n", *c.host.ID)
 	}
-	return ValidationSuccess, nil, nil
+	return message + v.generatePingCommandAdvisoryForInventory(c, inventory)
+}
+
+func (v *validator) hasSufficientNetworkLatencyRequirementForRole(c *validationContext) (ValidationStatus, string) {
+	if c.inventory == nil {
+		return ValidationPending, "The inventory is not available yet."
+	}
+	if c.infraEnv != nil {
+		return ValidationSuccessSuppressOutput, ""
+	}
+	if len(c.cluster.Hosts) == 1 || c.clusterHostRequirements.Total.NetworkLatencyThresholdMs == nil || common.GetEffectiveRole(c.host) == models.HostRoleAutoAssign || hostutil.IsDay2Host(c.host) {
+		// Single Node use case || no requirements defined || role is auto assign
+		return ValidationSuccess, "Network latency requirement has been satisfied."
+	}
+	if len(c.host.Connectivity) == 0 {
+		return ValidationPending, "Missing network latency information."
+	}
+	status, hostMetrics, err := v.thresholdExceededTest(thresholdTestL3AverageRTTMs, c.host, c.clusterHostRequirements, c.cluster.Hosts, c.inventoryCache)
+	if status == ValidationFailure {
+		if err != nil {
+			return ValidationFailure, fmt.Sprintf("Error while attempting to validate network latency: %s", err)
+		}
+
+		// When logging, make sure the full timing metrics are logged.
+		fullHostTimingMetrics := v.summarizeHostTimingMetrics(hostMetrics, false)
+		v.log.Info(fmt.Sprintf(`A total network latency above the tolerated threshold of %.2f ms was encountered when performing network latency tests between host %s and %s\n`,
+			*c.clusterHostRequirements.Total.NetworkLatencyThresholdMs,
+			c.host.ID,
+			fullHostTimingMetrics,
+		))
+
+		// For the advisory message, a truncated summary of the timing metrics.
+		shortHostTimingMetrics := v.summarizeHostTimingMetrics(hostMetrics, true)
+		networkLatencyAdvisoryMessage := fmt.Sprintf(`A total network latency above the tolerated threshold of %.2f ms was encountered when performing network latency tests between host %s and %s\n`,
+			*c.clusterHostRequirements.Total.NetworkLatencyThresholdMs,
+			c.host.ID,
+			shortHostTimingMetrics,
+		)
+
+		networkLatencyAdvisoryMessage += v.generateExcessiveLatencyAdvisoryForHost(c)
+		return ValidationFailure, networkLatencyAdvisoryMessage
+	}
+	if status == ValidationError {
+		return ValidationError, "Parse error while attempting to process the connectivity report"
+	}
+	return ValidationSuccess, "Network latency requirement has been satisfied."
+}
+
+func (v *validator) generateExcessiveLatencyAdvisoryForHost(c *validationContext) string {
+	var message string
+	inventory, err := c.inventoryCache.GetOrUnmarshal(c.host)
+	if err != nil {
+		v.log.WithError(err).Warnf("Could not parse inventory of host %s\n", *c.host.ID)
+	}
+	if len(inventory.Interfaces) > 0 {
+		message += fmt.Sprintf("Actions:\n1: Please try the following commands on the host %s and examine averages to investigate the latency issue further\n\n", getRealHostname(c.host, inventory))
+		message += v.generatePingCommandAdvisoryForInventory(c, inventory)
+	}
+	return message
 }
 
 func (v *validator) hasDefaultRoute(c *validationContext) (ValidationStatus, string) {


### PR DESCRIPTION
The current message for host packet loss is not helpful to end users and does little to help them get to the root of their issues. This update attempts to remedy that by providing more concise information on how to troubleshoot the issue.

Both the messaging around network latency and around packet loss have been updated to include detailed information in the logs about the hosts involved and to offer potential troubleshooting hints in the form of ping commands that can be used by the user to perform checks themelves.

In the process, I improved code reuse by introducing a method to determine if a threshold for ping or latency has been met, the idea is that this should be extensible to future needs while also making the code simpler.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
