### PR TITLE
Move version API handlers to a separate struct

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -290,8 +290,9 @@ func main() {
 		oc.Config{MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay}, mirrorRegistriesBuilder)
 	extracterHandler := oc.NewExtracter(&executer.CommonExecuter{},
 		oc.Config{MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay})
-	versionHandler, err := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler,
-		Options.Versions, osImagesArray, releaseImagesArray, mustGatherVersionsMap, Options.ReleaseImageMirror, authzHandler)
+	versionHandler, err := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler, osImagesArray,
+		releaseImagesArray, mustGatherVersionsMap, Options.ReleaseImageMirror)
+	versionsAPIHandler := versions.NewAPIHandler(log, Options.Versions, authzHandler, versionHandler)
 	failOnError(err, "failed to create Versions handler")
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)
@@ -478,7 +479,7 @@ func main() {
 		InstallerAPI:        bm,
 		EventsAPI:           events,
 		Logger:              log.Printf,
-		VersionsAPI:         versionHandler,
+		VersionsAPI:         versionsAPIHandler,
 		ManagedDomainsAPI:   domainHandler,
 		InnerMiddleware:     innerHandler(),
 		ManifestsAPI:        manifestsApi,

--- a/internal/versions/api.go
+++ b/internal/versions/api.go
@@ -1,0 +1,149 @@
+package versions
+
+import (
+	context "context"
+	"strings"
+
+	middleware "github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/internal/common"
+	models "github.com/openshift/assisted-service/models"
+	auth "github.com/openshift/assisted-service/pkg/auth"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/openshift/assisted-service/restapi"
+	operations "github.com/openshift/assisted-service/restapi/operations/versions"
+	"github.com/sirupsen/logrus"
+)
+
+type Versions struct {
+	SelfVersion     string `envconfig:"SELF_VERSION" default:"Unknown"`
+	AgentDockerImg  string `envconfig:"AGENT_DOCKER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-agent:latest"`
+	InstallerImage  string `envconfig:"INSTALLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer:latest"`
+	ControllerImage string `envconfig:"CONTROLLER_IMAGE" default:"quay.io/edge-infrastructure/assisted-installer-controller:latest"`
+	ReleaseTag      string `envconfig:"RELEASE_TAG" default:""`
+}
+
+type apiHandler struct {
+	authzHandler    auth.Authorizer
+	versions        Versions
+	log             logrus.FieldLogger
+	versionsHandler *handler
+}
+
+var _ restapi.VersionsAPI = (*apiHandler)(nil)
+
+func NewAPIHandler(log logrus.FieldLogger, versions Versions, authzHandler auth.Authorizer, versionsHandler *handler) restapi.VersionsAPI {
+	return &apiHandler{
+		authzHandler:    authzHandler,
+		versions:        versions,
+		log:             log,
+		versionsHandler: versionsHandler,
+	}
+}
+
+func (h *apiHandler) V2ListComponentVersions(ctx context.Context, params operations.V2ListComponentVersionsParams) middleware.Responder {
+	return operations.NewV2ListComponentVersionsOK().WithPayload(
+		&models.ListVersions{
+			Versions: models.Versions{
+				"assisted-installer-service":    h.versions.SelfVersion,
+				"discovery-agent":               h.versions.AgentDockerImg,
+				"assisted-installer":            h.versions.InstallerImage,
+				"assisted-installer-controller": h.versions.ControllerImage,
+			},
+			ReleaseTag: h.versions.ReleaseTag,
+		})
+}
+
+func (h *apiHandler) V2ListSupportedOpenshiftVersions(ctx context.Context, params operations.V2ListSupportedOpenshiftVersionsParams) middleware.Responder {
+	openshiftVersions := models.OpenshiftVersions{}
+	hasMultiarchAuthorization := false
+	checkedForMultiarchAuthorization := false
+
+	for _, releaseImage := range h.versionsHandler.releaseImages {
+		supportedArchs := releaseImage.CPUArchitectures
+		// We need to have backwards-compatibility for release images that provide supported
+		// architecture only as string and not []string. This code should be unreachable as
+		// at this moment we should have already propagated []string in the init handler for
+		// Versions, but for safety an additional check is added here.
+		if len(supportedArchs) == 0 {
+			supportedArchs = []string{*releaseImage.CPUArchitecture}
+		}
+
+		// (MGMT-11859) We are filtering out multiarch release images so that they are available
+		//              only for customers allowed to use them. This is in order to be able to
+		//              expose them in OCP pre-4.13 without making them generally available.
+		if len(supportedArchs) > 1 {
+			if !checkedForMultiarchAuthorization {
+				var err error
+				hasMultiarchAuthorization, err = h.authzHandler.HasOrgBasedCapability(ctx, ocm.MultiarchCapabilityName)
+				if err == nil {
+					checkedForMultiarchAuthorization = true
+				} else {
+					h.log.WithError(err).Errorf("failed to get %s capability", ocm.MultiarchCapabilityName)
+					continue
+				}
+			}
+			if !hasMultiarchAuthorization {
+				continue
+			}
+		}
+
+		for _, arch := range supportedArchs {
+			key := *releaseImage.OpenshiftVersion
+			if arch == "" {
+				// Empty implies default architecture
+				arch = common.DefaultCPUArchitecture
+			}
+
+			// In order to mark a specific version and architecture as supported we do not
+			// only need to have an available release image, but we need RHCOS image as well.
+			if _, err := h.versionsHandler.GetOsImage(key, arch); err != nil {
+				h.log.Debugf("Marking architecture %s for version %s as not available because no matching OS image found", arch, key)
+				continue
+			}
+
+			openshiftVersion, exists := openshiftVersions[key]
+			if !exists {
+				openshiftVersion = models.OpenshiftVersion{
+					CPUArchitectures: []string{arch},
+					Default:          releaseImage.Default,
+					DisplayName:      releaseImage.Version,
+					SupportLevel:     getSupportLevel(*releaseImage),
+				}
+				openshiftVersions[key] = openshiftVersion
+			} else {
+				// For backwards compatibility we handle a scenario when single-arch image exists
+				// next to the multi-arch one containing the same architecture. We want to avoid
+				// duplicated entry in such a case.
+				exists := func(slice []string, x string) bool {
+					for _, elem := range slice {
+						if x == elem {
+							return true
+						}
+					}
+					return false
+				}
+				if !exists(openshiftVersion.CPUArchitectures, arch) {
+					openshiftVersion.CPUArchitectures = append(openshiftVersion.CPUArchitectures, arch)
+				}
+				openshiftVersion.Default = releaseImage.Default || openshiftVersion.Default
+				openshiftVersions[key] = openshiftVersion
+			}
+		}
+	}
+	return operations.NewV2ListSupportedOpenshiftVersionsOK().WithPayload(openshiftVersions)
+}
+
+func getSupportLevel(releaseImage models.ReleaseImage) *string {
+	if releaseImage.SupportLevel != "" {
+		return &releaseImage.SupportLevel
+	}
+
+	preReleases := []string{"-fc", "-rc", "nightly"}
+	for _, preRelease := range preReleases {
+		if strings.Contains(*releaseImage.Version, preRelease) {
+			return swag.String(models.OpenshiftVersionSupportLevelBeta)
+		}
+	}
+	return swag.String(models.OpenshiftVersionSupportLevelProduction)
+}

--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -1,0 +1,387 @@
+package versions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-openapi/swag"
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/models"
+	auth "github.com/openshift/assisted-service/pkg/auth"
+	"github.com/openshift/assisted-service/pkg/ocm"
+	"github.com/openshift/assisted-service/restapi"
+	operations "github.com/openshift/assisted-service/restapi/operations/versions"
+	"github.com/patrickmn/go-cache"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("ListComponentVersions", func() {
+	var (
+		h *apiHandler
+	)
+
+	BeforeEach(func() {
+		versions := Versions{
+			SelfVersion:     "self-version",
+			AgentDockerImg:  "agent-image",
+			InstallerImage:  "installer-image",
+			ControllerImage: "controller-image",
+			ReleaseTag:      "v1.2.3",
+		}
+
+		h = &apiHandler{
+			log:             common.GetTestLog(),
+			versions:        versions,
+			authzHandler:    nil,
+			versionsHandler: &handler{},
+		}
+	})
+
+	It("returns the configured versions", func() {
+		reply := h.V2ListComponentVersions(context.Background(), operations.V2ListComponentVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
+		val, _ := reply.(*operations.V2ListComponentVersionsOK)
+
+		Expect(val.Payload.Versions["assisted-installer-service"]).Should(Equal("self-version"))
+		Expect(val.Payload.Versions["discovery-agent"]).Should(Equal("agent-image"))
+		Expect(val.Payload.Versions["assisted-installer"]).Should(Equal("installer-image"))
+		Expect(val.Payload.Versions["assisted-installer-controller"]).Should(Equal("controller-image"))
+		Expect(val.Payload.ReleaseTag).Should(Equal("v1.2.3"))
+	})
+})
+
+var _ = Describe("ListSupportedOpenshiftVersions", func() {
+	var (
+		db           *gorm.DB
+		dbName       string
+		ctrl         *gomock.Controller
+		mockRelease  *oc.MockRelease
+		versions     Versions
+		authzHandler auth.Authorizer
+
+		logger          = common.GetTestLog()
+		cpuArchitecture = common.TestDefaultConfig.CPUArchitecture
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		ctrl = gomock.NewController(GinkgoT())
+
+		mockRelease = oc.NewMockRelease(ctrl)
+
+		cfg := auth.GetConfigRHSSO()
+		authzHandler = auth.NewAuthzHandler(cfg, nil, logger, db)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		common.DeleteTestDB(db, dbName)
+	})
+
+	readDefaultOsImages := func() models.OsImages {
+		bytes, err := os.ReadFile("../../data/default_os_images.json")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		osImages := models.OsImages{}
+		err = json.Unmarshal(bytes, &osImages)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return osImages
+	}
+
+	readDefaultReleaseImages := func(osImages models.OsImages) *handler {
+		bytes, err := os.ReadFile("../../data/default_release_images.json")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		releaseImages := &models.ReleaseImages{}
+		err = json.Unmarshal(bytes, releaseImages)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, *releaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		return versionsHandler
+	}
+
+	It("get_defaults from data directory", func() {
+		osImages := readDefaultOsImages()
+		versionsHandler := readDefaultReleaseImages(osImages)
+
+		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler)
+		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+		defaultExists := false
+
+		for _, releaseImage := range versionsHandler.releaseImages {
+			key := *releaseImage.OpenshiftVersion
+			version := val.Payload[key]
+			architecture := *releaseImage.CPUArchitecture
+			architectures := releaseImage.CPUArchitectures
+			defaultExists = defaultExists || releaseImage.Default
+			if len(architectures) < 2 {
+				// For single-arch release we require in the test that there is a matching
+				// OS image for the provided release image. Otherwise the whole release image
+				// is not usable and indicates a mistake.
+				if architecture == "" {
+					architecture = common.CPUArchitecture
+				}
+				if architecture == common.CPUArchitecture {
+					Expect(version.Default).Should(Equal(releaseImage.Default))
+				}
+				Expect(version.CPUArchitectures).Should(ContainElement(architecture))
+				Expect(version.DisplayName).Should(Equal(releaseImage.Version))
+				Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
+			} else {
+				// For multi-arch release we don't require a strict matching for every
+				// architecture supported by this image. As long as we have at least one OS
+				// image that matches, we are okay. This is to allow setups where release
+				// image supports more architectures than we have available RHCOS images.
+				Expect(len(version.CPUArchitectures)).ShouldNot(Equal(0))
+				Expect(*releaseImage.Version).Should(ContainSubstring(*version.DisplayName))
+				Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
+			}
+		}
+
+		// We want to make sure after parsing the default file, there is always a release
+		// image marked as default. It is not desired to have a service without anything
+		// to default to.
+		Expect(defaultExists).Should(Equal(true))
+	})
+
+	It("getSupportLevel", func() {
+		releaseImage := models.ReleaseImage{
+			CPUArchitecture:  &cpuArchitecture,
+			OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
+			URL:              &common.TestDefaultConfig.ReleaseImageUrl,
+			Version:          &common.TestDefaultConfig.ReleaseVersion,
+		}
+
+		// Production release version
+		releaseImage.Version = swag.String("4.8.12")
+		Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
+
+		// Beta release version
+		releaseImage.Version = swag.String("4.9.0-rc.4")
+		Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelBeta))
+
+		// Support level specified in release image
+		releaseImage.SupportLevel = models.OpenshiftVersionSupportLevelProduction
+		Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
+	})
+
+	It("missing release images", func() {
+		osImages := readDefaultOsImages()
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ToNot(HaveOccurred())
+		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler)
+		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+		Expect(val.Payload).Should(BeEmpty())
+	})
+
+	It("release image without cpu_architectures field", func() {
+		releaseImages := models.ReleaseImages{
+			// This image uses a syntax with missing "cpu_architectures". It is crafted
+			// in order to make sure the change in MGMT-11494 is backwards-compatible.
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Default:          true,
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+		}
+
+		osImages := readDefaultOsImages()
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		Expect(err).ToNot(HaveOccurred())
+		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler)
+
+		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+
+		version := val.Payload["4.11.1"]
+		Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
+		Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
+		Expect(version.Default).Should(Equal(true))
+	})
+
+	It("release image without matching OS image", func() {
+		releaseImages := models.ReleaseImages{
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.PowerCPUArchitecture},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Default:          true,
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+		}
+		osImages := readDefaultOsImages()
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		Expect(err).ToNot(HaveOccurred())
+		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler)
+
+		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+
+		version := val.Payload["4.11.1"]
+		Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
+		Expect(version.CPUArchitectures).ShouldNot(ContainElement(common.PowerCPUArchitecture))
+		Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
+		Expect(version.Default).Should(Equal(true))
+	})
+
+	It("single-arch and multi-arch for the same version", func() {
+		releaseImages := models.ReleaseImages{
+			// Those images provide the same architecture using single-arch as well as multi-arch
+			// release images. This is to test if in this scenario we don't return duplicated
+			// entries in the supported architectures list.
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+				CPUArchitectures: []string{common.ARM64CPUArchitecture},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Default:          true,
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+		}
+		osImages := readDefaultOsImages()
+		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "")
+		Expect(err).ToNot(HaveOccurred())
+		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler)
+
+		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
+		Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+		val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+
+		version := val.Payload["4.11.1"]
+		Expect(version.CPUArchitectures).Should(ContainElement(common.ARM64CPUArchitecture))
+		Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
+		Expect(len(version.CPUArchitectures)).Should(Equal(2))
+		Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
+		Expect(version.Default).Should(Equal(true))
+	})
+})
+
+var _ = Describe("Test list versions with capability restrictions", func() {
+	var (
+		db            *gorm.DB
+		dbName        string
+		ctrl          *gomock.Controller
+		mockOcmAuthz  *ocm.MockOCMAuthorization
+		mockOcmClient *ocm.Client
+		authCtx       context.Context
+		orgID1        = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
+		userName1     = "test_user_1"
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		ctrl = gomock.NewController(GinkgoT())
+		mockOcmAuthz = ocm.NewMockOCMAuthorization(ctrl)
+
+		payload := &ocm.AuthPayload{
+			Username:     userName1,
+			Organization: orgID1,
+			Role:         ocm.UserRole,
+		}
+		authCtx = context.WithValue(context.Background(), restapi.AuthKey, payload)
+		mockOcmClient = &ocm.Client{Cache: cache.New(10*time.Minute, 30*time.Minute), Authorization: mockOcmAuthz}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		common.DeleteTestDB(db, dbName)
+	})
+
+	handlerWithAuthConfig := func(enableOrgBasedFeatureGates bool) restapi.VersionsAPI {
+		cfg := auth.GetConfigRHSSO()
+		cfg.EnableOrgBasedFeatureGates = enableOrgBasedFeatureGates
+		authzHandler := auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog(), db)
+
+		versionsHandler, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, defaultReleaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return NewAPIHandler(common.GetTestLog(), Versions{}, authzHandler, versionsHandler)
+	}
+
+	hasMultiarch := func(versions models.OpenshiftVersions) bool {
+		hasMultiarch := false
+		for _, version := range versions {
+			if strings.HasSuffix(*version.DisplayName, "-multi") {
+				hasMultiarch = true
+				break
+			}
+		}
+		return hasMultiarch
+	}
+
+	Context("V2ListSupportedOpenshiftVersions", func() {
+		It("returns multiarch with multiarch capability", func() {
+			h := handlerWithAuthConfig(true)
+			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(true, nil).Times(1)
+
+			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+			Expect(hasMultiarch(val.Payload)).To(BeTrue())
+		})
+		It("does not return multiarch without multiarch capability", func() {
+			h := handlerWithAuthConfig(true)
+			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, nil).Times(1)
+
+			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+			Expect(hasMultiarch(val.Payload)).To(BeFalse())
+		})
+		It("does not return multiarch when capability query fails", func() {
+			h := handlerWithAuthConfig(true)
+
+			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, errors.New("failed to query capability")).Times(1)
+			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+			Expect(hasMultiarch(val.Payload)).To(BeFalse())
+		})
+		It("returns multiarch with org-based features disabled", func() {
+			h := handlerWithAuthConfig(false)
+
+			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
+			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
+
+			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
+			Expect(hasMultiarch(val.Payload)).To(BeTrue())
+		})
+	})
+})

--- a/internal/versions/mock_versions.go
+++ b/internal/versions/mock_versions.go
@@ -5,13 +5,10 @@
 package versions
 
 import (
-	context "context"
 	reflect "reflect"
 
-	middleware "github.com/go-openapi/runtime/middleware"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
-	versions0 "github.com/openshift/assisted-service/restapi/operations/versions"
 )
 
 // MockHandler is a mock of Handler interface.
@@ -168,34 +165,6 @@ func (m *MockHandler) GetReleaseImage(arg0, arg1 string) (*models.ReleaseImage, 
 func (mr *MockHandlerMockRecorder) GetReleaseImage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseImage", reflect.TypeOf((*MockHandler)(nil).GetReleaseImage), arg0, arg1)
-}
-
-// V2ListComponentVersions mocks base method.
-func (m *MockHandler) V2ListComponentVersions(arg0 context.Context, arg1 versions0.V2ListComponentVersionsParams) middleware.Responder {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2ListComponentVersions", arg0, arg1)
-	ret0, _ := ret[0].(middleware.Responder)
-	return ret0
-}
-
-// V2ListComponentVersions indicates an expected call of V2ListComponentVersions.
-func (mr *MockHandlerMockRecorder) V2ListComponentVersions(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2ListComponentVersions", reflect.TypeOf((*MockHandler)(nil).V2ListComponentVersions), arg0, arg1)
-}
-
-// V2ListSupportedOpenshiftVersions mocks base method.
-func (m *MockHandler) V2ListSupportedOpenshiftVersions(arg0 context.Context, arg1 versions0.V2ListSupportedOpenshiftVersionsParams) middleware.Responder {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "V2ListSupportedOpenshiftVersions", arg0, arg1)
-	ret0, _ := ret[0].(middleware.Responder)
-	return ret0
-}
-
-// V2ListSupportedOpenshiftVersions indicates an expected call of V2ListSupportedOpenshiftVersions.
-func (mr *MockHandlerMockRecorder) V2ListSupportedOpenshiftVersions(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V2ListSupportedOpenshiftVersions", reflect.TypeOf((*MockHandler)(nil).V2ListSupportedOpenshiftVersions), arg0, arg1)
 }
 
 // ValidateReleaseImageForRHCOS mocks base method.

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -1,41 +1,19 @@
 package versions
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/go-openapi/swag"
 	gomock "github.com/golang/mock/gomock"
-	"github.com/kelseyhightower/envconfig"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	amgmtv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/auth"
-	"github.com/openshift/assisted-service/pkg/ocm"
-	"github.com/openshift/assisted-service/restapi"
-	operations "github.com/openshift/assisted-service/restapi/operations/versions"
-	"github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
-	"gopkg.in/square/go-jose.v2/json"
-	"gorm.io/gorm"
 )
-
-var (
-	mockAccountsMgmt *ocm.MockOCMAccountsMgmt
-)
-
-func mockAMSSubscription(ctx context.Context) {
-	mockAccountsMgmt.EXPECT().CreateSubscription(ctx, gomock.Any(), gomock.Any()).Return(&amgmtv1.Subscription{}, nil)
-}
 
 func TestHandler_ListComponentVersions(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -54,8 +32,14 @@ var defaultOsImages = models.OsImages{
 	&models.OsImage{
 		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
 		OpenshiftVersion: swag.String("4.10.1"),
-		URL:              swag.String("rhcos_4.10"),
-		Version:          swag.String("version-410.123-0"),
+		URL:              swag.String("rhcos_4.10.1"),
+		Version:          swag.String("version-4101.123-0"),
+	},
+	&models.OsImage{
+		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+		OpenshiftVersion: swag.String("4.10.2"),
+		URL:              swag.String("rhcos_4.10.2"),
+		Version:          swag.String("version-4102.123-0"),
 	},
 	&models.OsImage{
 		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
@@ -110,6 +94,13 @@ var defaultReleaseImages = models.ReleaseImages{
 	&models.ReleaseImage{
 		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
 		CPUArchitectures: []string{common.X86CPUArchitecture},
+		OpenshiftVersion: swag.String("4.10.2"),
+		URL:              swag.String("release_4.10.1"),
+		Version:          swag.String("4.10.1-candidate"),
+	},
+	&models.ReleaseImage{
+		CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+		CPUArchitectures: []string{common.X86CPUArchitecture},
 		OpenshiftVersion: swag.String("4.9"),
 		URL:              swag.String("release_4.9"),
 		Version:          swag.String("4.9-candidate"),
@@ -138,1018 +129,724 @@ var defaultReleaseImages = models.ReleaseImages{
 	},
 }
 
-var mustgatherImages = MustGatherVersions{
-	"4.8": MustGatherVersion{
-		"cnv": "registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v2.6.5",
-		"odf": "registry.redhat.io/ocs4/odf-must-gather-rhel8",
-		"lso": "registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel8",
-	},
-}
+var _ = Describe("GetOsImage", func() {
+	var h *handler
 
-var _ = Describe("list versions", func() {
+	BeforeEach(func() {
+		var err error
+		h, err = NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("unsupported openshiftVersion", func() {
+		osImage, err := h.GetOsImage("unsupported", common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(osImage).Should(BeNil())
+	})
+
+	It("unsupported cpuArchitecture", func() {
+		osImage, err := h.GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
+		Expect(err).Should(HaveOccurred())
+		Expect(osImage).Should(BeNil())
+		Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
+	})
+
+	It("empty architecture fallback to default", func() {
+		osImage, err := h.GetOsImage("4.9", "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.CPUArchitecture).Should(Equal(common.DefaultCPUArchitecture))
+	})
+
+	It("multiarch returns error", func() {
+		osImage, err := h.GetOsImage("4.11", common.MultiCPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(osImage).Should(BeNil())
+		Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
+	})
+
+	It("fetch OS image by major.minor", func() {
+		osImage, err := h.GetOsImage("4.9", common.DefaultCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.9"))
+	})
+
+	It("fetch missing major.minor.patch - find latest patch version by major.minor", func() {
+		osImage, err := h.GetOsImage("4.10.0", common.DefaultCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.2"))
+	})
+
+	It("missing major.minor - find latest patch version by major.minor", func() {
+		osImage, err := h.GetOsImage("4.10", common.DefaultCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.2"))
+	})
+
+	It("get from OsImages", func() {
+		for _, key := range h.GetOpenshiftVersions() {
+			for _, architecture := range h.GetCPUArchitectures(key) {
+				osImage, err := h.GetOsImage(key, architecture)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				for _, rhcos := range defaultOsImages {
+					if *rhcos.OpenshiftVersion == key && *rhcos.CPUArchitecture == architecture {
+						Expect(osImage).Should(Equal(rhcos))
+					}
+				}
+			}
+		}
+	})
+})
+
+var _ = Describe("GetReleaseImage", func() {
+	var h *handler
+
+	BeforeEach(func() {
+		var err error
+		h, err = NewHandler(common.GetTestLog(), nil, defaultOsImages, defaultReleaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("unsupported openshiftVersion", func() {
+		releaseImage, err := h.GetReleaseImage("unsupported", common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(releaseImage).Should(BeNil())
+	})
+
+	It("unsupported cpuArchitecture", func() {
+		releaseImage, err := h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
+		Expect(err).Should(HaveOccurred())
+		Expect(releaseImage).Should(BeNil())
+		Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
+	})
+
+	It("empty openshiftVersion", func() {
+		releaseImage, err := h.GetReleaseImage("", common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(releaseImage).Should(BeNil())
+	})
+
+	It("empty cpuArchitecture", func() {
+		releaseImage, err := h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(releaseImage).Should(BeNil())
+	})
+
+	It("fetch release image by major.minor", func() {
+		releaseImage, err := h.GetReleaseImage("4.9", common.DefaultCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
+		Expect(*releaseImage.Version).Should(Equal("4.9-candidate"))
+	})
+
+	It("get from ReleaseImages", func() {
+		for _, key := range h.GetOpenshiftVersions() {
+			for _, architecture := range h.GetCPUArchitectures(key) {
+				releaseImage, err := h.GetReleaseImage(key, architecture)
+				if err != nil {
+					releaseImage, err = h.GetReleaseImage(key, common.MultiCPUArchitecture)
+					Expect(err).ShouldNot(HaveOccurred())
+				}
+
+				for _, release := range defaultReleaseImages {
+					if *release.OpenshiftVersion == key && *release.CPUArchitecture == architecture {
+						Expect(releaseImage).Should(Equal(release))
+					}
+				}
+			}
+		}
+	})
+
+	It("gets successfuly image with old syntax", func() {
+		releaseImage, err := h.GetReleaseImage("4.11.2", "fake-architecture-chocobomb")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.2"))
+		Expect(*releaseImage.Version).Should(Equal("4.11.2-fake-chocobomb"))
+	})
+
+	It("gets successfuly image with new syntax", func() {
+		releaseImage, err := h.GetReleaseImage("4.10.1", common.X86CPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.10.1"))
+		Expect(*releaseImage.Version).Should(Equal("4.10.1-candidate"))
+	})
+
+	It("gets successfuly image using generic multiarch query", func() {
+		releaseImage, err := h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
+		Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
+	})
+
+	It("gets successfuly image using sub-architecture", func() {
+		releaseImage, err := h.GetReleaseImage("4.11.1", common.PowerCPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
+		Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
+	})
+})
+
+var _ = Describe("ValidateReleaseImageForRHCOS", func() {
+	var h *handler
+
+	BeforeEach(func() {
+		var err error
+		releaseImages := models.ReleaseImages{
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+				OpenshiftVersion: swag.String("4.11.1"),
+				URL:              swag.String("release_4.11.1"),
+				Default:          false,
+				Version:          swag.String("4.11.1-chocobomb-for-test"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+				OpenshiftVersion: swag.String("4.12"),
+				URL:              swag.String("release_4.12"),
+				Default:          false,
+				Version:          swag.String("4.12"),
+			},
+		}
+		h, err = NewHandler(common.GetTestLog(), nil, defaultOsImages, releaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("validates successfuly using exact match", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("4.11.1", common.X86CPUArchitecture)).To(Succeed())
+	})
+	It("validates successfuly using major.minor", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("4.11", common.X86CPUArchitecture)).To(Succeed())
+	})
+	It("validates successfuly using major.minor using default architecture", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("4.11", "")).To(Succeed())
+	})
+	It("validates successfuly using major.minor.patch-something", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("4.12.2-chocobomb", common.X86CPUArchitecture)).To(Succeed())
+	})
+	It("fails validation using non-existing major.minor.patch-something", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("9.9.9-chocobomb", common.X86CPUArchitecture)).NotTo(Succeed())
+	})
+	It("fails validation using multiarch", func() {
+		// This test is supposed to fail because there exists no RHCOS image that supports
+		// multiple architectures.
+		Expect(h.ValidateReleaseImageForRHCOS("4.11", common.MultiCPUArchitecture)).NotTo(Succeed())
+	})
+	It("fails validation using invalid version", func() {
+		Expect(h.ValidateReleaseImageForRHCOS("invalid", common.X86CPUArchitecture)).NotTo(Succeed())
+	})
+})
+
+var _ = Describe("GetDefaultReleaseImage", func() {
+	It("Default release image exists", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, defaultReleaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		releaseImage, err := h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(releaseImage.Default).Should(Equal(true))
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
+		Expect(*releaseImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+	})
+
+	It("Missing default release image", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		_, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).Should(Equal("Default release image is not available"))
+	})
+})
+
+var _ = Describe("GetMustGatherImages", func() {
 	var (
-		h               *handler
-		err             error
-		db              *gorm.DB
-		dbName          string
-		logger          logrus.FieldLogger
-		mockRelease     *oc.MockRelease
-		versions        Versions
-		osImages        *models.OsImages
-		releaseImages   *models.ReleaseImages
-		cpuArchitecture string
-		authzHandler    auth.Authorizer
+		h                *handler
+		ctrl             *gomock.Controller
+		mockRelease      *oc.MockRelease
+		cpuArchitecture  = common.TestDefaultConfig.CPUArchitecture
+		pullSecret       = "test_pull_secret"
+		ocpVersion       = "4.8.0-fc.1"
+		mirror           = "release-mirror"
+		mustgatherImages = MustGatherVersions{
+			"4.8": MustGatherVersion{
+				"cnv": "registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v2.6.5",
+				"odf": "registry.redhat.io/ocs4/odf-must-gather-rhel8",
+				"lso": "registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel8",
+			},
+		}
 	)
 
 	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
+		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
-		db, dbName = common.PrepareTestDB()
-
-		logger = logrus.New()
-		osImages = &models.OsImages{}
-		releaseImages = &models.ReleaseImages{}
-		cpuArchitecture = common.TestDefaultConfig.CPUArchitecture
-		cfg := auth.GetConfigRHSSO()
-		authzHandler = auth.NewAuthzHandler(cfg, nil, common.GetTestLog().WithField("pkg", "auth"), db)
+		var err error
+		h, err = NewHandler(common.GetTestLog(), mockRelease, defaultOsImages, defaultReleaseImages, mustgatherImages, mirror)
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		common.DeleteTestDB(db, dbName)
+		ctrl.Finish()
 	})
 
-	Context("ListComponentVersions", func() {
-		It("default values", func() {
-			Expect(envconfig.Process("test", &versions)).ShouldNot(HaveOccurred())
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListComponentVersions(context.Background(), operations.V2ListComponentVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
-			val, _ := reply.(*operations.V2ListComponentVersionsOK)
-			Expect(val.Payload.Versions["assisted-installer-service"]).
-				Should(Equal("Unknown"))
-			Expect(val.Payload.Versions["discovery-agent"]).Should(Equal("quay.io/edge-infrastructure/assisted-installer-agent:latest"))
-			Expect(val.Payload.Versions["assisted-installer"]).Should(Equal("quay.io/edge-infrastructure/assisted-installer:latest"))
-			Expect(val.Payload.ReleaseTag).Should(Equal(""))
-		})
+	verifyOcpVersion := func(images MustGatherVersion, size int) {
+		Expect(len(images)).To(Equal(size))
+		Expect(images["ocp"]).To(Equal("blah"))
+	}
 
-		It("mix default and non default", func() {
-			os.Setenv("SELF_VERSION", "self-version")
-			os.Setenv("AGENT_DOCKER_IMAGE", "agent-image")
-			os.Setenv("INSTALLER_IMAGE", "installer-image")
-			os.Setenv("CONTROLLER_IMAGE", "controller-image")
-			Expect(envconfig.Process("test", &versions)).ShouldNot(HaveOccurred())
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListComponentVersions(context.Background(), operations.V2ListComponentVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListComponentVersionsOK()))
-			val, _ := reply.(*operations.V2ListComponentVersionsOK)
-			Expect(val.Payload.Versions["assisted-installer-service"]).Should(Equal("self-version"))
-			Expect(val.Payload.Versions["discovery-agent"]).Should(Equal("agent-image"))
-			Expect(val.Payload.Versions["assisted-installer"]).Should(Equal("installer-image"))
-			Expect(val.Payload.Versions["assisted-installer-controller"]).Should(Equal("controller-image"))
-			Expect(val.Payload.ReleaseTag).Should(Equal(""))
-		})
+	It("happy flow", func() {
+		mockRelease.EXPECT().GetMustGatherImage(gomock.Any(), "release_4.8", mirror, pullSecret).Return("blah", nil).Times(1)
+		images, err := h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		verifyOcpVersion(images, 4)
+		Expect(images["lso"]).To(Equal(mustgatherImages["4.8"]["lso"]))
 	})
 
-	Context("ListSupportedOpenshiftVersions", func() {
-		readDefaultOsImages := func() {
-			var bytes []byte
-			bytes, err = os.ReadFile("../../data/default_os_images.json")
-			Expect(err).ShouldNot(HaveOccurred())
-			err = json.Unmarshal(bytes, osImages)
-			Expect(err).ShouldNot(HaveOccurred())
-		}
-
-		readDefaultReleaseImages := func() {
-			var bytes []byte
-			bytes, err = os.ReadFile("../../data/default_release_images.json")
-			Expect(err).ShouldNot(HaveOccurred())
-			err = json.Unmarshal(bytes, releaseImages)
-			Expect(err).ShouldNot(HaveOccurred())
-		}
-
-		It("get_defaults from data directory", func() {
-			readDefaultOsImages()
-			readDefaultReleaseImages()
-
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			defaultExists := false
-
-			for _, releaseImage := range *releaseImages {
-				key := *releaseImage.OpenshiftVersion
-				version := val.Payload[key]
-				architecture := *releaseImage.CPUArchitecture
-				architectures := releaseImage.CPUArchitectures
-				defaultExists = defaultExists || releaseImage.Default
-				if len(architectures) < 2 {
-					// For single-arch release we require in the test that there is a matching
-					// OS image for the provided release image. Otherwise the whole release image
-					// is not usable and indicates a mistake.
-					if architecture == "" {
-						architecture = common.CPUArchitecture
-					}
-					if architecture == common.CPUArchitecture {
-						Expect(version.Default).Should(Equal(releaseImage.Default))
-					}
-					Expect(version.CPUArchitectures).Should(ContainElement(architecture))
-					Expect(version.DisplayName).Should(Equal(releaseImage.Version))
-					Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
-				} else {
-					// For multi-arch release we don't require a strict matching for every
-					// architecture supported by this image. As long as we have at least one OS
-					// image that matches, we are okay. This is to allow setups where release
-					// image supports more architectures than we have available RHCOS images.
-					Expect(len(version.CPUArchitectures)).ShouldNot(Equal(0))
-					Expect(*releaseImage.Version).Should(ContainSubstring(*version.DisplayName))
-					Expect(version.SupportLevel).Should(Equal(getSupportLevel(*releaseImage)))
-				}
-			}
-
-			// We want to make sure after parsing the default file, there is always a release
-			// image marked as default. It is not desired to have a service without anything
-			// to default to.
-			Expect(defaultExists).Should(Equal(true))
-		})
-
-		It("getSupportLevel", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			releaseImage := models.ReleaseImage{
-				CPUArchitecture:  &cpuArchitecture,
-				OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
-				URL:              &common.TestDefaultConfig.ReleaseImageUrl,
-				Version:          &common.TestDefaultConfig.ReleaseVersion,
-			}
-
-			// Production release version
-			releaseImage.Version = swag.String("4.8.12")
-			Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
-
-			// Beta release version
-			releaseImage.Version = swag.String("4.9.0-rc.4")
-			Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelBeta))
-
-			// Support level specified in release image
-			releaseImage.SupportLevel = models.OpenshiftVersionSupportLevelProduction
-			Expect(*getSupportLevel(releaseImage)).Should(Equal(models.OpenshiftVersionSupportLevelProduction))
-		})
-
-		It("missing release images", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			Expect(val.Payload).Should(BeEmpty())
-		})
-
-		It("release image without cpu_architectures field", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{
-				// This image uses a syntax with missing "cpu_architectures". It is crafted
-				// in order to make sure the change in MGMT-11494 is backwards-compatible.
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					CPUArchitectures: []string{},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Default:          true,
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-			}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-
-			version := val.Payload["4.11.1"]
-			Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
-			Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
-			Expect(version.Default).Should(Equal(true))
-		})
-
-		It("release image without matching OS image", func() {
-			readDefaultOsImages()
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, models.ReleaseImages{
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
-					CPUArchitectures: []string{common.X86CPUArchitecture, common.PowerCPUArchitecture},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Default:          true,
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-			}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-
-			version := val.Payload["4.11.1"]
-			Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
-			Expect(version.CPUArchitectures).ShouldNot(ContainElement(common.PowerCPUArchitecture))
-			Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
-			Expect(version.Default).Should(Equal(true))
-		})
-
-		It("single-arch and multi-arch for the same version", func() {
-			readDefaultOsImages()
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, models.ReleaseImages{
-				// Those images provide the same architecture using single-arch as well as multi-arch
-				// release images. This is to test if in this scenario we don't return duplicated
-				// entries in the supported architectures list.
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
-					CPUArchitectures: []string{common.ARM64CPUArchitecture},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					CPUArchitectures: []string{common.X86CPUArchitecture},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
-					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Default:          true,
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-			}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-
-			version := val.Payload["4.11.1"]
-			Expect(version.CPUArchitectures).Should(ContainElement(common.ARM64CPUArchitecture))
-			Expect(version.CPUArchitectures).Should(ContainElement(common.X86CPUArchitecture))
-			Expect(len(version.CPUArchitectures)).Should(Equal(2))
-			Expect(version.DisplayName).Should(Equal(swag.String("4.11.1-chocobomb-for-test")))
-			Expect(version.Default).Should(Equal(true))
-		})
+	It("unsupported_key", func() {
+		images, err := h.GetMustGatherImages("unsupported", cpuArchitecture, pullSecret)
+		Expect(err).Should(HaveOccurred())
+		Expect(images).Should(BeEmpty())
 	})
 
-	Context("GetOsImage", func() {
-		var (
-			osImage              *models.OsImage
-			architectures        []string
-			patchVersionOsImages = models.OsImages{
-				&models.OsImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					OpenshiftVersion: swag.String("4.10.10"),
-					URL:              swag.String("rhcos_4.10.2"),
-					Version:          swag.String("version-4102.123-0"),
-				},
-				&models.OsImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					OpenshiftVersion: swag.String("4.10.9"),
-					URL:              swag.String("rhcos_4.10.1"),
-					Version:          swag.String("version-4101.123-0"),
-				},
-			}
-		)
+	It("caching", func() {
+		images, err := h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		verifyOcpVersion(images, 4)
 
-		BeforeEach(func() {
-			osImages = &defaultOsImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("unsupported openshiftVersion", func() {
-			osImage, err = h.GetOsImage("unsupported", common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(osImage).Should(BeNil())
-		})
-
-		It("unsupported cpuArchitecture", func() {
-			osImage, err = h.GetOsImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
-			Expect(err).Should(HaveOccurred())
-			Expect(osImage).Should(BeNil())
-			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
-		})
-
-		It("empty architecture fallback to default", func() {
-			osImage, err = h.GetOsImage("4.9", "")
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.CPUArchitecture).Should(Equal(common.DefaultCPUArchitecture))
-		})
-
-		It("multiarch returns error", func() {
-			osImage, err = h.GetOsImage("4.11", common.MultiCPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(osImage).Should(BeNil())
-			Expect(err.Error()).To(ContainSubstring("isn't specified in OS images list"))
-		})
-
-		It("fetch OS image by major.minor", func() {
-			osImage, err = h.GetOsImage("4.9", common.DefaultCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.9"))
-		})
-
-		It("fetch missing major.minor.patch - find latest patch version by major.minor", func() {
-			h, err = NewHandler(logger, mockRelease, versions, patchVersionOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			osImage, err = h.GetOsImage("4.10.1", common.DefaultCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.10"))
-		})
-
-		It("missing major.minor - find latest patch version by major.minor", func() {
-			h, err = NewHandler(logger, mockRelease, versions, patchVersionOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			osImage, err = h.GetOsImage("4.10", common.DefaultCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.10.10"))
-		})
-
-		It("get from OsImages", func() {
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			for _, key := range h.GetOpenshiftVersions() {
-				architectures = h.GetCPUArchitectures(key)
-
-				for _, architecture := range architectures {
-					osImage, err = h.GetOsImage(key, architecture)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					for _, rhcos := range *osImages {
-						if *rhcos.OpenshiftVersion == key && *rhcos.CPUArchitecture == architecture {
-							Expect(osImage).Should(Equal(rhcos))
-						}
-					}
-				}
-			}
-		})
+		images, err = h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		verifyOcpVersion(images, 4)
 	})
 
-	Context("GetReleaseImage", func() {
-		var (
-			releaseImage  *models.ReleaseImage
-			architectures []string
-		)
+	It("missing release image", func() {
+		images, err := h.GetMustGatherImages("4.7", cpuArchitecture, pullSecret)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
+		Expect(images).Should(BeEmpty())
+	})
+})
 
-		BeforeEach(func() {
-			releaseImages = &defaultReleaseImages
-			osImages = &defaultOsImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
+var _ = Describe("AddReleaseImage", func() {
+	var (
+		h                  *handler
+		ctrl               *gomock.Controller
+		mockRelease        *oc.MockRelease
+		cpuArchitecture    = common.TestDefaultConfig.CPUArchitecture
+		pullSecret         = "test_pull_secret"
+		releaseImageUrl    = "releaseImage"
+		customOcpVersion   = "4.8.0"
+		existingOcpVersion = "4.9.1"
+	)
 
-		It("unsupported openshiftVersion", func() {
-			releaseImage, err = h.GetReleaseImage("unsupported", common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(releaseImage).Should(BeNil())
-		})
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockRelease = oc.NewMockRelease(ctrl)
 
-		It("unsupported cpuArchitecture", func() {
-			releaseImage, err = h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "unsupported")
-			Expect(err).Should(HaveOccurred())
-			Expect(releaseImage).Should(BeNil())
-			Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
-		})
-
-		It("empty openshiftVersion", func() {
-			releaseImage, err = h.GetReleaseImage("", common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(releaseImage).Should(BeNil())
-		})
-
-		It("empty cpuArchitecture", func() {
-			releaseImage, err = h.GetReleaseImage(common.TestDefaultConfig.OpenShiftVersion, "")
-			Expect(err).Should(HaveOccurred())
-			Expect(releaseImage).Should(BeNil())
-		})
-
-		It("fetch release image by major.minor", func() {
-			releaseImage, err = h.GetReleaseImage("4.9", common.DefaultCPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
-			Expect(*releaseImage.Version).Should(Equal("4.9-candidate"))
-		})
-
-		It("get from ReleaseImages", func() {
-			for _, key := range h.GetOpenshiftVersions() {
-				architectures = h.GetCPUArchitectures(key)
-
-				for _, architecture := range architectures {
-					releaseImage, err = h.GetReleaseImage(key, architecture)
-					if err != nil {
-						releaseImage, err = h.GetReleaseImage(key, common.MultiCPUArchitecture)
-						Expect(err).ShouldNot(HaveOccurred())
-					}
-
-					for _, release := range *releaseImages {
-						if *release.OpenshiftVersion == key && *release.CPUArchitecture == architecture {
-							Expect(releaseImage).Should(Equal(release))
-						}
-					}
-				}
-			}
-		})
-
-		Context("for single-arch release image", func() {
-			It("gets successfuly image with old syntax", func() {
-				releaseImage, err = h.GetReleaseImage("4.11.2", "fake-architecture-chocobomb")
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.2"))
-				Expect(*releaseImage.Version).Should(Equal("4.11.2-fake-chocobomb"))
-			})
-
-			It("gets successfuly image with new syntax", func() {
-				releaseImage, err = h.GetReleaseImage("4.10.1", common.X86CPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.10.1"))
-				Expect(*releaseImage.Version).Should(Equal("4.10.1-candidate"))
-			})
-		})
-
-		Context("for multi-arch release image", func() {
-			It("gets successfuly image using generic multiarch query", func() {
-				releaseImage, err = h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
-				Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
-			})
-			It("gets successfuly image using sub-architecture", func() {
-				releaseImage, err = h.GetReleaseImage("4.11.1", common.PowerCPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.11.1"))
-				Expect(*releaseImage.Version).Should(Equal("4.11.1-multi"))
-			})
-		})
+		var err error
+		h, err = NewHandler(common.GetTestLog(), mockRelease, defaultOsImages, defaultReleaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("ValidateReleaseImageForRHCOS", func() {
-		BeforeEach(func() {
-			osImages = &defaultOsImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, models.ReleaseImages{
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
-					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
-					OpenshiftVersion: swag.String("4.11.1"),
-					URL:              swag.String("release_4.11.1"),
-					Default:          false,
-					Version:          swag.String("4.11.1-chocobomb-for-test"),
-				},
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
-					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
-					OpenshiftVersion: swag.String("4.12"),
-					URL:              swag.String("release_4.12"),
-					Default:          false,
-					Version:          swag.String("4.12"),
-				},
-			}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("validates successfuly using exact match", func() {
-			err = h.ValidateReleaseImageForRHCOS("4.11.1", common.X86CPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("validates successfuly using major.minor", func() {
-			err = h.ValidateReleaseImageForRHCOS("4.11", common.X86CPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("validates successfuly using major.minor using default architecture", func() {
-			err = h.ValidateReleaseImageForRHCOS("4.11", "")
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("validates successfuly using major.minor.patch-something", func() {
-			err = h.ValidateReleaseImageForRHCOS("4.12.2-chocobomb", common.X86CPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-		It("fails validation using non-existing major.minor.patch-something", func() {
-			err = h.ValidateReleaseImageForRHCOS("9.9.9-chocobomb", common.X86CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-		})
-		It("fails validation using multiarch", func() {
-			// This test is supposed to fail because there exists no RHCOS image that supports
-			// multiple architectures.
-			err = h.ValidateReleaseImageForRHCOS("4.11", common.MultiCPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-		})
-		It("fails validation using invalid version", func() {
-			err = h.ValidateReleaseImageForRHCOS("invalid", common.X86CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-		})
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
-	Context("GetDefaultReleaseImage", func() {
-		var (
-			releaseImage *models.ReleaseImage
-		)
-
-		It("Default release image exists", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, defaultReleaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			releaseImage, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(releaseImage.Default).Should(Equal(true))
-			Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
-			Expect(*releaseImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
-		})
-
-		It("Missing default release image", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, models.ReleaseImages{}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-			releaseImage, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(Equal("Default release image is not available"))
-		})
-	})
-
-	Context("GetMustGatherImages", func() {
-		var (
-			pullSecret = "test_pull_secret"
-			ocpVersion = "4.8.0-fc.1"
-			keyVersion = "4.8"
-			mirror     = "release-mirror"
-			images     MustGatherVersion
-		)
-
-		BeforeEach(func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, defaultReleaseImages, mustgatherImages, mirror, authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		verifyOcpVersion := func(images MustGatherVersion, size int) {
-			Expect(len(images)).To(Equal(size))
-			Expect(images["ocp"]).To(Equal("blah"))
-		}
-
-		It("happy flow", func() {
-			mockRelease.EXPECT().GetMustGatherImage(gomock.Any(), "release_4.8", mirror, pullSecret).Return("blah", nil).Times(1)
-			images, err = h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			verifyOcpVersion(images, 4)
-			Expect(images["lso"]).To(Equal(mustgatherImages[keyVersion]["lso"]))
-		})
-
-		It("unsupported_key", func() {
-			images, err = h.GetMustGatherImages("unsupported", cpuArchitecture, pullSecret)
-			Expect(err).Should(HaveOccurred())
-			Expect(images).Should(BeEmpty())
-		})
-
-		It("caching", func() {
-			mockRelease.EXPECT().GetMustGatherImage(gomock.Any(), "release_4.8", mirror, pullSecret).Return("blah", nil).Times(1)
-			images, err = h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-			verifyOcpVersion(images, 4)
-
-			images, err = h.GetMustGatherImages(ocpVersion, cpuArchitecture, pullSecret)
-			Expect(err).ShouldNot(HaveOccurred())
-			verifyOcpVersion(images, 4)
-		})
-
-		It("missing release image", func() {
-			images, err = h.GetMustGatherImages("4.7", cpuArchitecture, pullSecret)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("isn't specified in release images list"))
-			Expect(images).Should(BeEmpty())
-		})
-	})
-
-	Context("AddReleaseImage", func() {
-		var (
-			pullSecret            = "test_pull_secret"
-			releaseImageUrl       = "releaseImage"
-			customOcpVersion      = "4.8.0"
-			existingOcpVersion    = "4.9.1"
-			releaseImageFromCache *models.ReleaseImage
-			releaseImage          *models.ReleaseImage
-		)
-
-		BeforeEach(func() {
-			osImages = &defaultOsImages
-			releaseImages = &defaultReleaseImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		Context("for single-arch release image", func() {
-			It("added successfully", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-				releaseImage, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(*releaseImage.CPUArchitecture).Should(Equal(cpuArchitecture))
-				Expect(releaseImage.CPUArchitectures).Should(Equal([]string{cpuArchitecture}))
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
-				Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
-				Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
-			})
-
-			It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture})
-				Expect(err).ShouldNot(HaveOccurred())
-				releaseImageFromCache, err = h.GetReleaseImage(customOcpVersion, cpuArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-				Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-				Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(cpuArchitecture))
-				Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture}))
-			})
-
-			It("when release image already exists", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existingOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-				releaseImageFromCache := funk.Find(h.releaseImages, func(releaseImage *models.ReleaseImage) bool {
-					return *releaseImage.OpenshiftVersion == existingOcpVersion && *releaseImage.CPUArchitecture == cpuArchitecture
-				})
-				Expect(releaseImageFromCache).ShouldNot(BeNil())
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				releaseImage, err = h.GetReleaseImage(existingOcpVersion, cpuArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
-			})
-
-			It("fails when missing OS image", func() {
-				ocpVersion := "4.7"
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(ocpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-				_, err = h.AddReleaseImage("invalidRelease", pullSecret, "", nil)
-				Expect(err).Should(HaveOccurred())
-				Expect(err.Error()).Should(Equal(fmt.Sprintf("No OS images are available for version %s and architecture %s", ocpVersion, cpuArchitecture)))
-			})
-		})
-
-		Context("for multi-arch release image", func() {
-			It("added successfully", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
-
-				releaseImage, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(*releaseImage.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
-				Expect(releaseImage.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
-				Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
-				Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
-				Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
-			})
-
-			It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture, common.ARM64CPUArchitecture})
-				Expect(err).ShouldNot(HaveOccurred())
-				releaseImageFromCache, err = h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-				Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-				Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
-				Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
-			})
-
-			It("added successfuly and recalculated using specified ocpReleaseVersion and 'multiarch' cpuArchitecture", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{common.MultiCPUArchitecture})
-				Expect(err).ShouldNot(HaveOccurred())
-				releaseImageFromCache, err = h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
-				Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
-				Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
-				Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
-			})
-
-			It("when release image already exists", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("4.11.1", nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
-
-				releaseImageFromCache := funk.Find(h.releaseImages, func(releaseImage *models.ReleaseImage) bool {
-					return *releaseImage.OpenshiftVersion == "4.11.1" && *releaseImage.CPUArchitecture == common.MultiCPUArchitecture
-				})
-				Expect(releaseImageFromCache).ShouldNot(BeNil())
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// Query for multi-arch release image using generic multiarch
-				releaseImage, err = h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
-
-				// Query for multi-arch release image using specific arch
-				releaseImage, err = h.GetReleaseImage("4.11.1", common.X86CPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
-				releaseImage, err = h.GetReleaseImage("4.11.1", common.ARM64CPUArchitecture)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
-
-				// Query for non-existing architecture
-				releaseImage, err = h.GetReleaseImage("4.11.1", "architecture-chocobomb")
-				Expect(err.Error()).Should(Equal("The requested CPU architecture (architecture-chocobomb) isn't specified in release images list"))
-			})
-		})
-
-		Context("with failing OCP version extraction", func() {
-			It("using default syntax", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).Should(HaveOccurred())
-			})
-
-			It("using specified cpuArchitectures", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", []string{cpuArchitecture})
-				Expect(err).Should(HaveOccurred())
-			})
-		})
-
-		Context("with failing architecture extraction", func() {
-			It("using default syntax", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
-				Expect(err).Should(HaveOccurred())
-			})
-
-			It("using specified ocpReleaseVersion", func() {
-				mockRelease.EXPECT().GetOpenshiftVersion(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
-				mockRelease.EXPECT().GetReleaseArchitecture(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
-
-				_, err = h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, nil)
-				Expect(err).Should(HaveOccurred())
-			})
-		})
-
-		It("keep support level from cache", func() {
+	Context("for single-arch release image", func() {
+		It("added successfully", func() {
 			mockRelease.EXPECT().GetOpenshiftVersion(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
 			mockRelease.EXPECT().GetReleaseArchitecture(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-			releaseImage, err = h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 			Expect(err).ShouldNot(HaveOccurred())
-			releaseImage, err = h.GetReleaseImage(customOcpVersion, cpuArchitecture)
+
+			Expect(*releaseImage.CPUArchitecture).Should(Equal(cpuArchitecture))
+			Expect(releaseImage.CPUArchitectures).Should(Equal([]string{cpuArchitecture}))
+			Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
+			Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
+			Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
+		})
+
+		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
+			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, cpuArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
+			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
+			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(cpuArchitecture))
+			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture}))
+		})
+
+		It("when release image already exists", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existingOcpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
+
+			releaseImageFromCache := funk.Find(h.releaseImages, func(releaseImage *models.ReleaseImage) bool {
+				return *releaseImage.OpenshiftVersion == existingOcpVersion && *releaseImage.CPUArchitecture == cpuArchitecture
+			})
+			Expect(releaseImageFromCache).ShouldNot(BeNil())
+
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			releaseImage, err := h.GetReleaseImage(existingOcpVersion, cpuArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
+		})
+
+		It("fails when missing OS image", func() {
+			ocpVersion := "4.7"
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(ocpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
+
+			_, err := h.AddReleaseImage("invalidRelease", pullSecret, "", nil)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(Equal(fmt.Sprintf("No OS images are available for version %s and architecture %s", ocpVersion, cpuArchitecture)))
 		})
 	})
 
-	Context("GetLatestOsImage", func() {
-		var (
-			osImage *models.OsImage
-		)
+	Context("for multi-arch release image", func() {
+		It("added successfully", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
 
-		It("only one OS image", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages[0:1], *releaseImages, nil, "", authzHandler)
+			releaseImage, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 			Expect(err).ShouldNot(HaveOccurred())
-			osImage, err = h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
-			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+
+			Expect(*releaseImage.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
+			Expect(releaseImage.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
+			Expect(*releaseImage.OpenshiftVersion).Should(Equal(customOcpVersion))
+			Expect(*releaseImage.URL).Should(Equal(releaseImageUrl))
+			Expect(*releaseImage.Version).Should(Equal(customOcpVersion))
 		})
 
-		It("Multiple OS images", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
+		It("added successfuly using specified ocpReleaseVersion and cpuArchitecture", func() {
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{cpuArchitecture, common.ARM64CPUArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
-			osImage, err = h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
+			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
-			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+
+			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
+			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
+			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
+			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
 		})
 
-		It("fails to get OS images for multiarch", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
+		It("added successfuly and recalculated using specified ocpReleaseVersion and 'multiarch' cpuArchitecture", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
+
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, []string{common.MultiCPUArchitecture})
 			Expect(err).ShouldNot(HaveOccurred())
-			osImage, err = h.GetLatestOsImage(common.MultiCPUArchitecture)
-			Expect(err).Should(HaveOccurred())
-			Expect(osImage).Should(BeNil())
-			Expect(err.Error()).To(ContainSubstring("No OS images are available"))
+			releaseImageFromCache, err := h.GetReleaseImage(customOcpVersion, common.MultiCPUArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(*releaseImageFromCache.URL).Should(Equal(releaseImageUrl))
+			Expect(*releaseImageFromCache.Version).Should(Equal(customOcpVersion))
+			Expect(*releaseImageFromCache.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
+			Expect(releaseImageFromCache.CPUArchitectures).Should(Equal([]string{cpuArchitecture, common.ARM64CPUArchitecture}))
+		})
+
+		It("when release image already exists", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("4.11.1", nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture, common.ARM64CPUArchitecture}, nil).AnyTimes()
+
+			releaseImageFromCache := funk.Find(h.releaseImages, func(releaseImage *models.ReleaseImage) bool {
+				return *releaseImage.OpenshiftVersion == "4.11.1" && *releaseImage.CPUArchitecture == common.MultiCPUArchitecture
+			})
+			Expect(releaseImageFromCache).ShouldNot(BeNil())
+
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// Query for multi-arch release image using generic multiarch
+			releaseImage, err := h.GetReleaseImage("4.11.1", common.MultiCPUArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
+
+			// Query for multi-arch release image using specific arch
+			releaseImage, err = h.GetReleaseImage("4.11.1", common.X86CPUArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
+			releaseImage, err = h.GetReleaseImage("4.11.1", common.ARM64CPUArchitecture)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
+
+			// Query for non-existing architecture
+			_, err = h.GetReleaseImage("4.11.1", "architecture-chocobomb")
+			Expect(err.Error()).Should(Equal("The requested CPU architecture (architecture-chocobomb) isn't specified in release images list"))
 		})
 	})
 
-	Context("GetOsImageOrLatest", func() {
-		var (
-			osImage *models.OsImage
-		)
+	Context("with failing OCP version extraction", func() {
+		It("using default syntax", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		BeforeEach(func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).To(BeNil())
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+			Expect(err).Should(HaveOccurred())
 		})
 
-		It("successfully gets an OS image with a valid openshift version and cpu architecture", func() {
-			osImage, err = h.GetOsImageOrLatest("4.9", common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).To(BeNil())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.9"))
-			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
-		})
+		It("using specified cpuArchitectures", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("invalid")).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		It("successfully gets the latest OS image with a valid cpu architecture", func() {
-			osImage, err = h.GetOsImageOrLatest("", common.TestDefaultConfig.CPUArchitecture)
-			Expect(err).To(BeNil())
-			Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
-			Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
-		})
-
-		It("fails to get OS images for invalid cpu architecture and valid openshift version", func() {
-			osImage, err = h.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866")
-			Expect(err).ToNot(BeNil())
-			Expect(osImage).Should(BeNil())
-		})
-
-		It("fails to get OS images for invalid cpu architecture and invalid openshift version", func() {
-			osImage, err = h.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866")
-			Expect(err).ToNot(BeNil())
-			Expect(osImage).Should(BeNil())
-		})
-
-		It("fails to get OS images for invalid cpu architecture and no openshift version", func() {
-			osImage, err = h.GetOsImageOrLatest("", "x866")
-			Expect(err).ToNot(BeNil())
-			Expect(osImage).Should(BeNil())
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", []string{cpuArchitecture})
+			Expect(err).Should(HaveOccurred())
 		})
 	})
 
-	Context("validateVersions", func() {
-		BeforeEach(func() {
-			osImages = &models.OsImages{
-				&models.OsImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("rhcos_4.9"),
-					Version:          swag.String("version-49.123-0"),
-				},
-				&models.OsImage{
-					CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("rhcos_4.9_arm64"),
-					Version:          swag.String("version-49.123-0_arm64"),
-				},
-			}
+	Context("with failing architecture extraction", func() {
+		It("using default syntax", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
 
-			releaseImages = &models.ReleaseImages{
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.X86CPUArchitecture),
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("release_4.9"),
-					Version:          swag.String("4.9-candidate"),
-				},
-				&models.ReleaseImage{
-					CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("release_4.9_arm64"),
-					Version:          swag.String("4.9-candidate_arm64"),
-				},
-			}
-		})
-
-		It("OS images specified", func() {
-			osImages = &defaultOsImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("only OpenShift versions specified", func() {
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It("missing URL in OS images", func() {
-			(*osImages)[0].URL = nil
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("url"))
 		})
 
-		It("missing Version in OS images", func() {
-			(*osImages)[0].Version = nil
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("version"))
-		})
+		It("using specified ocpReleaseVersion", func() {
+			mockRelease.EXPECT().GetOpenshiftVersion(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+			mockRelease.EXPECT().GetReleaseArchitecture(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error when getting architecture")).AnyTimes()
 
-		It("missing CPUArchitecture in Release images", func() {
-			(*releaseImages)[0].CPUArchitecture = nil
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
+			_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, customOcpVersion, nil)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cpu_architecture"))
-		})
-
-		It("missing URL in Release images", func() {
-			(*releaseImages)[0].URL = nil
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("url"))
-		})
-
-		It("missing Version in Release images", func() {
-			(*releaseImages)[0].Version = nil
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("version"))
-		})
-
-		It("empty osImages and openshiftVersions", func() {
-			h, err = NewHandler(logger, mockRelease, versions, models.OsImages{}, *releaseImages, nil, "", authzHandler)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("No OS images are available"))
 		})
 	})
 
-	Context("GetCPUArchitectures", func() {
-		var (
-			architectures []string
-		)
+	It("keep support level from cache", func() {
+		mockRelease.EXPECT().GetOpenshiftVersion(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(customOcpVersion, nil).AnyTimes()
+		mockRelease.EXPECT().GetReleaseArchitecture(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
-		BeforeEach(func() {
-			osImages = &defaultOsImages
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, *releaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
+		_, err := h.AddReleaseImage(releaseImageUrl, pullSecret, "", nil)
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = h.GetReleaseImage(customOcpVersion, cpuArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+})
 
-		It("unsupported version", func() {
-			architectures = h.GetCPUArchitectures("unsupported")
-		})
+var _ = Describe("GetLatestOsImage", func() {
+	It("only one OS image", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages[0:1], models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		osImage, err := h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
+		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+	})
 
-		It("multiple CPU architectures", func() {
-			h, err = NewHandler(logger, mockRelease, versions, defaultOsImages, defaultReleaseImages, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
+	It("Multiple OS images", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		osImage, err := h.GetLatestOsImage(common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
+		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+	})
 
-			architectures = h.GetCPUArchitectures("4.9")
-			Expect(architectures).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture, common.ARM64CPUArchitecture}))
+	It("fails to get OS images for multiarch", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		osImage, err := h.GetLatestOsImage(common.MultiCPUArchitecture)
+		Expect(err).Should(HaveOccurred())
+		Expect(osImage).Should(BeNil())
+		Expect(err.Error()).To(ContainSubstring("No OS images are available"))
+	})
+})
 
-			architectures = h.GetCPUArchitectures("4.9.1")
-			Expect(architectures).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture, common.ARM64CPUArchitecture}))
-		})
+var _ = Describe("GetOsImageOrLatest", func() {
+	var h *handler
 
-		It("empty architecture fallback to default", func() {
-			osImages = &models.OsImages{
-				&models.OsImage{
-					CPUArchitecture:  swag.String(""),
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("rhcos_4.9"),
-					Version:          swag.String("version-49.123-0"),
-				},
-				&models.OsImage{
-					CPUArchitecture:  nil,
-					OpenshiftVersion: swag.String("4.9"),
-					URL:              swag.String("rhcos_4.9"),
-					Version:          swag.String("version-49.123-0"),
-				},
-			}
-			h, err = NewHandler(logger, mockRelease, versions, *osImages, models.ReleaseImages{}, nil, "", authzHandler)
-			Expect(err).ShouldNot(HaveOccurred())
+	BeforeEach(func() {
+		var err error
+		h, err = NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).To(BeNil())
+	})
 
-			for _, key := range h.GetOpenshiftVersions() {
-				architectures = h.GetCPUArchitectures(key)
-				Expect(architectures).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture}))
-			}
-		})
+	It("successfully gets an OS image with a valid openshift version and cpu architecture", func() {
+		osImage, err := h.GetOsImageOrLatest("4.9", common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).To(BeNil())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.9"))
+		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+	})
+
+	It("successfully gets the latest OS image with a valid cpu architecture", func() {
+		osImage, err := h.GetOsImageOrLatest("", common.TestDefaultConfig.CPUArchitecture)
+		Expect(err).To(BeNil())
+		Expect(*osImage.OpenshiftVersion).Should(Equal("4.11.1"))
+		Expect(*osImage.CPUArchitecture).Should(Equal(common.TestDefaultConfig.CPUArchitecture))
+	})
+
+	It("fails to get OS images for invalid cpu architecture and valid openshift version", func() {
+		osImage, err := h.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866")
+		Expect(err).ToNot(BeNil())
+		Expect(osImage).Should(BeNil())
+	})
+
+	It("fails to get OS images for invalid cpu architecture and invalid openshift version", func() {
+		osImage, err := h.GetOsImageOrLatest(common.TestDefaultConfig.OpenShiftVersion, "x866")
+		Expect(err).ToNot(BeNil())
+		Expect(osImage).Should(BeNil())
+	})
+
+	It("fails to get OS images for invalid cpu architecture and no openshift version", func() {
+		osImage, err := h.GetOsImageOrLatest("", "x866")
+		Expect(err).ToNot(BeNil())
+		Expect(osImage).Should(BeNil())
+	})
+})
+
+var _ = Describe("NewHandler", func() {
+	var (
+		osImages      models.OsImages
+		releaseImages models.ReleaseImages
+	)
+
+	BeforeEach(func() {
+		osImages = models.OsImages{
+			&models.OsImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9"),
+				Version:          swag.String("version-49.123-0"),
+			},
+			&models.OsImage{
+				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9_arm64"),
+				Version:          swag.String("version-49.123-0_arm64"),
+			},
+		}
+
+		releaseImages = models.ReleaseImages{
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("release_4.9"),
+				Version:          swag.String("4.9-candidate"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("release_4.9_arm64"),
+				Version:          swag.String("4.9-candidate_arm64"),
+			},
+		}
+	})
+
+	It("both images specified", func() {
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("only OS images specified", func() {
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("missing URL in OS images", func() {
+		osImages[0].URL = nil
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("url"))
+	})
+
+	It("missing Version in OS images", func() {
+		osImages[0].Version = nil
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("version"))
+	})
+
+	It("missing CPUArchitecture in Release images", func() {
+		releaseImages[0].CPUArchitecture = nil
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("cpu_architecture"))
+	})
+
+	It("missing URL in Release images", func() {
+		releaseImages[0].URL = nil
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("url"))
+	})
+
+	It("missing Version in Release images", func() {
+		releaseImages[0].Version = nil
+		_, err := NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("version"))
+	})
+
+	It("empty osImages and openshiftVersions", func() {
+		_, err := NewHandler(common.GetTestLog(), nil, models.OsImages{}, releaseImages, nil, "")
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("No OS images are available"))
+	})
+})
+
+var _ = Describe("GetCPUArchitectures", func() {
+	It("returns an empty list for an unsupported version", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(h.GetCPUArchitectures("unsupported")).To(BeEmpty())
+	})
+
+	It("multiple CPU architectures", func() {
+		h, err := NewHandler(common.GetTestLog(), nil, defaultOsImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(h.GetCPUArchitectures("4.9")).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture, common.ARM64CPUArchitecture}))
+		Expect(h.GetCPUArchitectures("4.9.1")).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture, common.ARM64CPUArchitecture}))
+	})
+
+	It("empty architecture fallback to default", func() {
+		osImages := models.OsImages{
+			&models.OsImage{
+				CPUArchitecture:  swag.String(""),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9"),
+				Version:          swag.String("version-49.123-0"),
+			},
+			&models.OsImage{
+				CPUArchitecture:  nil,
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9"),
+				Version:          swag.String("version-49.123-0"),
+			},
+		}
+		h, err := NewHandler(common.GetTestLog(), nil, osImages, models.ReleaseImages{}, nil, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		for _, key := range h.GetOpenshiftVersions() {
+			Expect(h.GetCPUArchitectures(key)).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture}))
+		}
 	})
 })
 
@@ -1176,105 +873,5 @@ var _ = Describe("toMajorMinor", func() {
 		res, err := toMajorMinor("ere.654.45")
 		Expect(err).Should(HaveOccurred())
 		Expect(res).Should(Equal(""))
-	})
-})
-
-func hasMultiarch(versions models.OpenshiftVersions) bool {
-	hasMultiarch := false
-	for _, version := range versions {
-		if strings.HasSuffix(*version.DisplayName, "-multi") {
-			hasMultiarch = true
-			break
-		}
-	}
-	return hasMultiarch
-}
-
-var _ = Describe("Test list versions with capability restrictions", func() {
-	var (
-		h             *handler
-		err           error
-		db            *gorm.DB
-		dbName        string
-		cfg           *auth.Config
-		mockOcmAuthz  *ocm.MockOCMAuthorization
-		mockOcmClient *ocm.Client
-		authzHandler  auth.Authorizer
-		authCtx       context.Context
-		payload       *ocm.AuthPayload
-		orgID1        = "300F3CE2-F122-4DA5-A845-2A4BC5956996"
-		userName1     = "test_user_1"
-		ctx           = context.Background()
-	)
-
-	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		db, dbName = common.PrepareTestDB()
-		cfg = auth.GetConfigRHSSO()
-
-		mockOcmAuthz = ocm.NewMockOCMAuthorization(ctrl)
-		h, err = NewHandler(common.GetTestLog(), nil, Versions{}, defaultOsImages, models.ReleaseImages{}, nil, "", authzHandler)
-		Expect(err).ShouldNot(HaveOccurred())
-		h.releaseImages = defaultReleaseImages
-		payload = &ocm.AuthPayload{
-			Username:     userName1,
-			Organization: orgID1,
-			Role:         ocm.UserRole,
-		}
-		authCtx = context.WithValue(ctx, restapi.AuthKey, payload)
-		mockAccountsMgmt = ocm.NewMockOCMAccountsMgmt(ctrl)
-
-		mockAMSSubscription(authCtx)
-		mockOcmClient = &ocm.Client{Cache: cache.New(10*time.Minute, 30*time.Minute), Authorization: mockOcmAuthz}
-	})
-
-	AfterEach(func() {
-		common.DeleteTestDB(db, dbName)
-	})
-
-	Context("V2ListSupportedOpenshiftVersions", func() {
-		It("returns multiarch with multiarch capability", func() {
-			cfg.EnableOrgBasedFeatureGates = true
-			h.authzHandler = auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog().WithField("pkg", "auth"), db)
-
-			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(true, nil).Times(1)
-			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			Expect(hasMultiarch(val.Payload)).To(BeTrue())
-		})
-		It("does not return multiarch without multiarch capability", func() {
-			cfg.EnableOrgBasedFeatureGates = true
-			h.authzHandler = auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog().WithField("pkg", "auth"), db)
-
-			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, nil).Times(1)
-			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			Expect(hasMultiarch(val.Payload)).To(BeFalse())
-		})
-		It("does not return multiarch when capability query fails", func() {
-			cfg.EnableOrgBasedFeatureGates = true
-			h.authzHandler = auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog().WithField("pkg", "auth"), db)
-
-			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, errors.New("failed to query capability")).Times(1)
-			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			Expect(hasMultiarch(val.Payload)).To(BeFalse())
-		})
-		It("returns multiarch with org-based features disabled", func() {
-			cfg.EnableOrgBasedFeatureGates = false
-			h.authzHandler = auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog().WithField("pkg", "auth"), db)
-
-			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
-			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
-
-			val, _ := reply.(*operations.V2ListSupportedOpenshiftVersionsOK)
-			Expect(hasMultiarch(val.Payload)).To(BeTrue())
-		})
 	})
 })


### PR DESCRIPTION
Tracking versions generally and specifically responding to API requests are very different things. There's no reason for these methods to be on the same struct.

Compose the objects instead of reusing one.

Part of the ongoing versions handler refactor.
The entire thing can be found [here](https://github.com/openshift/assisted-service/pull/4645)

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
