### PR TITLE
MGMT-12794: allow to edit ProvisionRequirement post install

### DIFF
--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -246,7 +246,14 @@ func (a *AgentClusterInstallValidatingAdmissionHook) validateUpdate(admissionSpe
 	}
 
 	if installAlreadyStarted(newObject.Status.Conditions) {
-		hasChangedImmutableField, unsupportedDiff := hasChangedImmutableField(&oldObject.Spec, &newObject.Spec)
+		ignoreChanges := mutableFields
+		// MGMT-12794 This function returns true if the ProvisionRequirements field
+		// has changed after installation completion. A change to this section has no effect
+		// at this stage, but it is needed to serve some CI/CD gitops flows.
+		if installCompleted(newObject.Status.Conditions) {
+			ignoreChanges = append(ignoreChanges, "ProvisionRequirements")
+		}
+		hasChangedImmutableField, unsupportedDiff := hasChangedImmutableField(&oldObject.Spec, &newObject.Spec, ignoreChanges)
 		if hasChangedImmutableField {
 			message := fmt.Sprintf("Attempted to change AgentClusterInstall.Spec which is immutable after install started, except for %s fields. Unsupported change: \n%s", strings.Join(mutableFields, ","), unsupportedDiff)
 			contextLogger.Infof("Failed validation: %v", message)
@@ -281,6 +288,14 @@ func installAlreadyStarted(conditions []hivev1.ClusterInstallCondition) bool {
 	}
 }
 
+func installCompleted(conditions []hivev1.ClusterInstallCondition) bool {
+	cond := FindStatusCondition(conditions, hiveext.ClusterCompletedCondition)
+	if cond == nil {
+		return false
+	}
+	return cond.Reason == hiveext.ClusterInstalledReason || cond.Reason == hiveext.ClusterInstallationFailedReason
+}
+
 // FindStatusCondition finds the conditionType in conditions.
 func FindStatusCondition(conditions []hivev1.ClusterInstallCondition, conditionType string) *hivev1.ClusterInstallCondition {
 	for i := range conditions {
@@ -293,7 +308,7 @@ func FindStatusCondition(conditions []hivev1.ClusterInstallCondition, conditionT
 
 // hasChangedImmutableField determines if a AgentClusterInstall.spec immutable field was changed.
 // it returns the diff string that shows the changes that are not supported
-func hasChangedImmutableField(oldObject, cd *hiveext.AgentClusterInstallSpec) (bool, string) {
+func hasChangedImmutableField(oldObject, cd *hiveext.AgentClusterInstallSpec, mutableFields []string) (bool, string) {
 	r := &diffReporter{}
 	opts := cmp.Options{
 		cmpopts.EquateEmpty(),

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -163,6 +163,29 @@ var _ = Describe("ACI web validate", func() {
 			expectedAllowed: false,
 		},
 		{
+			name: "Test AgentClusterInstall.Spec update allowed for provision fields when Install finished",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			conditions: []hivev1.ClusterInstallCondition{
+				{
+					Type:   hiveext.ClusterCompletedCondition,
+					Reason: hiveext.ClusterInstalledReason,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
 			name: "Test AgentClusterInstall.Spec is immutable (updates not allowed) Install failed",
 			newSpec: hiveext.AgentClusterInstallSpec{
 				SSHPublicKey: "somekey",
@@ -178,6 +201,29 @@ var _ = Describe("ACI web validate", func() {
 			},
 			operation:       admissionv1.Update,
 			expectedAllowed: false,
+		},
+		{
+			name: "Test AgentClusterInstall.Spec update allowed for provision fields when Install finished",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			conditions: []hivev1.ClusterInstallCondition{
+				{
+					Type:   hiveext.ClusterCompletedCondition,
+					Reason: hiveext.ClusterInstallationFailedReason,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
 		},
 		{
 			name: "Test AgentClusterInstall.Spec.ClusterMetadata is mutable (updates are allowed) Install started",

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -203,7 +203,7 @@ var _ = Describe("ACI web validate", func() {
 			expectedAllowed: false,
 		},
 		{
-			name: "Test AgentClusterInstall.Spec update allowed for provision fields when Install finished",
+			name: "Test AgentClusterInstall.Spec update allowed for provision fields when Install failed",
 			newSpec: hiveext.AgentClusterInstallSpec{
 				ProvisionRequirements: hiveext.ProvisionRequirements{
 					ControlPlaneAgents: 3,


### PR DESCRIPTION
To support gitops ZTP ArgoCD flow we should allow editing the ACI CR after the installation has finished.

The only edit operation that is allowed is changing the provision requirment field.

From the perspective of assisted service, this has no meaning, but for the gitops flow on day-2, it is important because they are going to use the edited CR as a template for future actions.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
