### PR TITLE
MGMT-12806: Allow registration when pending for input

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -53,6 +53,7 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 			stateswitch.State(models.HostStatusPreparingForInstallation),
 			stateswitch.State(models.HostStatusPreparingSuccessful),
 			stateswitch.State(models.HostStatusBinding),
+			stateswitch.State(models.HostStatusPendingForInput),
 		},
 		DestinationState: stateswitch.State(models.HostStatusDiscovering),
 		PostTransition:   th.PostRegisterHost,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -269,6 +269,11 @@ var _ = Describe("RegisterHost", func() {
 				kind:     models.HostKindHost,
 			},
 			{
+				name:     "pending for input",
+				srcState: models.HostStatusPendingForInput,
+				kind:     models.HostKindHost,
+			},
+			{
 				name:     "binding day1",
 				srcState: models.HostStatusBinding,
 				kind:     models.HostKindHost,


### PR DESCRIPTION
Currently when a host is in the _pending for input_ state it can't register again. This produces the following situation when the host is rebooted or when the agent restarts to upgrade the agent:

- The host tries to register, fails and retries. This generates error events indicating that the host can't register.

- Eventually, after several tries, the host will be moved to the _disconnected_ state.

- The host will try again to register and now it will succeed because we do allow the registration from the _disconnected_ state.

This patch changes the state machine so that the host will be allowed to register from the _pending for input_ state.

https://issues.redhat.com/browse/MGMT-12806

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
