### PR TITLE
Setting minikube registry addon to use images from quay.io

### DIFF
--- a/docs/dev/running-test.md
+++ b/docs/dev/running-test.md
@@ -32,8 +32,11 @@ First we must prepare the minikube cluster -
 # Clean remains of any networks created by minikube
 podman network rm minikube || true
 
-# Start minikube with registry addon
-minikube start --driver=podman --addons registry --addons dashboard --force
+# Start minikube
+minikube start --driver=podman --addons dashboard --force
+
+# enable the registry addon using quay.io images (to overcome docker-hub's rate-limiter)
+minikube addons enable registry --images="Registry=quay.io/libpod/registry:2.8"
 
 # Make the registry addon accessible locally:
 nohup kubectl port-forward svc/registry 5000:80 -n kube-system &>/dev/null &
@@ -52,7 +55,7 @@ done
 nohup minikube tunnel &>/dev/null &
 ```
 
-Now that the cluster is prepared, we can deploy the service - 
+Now that the cluster is prepared, we can deploy the service -
 
 To deploy the service in REST-API mode, run:
 


### PR DESCRIPTION
In local environments, we sometimes hit the rate-limitter of docker hub when creating and destroying the minikube environment. This is because the registry addon of minikube relies on images that are not in ghcr.io but from docker-hub.

This change uses images from quay.io for the registry, as a simple workaround.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] Local envs manual setup
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (I ran it locally)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
