### PR TITLE
MGMT-12755: Disallow periods in cluster name

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -603,7 +603,8 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	}
 	setPullSecret(&cluster, ps)
 
-	if err = validations.ValidateClusterNameFormat(swag.StringValue(params.NewClusterParams.Name)); err != nil {
+	if err = validations.ValidateClusterNameFormat(swag.StringValue(params.NewClusterParams.Name),
+		getPlatformType(params.NewClusterParams.Platform)); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 
@@ -868,7 +869,7 @@ func (b *bareMetalInventory) V2ImportClusterInternal(ctx context.Context, kubeKe
 		KubeKeyNamespace: kubeKey.Namespace,
 	}
 
-	err := validations.ValidateClusterNameFormat(clusterName)
+	err := validations.ValidateClusterNameFormat(clusterName, getPlatformType(newCluster.Platform))
 	if err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
@@ -1777,7 +1778,11 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 	}
 
 	if swag.StringValue(params.ClusterUpdateParams.Name) != "" {
-		if err := validations.ValidateClusterNameFormat(*params.ClusterUpdateParams.Name); err != nil {
+		platform := getPlatformType(params.ClusterUpdateParams.Platform)
+		if platform == "" {
+			platform = getPlatformType(cluster.Platform)
+		}
+		if err := validations.ValidateClusterNameFormat(*params.ClusterUpdateParams.Name, platform); err != nil {
 			return installer.V2UpdateClusterParams{}, err
 		}
 	}

--- a/internal/cluster/validations/validation_test.go
+++ b/internal/cluster/validations/validation_test.go
@@ -212,44 +212,48 @@ func (m *mockOCMAuthorization) CapabilityReview(ctx context.Context, username, c
 }
 
 var _ = Describe("Cluster name validation", func() {
+	const (
+		bareMetalPlatform = string(models.PlatformTypeBaremetal)
+		nonePlatform      = string(models.PlatformTypeNone)
+	)
 	It("valid", func() {
-		err := ValidateClusterNameFormat("test-1")
+		err := ValidateClusterNameFormat("test-1", bareMetalPlatform)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 	It("valid - starts with number", func() {
-		err := ValidateClusterNameFormat("1-test")
+		err := ValidateClusterNameFormat("1-test", bareMetalPlatform)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	It("valid - contains subdomain", func() {
-		err := ValidateClusterNameFormat("test.test")
+	It("valid - contains a period and None platform", func() {
+		err := ValidateClusterNameFormat("test.test", nonePlatform)
 		Expect(err).ShouldNot(HaveOccurred())
+	})
+	It("invalid format - contains a period and not None platform", func() {
+		err := ValidateClusterNameFormat("test.test", bareMetalPlatform)
+		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - special character", func() {
-		err := ValidateClusterNameFormat("test!")
+		err := ValidateClusterNameFormat("test!", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - capital letter", func() {
-		err := ValidateClusterNameFormat("testA")
+		err := ValidateClusterNameFormat("testA", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - starts with capital letter", func() {
-		err := ValidateClusterNameFormat("Test")
+		err := ValidateClusterNameFormat("Test", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - ends with hyphen", func() {
-		err := ValidateClusterNameFormat("test-")
+		err := ValidateClusterNameFormat("test-", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
 	It("invalid format - starts with hyphen", func() {
-		err := ValidateClusterNameFormat("-test")
+		err := ValidateClusterNameFormat("-test", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
-	It("invalid format - starts with dot", func() {
-		err := ValidateClusterNameFormat(".test")
-		Expect(err).Should(HaveOccurred())
-	})
-	It("invalid format - contains two dots in a row", func() {
-		err := ValidateClusterNameFormat("test..test")
+	It("invalid format - starts with a period", func() {
+		err := ValidateClusterNameFormat(".test", bareMetalPlatform)
 		Expect(err).Should(HaveOccurred())
 	})
 })


### PR DESCRIPTION
[MGMT-12755](https://issues.redhat.com/browse/MGMT-12755)
Cluster names containing periods "." are not allowed
by the openshift installer when using a platform that's
not the None platform.

This prevents a cluster name from passing the validation
if it contains any periods and if it's not the None platform.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment: install a cluster with a period in the name (export CLUSTER_NAME=test.cluster) and see that it fails (check the service logs for error message:
```
Failed to registered cluster
```


## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
