### PR TITLE
OCPBUGS-1683: Allow setting machine cidr in with UserManagedNetwork set to true

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2530,11 +2530,6 @@ func validateUserManagedNetworkConflicts(params *models.V2ClusterUpdateParams, s
 		log.WithError(err)
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
-	if common.IsSliceNonEmpty(params.MachineNetworks) && !singleNodeCluster {
-		err := errors.Errorf("Machine Network CIDR cannot be set with User Managed Networking")
-		log.WithError(err)
-		return common.NewApiError(http.StatusBadRequest, err)
-	}
 	return nil
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -3978,8 +3978,9 @@ var _ = Describe("cluster", func() {
 					verifyApiErrorString(reply, http.StatusBadRequest, "configuration must include the same number of apiVIPs (got 1) and ingressVIPs (got 0)")
 				})
 
-				It("Fail with Machine CIDR", func() {
+				It("Don't fail with Machine CIDR", func() {
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+					mockSuccess(1)
 					mockClusterUpdatability(1)
 					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
@@ -3988,7 +3989,8 @@ var _ = Describe("cluster", func() {
 							MachineNetworks:       []*models.MachineNetwork{{Cidr: "10.11.0.0/16"}},
 						},
 					})
-					verifyApiErrorString(reply, http.StatusBadRequest, "Machine Network CIDR cannot be set with User Managed Networking")
+
+					Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 				})
 
 				It("Fail with non-x86_64 CPU architecture with 4.10", func() {

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -599,9 +599,11 @@ func (v *validator) belongsToMachineCidr(c *validationContext) (ValidationStatus
 	if c.infraEnv != nil {
 		return ValidationSuccessSuppressOutput, ""
 	}
-	if swag.BoolValue(c.cluster.UserManagedNetworking) && !common.IsSingleNodeCluster(c.cluster) {
+
+	if swag.BoolValue(c.cluster.UserManagedNetworking) && !common.IsSingleNodeCluster(c.cluster) && !c.host.Bootstrap {
 		return ValidationSuccess, "No machine network CIDR validation needed: User Managed Networking"
 	}
+
 	if swag.StringValue(c.cluster.Kind) == models.ClusterKindAddHostsCluster {
 		return ValidationSuccess, "No machine network CIDR validation needed: Day2 cluster"
 	}


### PR DESCRIPTION
Assisted-install failing with None platform when multiple IP interfaces configured
Allow setting machine cidr in with UserManagedNetwork set to true


<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [X] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [X] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
