### PR TITLE
MGMT-13342: Git fails to trust git repository because of mismatch with files

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -40,6 +40,11 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         openssl postgresql nmstate-devel sqlite gcc genisoimage git docker-ce-cli libvirt-client libvirt-devel java && \
     dnf clean all
 
+# Git checks if the user that owns the files on the filesystem match the
+# current user.  We need to disable this check because tests in Prow are
+# running with a random user.
+RUN git config --system --add safe.directory '*'
+
 WORKDIR /home/assisted-service
 RUN mkdir build $TOOLS --mode g+xw
 COPY ./hack/setup_env.sh ./dev-requirements.txt ./


### PR DESCRIPTION
Occurs with publish-python-client job which relies on
assisted-service-build image.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-assisted-service-master-edge-publish-python-client/1615200110763839488
