### PR TITLE
MGMT-13447: Fix LVM subscription name is empty on SNO CNV

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2789,27 +2789,34 @@ func (b *bareMetalInventory) getOLMOperators(cluster *common.Cluster, newOperato
 			return nil, common.NewApiError(http.StatusBadRequest, err)
 		}
 
-		// TODO - Need to find a better way for creating LVMO/LVMS operator on different openshift-version
-		if operator.Name == "lvm" {
-			lvmsMetMinOpenshiftVersion, err := common.VersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion)
-			if err != nil {
-				log.Warnf("Error parsing cluster.OpenshiftVersion: %s, setting subscription name to %s", err.Error(), lvm.LvmsSubscriptionName)
-				operator.SubscriptionName = lvm.LvmsSubscriptionName
-			} else if lvmsMetMinOpenshiftVersion {
-				log.Infof("LVMS minimum requirement met (OpenshiftVersion=%s), setting subscription name to %s ", cluster.OpenshiftVersion, lvm.LvmsSubscriptionName)
-				operator.SubscriptionName = lvm.LvmsSubscriptionName
-			} else {
-				log.Infof("LVMS minimum requirement didn't met (OpenshiftVersion=%s), setting subscription name to %s ", cluster.OpenshiftVersion, lvm.LvmoSubscriptionName)
-				operator.SubscriptionName = lvm.LvmoSubscriptionName
-			}
-		}
-
 		operator.Properties = newOperator.Properties
-
 		monitoredOperators = append(monitoredOperators, operator)
 	}
 
-	return b.operatorManagerApi.ResolveDependencies(cluster, monitoredOperators)
+	operatorDependencies, err := b.operatorManagerApi.ResolveDependencies(cluster, monitoredOperators)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, monitoredOperator := range operatorDependencies {
+		// TODO - Need to find a better way for creating LVMO/LVMS operator on different openshift-version
+		if monitoredOperator.Name == "lvm" {
+			lvmsMetMinOpenshiftVersion, err := common.VersionGreaterOrEqual(cluster.OpenshiftVersion, lvm.LvmsMinOpenshiftVersion)
+			if err != nil {
+				log.Warnf("Error parsing cluster.OpenshiftVersion: %s, setting subscription name to %s", err.Error(), lvm.LvmsSubscriptionName)
+				monitoredOperator.SubscriptionName = lvm.LvmsSubscriptionName
+			} else if lvmsMetMinOpenshiftVersion {
+				log.Infof("LVMS minimum requirement met (OpenshiftVersion=%s), setting subscription name to %s ", cluster.OpenshiftVersion, lvm.LvmsSubscriptionName)
+				monitoredOperator.SubscriptionName = lvm.LvmsSubscriptionName
+			} else {
+				log.Infof("LVMS minimum requirement didn't met (OpenshiftVersion=%s), setting subscription name to %s ", cluster.OpenshiftVersion, lvm.LvmoSubscriptionName)
+				monitoredOperator.SubscriptionName = lvm.LvmoSubscriptionName
+			}
+		}
+
+	}
+
+	return operatorDependencies, nil
 }
 
 func (b *bareMetalInventory) updateHostsAndClusterStatus(ctx context.Context, cluster *common.Cluster, db *gorm.DB, log logrus.FieldLogger) error {


### PR DESCRIPTION
It seems that we are setting the subscription name before getting the operator dependencies, that causing the LVM subscription name to be empty when setting CNV alone via the API

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

/cc @osherdp 
/cc @gamli75 
/cc @tsorya 