### PR TITLE
MGMT-13098: add missing networks on V2GetClusterInstallConfig

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -93,7 +93,7 @@ func (b *bareMetalInventory) V2DeregisterCluster(ctx context.Context, params ins
 }
 
 func (b *bareMetalInventory) V2GetClusterInstallConfig(ctx context.Context, params installer.V2GetClusterInstallConfigParams) middleware.Responder {
-	cluster, err := b.getCluster(ctx, params.ClusterID.String())
+	cluster, err := b.getCluster(ctx, params.ClusterID.String(), common.UseEagerLoading)
 	if err != nil {
 		return common.GenerateErrorResponder(fmt.Errorf("Failed to get cluster %s: %w", params.ClusterID, err))
 	}

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -5208,7 +5208,7 @@ var _ = Describe("Verify install-config manifest", func() {
 		return installConfig
 	}
 
-	validateInstallConfig := func(installConfig map[string]interface{}, networksIncluded bool) {
+	validateInstallConfig := func(installConfig map[string]interface{}) {
 		By("Validate 'baseDomain'")
 		baseDomain, ok := installConfig["baseDomain"].(string)
 		Expect(ok).To(Equal(true))
@@ -5241,32 +5241,28 @@ var _ = Describe("Verify install-config manifest", func() {
 		networking, ok := installConfig["networking"].(map[interface{}]interface{})
 		Expect(ok).To(Equal(true))
 
-		// Networks are not included when fetching using V2GetClusterInstallConfig
-		// (the cluster is fetched without eager loading)
-		if networksIncluded {
-			// Validate 'clusterNetwork'
-			clusterNetwork, ok := networking["clusterNetwork"].([]interface{})
-			Expect(ok).To(Equal(true))
-			cidrEntry, ok := clusterNetwork[0].(map[interface{}]interface{})
-			Expect(ok).To(Equal(true))
-			cidr, ok := cidrEntry["cidr"].(string)
-			Expect(ok).To(Equal(true))
-			Expect(cidr).To(Equal(clusterCIDR))
-			// Validate 'machineNetwork'
-			machineNetwork, ok := networking["machineNetwork"].([]interface{})
-			Expect(ok).To(Equal(true))
-			cidrEntry, ok = machineNetwork[0].(map[interface{}]interface{})
-			Expect(ok).To(Equal(true))
-			cidr, ok = cidrEntry["cidr"].(string)
-			Expect(ok).To(Equal(true))
-			Expect(cidr).To(Equal(machineCIDR))
-			// Validate 'serviceNetwork'
-			serviceNetwork, ok := networking["serviceNetwork"].([]interface{})
-			Expect(ok).To(Equal(true))
-			cidr, ok = serviceNetwork[0].(string)
-			Expect(ok).To(Equal(true))
-			Expect(cidr).To(Equal(serviceCIDR))
-		}
+		// Validate 'clusterNetwork'
+		clusterNetwork, ok := networking["clusterNetwork"].([]interface{})
+		Expect(ok).To(Equal(true))
+		cidrEntry, ok := clusterNetwork[0].(map[interface{}]interface{})
+		Expect(ok).To(Equal(true))
+		cidr, ok := cidrEntry["cidr"].(string)
+		Expect(ok).To(Equal(true))
+		Expect(cidr).To(Equal(clusterCIDR))
+		// Validate 'machineNetwork'
+		machineNetwork, ok := networking["machineNetwork"].([]interface{})
+		Expect(ok).To(Equal(true))
+		cidrEntry, ok = machineNetwork[0].(map[interface{}]interface{})
+		Expect(ok).To(Equal(true))
+		cidr, ok = cidrEntry["cidr"].(string)
+		Expect(ok).To(Equal(true))
+		Expect(cidr).To(Equal(machineCIDR))
+		// Validate 'serviceNetwork'
+		serviceNetwork, ok := networking["serviceNetwork"].([]interface{})
+		Expect(ok).To(Equal(true))
+		cidr, ok = serviceNetwork[0].(string)
+		Expect(ok).To(Equal(true))
+		Expect(cidr).To(Equal(serviceCIDR))
 	}
 
 	BeforeEach(func() {
@@ -5302,10 +5298,10 @@ var _ = Describe("Verify install-config manifest", func() {
 	})
 
 	It("Validate install-config.yaml content retrieved from V2DownloadClusterFiles", func() {
-		validateInstallConfig(getInstallConfigFromFile(), true)
+		validateInstallConfig(getInstallConfigFromFile())
 	})
 
 	It("Validate install-config.yaml content retrieved from V2GetClusterInstallConfig", func() {
-		validateInstallConfig(getInstallConfigFromDB(), false)
+		validateInstallConfig(getInstallConfigFromDB())
 	})
 })


### PR DESCRIPTION
When invoking V2GetClusterInstallConfig API (/v2/clusters/{cluster_id}/install-config) the returned config doesn't include network lists (in 'networking' key). I.e. these lists are missing: clusterNetwork/machineNetwork/serviceNetwork.

To resolve this issue, added 'UseEagerLoading' when fetching the cluster in order to include the networks info.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
