### PR TITLE
Remove references to edge-infrastrcuture/psql image

### DIFF
--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -177,7 +177,7 @@ func (c *K8SDBContext) Create() error {
 					Containers: []corev1.Container{
 						{
 							Name:  "psql",
-							Image: "quay.io/edge-infrastructure/postgresql-12-centos7",
+							Image: "quay.io/centos7/postgresql-12-centos7",
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "tcp-5432",

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -33,7 +33,7 @@ func ImageServiceImage() string {
 }
 
 func DatabaseImage() string {
-	return getEnvVar("DATABASE_IMAGE", "quay.io/edge-infrastructure/postgresql-12-centos7:latest")
+	return getEnvVar("DATABASE_IMAGE", "quay.io/centos7/postgresql-12-centos7:latest")
 }
 
 func AgentImage() string {


### PR DESCRIPTION
Only most places we use the upstream image already, so for consistency we should change those places as well.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
