### PR TITLE
MGMT-12714: Define RAID drive type

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -59,6 +59,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -66,7 +69,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/models/drive_type.go
+++ b/models/drive_type.go
@@ -59,6 +59,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -66,7 +69,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6784,7 +6784,8 @@ func init() {
         "Multipath",
         "iSCSI",
         "FC",
-        "LVM"
+        "LVM",
+        "RAID"
       ]
     },
     "error": {
@@ -16527,7 +16528,8 @@ func init() {
         "Multipath",
         "iSCSI",
         "FC",
-        "LVM"
+        "LVM",
+        "RAID"
       ]
     },
     "error": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5398,6 +5398,7 @@ definitions:
       - iSCSI
       - FC
       - LVM
+      - RAID
 
   io_perf:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -59,6 +59,9 @@ const (
 
 	// DriveTypeLVM captures enum value "LVM"
 	DriveTypeLVM DriveType = "LVM"
+
+	// DriveTypeRAID captures enum value "RAID"
+	DriveTypeRAID DriveType = "RAID"
 )
 
 // for schema
@@ -66,7 +69,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
This PR does nothing but define a new disk drive type for RAID, which will be used by the agent for reporting.