### PR TITLE
NO-ISSUE: Fix wrong unit test for CIDR autoallocation

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1321,8 +1321,8 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			}
 			if t.expectedMachineNetworks != nil {
 				Expect(cluster.MachineNetworks).To(HaveLen(len(t.expectedMachineNetworks)))
-				for _, m := range t.expectedMachineNetworks {
-					Expect(t.expectedMachineNetworks).To(ContainElement(m))
+				for i, cidr := range t.expectedMachineNetworks {
+					Expect(string(cluster.MachineNetworks[i].Cidr)).To(Equal(cidr))
 				}
 			}
 


### PR DESCRIPTION
This PR fixes a wrong unit test in the machine network autoallocation. In the current form the test does not compare the cluster value with expected value, but only expected value with itself. This is not a correct behaviour as in order to test the functionality we need to assert cluster's state with a desired state, and not a desired state with itself.

/cc @ori-amizur 