### PR TITLE
MGMT-11979: verify install-config manifest in subsystem

### DIFF
--- a/internal/ignition/dummy.go
+++ b/internal/ignition/dummy.go
@@ -31,12 +31,6 @@ func NewDummyGenerator(workDir string, cluster *common.Cluster, s3Client s3wrapp
 
 // Generate creates the expected ignition and related files but with nonsense content
 func (g *dummyGenerator) Generate(_ context.Context, installConfig []byte, platformType models.PlatformType) error {
-	installConfigPath := filepath.Join(g.workDir, "install-config.yaml")
-	err := os.WriteFile(installConfigPath, installConfig, 0600)
-	if err != nil {
-		return err
-	}
-
 	toUpload := fileNames[:]
 	for _, host := range g.cluster.Hosts {
 		toUpload = append(toUpload, hostutil.IgnitionFileName(host))
@@ -54,6 +48,8 @@ func (g *dummyGenerator) Generate(_ context.Context, installConfig []byte, platf
 			data = kubeconfig
 		} else if fileName == "bootstrap.ign" {
 			data = bootstrapIgnition
+		} else if fileName == "install-config.yaml" {
+			data = string(installConfig)
 		}
 		_, err = f.WriteString(data)
 		if err != nil {


### PR DESCRIPTION
When installing a cluster, we generate the install-config file with values specified in the cluster struct.
This change is adding some basic validations for the content of install-config.yaml.
I.e. added to subsystem tests a verification for the generated manifest to ensure relevant values are populated properly.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
