### PR TITLE
MGMT-13305: Fix invalid lvms version installed on 4.11 (#4942)

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/operators/lvm"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/internal/provider/registry"
 	"github.com/openshift/assisted-service/internal/usage"
@@ -2785,6 +2786,19 @@ func (b *bareMetalInventory) getOLMOperators(cluster *common.Cluster, newOperato
 		if err != nil {
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}
+
+		// TODO - Need to find a better way for creating LVMO/LVMS operator on different openshift-version
+		if operator.Name == "lvm" {
+			lvmsMetMinOpenshiftVersion, err := common.VersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion)
+			if err != nil {
+				operator.SubscriptionName = lvm.LvmsSubscriptionName
+			} else if lvmsMetMinOpenshiftVersion {
+				operator.SubscriptionName = lvm.LvmsSubscriptionName
+			} else {
+				operator.SubscriptionName = lvm.LvmoSubscriptionName
+			}
+		}
+
 		operator.Properties = newOperator.Properties
 
 		monitoredOperators = append(monitoredOperators, operator)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2014,11 +2014,10 @@ var _ = Describe("cluster", func() {
 			mockLVMGetOperatorByName := func(operatorName string) {
 				mockOperatorManager.EXPECT().GetOperatorByName(operatorName).Return(
 					&models.MonitoredOperator{
-						Name:             "lvm",
-						OperatorType:     models.OperatorTypeOlm,
-						Namespace:        "openshift-storage",
-						SubscriptionName: "lvms-operator",
-						TimeoutSeconds:   30 * 60,
+						Name:           "lvm",
+						OperatorType:   models.OperatorTypeOlm,
+						Namespace:      "openshift-storage",
+						TimeoutSeconds: 30 * 60,
 					}, nil).Times(1)
 			}
 

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -33,7 +33,7 @@ func GenerateTestClusterWithMachineNetworks(clusterID strfmt.UUID, machineNetwor
 				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
 				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 			},
-			OpenshiftVersion: lvm.LvmMinOpenshiftVersion,
+			OpenshiftVersion: lvm.LvmsMinOpenshiftVersion,
 		},
 	}
 }
@@ -51,7 +51,7 @@ func GenerateTestCluster(clusterID strfmt.UUID) common.Cluster {
 				EnableOn: swag.String(models.DiskEncryptionEnableOnNone),
 				Mode:     swag.String(models.DiskEncryptionModeTpmv2),
 			},
-			OpenshiftVersion: lvm.LvmMinOpenshiftVersion,
+			OpenshiftVersion: lvm.LvmsMinOpenshiftVersion,
 		},
 	}
 }

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -63,11 +63,11 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 		return []string{}, err
 	}
 
-	minOCPVersionForLVM, err := version.NewVersion(lvm.LvmMinOpenshiftVersion)
+	minOCPVersionForLVMS, err := version.NewVersion(lvm.LvmsMinOpenshiftVersion)
 	if err != nil {
 		return []string{}, err
 	}
-	if common.IsSingleNodeCluster(cluster) && ocpVersion.GreaterThanOrEqual(minOCPVersionForLVM) {
+	if common.IsSingleNodeCluster(cluster) && ocpVersion.GreaterThanOrEqual(minOCPVersionForLVMS) {
 		return []string{lvm.Operator.Name}, nil
 	}
 

--- a/internal/operators/cnv/cnv_operator_test.go
+++ b/internal/operators/cnv/cnv_operator_test.go
@@ -39,7 +39,7 @@ var _ = Describe("CNV operator", func() {
 		It("request for lvmo", func() {
 			haMode := models.ClusterHighAvailabilityModeNone
 			cluster := common.Cluster{
-				Cluster: models.Cluster{HighAvailabilityMode: &haMode, OpenshiftVersion: lvm.LvmMinOpenshiftVersion},
+				Cluster: models.Cluster{HighAvailabilityMode: &haMode, OpenshiftVersion: lvm.LvmsMinOpenshiftVersion},
 			}
 
 			requirements, err := operator.GetDependencies(&cluster)
@@ -68,7 +68,7 @@ var _ = Describe("CNV operator", func() {
 		BeforeEach(func() {
 			mode := models.ClusterHighAvailabilityModeFull
 			cluster = common.Cluster{
-				Cluster: models.Cluster{HighAvailabilityMode: &mode, OpenshiftVersion: lvm.LvmMinOpenshiftVersion},
+				Cluster: models.Cluster{HighAvailabilityMode: &mode, OpenshiftVersion: lvm.LvmsMinOpenshiftVersion},
 			}
 		})
 
@@ -234,7 +234,7 @@ var _ = Describe("CNV operator", func() {
 			host := models.Host{Role: models.HostRoleMaster}
 			haMode := models.ClusterHighAvailabilityModeNone
 			cluster = common.Cluster{
-				Cluster: models.Cluster{HighAvailabilityMode: &haMode, OpenshiftVersion: lvm.LvmMinOpenshiftVersion},
+				Cluster: models.Cluster{HighAvailabilityMode: &haMode, OpenshiftVersion: lvm.LvmsMinOpenshiftVersion},
 			}
 
 			requirements, err := operator.GetHostRequirements(context.TODO(), &cluster, &host)

--- a/internal/operators/lvm/config.go
+++ b/internal/operators/lvm/config.go
@@ -7,13 +7,17 @@ import (
 const (
 	// LvmMinOpenshiftVersion is the minimum OCP version in which lvmo is supported
 	// Any changes here should be updated at line 16 too.
-	LvmMinOpenshiftVersion string = "4.12.0-0.0"
+	LvmoMinOpenshiftVersion string = "4.11.0"
+	LvmsMinOpenshiftVersion string = "4.12.0"
+
+	LvmoSubscriptionName string = "odf-lvm-operator"
+	LvmsSubscriptionName string = "lvms-operator"
 )
 
 type Config struct {
 	LvmCPUPerHost          int64  `envconfig:"LVM_CPU_PER_HOST" default:"1"`
 	LvmMemoryPerHostMiB    int64  `envconfig:"LVM_MEMORY_PER_HOST_MIB" default:"1200"`
-	LvmMinOpenshiftVersion string `envconfig:"LVM_MIN_OPENSHIFT_VERSION" default:"4.12.0-0.0"`
+	LvmMinOpenshiftVersion string `envconfig:"LVM_MIN_OPENSHIFT_VERSION" default:"4.11.0"`
 }
 
 // count all disks of drive type ssd or hdd

--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -25,7 +25,7 @@ var Operator = models.MonitoredOperator{
 	Name:             "lvm",
 	OperatorType:     models.OperatorTypeOlm,
 	Namespace:        "openshift-storage",
-	SubscriptionName: "lvms-operator",
+	SubscriptionName: "",
 	TimeoutSeconds:   30 * 60,
 }
 
@@ -121,8 +121,8 @@ func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, ho
 }
 
 // GenerateManifests generates manifests for the operator
-func (o *operator) GenerateManifests(_ *common.Cluster) (map[string][]byte, []byte, error) {
-	return Manifests()
+func (o *operator) GenerateManifests(cluster *common.Cluster) (map[string][]byte, []byte, error) {
+	return Manifests(cluster)
 }
 
 // GetProperties provides description of operator properties: none required

--- a/internal/operators/lvm/lvm_operator_test.go
+++ b/internal/operators/lvm/lvm_operator_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Lvm Operator", func() {
 			),
 			table.Entry("High Availability Mode None and Openshift version less than minimal",
 				&common.Cluster{Cluster: models.Cluster{HighAvailabilityMode: &noneHaMode, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: "4.10.0"}},
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"ODF LVM storage is only supported for openshift versions 4.12.0-0.0 and above"}},
+				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"ODF LVM storage is only supported for openshift versions 4.11.0 and above"}},
 			),
 			table.Entry("High Availability Mode None and Openshift version more than minimal",
 				&common.Cluster{Cluster: models.Cluster{HighAvailabilityMode: &noneHaMode, Hosts: []*models.Host{hostWithSufficientResources}, OpenshiftVersion: operator.config.LvmMinOpenshiftVersion}},

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -404,7 +404,7 @@ func (mgr *Manager) GetSupportedOperatorsByType(operatorType models.OperatorType
 
 func EnsureLVMAndCNVDoNotClash(openshiftVersion string, operators []*models.MonitoredOperator) error {
 
-	minOCPVersionForLVM, err := version.NewVersion(lvm.LvmMinOpenshiftVersion)
+	minOCPVersionForLVMS, err := version.NewVersion(lvm.LvmsMinOpenshiftVersion)
 	if err != nil {
 		return err
 	}
@@ -414,8 +414,8 @@ func EnsureLVMAndCNVDoNotClash(openshiftVersion string, operators []*models.Moni
 		return err
 	}
 
-	// Openshift version greater or Equal to 4.12.0 support cnv and lvm
-	if ocpVersion.GreaterThanOrEqual(minOCPVersionForLVM) {
+	// Openshift version greater or Equal to 4.12.0 support cnv and lvms
+	if ocpVersion.GreaterThanOrEqual(minOCPVersionForLVMS) {
 		return nil
 	}
 

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Operators manager", func() {
 				{Name: "lso"},
 				{Name: "odf"},
 			}
-			err := operators.EnsureLVMAndCNVDoNotClash("4.12.0-ec.3", monitoredOperators)
+			err := operators.EnsureLVMAndCNVDoNotClash("4.12.0", monitoredOperators)
 			Expect(err).To(BeNil())
 		})
 		It("lvm operator enabled without cnv before 4.12", func() {


### PR DESCRIPTION
Backports https://github.com/openshift/assisted-service/pull/4942