### PR TITLE
MGMT-12911: Update assisted service operator docs with new icsp behavior

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -242,7 +242,7 @@ function registry_config() {
     [[registry]]
       location = "%s"
       insecure = false
-      mirror-by-digest-only = false
+      mirror-by-digest-only = true
 
       [[registry.mirror]]
         location = "%s"

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -1687,7 +1687,7 @@ var _ = Describe("newAssistedCM", func() {
 		[[registry]]
 			prefix = ""
 			location = "quay.io/edge-infrastructure"
-			mirror-by-digest-only = false
+			mirror-by-digest-only = true
 	
 		[[registry.mirror]]
 			location = "mirror1.registry.corp.com:5000/edge-infrastructure"`

--- a/pkg/mirrorregistries/generator_test.go
+++ b/pkg/mirrorregistries/generator_test.go
@@ -21,7 +21,7 @@ var (
 
 [[registry]]
 location = "location1"
-mirror-by-digest-only = false
+mirror-by-digest-only = true
 prefix = "prefix1"
 
 [[registry.mirror]]
@@ -29,7 +29,7 @@ location = "mirror_location1"
 
 [[registry]]
 location = "location2"
-mirror-by-digest-only = false
+mirror-by-digest-only = true
 prefix = "prefix1"
 
 [[registry.mirror]]
@@ -37,7 +37,7 @@ location = "mirror_location2"
 
 [[registry]]
 location = "location3"
-mirror-by-digest-only = false
+mirror-by-digest-only = true
 prefix = "prefix1"
 
 [[registry.mirror]]


### PR DESCRIPTION
Docs update, now that we use upstream oc with its ICSP support we can document the default ICSP configuration (no need to mirror tags, mirror by digest should suffice).

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? no
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-12911

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
