### PR TITLE
MGMT-10534: Add infra-env override for ironic agent image

### DIFF
--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -103,6 +103,12 @@ type InfraEnvSpec struct {
 	// Applicable for both iPXE, and ISO streaming from Image Service.
 	// +optional
 	KernelArguments []KernelArgument `json:"kernelArguments,omitempty"`
+
+	// IronicAgentImageOverride is the pull spec for the ironic agent image to use when discovering hosts.
+	// Only applies when provisioning using a BareMetalHost.
+	// If unspecified, the ironic agent image from the hub cluster release is used.
+	// +optional
+	IronicAgentImageOverride string `json:"ironicAgentImageOverride,omitempty"`
 }
 
 type KernelArgument struct {

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -97,6 +97,12 @@ spec:
                 - DiscoveryImageAlways
                 - BootOrderControl
                 type: string
+              ironicAgentImageOverride:
+                description: IronicAgentImageOverride is the pull spec for the ironic
+                  agent image to use when discovering hosts. Only applies when provisioning
+                  using a BareMetalHost. If unspecified, the ironic agent image from
+                  the hub cluster release is used.
+                type: string
               kernelArguments:
                 description: KernelArguments is the additional kernel arguments to
                   be passed during boot time of the discovery image. Applicable for

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -2489,6 +2489,12 @@ spec:
                 - DiscoveryImageAlways
                 - BootOrderControl
                 type: string
+              ironicAgentImageOverride:
+                description: IronicAgentImageOverride is the pull spec for the ironic
+                  agent image to use when discovering hosts. Only applies when provisioning
+                  using a BareMetalHost. If unspecified, the ironic agent image from
+                  the hub cluster release is used.
+                type: string
               kernelArguments:
                 description: KernelArguments is the additional kernel arguments to
                   be passed during boot time of the discovery image. Applicable for

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
@@ -95,6 +95,12 @@ spec:
                 - DiscoveryImageAlways
                 - BootOrderControl
                 type: string
+              ironicAgentImageOverride:
+                description: IronicAgentImageOverride is the pull spec for the ironic
+                  agent image to use when discovering hosts. Only applies when provisioning
+                  using a BareMetalHost. If unspecified, the ironic agent image from
+                  the hub cluster release is used.
+                type: string
               kernelArguments:
                 description: KernelArguments is the additional kernel arguments to
                   be passed during boot time of the discovery image. Applicable for

--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -55,7 +55,7 @@ More details on conditions is available [here](kube-api-conditions.md)
 #### Debug Information
 
 The `DebugInfo` field under `Status` provides additional information for debugging installation process:
-- `EventsURL` specifies an HTTP/S URL that contains events occured during cluster installation process
+- `EventsURL` specifies an HTTP/S URL that contains events occurred during cluster installation process
 
 
 
@@ -198,7 +198,7 @@ It will continue to:
 The assisted agent will not reboot the machine at the end of the installation, instead it will stop
 the assisted agent service and let the ironic agent to manage the machine power state
 
-The converged flow is disalbed by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
+The converged flow is disabled by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
 
 ### Ironic Agent Image
 
@@ -213,6 +213,9 @@ The environment var for the ironicAgent image to be used on X86_64 CPU architect
 `IRONIC_AGENT_IMAGE`
 The environment var for the ironicAgent image to be used on arm64 CPU architecture:
 `IRONIC_AGENT_IMAGE_ARM`
+
+The ironic agent image can also be overridden using the InfraEnv spec field `ironicAgentImageOverride`
+If this field is set this image will be used instead of the hub or default image.
 
 **NOTE**
 Ensure the correct images are mirrored if installing in a disconnected environment.

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -356,15 +356,12 @@ func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(a client.Object) 
 		reconcileRequests := []reconcile.Request{}
 
 		for i := range images {
-			// Don't queue if the Image URL and InfraEnv's URL is the same.
-			if images[i].Status.ImageUrl != infraEnv.Status.ISODownloadURL {
-				reconcileRequests = append(reconcileRequests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Namespace: images[i].Namespace,
-						Name:      images[i].Name,
-					},
-				})
-			}
+			reconcileRequests = append(reconcileRequests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: images[i].Namespace,
+					Name:      images[i].Name,
+				},
+			})
 		}
 		return reconcileRequests
 	}

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -138,8 +137,9 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		return ctrl.Result{}, err
 	}
 
-	if !IronicAgentEnabled(log, infraEnv) {
-		return r.AddIronicAgentToInfraEnv(ctx, log, infraEnv)
+	infraEnvUpdated, err := r.AddIronicAgentToInfraEnv(ctx, log, infraEnv)
+	if infraEnvUpdated || err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if infraEnv.Status.CreatedTime == nil {
@@ -371,8 +371,9 @@ func (r *PreprovisioningImageReconciler) mapInfraEnvPPI() func(a client.Object) 
 	return mapInfraEnvPPI
 }
 
-func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) (ctrl.Result, error) {
-	// Retrieve infraenv from the database
+// AddIronicAgentToInfraEnv updates the infra-env in the database with the ironic agent ignition config if required
+// returns true when the infra-env was updated, false otherwise
+func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) (bool, error) {
 	key := types.NamespacedName{
 		Name:      infraEnv.Name,
 		Namespace: infraEnv.Namespace,
@@ -380,11 +381,16 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	infraEnvInternal, err := r.Installer.GetInfraEnvByKubeKey(key)
 	if err != nil {
 		log.WithError(err).Error("failed to get corresponding infraEnv")
-		return ctrl.Result{}, err
+		return false, err
 	}
-	ironicAgentImage, err := r.getIronicAgentImageByRelease(ctx, log, infraEnvInternal)
-	if err != nil {
-		log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
+	ironicAgentImage := infraEnv.Spec.IronicAgentImageOverride
+	if ironicAgentImage == "" {
+		ironicAgentImage, err = r.getIronicAgentImageByRelease(ctx, log, infraEnvInternal)
+		if err != nil {
+			log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
+		}
+	} else {
+		log.Infof("Using override ironic agent image (%s) for infraEnv %s", ironicAgentImage, infraEnv.Name)
 	}
 
 	// if ironicAgentImage can't be found by version use the default
@@ -400,25 +406,30 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	conf, err := ignition.GenerateIronicConfig(r.IronicServiceURL, r.IronicInspectorURL, *infraEnvInternal, ironicAgentImage)
 	if err != nil {
 		log.WithError(err).Error("failed to generate Ironic ignition config")
-		return ctrl.Result{}, err
+		return false, err
 	}
 
-	_, err = r.Installer.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{InfraEnvID: *infraEnvInternal.ID, InfraEnvUpdateParams: &models.InfraEnvUpdateParams{}}, swag.String(string(conf)))
-	if err != nil {
-		return ctrl.Result{}, err
+	updated := false
+	if string(conf) != infraEnvInternal.InternalIgnitionConfigOverride {
+		_, err = r.Installer.UpdateInfraEnvInternal(ctx, installer.UpdateInfraEnvParams{InfraEnvID: *infraEnvInternal.ID, InfraEnvUpdateParams: &models.InfraEnvUpdateParams{}}, swag.String(string(conf)))
+		if err != nil {
+			return false, err
+		}
+		updated = true
+		r.CRDEventsHandler.NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace)
 	}
-	if infraEnv.ObjectMeta.Annotations == nil {
-		infraEnv.ObjectMeta.Annotations = make(map[string]string)
+	if _, haveAnnotation := infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]; !haveAnnotation {
+		if infraEnv.ObjectMeta.Annotations == nil {
+			infraEnv.ObjectMeta.Annotations = make(map[string]string)
+		}
+		infraEnv.Annotations[EnableIronicAgentAnnotation] = "true"
+		if err := r.Client.Update(ctx, infraEnv); err != nil {
+			// Just warn here if the update fails as this annotation is just informational
+			log.WithError(err).Warnf("failed to set %s annotation on infraEnv %s", EnableIronicAgentAnnotation, infraEnv.Name)
+		}
 	}
 
-	infraEnv.Annotations[EnableIronicAgentAnnotation] = "true"
-	err = r.Client.Update(ctx, infraEnv)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	// TODO: if the annotation is enough to trigger the infraEnv reconciliation remove the notification
-	r.CRDEventsHandler.NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace)
-	return ctrl.Result{}, err
+	return updated, nil
 }
 
 func (r *PreprovisioningImageReconciler) getIronicAgentImageByRelease(ctx context.Context, log logrus.FieldLogger, infraEnv *common.InfraEnv) (string, error) {
@@ -448,17 +459,4 @@ func (r *PreprovisioningImageReconciler) getIronicAgentImageByRelease(ctx contex
 	}
 
 	return image, nil
-}
-
-func IronicAgentEnabled(log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) bool {
-	value, ok := infraEnv.GetAnnotations()[EnableIronicAgentAnnotation]
-	if !ok {
-		return false
-	}
-	log.Debugf("InfraEnv annotation %s value %s", EnableIronicAgentAnnotation, value)
-	enabled, err := strconv.ParseBool(value)
-	if err != nil {
-		log.WithError(err).Errorf("failed to parse %s to bool value", value)
-	}
-	return enabled
 }

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -590,17 +590,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 
 			Expect(len(requests)).To(Equal(0))
 		})
-		It("Single PreprovisioningImage for infraEnv - nothing ot update", func() {
-			infraEnv.Status.ISODownloadURL = downloadURL
-			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-			ppi.Status.ImageUrl = downloadURL
-			Expect(c.Create(ctx, ppi)).To(BeNil())
-
-			requests := pr.mapInfraEnvPPI()(infraEnv)
-
-			Expect(len(requests)).To(Equal(0))
-		})
-
 	})
 
 })

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -4632,6 +4632,18 @@ var _ = Describe("PreprovisioningImage reconcile flow", func() {
 			}, "30s", "10s").Should(Equal(true))
 			infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
 			Expect(infraEnv.InternalIgnitionConfigOverride).Should(ContainSubstring("ironic-agent.service"))
+
+			By("updates the ignition when an ironic agent override image is specified")
+			overrideImage := "example.com/ironic/agent:latest"
+			Expect(infraEnv.InternalIgnitionConfigOverride).ShouldNot(ContainSubstring(overrideImage))
+			Eventually(func() error {
+				infraEnv := getInfraEnvCRD(ctx, kubeClient, infraNsName)
+				infraEnv.Spec.IronicAgentImageOverride = overrideImage
+				return kubeClient.Update(ctx, infraEnv)
+			}, "30s", "5s").Should(Succeed())
+			Eventually(func() string {
+				return getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout).InternalIgnitionConfigOverride
+			}, "30s", "5s").Should(ContainSubstring(overrideImage))
 		})
 		It("should get ImageUrl from the infraEnv", func() {
 			ppi = getPPICRD(ctx, kubeClient, ppiNsName)

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -103,6 +103,12 @@ type InfraEnvSpec struct {
 	// Applicable for both iPXE, and ISO streaming from Image Service.
 	// +optional
 	KernelArguments []KernelArgument `json:"kernelArguments,omitempty"`
+
+	// IronicAgentImageOverride is the pull spec for the ironic agent image to use when discovering hosts.
+	// Only applies when provisioning using a BareMetalHost.
+	// If unspecified, the ironic agent image from the hub cluster release is used.
+	// +optional
+	IronicAgentImageOverride string `json:"ironicAgentImageOverride,omitempty"`
 }
 
 type KernelArgument struct {


### PR DESCRIPTION
Adds a field to the infra-env CR for overriding the ironic agent image when using the ZTP converged flow.
This also changes the behavior of the preprovisioning image reconciler so that we update the ironic ignition whenever it changes rather than only updating the ignition when the annotation is missing.

## List all the issues related to this PR

~~Built on top of https://github.com/openshift/assisted-service/pull/4798 (WIP until hub image PR is merged)~~ Merged
Resolves https://issues.redhat.com/browse/MGMT-10534

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?
1. Deployed a dev-scripts cluster
2. Created an infraenv + BMH
3. Observed the image from the hub cluster in the discovery ignition
4. Set the override image
5. Observed the override image used in the discovery ignition
6. Changed/removed override - got expected behavior

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) TODO
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
