### PR TITLE
MGMT-13317: missing transition on refresh when media is disconnected

### DIFF
--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -533,12 +533,13 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 			stateswitch.State(models.HostStatusDisconnected),
 			stateswitch.State(models.HostStatusPreparingFailed),
 		},
-		Condition:        stateswitch.Not(If(IsConnected)),
+		Condition: stateswitch.Or(stateswitch.Not(If(IsConnected)),
+			stateswitch.Not(If(IsMediaConnected))),
 		DestinationState: stateswitch.State(models.HostStatusDisconnected),
 		PostTransition:   th.PostRefreshHost(statusInfoDisconnected),
 		Documentation: stateswitch.TransitionRuleDoc{
 			Name:        "Move host to disconnected when connected times out",
-			Description: "TODO: Document this transition rule.",
+			Description: "This transition occurs when no requests are detected from the agent or when the discovery media gets disconnected during pre-installation phases",
 		},
 	})
 
@@ -617,12 +618,13 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 			stateswitch.State(models.HostStatusPreparingForInstallation),
 			stateswitch.State(models.HostStatusPreparingSuccessful),
 		},
-		Condition:        stateswitch.Not(If(IsConnected)),
+		Condition: stateswitch.Or(stateswitch.Not(If(IsConnected)),
+			stateswitch.Not(If(IsMediaConnected))),
 		DestinationState: stateswitch.State(models.HostStatusDisconnected),
 		PostTransition:   th.PostRefreshHost(statusInfoConnectionTimedOutPreparing),
 		Documentation: stateswitch.TransitionRuleDoc{
 			Name:        "Move preparing host to disconnected when connection times out",
-			Description: "TODO: Document this transition rule.",
+			Description: "This transition occurs when no requests are detected from the agent or when the discovery media gets disconnected during prepare for installation phases",
 		},
 	})
 


### PR DESCRIPTION
Users can not update cluster when one of the hosts is in disconnected state due to a disconnected discovery media.

The root cause is a missing transition from disconnected to disconnected when the condition is media disconnection.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
