### PR TITLE
MGMT-13170: Fix nil pointer dereference in validation if host inventory is nil

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1781,6 +1781,9 @@ func (v *validator) noIPCollisionsInNetwork(c *validationContext) (ValidationSta
 	if c.cluster == nil {
 		return ValidationSuccess, "Cluster has not yet been defined, skipping validation."
 	}
+	if c.inventory == nil {
+		return ValidationSuccess, "Host inventory has not yet been defined, skipping validation."
+	}
 	if common.IsDay2Cluster(c.cluster) {
 		return ValidationSuccess, fmt.Sprintf("Skipping validation for day 2 host %s", c.host.ID)
 	}


### PR DESCRIPTION
In some scenarios, if a host inventory is nil, it is possible for the noIPCollisionsInNetwork host validation to crash with a nil pointer dereference panic. This PR fixes that by adding a check to ensure that the validation should be skipped if the host inventory is nil and adds a unit test for this.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed
New unit test written and executed.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
