### PR TITLE
MGMT-12886: fetch CRDs by group in HASC ctrl

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -169,7 +169,6 @@ func main() {
 		},
 		Client:       mgr.GetClient(),
 		SpokeClients: spokeClientCache,
-		Namespace:    ns,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HypershiftAgentServiceConfig")
 		os.Exit(1)

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller_test.go
@@ -115,12 +115,12 @@ var _ = Describe("HypershiftAgentServiceConfig reconcile", func() {
 		c := &apiextensionsv1.CustomResourceDefinition{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: testCRDName,
-				Labels: map[string]string{
-					fmt.Sprintf("operators.coreos.com/assisted-service-operator.%s", testNamespace): "",
-				},
+				Name:   testCRDName,
+				Labels: map[string]string{},
 			},
-			Spec:   apiextensionsv1.CustomResourceDefinitionSpec{},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "agent-install.openshift.io",
+			},
 			Status: apiextensionsv1.CustomResourceDefinitionStatus{},
 		}
 		c.ResourceVersion = ""


### PR DESCRIPTION
In HypershiftAgentServiceConfigReconciler, we fetch the agent-install CRDs by filtering using the label added by OLM ('operators.coreos.com/assisted-service-operator.[ns]').

However, MCE are [applying](https://github.com/stolostron/backplane-operator/blob/main/main.go#L148-L164) the [CRDs](https://github.com/stolostron/backplane-operator/tree/main/pkg/templates/crds/assisted-service) (scraped from [community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod/tree/main/operators/assisted-service-operator/0.4.50)) manually without using OLM.
Hence, no labels exist in the CRDs. So instead of relying on the label, search for relevent CRDs according to 'agent-install.openshift.io' group.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
