### PR TITLE
MGMT-12445: Update host install progress response

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -176,7 +176,7 @@ type InstallerInternals interface {
 	GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*common.Host, error)
 	ValidatePullSecret(secret string, username string) error
 	GetInfraEnvInternal(ctx context.Context, params installer.GetInfraEnvParams) (*common.InfraEnv, error)
-	V2UpdateHostInstallProgressInternal(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) (*common.Host, error)
+	V2UpdateHostInstallProgressInternal(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) error
 }
 
 //go:generate mockgen --build_flags=--mod=mod -package bminventory -destination mock_crd_utils.go . CRDUtils

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5234,29 +5234,25 @@ func (b *bareMetalInventory) V2GetHost(ctx context.Context, params installer.V2G
 }
 
 func (b *bareMetalInventory) V2UpdateHostInstallProgress(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) middleware.Responder {
-	h, err := b.V2UpdateHostInstallProgressInternal(ctx, params)
+	err := b.V2UpdateHostInstallProgressInternal(ctx, params)
 	if err != nil {
-		if h == nil {
-			return installer.NewV2UpdateHostInstallProgressNotFound().
-				WithPayload(common.GenerateError(http.StatusNotFound, err))
-		}
-		return installer.NewV2UpdateHostInstallProgressInternalServerError().WithPayload(common.GenerateError(http.StatusInternalServerError, err))
+		return common.GenerateErrorResponder(err)
 	}
 	return installer.NewV2UpdateHostInstallProgressOK()
 }
-func (b *bareMetalInventory) V2UpdateHostInstallProgressInternal(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) (*common.Host, error) {
+func (b *bareMetalInventory) V2UpdateHostInstallProgressInternal(ctx context.Context, params installer.V2UpdateHostInstallProgressParams) error {
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Update host %s install progress", params.HostID)
 	host, err := common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())
 	if err != nil {
 		log.WithError(err).Errorf("failed to find host %s", params.HostID)
-		return nil, err
+		return err
 	}
 
 	if host.ClusterID == nil {
 		err = fmt.Errorf("host %s is not bound to any cluster, cannot update progress", params.HostID)
 		log.WithError(err).Error()
-		return host, err
+		return common.NewApiError(http.StatusBadRequest, err)
 	}
 
 	stageChanged := params.HostProgress.CurrentStage != host.Progress.CurrentStage
@@ -5265,7 +5261,7 @@ func (b *bareMetalInventory) V2UpdateHostInstallProgressInternal(ctx context.Con
 	if stageChanged || params.HostProgress.ProgressInfo != host.Progress.ProgressInfo {
 		if err := b.hostApi.UpdateInstallProgress(ctx, &host.Host, params.HostProgress); err != nil {
 			log.WithError(err).Errorf("failed to update host %s progress", params.HostID)
-			return host, err
+			return err
 		}
 
 		event := fmt.Sprintf("reached installation stage %s", params.HostProgress.CurrentStage)
@@ -5278,12 +5274,12 @@ func (b *bareMetalInventory) V2UpdateHostInstallProgressInternal(ctx context.Con
 		if stageChanged {
 			if err := b.clusterApi.UpdateInstallProgress(ctx, *host.ClusterID); err != nil {
 				log.WithError(err).Errorf("failed to update cluster %s progress", host.ClusterID)
-				return host, err
+				return err
 			}
 		}
 	}
 
-	return host, nil
+	return nil
 }
 
 func (b *bareMetalInventory) BindHost(ctx context.Context, params installer.BindHostParams) middleware.Responder {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1300,7 +1300,7 @@ var _ = Describe("V2UpdateHostInstallProgress", func() {
 				HostProgress: progressParams,
 				HostID:       hostID,
 			})
-			Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateHostInstallProgressInternalServerError()))
+			Expect(reply).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusInternalServerError, errors.Errorf("some error"))))
 		})
 	})
 
@@ -1312,7 +1312,7 @@ var _ = Describe("V2UpdateHostInstallProgress", func() {
 			},
 			HostID: strfmt.UUID(uuid.New().String()),
 		})
-		Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateHostInstallProgressNotFound()))
+		Expect(reply).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusNotFound, errors.Errorf(""))))
 	})
 })
 

--- a/internal/bminventory/mock_installer_internal.go
+++ b/internal/bminventory/mock_installer_internal.go
@@ -504,12 +504,11 @@ func (mr *MockInstallerInternalsMockRecorder) V2UpdateHostIgnitionInternal(arg0,
 }
 
 // V2UpdateHostInstallProgressInternal mocks base method.
-func (m *MockInstallerInternals) V2UpdateHostInstallProgressInternal(arg0 context.Context, arg1 installer.V2UpdateHostInstallProgressParams) (*common.Host, error) {
+func (m *MockInstallerInternals) V2UpdateHostInstallProgressInternal(arg0 context.Context, arg1 installer.V2UpdateHostInstallProgressParams) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "V2UpdateHostInstallProgressInternal", arg0, arg1)
-	ret0, _ := ret[0].(*common.Host)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // V2UpdateHostInstallProgressInternal indicates an expected call of V2UpdateHostInstallProgressInternal.

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -1400,7 +1400,7 @@ func (r *AgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *AgentReconciler) updateHostInstallProgress(ctx context.Context, host *models.Host, stage models.HostStage) error {
 	r.Log.Infof("Updating host %s install progress to %s", host.ID, stage)
-	_, err := r.Installer.V2UpdateHostInstallProgressInternal(ctx, installer.V2UpdateHostInstallProgressParams{
+	err := r.Installer.V2UpdateHostInstallProgressInternal(ctx, installer.V2UpdateHostInstallProgressParams{
 		InfraEnvID: host.InfraEnvID,
 		HostID:     *host.ID,
 		HostProgress: &models.HostProgress{

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -555,7 +555,9 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 		models.HostStatusInstalling, models.HostStatusInstallingInProgress, models.HostStatusInstallingPendingUserAction,
 	}
 	if !funk.ContainsString(validStatuses, swag.StringValue(h.Status)) {
-		return errors.Errorf("Can't set progress <%s> to host in status <%s>", progress.CurrentStage, swag.StringValue(h.Status))
+		return common.NewApiError(http.StatusConflict,
+			errors.Errorf("Can't set progress <%s> to host in status <%s>",
+				progress.CurrentStage, swag.StringValue(h.Status)))
 	}
 
 	var extra []interface{}
@@ -568,12 +570,14 @@ func (m *Manager) UpdateInstallProgress(ctx context.Context, h *models.Host, pro
 			currentIndex := m.IndexOfStage(progress.CurrentStage, stages)
 
 			if currentIndex == -1 {
-				return errors.Errorf("Stages %s isn't available for host role %s bootstrap %s",
-					progress.CurrentStage, h.Role, strconv.FormatBool(h.Bootstrap))
+				return common.NewApiError(http.StatusConflict,
+					errors.Errorf("Stages %s isn't available for host role %s bootstrap %s",
+						progress.CurrentStage, h.Role, strconv.FormatBool(h.Bootstrap)))
 			}
 			if currentIndex < m.IndexOfStage(previousProgress.CurrentStage, stages) {
-				return errors.Errorf("Can't assign lower stage \"%s\" after host has been in stage \"%s\"",
-					progress.CurrentStage, previousProgress.CurrentStage)
+				return common.NewApiError(http.StatusConflict,
+					errors.Errorf("Can't assign lower stage \"%s\" after host has been in stage \"%s\"",
+						progress.CurrentStage, previousProgress.CurrentStage))
 			}
 		}
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->
[MGMT-12445](https://issues.redhat.com/browse/MGMT-12445)
When a host updates its install progress from an invalid state, the service
would initially respond with a 500 internal server error. This caused a lot
of noise that made it seem as if the service was down, when it wasn't.

This PR modifies the response to send a 409 conflict when updating
a host's install progress fails when updating the host from an invalid state.

Additionally, it modifies the error response sent to be the appropriate
code depending on the error that occurred.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

1. Deploy assisted-service with these changes
2. Install a cluster using assisted-test-infra and let it timeout (fail), ensure the hosts have reached an error state
3. Call the update host install progress API, ensure it's a 409 error returned with the correct error message
```bash
$ curl -X PUT ${SERVICE_URL}/api/assisted-install/v2/infra-envs/${INFRA_ENV_ID}/hosts/${HOST_ID}/progress -d '{"current_stage":"Rebooting", "progress_info":"test"}' -H "X-Secret-Key: ${TOKEN}" -H "Content-Type: application/json"
```

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @carbonin 
