### PR TITLE
MGMT-13465: remove SNO validation from LVMS operator

### DIFF
--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -70,11 +70,6 @@ func (o *operator) GetHostValidationID() string {
 
 // ValidateCluster always return "valid" result
 func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
-	if !common.IsSingleNodeCluster(cluster) {
-		message := "ODF LVM storage is only supported for Single Node Openshift"
-		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
-	}
-
 	var ocpVersion, minOpenshiftVersionForLvm *version.Version
 	var err error
 

--- a/internal/operators/lvm/lvm_operator_test.go
+++ b/internal/operators/lvm/lvm_operator_test.go
@@ -92,17 +92,12 @@ var _ = Describe("Lvm Operator", func() {
 		)
 	})
 	Context("ValidateCluster", func() {
-		fullHaMode := models.ClusterHighAvailabilityModeFull
 		noneHaMode := models.ClusterHighAvailabilityModeNone
 
 		table.DescribeTable("validate cluster when ", func(cluster *common.Cluster, expectedResult api.ValidationResult) {
 			res, _ := operator.ValidateCluster(ctx, cluster)
 			Expect(res).Should(Equal(expectedResult))
 		},
-			table.Entry("High Availability Mode Full",
-				&common.Cluster{Cluster: models.Cluster{HighAvailabilityMode: &fullHaMode, Hosts: []*models.Host{hostWithSufficientResources, hostWithSufficientResources}, OpenshiftVersion: operator.config.LvmMinOpenshiftVersion}},
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"ODF LVM storage is only supported for Single Node Openshift"}},
-			),
 			table.Entry("High Availability Mode None and Openshift version less than minimal",
 				&common.Cluster{Cluster: models.Cluster{HighAvailabilityMode: &noneHaMode, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: "4.10.0"}},
 				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"ODF LVM storage is only supported for openshift versions 4.12.0-0.0 and above"}},


### PR DESCRIPTION
The [LVM-Operator](https://github.com/red-hat-storage/lvm-operator) provides dynamically provisioned local storage using [TopoLVM](https://github.com/topolvm/topolvm) CSI plugin. Similarly, the [local-storage-operator](https://github.com/openshift/local-storage-operator) facilitates provisioning of persistent storage by using local volumes.

Both operators support local volume provisioning on multiple nodes. I.e. there's no technical limitation for using LSO or LVM with multi-node clusters. So as our LSO operator isn't [limited](https://github.com/openshift/assisted-service/blob/f8a03caa9ff758b08b7590a31aecc77e083fb157/internal/operators/lso/ls_operator.go#L49) for SNO only, LVM operator should behave the same.

Currently, only the CNV operator has LVM as a [dependency](https://github.com/openshift/assisted-service/blob/245667c0a5bcbd34e95747bc218dbf045c03ec58/internal/operators/cnv/cnv_operator.go#L77), and already has a [validation](https://github.com/openshift/assisted-service/blob/245667c0a5bcbd34e95747bc218dbf045c03ec58/internal/operators/cnv/cnv_operator.go#L62-L64) for SNO scenario.
Thus, we can safely remove the [SNO limitation](https://github.com/openshift/assisted-service/blob/194fafb9c2b41cc5d2b14a74e8aac3e34b81d3e0/internal/operators/lvm/lvm_operator.go#L73-L76) from our LVM operator, so it could be used later by other operators.
I.e. such validations should be up to the operators that are using LVMS.

Note: removing this limitation would be useful for a new MCE operator for example, which could add LVMS as a dependency.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
