### PR TITLE
MGMT-13038: Git fails to trust git repository because of mismatch with files

### DIFF
--- a/ci-images/Dockerfile.base
+++ b/ci-images/Dockerfile.base
@@ -4,6 +4,11 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
     dnf install -y git unzip make gcc which nmstate-devel
 
+# Git checks if the user that owns the files on the filesystem match the
+# current user.  We need to disable this check because tests in Prow are
+# running with a random user.
+RUN git config --system --add safe.directory '*'
+
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.18 /usr/local/go /usr/local/go
 
 ENV GOPATH=/go


### PR DESCRIPTION
git was updated in centos 9 stream repository and now checks if the owner of the files on the filesystem match the current user.

This change disable the check because Prow runs jobs with a random user.