### PR TITLE
NO-ISSUE: Pass HA mode of the cluster to network validations

### DIFF
--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -442,6 +442,7 @@ func ValidateClusterCreateIPAddresses(ipV6Supported bool, clusterId strfmt.UUID,
 	targetConfiguration.IngressVips = params.IngressVips
 	targetConfiguration.UserManagedNetworking = params.UserManagedNetworking
 	targetConfiguration.VipDhcpAllocation = params.VipDhcpAllocation
+	targetConfiguration.HighAvailabilityMode = params.HighAvailabilityMode
 	targetConfiguration.ClusterNetworks = params.ClusterNetworks
 	targetConfiguration.ServiceNetworks = params.ServiceNetworks
 	targetConfiguration.MachineNetworks = params.MachineNetworks
@@ -502,6 +503,7 @@ func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Clust
 	targetConfiguration.IngressVips = params.IngressVips
 	targetConfiguration.UserManagedNetworking = params.UserManagedNetworking
 	targetConfiguration.VipDhcpAllocation = params.VipDhcpAllocation
+	targetConfiguration.HighAvailabilityMode = cluster.HighAvailabilityMode
 	targetConfiguration.ClusterNetworks = params.ClusterNetworks
 	targetConfiguration.ServiceNetworks = params.ServiceNetworks
 	targetConfiguration.MachineNetworks = params.MachineNetworks


### PR DESCRIPTION
This PR adds an ability for network validation functions to access the HA mode of the cluster. This will be useful when those validations will have a different logic depending on whether the cluster is SNO or multi-node.

/cc @nmagnezi 