### PR TITLE
NO-ISSUE: Increase proxy timeout

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -521,7 +521,9 @@ objects:
                     domains: ["*"]
                     routes:
                     - match: { prefix: "/" }
-                      route: { cluster: assisted_service }
+                      route:
+                        cluster: assisted_service
+                        timeout: 180s
                 http_filters:
                 - name: envoy.filters.http.router
                   typed_config:


### PR DESCRIPTION
Currently we don't set the timeout for routes in the Envoy proxy configuration, that means that we use the default which is 15s, and not enough for some of our requests. This patch increases it to 180s which is what we use in the OCM gateway.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
