### PR TITLE
MGMT-12875: fail gracefully when konnectivity is missing

### DIFF
--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -777,8 +777,10 @@ func newHypershiftWebHookAPIService(ctx context.Context, log logrus.FieldLogger,
 func newKonnectivityAgentDeployment(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {
 	//read the existing konnectivity deployment
 	ka := &appsv1.Deployment{}
-	if err := asc.Client.Get(ctx, types.NamespacedName{Name: "konnectivity-agent", Namespace: asc.namespace}, ka); err != nil {
-		log.WithError(err).Errorf("Failed retrieving konnectivity-agend Deployment from namespace %s", asc.namespace)
+	if e := asc.Client.Get(ctx, types.NamespacedName{Name: "konnectivity-agent", Namespace: asc.namespace}, ka); e != nil {
+		err := pkgerror.Wrap(e, fmt.Sprintf("Failed to retrieve konnectivity-agent Deployment from namespace %s", asc.namespace))
+		log.WithError(err)
+		return nil, nil, err
 	}
 	ka.ObjectMeta = metav1.ObjectMeta{
 		Name:      "konnectivity-agent-assisted-service",


### PR DESCRIPTION


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
