### PR TITLE
MGMT-12978: Handle multiple images with the same OCP version

### DIFF
--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Test list versions with capability restrictions", func() {
 		It("does not return multiarch when capability query fails", func() {
 			h := handlerWithAuthConfig(true)
 
-			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, errors.New("failed to query capability")).Times(1)
+			mockOcmAuthz.EXPECT().CapabilityReview(context.Background(), userName1, ocm.MultiarchCapabilityName, ocm.OrganizationCapabilityType).Return(false, errors.New("failed to query capability")).Times(2)
 			reply := h.V2ListSupportedOpenshiftVersions(authCtx, operations.V2ListSupportedOpenshiftVersionsParams{})
 			Expect(reply).Should(BeAssignableToTypeOf(operations.NewV2ListSupportedOpenshiftVersionsOK()))
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	"fmt"
 	"runtime/debug"
+	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/hashicorp/go-version"
@@ -172,7 +173,11 @@ func (h *handler) getReleaseImageFromCache(openshiftVersion, cpuArchitecture str
 			return nil, err
 		}
 		releaseImage = funk.Find(releaseImages, func(releaseImage *models.ReleaseImage) bool {
-			return *releaseImage.OpenshiftVersion == versionKey
+			// Starting from OCP 4.12 multi-arch release images do not have "-multi" suffix
+			// reported by the CVO, but we still offer the sufix internally to allow for explicit
+			// selection or single- or multi-arch payload.
+			version := strings.TrimSuffix(*releaseImage.OpenshiftVersion, "-multi")
+			return version == versionKey
 		})
 	}
 


### PR DESCRIPTION
This PR fixes the behaviour of filtering release images by architecture in case there are multiple images that have exactly the same version as reported by the CVO.

As a consequence, it was no longer possible to correctly handle single- and multi-arch release payloads that correspond to the same OCP version. With this change, we again have ability to support this scenario.

Contributes-to: [MGMT-12978](https://issues.redhat.com//browse/MGMT-12978)

/cc @danielerez 
/cc @carbonin 