### PR TITLE
MGMT-6536: select default cidr in SNO based on default route metrics

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1278,10 +1278,12 @@ var _ = Describe("Auto assign machine CIDR", func() {
 					Inventory: common.GenerateTest2IPv4AddressesInventory(),
 				},
 			},
-			sno:                     true,
-			expectedMachineCIDR:     "",
-			expectedMachineNetworks: []string{},
-			dhcpEnabled:             false,
+			sno:                 true,
+			expectedMachineCIDR: "1.2.3.0/24",
+			expectedMachineNetworks: []string{
+				"1.2.3.0/24",
+			},
+			dhcpEnabled: false,
 		},
 		{
 			name:     "Pending SNO IPv6",

--- a/internal/cluster/common.go
+++ b/internal/cluster/common.go
@@ -272,7 +272,7 @@ func UpdateMachineCidr(db *gorm.DB, cluster *common.Cluster, machineCidr []strin
 		previousSecondaryMachineCidr = network.GetMachineCidrById(cluster, 1)
 	}
 
-	if machineCidr[0] != previousPrimaryMachineCidr || (len(machineCidr) > 1 && machineCidr[1] != previousSecondaryMachineCidr) {
+	if (len(machineCidr) > 0 && machineCidr[0] != previousPrimaryMachineCidr) || (len(machineCidr) > 1 && machineCidr[1] != previousSecondaryMachineCidr) {
 		err := db.Transaction(func(tx *gorm.DB) error {
 			if err := db.Where("cluster_id = ?", *cluster.ID).Delete(&models.MachineNetwork{}).Error; err != nil {
 				err = errors.Wrapf(err, "failed to delete machine networks of cluster %s", *cluster.ID)

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -198,7 +198,7 @@ var TestDomainResolutionsNoAPI = &models.DomainResolutionResponse{Resolutions: D
 var TestDomainResolutionsAllEmpty = &models.DomainResolutionResponse{Resolutions: DomainResolutionAllEmpty}
 var TestDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: WildcardResolved}
 
-var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "192.168.1.1", Destination: "0.0.0.0"}}
+var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "1.2.3.10", Destination: "0.0.0.0", Metric: 600}}
 
 var TestIPv4Networking = TestNetworking{
 	ClusterNetworks: []*models.ClusterNetwork{{Cidr: "1.3.0.0/16", HostPrefix: 24}},

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1156,17 +1156,12 @@ func (v *validator) validateDefaultRoute(routes []*models.Route) bool {
 		if len(r.Destination) == 0 || len(r.Gateway) == 0 {
 			continue
 		}
-		dst := net.ParseIP(r.Destination)
-		if dst == nil {
-			v.log.Errorf("unable to parse destination IP: %s", r.Destination)
+		isDefault, err := network.IsDefaultRoute(r)
+		if err != nil {
+			v.log.Error(err)
 			continue
 		}
-		gw := net.ParseIP(r.Gateway)
-		if gw == nil {
-			v.log.Errorf("unable to parse gateway IP: %s", r.Gateway)
-			continue
-		}
-		if dst.IsUnspecified() && !gw.IsUnspecified() {
+		if isDefault {
 			return true
 		}
 	}

--- a/internal/network/utils.go
+++ b/internal/network/utils.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"sort"
@@ -13,6 +14,20 @@ import (
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
 )
+
+func IsDefaultRoute(r *models.Route) (bool, error) {
+	gw := net.ParseIP(r.Gateway)
+	if gw == nil {
+		return false, nil //gateway is empty for non default routes
+	}
+
+	dst := net.ParseIP(r.Destination)
+	if dst == nil {
+		return false, fmt.Errorf("unable to parse destination IP: %s", r.Destination)
+	}
+
+	return dst.IsUnspecified() && !gw.IsUnspecified(), nil
+}
 
 // Obtains the IP addresses used by a host
 func GetInventoryIPAddresses(inventory *models.Inventory) ([]string, []string) {


### PR DESCRIPTION
## Desciprtion
To enable selecting a recommended CIDR when there are multiple options, we will use the following method:
    
    1. Select the default route(s). Use the Metric field to choose the route with the least cost
    2. Check if the gateway IP is part of any known machine CIDR
    3. Choose this CIDR as the machine network
    
    The network for the default route will also be selected by the OVN after
    rebooting of the bootstrap node regardless of the selection of the user,
    so this mechanism informs the user what network is the best to use
    
#### Example of Route data in the DB:</u>
    routes":[{"destination":"0.0.0.0","family":2,"gateway":"192.168.127.1","interface":"ens3","metric
    ":100},{"destination":"0.0.0.0","family":2,"gateway":"192.168.145.1","interface":"e
    ns4","metric":101},{"destination":"10.88.0.0","family":2,"interface":"cni-podman0"}
    ,{"destination":"192.168.127.0","family":2,"interface":"ens3","metric":100},{"desti
    nation":"192.168.145.0","family":2,"interface":"ens4","metric":101},{"destination":
    "::1","family":10,"interface":"lo","metric":256},{"destination":"fe80::","family":1
    0,"interface":"cni-podman0","metric":256},{"destination":"fe80::","family":10,"inte
    rface":"ens3","metric":1024},{"destination":"fe80::","family":10,"interface":"ens4"
    ,"metric":1024}]
    
    In this case the selected CIDR will be: 192.168.127.0/24 which was
    calculated from the interface {"name": "ens3, "ipv4_addresses":["192.168.127.10/24"],"ipv6_addresses":[] ...}
    
#### Manual Tests
    Delete the machine network from the db and see that the correct route is chosen

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
