### PR TITLE
MGMT-13040: Check cluster state before delete

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -70,6 +70,17 @@ func (b *bareMetalInventory) V2DeregisterCluster(ctx context.Context, params ins
 		return common.NewApiError(http.StatusNotFound, err)
 	}
 
+	if swag.StringValue(cluster.Status) == models.ClusterStatusInstalling {
+		return common.NewApiError(
+			http.StatusConflict,
+			fmt.Errorf(
+				"cluster %s can not be removed while being installed, wait for "+
+					"the installation to timeout or reset the installation",
+				cluster.ID,
+			),
+		)
+	}
+
 	if b.ocmClient != nil {
 		if err = b.integrateWithAMSClusterDeregistration(ctx, cluster); err != nil {
 			log.WithError(err).Errorf("Cluster %s failed to integrate with AMS on cluster deregistration", params.ClusterID)


### PR DESCRIPTION
Currently when the user tries to delete a cluster via the API we perform multiple operations, in the following order:

- Delete the cluster from AMS.
- Delete DNS records.
- Delete hosts.
- Delete the cluster itself.

The last operation, deleting the cluster itself, will fail if the cluster is being installed. The result of that is that the cluster will be partially deleted, in particular the hosts will be deleted, and therefore they will try to register again and fail. To avoid that this patch adds a check so that the requests to delete a cluster that is being installed will be rejected before any of those operations.

Related: https://issues.redhat.com/browse/MGMT-13040

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
