### PR TITLE
MGMT-12697: Add `ENABLE_REJECT_UNKNOWN_FIELDS` to SaaS template

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -173,6 +173,9 @@ parameters:
 - name: ENABLE_EVENT_STREAMING
   required: false
   value: "true"
+- name: ENABLE_REJECT_UNKNOWN_FIELDS
+  required: false
+  value: "true"
 apiVersion: v1
 kind: Template
 metadata:
@@ -422,6 +425,8 @@ objects:
                 value: ${ENABLE_UPGRADE_AGENT}
               - name: WORK_DIR
                 value: ${WORK_DIR}
+              - name: ENABLE_REJECT_UNKNOWN_FIELDS
+                value: ${ENABLE_REJECT_UNKNOWN_FIELDS}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
Currently the `ENABLE_REJECT_UNKNOWN_FIELDS` can't be changed in the SaaS environment because there is not a corresponding parameter in the OpenShift template. This patch adds it.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
