### PR TITLE
MGMT-12655: Add installation disk ID to Agent's status

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -236,6 +236,10 @@ type AgentStatus struct {
 	// ValidationsInfo is a JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
 	// +optional
 	ValidationsInfo common.ValidationsStatus `json:"validationsInfo,omitempty"`
+
+	// InstallationDiskID is the disk that will be used for the installation.
+	// +optional
+	InstallationDiskID string `json:"installation_disk_id,omitempty"`
 }
 
 type DebugInfo struct {

--- a/config/crd/bases/agent-install.openshift.io_agents.yaml
+++ b/config/crd/bases/agent-install.openshift.io_agents.yaml
@@ -168,6 +168,10 @@ spec:
                       the Agent
                     type: string
                 type: object
+              installation_disk_id:
+                description: InstallationDiskID is the disk that will be used for
+                  the installation.
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -824,6 +824,10 @@ spec:
                       the Agent
                     type: string
                 type: object
+              installation_disk_id:
+                description: InstallationDiskID is the disk that will be used for
+                  the installation.
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_agents.yaml
@@ -166,6 +166,10 @@ spec:
                       the Agent
                     type: string
                 type: object
+              installation_disk_id:
+                description: InstallationDiskID is the disk that will be used for
+                  the installation.
+                type: string
               inventory:
                 properties:
                   bmcAddress:

--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -537,6 +537,7 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		}
 		agent.Status.DebugInfo.State = swag.StringValue(h.Status)
 		agent.Status.DebugInfo.StateInfo = swag.StringValue(h.StatusInfo)
+		agent.Status.InstallationDiskID = h.InstallationDiskID
 
 		if h.ValidationsInfo != "" {
 			newValidationsInfo := ValidationsStatus{}

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -356,12 +356,13 @@ var _ = Describe("agent reconcile", func() {
 		}
 		afterUpdateHost := &common.Host{
 			Host: models.Host{
-				ID:         &hostId,
-				ClusterID:  &sId,
-				Inventory:  common.GenerateTestDefaultInventory(),
-				Status:     swag.String(models.HostStatusKnown),
-				StatusInfo: swag.String("I am known"),
-				InfraEnvID: infraEnvId,
+				ID:                 &hostId,
+				ClusterID:          &sId,
+				Inventory:          common.GenerateTestDefaultInventory(),
+				Status:             swag.String(models.HostStatusKnown),
+				StatusInfo:         swag.String("I am known"),
+				InfraEnvID:         infraEnvId,
+				InstallationDiskID: newInstallDiskPath,
 			},
 		}
 		backEndCluster = &common.Cluster{Cluster: models.Cluster{
@@ -384,8 +385,6 @@ var _ = Describe("agent reconcile", func() {
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil).Times(2)
 		mockInstallerInternal.EXPECT().V2UpdateHostInternal(gomock.Any(), gomock.Any(), bminventory.NonInteractive).
 			Do(func(ctx context.Context, param installer.V2UpdateHostParams, interactive bminventory.Interactivity) {
-				Expect(param.HostUpdateParams.DisksSelectedConfig[0].ID).To(Equal(&newInstallDiskPath))
-				Expect(param.HostUpdateParams.DisksSelectedConfig[0].Role).To(Equal(models.DiskRoleInstall))
 				Expect(swag.StringValue(param.HostUpdateParams.HostName)).To(Equal(newHostName))
 				Expect(param.HostID).To(Equal(hostId))
 				Expect(param.InfraEnvID).To(Equal(infraEnvId))
@@ -433,6 +432,8 @@ var _ = Describe("agent reconcile", func() {
 			Expect(agent.Status.DebugInfo.State).To(Equal(models.HostStatusKnown))
 			Expect(agent.Status.DebugInfo.StateInfo).To(Equal("I am known"))
 			Expect(agent.GetLabels()[BaseLabelPrefix+"clusterdeployment-namespace"]).To(Equal("test-namespace"))
+			Expect(agent.Status.InstallationDiskID).To(Equal(newInstallDiskPath))
+			Expect(agent.Spec.InstallationDiskID).To(Equal(newInstallDiskPath))
 		}
 	})
 

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1643,6 +1643,12 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Expect(err).To(BeNil())
 			return h.InstallationDiskID
 		}, "2m", "10s").Should(Equal(sdb.ID))
+		Eventually(func() string {
+			return getAgentCRD(ctx, kubeClient, key).Status.InstallationDiskID
+		}, "2m", "10s").Should(Equal(sdb.ID))
+		Eventually(func() string {
+			return getAgentCRD(ctx, kubeClient, key).Spec.InstallationDiskID
+		}, "2m", "10s").Should(Equal(sdb.ID))
 		Eventually(func() bool {
 			return conditionsv1.IsStatusConditionTrue(getAgentCRD(ctx, kubeClient, key).Status.Conditions, v1beta1.SpecSyncedCondition)
 		}, "2m", "10s").Should(Equal(true))

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -236,6 +236,10 @@ type AgentStatus struct {
 	// ValidationsInfo is a JSON-formatted string containing the validation results for each validation id grouped by category (network, hosts-data, etc.)
 	// +optional
 	ValidationsInfo common.ValidationsStatus `json:"validationsInfo,omitempty"`
+
+	// InstallationDiskID is the disk that will be used for the installation.
+	// +optional
+	InstallationDiskID string `json:"installation_disk_id,omitempty"`
 }
 
 type DebugInfo struct {


### PR DESCRIPTION
Contributes-to: [MGMT-12655](https://issues.redhat.com//browse/MGMT-12655)