### PR TITLE
MGMT-13188: Change error message when host disconnected during installation

### DIFF
--- a/internal/host/transition.go
+++ b/internal/host/transition.go
@@ -136,7 +136,7 @@ func (th *transitionHandler) PostRegisterDuringInstallation(sw stateswitch.State
 	}
 
 	return th.updateTransitionHost(params.ctx, logutil.FromContext(params.ctx, th.log), params.db, sHost,
-		"The host unexpectedly restarted during the installation")
+		"Unable to reach the host. There might be network issues or it was restarted.\n Make sure the host is connected to the service and try to start the installation again.")
 }
 
 func (th *transitionHandler) PostRegisterAfterInstallation(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {


### PR DESCRIPTION
During cluster installation one of the node's agent service went down / up 

You get a message that the host is unexpectedly restarted but this is not always the case.

So this PR updates the message for better clarity, for more information please see https://issues.redhat.com/browse/MGMT-13188

Message now reads:
"Unable to reach the host. There might be network issues or it was restarted. Make sure the host is connected to the service and try to start the installation again."

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
