### PR TITLE
Increase timeout waiting for image-service

### DIFF
--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -10,6 +10,7 @@ from urllib.parse import urlunsplit, urlsplit
 from retry import retry
 
 TIMEOUT = 60 * 30
+IMAGE_SERVICE_TIMEOUT = 60 * 40
 REQUEST_TIMEOUT = 2
 SLEEP = 10
 
@@ -67,7 +68,7 @@ def main():
             domain=deploy_options.domain,
             namespace=deploy_options.namespace,
             disable_tls=deploy_options.disable_tls),
-        timeout_seconds=TIMEOUT,
+        timeout_seconds=IMAGE_SERVICE_TIMEOUT,
         expected_exceptions=(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout),
         sleep_seconds=SLEEP, waiting_for="assisted-image-service to be healthy")
 


### PR DESCRIPTION
Because we have 2 more CPU archs supported by the image-service (which results in 4 more images served) we probably need more time for the image-service to come healthy.

This increases it by 10 minutes, hopefully making it more stable.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
