### PR TITLE
Revert "OKD-90: Support automated extraction of OKD RPMs (#4650)"

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -297,7 +297,7 @@ func main() {
 	failOnError(err, "failed to create Versions handler")
 	domainHandler := domains.NewHandler(Options.BMConfig.BaseDNSDomains)
 	staticNetworkConfig := staticnetworkconfig.New(log.WithField("pkg", "static_network_config"), Options.StaticNetworkConfig)
-	ignitionBuilder, err := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder, releaseHandler, versionHandler)
+	ignitionBuilder, err := ignition.NewBuilder(log.WithField("pkg", "ignition"), staticNetworkConfig, mirrorRegistriesBuilder)
 	failOnError(err, "failed to create ignition builder")
 	installConfigBuilder := installcfg.NewInstallConfigBuilder(log.WithField("pkg", "installcfg"), mirrorRegistriesBuilder, providerRegistry)
 

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -35,10 +35,8 @@ import (
 	"github.com/openshift/assisted-service/internal/installercache"
 	"github.com/openshift/assisted-service/internal/manifests"
 	"github.com/openshift/assisted-service/internal/network"
-	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/provider/registry"
-	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	logutil "github.com/openshift/assisted-service/pkg/log"
@@ -150,6 +148,10 @@ do
     sleep 5
 done
 mnt=$(podman image mount "${RPMS_IMAGE}")
+# Extract machine-config-daemon binary
+cp -rvf ${mnt}/binaries/machine-config-daemon /usr/local/bin/machine-config-daemon
+chmod a+x /usr/local/bin/machine-config-daemon
+restorecon -Rv /usr/local/bin/machine-config-daemon
 # Install RPMs in overlayed FS
 mkdir /tmp/rpms
 cp -rvf ${mnt}/rpms/* /tmp/rpms
@@ -166,9 +168,6 @@ fi
 losetup -c /dev/loop0
 xfs_growfs /var
 mount -o remount,size=6G /run
-# Symlink kubelet pull secret
-mkdir -p /var/lib/kubelet
-ln -s /root/.docker/config.json /var/lib/kubelet/config.json
 `
 
 const okdHoldAgentUntilBinariesLanded = `[Unit]
@@ -248,12 +247,10 @@ type ignitionBuilder struct {
 	templates               *template.Template
 	staticNetworkConfig     staticnetworkconfig.StaticNetworkConfig
 	mirrorRegistriesBuilder mirrorregistries.MirrorRegistriesConfigBuilder
-	ocRelease               oc.Release
-	versionHandler          versions.Handler
 }
 
 func NewBuilder(log logrus.FieldLogger, staticNetworkConfig staticnetworkconfig.StaticNetworkConfig,
-	mirrorRegistriesBuilder mirrorregistries.MirrorRegistriesConfigBuilder, ocRelease oc.Release, versionHandler versions.Handler) (result IgnitionBuilder, err error) {
+	mirrorRegistriesBuilder mirrorregistries.MirrorRegistriesConfigBuilder) (result IgnitionBuilder, err error) {
 	// Parse the templates file system:
 	templates, err := loadTemplates()
 	if err != nil {
@@ -266,8 +263,6 @@ func NewBuilder(log logrus.FieldLogger, staticNetworkConfig staticnetworkconfig.
 		templates:               templates,
 		staticNetworkConfig:     staticNetworkConfig,
 		mirrorRegistriesBuilder: mirrorRegistriesBuilder,
-		ocRelease:               ocRelease,
-		versionHandler:          versionHandler,
 	}
 	return
 }
@@ -1448,24 +1443,6 @@ func SetHostnameForNodeIgnition(ignition []byte, host *models.Host) ([]byte, err
 	return configBytes, nil
 }
 
-func (ib *ignitionBuilder) shouldAppendOKDFiles(ctx context.Context, infraEnv *common.InfraEnv, cfg IgnitionConfig) (string, bool) {
-	// Use OKD override if OKD_RPMS_IMAGE explicitly set in config
-	if cfg.OKDRPMsImage != "" {
-		return cfg.OKDRPMsImage, true
-	}
-	// Check if selected payload contains `okd-rpms` image
-	releaseImage, err := ib.versionHandler.GetReleaseImage(infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
-	if err != nil {
-		ib.log.Warnf("unable to find release image for %s/%s", infraEnv.OpenshiftVersion, infraEnv.CPUArchitecture)
-		return "", false
-	}
-	okdRpmsImage, err := ib.ocRelease.GetOKDRPMSImage(ib.log, *releaseImage.URL, "", infraEnv.PullSecret)
-	if err != nil {
-		return "", false
-	}
-	return okdRpmsImage, true
-}
-
 func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infraEnv *common.InfraEnv, cfg IgnitionConfig, safeForLogs bool, authType auth.AuthType, overrideDiscoveryISOType string) (string, error) {
 	pullSecretToken, err := clusterPkg.AgentToken(infraEnv, authType)
 	if err != nil {
@@ -1553,8 +1530,8 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		ignitionParams["MirrorRegistriesCAConfig"] = base64.StdEncoding.EncodeToString(caContents)
 	}
 
-	if okdRpmsImage, ok := ib.shouldAppendOKDFiles(ctx, infraEnv, cfg); ok {
-		okdBinariesOverlay := fmt.Sprintf(okdBinariesOverlayTemplate, okdRpmsImage)
+	if cfg.OKDRPMsImage != "" {
+		okdBinariesOverlay := fmt.Sprintf(okdBinariesOverlayTemplate, cfg.OKDRPMsImage)
 		ignitionParams["OKDBinaries"] = base64.StdEncoding.EncodeToString([]byte(okdBinariesOverlay))
 		ignitionParams["OKDHoldPivot"] = base64.StdEncoding.EncodeToString([]byte(okdHoldPivot))
 		ignitionParams["OKDHoldAgent"] = base64.StdEncoding.EncodeToString([]byte(okdHoldAgentUntilBinariesLanded))

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -24,10 +24,8 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/installcfg"
-	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/provider/registry"
-	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
@@ -976,8 +974,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		mockStaticNetworkConfig           *staticnetworkconfig.MockStaticNetworkConfig
 		mockMirrorRegistriesConfigBuilder *mirrorregistries.MockMirrorRegistriesConfigBuilder
 		infraEnvID                        strfmt.UUID
-		mockOcRelease                     *oc.MockRelease
-		mockVersionHandler                *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -986,15 +982,13 @@ var _ = Describe("IgnitionBuilder", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
-		mockOcRelease = oc.NewMockRelease(ctrl)
-		mockVersionHandler = versions.NewMockHandler(ctrl)
 		infraEnv = common.InfraEnv{InfraEnv: models.InfraEnv{
 			ID:            &infraEnvID,
 			PullSecretSet: false,
 		}, PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}"}
 		//cluster.ImageInfo = &models.ImageInfo{}
 		var err error
-		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder, mockOcRelease, mockVersionHandler)
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -1017,7 +1011,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		It("ignition_file_contains_pull_secret_token", func() {
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 			Expect(err).Should(BeNil())
@@ -1027,7 +1020,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("auth_disabled_no_pull_secret_token", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeNone, "")
 
 		Expect(err).Should(BeNil())
@@ -1038,7 +1030,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1049,7 +1040,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, true, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1060,7 +1050,6 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("enabled_cert_verification", func() {
 		config := IgnitionConfig{SkipCertVerification: false}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1070,7 +1059,6 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("disabled_cert_verification", func() {
 		config := IgnitionConfig{SkipCertVerification: true}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1079,7 +1067,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("cert_verification_enabled_by_default", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1097,7 +1084,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1115,7 +1101,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		serviceBaseURL := "file://10.56.20.70:7878"
 		config := IgnitionConfig{ServiceBaseURL: serviceBaseURL}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1124,7 +1109,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition v3.1 spec by default", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1137,7 +1121,6 @@ var _ = Describe("IgnitionBuilder", func() {
 	// TODO(deprecate-ignition-3.1.0)
 	It("produces a valid ignition v3.1 spec with overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1148,7 +1131,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1161,7 +1143,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition spec with internal overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1174,7 +1155,6 @@ var _ = Describe("IgnitionBuilder", func() {
 		ironicIgn := `{ "ignition": { "version": "3.2.0" }, "storage": { "files": [ { "group": { }, "overwrite": false, "path": "/etc/ironic-python-agent.conf", "user": { }, "contents": { "source": "data:text/plain,%0A%5BDEFAULT%5D%0Aapi_url%20%3D%20https%3A%2F%2Fironic.redhat.com%3A6385%0Ainspection_callback_url%20%3D%20https%3A%2F%2Fironic.redhat.com%3A5050%2Fv1%2Fcontinue%0Ainsecure%20%3D%20True%0A%0Acollect_lldp%20%3D%20True%0Aenable_vlan_interfaces%20%3D%20all%0Ainspection_collectors%20%3D%20default%2Cextra-hardware%2Clogs%0Ainspection_dhcp_all_interfaces%20%3D%20True%0A", "verification": { } }, "mode": 420 } ] }, "systemd": { "units": [ { "contents": "[Unit]\nDescription=Ironic Agent\nAfter=network-online.target\nWants=network-online.target\n[Service]\nEnvironment=\"HTTP_PROXY=\"\nEnvironment=\"HTTPS_PROXY=\"\nEnvironment=\"NO_PROXY=\"\nTimeoutStartSec=0\nExecStartPre=/bin/podman pull some-ironic-image --tls-verify=false --authfile=/etc/authfile.json\nExecStart=/bin/podman run --privileged --network host --mount type=bind,src=/etc/ironic-python-agent.conf,dst=/etc/ironic-python-agent/ignition.conf --mount type=bind,src=/dev,dst=/dev --mount type=bind,src=/sys,dst=/sys --mount type=bind,src=/run/dbus/system_bus_socket,dst=/run/dbus/system_bus_socket --mount type=bind,src=/,dst=/mnt/coreos --env \"IPA_COREOS_IP_OPTIONS=ip=dhcp\" --name ironic-agent somce-ironic-image\n[Install]\nWantedBy=multi-user.target\n", "enabled": true, "name": "ironic-agent.service" } ] } }`
 		infraEnv.IgnitionConfigOverride = ironicIgn
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(text).Should(ContainSubstring("ironic-agent.service"))
@@ -1190,7 +1170,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 	It("produces a valid ignition spec with v3.2 overrides", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1202,7 +1181,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "3.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err = builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1216,7 +1194,6 @@ var _ = Describe("IgnitionBuilder", func() {
 	It("fails when given overrides with an incompatible version", func() {
 		infraEnv.IgnitionConfigOverride = `{"ignition": {"version": "2.2.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		_, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 
 		Expect(err).To(HaveOccurred())
@@ -1238,7 +1215,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).Should(ContainSubstring("/tmp/example"))
 	})
 
-	It("no multipath for okd - config setting", func() {
+	It("no multipath for okd", func() {
 		config := IgnitionConfig{OKDRPMsImage: "image"}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
@@ -1247,29 +1224,9 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).ShouldNot(ContainSubstring("multipathd"))
 	})
 
-	It("no multipath for okd - okd payload", func() {
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		okdNewImageVersion := "4.12.0-0.okd-2022-11-20-010424"
-		okdNewImageURL := "registry.ci.openshift.org/origin/release:4.12.0-0.okd-2022-11-20-010424"
-		okdNewImage := &models.ReleaseImage{
-			CPUArchitecture:  &common.TestDefaultConfig.CPUArchitecture,
-			OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
-			CPUArchitectures: []string{common.TestDefaultConfig.CPUArchitecture},
-			URL:              &okdNewImageURL,
-			Version:          &okdNewImageVersion,
-		}
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
-		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("quay.io/foo/bar:okd-rpms", nil)
-		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
-
-		Expect(err).Should(BeNil())
-		Expect(text).ShouldNot(ContainSubstring("multipathd"))
-	})
-
 	It("multipath configured for non-okd", func() {
 		config := IgnitionConfig{}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
@@ -1298,7 +1255,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1316,7 +1272,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1333,7 +1288,6 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		It("Will include static network config for minimal iso type in infraenv if overridden in call to FormatDiscoveryIgnitionFile", func() {
 			mockStaticNetworkConfig.EXPECT().GenerateStaticNetworkConfigData(gomock.Any(), formattedInput).Return(staticnetworkConfigOutput, nil).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeMinimalIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
@@ -1355,7 +1309,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			infraEnv.StaticNetworkConfig = formattedInput
 			infraEnv.Type = common.ImageTypePtr(models.ImageTypeFullIso)
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1377,7 +1330,6 @@ var _ = Describe("IgnitionBuilder", func() {
 			mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(true).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return([]byte("some ca config"), nil).Times(1)
 			mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorRegistries().Return([]byte("some mirror registries config"), nil).Times(1)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 			text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, IgnitionConfig{}, false, auth.TypeRHSSO, "")
 			Expect(err).NotTo(HaveOccurred())
 			config, report, err := config_31.Parse([]byte(text))
@@ -1402,8 +1354,6 @@ var _ = Describe("Ignition SSH key building", func() {
 		mockStaticNetworkConfig           *staticnetworkconfig.MockStaticNetworkConfig
 		mockMirrorRegistriesConfigBuilder *mirrorregistries.MockMirrorRegistriesConfigBuilder
 		infraEnvID                        strfmt.UUID
-		mockOcRelease                     *oc.MockRelease
-		mockVersionHandler                *versions.MockHandler
 	)
 	buildIgnitionAndAssertSubString := func(SSHPublicKey string, shouldExist bool, subStr string) {
 		infraEnv.SSHAuthorizedKey = SSHPublicKey
@@ -1421,9 +1371,6 @@ var _ = Describe("Ignition SSH key building", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
-		mockOcRelease = oc.NewMockRelease(ctrl)
-		mockVersionHandler = versions.NewMockHandler(ctrl)
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
 		infraEnv = common.InfraEnv{
 			InfraEnv: models.InfraEnv{
 				ID:            &infraEnvID,
@@ -1433,7 +1380,7 @@ var _ = Describe("Ignition SSH key building", func() {
 		}
 		//cluster.ImageInfo = &models.ImageInfo{}
 		var err error
-		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder, mockOcRelease, mockVersionHandler)
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
 		Expect(err).ToNot(HaveOccurred())
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 	})
@@ -1487,8 +1434,6 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		mockStaticNetworkConfig           *staticnetworkconfig.MockStaticNetworkConfig
 		mockMirrorRegistriesConfigBuilder *mirrorregistries.MockMirrorRegistriesConfigBuilder
 		mockHost                          *models.Host
-		mockOcRelease                     *oc.MockRelease
-		mockVersionHandler                *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -1498,7 +1443,7 @@ var _ = Describe("FormatSecondDayWorkerIgnitionFile", func() {
 		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
 		mockHost = &models.Host{Inventory: hostInventory}
 		var err error
-		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder, mockOcRelease, mockVersionHandler)
+		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -1946,118 +1891,5 @@ var _ = Describe("Set kubelet node ip", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{}
 		basicEnvVars, err = generator.addBootstrapKubeletIpIfRequired(generator.log, basicEnvVars)
 		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("OKD overrides", func() {
-	var (
-		ctrl                               *gomock.Controller
-		infraEnv                           common.InfraEnv
-		builder                            IgnitionBuilder
-		mockStaticNetworkConfig            *staticnetworkconfig.MockStaticNetworkConfig
-		mockMirrorRegistriesConfigBuilder  *mirrorregistries.MockMirrorRegistriesConfigBuilder
-		infraEnvID                         strfmt.UUID
-		mockOcRelease                      *oc.MockRelease
-		mockVersionHandler                 *versions.MockHandler
-		ocpImage, okdOldImage, okdNewImage *models.ReleaseImage
-		defaultCfg, okdCfg                 IgnitionConfig
-	)
-
-	BeforeEach(func() {
-		infraEnvID = strfmt.UUID("a64fff36-dcb1-11ea-87d0-0242ac130003")
-		ctrl = gomock.NewController(GinkgoT())
-		mockStaticNetworkConfig = staticnetworkconfig.NewMockStaticNetworkConfig(ctrl)
-		mockMirrorRegistriesConfigBuilder = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(ctrl)
-		mockVersionHandler = versions.NewMockHandler(ctrl)
-		mockOperatorManager = operators.NewMockAPI(ctrl)
-		mockOcRelease = oc.NewMockRelease(ctrl)
-		infraEnv = common.InfraEnv{
-			InfraEnv: models.InfraEnv{
-				ID:            &infraEnvID,
-				PullSecretSet: false,
-			},
-			PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
-		}
-		var err error
-		builder, err = NewBuilder(log, mockStaticNetworkConfig, mockMirrorRegistriesConfigBuilder, mockOcRelease, mockVersionHandler)
-		Expect(err).ToNot(HaveOccurred())
-		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
-		ocpImage = common.TestDefaultConfig.ReleaseImage
-		okdOldImageVersion := "4.11.0-0.okd-2022-11-19-050030"
-		okdOldImageURL := "quay.io/openshift/okd:4.11.0-0.okd-2022-11-19-050030"
-		okdOldImage = &models.ReleaseImage{
-			CPUArchitecture:  &common.TestDefaultConfig.CPUArchitecture,
-			OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
-			CPUArchitectures: []string{common.TestDefaultConfig.CPUArchitecture},
-			URL:              &okdOldImageURL,
-			Version:          &okdOldImageVersion,
-		}
-		okdNewImageVersion := "4.12.0-0.okd-2022-11-20-010424"
-		okdNewImageURL := "registry.ci.openshift.org/origin/release:4.12.0-0.okd-2022-11-20-010424"
-		okdNewImage = &models.ReleaseImage{
-			CPUArchitecture:  &common.TestDefaultConfig.CPUArchitecture,
-			OpenshiftVersion: &common.TestDefaultConfig.OpenShiftVersion,
-			CPUArchitectures: []string{common.TestDefaultConfig.CPUArchitecture},
-			URL:              &okdNewImageURL,
-			Version:          &okdNewImageVersion,
-		}
-		defaultCfg = IgnitionConfig{}
-		okdCfg = IgnitionConfig{
-			OKDRPMsImage: "quay.io/okd/foo:bar",
-		}
-	})
-
-	checkOKDFiles := func(text string, err error, present bool) {
-		Expect(err).NotTo(HaveOccurred())
-		config, report, err := config_31.Parse([]byte(text))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(report.IsFatal()).To(BeFalse())
-		count := 0
-		for _, f := range config.Storage.Files {
-			if f.Path == "/usr/local/bin/okd-binaries.sh" {
-				count += 1
-				continue
-			}
-			if f.Path == "/etc/systemd/system/release-image-pivot.service.d/wait-for-okd.conf" {
-				count += 1
-				continue
-			}
-			if f.Path == "/etc/systemd/system/agent.service.d/wait-for-okd.conf" {
-				count += 1
-				continue
-			}
-		}
-		if present {
-			Expect(count).Should(Equal(3))
-		} else {
-			Expect(count).Should(Equal(0))
-		}
-	}
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
-	It("OKD_RPMS config option unset", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(ocpImage, nil).Times(1)
-		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
-		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
-		checkOKDFiles(text, err, false)
-	})
-	It("OKD_RPMS config option not set, OKD release has no RPM image", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdOldImage, nil).Times(1)
-		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("some error"))
-		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
-		checkOKDFiles(text, err, false)
-	})
-	It("OKD_RPMS config option set, OKD release has no RPM image", func() {
-		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, okdCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
-		checkOKDFiles(text, err, true)
-	})
-	It("OKD_RPMS config option not set, RPM image present in release payload", func() {
-		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any()).Return(okdNewImage, nil).Times(1)
-		mockOcRelease.EXPECT().GetOKDRPMSImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("quay.io/foo/bar:okd-rpms", nil)
-		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
-		checkOKDFiles(text, err, true)
 	})
 })

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -110,21 +110,6 @@ func (mr *MockReleaseMockRecorder) GetMustGatherImage(log, releaseImage, release
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMustGatherImage", reflect.TypeOf((*MockRelease)(nil).GetMustGatherImage), log, releaseImage, releaseImageMirror, pullSecret)
 }
 
-// GetOKDRPMSImage mocks base method.
-func (m *MockRelease) GetOKDRPMSImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOKDRPMSImage", log, releaseImage, releaseImageMirror, pullSecret)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOKDRPMSImage indicates an expected call of GetOKDRPMSImage.
-func (mr *MockReleaseMockRecorder) GetOKDRPMSImage(log, releaseImage, releaseImageMirror, pullSecret interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOKDRPMSImage", reflect.TypeOf((*MockRelease)(nil).GetOKDRPMSImage), log, releaseImage, releaseImageMirror, pullSecret)
-}
-
 // GetOpenshiftVersion mocks base method.
 func (m *MockRelease) GetOpenshiftVersion(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -28,7 +28,6 @@ const (
 	mcoImageName         = "machine-config-operator"
 	ironicAgentImageName = "ironic-agent"
 	mustGatherImageName  = "must-gather"
-	okdRPMSImageName     = "okd-rpms"
 	DefaultTries         = 5
 	DefaltRetryDelay     = time.Second * 5
 )
@@ -42,7 +41,6 @@ type Config struct {
 type Release interface {
 	GetMCOImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
-	GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMustGatherImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
@@ -93,11 +91,6 @@ func (r *release) GetMCOImage(log logrus.FieldLogger, releaseImage string, relea
 // Else gets it from the source releaseImage
 func (r *release) GetIronicAgentImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
 	return r.getImageByName(log, ironicAgentImageName, releaseImage, releaseImageMirror, pullSecret)
-}
-
-// GetOKDRPMSImage gets okd RPMS image URL from the release image or releaseImageMirror, if provided.
-func (r *release) GetOKDRPMSImage(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error) {
-	return r.getImageByName(log, okdRPMSImageName, releaseImage, releaseImageMirror, pullSecret)
 }
 
 // GetMustGatherImage gets must-gather image URL from the release image or releaseImageMirror, if provided.


### PR DESCRIPTION
This reverts commit cfc9256b05631819144d97d6e1331f82f0a2a4f6.

On QE env `oc adm release info --image-for` is throwing an error and halts the service
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
