### PR TITLE
Use the cluster version when extracting the ironic agent image from a release

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,56 +99,56 @@ const (
 )
 
 var Options struct {
-	Auth                           auth.Config
-	BMConfig                       bminventory.Config
-	DBConfig                       dbPkg.Config
-	HWValidatorConfig              hardware.ValidatorCfg
-	GeneratorConfig                generator.Config
-	InstructionConfig              hostcommands.InstructionConfig
-	OperatorsConfig                operators.Options
-	GCConfig                       garbagecollector.Config
-	StaticNetworkConfig            staticnetworkconfig.Config
-	ClusterStateMonitorInterval    time.Duration `envconfig:"CLUSTER_MONITOR_INTERVAL" default:"10s"`
-	S3Config                       s3wrapper.Config
-	HostStateMonitorInterval       time.Duration `envconfig:"HOST_MONITOR_INTERVAL" default:"8s"`
-	Versions                       versions.Versions
-	OsImages                       string        `envconfig:"OS_IMAGES" default:""`
-	ReleaseImages                  string        `envconfig:"RELEASE_IMAGES" default:""`
-	MustGatherImages               string        `envconfig:"MUST_GATHER_IMAGES" default:""`
-	ReleaseImageMirror             string        `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
-	CreateS3Bucket                 bool          `envconfig:"CREATE_S3_BUCKET" default:"false"`
-	ImageExpirationInterval        time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
-	ClusterConfig                  cluster.Config
-	DeployTarget                   string `envconfig:"DEPLOY_TARGET" default:"k8s"`
-	Storage                        string `envconfig:"STORAGE" default:"s3"`
-	OCMConfig                      ocm.Config
-	HostConfig                     host.Config
-	LogConfig                      logconfig.Config
-	LeaderConfig                   leader.Config
-	ValidationsConfig              validations.Config
-	ManifestsGeneratorConfig       network.Config
-	EnableKubeAPI                  bool `envconfig:"ENABLE_KUBE_API" default:"false"`
-	InfraEnvConfig                 controllers.InfraEnvConfig
-	CheckClusterVersion            bool          `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
-	DeletionWorkerInterval         time.Duration `envconfig:"DELETION_WORKER_INTERVAL" default:"1h"`
-	InfraEnvDeletionWorkerInterval time.Duration `envconfig:"INFRAENV_DELETION_WORKER_INTERVAL" default:"1h"`
-	DeregisterWorkerInterval       time.Duration `envconfig:"DEREGISTER_WORKER_INTERVAL" default:"1h"`
-	EnableDeletedUnregisteredGC    bool          `envconfig:"ENABLE_DELETE_UNREGISTER_GC" default:"true"`
-	EnableDeregisterInactiveGC     bool          `envconfig:"ENABLE_DEREGISTER_INACTIVE_GC" default:"true"`
-	ServeHTTPS                     bool          `envconfig:"SERVE_HTTPS" default:"false"`
-	HTTPSKeyFile                   string        `envconfig:"HTTPS_KEY_FILE" default:""`
-	HTTPSCertFile                  string        `envconfig:"HTTPS_CERT_FILE" default:""`
-	MaxIdleConns                   int           `envconfig:"DB_MAX_IDLE_CONNECTIONS" default:"50"`
-	MaxOpenConns                   int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"90"`
-	ConnMaxLifetime                time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
-	FileSystemUsageThreshold       int           `envconfig:"FILESYSTEM_USAGE_THRESHOLD" default:"80"`
-	EnableElasticAPM               bool          `envconfig:"ENABLE_ELASTIC_APM" default:"false"`
-	WorkDir                        string        `envconfig:"WORK_DIR" default:"/data/"`
-	LivenessValidationTimeout      time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
-	ApproveCsrsRequeueDuration     time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
-	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
-	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"`
-	IronicIgnitionBuilderConfig    ignition.IronicIgnitionBuilderConfig
+	Auth                                 auth.Config
+	BMConfig                             bminventory.Config
+	DBConfig                             dbPkg.Config
+	HWValidatorConfig                    hardware.ValidatorCfg
+	GeneratorConfig                      generator.Config
+	InstructionConfig                    hostcommands.InstructionConfig
+	OperatorsConfig                      operators.Options
+	GCConfig                             garbagecollector.Config
+	StaticNetworkConfig                  staticnetworkconfig.Config
+	ClusterStateMonitorInterval          time.Duration `envconfig:"CLUSTER_MONITOR_INTERVAL" default:"10s"`
+	S3Config                             s3wrapper.Config
+	HostStateMonitorInterval             time.Duration `envconfig:"HOST_MONITOR_INTERVAL" default:"8s"`
+	Versions                             versions.Versions
+	OsImages                             string        `envconfig:"OS_IMAGES" default:""`
+	ReleaseImages                        string        `envconfig:"RELEASE_IMAGES" default:""`
+	MustGatherImages                     string        `envconfig:"MUST_GATHER_IMAGES" default:""`
+	ReleaseImageMirror                   string        `envconfig:"OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR" default:""`
+	CreateS3Bucket                       bool          `envconfig:"CREATE_S3_BUCKET" default:"false"`
+	ImageExpirationInterval              time.Duration `envconfig:"IMAGE_EXPIRATION_INTERVAL" default:"30m"`
+	ClusterConfig                        cluster.Config
+	DeployTarget                         string `envconfig:"DEPLOY_TARGET" default:"k8s"`
+	Storage                              string `envconfig:"STORAGE" default:"s3"`
+	OCMConfig                            ocm.Config
+	HostConfig                           host.Config
+	LogConfig                            logconfig.Config
+	LeaderConfig                         leader.Config
+	ValidationsConfig                    validations.Config
+	ManifestsGeneratorConfig             network.Config
+	EnableKubeAPI                        bool `envconfig:"ENABLE_KUBE_API" default:"false"`
+	InfraEnvConfig                       controllers.InfraEnvConfig
+	CheckClusterVersion                  bool          `envconfig:"CHECK_CLUSTER_VERSION" default:"false"`
+	DeletionWorkerInterval               time.Duration `envconfig:"DELETION_WORKER_INTERVAL" default:"1h"`
+	InfraEnvDeletionWorkerInterval       time.Duration `envconfig:"INFRAENV_DELETION_WORKER_INTERVAL" default:"1h"`
+	DeregisterWorkerInterval             time.Duration `envconfig:"DEREGISTER_WORKER_INTERVAL" default:"1h"`
+	EnableDeletedUnregisteredGC          bool          `envconfig:"ENABLE_DELETE_UNREGISTER_GC" default:"true"`
+	EnableDeregisterInactiveGC           bool          `envconfig:"ENABLE_DEREGISTER_INACTIVE_GC" default:"true"`
+	ServeHTTPS                           bool          `envconfig:"SERVE_HTTPS" default:"false"`
+	HTTPSKeyFile                         string        `envconfig:"HTTPS_KEY_FILE" default:""`
+	HTTPSCertFile                        string        `envconfig:"HTTPS_CERT_FILE" default:""`
+	MaxIdleConns                         int           `envconfig:"DB_MAX_IDLE_CONNECTIONS" default:"50"`
+	MaxOpenConns                         int           `envconfig:"DB_MAX_OPEN_CONNECTIONS" default:"90"`
+	ConnMaxLifetime                      time.Duration `envconfig:"DB_CONNECTIONS_MAX_LIFETIME" default:"30m"`
+	FileSystemUsageThreshold             int           `envconfig:"FILESYSTEM_USAGE_THRESHOLD" default:"80"`
+	EnableElasticAPM                     bool          `envconfig:"ENABLE_ELASTIC_APM" default:"false"`
+	WorkDir                              string        `envconfig:"WORK_DIR" default:"/data/"`
+	LivenessValidationTimeout            time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
+	ApproveCsrsRequeueDuration           time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
+	HTTPListenPort                       string        `envconfig:"HTTP_LISTEN_PORT" default:""`
+	AllowConvergedFlow                   bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"`
+	PreprovisioningImageControllerConfig controllers.PreprovisioningImageControllerConfig
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
 	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`
@@ -595,14 +595,14 @@ func main() {
 					log.WithError(err).Fatal("failed to get IronicServiceURL")
 				}
 				failOnError((&controllers.PreprovisioningImageReconciler{
-					Client:                ctrlMgr.GetClient(),
-					Log:                   log,
-					Installer:             bm,
-					CRDEventsHandler:      crdEventsHandler,
-					VersionsHandler:       versionHandler,
-					OcRelease:             releaseHandler,
-					IronicIgnitionBuilder: ignition.NewIronicIgnitionBuilder(Options.IronicIgnitionBuilderConfig),
-					IronicServiceURL:      ironicBaseURL,
+					Client:           ctrlMgr.GetClient(),
+					Log:              log,
+					Installer:        bm,
+					CRDEventsHandler: crdEventsHandler,
+					VersionsHandler:  versionHandler,
+					OcRelease:        releaseHandler,
+					IronicServiceURL: ironicBaseURL,
+					Config:           Options.PreprovisioningImageControllerConfig,
 				}).SetupWithManager(ctrlMgr), "failed to create PreprovisioningImage ceontroller")
 			}
 			log.Infof("Starting controllers")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,7 +148,7 @@ var Options struct {
 	ApproveCsrsRequeueDuration     time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
 	HTTPListenPort                 string        `envconfig:"HTTP_LISTEN_PORT" default:""`
 	AllowConvergedFlow             bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"`
-	IronicIgnitionBuilderConfig    ignition.IronicIgniotionBuilderConfig
+	IronicIgnitionBuilderConfig    ignition.IronicIgnitionBuilderConfig
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
 	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`
@@ -595,14 +595,14 @@ func main() {
 					log.WithError(err).Fatal("failed to get IronicServiceURL")
 				}
 				failOnError((&controllers.PreprovisioningImageReconciler{
-					Client:                 ctrlMgr.GetClient(),
-					Log:                    log,
-					Installer:              bm,
-					CRDEventsHandler:       crdEventsHandler,
-					VersionsHandler:        versionHandler,
-					OcRelease:              releaseHandler,
-					IronicIgniotionBuilder: ignition.NewIronicIgniotionBuilder(Options.IronicIgnitionBuilderConfig),
-					IronicServiceURL:       ironicBaseURL,
+					Client:                ctrlMgr.GetClient(),
+					Log:                   log,
+					Installer:             bm,
+					CRDEventsHandler:      crdEventsHandler,
+					VersionsHandler:       versionHandler,
+					OcRelease:             releaseHandler,
+					IronicIgnitionBuilder: ignition.NewIronicIgnitionBuilder(Options.IronicIgnitionBuilderConfig),
+					IronicServiceURL:      ironicBaseURL,
 				}).SetupWithManager(ctrlMgr), "failed to create PreprovisioningImage ceontroller")
 			}
 			log.Infof("Starting controllers")

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -53,17 +53,25 @@ type imageConditionReason string
 
 const archMismatchReason = "InfraEnvArchMismatch"
 
+type PreprovisioningImageControllerConfig struct {
+	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
+	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
+	// The default ironic agent image for arm architecture was obtained by running "oc adm release info --image-for=ironic-agent quay.io/openshift-release-dev/ocp-release@sha256:1b8e71b9bccc69c732812ebf2bfba62af6de77378f8329c8fec10b63a0dbc33c"
+	// The release image digest for arm architecture was obtained from this link https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp-dev-preview/4.11.0-fc.0/release.txt
+	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
+}
+
 // PreprovisioningImage reconciles a AgentClusterInstall object
 type PreprovisioningImageReconciler struct {
 	client.Client
-	Log                   logrus.FieldLogger
-	Installer             bminventory.InstallerInternals
-	CRDEventsHandler      CRDEventsHandler
-	IronicIgnitionBuilder *ignition.IronicIgnitionBuilder
-	VersionsHandler       versions.Handler
-	OcRelease             oc.Release
-	ReleaseImageMirror    string
-	IronicServiceURL      string
+	Log                logrus.FieldLogger
+	Installer          bminventory.InstallerInternals
+	CRDEventsHandler   CRDEventsHandler
+	VersionsHandler    versions.Handler
+	OcRelease          oc.Release
+	ReleaseImageMirror string
+	IronicServiceURL   string
+	Config             PreprovisioningImageControllerConfig
 }
 
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages,verbs=get;list;watch;create;update;patch;delete
@@ -171,7 +179,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 
 // getConvergedDiscoveryTemplate merge the ironic ignition with the discovery ignition
 func (r *PreprovisioningImageReconciler) getIronicIgnitionConfig(log logrus.FieldLogger, infraEnvInternal common.InfraEnv, ironicAgentImage string) (string, error) {
-	config, err := r.IronicIgnitionBuilder.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, ironicAgentImage)
+	config, err := ignition.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, ironicAgentImage)
 	if err != nil {
 		log.WithError(err).Error("failed to generate Ironic ignition config")
 		return "", err
@@ -372,6 +380,15 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 		ironicAgentImage, err = r.getIronicAgentImage(log, *infraEnvInternal)
 		if err != nil {
 			log.WithError(err).Warningf("Failed to get ironicAgentImage for infraEnv: %s", infraEnv.Name)
+		}
+	}
+
+	if ironicAgentImage == "" {
+		// if ironicAgentImage wasn't specified use the default image for the CPU arch
+		if infraEnvInternal.CPUArchitecture == common.ARM64CPUArchitecture {
+			ironicAgentImage = r.Config.BaremetalIronicAgentImageForArm
+		} else {
+			ironicAgentImage = r.Config.BaremetalIronicAgentImage
 		}
 	}
 

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -59,7 +59,7 @@ type PreprovisioningImageReconciler struct {
 	Log                   logrus.FieldLogger
 	Installer             bminventory.InstallerInternals
 	CRDEventsHandler      CRDEventsHandler
-	IronicIgnitionBuilder ignition.IronicIgnitionBuilder
+	IronicIgnitionBuilder *ignition.IronicIgnitionBuilder
 	VersionsHandler       versions.Handler
 	OcRelease             oc.Release
 	ReleaseImageMirror    string

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -56,14 +56,14 @@ const archMismatchReason = "InfraEnvArchMismatch"
 // PreprovisioningImage reconciles a AgentClusterInstall object
 type PreprovisioningImageReconciler struct {
 	client.Client
-	Log                    logrus.FieldLogger
-	Installer              bminventory.InstallerInternals
-	CRDEventsHandler       CRDEventsHandler
-	IronicIgniotionBuilder ignition.IronicIgniotionBuilder
-	VersionsHandler        versions.Handler
-	OcRelease              oc.Release
-	ReleaseImageMirror     string
-	IronicServiceURL       string
+	Log                   logrus.FieldLogger
+	Installer             bminventory.InstallerInternals
+	CRDEventsHandler      CRDEventsHandler
+	IronicIgnitionBuilder ignition.IronicIgnitionBuilder
+	VersionsHandler       versions.Handler
+	OcRelease             oc.Release
+	ReleaseImageMirror    string
+	IronicServiceURL      string
 }
 
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages,verbs=get;list;watch;create;update;patch;delete
@@ -171,7 +171,7 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 
 // getConvergedDiscoveryTemplate merge the ironic ignition with the discovery ignition
 func (r *PreprovisioningImageReconciler) getIronicIgnitionConfig(log logrus.FieldLogger, infraEnvInternal common.InfraEnv, ironicAgentImage string) (string, error) {
-	config, err := r.IronicIgniotionBuilder.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, ironicAgentImage)
+	config, err := r.IronicIgnitionBuilder.GenerateIronicConfig(r.IronicServiceURL, infraEnvInternal, ironicAgentImage)
 	if err != nil {
 		log.WithError(err).Error("failed to generate Ironic ignition config")
 		return "", err

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -78,7 +78,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCRDEventsHandler  *MockCRDEventsHandler
 		mockVersionHandler    *versions.MockHandler
 		mockOcRelease         *oc.MockRelease
-		ironicIgnitionBuilder ignition.IronicIgnitionBuilder
+		ironicIgnitionBuilder *ignition.IronicIgnitionBuilder
 		ctx                   = context.Background()
 		sId                   strfmt.UUID
 		backendInfraEnv       = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -14,7 +14,6 @@ import (
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
@@ -78,7 +77,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCRDEventsHandler  *MockCRDEventsHandler
 		mockVersionHandler    *versions.MockHandler
 		mockOcRelease         *oc.MockRelease
-		ironicIgnitionBuilder *ignition.IronicIgnitionBuilder
 		ctx                   = context.Background()
 		sId                   strfmt.UUID
 		backendInfraEnv       = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}
@@ -96,19 +94,18 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
-		ironicIgnitionBuilder = ignition.NewIronicIgnitionBuilder(ignition.IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"})
 		mockVersionHandler = versions.NewMockHandler(mockCtrl)
 		mockOcRelease = oc.NewMockRelease(mockCtrl)
 		sId = strfmt.UUID(uuid.New().String())
 		pr = &PreprovisioningImageReconciler{
-			Client:                c,
-			Log:                   common.GetTestLog(),
-			Installer:             mockInstallerInternal,
-			CRDEventsHandler:      mockCRDEventsHandler,
-			IronicIgnitionBuilder: ironicIgnitionBuilder,
-			VersionsHandler:       mockVersionHandler,
-			OcRelease:             mockOcRelease,
-			IronicServiceURL:      "ironic.url",
+			Client:           c,
+			Log:              common.GetTestLog(),
+			Installer:        mockInstallerInternal,
+			CRDEventsHandler: mockCRDEventsHandler,
+			VersionsHandler:  mockVersionHandler,
+			OcRelease:        mockOcRelease,
+			IronicServiceURL: "ironic.url",
+			Config:           PreprovisioningImageControllerConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"},
 		}
 	})
 

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -78,7 +78,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCRDEventsHandler  *MockCRDEventsHandler
 		mockVersionHandler    *versions.MockHandler
 		mockOcRelease         *oc.MockRelease
-		ironicIgnitionBuilder ignition.IronicIgniotionBuilder
+		ironicIgnitionBuilder ignition.IronicIgnitionBuilder
 		ctx                   = context.Background()
 		sId                   strfmt.UUID
 		backendInfraEnv       = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}
@@ -96,19 +96,19 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
-		ironicIgnitionBuilder = ignition.NewIronicIgniotionBuilder(ignition.IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"})
+		ironicIgnitionBuilder = ignition.NewIronicIgnitionBuilder(ignition.IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"})
 		mockVersionHandler = versions.NewMockHandler(mockCtrl)
 		mockOcRelease = oc.NewMockRelease(mockCtrl)
 		sId = strfmt.UUID(uuid.New().String())
 		pr = &PreprovisioningImageReconciler{
-			Client:                 c,
-			Log:                    common.GetTestLog(),
-			Installer:              mockInstallerInternal,
-			CRDEventsHandler:       mockCRDEventsHandler,
-			IronicIgniotionBuilder: ironicIgnitionBuilder,
-			VersionsHandler:        mockVersionHandler,
-			OcRelease:              mockOcRelease,
-			IronicServiceURL:       "ironic.url",
+			Client:                c,
+			Log:                   common.GetTestLog(),
+			Installer:             mockInstallerInternal,
+			CRDEventsHandler:      mockCRDEventsHandler,
+			IronicIgnitionBuilder: ironicIgnitionBuilder,
+			VersionsHandler:       mockVersionHandler,
+			OcRelease:             mockOcRelease,
+			IronicServiceURL:      "ironic.url",
 		}
 	})
 

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -78,8 +78,8 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockVersionHandler    *versions.MockHandler
 		mockOcRelease         *oc.MockRelease
 		ctx                   = context.Background()
-		sId                   strfmt.UUID
-		backendInfraEnv       = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}
+		infraEnvID, clusterID strfmt.UUID
+		backendInfraEnv       *common.InfraEnv
 		downloadURL           = "https://downloadurl"
 		rootfsURL             = "https://rootfs.example.com"
 		kernelURL             = "https://kernel.example.com"
@@ -96,7 +96,9 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 		mockVersionHandler = versions.NewMockHandler(mockCtrl)
 		mockOcRelease = oc.NewMockRelease(mockCtrl)
-		sId = strfmt.UUID(uuid.New().String())
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		clusterID = strfmt.UUID(uuid.New().String())
+		backendInfraEnv = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID}}
 		pr = &PreprovisioningImageReconciler{
 			Client:           c,
 			Log:              common.GetTestLog(),
@@ -111,8 +113,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		backendInfraEnv = &common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId}}
-
 	})
 
 	Context("reconcile new PreprovisioningImage - success", func() {
@@ -144,7 +144,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Expect(params.InfraEnvUpdateParams.IgnitionConfigOverride).To(Equal(""))
 					Expect(*internalIgnitionConfig).Should(ContainSubstring("ironic"))
 				}).Return(
-				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -280,7 +280,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Expect(*internalIgnitionConfig).Should(ContainSubstring("ironic"))
 					Expect(*internalIgnitionConfig).Should(ContainSubstring(ironicAgentImage))
 				}).Return(
-				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -305,7 +305,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Expect(*internalIgnitionConfig).Should(ContainSubstring("ironic"))
 					Expect(*internalIgnitionConfig).Should(ContainSubstring("ironic-agent-image:latest"))
 				}).Return(
-				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())

--- a/internal/ignition/ironic.go
+++ b/internal/ignition/ironic.go
@@ -8,11 +8,11 @@ import (
 	iccignition "github.com/openshift/image-customization-controller/pkg/ignition"
 )
 
-type IronicIgniotionBuilder interface {
+type IronicIgnitionBuilder interface {
 	GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error)
 }
 
-type IronicIgniotionBuilderConfig struct {
+type IronicIgnitionBuilderConfig struct {
 	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
 	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
 	// The default ironic agent image for arm architecture was obtained by running "oc adm release info --image-for=ironic-agent quay.io/openshift-release-dev/ocp-release@sha256:1b8e71b9bccc69c732812ebf2bfba62af6de77378f8329c8fec10b63a0dbc33c"
@@ -20,16 +20,16 @@ type IronicIgniotionBuilderConfig struct {
 	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
 }
 
-type ironicIgniotionBuilder struct {
-	config IronicIgniotionBuilderConfig
+type ironicIgnitionBuilder struct {
+	config IronicIgnitionBuilderConfig
 }
 
-func NewIronicIgniotionBuilder(config IronicIgniotionBuilderConfig) IronicIgniotionBuilder {
-	ib := ironicIgniotionBuilder{config}
+func NewIronicIgnitionBuilder(config IronicIgnitionBuilderConfig) IronicIgnitionBuilder {
+	ib := ironicIgnitionBuilder{config}
 	return &ib
 }
 
-func (r *ironicIgniotionBuilder) GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
+func (r *ironicIgnitionBuilder) GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
 	config := ignition_config_types_32.Config{}
 	config.Ignition.Version = "3.2.0"
 

--- a/internal/ignition/ironic.go
+++ b/internal/ignition/ironic.go
@@ -8,36 +8,11 @@ import (
 	iccignition "github.com/openshift/image-customization-controller/pkg/ignition"
 )
 
-type IronicIgnitionBuilderConfig struct {
-	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
-	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
-	// The default ironic agent image for arm architecture was obtained by running "oc adm release info --image-for=ironic-agent quay.io/openshift-release-dev/ocp-release@sha256:1b8e71b9bccc69c732812ebf2bfba62af6de77378f8329c8fec10b63a0dbc33c"
-	// The release image digest for arm architecture was obtained from this link https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp-dev-preview/4.11.0-fc.0/release.txt
-	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
-}
-
-type IronicIgnitionBuilder struct {
-	config IronicIgnitionBuilderConfig
-}
-
-func NewIronicIgnitionBuilder(config IronicIgnitionBuilderConfig) *IronicIgnitionBuilder {
-	ib := IronicIgnitionBuilder{config}
-	return &ib
-}
-
-func (r *IronicIgnitionBuilder) GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
+func GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
 	config := ignition_config_types_32.Config{}
 	config.Ignition.Version = "3.2.0"
 
 	httpProxy, httpsProxy, noProxy := common.GetProxyConfigs(infraEnv.Proxy)
-	if ironicAgentImage == "" {
-		// if ironicAgentImage wasn't specified use the default image for the CPU arch
-		if infraEnv.CPUArchitecture == common.ARM64CPUArchitecture {
-			ironicAgentImage = r.config.BaremetalIronicAgentImageForArm
-		} else {
-			ironicAgentImage = r.config.BaremetalIronicAgentImage
-		}
-	}
 	// TODO: this should probably get the pullSecret as well
 	ib, err := iccignition.New([]byte{}, []byte{}, ironicBaseURL, ironicAgentImage, "", "", "", httpProxy, httpsProxy, noProxy, "")
 	if err != nil {

--- a/internal/ignition/ironic.go
+++ b/internal/ignition/ironic.go
@@ -8,10 +8,6 @@ import (
 	iccignition "github.com/openshift/image-customization-controller/pkg/ignition"
 )
 
-type IronicIgnitionBuilder interface {
-	GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error)
-}
-
 type IronicIgnitionBuilderConfig struct {
 	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
 	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
@@ -20,16 +16,16 @@ type IronicIgnitionBuilderConfig struct {
 	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
 }
 
-type ironicIgnitionBuilder struct {
+type IronicIgnitionBuilder struct {
 	config IronicIgnitionBuilderConfig
 }
 
-func NewIronicIgnitionBuilder(config IronicIgnitionBuilderConfig) IronicIgnitionBuilder {
-	ib := ironicIgnitionBuilder{config}
+func NewIronicIgnitionBuilder(config IronicIgnitionBuilderConfig) *IronicIgnitionBuilder {
+	ib := IronicIgnitionBuilder{config}
 	return &ib
 }
 
-func (r *ironicIgnitionBuilder) GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
+func (r *IronicIgnitionBuilder) GenerateIronicConfig(ironicBaseURL string, infraEnv common.InfraEnv, ironicAgentImage string) ([]byte, error) {
 	config := ignition_config_types_32.Config{}
 	config.Ignition.Version = "3.2.0"
 

--- a/internal/ignition/ironic_test.go
+++ b/internal/ignition/ironic_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Ignition with converged flow", func() {
 		infraEnv      common.InfraEnv
 		infraEnvID    strfmt.UUID
 		ironicBaseURL string
-		iib           IronicIgniotionBuilder
+		iib           IronicIgnitionBuilder
 	)
 	BeforeEach(func() {
 		infraEnvID = "a64fff36-dcb1-11ea-87d0-0242ac130003"
@@ -31,8 +31,8 @@ var _ = Describe("Ignition with converged flow", func() {
 		}
 	})
 	It("GenerateIronicConfig success", func() {
-		config := IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest", BaremetalIronicAgentImageForArm: "defaultIronicAgentImageForArm:latest"}
-		iib = NewIronicIgniotionBuilder(config)
+		config := IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest", BaremetalIronicAgentImageForArm: "defaultIronicAgentImageForArm:latest"}
+		iib = NewIronicIgnitionBuilder(config)
 
 		conf, err := iib.GenerateIronicConfig(ironicBaseURL, infraEnv, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -42,7 +42,7 @@ var _ = Describe("Ignition with converged flow", func() {
 		validateIgnition(conf)
 	})
 	It("GenerateIronicConfig override default ironic agent image", func() {
-		iib = NewIronicIgniotionBuilder(IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest"})
+		iib = NewIronicIgnitionBuilder(IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest"})
 		ironicAgentImage := "ironicAgentImage:custom"
 		conf, err := iib.GenerateIronicConfig(ironicBaseURL, infraEnv, ironicAgentImage)
 		Expect(err).NotTo(HaveOccurred())
@@ -52,8 +52,8 @@ var _ = Describe("Ignition with converged flow", func() {
 		validateIgnition(conf)
 	})
 	It("GenerateIronicConfig use default ironic agent image for arm", func() {
-		config := IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest", BaremetalIronicAgentImageForArm: "defaultIronicAgentImageForArm:latest"}
-		iib = NewIronicIgniotionBuilder(config)
+		config := IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest", BaremetalIronicAgentImageForArm: "defaultIronicAgentImageForArm:latest"}
+		iib = NewIronicIgnitionBuilder(config)
 		infraEnv.CPUArchitecture = common.ARM64CPUArchitecture
 
 		conf, err := iib.GenerateIronicConfig(ironicBaseURL, infraEnv, "")
@@ -65,12 +65,12 @@ var _ = Describe("Ignition with converged flow", func() {
 		validateIgnition(conf)
 	})
 	It("GenerateIronicConfig missing ironic service URL", func() {
-		iib = NewIronicIgniotionBuilder(IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest"})
+		iib = NewIronicIgnitionBuilder(IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: "defaultIronicAgentImage:latest"})
 		_, err := iib.GenerateIronicConfig("", infraEnv, "")
 		Expect(err).To(HaveOccurred())
 	})
 	It("GenerateIronicConfig missing ironic agent image", func() {
-		iib = NewIronicIgniotionBuilder(IronicIgniotionBuilderConfig{BaremetalIronicAgentImage: ""})
+		iib = NewIronicIgnitionBuilder(IronicIgnitionBuilderConfig{BaremetalIronicAgentImage: ""})
 		_, err := iib.GenerateIronicConfig(ironicBaseURL, infraEnv, "")
 		Expect(err).To(HaveOccurred())
 	})

--- a/internal/ignition/ironic_test.go
+++ b/internal/ignition/ironic_test.go
@@ -16,7 +16,7 @@ var _ = Describe("Ignition with converged flow", func() {
 		infraEnv      common.InfraEnv
 		infraEnvID    strfmt.UUID
 		ironicBaseURL string
-		iib           IronicIgnitionBuilder
+		iib           *IronicIgnitionBuilder
 	)
 	BeforeEach(func() {
 		infraEnvID = "a64fff36-dcb1-11ea-87d0-0242ac130003"


### PR DESCRIPTION
Previously the preprovisioning image controller was using the infra-env
`OpenshiftVersion` field to attempt to find a release image, but this
field is an rhcos version (i.e. a key in `OS_IMAGES`), not a release
image version.

This caused issues when the OS version keys didn't match the release
image keys which can happen when specifying a particular z-stream or
during pre-releases.

This commit only attempts to extract the ironic agent image from the
release image if the infra-env has a cluster reference
(non-late-binding) and if that release image is above the minimum
required for the converged flow.\

This PR also moves all the logic about what image should be used into the
preprovisioning image controller. This makes the logic a bit easier to reason about
rather than sometimes passing an empty image string to the ignition builder.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-12482

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested in dev-scripts env.
Deployed master assisted-service and observed that when the release image name didn't match the OS image we used the default ironic agent image even though the infraenv was bound to a cluster and the cluster had an image set configured.

After deploying this branch the ironic agent image in the ignition was pulled from the release image.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
