### PR TITLE
MGMT-13132: Respond with 409 when rejecting registration

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4999,7 +4999,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 					params.NewHostParams.HostID, params.InfraEnvID.String(), err.Error())
 				eventgen.SendHostRegistrationFailedEvent(ctx, b.eventsHandler, *params.NewHostParams.HostID, params.InfraEnvID, cluster.ID, err.Error())
 
-				return common.NewApiError(http.StatusBadRequest, err)
+				return common.NewApiError(http.StatusConflict, err)
 			}
 		}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -485,7 +485,7 @@ var _ = Describe("RegisterHost", func() {
 		By("verifying returned response")
 		apiErr, ok := reply.(*common.ApiErrorResponse)
 		Expect(ok).Should(BeTrue())
-		Expect(apiErr.StatusCode()).Should(Equal(int32(http.StatusBadRequest)))
+		Expect(apiErr.StatusCode()).Should(Equal(int32(http.StatusConflict)))
 		Expect(apiErr.Error()).Should(Equal(err.Error()))
 	})
 

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1772,7 +1772,7 @@ var _ = Describe("cluster install", func() {
 					HostID: strToUUID(uuid.New().String()),
 				},
 			})
-			Expect(err).To(BeAssignableToTypeOf(installer.NewV2RegisterHostBadRequest()))
+			Expect(err).To(BeAssignableToTypeOf(installer.NewV2RegisterHostConflict()))
 		})
 
 		It("register host while cluster in error state", func() {
@@ -1786,7 +1786,7 @@ var _ = Describe("cluster install", func() {
 					HostID: strToUUID(uuid.New().String()),
 				},
 			})
-			Expect(err).To(BeAssignableToTypeOf(installer.NewV2RegisterHostBadRequest()))
+			Expect(err).To(BeAssignableToTypeOf(installer.NewV2RegisterHostConflict()))
 		})
 
 		It("fail installation if there is only a single worker that manages to install", func() {


### PR DESCRIPTION
Currently when an agent tries to register while the cluster is installing the service will return a 400 response code. As a result the agent will retry the request after one minute. To avoid that this patch changes the response code to 409, which will cause the agent to freeze.

Related: https://issues.redhat.com/browse/MGMT-13132

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Manually.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
