### PR TITLE
MGMT-12794: allow to edit ACI post install

### DIFF
--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -268,13 +268,19 @@ func (a *AgentClusterInstallValidatingAdmissionHook) validateUpdate(admissionSpe
 	}
 }
 
+// MGMT-12794 This function returns true if the installation is in progress.
+// If the cluster installation has finished (successfully or with errors) or
+// did not start yet, it returns false.
+// This logic allows editing the ACI in day-2 scenarios.
+// Changes to the ACI at a post-install time have no impact on the flow but
+// serve some CI/CD gitops flows.
 func installAlreadyStarted(conditions []hivev1.ClusterInstallCondition) bool {
 	cond := FindStatusCondition(conditions, hiveext.ClusterCompletedCondition)
 	if cond == nil {
 		return false
 	}
 	switch cond.Reason {
-	case hiveext.ClusterInstallationFailedReason, hiveext.ClusterInstalledReason, hiveext.ClusterInstallationInProgressReason, hiveext.ClusterAlreadyInstallingReason:
+	case hiveext.ClusterInstallationInProgressReason, hiveext.ClusterAlreadyInstallingReason:
 		return true
 	default:
 		return false

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -146,7 +146,7 @@ var _ = Describe("ACI web validate", func() {
 			expectedAllowed: false,
 		},
 		{
-			name: "Test AgentClusterInstall.Spec is immutable (updates not allowed) Install finished",
+			name: "Test AgentClusterInstall.Spec updates allowed on Install finished",
 			newSpec: hiveext.AgentClusterInstallSpec{
 				SSHPublicKey: "somekey",
 			},
@@ -160,10 +160,10 @@ var _ = Describe("ACI web validate", func() {
 				SSHPublicKey: "someotherkey",
 			},
 			operation:       admissionv1.Update,
-			expectedAllowed: false,
+			expectedAllowed: true,
 		},
 		{
-			name: "Test AgentClusterInstall.Spec is immutable (updates not allowed) Install failed",
+			name: "Test AgentClusterInstall.Spec updates allowed after Install failed",
 			newSpec: hiveext.AgentClusterInstallSpec{
 				SSHPublicKey: "somekey",
 			},
@@ -177,7 +177,7 @@ var _ = Describe("ACI web validate", func() {
 				SSHPublicKey: "someotherkey",
 			},
 			operation:       admissionv1.Update,
-			expectedAllowed: false,
+			expectedAllowed: true,
 		},
 		{
 			name: "Test AgentClusterInstall.Spec.ClusterMetadata is mutable (updates are allowed) Install started",


### PR DESCRIPTION
To support gitops ZTP ArgoCD flow we should allow editing the ACI CR after the installation has finished.

From the perspective of assisted service, this has no meaning, but for the gitops flow on day-2, it is important because they are going to use the edited CR as a template for future actions.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
