### PR TITLE
MGMT-12237: Limit upgrade agent events

### DIFF
--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -15,7 +15,6 @@ type Sender interface {
 	//     host added to cluster, we have the host-ID as the main entityID and
 	//     the cluster-ID as another ID that this event should be related to
 	// Use the prop field to add list of arbitrary key value pairs when additional information is needed (for example: "vendor": "RedHat")
-	AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	V2AddEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{})
 	// Used for events that are not interesting for metrics or for users, but we still
 	// want to raise them for internal notification between systems. e.g. notify kube-api
@@ -25,7 +24,6 @@ type Sender interface {
 	NotifyInternalEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, msg string)
 
 	//Add metric-related event. These events are hidden from the user and has 'metrics' Category field
-	AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity string, msg string, eventTime time.Time, props ...interface{})
 	V2AddMetricsEvent(ctx context.Context, clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID, name string, severity string, msg string, eventTime time.Time, props ...interface{})
 
 	SendClusterEvent(ctx context.Context, event ClusterEvent)

--- a/internal/events/api/mock_event.go
+++ b/internal/events/api/mock_event.go
@@ -37,40 +37,6 @@ func (m *MockSender) EXPECT() *MockSenderMockRecorder {
 	return m.recorder
 }
 
-// AddEvent mocks base method.
-func (m *MockSender) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddEvent", varargs...)
-}
-
-// AddEvent indicates an expected call of AddEvent.
-func (mr *MockSenderMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockSender)(nil).AddEvent), varargs...)
-}
-
-// AddMetricsEvent mocks base method.
-func (m *MockSender) AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddMetricsEvent", varargs...)
-}
-
-// AddMetricsEvent indicates an expected call of AddMetricsEvent.
-func (mr *MockSenderMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockSender)(nil).AddMetricsEvent), varargs...)
-}
-
 // NotifyInternalEvent mocks base method.
 func (m *MockSender) NotifyInternalEvent(ctx context.Context, clusterID, hostID, infraEnvID *strfmt.UUID, msg string) {
 	m.ctrl.T.Helper()
@@ -210,40 +176,6 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
-}
-
-// AddEvent mocks base method.
-func (m *MockHandler) AddEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddEvent", varargs...)
-}
-
-// AddEvent indicates an expected call of AddEvent.
-func (mr *MockHandlerMockRecorder) AddEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEvent", reflect.TypeOf((*MockHandler)(nil).AddEvent), varargs...)
-}
-
-// AddMetricsEvent mocks base method.
-func (m *MockHandler) AddMetricsEvent(ctx context.Context, clusterID strfmt.UUID, hostID *strfmt.UUID, severity, msg string, eventTime time.Time, props ...interface{}) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, clusterID, hostID, severity, msg, eventTime}
-	for _, a := range props {
-		varargs = append(varargs, a)
-	}
-	m.ctrl.Call(m, "AddMetricsEvent", varargs...)
-}
-
-// AddMetricsEvent indicates an expected call of AddMetricsEvent.
-func (mr *MockHandlerMockRecorder) AddMetricsEvent(ctx, clusterID, hostID, severity, msg, eventTime interface{}, props ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, clusterID, hostID, severity, msg, eventTime}, props...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetricsEvent", reflect.TypeOf((*MockHandler)(nil).AddMetricsEvent), varargs...)
 }
 
 // NotifyInternalEvent mocks base method.

--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/internal/common"
+	commonevents "github.com/openshift/assisted-service/internal/common/events"
 	eventsapi "github.com/openshift/assisted-service/internal/events/api"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
@@ -83,7 +84,103 @@ func (e *Events) v2SaveEvent(ctx context.Context, clusterID *strfmt.UUID, hostID
 			tx.Commit()
 		}
 	}()
+
+	// Check and if the event exceeds the limits:
+	limitExceeded, limitReason, dberr := e.exceedsLimits(ctx, tx, &event)
+	if dberr != nil {
+		return
+	}
+	if limitExceeded {
+		e.reportDiscarded(ctx, &event, limitReason)
+		return
+	}
+
+	// Create the new event:
 	dberr = tx.Create(&event).Error
+}
+
+// exceedsLimit checks if there are already events that are too close to the given one. It returns
+// a boolean flag with the result and a set of log fields that explain why the limit was exceeded.
+func (e *Events) exceedsLimits(ctx context.Context, tx *gorm.DB, event *common.Event) (result bool,
+	reason logrus.Fields, err error) {
+	// Do nothing if there is no configured limit:
+	limit, ok := eventLimits[event.Name]
+	if !ok {
+		return
+	}
+
+	// Prepare the query to find the events whose distance to this one is less than the limit:
+	query := tx.Table("events").
+		Select("count(*)").
+		Where("name = ?", event.Name).
+		Where("event_time > ?", time.Now().Add(-limit))
+	if event.ClusterID != nil {
+		query = query.Where("cluster_id = ?", event.ClusterID.String())
+	}
+	if event.HostID != nil {
+		query = query.Where("host_id = ?", event.HostID.String())
+	}
+	if event.InfraEnvID != nil {
+		query = query.Where("infra_env_id = ?", event.InfraEnvID.String())
+	}
+
+	// Run the query:
+	var count int
+	err = query.Scan(&count).Error
+	if err != nil {
+		return
+	}
+	if count > 0 {
+		result = true
+		reason = logrus.Fields{
+			"limit": limit,
+			"count": count,
+		}
+	}
+	return
+}
+
+// reportDiscarded writes to the log a message indicating that the given event has been discarded.
+// The log message will include the details of the event and the reason.
+func (e *Events) reportDiscarded(ctx context.Context, event *common.Event,
+	reason logrus.Fields) {
+	log := logutil.FromContext(ctx, e.log)
+	fields := logrus.Fields{
+		"name":       event.Name,
+		"category":   event.Category,
+		"request_id": event.RequestID.String(),
+		"props":      event.Props,
+	}
+	if event.EventTime != nil {
+		fields["time"] = event.EventTime.String()
+	}
+	if event.ClusterID != nil {
+		fields["cluster_id"] = event.ClusterID.String()
+	}
+	if event.HostID != nil {
+		fields["host_id"] = event.HostID.String()
+	}
+	if event.InfraEnvID != nil {
+		fields["infra_env_id"] = event.InfraEnvID.String()
+	}
+	if event.Severity != nil {
+		fields["severity"] = *event.Severity
+	}
+	if event.Message != nil {
+		fields["message"] = *event.Message
+	}
+	for name, value := range reason {
+		fields[name] = value
+	}
+	log.WithFields(fields).Warn("Event will be discarded")
+}
+
+// eventLimits contains the minimum distance in time between events. The key of the map is the
+// event name and the value is the distance.
+var eventLimits = map[string]time.Duration{
+	commonevents.UpgradeAgentFailedEventName:   time.Hour,
+	commonevents.UpgradeAgentFinishedEventName: time.Hour,
+	commonevents.UpgradeAgentStartedEventName:  time.Hour,
 }
 
 func (e *Events) SendClusterEvent(ctx context.Context, event eventsapi.ClusterEvent) {

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/openshift/assisted-service/internal/common"
@@ -33,7 +34,9 @@ var _ = Describe("Events library", func() {
 		cluster1  = strfmt.UUID("46a8d745-dfce-4fd8-9df0-549ee8eabb3d")
 		cluster2  = strfmt.UUID("60415d9c-7c44-4978-89f5-53d510b03a47")
 		infraEnv1 = strfmt.UUID("46a8d745-dfce-4a69-9df0-a0c627217f3e")
+		infraEnv2 = strfmt.UUID("705c994b-eaa0-4b77-880b-66d4cd34cb4e")
 		host      = strfmt.UUID("1e45d128-4a69-4e71-9b50-a0c627217f3e")
+		host2     = strfmt.UUID("ad647798-a7af-4b1d-b96e-69f1beb9b4c3")
 	)
 	BeforeEach(func() {
 		db, dbName = common.PrepareTestDB()
@@ -44,6 +47,8 @@ var _ = Describe("Events library", func() {
 		Expect(db.Create(&c2).Error).ShouldNot(HaveOccurred())
 		i1 := common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnv1, UserName: "user1", OrgID: "org1"}}
 		Expect(db.Create(&i1).Error).ShouldNot(HaveOccurred())
+		i2 := common.InfraEnv{InfraEnv: models.InfraEnv{ID: &infraEnv2, UserName: "user2", OrgID: "org1"}}
+		Expect(db.Create(&i2).Error).ShouldNot(HaveOccurred())
 	})
 	numOfEvents := func(clusterID *strfmt.UUID, hostID *strfmt.UUID, infraEnvID *strfmt.UUID) int {
 		evs, err := theEvents.V2GetEvents(context.TODO(), clusterID, hostID, infraEnvID)
@@ -371,10 +376,144 @@ var _ = Describe("Events library", func() {
 		})
 	})
 
+	Context("Limits", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		DescribeTable(
+			"Discards event if sent multiple times",
+			func(count int) {
+				for i := 0; i < count; i++ {
+					theEvents.V2AddEvent(
+						ctx,
+						&cluster1,
+						&host,
+						&infraEnv1,
+						eventgen.UpgradeAgentFailedEventName,
+						models.EventSeverityError,
+						"Upgrade failed",
+						time.Now(),
+					)
+				}
+				events, err := theEvents.V2GetEvents(
+					ctx,
+					&cluster1,
+					&host,
+					&infraEnv1,
+					models.EventCategoryUser,
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(events).To(HaveLen(1))
+			},
+			Entry("Twice", 2),
+			Entry("Ten times", 10),
+			Entry("Many times", 42),
+		)
+
+		It("Doesn't discard events from different clusters", func() {
+			theEvents.V2AddEvent(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				eventgen.UpgradeAgentFailedEventName,
+				models.EventSeverityError,
+				"Upgrade failed",
+				time.Now(),
+			)
+			theEvents.V2AddEvent(
+				ctx,
+				&cluster2,
+				&host2,
+				&infraEnv2,
+				eventgen.UpgradeAgentFailedEventName,
+				models.EventSeverityError,
+				"Upgrade failed",
+				time.Now(),
+			)
+			events1, err := theEvents.V2GetEvents(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				models.EventCategoryUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events1).To(HaveLen(1))
+			events2, err := theEvents.V2GetEvents(
+				ctx,
+				&cluster2,
+				&host2,
+				&infraEnv2,
+				models.EventCategoryUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events2).To(HaveLen(1))
+		})
+
+		It("Doesn't discard event that doesn't exceed limit", func() {
+			theEvents.V2AddEvent(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				eventgen.UpgradeAgentFailedEventName,
+				models.EventSeverityError,
+				"Upgrade failed",
+				time.Now().Add(-2*time.Hour),
+			)
+			theEvents.V2AddEvent(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				eventgen.UpgradeAgentFailedEventName,
+				models.EventSeverityError,
+				"Upgrade failed",
+				time.Now(),
+			)
+			events, err := theEvents.V2GetEvents(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				models.EventCategoryUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(HaveLen(2))
+		})
+
+		It("Doesn't discard events that don't have limits", func() {
+			for i := 0; i < 2; i++ {
+				theEvents.V2AddEvent(
+					ctx,
+					&cluster1,
+					&host,
+					&infraEnv1,
+					eventgen.ClusterInstallationCompletedEventName,
+					models.EventSeverityInfo,
+					"Installation completed",
+					time.Now(),
+				)
+			}
+			events, err := theEvents.V2GetEvents(
+				ctx,
+				&cluster1,
+				&host,
+				&infraEnv1,
+				models.EventCategoryUser,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(HaveLen(2))
+		})
+	})
+
 	AfterEach(func() {
 		common.DeleteTestDB(db, dbName)
 	})
-
 })
 
 func WithRequestID(requestID string) types.GomegaMatcher {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -358,8 +358,8 @@ func (m *Manager) updateInventory(ctx context.Context, cluster *common.Cluster, 
 	// Only record metrics if it's new/changed inventory and the host is associated with a cluster
 	if existingHostInventory == nil || (existingHostInventory != nil && len(physicalInterfaces) != len(existingHostInventory.Interfaces)) {
 		if h.ClusterID != nil {
-			m.eventsHandler.AddMetricsEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, "nic.virtual_interfaces", time.Now(), "count", len(virtualInterfaces), "types", virtualInterfaces)
-			m.eventsHandler.AddMetricsEvent(ctx, *h.ClusterID, h.ID, models.EventSeverityInfo, "nic.physical_interfaces", time.Now(), "count", len(physicalInterfaces))
+			m.eventsHandler.V2AddMetricsEvent(ctx, h.ClusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.virtual_interfaces", time.Now(), "count", len(virtualInterfaces), "types", virtualInterfaces)
+			m.eventsHandler.V2AddMetricsEvent(ctx, h.ClusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.physical_interfaces", time.Now(), "count", len(physicalInterfaces))
 		}
 	}
 

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -1143,8 +1143,8 @@ var _ = Describe("UpdateInventory", func() {
 				Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(test.inventory.Disks)
-				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 				inventoryStr, err := common.MarshalInventory(&test.inventory)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hapi.(*Manager).UpdateInventory(ctx, &host, inventoryStr)).ToNot(HaveOccurred())
@@ -1272,8 +1272,8 @@ var _ = Describe("UpdateInventory", func() {
 					},
 				}
 
-				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-				mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().DiskIsEligible(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				mockValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return(inventory.Disks)
 				if test.expectMatch {
@@ -1432,8 +1432,8 @@ var _ = Describe("UpdateInventory", func() {
 			Expect(inventory.Interfaces).Should(HaveLen(1))
 		})
 		It("Doesn't save virtual interfaces when virtual interface flag is not enabled", func() {
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
@@ -1462,8 +1462,8 @@ var _ = Describe("UpdateInventory", func() {
 			defaultConfig.EnableVirtualInterfaces = true
 			enabled_hapi := NewManager(common.GetTestLog(), db, mockEvents, mockValidator,
 				nil, createValidatorCfg(), nil, defaultConfig, dummy, nil, nil, false, nil)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
-			mockEvents.EXPECT().AddMetricsEvent(ctx, *host.ClusterID, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, host.ClusterID, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any())
 			Expect(enabled_hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 
 			h := hostutil.GetHostFromDB(hostId, infraEnvId, db)
@@ -1484,27 +1484,27 @@ var _ = Describe("UpdateInventory", func() {
 		It("Records metrics for new inventory", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(2, 1)
 			host.Inventory = ""
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 		It("Records metrics for changed inventory", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(3, 1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 		It("Doesn't record metrics for unchanged inventory", func() {
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 			Expect(hapi.UpdateInventory(ctx, &host, host.Inventory)).To(Succeed())
 		})
 		It("Doesn't record metrics for unbound hosts", func() {
 			newInventory := common.GenerateTestInventoryWithVirtualInterface(2, 1)
 			host.Inventory = ""
 			host.ClusterID = nil
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-			mockEvents.EXPECT().AddMetricsEvent(ctx, clusterId, &hostId, models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.virtual_interfaces", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			mockEvents.EXPECT().V2AddMetricsEvent(ctx, &clusterId, &hostId, gomock.Any(), gomock.Any(), models.EventSeverityInfo, "nic.physical_interfaces", gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			Expect(hapi.UpdateInventory(ctx, &host, newInventory)).To(Succeed())
 		})
 	})

--- a/internal/metrics/metricsManager.go
+++ b/internal/metrics/metricsManager.go
@@ -332,7 +332,7 @@ func (m *MetricsManager) InstallationStarted() {
 
 func (m *MetricsManager) ClusterInstallationFinished(ctx context.Context, result string, prevState string, clusterVersion string, clusterID strfmt.UUID, emailDomain string, installationStartedTime strfmt.DateTime) {
 	duration := time.Since(time.Time(installationStartedTime)).Seconds()
-	m.handler.AddMetricsEvent(ctx, clusterID, nil, models.EventSeverityInfo, "cluster.installation.results", time.Now(),
+	m.handler.V2AddMetricsEvent(ctx, &clusterID, nil, nil, "", models.EventSeverityInfo, "cluster.installation.results", time.Now(),
 		"duration", duration, "result", result, "lastState", prevState)
 
 	log := logutil.FromContext(ctx, logrus.New())
@@ -389,7 +389,7 @@ func (m *MetricsManager) ReportHostInstallationMetrics(ctx context.Context, clus
 			}
 			log.Infof("service Logic Host Installation Phase Seconds phase %s, vendor %s product %s disk %s result %s, duration %f",
 				string(previousProgress.CurrentStage), hwVendor, hwProduct, diskType, string(phaseResult), duration)
-			m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.stage.duration", time.Now(),
+			m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "host.stage.duration", time.Now(),
 				"result", string(phaseResult), "duration", duration, "host_stage", string(previousProgress.CurrentStage), "vendor", hwVendor, "product", hwProduct, "disk_type", diskType, "host_role", roleStr)
 
 			m.serviceLogicHostInstallationPhaseSeconds.WithLabelValues(string(previousProgress.CurrentStage),
@@ -427,7 +427,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	m.serviceLogicClusterHostRAMGb.WithLabelValues(roleStr, installationStageStr).
 		Observe(float64(bytesToGib(hwInfo.Memory.PhysicalBytes)))
 
-	m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "host.mem.cpu", time.Now(),
+	m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "host.mem.cpu", time.Now(),
 		"host_result", installationStageStr, "host_role", roleStr, "mem_bytes", bytesToGib(hwInfo.Memory.PhysicalBytes),
 		"core_count", hwInfo.CPU.Count)
 
@@ -438,7 +438,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 		diskTypeStr := string(disk.DriveType) //+ "-" + disk.StorageController
 		log.Infof("service Logic Cluster Host DiskGb role %s, result %s diskType %s diskSize %d",
 			roleStr, installationStageStr, diskTypeStr, bytesToGib(disk.SizeBytes))
-		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "disk.size.type", time.Now(),
+		m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "disk.size.type", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "disk_type", diskTypeStr, "disk_size", bytesToGib(disk.SizeBytes))
 
 		m.serviceLogicClusterHostDiskGb.WithLabelValues(diskTypeStr, roleStr, installationStageStr).
@@ -448,7 +448,7 @@ func (m *MetricsManager) reportHostMetricsOnInstallationComplete(ctx context.Con
 	for _, inter := range hwInfo.Interfaces {
 		log.Infof("service Logic Cluster Host NicGb role %s, result %s SpeedMbps %f",
 			roleStr, installationStageStr, float64(inter.SpeedMbps))
-		m.handler.AddMetricsEvent(ctx, clusterID, h.ID, models.EventSeverityInfo, "nic.speed", time.Now(),
+		m.handler.V2AddMetricsEvent(ctx, &clusterID, h.ID, nil, "", models.EventSeverityInfo, "nic.speed", time.Now(),
 			"host_result", installationStageStr, "host_role", roleStr, "nic_speed", inter.SpeedMbps)
 
 		m.serviceLogicClusterHostNicGb.WithLabelValues(roleStr, installationStageStr).

--- a/internal/metrics/metricsManager_test.go
+++ b/internal/metrics/metricsManager_test.go
@@ -30,7 +30,9 @@ var _ = DescribeTable(
 		// We are not testing generation of events here, we just need to make sure that the
 		// call to generating metrics doesn't fail:
 		handler := eventsapi.NewMockHandler(ctrl)
-		handler.EXPECT().AddMetricsEvent(
+		handler.EXPECT().V2AddMetricsEvent(
+			gomock.Any(),
+			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),
 			gomock.Any(),


### PR DESCRIPTION
When agent fails to upgrade the generated events will be generated each
time that the agent asks for next steps, approxy once per minute. This
can fill the collection of events with useless repeated information. To
avoid that this patch changes the event handling so that it will be
possible to define a minimum distance (in time) between those events.
Events that are closer than that minimum distance will be discarded.
    
Related: https://issues.redhat.com/browse/MGMT-12237

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
