### PR TITLE
bump version for hacking LSO catalog

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -23,22 +23,22 @@ function install_lso() {
   catalog_source_name="redhat-operators"
 
   OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
-  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.12" && "${DISCONNECTED}" != true ]]; then
-      # LSO has not been published to the 4.12 redhat-operators catalog, so
-      # it cannot be installed on OpenShift 4.12. Until this is resolved,
-      # we explicitly install the 4.11 catalog as redhat-operators-v4-11
-      # and then subscribe to the LSO version from the 4.11 rather than the 4.12 catalog.
-      # TODO: Remove this once LSO is published to the 4.12 catalog.
-      catalog_source_name="redhat-operators-v4-11"
+  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.13" && "${DISCONNECTED}" != true ]]; then
+      # LSO has not been published to the 4.13 redhat-operators catalog, so
+      # it cannot be installed on OpenShift 4.13. Until this is resolved,
+      # we explicitly install the 4.12 catalog as redhat-operators-v4-12
+      # and then subscribe to the LSO version from the 4.12 rather than the 4.13 catalog.
+      # TODO: Bump the versions once LSO is published to the 4.13 catalog.
+      catalog_source_name="redhat-operators-v4-12"
       tee << EOCR >(oc apply -f -)
 kind: CatalogSource
 apiVersion: operators.coreos.com/v1alpha1
 metadata:
-  name: redhat-operators-v4-11
+  name: redhat-operators-v4-12
   namespace: openshift-marketplace
 spec:
-  displayName: Red Hat Operators v4.11
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.11
+  displayName: Red Hat Operators v4.12
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.12
   priority: -100
   publisher: Red Hat
   sourceType: grpc


### PR DESCRIPTION
Instead of removing and re-adding every time a new OCP version gets
introduced, this change just bumps our hack of using 4.12 catalog for
LSO installation to OCP 4.13.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
