### PR TITLE
MGMT-13081: Re-enable and fix a negative NNState subsystem test

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -2702,7 +2702,6 @@ var _ = Describe("[kube-api]cluster installation", func() {
 	})
 
 	It("deploy clusterDeployment and infraEnv and with an invalid NMState config YAML", func() {
-		Skip("temporarily disabled until an investigation on why it is failing in CI")
 		var (
 			NMStateLabelName  = "someName"
 			NMStateLabelValue = "someValue"
@@ -2727,7 +2726,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			Name:      infraNsName.Name,
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
-		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, "nmstate generated an empty NetworkManager config file content")
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, "Unsupported keys found")
 	})
 
 	It("Unbind", func() {


### PR DESCRIPTION
Broken NMState subsystem test root cause analysis:

The test in question is a negative test: It sends a configuration
file content with a single line: `"foo: bar"` and expects a response.

Response to an invalid config:
`nmstate-1.3.x` used to differ from `nmstate-2.x.x` in response to unknown
keys (`foo`, in this case). The `1.3.x` version response is an empty
configuration, whereas the response coming from `2.x.x` version
is `Unsupported keys found`.

CentOS stream8  recently got a newer NMState version.
It used to deploy `nmstate-1.3.3`, and now it deploys `nmstate-1.4.0`.

Looking[1] at the `nmstate-1.4.0` source code, it shows that the response
to invalid keys has changed to be the same as the `2.x.x` version.
The commit[2] that introduced this change is not a part of the `1.3.3` version.

The solution is to change the test to assert against the new response.

[1] https://github.com/nmstate/nmstate/blob/a676ddce76218378a672dbf087e1f4b7a3aae762/rust/src/lib/net_state.rs#L177
[2] https://github.com/nmstate/nmstate/commit/c9fea9edb098a5758ec3545dda3058649e4ab7d7
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
