### PR TITLE
MGMT-12366: Allow to use UpdateMachineCidr for multiple networks

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -404,7 +404,7 @@ func (m *Manager) tryAssignMachineCidrDHCPMode(cluster *common.Cluster) error {
 		 * Auto assign machine network CIDR is relevant if there is only single host network.  Otherwise the user
 		 * has to select the machine network CIDR
 		 */
-		return UpdateMachineCidr(m.db, cluster, networks[0])
+		return UpdateMachineCidr(m.db, cluster, []string{networks[0]})
 	}
 	return nil
 }
@@ -419,7 +419,7 @@ func (m *Manager) tryAssignMachineCidrNonDHCPMode(cluster *common.Cluster) error
 		return nil
 	}
 
-	return UpdateMachineCidr(m.db, cluster, machineCidr)
+	return UpdateMachineCidr(m.db, cluster, []string{machineCidr})
 }
 
 func (m *Manager) tryAssignMachineCidrSNO(cluster *common.Cluster) error {
@@ -448,7 +448,7 @@ func (m *Manager) tryAssignMachineCidrSNO(cluster *common.Cluster) error {
 			}
 			pendingCidrs = append(pendingCidrs, familyCidrs[0])
 		}
-		return updateMachineNetworks(m.db, cluster, pendingCidrs)
+		return UpdateMachineCidr(m.db, cluster, pendingCidrs)
 	}
 	return nil
 }

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -285,7 +285,7 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr []strin
 						Cidr:      models.Subnet(cidr),
 					}
 					if err := db.Save(machineNetwork).Error; err != nil {
-						err = errors.Wrapf(err, "failed to update cluster machineNetwork %v of cluster %s", *machineNetwork, *cluster.ID)
+						err = errors.Wrapf(err, "failed to update cluster machineNetwork %s of cluster %s", cidr, *cluster.ID)
 						return common.NewApiError(http.StatusInternalServerError, err)
 					}
 				}


### PR DESCRIPTION
Contributes-to: [MGMT-12366](https://issues.redhat.com//browse/MGMT-12366)
Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi 