### PR TITLE
NO-ISSUE: use two logger instance for generic and ocm logging

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -34,9 +34,6 @@ parameters:
 - name: OCM_BASE_URL
   value: ''
   required: true
-- name: OCM_LOG_LEVEL
-  value: "info"
-  required: false
 - name: S3_USE_SSL
   value: "true"
 - name: ENABLE_AUTO_ASSIGN
@@ -322,8 +319,6 @@ objects:
                 value: ${ALLOWED_DOMAINS}
               - name: OCM_BASE_URL
                 value: ${OCM_BASE_URL}
-              - name: OCM_LOG_LEVEL
-                value: ${OCM_LOG_LEVEL}
               - name: HW_VALIDATOR_REQUIREMENTS
                 value: ${HW_VALIDATOR_REQUIREMENTS}
               - name: INSTALLER_IMAGE

--- a/pkg/ocm/client.go
+++ b/pkg/ocm/client.go
@@ -30,7 +30,6 @@ type Config struct {
 	ClientSecret string `envconfig:"OCM_SERVICE_CLIENT_SECRET" default:""`
 	SelfToken    string `envconfig:"OCM_SELF_TOKEN" default:""`
 	TokenURL     string `envconfig:"OCM_TOKEN_URL" default:""`
-	LogLevel     string `envconfig:"OCM_LOG_LEVEL" default:"info"`
 }
 
 type SdKLogger struct {
@@ -77,9 +76,6 @@ func (l *SdKLogger) Fatal(ctx context.Context, format string, args ...interface{
 func NewClient(config Config, log logrus.FieldLogger) (*Client, error) {
 	entry := log.(*logrus.Entry)
 	logger := &SdKLogger{Log: entry.Logger, FieldLogger: log}
-	if logLevel, err := logrus.ParseLevel(config.LogLevel); err == nil {
-		logger.Log.SetLevel(logLevel)
-	}
 
 	client := &Client{
 		Config: &config,


### PR DESCRIPTION
After https://github.com/openshift/assisted-service/pull/4712 setting log level was racing between OCM logger and generic loger.

The idea is to instantiate two new instances of the logger so we can have independent settings.


Signed-off-by: Riccardo piccoli <rpiccoli@redhat.com>

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
