### PR TITLE
MGMT-12863: Assisted Spoke install-config does not generate icsp with multiple mirror to entries

### DIFF
--- a/internal/installcfg/builder/builder.go
+++ b/internal/installcfg/builder/builder.go
@@ -149,7 +149,7 @@ func (i *installConfigBuilder) setImageContentSources(cfg *installcfg.InstallerC
 	}
 	imageContentSourceList := make([]installcfg.ImageContentSource, len(mirrorRegistriesConfigs))
 	for i, mirrorRegistriesConfig := range mirrorRegistriesConfigs {
-		imageContentSourceList[i] = installcfg.ImageContentSource{Source: mirrorRegistriesConfig.Location, Mirrors: []string{mirrorRegistriesConfig.Mirror}}
+		imageContentSourceList[i] = installcfg.ImageContentSource{Source: mirrorRegistriesConfig.Location, Mirrors: mirrorRegistriesConfig.Mirror}
 	}
 	cfg.ImageContentSources = imageContentSourceList
 	return nil

--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -150,7 +150,7 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 
 	It("create_configuration_with_mirror_registries", func() {
 		var result installcfg.InstallerConfigBaremetal
-		regData := []mirrorregistries.RegistriesConf{{Location: "location1", Mirror: "mirror1"}, {Location: "location2", Mirror: "mirror2"}}
+		regData := []mirrorregistries.RegistriesConf{{Location: "location1", Mirror: []string{"mirror1"}}, {Location: "location2", Mirror: []string{"mirror2"}}}
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(true).Times(2)
 		mockMirrorRegistriesConfigBuilder.EXPECT().ExtractLocationMirrorDataFromRegistries().Return(regData, nil).Times(1)
 		mockMirrorRegistriesConfigBuilder.EXPECT().GetMirrorCA().Return([]byte("some sa data"), nil).Times(1)

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -461,7 +461,7 @@ func getIcspContents(mirrorConfig []mirrorregistries.RegistriesConf) ([]byte, er
 
 	icsp.Spec.RepositoryDigestMirrors = make([]operatorv1alpha1.RepositoryDigestMirrors, len(mirrorConfig))
 	for i, mirrorRegistries := range mirrorConfig {
-		icsp.Spec.RepositoryDigestMirrors[i] = operatorv1alpha1.RepositoryDigestMirrors{Source: mirrorRegistries.Location, Mirrors: []string{mirrorRegistries.Mirror}}
+		icsp.Spec.RepositoryDigestMirrors[i] = operatorv1alpha1.RepositoryDigestMirrors{Source: mirrorRegistries.Location, Mirrors: mirrorRegistries.Mirror}
 	}
 
 	// Convert to json first so json tags are handled

--- a/pkg/mirrorregistries/generator.go
+++ b/pkg/mirrorregistries/generator.go
@@ -30,7 +30,7 @@ func New() MirrorRegistriesConfigBuilder {
 
 type RegistriesConf struct {
 	Location string
-	Mirror   string
+	Mirror   []string
 }
 
 // IsMirrorRegistriesConfigured We consider mirror registries to be configured if the following conditions are all met
@@ -97,11 +97,15 @@ func extractLocationMirrorDataFromRegistries(registriesConfToml string) ([]Regis
 		if !ok {
 			return nil, fmt.Errorf("failed to cast mirror key to toml Tree, registriesConfToml: %s", registriesConfToml)
 		}
-		mirror, ok := mirrorTree[0].Get("location").(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to cast mirror location key to string, registriesConfToml: %s", registriesConfToml)
+		var mirrors []string
+		for i := range mirrorTree {
+			currentMirror, ok := mirrorTree[i].Get("location").(string)
+			if !ok {
+				return nil, fmt.Errorf("failed to cast mirror location key to string, registriesConfToml: %s", registriesConfToml)
+			}
+			mirrors = append(mirrors, currentMirror)
 		}
-		registriesConfList[i] = RegistriesConf{Location: location, Mirror: mirror}
+		registriesConfList[i] = RegistriesConf{Location: location, Mirror: mirrors}
 	}
 
 	return registriesConfList, nil

--- a/pkg/mirrorregistries/generator_test.go
+++ b/pkg/mirrorregistries/generator_test.go
@@ -14,7 +14,7 @@ func TestMirrorRegistriesConfig(t *testing.T) {
 }
 
 var (
-	expectedExtractList  = []RegistriesConf{{"location1", "mirror_location1"}, {"location2", "mirror_location2"}, {"location3", "mirror_location3"}}
+	expectedExtractList  = []RegistriesConf{{"location1", []string{"mirror_location1"}}, {"location2", []string{"mirror_location2"}}, {"location3", []string{"mirror_location3"}}}
 	configWithGarbage    = `?;,!`
 	configWithoutMirrors = `unqualified-search-registries = ["registry1", "registry2", "registry3"]`
 	configWithMirrors    = `unqualified-search-registries = ["registry1", "registry2", "registry3"]


### PR DESCRIPTION
/wip
extractLocationMirrorDataFromRegistries had a bug that just picked the first mirror for each sources.
as long the mirror registry was created using `oc adm release mirror` this wasn't an issue since each source had a single mirror.
For some time now customers use `oc-mirror` for creating the mirror registry, `oc-mirror` create few mirrors for a single source and thus triggers the bug in the title.

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? for regression
- Should this PR be tested in a specific environment? disconnected
- Any logs, screenshots, etc that can help with the review process? you can check the install-config.yaml ImageContentSource content

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-12863
- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported? yes to ocm-2.6, ocm-2.7 and release-4.12

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
