### PR TITLE
MGMT-12655: Propagate installation disk from Host to Agent

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -582,6 +582,7 @@ func main() {
 				APIReader:             ctrlMgr.GetAPIReader(),
 				Log:                   log,
 				Scheme:                ctrlMgr.GetScheme(),
+				Installer:             bm,
 				SpokeK8sClientFactory: spoke_k8s_client.NewSpokeK8sClientFactory(log),
 				ConvergedFlowEnabled:  useConvergedFlow,
 			}).SetupWithManager(ctrlMgr), "unable to create controller BMH")

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
+	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
@@ -34,20 +35,24 @@ var BASIC_CERT = `test`
 
 var _ = Describe("bmac reconcile", func() {
 	var (
-		c        client.Client
-		bmhr     *BMACReconciler
-		ctx      = context.Background()
-		mockCtrl *gomock.Controller
+		c                     client.Client
+		bmhr                  *BMACReconciler
+		ctx                   = context.Background()
+		mockCtrl              *gomock.Controller
+		mockInstallerInternal *bminventory.MockInstallerInternals
 	)
 
 	BeforeEach(func() {
 		schemes := GetKubeClientSchemes()
 		c = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
+		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&common.Host{Host: models.Host{}}, nil).AnyTimes()
 		bmhr = &BMACReconciler{
 			Client:               c,
 			APIReader:            c,
 			Scheme:               scheme.Scheme,
+			Installer:            mockInstallerInternal,
 			Log:                  common.GetTestLog(),
 			spokeClient:          fakeclient.NewClientBuilder().WithScheme(schemes).Build(),
 			ConvergedFlowEnabled: false,
@@ -1279,20 +1284,24 @@ var _ = Describe("bmac reconcile", func() {
 
 var _ = Describe("bmac reconcile - converged flow enabled", func() {
 	var (
-		c        client.Client
-		bmhr     *BMACReconciler
-		ctx      = context.Background()
-		mockCtrl *gomock.Controller
+		c                     client.Client
+		bmhr                  *BMACReconciler
+		ctx                   = context.Background()
+		mockCtrl              *gomock.Controller
+		mockInstallerInternal *bminventory.MockInstallerInternals
 	)
 
 	BeforeEach(func() {
 		schemes := GetKubeClientSchemes()
 		c = fakeclient.NewClientBuilder().WithScheme(schemes).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
+		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(&common.Host{Host: models.Host{}}, nil).AnyTimes()
 		bmhr = &BMACReconciler{
 			Client:               c,
 			APIReader:            c,
 			Scheme:               scheme.Scheme,
+			Installer:            mockInstallerInternal,
 			Log:                  common.GetTestLog(),
 			spokeClient:          fakeclient.NewClientBuilder().WithScheme(schemes).Build(),
 			ConvergedFlowEnabled: true,


### PR DESCRIPTION
This PR introduces a backwards synchronization of the installation disk ID from the Host (AI DB) to the Agent (K8s) in a scenario when no device hints are provided.

In the non-ZTP scenarios that use ACM it allows to query for the installation disk selected by the backend directly from the Agent CR. Until now Agent CR carried installation disk ID only in case there was an override, but with this change it should always contain the ID no matter whether it has been selected by the user explicitly or autocalculated by the backend.

Contributes-to: [MGMT-12655](https://issues.redhat.com//browse/MGMT-12655)