### PR TITLE
Enable converged flow by default

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -155,7 +155,7 @@ var Options struct {
 	LivenessValidationTimeout            time.Duration `envconfig:"LIVENESS_VALIDATION_TIMEOUT" default:"5m"`
 	ApproveCsrsRequeueDuration           time.Duration `envconfig:"APPROVE_CSRS_REQUEUE_DURATION" default:"1m"`
 	HTTPListenPort                       string        `envconfig:"HTTP_LISTEN_PORT" default:""`
-	AllowConvergedFlow                   bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"false"`
+	AllowConvergedFlow                   bool          `envconfig:"ALLOW_CONVERGED_FLOW" default:"true"`
 	PreprovisioningImageControllerConfig controllers.PreprovisioningImageControllerConfig
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer

--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -198,7 +198,7 @@ It will continue to:
 The assisted agent will not reboot the machine at the end of the installation, instead it will stop
 the assisted agent service and let the ironic agent to manage the machine power state
 
-The converged flow is disalbed by default, you can enable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to true [here](../operator.md##specifying-environmental-variables-via-configmap)
+The converged flow is enabled by default, you can disable the converged flow by setting the `ALLOW_CONVERGED_FLOW` env to false [here](../operator.md##specifying-environmental-variables-via-configmap)
 
 ### Ironic Agent Image
 


### PR DESCRIPTION
Going ahead and enabling this before https://github.com/openshift/assisted-service/pull/4827 is merged as it's not really necessary (we already have an env override if the architectures don't match) and that PR is taking a long time to discuss.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-11997

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Tested as a part of all the previous PRs related to converged flow.
This doesn't change behavior, just changes the default.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
