### PR TITLE
MGMT-12850: Add host id header

### DIFF
--- a/client/installer/v2_get_next_steps_parameters.go
+++ b/client/installer/v2_get_next_steps_parameters.go
@@ -88,6 +88,14 @@ type V2GetNextStepsParams struct {
 	*/
 	Timestamp *int64
 
+	/* XHostID.
+
+	   Identifier of the host used for rate limiting.
+
+	   Format: uuid
+	*/
+	XHostID *strfmt.UUID
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -185,6 +193,17 @@ func (o *V2GetNextStepsParams) SetTimestamp(timestamp *int64) {
 	o.Timestamp = timestamp
 }
 
+// WithXHostID adds the xHostID to the v2 get next steps params
+func (o *V2GetNextStepsParams) WithXHostID(xHostID *strfmt.UUID) *V2GetNextStepsParams {
+	o.SetXHostID(xHostID)
+	return o
+}
+
+// SetXHostID adds the xHostId to the v2 get next steps params
+func (o *V2GetNextStepsParams) SetXHostID(xHostID *strfmt.UUID) {
+	o.XHostID = xHostID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2GetNextStepsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -225,6 +244,14 @@ func (o *V2GetNextStepsParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 			if err := r.SetQueryParam("timestamp", qTimestamp); err != nil {
 				return err
 			}
+		}
+	}
+
+	if o.XHostID != nil {
+
+		// header param x-host-id
+		if err := r.SetHeaderParam("x-host-id", o.XHostID.String()); err != nil {
+			return err
 		}
 	}
 

--- a/client/installer/v2_post_step_reply_parameters.go
+++ b/client/installer/v2_post_step_reply_parameters.go
@@ -89,6 +89,14 @@ type V2PostStepReplyParams struct {
 	*/
 	Reply *models.StepReply
 
+	/* XHostID.
+
+	   Identifier of the host used for rate limiting.
+
+	   Format: uuid
+	*/
+	XHostID *strfmt.UUID
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -186,6 +194,17 @@ func (o *V2PostStepReplyParams) SetReply(reply *models.StepReply) {
 	o.Reply = reply
 }
 
+// WithXHostID adds the xHostID to the v2 post step reply params
+func (o *V2PostStepReplyParams) WithXHostID(xHostID *strfmt.UUID) *V2PostStepReplyParams {
+	o.SetXHostID(xHostID)
+	return o
+}
+
+// SetXHostID adds the xHostId to the v2 post step reply params
+func (o *V2PostStepReplyParams) SetXHostID(xHostID *strfmt.UUID) {
+	o.XHostID = xHostID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2PostStepReplyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -213,6 +232,14 @@ func (o *V2PostStepReplyParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	}
 	if o.Reply != nil {
 		if err := r.SetBodyParam(o.Reply); err != nil {
+			return err
+		}
+	}
+
+	if o.XHostID != nil {
+
+		// header param x-host-id
+		if err := r.SetHeaderParam("x-host-id", o.XHostID.String()); err != nil {
 			return err
 		}
 	}

--- a/client/installer/v2_register_host_parameters.go
+++ b/client/installer/v2_register_host_parameters.go
@@ -81,6 +81,14 @@ type V2RegisterHostParams struct {
 	*/
 	NewHostParams *models.HostCreateParams
 
+	/* XHostID.
+
+	   Identifier of the host, used for rate limiting.
+
+	   Format: uuid
+	*/
+	XHostID *strfmt.UUID
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -167,6 +175,17 @@ func (o *V2RegisterHostParams) SetNewHostParams(newHostParams *models.HostCreate
 	o.NewHostParams = newHostParams
 }
 
+// WithXHostID adds the xHostID to the v2 register host params
+func (o *V2RegisterHostParams) WithXHostID(xHostID *strfmt.UUID) *V2RegisterHostParams {
+	o.SetXHostID(xHostID)
+	return o
+}
+
+// SetXHostID adds the xHostId to the v2 register host params
+func (o *V2RegisterHostParams) SetXHostID(xHostID *strfmt.UUID) {
+	o.XHostID = xHostID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2RegisterHostParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -189,6 +208,14 @@ func (o *V2RegisterHostParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 	}
 	if o.NewHostParams != nil {
 		if err := r.SetBodyParam(o.NewHostParams); err != nil {
+			return err
+		}
+	}
+
+	if o.XHostID != nil {
+
+		// header param x-host-id
+		if err := r.SetHeaderParam("x-host-id", o.XHostID.String()); err != nil {
 			return err
 		}
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -3708,6 +3708,13 @@ func init() {
             "description": "The software version of the discovery agent that is registering the agent.",
             "name": "discovery_agent_version",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host, used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -4684,6 +4691,13 @@ func init() {
             "description": "The software version of the discovery agent that is retrieving instructions.",
             "name": "discovery_agent_version",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -4770,6 +4784,13 @@ func init() {
             "name": "host_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           },
           {
             "description": "The results to be posted.",
@@ -13152,6 +13173,13 @@ func init() {
             "description": "The software version of the discovery agent that is registering the agent.",
             "name": "discovery_agent_version",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host, used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -14128,6 +14156,13 @@ func init() {
             "description": "The software version of the discovery agent that is retrieving instructions.",
             "name": "discovery_agent_version",
             "in": "header"
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -14214,6 +14249,13 @@ func init() {
             "name": "host_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the host used for rate limiting.",
+            "name": "x-host-id",
+            "in": "header"
           },
           {
             "description": "The results to be posted.",

--- a/restapi/operations/installer/v2_get_next_steps_parameters.go
+++ b/restapi/operations/installer/v2_get_next_steps_parameters.go
@@ -51,6 +51,10 @@ type V2GetNextStepsParams struct {
 	  In: query
 	*/
 	Timestamp *int64
+	/*Identifier of the host used for rate limiting.
+	  In: header
+	*/
+	XHostID *strfmt.UUID
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -80,6 +84,10 @@ func (o *V2GetNextStepsParams) BindRequest(r *http.Request, route *middleware.Ma
 
 	qTimestamp, qhkTimestamp, _ := qs.GetOK("timestamp")
 	if err := o.bindTimestamp(qTimestamp, qhkTimestamp, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.bindXHostID(r.Header[http.CanonicalHeaderKey("x-host-id")], true, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -191,5 +199,41 @@ func (o *V2GetNextStepsParams) bindTimestamp(rawData []string, hasKey bool, form
 	}
 	o.Timestamp = &value
 
+	return nil
+}
+
+// bindXHostID binds and validates parameter XHostID from header.
+func (o *V2GetNextStepsParams) bindXHostID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: uuid
+	value, err := formats.Parse("uuid", raw)
+	if err != nil {
+		return errors.InvalidType("x-host-id", "header", "strfmt.UUID", raw)
+	}
+	o.XHostID = (value.(*strfmt.UUID))
+
+	if err := o.validateXHostID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateXHostID carries on validations for parameter XHostID
+func (o *V2GetNextStepsParams) validateXHostID(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("x-host-id", "header", "uuid", o.XHostID.String(), formats); err != nil {
+		return err
+	}
 	return nil
 }

--- a/restapi/operations/installer/v2_post_step_reply_parameters.go
+++ b/restapi/operations/installer/v2_post_step_reply_parameters.go
@@ -53,6 +53,10 @@ type V2PostStepReplyParams struct {
 	  In: body
 	*/
 	Reply *models.StepReply
+	/*Identifier of the host used for rate limiting.
+	  In: header
+	*/
+	XHostID *strfmt.UUID
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -98,6 +102,10 @@ func (o *V2PostStepReplyParams) BindRequest(r *http.Request, route *middleware.M
 				o.Reply = &body
 			}
 		}
+	}
+
+	if err := o.bindXHostID(r.Header[http.CanonicalHeaderKey("x-host-id")], true, route.Formats); err != nil {
+		res = append(res, err)
 	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
@@ -183,6 +191,42 @@ func (o *V2PostStepReplyParams) bindInfraEnvID(rawData []string, hasKey bool, fo
 func (o *V2PostStepReplyParams) validateInfraEnvID(formats strfmt.Registry) error {
 
 	if err := validate.FormatOf("infra_env_id", "path", "uuid", o.InfraEnvID.String(), formats); err != nil {
+		return err
+	}
+	return nil
+}
+
+// bindXHostID binds and validates parameter XHostID from header.
+func (o *V2PostStepReplyParams) bindXHostID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+
+	// Format: uuid
+	value, err := formats.Parse("uuid", raw)
+	if err != nil {
+		return errors.InvalidType("x-host-id", "header", "strfmt.UUID", raw)
+	}
+	o.XHostID = (value.(*strfmt.UUID))
+
+	if err := o.validateXHostID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateXHostID carries on validations for parameter XHostID
+func (o *V2PostStepReplyParams) validateXHostID(formats strfmt.Registry) error {
+
+	if err := validate.FormatOf("x-host-id", "header", "uuid", o.XHostID.String(), formats); err != nil {
 		return err
 	}
 	return nil

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -743,6 +743,12 @@ paths:
           description: The software version of the discovery agent that is registering the agent.
           type: string
           required: false
+        - in: header
+          name: x-host-id
+          description: Identifier of the host, used for rate limiting.
+          type: string
+          format: uuid
+          required: false
       responses:
         "201":
           description: Success.
@@ -1013,6 +1019,12 @@ paths:
           description: The software version of the discovery agent that is retrieving instructions.
           type: string
           required: false
+        - in: header
+          name: x-host-id
+          description: Identifier of the host used for rate limiting.
+          type: string
+          format: uuid
+          required: false
       responses:
         "200":
           description: Success.
@@ -1072,6 +1084,12 @@ paths:
           type: string
           format: uuid
           required: true
+        - in: header
+          name: x-host-id
+          description: Identifier of the host used for rate limiting.
+          type: string
+          format: uuid
+          required: false
         - name: reply
           description: The results to be posted.
           in: body


### PR DESCRIPTION
This patch adds a `X-Host-ID` header that will be populated by the agent and used for rate limiting.

Related: https://issues.redhat.com/browse/MGMT-12850

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
