### PR TITLE
NO-ISSUE: extract client from reconcile context

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -146,13 +146,13 @@ func main() {
 
 	if err = (&controllers.AgentServiceConfigReconciler{
 		AgentServiceConfigReconcileContext: controllers.AgentServiceConfigReconcileContext{
-			Client:       mgr.GetClient(),
 			Log:          log,
 			Scheme:       mgr.GetScheme(),
 			NodeSelector: nodeSelector,
 			Tolerations:  tolerations,
 			Recorder:     mgr.GetEventRecorderFor("agentserviceconfig-controller"),
 		},
+		Client:    mgr.GetClient(),
 		Namespace: ns,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AgentServiceConfig")
@@ -161,13 +161,13 @@ func main() {
 
 	if err = (&controllers.HypershiftAgentServiceConfigReconciler{
 		AgentServiceConfigReconcileContext: controllers.AgentServiceConfigReconcileContext{
-			Client:       mgr.GetClient(),
 			Log:          log,
 			Scheme:       mgr.GetScheme(),
 			NodeSelector: nodeSelector,
 			Tolerations:  tolerations,
-			Recorder:     mgr.GetEventRecorderFor("agentserviceconfig-controller"),
+			Recorder:     mgr.GetEventRecorderFor("hypershiftagentserviceconfig-controller"),
 		},
+		Client:       mgr.GetClient(),
 		SpokeClients: spokeClientCache,
 		Namespace:    ns,
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_storage_validation_test.go
@@ -88,11 +88,11 @@ var _ = Describe("Agent service config controller storage validation", func() {
 		// Create the reconciler:
 		reconciler = &AgentServiceConfigReconciler{
 			AgentServiceConfigReconcileContext: AgentServiceConfigReconcileContext{
-				Client:   client,
 				Scheme:   cluster.Scheme(),
 				Log:      logrusLogger,
 				Recorder: cluster.Recorder(),
 			},
+			Client:    client,
 			Namespace: "assisted-installer",
 		}
 	})


### PR DESCRIPTION
In HypershiftAgentServiceConfigReconciler, we currently need to switch between clients (hub and spoke), since a single client property exists in AgentServiceConfigReconcileContext.

Hence, to avoid sharing the property with both clients in order to have a clear notion of the client in use; moved it to ASC struct for explicitly specifying the required client.
I.e. instead of a single ASC with alternating clients, created a separate one for the spoke using the generated client.

Also, moved the 'properties' from ASC to AgentServiceConfigReconcileContext as the map is used for sharing values between clients.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
