### PR TITLE
MGMT-13548: add feature-support-level list for 4.13

### DIFF
--- a/internal/featuresupport/support_levels_list.go
+++ b/internal/featuresupport/support_levels_list.go
@@ -325,6 +325,55 @@ var SupportLevelsList = models.FeatureSupportLevels{
 			// Unsupported features
 		},
 	},
+	&models.FeatureSupportLevel{
+		OpenshiftVersion: "4.13",
+		Features: []*models.FeatureSupportLevelFeaturesItems0{
+			// Supported
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDSNO),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTURE),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTUREWITHCLUSTERMANAGEDNETWORKING),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDSINGLENODEEXPANSION),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDLVM),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDDUALSTACKNETWORKING),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDNUTANIXINTEGRATION),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDDUALSTACKVIPS),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelSupported),
+			},
+			// Tech-Preview features
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDMULTIARCHRELEASEIMAGE),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelTechPreview),
+			},
+			// Dev-Preview features
+			{
+				FeatureID:    swag.String(models.FeatureSupportLevelFeaturesItems0FeatureIDVIPAUTOALLOC),
+				SupportLevel: swag.String(models.FeatureSupportLevelFeaturesItems0SupportLevelDevPreview),
+			},
+			// Unsupported features
+		},
+	},
 }
 
 // default is supported


### PR DESCRIPTION
It's currently missing, which makes the UI to fail displaying the cluster view.

This adds a similar list as in OCP 4.12 (because for all I know multi-arch is still Tech-Preview).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual. I'll try to verify it in a local environment to see I can watch a cluster of that version.
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
