### PR TITLE
MGMT-12655: Set Agent's installation disk ID only if hints exist

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -406,7 +406,7 @@ func (r *BMACReconciler) reconcileAgentSpec(log logrus.FieldLogger, bmh *bmh_v1a
 	// to "overwrite" this value everytime as the default
 	// is ""
 	installationDiskID := r.findInstallationDiskID(agent.Status.Inventory.Disks, bmh.Spec.RootDeviceHints)
-	if agent.Spec.InstallationDiskID != installationDiskID {
+	if installationDiskID != "" && bmh.Spec.RootDeviceHints != nil && agent.Spec.InstallationDiskID != installationDiskID {
 		agent.Spec.InstallationDiskID = installationDiskID
 		dirty = true
 	}


### PR DESCRIPTION
This PR changes the logic of setting installation disk ID in the Agent CR so that the backend modifies CR only if user has provided a custom root device hints. This prevents a scenario when empty hints cause setting the Agent's field to the empty value even if the value has been set explicitly by the user.

With this change the behaviour will be as follows

* empty ID in Agent and empty hints - nothing happens
* empty ID in Agent and non-empty hints - autocalculation
* non-empty ID in Agent and empty hints - ID is preserved
* non-empty ID in Agent and non-empty hints - autocalculation

Contributes-to: [MGMT-12655](https://issues.redhat.com//browse/MGMT-12655)