### PR TITLE
MGMT-12894: Use the hub release image when determining the ironic agent image

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -268,6 +268,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   verbs:
   - get

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -547,6 +547,14 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - infrastructures
           verbs:
           - get

--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -202,8 +202,8 @@ The converged flow is disalbed by default, you can enable the converged flow by 
 
 ### Ironic Agent Image
 
-If the InfraEnv is configured with a cluster reference the agent image used during discovery will be the one from the cluster's release image.
-If the InfraEnv does not reference a cluster (late binding) a default ironic agent image will be used.
+The ironic agent image will be determined based on the hub release image set in the ClusterVersion resource.
+If the hub cluster architecture does not match that of the InfraEnv or if the release image cannot be retrieved for some reason a default ironic agent image will be used.
 The defaults are:
 - x86_64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446`
 - arm64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43`
@@ -215,7 +215,12 @@ The environment var for the ironicAgent image to be used on arm64 CPU architectu
 `IRONIC_AGENT_IMAGE_ARM`
 
 **NOTE**
-Ensure the correct images are mirrored if installing in a disconnected environment
+Ensure the correct images are mirrored if installing in a disconnected environment.
+Specifically the ironic agent image from the hub cluster release needs to be accessible in the spoke installation environment.
+This can be found using the following command:
+```
+oc adm release info --image-for=ironic-agent <hub-release-image>
+```
 
 [ZTP converged flow](ZTP_converged_flow.png)
 

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/iancoleman/strcase"
 	metal3_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
@@ -81,6 +82,7 @@ type PreprovisioningImageReconciler struct {
 // +kubebuilder:rbac:groups=metal3.io,resources=preprovisioningimages/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=agent-install.openshift.io,resources=infraenvs/status,verbs=get
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	ctx := addRequestIdIfNeeded(origCtx)
@@ -378,12 +380,9 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 		log.WithError(err).Error("failed to get corresponding infraEnv")
 		return ctrl.Result{}, err
 	}
-	var ironicAgentImage string
-	if infraEnvInternal.ClusterID != "" {
-		ironicAgentImage, err = r.getIronicAgentImageByRelease(ctx, log, *infraEnvInternal)
-		if err != nil {
-			log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
-		}
+	ironicAgentImage, err := r.getIronicAgentImageByRelease(ctx, log, infraEnvInternal)
+	if err != nil {
+		log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
 	}
 
 	// if ironicAgentImage can't be found by version use the default
@@ -420,26 +419,22 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	return ctrl.Result{}, err
 }
 
-func (r *PreprovisioningImageReconciler) getIronicAgentImageByRelease(ctx context.Context, log logrus.FieldLogger, infraEnv common.InfraEnv) (string, error) {
-	cluster, err := r.Installer.GetClusterInternal(ctx, installer.V2GetClusterParams{ClusterID: infraEnv.ClusterID})
+func (r *PreprovisioningImageReconciler) getIronicAgentImageByRelease(ctx context.Context, log logrus.FieldLogger, infraEnv *common.InfraEnv) (string, error) {
+	cv := &configv1.ClusterVersion{}
+	if err := r.Get(ctx, types.NamespacedName{Name: "version"}, cv); err != nil {
+		return "", err
+	}
+
+	architectures, err := r.OcRelease.GetReleaseArchitecture(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnv.PullSecret)
 	if err != nil {
 		return "", err
 	}
 
-	supportConvergedFlow, _ := common.VersionGreaterOrEqual(cluster.OpenshiftVersion, MinimalVersionForConvergedFlow)
-	if !supportConvergedFlow {
-		return "", fmt.Errorf("Openshift version (%s) is lower than the minimal version for the converged flow (%s)", cluster.OpenshiftVersion, MinimalVersionForConvergedFlow)
+	if !funk.Contains(architectures, infraEnv.CPUArchitecture) {
+		return "", fmt.Errorf("release image architectures %v do not match infraEnv architecture %s", architectures, infraEnv.CPUArchitecture)
 	}
 
-	releaseImage, err := r.VersionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, infraEnv.CPUArchitecture, infraEnv.PullSecret)
-	if err != nil {
-		return "", err
-	}
-	ironicAgentImage, err := r.OcRelease.GetIronicAgentImage(log, *releaseImage.URL, r.ReleaseImageMirror, infraEnv.PullSecret)
-	if err != nil {
-		return "", err
-	}
-	return ironicAgentImage, nil
+	return r.OcRelease.GetIronicAgentImage(log, cv.Status.Desired.Image, r.ReleaseImageMirror, infraEnv.PullSecret)
 }
 
 func IronicAgentEnabled(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) bool {

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -11,6 +11,7 @@ import (
 	metal3_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
@@ -23,8 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -56,10 +57,6 @@ func newPreprovisioningImage(name, namespace string, labelKey string, labelValue
 
 func newInfraEnv(name, namespace string, spec aiv1beta1.InfraEnvSpec) *aiv1beta1.InfraEnv {
 	return &aiv1beta1.InfraEnv{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "InfraEnv",
-			APIVersion: fmt.Sprintf("%s/%s", aiv1beta1.GroupVersion.Group, aiv1beta1.GroupVersion.Version),
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -87,10 +84,16 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		infraEnvArch          = "x86_64"
 		infraEnv              *aiv1beta1.InfraEnv
 		ppi                   *metal3_v1alpha1.PreprovisioningImage
+		hubReleaseImage       = "quay.io/openshift-release-dev/ocp-release@sha256:5fdcafc349e184af11f71fe78c0c87531b9df123c664ff1ac82711dc15fa1532"
+		clusterVersion        *configv1.ClusterVersion
 	)
 
 	BeforeEach(func() {
-		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+		schemes := runtime.NewScheme()
+		Expect(configv1.AddToScheme(schemes)).To(Succeed())
+		Expect(metal3_v1alpha1.AddToScheme(schemes)).To(Succeed())
+		Expect(aiv1beta1.AddToScheme(schemes)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
@@ -108,6 +111,13 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			OcRelease:        mockOcRelease,
 			IronicServiceURL: "ironic.url",
 			Config:           PreprovisioningImageControllerConfig{BaremetalIronicAgentImage: "ironic-agent-image:latest"},
+		}
+		clusterVersion = &configv1.ClusterVersion{
+			ObjectMeta: metav1.ObjectMeta{Name: "version"},
+			Spec:       configv1.ClusterVersionSpec{ClusterID: configv1.ClusterID(uuid.New().String())},
+			Status: configv1.ClusterVersionStatus{
+				Desired: configv1.Release{Image: hubReleaseImage, Version: "4.12.0-rc.3"},
+			},
 		}
 	})
 
@@ -297,18 +307,16 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Get(ctx, key, ppi)).To(BeNil())
 			validateStatus(infraEnv.Status.ISODownloadURL, conditionsv1.FindStatusCondition(infraEnv.Status.Conditions, aiv1beta1.ImageCreatedCondition), ppi)
 		})
-		It("Add the ironic Ignition to the infraEnv using the ironic agent image from the release", func() {
+		It("Add the ironic Ignition to the infraEnv using the ironic agent image from the hub release", func() {
+			Expect(c.Create(ctx, clusterVersion)).To(Succeed())
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-			openshiftRelaseImage := "release-image:4.12.0"
 			ironicAgentImage := "ironic-image:4.12.0"
-			backendInfraEnv.OpenshiftVersion = "4.12.0-test.release"
 			backendInfraEnv.CPUArchitecture = "x86_64"
 			backendInfraEnv.PullSecret = "mypullsecret"
-			backendCluster := common.Cluster{Cluster: models.Cluster{ID: &clusterID, OpenshiftVersion: "4.12"}}
-			mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: clusterID}).Return(&backendCluster, nil)
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
-			mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), backendCluster.OpenshiftVersion, backendInfraEnv.CPUArchitecture, backendInfraEnv.PullSecret).Return(&models.ReleaseImage{URL: &openshiftRelaseImage}, nil)
-			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), openshiftRelaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil)
+
+			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
+			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
@@ -329,13 +337,14 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Get(ctx, key, infraEnv)).To(BeNil())
 			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
 		})
-		It("uses the default ironic agent image when the cluster openshift version is too low", func() {
+		It("uses the default ironic agent image when the infraenv arch isn't supported by the hub release image", func() {
+			Expect(c.Create(ctx, clusterVersion)).To(Succeed())
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-			backendInfraEnv.OpenshiftVersion = "4.10.0-test.release"
 			backendInfraEnv.CPUArchitecture = "x86_64"
-			backendCluster := common.Cluster{Cluster: models.Cluster{ID: &clusterID, OpenshiftVersion: "4.10"}}
-			mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: clusterID}).Return(&backendCluster, nil)
+			backendInfraEnv.PullSecret = "mypullsecret"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
+
+			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"arm64"}, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))


### PR DESCRIPTION
Previously, when using the converged flow, the service attempted to extract the ironic agent image using the spoke release. This was not ideal for a few reasons:

1. The agent version should match that of the hub ironic service
    - While it was likely the agent from the spoke version would be compatible with the hub service it's objectively better for them to actually match.
2. The default image was used for late-binding cases
    - This meant that a rather old and seemingly random image was used when the service didn't have a cluster from which to pull a release image
3. It's difficult to communicate to a user what to mirror in disconnected cases

With this change the agent will always match the hub service, the hub agent will be used regardless of late-binding or not, and the user just needs to know to mirror the hub release into their spoke environment when disconnected.

The only case when we should use the default image now is if the hub release image doesn't support the CPU architecture of the spoke infraEnv, but with multi-arch images coming soon and differing hub/spoke architectures exceedingly rare already this shouldn't be a problem.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-12894

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

1. Deployed this change in a dev-scripts environment.
2. Created a bmh referencing an infraenv (late binding)
3. Downloaded discovery ignition for the infraenv
4. Validated the ironic agent image in the ignition matched the one from the hub release image

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
