### PR TITLE
MGMT-12366: Automatically calculate 2nd Machine Network from 2nd VIP

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -411,16 +411,38 @@ func (m *Manager) tryAssignMachineCidrDHCPMode(cluster *common.Cluster) error {
 }
 
 func (m *Manager) tryAssignMachineCidrNonDHCPMode(cluster *common.Cluster) error {
-	machineCidr, err := network.CalculateMachineNetworkCIDR(
-		cluster.APIVip, cluster.IngressVip, cluster.Hosts, false)
-
+	primaryMachineCidr, err := network.CalculateMachineNetworkCIDR(
+		network.GetApiVipById(cluster, 0), network.GetIngressVipById(cluster, 0), cluster.Hosts, false)
 	if err != nil {
 		return err
-	} else if network.IsMachineCidrAvailable(cluster) && machineCidr == network.GetMachineCidrById(cluster, 0) {
+	} else if primaryMachineCidr == "" && network.CheckIfClusterIsDualStack(cluster) {
+		// This function is running inside the monitoring loop, therefore it only relates to
+		// cases when we autocalculate Machine Networks. In case we run it against a cluster with
+		// no hosts, it will remove currently configured entries (provided e.g. in the creation
+		// payload). In order to prevent this, for a cluster with no hosts we return without any
+		// modifications.
 		return nil
 	}
 
-	return UpdateMachineCidr(m.db, cluster, []string{machineCidr})
+	secondaryMachineCidr, err := network.CalculateMachineNetworkCIDR(
+		network.GetApiVipById(cluster, 1), network.GetIngressVipById(cluster, 1), cluster.Hosts, false)
+	if err != nil {
+		return err
+	}
+
+	// The condition below is preventing a scenario where a cluster has 2 Machine Networks
+	// configured manually, but we can only autocalculate the first one. We need to prevent the
+	// case where we would transparently remove the second network. Therefore we will skip if the
+	// following happens
+	//   * autocalculated 1st machine network is the same as currently configured, and
+	//   * autocalculated 2nd machine network is empty or the same as currently configured
+	if primaryMachineCidr == network.GetMachineCidrById(cluster, 0) &&
+		(secondaryMachineCidr == "" || secondaryMachineCidr == network.GetMachineCidrById(cluster, 1)) {
+
+		return nil
+	}
+
+	return UpdateMachineCidr(m.db, cluster, []string{primaryMachineCidr, secondaryMachineCidr})
 }
 
 func (m *Manager) tryAssignMachineCidrSNO(cluster *common.Cluster) error {

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -859,10 +859,10 @@ var _ = Describe("Auto assign machine CIDR", func() {
 	tests := []struct {
 		name                    string
 		srcState                string
-		machineNetworkCIDR      string
 		expectedMachineCIDR     string
 		expectedMachineNetworks []string
 		apiVip                  string
+		apiVips                 []*models.APIVip
 		hosts                   []*models.Host
 		eventCallExpected       bool
 		userActionResetExpected bool
@@ -871,6 +871,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 		sno                     bool
 		clusterNetworks         []*models.ClusterNetwork
 		serviceNetworks         []*models.ServiceNetwork
+		machineNetworks         []*models.MachineNetwork
 	}{
 		{
 			name:        "No hosts",
@@ -957,7 +958,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "192.168.0.0/16",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}},
 			expectedMachineCIDR:     "192.168.0.0/16",
 			dhcpEnabled:             true,
 		},
@@ -983,6 +984,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			srcState:    models.ClusterStatusPendingForInput,
 			dhcpEnabled: false,
 			apiVip:      "1.2.3.8",
+			apiVips:     []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One discovering host - dhcp disabled",
@@ -994,6 +996,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			dhcpEnabled: false,
 			apiVip:      "1.2.3.8",
+			apiVips:     []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One insufficient host, one network - dhcp disabled",
@@ -1009,6 +1012,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			expectedMachineCIDR:     "1.2.3.0/24",
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "Host with two networks - dhcp disabled",
@@ -1021,6 +1025,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			dhcpEnabled:         false,
 			apiVip:              "1.2.3.8",
+			apiVips:             []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 			expectedMachineCIDR: "1.2.3.0/24",
 		},
 		{
@@ -1041,6 +1046,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			dhcpEnabled:             false,
 			expectedMachineCIDR:     "1.2.3.0/24",
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "Two hosts, one networks - dhcp disabled, user managed networking",
@@ -1059,6 +1065,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			eventCallExpected:       true,
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 			userManagedNetworking:   true,
 		},
 		{
@@ -1079,6 +1086,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			expectedMachineCIDR:     "1.2.3.0/24",
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "Two hosts, two networks - dhcp disabled",
@@ -1096,6 +1104,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			dhcpEnabled:         false,
 			expectedMachineCIDR: "1.2.3.0/24",
 			apiVip:              "1.2.3.8",
+			apiVips:             []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One insufficient host, one network, different machine cidr already set - dhcp disabled",
@@ -1108,10 +1117,11 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "192.168.0.0/16",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}},
 			expectedMachineCIDR:     "1.2.3.0/24",
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One insufficient host, one network, same machine cidr already set - dhcp disabled",
@@ -1124,19 +1134,21 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "1.2.3.0/24",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("1.2.3.0/24")}},
 			expectedMachineCIDR:     "1.2.3.0/24",
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:                    "No hosts, machine cidr already set - dhcp disabled",
 			srcState:                models.ClusterStatusPendingForInput,
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "192.168.0.0/16",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}},
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One insufficient host, no networks, machine cidr already set - dhcp disabled",
@@ -1148,9 +1160,10 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "192.168.0.0/16",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}},
 			dhcpEnabled:             false,
 			apiVip:                  "1.2.3.8",
+			apiVips:                 []*models.APIVip{{IP: models.IP("1.2.3.8")}},
 		},
 		{
 			name:     "One insufficient host, one network, machine cidr already set, no vips - dhcp disabled",
@@ -1163,7 +1176,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			},
 			userActionResetExpected: true,
 			eventCallExpected:       true,
-			machineNetworkCIDR:      "192.168.0.0/16",
+			machineNetworks:         []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}},
 			dhcpEnabled:             false,
 		},
 		{
@@ -1215,6 +1228,43 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			expectedMachineCIDR: "1.2.3.0/24",
 			expectedMachineNetworks: []string{
 				"1.2.3.0/24",
+				"1001:db8::/120",
+			},
+			dhcpEnabled: false,
+		},
+		{
+			name:     "Pending multi-node dual-stack with dual-stack VIPs - autocalculation of machine networks",
+			srcState: models.ClusterStatusPendingForInput,
+			hosts: []*models.Host{
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+				{
+					Status:    swag.String(models.HostStatusInsufficient),
+					Inventory: common.GenerateTestDefaultInventory(),
+				},
+			},
+			clusterNetworks:     common.TestDualStackNetworking.ClusterNetworks,
+			serviceNetworks:     common.TestDualStackNetworking.ServiceNetworks,
+			expectedMachineCIDR: "1.2.3.0/24",
+			expectedMachineNetworks: []string{
+				"1.2.3.0/24",
+				"1001:db8::/120",
+			},
+			apiVip:      "1.2.3.8",
+			apiVips:     []*models.APIVip{{IP: models.IP("1.2.3.8")}, {IP: models.IP("1001:db8::8")}},
+			dhcpEnabled: false,
+		},
+		{
+			name:                "No hosts, dual-stack - don't remove machine networks",
+			srcState:            models.ClusterStatusPendingForInput,
+			clusterNetworks:     common.TestIPv6Networking.ClusterNetworks,
+			serviceNetworks:     common.TestIPv6Networking.ServiceNetworks,
+			machineNetworks:     []*models.MachineNetwork{{Cidr: models.Subnet("192.168.0.0/16")}, {Cidr: models.Subnet("1001:db8::/120")}},
+			expectedMachineCIDR: "192.168.0.0/16",
+			expectedMachineNetworks: []string{
+				"192.168.0.0/16",
 				"1001:db8::/120",
 			},
 			dhcpEnabled: false,
@@ -1276,9 +1326,10 @@ var _ = Describe("Auto assign machine CIDR", func() {
 				BaseDNSDomain:         "test.com",
 				PullSecretSet:         true,
 				APIVip:                t.apiVip,
+				APIVips:               t.apiVips,
 				ClusterNetworks:       common.TestIPv4Networking.ClusterNetworks,
 				ServiceNetworks:       common.TestIPv4Networking.ServiceNetworks,
-				MachineNetworks:       network.CreateMachineNetworksArray(t.machineNetworkCIDR),
+				MachineNetworks:       t.machineNetworks,
 				VipDhcpAllocation:     swag.Bool(t.dhcpEnabled),
 				UserManagedNetworking: swag.Bool(t.userManagedNetworking),
 			}}


### PR DESCRIPTION
This PR extends the cluster monitoring loop for scenarios where a cluster is using dual-stack and has dual-stack VIPs configured. In this case we will use available hosts' inventory in order to calculate both Machine Networks based on the VIPs configured.

This extends the current flow in which we only ever use the first pair of VIPs to calculate machine networks. In the current flow it can also happen that by mistake we remove the 2nd machine network for a dual-stack cluster manually configured. This is a bug that we are fixing with this change.

Contributes-to: [MGMT-12366](https://issues.redhat.com//browse/MGMT-12366)
Contributes-to: [MGMT-9915](https://issues.redhat.com//browse/MGMT-9915)
Implements: #4245

/cc @nmagnezi 
/cc @omertuc 