### PR TITLE
Document the ironic agent image behavior for converged flow

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -200,11 +200,22 @@ the assisted agent service and let the ironic agent to manage the machine power 
 
 The converged flow is disalbed by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
 
+### Ironic Agent Image
+
+If the InfraEnv is configured with a cluster reference the agent image used during discovery will be the one from the cluster's release image.
+If the InfraEnv does not reference a cluster (late binding) a default ironic agent image will be used.
+The defaults are:
+- x86_64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446`
+- arm64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43`
+
 To set a different default ironicAgent image you can override the following env vars:
 The environment var for the ironicAgent image to be used on X86_64 CPU architecture:
 `IRONIC_AGENT_IMAGE`
 The environment var for the ironicAgent image to be used on arm64 CPU architecture:
 `IRONIC_AGENT_IMAGE_ARM`
+
+**NOTE**
+Ensure the correct images are mirrored if installing in a disconnected environment
 
 [ZTP converged flow](ZTP_converged_flow.png)
 


### PR DESCRIPTION
It not using late binding the ironic agent image is extracted from the spoke cluster release.
If using late binding the image ref is taken from the env vars which can be overridden.

Also add a note to ensure these are mirrored if required.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-10877

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
