### PR TITLE
MGMT-13204: Implement skipping of host and cluster validations

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -127,6 +127,12 @@ type Cluster struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string "all" to ignore all cluster validations. Some validations cannot be ignored.
+	IgnoredClusterValidations string `json:"ignored_cluster_validations,omitempty" gorm:"type:text"`
+
+	// Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string "all" to ignore all host validations. Some validations cannot be ignored.
+	IgnoredHostValidations string `json:"ignored_host_validations,omitempty" gorm:"type:text"`
+
 	// image info
 	// Required: true
 	ImageInfo *ImageInfo `json:"image_info" gorm:"embedded;embeddedPrefix:image_"`

--- a/docs/events.yaml
+++ b/docs/events.yaml
@@ -682,3 +682,10 @@ x-events:
     infra_env_id: UUID
     cluster_id: UUID_PTR
     agent_image: string
+
+- name: validations_ignored
+  message: "Cluster {cluster_id}: ignored some or all validations at the discretion of the user"
+  event_type: cluster
+  severity: info
+  properties:
+    cluster_id: UUID

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -77,6 +77,31 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var NonIgnorableHostValidations []string = []string{"connected", "has-inventory", "machine-cidr-defined", "hostname-unique", "hostname-valid"}
+var NonIgnorableClusterValidations []string = []string{"api-vips-defined", "ingress-vips-defined", "all-hosts-are-ready-to-install", "sufficient-masters-count", "pull-secret-set", "cluster-preparation-succeeded"}
+
+var MayIgnoreValidation = func(validationID string, nonIgnorables []string) bool {
+	if validationID == "all" {
+		return true
+	}
+	return !swag.ContainsStrings(nonIgnorables, validationID)
+}
+
+var MayIgnoreValidations = func(validationIDs []string, nonIgnorables []string) (bool, string) {
+	result := true
+	cantBeIgnored := []string{}
+	for _, validation := range validationIDs {
+		if validation == "all" {
+			return true, ""
+		}
+		if !MayIgnoreValidation(validation, nonIgnorables) {
+			cantBeIgnored = append(cantBeIgnored, validation)
+			result = false
+		}
+	}
+	return result, strings.Join(cantBeIgnored, ",")
+}
+
 const DefaultUser = "kubeadmin"
 
 const WindowBetweenRequestsInSeconds = 10 * time.Second

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -611,8 +611,13 @@ func (b *bareMetalInventory) V2SetIgnoredValidations(ctx context.Context, params
 	problems := []string{}
 	cluster.IgnoredClusterValidations = params.IgnoredValidations.ClusterValidationIds
 	cluster.IgnoredHostValidations = params.IgnoredValidations.HostValidationIds
+<<<<<<< HEAD
 	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, common.NonIgnorableClusterValidations, "cluster")
 	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, common.NonIgnorableHostValidations, "host")
+=======
+	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, NonIgnorableClusterValidations, "cluster")
+	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, NonIgnorableHostValidations, "host")
+>>>>>>> e5d544994 (MGMT-13203: Create REST points for validation ignore feature.)
 	if len(problems) > 0 {
 		return b.setIgnoredValidationsBadRequest("cannot proceed due to the following errors: " + strings.Join(problems, "\n"))
 	}

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -611,13 +611,8 @@ func (b *bareMetalInventory) V2SetIgnoredValidations(ctx context.Context, params
 	problems := []string{}
 	cluster.IgnoredClusterValidations = params.IgnoredValidations.ClusterValidationIds
 	cluster.IgnoredHostValidations = params.IgnoredValidations.HostValidationIds
-<<<<<<< HEAD
 	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, common.NonIgnorableClusterValidations, "cluster")
 	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, common.NonIgnorableHostValidations, "host")
-=======
-	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, NonIgnorableClusterValidations, "cluster")
-	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, NonIgnorableHostValidations, "host")
->>>>>>> e5d544994 (MGMT-13203: Create REST points for validation ignore feature.)
 	if len(problems) > 0 {
 		return b.setIgnoredValidationsBadRequest("cannot proceed due to the following errors: " + strings.Join(problems, "\n"))
 	}

--- a/internal/cluster/refresh_status_preprocessor_test.go
+++ b/internal/cluster/refresh_status_preprocessor_test.go
@@ -1,0 +1,156 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Cluster Refresh Status Preprocessor", func() {
+
+	var (
+		preprocessor        *refreshPreprocessor
+		ctrl                *gomock.Controller
+		mockHostApi         *host.MockAPI
+		mockOperatorManager *operators.MockAPI
+		db                  *gorm.DB
+		dbName              string
+		cluster             *common.Cluster
+		clusterID           strfmt.UUID
+		ctx                 context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		mockHostApi = host.NewMockAPI(ctrl)
+		mockOperatorManager = operators.NewMockAPI(ctrl)
+		mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+		db, dbName = common.PrepareTestDB()
+		preprocessor = newRefreshPreprocessor(
+			logrus.New(),
+			mockHostApi,
+			mockOperatorManager,
+		)
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	createCluster := func() {
+		clusterID = strfmt.UUID(uuid.New().String())
+		testCluster := hostutil.GenerateTestCluster(clusterID)
+		cluster = &testCluster
+		clusterStatus := "insufficient"
+		cluster.Status = &clusterStatus
+		cluster.InstallationPreparationCompletionStatus = common.InstallationPreparationFailed
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+	}
+
+	deleteCluster := func() {
+		Expect(db.Delete(&common.Cluster{}, clusterID).Error).NotTo(HaveOccurred())
+	}
+
+	mockFailingValidator := func(context *clusterPreprocessContext) (ValidationStatus, string) {
+		return ValidationFailure, "Mock of a failed validation"
+	}
+
+	mockFailingCondition := func(context *clusterPreprocessContext) bool {
+		return false
+	}
+
+	mockFailAllValidations := func() {
+		for i, validation := range preprocessor.validations {
+			validation.condition = mockFailingValidator
+			preprocessor.validations[i] = validation
+		}
+
+		for i, condition := range preprocessor.conditions {
+			condition.fn = mockFailingCondition
+			preprocessor.conditions[i] = condition
+		}
+	}
+
+	Context("Skipping Validations", func() {
+
+		cantBeIgnored := common.NonIgnorableClusterValidations
+
+		var (
+			validationContext *clusterPreprocessContext
+		)
+
+		var conditionIsValidation = func(r *refreshPreprocessor, condition string) bool {
+			for _, validation := range r.validations {
+				if condition == validation.id.String() {
+					return true
+				}
+			}
+			return false
+		}
+
+		BeforeEach(func() {
+			createCluster()
+			mockFailAllValidations()
+			validationContext = newClusterValidationContext(cluster, db)
+		})
+
+		AfterEach(func() {
+			deleteCluster()
+		})
+
+		It("Should not ignore any validations if IgnoredClusterValidations is empty or invalid", func() {
+			validationContext.cluster.IgnoredClusterValidations = "bad JSON"
+			_, _, err := preprocessor.preprocess(ctx, validationContext)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to deserialize ignored cluster validations"))
+		})
+
+		It("Should allow permitted ignorable validations to be ignored", func() {
+			validationContext.cluster.IgnoredClusterValidations = "[\"network-type-valid\", \"ingress-vips-valid\", \"ingress-vips-defined\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			Expect(conditions).ToNot(BeEmpty())
+			for _, conditionID := range []string{"network-type-valid", "ingress-vips-valid"} {
+				conditionState, conditionPresent := conditions[conditionID]
+				Expect(conditionPresent).To(BeTrue(), conditionID+" was not present as expected")
+				Expect(conditionState).To(BeTrue(), conditionID+" was not ignored as expected")
+			}
+			conditionState, conditionPresent := conditions["ingress-vips-defined"]
+			Expect(conditionPresent).To(BeTrue(), "ingress-vips-defined was not present as expected")
+			Expect(conditionState).To(BeFalse(), "ingress-vips-defined was ignored when this should not be permitted")
+		})
+
+		It("Should allow all permitted ignorable validations to be ignored", func() {
+			validationContext.cluster.IgnoredClusterValidations = "[\"all\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			Expect(conditions).ToNot(BeEmpty())
+			for condition, wasIgnored := range conditions {
+				if funk.ContainsString(cantBeIgnored, condition) || !conditionIsValidation(preprocessor, condition) {
+					continue
+				}
+				Expect(wasIgnored).To(BeTrue(), condition+" was not ignored as expected")
+			}
+		})
+
+		It("Should never allow a specific mandatory validation to be ignored", func() {
+			validationContext.cluster.IgnoredClusterValidations = "[\"all\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			for _, unskippableHostValidation := range cantBeIgnored {
+				unskippableHostValidationSkipped, unskippableHostValidationPresent := conditions[unskippableHostValidation]
+				Expect(unskippableHostValidationPresent).To(BeTrue(), unskippableHostValidation+" was not present as expected")
+				Expect(unskippableHostValidationSkipped).To(BeFalse(), unskippableHostValidation+" was ignored when this should not be possible")
+			}
+		})
+	})
+})

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -92,6 +93,33 @@ const NMDebugModeConf = `
 [logging]
 domains=ALL:DEBUG
 `
+
+func GetIgnoredValidations(validationsJSON string, clusterID string) ([]string, bool) {
+	ignoredValidations := []string{}
+	if validationsJSON != "" {
+		var err error
+		ignoredValidations, err = DeserializeJSONList(validationsJSON)
+		if err != nil {
+			return nil, false
+		}
+	}
+	return ignoredValidations, true
+}
+
+func IgnoredValidationsAreSet(cluster *Cluster) bool {
+	return cluster.IgnoredClusterValidations != "" || cluster.IgnoredHostValidations != ""
+}
+
+func DeserializeJSONList(jsonString string) ([]string, error) {
+	var list []string
+	if jsonString != "" {
+		err := json.Unmarshal([]byte(jsonString), &list)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
 
 func NormalizeCPUArchitecture(arch string) string {
 	switch arch {

--- a/internal/common/events/events.go
+++ b/internal/common/events/events.go
@@ -6414,3 +6414,68 @@ func (e *UpgradeAgentFailedEvent) FormatMessage() string {
     return e.format(&s)
 }
 
+//
+// Event validations_ignored
+//
+type ValidationsIgnoredEvent struct {
+    eventName string
+    ClusterId strfmt.UUID
+}
+
+var ValidationsIgnoredEventName string = "validations_ignored"
+
+func NewValidationsIgnoredEvent(
+    clusterId strfmt.UUID,
+) *ValidationsIgnoredEvent {
+    return &ValidationsIgnoredEvent{
+        eventName: ValidationsIgnoredEventName,
+        ClusterId: clusterId,
+    }
+}
+
+func SendValidationsIgnoredEvent(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    clusterId strfmt.UUID,) {
+    ev := NewValidationsIgnoredEvent(
+        clusterId,
+    )
+    eventsHandler.SendClusterEvent(ctx, ev)
+}
+
+func SendValidationsIgnoredEventAtTime(
+    ctx context.Context,
+    eventsHandler eventsapi.Sender,
+    clusterId strfmt.UUID,
+    eventTime time.Time) {
+    ev := NewValidationsIgnoredEvent(
+        clusterId,
+    )
+    eventsHandler.SendClusterEventAtTime(ctx, ev, eventTime)
+}
+
+func (e *ValidationsIgnoredEvent) GetName() string {
+    return e.eventName
+}
+
+func (e *ValidationsIgnoredEvent) GetSeverity() string {
+    return "info"
+}
+func (e *ValidationsIgnoredEvent) GetClusterId() strfmt.UUID {
+    return e.ClusterId
+}
+
+
+
+func (e *ValidationsIgnoredEvent) format(message *string) string {
+    r := strings.NewReplacer(
+        "{cluster_id}", fmt.Sprint(e.ClusterId),
+    )
+    return r.Replace(*message)
+}
+
+func (e *ValidationsIgnoredEvent) FormatMessage() string {
+    s := "Cluster {cluster_id}: ignored some or all validations at the discretion of the user"
+    return e.format(&s)
+}
+

--- a/internal/common/validations.go
+++ b/internal/common/validations.go
@@ -15,6 +15,16 @@ func IsAgentCompatible(expectedImage, agentImage string) bool {
 var NonIgnorableHostValidations []string = []string{"connected", "has-inventory", "machine-cidr-defined", "hostname-unique", "hostname-valid"}
 var NonIgnorableClusterValidations []string = []string{"api-vips-defined", "ingress-vips-defined", "all-hosts-are-ready-to-install", "sufficient-masters-count", "pull-secret-set", "cluster-preparation-succeeded"}
 
+func ShouldIgnoreValidation(ignoredValidations []string, validationId string, nonIgnoribles []string) bool {
+	if !MayIgnoreValidation(validationId, nonIgnoribles) {
+		return false
+	}
+	if swag.ContainsStrings(ignoredValidations, "all") {
+		return true
+	}
+	return swag.ContainsStrings(ignoredValidations, validationId)
+}
+
 func MayIgnoreValidation(validationID string, nonIgnorables []string) bool {
 	if validationID == "all" {
 		return true

--- a/internal/host/refresh_status_preprocessor_test.go
+++ b/internal/host/refresh_status_preprocessor_test.go
@@ -1,0 +1,212 @@
+package host
+
+import (
+	"context"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/hardware"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/provider/registry"
+	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/s3wrapper"
+	"github.com/sirupsen/logrus"
+	"github.com/thoas/go-funk"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Cluster Refresh Status Preprocessor", func() {
+
+	var (
+		preprocessor          *refreshPreprocessor
+		ctrl                  *gomock.Controller
+		mockHardwareValidator *hardware.MockValidator
+		mockOperatorManager   *operators.MockAPI
+		mockProviderRegistry  *registry.MockProviderRegistry
+		mockS3WrapperAPI      *s3wrapper.MockAPI
+		db                    *gorm.DB
+		dbName                string
+		cluster               *common.Cluster
+		clusterID             strfmt.UUID
+		host                  *models.Host
+		hostID                strfmt.UUID
+		infraEnv              *common.InfraEnv
+		infraEnvID            strfmt.UUID
+		inventoryCache        InventoryCache
+		ctx                   context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		inventoryCache = make(InventoryCache)
+		mockHardwareValidator = hardware.NewMockValidator(ctrl)
+		mockHardwareValidator.EXPECT().GetClusterHostRequirements(ctx, gomock.Any(), gomock.Any())
+		mockHardwareValidator.EXPECT().GetPreflightHardwareRequirements(gomock.Any(), gomock.Any()).AnyTimes().Return(&models.PreflightHardwareRequirements{
+			Ocp: &models.HostTypeHardwareRequirementsWrapper{
+				Worker: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+				Master: &models.HostTypeHardwareRequirements{
+					Quantitative: &models.ClusterHostRequirementsDetails{},
+				},
+			},
+		}, nil)
+		mockOperatorManager = operators.NewMockAPI(ctrl)
+		mockOperatorManager.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any())
+		mockProviderRegistry = registry.NewMockProviderRegistry(ctrl)
+		mockS3WrapperAPI = s3wrapper.NewMockAPI(ctrl)
+		mockOperatorManager.EXPECT().ValidateCluster(ctx, gomock.Any())
+		db, dbName = common.PrepareTestDB()
+		validatorConfig := &hardware.ValidatorCfg{}
+		disabledHostValidations := make(map[string]struct{})
+		preprocessor = newRefreshPreprocessor(
+			logrus.New(),
+			validatorConfig,
+			mockHardwareValidator,
+			mockOperatorManager,
+			disabledHostValidations,
+			mockProviderRegistry,
+		)
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	createHost := func() models.Host {
+		infraEnvID = strfmt.UUID(uuid.New().String())
+		infraEnv = hostutil.GenerateTestInfraEnv(infraEnvID)
+		Expect(db.Save(infraEnv).Error).ToNot(HaveOccurred())
+		hostID = strfmt.UUID(uuid.New().String())
+		newHost := models.Host{
+			ID:         &hostID,
+			InfraEnvID: infraEnvID,
+			ClusterID:  &clusterID,
+			Kind:       swag.String(models.HostKindHost),
+			Status:     swag.String(models.HostStatusInsufficient),
+			Role:       models.HostRoleAutoAssign,
+		}
+		Expect(db.Create(&newHost).Error).ShouldNot(HaveOccurred())
+		host = &newHost
+		hostProgressInfo := models.HostProgressInfo{}
+		host.Progress = &hostProgressInfo
+		return newHost
+	}
+
+	createCluster := func() {
+		clusterID = strfmt.UUID(uuid.New().String())
+		testCluster := hostutil.GenerateTestCluster(clusterID)
+		cluster = &testCluster
+		clusterStatus := "insufficient"
+		cluster.Status = &clusterStatus
+		hostToAdd := createHost()
+		cluster.Hosts = []*models.Host{&hostToAdd}
+		cluster.InstallationPreparationCompletionStatus = common.InstallationPreparationFailed
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+	}
+
+	deleteCluster := func() {
+		Expect(db.Delete(&common.Cluster{}, clusterID).Error).NotTo(HaveOccurred())
+	}
+
+	mockFailingValidator := func(context *validationContext) (ValidationStatus, string) {
+		return ValidationFailure, "Mock of a failed validation"
+	}
+
+	mockFailingCondition := func(context *validationContext) bool {
+		return false
+	}
+
+	mockFailAllValidations := func() {
+		for i, validation := range preprocessor.validations {
+			validation.condition = mockFailingValidator
+			preprocessor.validations[i] = validation
+		}
+
+		for i, condition := range preprocessor.conditions {
+			condition.fn = mockFailingCondition
+			preprocessor.conditions[i] = condition
+		}
+	}
+
+	Context("Skipping Validations", func() {
+
+		cantBeIgnored := common.NonIgnorableHostValidations
+
+		var (
+			validationContext *validationContext
+		)
+
+		var conditionIsValidation = func(r *refreshPreprocessor, condition string) bool {
+			for _, validation := range r.validations {
+				if condition == validation.id.String() {
+					return true
+				}
+			}
+			return false
+		}
+
+		BeforeEach(func() {
+			createCluster()
+			mockFailAllValidations()
+			var err error
+			validationContext, err = newValidationContext(ctx, host, cluster, infraEnv, db, inventoryCache, mockHardwareValidator, false, mockS3WrapperAPI)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			deleteCluster()
+		})
+
+		It("Should raise an error if IgnoredHostValidations is empty or invalid", func() {
+			validationContext.cluster.IgnoredHostValidations = "bad JSON"
+			_, _, err := preprocessor.preprocess(ctx, validationContext)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Unable to deserialize ignored host validations"))
+		})
+
+		It("Should allow specific ignorable validations to be ignored", func() {
+			validationContext.cluster.IgnoredHostValidations = "[\"has-memory-for-role\", \"has-cpu-cores-for-role\", \"has-inventory\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			Expect(conditions).ToNot(BeEmpty())
+			for _, conditionID := range []string{"has-memory-for-role", "has-cpu-cores-for-role"} {
+				conditionState, conditionPresent := conditions[conditionID]
+				Expect(conditionPresent).To(BeTrue(), conditionID+" was not present as expected")
+				Expect(conditionState).To(BeTrue(), conditionID+" was not ignored as expected")
+			}
+			conditionState, conditionPresent := conditions["has-inventory"]
+			Expect(conditionPresent).To(BeTrue(), "has-inventory was not present as expected")
+			Expect(conditionState).To(BeFalse(), "has-inventory was ignored when this should not be permitted")
+		})
+
+		It("Should allow all non-skippable validations to be ignored", func() {
+			validationContext.cluster.IgnoredHostValidations = "[\"all\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			Expect(conditions).ToNot(BeEmpty())
+			for condition, wasIgnored := range conditions {
+				// We need to make sure that this condition represents a validation
+				if funk.ContainsString(cantBeIgnored, condition) || !conditionIsValidation(preprocessor, condition) {
+					continue
+				}
+				Expect(wasIgnored).To(BeTrue(), condition+" was not ignored as expected")
+			}
+		})
+
+		It("Should never allow a specific mandatory validation to be ignored", func() {
+			validationContext.cluster.IgnoredHostValidations = "[\"all\"]"
+			conditions, _, _ := preprocessor.preprocess(ctx, validationContext)
+			for _, unskippableHostValidation := range cantBeIgnored {
+				unskippableHostValidationSkipped, unskippableHostValidationPresent := conditions[unskippableHostValidation]
+				Expect(unskippableHostValidationPresent).To(BeTrue(), unskippableHostValidation+" was not present as expected")
+				Expect(unskippableHostValidationSkipped).To(BeFalse(), unskippableHostValidation+" was ignored when this should not be possible")
+			}
+		})
+	})
+})

--- a/internal/usage/consts.go
+++ b/internal/usage/consts.go
@@ -57,4 +57,6 @@ const (
 	DualStackVipsUsage string = "Dual-stack VIPs"
 	// Usage of User Managed Networking With Multi Node
 	UserManagedNetworkingWithMultiNode string = "User Managed Networking With Multi Node"
+	// Usage of Validation Ignore
+	ValidationsIgnored string = "Validations have been ignored for this cluster"
 )

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -127,6 +127,12 @@ type Cluster struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string "all" to ignore all cluster validations. Some validations cannot be ignored.
+	IgnoredClusterValidations string `json:"ignored_cluster_validations,omitempty" gorm:"type:text"`
+
+	// Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string "all" to ignore all host validations. Some validations cannot be ignored.
+	IgnoredHostValidations string `json:"ignored_host_validations,omitempty" gorm:"type:text"`
+
 	// image info
 	// Required: true
 	ImageInfo *ImageInfo `json:"image_info" gorm:"embedded;embeddedPrefix:image_"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5671,6 +5671,16 @@ func init() {
           "description": "Explicit ignition endpoint overrides the default ignition endpoint.",
           "$ref": "#/definitions/ignition-endpoint"
         },
+        "ignored_cluster_validations": {
+          "description": "Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string \"all\" to ignore all cluster validations. Some validations cannot be ignored.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
+        "ignored_host_validations": {
+          "description": "Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string \"all\" to ignore all host validations. Some validations cannot be ignored.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
         "image_info": {
           "$ref": "#/definitions/image_info"
         },
@@ -15616,6 +15626,16 @@ func init() {
         "ignition_endpoint": {
           "description": "Explicit ignition endpoint overrides the default ignition endpoint.",
           "$ref": "#/definitions/ignition-endpoint"
+        },
+        "ignored_cluster_validations": {
+          "description": "Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string \"all\" to ignore all cluster validations. Some validations cannot be ignored.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
+        },
+        "ignored_host_validations": {
+          "description": "Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string \"all\" to ignore all host validations. Some validations cannot be ignored.",
+          "type": "string",
+          "x-go-custom-tag": "gorm:\"type:text\""
         },
         "image_info": {
           "$ref": "#/definitions/image_info"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4939,6 +4939,14 @@ definitions:
         type: string
         description: Json formatted string containing ip collisions detected in the cluster.
         x-go-custom-tag: gorm:"type:text"
+      ignored_host_validations:
+        type: string
+        description: Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string "all" to ignore all host validations. Some validations cannot be ignored.
+        x-go-custom-tag: gorm:"type:text"
+      ignored_cluster_validations:
+        type: string
+        description: Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string "all" to ignore all cluster validations. Some validations cannot be ignored.
+        x-go-custom-tag: gorm:"type:text"
       deleted_at:
         description: swagger:ignore
         x-go-custom-tag: gorm:"type:timestamp with time zone;index"

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -127,6 +127,12 @@ type Cluster struct {
 	// Explicit ignition endpoint overrides the default ignition endpoint.
 	IgnitionEndpoint *IgnitionEndpoint `json:"ignition_endpoint,omitempty" gorm:"embedded;embeddedPrefix:ignition_endpoint_"`
 
+	// Json formatted string containing a list of cluster validations to be ignored. May also contain a list with a single string "all" to ignore all cluster validations. Some validations cannot be ignored.
+	IgnoredClusterValidations string `json:"ignored_cluster_validations,omitempty" gorm:"type:text"`
+
+	// Json formatted string containing a list of host validations to be ignored. May also contain a list with a single string "all" to ignore all host validations. Some validations cannot be ignored.
+	IgnoredHostValidations string `json:"ignored_host_validations,omitempty" gorm:"type:text"`
+
 	// image info
 	// Required: true
 	ImageInfo *ImageInfo `json:"image_info" gorm:"embedded;embeddedPrefix:image_"`


### PR DESCRIPTION
Two cluster level fields have been introduced "SkippedHostValidations" and "SkippedClusterValidations"

Each field will hold a JSON encoded list of strings with the names of the validations to be skipped or "all"

If the "all" option is chosen then all validations, including operator validations will not execute. If specific validations are entered then just these will be skipped.


## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
