### PR TITLE
MGMT-12405: Enclose API endpoint with brackets if IPv6 address

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -3,6 +3,7 @@ package hostutil
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -325,7 +326,10 @@ func GetIgnitionEndpoint(cluster *common.Cluster, host *models.Host) (string, er
 		poolName = host.MachineConfigPoolName
 	}
 
-	ignitionEndpointUrl := fmt.Sprintf("http://%s:22624/config/%s", common.GetAPIHostname(cluster), poolName)
+	ignitionEndpointUrl := fmt.Sprintf(
+		"http://%s/config/%s",
+		net.JoinHostPort(common.GetAPIHostname(cluster), "22624"),
+		poolName)
 	if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
 		url, err := url.Parse(*cluster.IgnitionEndpoint.URL)
 		if err != nil {

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -175,6 +175,18 @@ var _ = Describe("Ignition endpoint URL generation", func() {
 			Expect(url).Should(Equal("http://test.com:22624/config/worker"))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
+		It("for host with IPv4 API endpoint", func() {
+			Expect(db.Model(&cluster).Update("api_vip_dns_name", "10.0.0.1").Error).ShouldNot(HaveOccurred())
+			url, err := GetIgnitionEndpoint(&cluster, &host)
+			Expect(url).Should(Equal("http://10.0.0.1:22624/config/worker"))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("for host with IPv6 API endpoint", func() {
+			Expect(db.Model(&cluster).Update("api_vip_dns_name", "fe80::1").Error).ShouldNot(HaveOccurred())
+			url, err := GetIgnitionEndpoint(&cluster, &host)
+			Expect(url).Should(Equal("http://[fe80::1]:22624/config/worker"))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION
This PR fixes the issue with returning the ignition endpoint in the form of an IPv6 address by adding missing brackets around the IPv6 address. This is required in order to form a correct HTTP URI which requires brackets to make IPv6 address distinguishable from the port.

Fixes: [MGMT-12405](https://issues.redhat.com//browse/MGMT-12405)
Cherry-picks: #4900

/cc @omertuc 
/cc @filanov 