### PR TITLE
MGMT-12950: Disable compatible agent validation while installing

### DIFF
--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -74,6 +74,21 @@ var manualRebootStages = []models.HostStage{
 	models.HostStageDone,
 }
 
+var allStages = []models.HostStage{
+	models.HostStageConfiguring,
+	models.HostStageDone,
+	models.HostStageFailed,
+	models.HostStageInstalling,
+	models.HostStageJoined,
+	models.HostStageRebooting,
+	models.HostStageStartingInstallation,
+	models.HostStageWaitingForBootkube,
+	models.HostStageWaitingForControlPlane,
+	models.HostStageWaitingForController,
+	models.HostStageWaitingForIgnition,
+	models.HostStageWritingImageToDisk,
+}
+
 var hostStatusesBeforeInstallation = [...]string{
 	models.HostStatusDiscovering, models.HostStatusKnown, models.HostStatusDisconnected,
 	models.HostStatusInsufficient, models.HostStatusPendingForInput,

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -266,8 +266,9 @@ func newValidations(v *validator) []validation {
 			condition: v.isVSphereDiskUUIDEnabled,
 		},
 		{
-			id:        CompatibleAgent,
-			condition: v.compatibleAgent,
+			id:            CompatibleAgent,
+			condition:     v.compatibleAgent,
+			skippedStates: allStages,
 		},
 		{
 			id:        NoSkipInstallationDisk,


### PR DESCRIPTION
Currently the agent compatibility validation is always enabled, even when the cluster is installing. If the service is restarted in the middle of the installation with a different version of the agent (with a different value for the `AGENT_DOCKER_IMAGE`) that results in warning event explaining that the agent isn't compatible with the service. That has no effect because the service will not be sending the upgrade agent step to the server, but it is confusing. This patch changes the service so that the validation is disabled when the cluster is installing.

Related: https://issues.redhat.com/browse/MGMT-12950

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
