### PR TITLE
MGMT-11799: change all 'go get' commands

### DIFF
--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -1,6 +1,6 @@
 ARG SERVICE=quay.io/edge-infrastructure/assisted-service:latest
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS download_dlv
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install -mod=mod github.com/go-delve/delve/cmd/dlv@v1.9.1
 
 FROM $SERVICE
 ARG DEBUG_SERVICE_PORT=40000

--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -9,7 +9,7 @@ RUN curl --retry 5 -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomi
     bash -s -- 3.8.8 && mv kustomize /usr/bin/
 RUN pip3 install waiting==1.4.1
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
-RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0
+RUN go install -mod=mod sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac) \
   && export OS=$(uname | awk '{print tolower($0)}') && export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.7.2 \
   && curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH} \

--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -79,14 +79,14 @@ function assisted_service() {
   chmod +x operator-sdk_${OS}_${ARCH}
   install operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
 
-  go get github.com/onsi/ginkgo/ginkgo@v1.16.4 \
-    golang.org/x/tools/cmd/goimports@v0.1.5 \
-    github.com/golang/mock/mockgen@v1.5.0 \
-    github.com/vektra/mockery/.../@v1.1.2 \
-    gotest.tools/gotestsum@v1.6.3 \
-    github.com/axw/gocov/gocov \
-    sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 \
-    github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
+  go install -mod=mod github.com/onsi/ginkgo/ginkgo@v1.16.4
+  go install -mod=mod golang.org/x/tools/cmd/goimports@v0.1.5
+  go install -mod=mod github.com/golang/mock/mockgen@v1.5.0
+  go install -mod=mod github.com/vektra/mockery/v2@v2.12.3
+  go install -mod=mod gotest.tools/gotestsum@v1.6.3
+  go install -mod=mod github.com/axw/gocov/gocov@latest
+  go install -mod=mod sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2
+  go install -mod=mod github.com/AlekSi/gocov-xml@v0.0.0-20190121064608-3a14fb1c4737
 
   python3 -m pip install --upgrade pip
   python3 -m pip install -r ./dev-requirements.txt


### PR DESCRIPTION
Since they have the tendency to change existing runtime dependencies, this changes all occurrences of 'go get' to 'go install' for wherever we want to just install a testing-related dependency.

Backports https://github.com/openshift/assisted-service/pull/4538