### PR TITLE
MGMT-12870: Add missing dual-stack VIP CRUD for KubeAPI

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -11714,7 +11714,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		verifyApiError(reply, http.StatusBadRequest)
 	})
 
-	It("Fail UserManagedNetworking with API Vip and Ingress Vip", func() {
+	It("Fail multi-node UserManagedNetworking with API Vip and Ingress Vip", func() {
 		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 			eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
 			eventstest.WithMessageContainsMatcher("Failed to register cluster. Error: API VIP cannot be set with User Managed Networking"),
@@ -11723,6 +11723,26 @@ var _ = Describe("TestRegisterCluster", func() {
 		clusterParams.UserManagedNetworking = swag.Bool(true)
 		clusterParams.APIVip = "10.35.10.11"
 		clusterParams.IngressVip = "10.35.10.10"
+		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
+			NewClusterParams: clusterParams,
+		})
+		verifyApiError(reply, http.StatusBadRequest)
+	})
+
+	It("Fail SNO (UserManagedNetworking) with API Vip and Ingress Vip", func() {
+		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
+			eventstest.WithMessageContainsMatcher("Failed to register cluster. Error: API VIP cannot be set with User Managed Networking"),
+			eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
+		clusterParams := getDefaultClusterCreateParams()
+		clusterParams.UserManagedNetworking = swag.Bool(true)
+		clusterParams.APIVip = "10.35.10.11"
+		clusterParams.IngressVip = "10.35.10.10"
+		clusterParams.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeNone)
+		clusterParams.OpenshiftVersion = swag.String("4.12")
+		clusterParams.Platform = &models.Platform{
+			Type: common.PlatformTypePtr(models.PlatformTypeNone),
+		}
 		reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
 			NewClusterParams: clusterParams,
 		})

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -763,6 +763,8 @@ var _ = Describe("cluster reconcile", func() {
 				Status:           swag.String(models.ClusterStatusReady),
 				IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 				APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+				IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+				APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 				BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 				SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 				Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -871,6 +873,8 @@ var _ = Describe("cluster reconcile", func() {
 				NetworkType:      swag.String(models.ClusterNetworkTypeOVNKubernetes),
 				APIVip:           aci.Spec.APIVIP,
 				IngressVip:       aci.Spec.IngressVIP,
+				APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(aci.Spec.APIVIP)}},
+				IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(aci.Spec.IngressVIP)}},
 			},
 			PullSecret: testPullSecretVal,
 		}
@@ -1251,6 +1255,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusReady),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -1458,6 +1464,7 @@ var _ = Describe("cluster reconcile", func() {
 					OpenshiftVersion: "4.8",
 					Status:           swag.String(models.ClusterStatusAddingHosts),
 					APIVip:           backEndCluster.APIVip,
+					APIVips:          []*models.APIVip{{ClusterID: *backEndCluster.ID, IP: models.IP(backEndCluster.APIVip)}},
 					BaseDNSDomain:    backEndCluster.BaseDNSDomain,
 					Kind:             swag.String(models.ClusterKindAddHostsCluster),
 					APIVipDNSName:    swag.String(fmt.Sprintf("api.%s.%s", backEndCluster.Name, backEndCluster.BaseDNSDomain)),
@@ -1542,6 +1549,7 @@ var _ = Describe("cluster reconcile", func() {
 					OpenshiftVersion: "4.8",
 					Status:           swag.String(models.ClusterStatusAddingHosts),
 					APIVip:           backEndCluster.APIVip,
+					APIVips:          []*models.APIVip{{ClusterID: *backEndCluster.ID, IP: models.IP(backEndCluster.APIVip)}},
 					BaseDNSDomain:    backEndCluster.BaseDNSDomain,
 					Kind:             swag.String(models.ClusterKindAddHostsCluster),
 					APIVipDNSName:    swag.String(fmt.Sprintf("api.%s.%s", backEndCluster.Name, backEndCluster.BaseDNSDomain)),
@@ -1594,6 +1602,7 @@ var _ = Describe("cluster reconcile", func() {
 					OpenshiftVersion: "4.8",
 					Status:           swag.String(models.ClusterStatusAddingHosts),
 					APIVip:           backEndCluster.APIVip,
+					APIVips:          []*models.APIVip{{ClusterID: *backEndCluster.ID, IP: models.IP(backEndCluster.APIVip)}},
 					BaseDNSDomain:    backEndCluster.BaseDNSDomain,
 					Kind:             swag.String(models.ClusterKindAddHostsCluster),
 					APIVipDNSName:    swag.String(fmt.Sprintf("api.%s.%s", backEndCluster.Name, backEndCluster.BaseDNSDomain)),
@@ -2370,11 +2379,13 @@ var _ = Describe("cluster reconcile", func() {
 
 			installClusterReply := &common.Cluster{
 				Cluster: models.Cluster{
-					ID:         backEndCluster.ID,
-					APIVip:     defaultAgentClusterInstallSpec.APIVIP,
-					IngressVip: defaultAgentClusterInstallSpec.IngressVIP,
-					Status:     swag.String(models.ClusterStatusPreparingForInstallation),
-					StatusInfo: swag.String("Waiting for control plane"),
+					ID:          backEndCluster.ID,
+					APIVip:      defaultAgentClusterInstallSpec.APIVIP,
+					IngressVip:  defaultAgentClusterInstallSpec.IngressVIP,
+					APIVips:     []*models.APIVip{{ClusterID: *backEndCluster.ID, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
+					IngressVips: []*models.IngressVip{{ClusterID: *backEndCluster.ID, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					Status:      swag.String(models.ClusterStatusPreparingForInstallation),
+					StatusInfo:  swag.String("Waiting for control plane"),
 				},
 			}
 			mockInstallerInternal.EXPECT().InstallClusterInternal(gomock.Any(), gomock.Any()).
@@ -2428,6 +2439,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusInsufficient),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -2702,6 +2715,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusInsufficient),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -2786,6 +2801,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusInsufficient),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -2830,6 +2847,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:                 swag.String(models.ClusterStatusInsufficient),
 					IngressVip:             defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:                 defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:            []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:                []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:          defaultClusterSpec.BaseDomain,
 					SSHPublicKey:           defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:         models.ClusterHyperthreadingAll,
@@ -2871,6 +2890,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:                 swag.String(models.ClusterStatusInsufficient),
 					IngressVip:             defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:                 defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:            []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:                []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:          defaultClusterSpec.BaseDomain,
 					SSHPublicKey:           defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:         models.ClusterHyperthreadingAll,
@@ -2916,6 +2937,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusInsufficient),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -2968,6 +2991,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:           swag.String(models.ClusterStatusInsufficient),
 					IngressVip:       defaultAgentClusterInstallSpec.IngressVIP,
 					APIVip:           defaultAgentClusterInstallSpec.APIVIP,
+					IngressVips:      []*models.IngressVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.IngressVIP)}},
+					APIVips:          []*models.APIVip{{ClusterID: sId, IP: models.IP(defaultAgentClusterInstallSpec.APIVIP)}},
 					BaseDNSDomain:    defaultClusterSpec.BaseDomain,
 					SSHPublicKey:     defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:   models.ClusterHyperthreadingAll,
@@ -3007,6 +3032,8 @@ var _ = Describe("cluster reconcile", func() {
 					Status:               swag.String(models.ClusterStatusInstalling),
 					IngressVip:           hostIP,
 					APIVip:               hostIP,
+					IngressVips:          []*models.IngressVip{{ClusterID: sId, IP: models.IP(hostIP)}},
+					APIVips:              []*models.APIVip{{ClusterID: sId, IP: models.IP(hostIP)}},
 					BaseDNSDomain:        defaultClusterSpec.BaseDomain,
 					SSHPublicKey:         defaultAgentClusterInstallSpec.SSHPublicKey,
 					Hyperthreading:       models.ClusterHyperthreadingAll,
@@ -3018,6 +3045,15 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil)
 			mockInstallerInternal.EXPECT().V2DownloadClusterCredentialsInternal(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader("kubeconfig")), int64(len("kubeconfig")), nil).Times(1)
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
+			mockInstallerInternal.EXPECT().UpdateClusterNonInteractive(gomock.Any(), gomock.Any()).
+				Do(func(ctx context.Context, param installer.V2UpdateClusterParams) {
+					Expect(swag.StringValue(param.ClusterUpdateParams.APIVip)).To(Equal(common.TestIPv4Networking.APIVip))
+					Expect(swag.StringValue(param.ClusterUpdateParams.IngressVip)).To(Equal(common.TestIPv4Networking.IngressVip))
+					Expect(len(param.ClusterUpdateParams.APIVips)).To(Equal(1))
+					Expect(len(param.ClusterUpdateParams.IngressVips)).To(Equal(1))
+					Expect(string(param.ClusterUpdateParams.APIVips[0].IP)).To(Equal(common.TestIPv4Networking.APIVip))
+					Expect(string(param.ClusterUpdateParams.IngressVips[0].IP)).To(Equal(common.TestIPv4Networking.IngressVip))
+				}).Return(backEndCluster, nil)
 
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())

--- a/internal/controller/controllers/common.go
+++ b/internal/controller/controllers/common.go
@@ -315,6 +315,30 @@ func machineNetworksEntriesToArray(entries []hiveext.MachineNetworkEntry) []*mod
 	}).([]*models.MachineNetwork)
 }
 
+func apiVipsArrayToStrings(vips []*models.APIVip) []string {
+	return funk.Map(vips, func(vip *models.APIVip) string {
+		return string(vip.IP)
+	}).([]string)
+}
+
+func apiVipsEntriesToArray(entries []string) []*models.APIVip {
+	return funk.Map(entries, func(entry string) *models.APIVip {
+		return &models.APIVip{IP: models.IP(entry)}
+	}).([]*models.APIVip)
+}
+
+func ingressVipsArrayToStrings(vips []*models.IngressVip) []string {
+	return funk.Map(vips, func(vip *models.IngressVip) string {
+		return string(vip.IP)
+	}).([]string)
+}
+
+func ingressVipsEntriesToArray(entries []string) []*models.IngressVip {
+	return funk.Map(entries, func(entry string) *models.IngressVip {
+		return &models.IngressVip{IP: models.IP(entry)}
+	}).([]*models.IngressVip)
+}
+
 func signURL(urlString string, authType auth.AuthType, id string, keyType gencrypto.LocalJWTKeyType) (string, error) {
 	if authType != auth.TypeLocal {
 		return urlString, nil

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -3917,10 +3917,34 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			return aci.Status.APIVIP
 		}, "30s", "1s").Should(Equal(aciSpec.APIVIP))
 
+		By("Ensure APIVIPs exist in status")
+		Eventually(func() int {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return len(aci.Status.APIVIPs)
+		}, "30s", "1s").ShouldNot(Equal(0))
+
+		By("Ensure correct APIVIPs exist in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.APIVIPs[0]
+		}, "30s", "1s").Should(Equal(aciSpec.APIVIP))
+
 		By("Ensure IngressVIP exists in status")
 		Eventually(func() string {
 			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
 			return aci.Status.IngressVIP
+		}, "30s", "1s").Should(Equal(aciSpec.IngressVIP))
+
+		By("Ensure IngressVIPs exists in status")
+		Eventually(func() int {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return len(aci.Status.IngressVIPs)
+		}, "30s", "1s").ShouldNot(Equal(0))
+
+		By("Ensure correct IngressVIPs exist in status")
+		Eventually(func() string {
+			aci := getAgentClusterInstallCRD(ctx, kubeClient, installkey)
+			return aci.Status.IngressVIPs[0]
 		}, "30s", "1s").Should(Equal(aciSpec.IngressVIP))
 
 		By("Complete Installation")


### PR DESCRIPTION
This PR implements a missing CRUD operations to handle dual-stack VIPs in case when KubeAPI is used.

Closes: [MGMT-12870](https://issues.redhat.com//browse/MGMT-12870)
Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi 