### PR TITLE
MGMT-12850: Check rate limits for requests from hosts

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -158,6 +158,8 @@ parameters:
   value: 512Mi
 - name: SVC_TARGET_PORT
   value: "8900"
+- name: RATE_LIMIT_DOMAIN
+  value: "development:assisted_install"
 apiVersion: v1
 kind: Template
 metadata:
@@ -429,6 +431,7 @@ objects:
     name: assisted-service-envoy-config
   data:
     main.yaml: |
+
       admin:
         access_log:
         - name: envoy.access_loggers.file
@@ -467,6 +470,7 @@ objects:
                         upstream_duration: "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"
                         x_forwarded_for: "%REQ(X-FORWARDED-FOR)%"
                         x_request_id: "%REQ(X-REQUEST-ID)%"
+                        x_host_id: "%REQ(X-HOST-ID)%"
                 stat_prefix: ingress_http
                 codec_type: AUTO
                 route_config:
@@ -475,12 +479,84 @@ objects:
                   - name: local_service
                     domains: ["*"]
                     routes:
+
+                    # Check rate limits for requests to get next steps and post results:
+                    - name: get_and_post_steps
+                      match:
+                        safe_regex:
+                          regex: "^/api/assisted-install/v2/infra-envs/.*/hosts/.*/instructions$"
+                      route:
+                        cluster: assisted_service
+                        rate_limits:
+                        - actions:
+                          - generic_key:
+                              descriptor_key: operation
+                              descriptor_value: get_and_post_steps
+                          - request_headers:
+                              header_name: x-host-id
+                              descriptor_key: host_id
+
+                    # Check rate limits for requests to register hosts:
+                    - name: post_host
+                      match:
+                        headers:
+                        - name: :method
+                          string_match:
+                            exact: POST
+                        safe_regex:
+                          regex: "^/api/assisted-install/v2/infra-envs/.*/hosts$"
+                      route:
+                        cluster: assisted_service
+                        rate_limits:
+                        - actions:
+                          - generic_key:
+                              descriptor_key: operation
+                              descriptor_value: post_host
+                          - request_headers:
+                              header_name: x-host-id
+                              descriptor_key: host_id
+
+                    # For everything else there are no rate limits:
                     - match: { prefix: "/" }
                       route: { cluster: assisted_service }
+
                 http_filters:
+
+                # This is needed to enable the rate limiter, and to specify how and where to connect
+                # to it:
+                - name: envoy.filters.http.ratelimit
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+                    domain: ${RATE_LIMIT_DOMAIN}
+                    failure_mode_deny: false
+                    timeout: 0.05s
+                    rate_limit_service:
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: limiter
+                      transport_api_version: v3
+
                 - name: envoy.filters.http.router
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+                # We need this in order to generate JSON responses according to our API practices,
+                # otherwise Envoy will generate plain text responses which will be hard to understand
+                # for our clients.
+                local_reply_config:
+                  mappers:
+                  - filter:
+                      status_code_filter:
+                        comparison:
+                          op: EQ
+                          value:
+                            default_value: 429
+                            runtime_key: none
+                    body_format_override:
+                      json_format:
+                        code: "%RESPONSE_CODE%"
+                        message: "Too many requests"
+
         clusters:
         - name: assisted_service
           connect_timeout: 1s
@@ -495,4 +571,19 @@ objects:
                     socket_address:
                       address: 127.0.0.1
                       port_value: 8090
- 
+
+        # This cluster us used to send requests to the rate limiting service:
+        - name: limiter
+          connect_timeout: 1s
+          type: STRICT_DNS
+          lb_policy: ROUND_ROBIN
+          http2_protocol_options: {}
+          load_assignment:
+            cluster_name: limiter
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: limitador.app-sre-rate-limit.svc
+                      port_value: 8081


### PR DESCRIPTION
This patch changes the configuration of the Envoy sidecar so that it will check rate limits for requests coming from hosts. Note that this is based on the use of a new `X-Host-ID` request header that hosts shold add.

Related: https://issues.redhat.com/browse/MGMT-12850
Related: https://github.com/openshift/assisted-installer-agent/pull/467
Related: https://github.com/openshift/assisted-service/pull/4724

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
