### PR TITLE
MGMT-12978: Append -multi suffix to multi-arch images in SupportedVersions

### DIFF
--- a/internal/versions/api.go
+++ b/internal/versions/api.go
@@ -104,12 +104,21 @@ func (h *apiHandler) V2ListSupportedOpenshiftVersions(ctx context.Context, param
 				continue
 			}
 
+			// In order to handle multi-arch release images correctly in the UI, we need to tune
+			// their DisplayName to contain an appropriate suffix. If the suffix comes from the
+			// JSON definition we do nothing, but in case it's missing there (because CVO is not
+			// reporting it), we add it ourselves.
+			displayName := *releaseImage.Version
+			if len(supportedArchs) > 1 && !strings.HasSuffix(displayName, "-multi") {
+				displayName = displayName + "-multi"
+			}
+
 			openshiftVersion, exists := openshiftVersions[key]
 			if !exists {
 				openshiftVersion = models.OpenshiftVersion{
 					CPUArchitectures: []string{arch},
 					Default:          releaseImage.Default,
-					DisplayName:      releaseImage.Version,
+					DisplayName:      swag.String(displayName),
 					SupportLevel:     getSupportLevel(*releaseImage),
 				}
 				openshiftVersions[key] = openshiftVersion


### PR DESCRIPTION
For OCP 4.12 and later the CVO does not anymore return version suffixed with `-multi`. However for the Assisted UI we want to distinguish between single- and multi-arch release images. In order not to require any manual implementation of this, we leverage the Supported Versions API call to automatically append the `-multi` suffix for any image that is multi-arch.

Fixes: [MGMT-12978](https://issues.redhat.com//browse/MGMT-12978)

/cc @danielerez 