### PR TITLE
OCPBUGS-2953: Fix regex to filter images by tag and by sha

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -136,7 +136,7 @@ const agentFixBZ1964591 = `#!/usr/bin/sh
 # In such a scenario agent.service will detect the image is not present and pull it again. In case
 # the image is present and can be detected correctly, no any action is required.
 
-IMAGE=$(echo $1 | sed 's/:.*//')
+IMAGE=$(echo $1 | sed 's/[@:].*//')
 podman images | grep $IMAGE || podman rmi --force $1 || true
 `
 


### PR DESCRIPTION
This PR modifies the regex expression that we use to extract the name of the image. The previous version worked only with images passed via tag, but did not support images passed by SHA. With this modification we now support both naming schemas.

/cc @omertuc 