### PR TITLE
MGMT-10869: Forbid multiple machine networks in single-stack clusters

### DIFF
--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -838,6 +838,11 @@ func ValidateDualStackNetworks(clusterParams interface{}, alreadyDualStack bool)
 				return err
 			}
 		}
+	} else {
+		if len(machineNetworks) > 1 {
+			err := errors.Errorf("Single-stack cluster cannot contain multiple Machine Networks")
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR makes the network config validation stricter so that single-stack clusters with multiple machine networks are not allowed.

As long as OCP does not allow for remote control plane, such a topology is not correct and AI should prevent it from being used.

Closes: [MGMT-10869](https://issues.redhat.com//browse/MGMT-10869)