### PR TITLE
MGMT-13526: Fix wrong subscription name on pre-release versions

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -375,7 +375,7 @@ func getDefaultNetworkType(params installer.V2RegisterClusterParams) (*string, e
 		return params.NewClusterParams.NetworkType, nil
 	}
 
-	isOpenShiftVersionRecentEnough, err := common.VersionGreaterOrEqual(swag.StringValue(params.NewClusterParams.OpenshiftVersion), minimalOpenShiftVersionForDefaultNetworkTypeOVNKubernetes)
+	isOpenShiftVersionRecentEnough, err := common.BaseVersionGreaterOrEqual(swag.StringValue(params.NewClusterParams.OpenshiftVersion), minimalOpenShiftVersionForDefaultNetworkTypeOVNKubernetes)
 	if err != nil {
 		return nil, err
 	}
@@ -2801,7 +2801,7 @@ func (b *bareMetalInventory) getOLMOperators(cluster *common.Cluster, newOperato
 	for _, monitoredOperator := range operatorDependencies {
 		// TODO - Need to find a better way for creating LVMO/LVMS operator on different openshift-version
 		if monitoredOperator.Name == "lvm" {
-			lvmsMetMinOpenshiftVersion, err := common.VersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion)
+			lvmsMetMinOpenshiftVersion, err := common.BaseVersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion)
 			if err != nil {
 				log.Warnf("Error parsing cluster.OpenshiftVersion: %s, setting subscription name to %s", err.Error(), lvm.LvmsSubscriptionName)
 				monitoredOperator.SubscriptionName = lvm.LvmsSubscriptionName
@@ -6195,7 +6195,7 @@ func (b *bareMetalInventory) updateMonitoredOperators(tx *gorm.DB, cluster *comm
 		"cluster_version": cluster.OpenshiftVersion,
 		"minimal_version": minimalOpenShiftVersionForConsoleCapability,
 	}
-	consoleCapabilitySupported, err := common.VersionGreaterOrEqual(
+	consoleCapabilitySupported, err := common.BaseVersionGreaterOrEqual(
 		cluster.OpenshiftVersion,
 		minimalOpenShiftVersionForConsoleCapability,
 	)

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -247,6 +247,46 @@ var _ = Describe("compare OCP 4.10 versions", func() {
 		is410Version, _ := VersionGreaterOrEqual("4.10.0-0.nightly-2022-01-23-013716", "4.10.0-0.alpha")
 		Expect(is410Version).Should(BeTrue())
 	})
+	It("pre release - rc", func() {
+		isGreater, _ := VersionGreaterOrEqual("4.12.0-rc.4", "4.12.0")
+		Expect(isGreater).Should(BeFalse())
+	})
+	It("compare pre releases", func() {
+		isGreater, _ := VersionGreaterOrEqual("4.12.0-ec.1", "4.12.0-rc.4")
+		Expect(isGreater).Should(BeFalse())
+	})
+	It("pre release", func() {
+		isGreater, _ := VersionGreaterOrEqual("4.12.0-ec.1", "4.12.0-0.0")
+		Expect(isGreater).Should(BeTrue())
+	})
+	It("pre release - ec", func() {
+		isGreater, _ := VersionGreaterOrEqual("4.12.0-ec.1", "4.12.0")
+		Expect(isGreater).Should(BeFalse())
+	})
+	It("nightly smaller base release", func() {
+		isGreater, _ := VersionGreaterOrEqual("4.12.0-0.nightly-2022-01-23-013716", "4.12.0")
+		Expect(isGreater).Should(BeFalse())
+	})
+	It("nightly equals base release", func() {
+		isGreater, _ := BaseVersionGreaterOrEqual("4.12.0-0.nightly-2022-01-23-013716", "4.12.0")
+		Expect(isGreater).Should(BeTrue())
+	})
+	It("nightly greater base release", func() {
+		isGreater, _ := BaseVersionGreaterOrEqual("4.12.1-0.nightly-2022-01-23-013716", "4.12.0")
+		Expect(isGreater).Should(BeTrue())
+	})
+	It("pre release base version", func() {
+		isGreater, _ := BaseVersionGreaterOrEqual("4.12.0-ec.1", "4.12.0")
+		Expect(isGreater).Should(BeTrue())
+	})
+	It("empty base version", func() {
+		_, err := BaseVersionGreaterOrEqual("", "4.12.0")
+		Expect(err).Should(Not(BeNil()))
+	})
+	It("empty versions", func() {
+		_, err := BaseVersionGreaterOrEqual("", "")
+		Expect(err).Should(Not(BeNil()))
+	})
 })
 
 var _ = Describe("Test AreMastersSchedulable", func() {

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -1,6 +1,10 @@
 package common
 
-import "github.com/hashicorp/go-version"
+import (
+	"strings"
+
+	"github.com/hashicorp/go-version"
+)
 
 func VersionGreaterOrEqual(version1, version2 string) (bool, error) {
 	v1, err := version.NewVersion(version1)
@@ -11,5 +15,13 @@ func VersionGreaterOrEqual(version1, version2 string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return !v1.LessThan(v2), nil
+	return v1.GreaterThanOrEqual(v2), nil
+}
+
+func BaseVersionGreaterOrEqual(version, versionMayGreaterThan string) (bool, error) {
+	// return version >= versionMayGreaterThan
+	version = strings.Split(version, "-")[0]
+	versionMayGreaterThan = strings.Split(versionMayGreaterThan, "-")[0]
+
+	return VersionGreaterOrEqual(version, versionMayGreaterThan)
 }

--- a/internal/operators/cnv/cnv_operator.go
+++ b/internal/operators/cnv/cnv_operator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-version"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/hardware/virt"
 	"github.com/openshift/assisted-service/internal/oc"
@@ -67,17 +66,7 @@ func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
 		return lsoOperator, nil
 	}
 
-	ocpVersion, err := version.NewVersion(cluster.OpenshiftVersion)
-	if err != nil {
-		return []string{}, err
-	}
-
-	minOCPVersionForLVMS, err := version.NewVersion(lvm.LvmsMinOpenshiftVersion)
-	if err != nil {
-		return []string{}, err
-	}
-
-	if ocpVersion.GreaterThanOrEqual(minOCPVersionForLVMS) {
+	if isGreaterOrEqual, _ := common.BaseVersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion); isGreaterOrEqual {
 		return []string{lvm.Operator.Name}, nil
 	}
 

--- a/internal/operators/lvm/manifests_test.go
+++ b/internal/operators/lvm/manifests_test.go
@@ -11,15 +11,22 @@ import (
 var _ = Describe("LVM manifest generation", func() {
 	noneHighAvailabilityMode := models.ClusterHighAvailabilityModeNone
 	operator := NewLvmOperator(common.GetTestLog(), nil)
+	var cluster *common.Cluster
+
+	getCluster := func(openshiftVersion string) *common.Cluster {
+		cluster := common.Cluster{Cluster: models.Cluster{
+			OpenshiftVersion:     openshiftVersion,
+			HighAvailabilityMode: &noneHighAvailabilityMode,
+		}}
+		Expect(common.IsSingleNodeCluster(&cluster)).To(BeTrue())
+		return &cluster
+	}
 
 	Context("LVM Manifest", func() {
 		It("Check YAMLs of LVM in SNO deployment mode", func() {
-			cluster := common.Cluster{Cluster: models.Cluster{
-				OpenshiftVersion:     "4.10.17",
-				HighAvailabilityMode: &noneHighAvailabilityMode,
-			}}
-			Expect(common.IsSingleNodeCluster(&cluster)).To(BeTrue())
-			openshiftManifests, manifest, err := operator.GenerateManifests(&cluster)
+			cluster = getCluster("4.10.17")
+			openshiftManifests, manifest, err := operator.GenerateManifests(cluster)
+
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(openshiftManifests).To(HaveLen(3))
 			Expect(openshiftManifests["50_openshift-lvm_ns.yaml"]).NotTo(HaveLen(0))
@@ -34,6 +41,25 @@ var _ = Describe("LVM manifest generation", func() {
 			_, err = yaml.YAMLToJSON(manifest)
 			Expect(err).ShouldNot(HaveOccurred(), "yamltojson err: %v", err)
 		})
+	})
+	It("Check Subscription information", func() {
+		cluster = getCluster("4.12.0-rc.4")
+		subscriptionInfo, err := getSubscriptionInfo(cluster.OpenshiftVersion)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(subscriptionInfo["OPERATOR_SUBSCRIPTION_NAME"]).To(Equal(LvmsSubscriptionName))
+	})
 
+	It("Check Subscription information", func() {
+		cluster = getCluster("4.12.0")
+		subscriptionInfo, err := getSubscriptionInfo(cluster.OpenshiftVersion)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(subscriptionInfo["OPERATOR_SUBSCRIPTION_NAME"]).To(Equal(LvmsSubscriptionName))
+	})
+
+	It("Check Subscription information", func() {
+		cluster = getCluster("4.10.17")
+		subscriptionInfo, err := getSubscriptionInfo(cluster.OpenshiftVersion)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(subscriptionInfo["OPERATOR_SUBSCRIPTION_NAME"]).To(Equal(LvmoSubscriptionName))
 	})
 })

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/swag"
-	"github.com/hashicorp/go-version"
 	"github.com/openshift/assisted-service/internal/common"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
 	"github.com/openshift/assisted-service/internal/operators/api"
@@ -331,11 +330,13 @@ func (mgr *Manager) getDependencies(cluster *common.Cluster, operators []*models
 		if op.OperatorType != models.OperatorTypeOlm {
 			continue
 		}
+		mgr.log.Infof("Attempting to resolve %s operator dependencies", op.Name)
 		deps, err := mgr.olmOperators[op.Name].GetDependencies(cluster)
 		if err != nil {
 			return map[string]bool{}, err
 		}
 		visited[op.Name] = true
+		mgr.log.Infof("Dependencies found for %s operator: %+v ", op.Name, deps)
 		for _, dep := range deps {
 			fifo.PushBack(dep)
 		}
@@ -430,25 +431,15 @@ func (mgr *Manager) EnsureOperatorArchCapability(cluster *common.Cluster, operat
 }
 
 func EnsureLVMAndCNVDoNotClash(cluster *common.Cluster, openshiftVersion string, operators []*models.MonitoredOperator) error {
-	minOCPVersionForLVMS, err := version.NewVersion(lvm.LvmsMinOpenshiftVersion)
-	if err != nil {
-		return err
-	}
-
-	ocpVersion, err := version.NewVersion(openshiftVersion)
-	if err != nil {
-		return err
-	}
-
 	// Openshift version greater or Equal to 4.12.0 support cnv and lvms
-	if ocpVersion.GreaterThanOrEqual(minOCPVersionForLVMS) {
+	if isGreaterOrEqual, _ := common.BaseVersionGreaterOrEqual(lvm.LvmsMinOpenshiftVersion, openshiftVersion); !isGreaterOrEqual {
 		return nil
 	}
 
 	cnvEnabled := false
 	lvmEnabled := false
 
-	operatorsCanCoexist, err := common.VersionGreaterOrEqual(openshiftVersion, minimalOpenShiftVersionForLVMAndCNV)
+	operatorsCanCoexist, err := common.BaseVersionGreaterOrEqual(openshiftVersion, minimalOpenShiftVersionForLVMAndCNV)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When creating SNO cluster with LVM enabled alongside pre-release 4.12 OCP version there is wrong subscription-name (odf-lvm-operator instead of  lvms-operator)

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None


/cc @eliorerz 
