### PR TITLE
MGMT-12237: Clean duplicated upgrade agent events

### DIFF
--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -68,6 +68,11 @@ type Cluster struct {
 type Event struct {
 	gorm.Model
 	models.Event
+
+	// Copies is the number of copies of this event that have been previously detected and
+	// deduplicated. If the value is one it means that there is only one copy and the event
+	// has never been deduplicated.
+	Copies int32 `gorm:"type:integer;not null;default:1"`
 }
 
 type Host struct {

--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -15,7 +15,6 @@ type Sender interface {
 	//     host added to cluster, we have the host-ID as the main entityID and
 	//     the cluster-ID as another ID that this event should be related to
 	// Use the prop field to add list of arbitrary key value pairs when additional information is needed (for example: "vendor": "RedHat")
-	AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	V2AddEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{})
 	// Used for events that are not interesting for metrics or for users, but we still
 	// want to raise them for internal notification between systems. e.g. notify kube-api
@@ -25,7 +24,6 @@ type Sender interface {
 	NotifyInternalEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, msg string)
 
 	//Add metric-related event. These events are hidden from the user and has 'metrics' Category field
-	AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	V2AddMetricsEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{})
 
 	SendClusterEvent(ctx context.Context, event ClusterEvent)

--- a/internal/events/api/mock_event.go
+++ b/internal/events/api/mock_event.go
@@ -37,40 +37,6 @@ func (m *MockSender) EXPECT() *MockSenderMockRecorder {
 	return m.recorder
 }
 
-// AddEvent mocks base method.
-func (m *MockSender) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddEvent", varargs...)
-}
-
-// AddEvent indicates an expected call of AddEvent.
-func (mr *MockSenderMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockSender)(nil).AddEvent), varargs...)
-}
-
-// AddMetricsEvent mocks base method.
-func (m *MockSender) AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddMetricsEvent", varargs...)
-}
-
-// AddMetricsEvent indicates an expected call of AddMetricsEvent.
-func (mr *MockSenderMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockSender)(nil).AddMetricsEvent), varargs...)
-}
-
 // NotifyInternalEvent mocks base method.
 func (m *MockSender) NotifyInternalEvent(ctx context.Context, clusterID, hostID, infraEnvID *strfmt.UUID, msg string) {
 	m.ctrl.T.Helper()
@@ -210,40 +176,6 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
-}
-
-// AddEvent mocks base method.
-func (m *MockHandler) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddEvent", varargs...)
-}
-
-// AddEvent indicates an expected call of AddEvent.
-func (mr *MockHandlerMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockHandler)(nil).AddEvent), varargs...)
-}
-
-// AddMetricsEvent mocks base method.
-func (m *MockHandler) AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddMetricsEvent", varargs...)
-}
-
-// AddMetricsEvent indicates an expected call of AddMetricsEvent.
-func (mr *MockHandlerMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockHandler)(nil).AddMetricsEvent), varargs...)
 }
 
 // NotifyInternalEvent mocks base method.

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -358,8 +358,8 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	// Only record metrics if it's new/changed inventory and the host is associated with a cluster
 	if existingHostInventory == nil || (existingHostInventory != nil && len(physicalInterfaces) != len(existingHostInventory.Interfaces)) {
 		if h.ClusterID != nil {
-			m.eventsHandler.AddMetricsEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, "nic.virtual_interfaces", time.Now(), "count", len(virtualInterfaces), "types", virtualInterfaces)
-			m.eventsHandler.AddMetricsEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, "nic.physical_interfaces", time.Now(), "count", len(physicalInterfaces))
+			m.eventsHandler.V2AddMetricsEvent(ctx, h.ClusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.virtual_interfaces", time.Now(), "count", len(virtualInterfaces), "types", virtualInterfaces)
+			m.eventsHandler.V2AddMetricsEvent(ctx, h.ClusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.physical_interfaces", time.Now(), "count", len(physicalInterfaces))
 		}
 	}
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1143,8 +1143,8 @@ var _ = Describe("UpdateInventory", func() {
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
-				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 				inventoryStr, err := common.MarshalInventory(&test.inventory)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hapi.(*Manager).UpdateInventory(ctx, &host, inventoryStr)).ToNot(HaveOccurred())
@@ -1272,8 +1272,8 @@ var _ = Describe("UpdateInventory", func() {
 					},
 				}
 
-				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(inventory.Disks)
 				if test.expectMatch {
@@ -1432,8 +1432,8 @@ var _ = Describe("UpdateInventory", func() {
 			Expect(inventory.Interfaces).Should(HaveLen(1))
 		})
 		It("Doesn't save virtual interfaces when virtual interface flag is not enabled", func() {
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
@@ -1462,8 +1462,8 @@ var _ = Describe("UpdateInventory", func() {
 			defaultConfig.EnableVirtualInterfaces = true
 			enabled_hapi := NewManager(common.GetTestLog(), db, mockEvents, mockValidator,
 				nil, createValidatorCfg(), nil, defaultConfig, dummy, nil, nil, false, nil)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(enabled_hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
@@ -1484,27 +1484,27 @@ var _ = Describe("UpdateInventory", func() {
 		It("Records metrics for new inventory", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(2, 1)
 			host.Inventory = ""
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 		It("Records metrics for changed inventory", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(3, 1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 		It("Doesn't record metrics for unchanged inventory", func() {
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 		})
 		It("Doesn't record metrics for unbound hosts", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(2, 1)
 			host.Inventory = ""
 			host.ClusterID = nil
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 	})

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -332,7 +332,7 @@ func (m *MetricsManager) InstallationStarted() {
 
 func (m *MetricsManager) ClusterInstallationFinished(ctx context.Context, result string, prevState string, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime) {
 	duration := time.Since(time.Time(installationStartedTime)).Seconds()
-	m.handler.AddMetricsEvent(ctx, clusterID, nil, models.EventSeverityInfo, "cluster.installation.results", time.Now(),
+	m.handler.V2AddMetricsEvent(ctx, &clusterID, nil, nil, "", models.EventSeverityInfo, "cluster.installation.results", time.Now(),
 		"duration", duration, "result", result, "lastState", prevState)
 
 	log := logutil.FromContext(ctx, logrus.New())
@@ -389,7 +389,7 @@ func (m *MetricsManager) ReportHostInstallationMetrics(ctx context.Context, clus
 			}
 			log.Infof("service Logic Host Installation Phase Seconds phase %s, vendor %s product %s disk %s result %s, duration %f",
 				string(previousProgress.CurrentStage), hwVendor, hwProduct, diskType, string(phaseResult), duration)
-			m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.stage.duration", time.Now(),
+			m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "host.stage.duration", time.Now(),
 				"result", string(phaseResult), "duration", duration, "host_stage", string(previousProgress.CurrentStage), "vendor", hwVendor, "product", hwProduct, "disk_type", diskType, "host_role", roleStr)
 
 			m.serviceLogicHostInstallationPhaseSeconds.WithLabelValues(string(previousProgress.CurrentStage),
@@ -427,7 +427,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	m.serviceLogicClusterHostRAMGb.WithLabelValues(roleStr, installationStageStr).
 		Observe(float64(bytesToGib(hwInfo.Memory.PhysicalBytes)))
 
-	m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.mem.cpu", time.Now(),
+	m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "host.mem.cpu", time.Now(),
 		"host_result", installationStageStr, "host_role", roleStr, "mem_bytes", bytesToGib(hwInfo.Memory.PhysicalBytes),
 		"core_count", hwInfo.CPU.Count)
 
@@ -438,7 +438,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 		diskTypeStr := string(disk.DriveType) //+ "-" + disk.StorageController
 		log.Infof("service Logic Cluster Host DiskGb role %s, result %s diskType %s diskSize %d",
 			roleStr, installationStageStr, diskTypeStr, bytesToGib(disk.SizeBytes))
-		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "disk.size.type", time.Now(),
+		m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "disk.size.type", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "disk_type", diskTypeStr, "disk_size", bytesToGib(disk.SizeBytes))
 
 		m.serviceLogicClusterHostDiskGb.WithLabelValues(diskTypeStr, roleStr, installationStageStr).
@@ -448,7 +448,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	for _, inter := range hwInfo.Interfaces {
 		log.Infof("service Logic Cluster Host NicGb role %s, result %s SpeedMbps %f",
 			roleStr, installationStageStr, float64(inter.SpeedMbps))
-		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "nic.speed", time.Now(),
+		m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.speed", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "nic_speed", inter.SpeedMbps)
 
 		m.serviceLogicClusterHostNicGb.WithLabelValues(roleStr, installationStageStr).

--- a/internal/metrics/metricsManager_test.go
+++ b/internal/metrics/metricsManager_test.go
@@ -30,7 +30,9 @@ var _ = DescribeTable(
 		// We are not testing generation of events here, we just need to make sure that the
 		// call to generating metrics doesn't fail:
 		handler := eventsapi.NewMockHandler(ctrl)
-		handler.EXPECT().AddMetricsEvent(
+		handler.EXPECT().V2AddMetricsEvent(
+			gomock.Any(),
+			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),


### PR DESCRIPTION
When agent fails to upgrade the generated events will be generated each
time that the agent asks for next steps, approxy once per minute. This
can fill the collection of events with useless repeated information. To
avoid that this patch changes the event handling so that it will be
possible to define a limit on the rate of creation of events. Events
that exceed that rate will be automatically replaced by a single event
that contains the original message and also the number of repetitions.
For example, the upgrade started event will look like this the fist
time:

```
Host mycluster: Agent has been instructed to download image
'quay.io/myrepo/myagent:14' and restart
```

But if it keeps repeating the copies will be removed and replaced by
something like this:

```
Host mycluster: Agent has been instructed to download image
'quay.io/myrepo/myagent:14' and restart (repeated 42 times)
```

This will be done only for the upgrade agent events, and those will be
limited to one event per hour.

The mechanism used to implement that event cleanup is based on adding a
new `copies` field to the `events` table. When a new event is added the
current number of events will be counted with a query equivalent to this:

```sql
select sum(copies) from events where
  name = 'upgrade_agent_started' and
  event_time > now() - interval '1 hour' and
  cluster_id = '...' and
  host_id = '...' and
  infra_env_id = '...'
```

If the result exceeds the limit, then the events will be deleted, with a
similar query:

```sql
delete events where
  name = 'upgrade_agent_started' and
  event_time > now() - interval '1 hour' and
  cluster_id = '...' and
  host_id = '...' and
  infra_env_id = '...'
```

The new event will then be created with an updated number of copies and
the _repeated X times_ part added to the message.

Related: https://issues.redhat.com/browse/MGMT-12237

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
