### PR TITLE
MGMT-13461: Fix tang validation when day2 hosts join an imported cluster

### DIFF
--- a/internal/host/hostcommands/tang_connectivity_check_cmd.go
+++ b/internal/host/hostcommands/tang_connectivity_check_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	ignition_types "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
@@ -26,14 +27,28 @@ func NewTangConnectivityCheckCmd(log logrus.FieldLogger, db *gorm.DB, tangConnec
 	}
 }
 
-func (c *tangConnectivityCheckCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
-	var cluster common.Cluster
-
-	if err := c.db.First(&cluster, "id = ?", host.ClusterID).Error; err != nil {
-		c.log.WithError(err).Errorf("failed to fetch cluster %s", host.ClusterID)
-		return nil, err
+func (c *tangConnectivityCheckCmd) getTangServersFromHostIgnition(host *models.Host) ([]byte, error) {
+	var (
+		luks        *ignition_types.Luks
+		tangServers []byte
+		err         error
+	)
+	if host.APIVipConnectivity != "" {
+		luks, err = hostutil.GetDiskEncryptionForDay2(c.log, host)
+		if err != nil {
+			return nil, err
+		}
+		if len(luks.Clevis.Tang) != 0 {
+			if tangServers, err = json.Marshal(luks.Clevis.Tang[0]); err != nil {
+				return nil, err
+			}
+			return tangServers, nil
+		}
 	}
+	return nil, nil
+}
 
+func (c *tangConnectivityCheckCmd) shouldRunTangConnectivityCheck(cluster common.Cluster, host *models.Host) bool {
 	// Skip tangConnectivityCheck for cases where:
 	// 1. DiskEncryption not set or not enabled.
 	// 2. DiskEncryption mode is not tang based.
@@ -42,15 +57,57 @@ func (c *tangConnectivityCheckCmd) GetSteps(ctx context.Context, host *models.Ho
 		swag.StringValue(cluster.DiskEncryption.EnableOn) == models.DiskEncryptionEnableOnNone ||
 		swag.StringValue(cluster.DiskEncryption.Mode) == models.DiskEncryptionModeTpmv2 ||
 		!hostutil.IsDiskEncryptionEnabledForRole(*cluster.DiskEncryption, common.GetEffectiveRole(host)) {
-		c.log.Debugf("skipping tangConnectivityCheck for host %s, DiskEncryption config do not require validation here", host.ID.String())
-		return []*models.Step{}, nil
+		c.log.Debugf("skipping tangConnectivityCheck for host %s, cluster DiskEncryption config does not require validation here",
+			host.ID.String())
+		return false
 	}
+	return true
+}
 
+func (c *tangConnectivityCheckCmd) getTangServersFromCluster(cluster common.Cluster, host *models.Host) ([]byte, error) {
+	var (
+		tangServers []byte
+		err         error
+	)
 	request := models.TangConnectivityRequest{TangServers: &cluster.DiskEncryption.TangServers}
-	tangServers, err := json.Marshal(request)
+	tangServers, err = json.Marshal(request)
 	if err != nil {
 		c.log.WithError(err).Errorf("failed to Marshal TangConnectivityRequest with for cluster %s", host.ClusterID)
 		return nil, err
+	}
+	return tangServers, nil
+}
+
+func (c *tangConnectivityCheckCmd) GetSteps(ctx context.Context, host *models.Host) ([]*models.Step, error) {
+	var (
+		cluster     common.Cluster
+		tangServers []byte
+		err         error
+	)
+
+	if err = c.db.First(&cluster, "id = ?", host.ClusterID).Error; err != nil {
+		c.log.WithError(err).Errorf("failed to fetch cluster %s", host.ClusterID)
+		return nil, err
+	}
+	if swag.BoolValue(cluster.Imported) { // Day 2 imported cluster
+		// In this case, it is assumed that the cluster was imported, and thus the DB will have no information
+		// about DiskEncryption settings. Therefore, try to read those settings from the host ignition.
+		if tangServers, err = c.getTangServersFromHostIgnition(host); err != nil {
+			return nil, err
+		}
+		if tangServers == nil {
+			c.log.Debugf(
+				"skipping tangConnectivityCheck for host %s, host ignition DiskEncryption config do not require validation here",
+				host.ID.String())
+			return []*models.Step{}, nil
+		}
+	} else { // Day 1
+		if !c.shouldRunTangConnectivityCheck(cluster, host) {
+			return []*models.Step{}, nil
+		}
+		if tangServers, err = c.getTangServersFromCluster(cluster, host); err != nil {
+			return nil, err
+		}
 	}
 
 	step := &models.Step{

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -371,30 +371,6 @@ func (v *validator) compatibleWithClusterPlatform(c *validationContext) (Validat
 		common.PlatformTypeValue(c.cluster.Platform.Type), hostAvailablePlatforms)
 }
 
-func (v *validator) getDiskEncryptionForDay2(host *models.Host) (*ignition_types.Luks, error) {
-	var response models.APIVipConnectivityResponse
-	if err := json.Unmarshal([]byte(host.APIVipConnectivity), &response); err != nil {
-		// APIVipConnectivityResponse is not available yet - retrying.
-		return nil, err
-	}
-
-	// Parse ignition from APIVipConnectivity (LUKS is supported in version >= 3.2)
-	config, _, err := v3_2.Parse([]byte(response.Ignition))
-	if err != nil {
-		v.log.WithError(err).Warn("Ignition is empty or invalid - can't get disk encryption")
-		return nil, nil
-	}
-
-	// Checks if LUKS (disk encryption) exists
-	if config.Storage.Luks == nil || len(config.Storage.Luks) == 0 {
-		// Disk encryption is disabled
-		return nil, nil
-	}
-
-	// Return LUKS object
-	return &config.Storage.Luks[0], nil
-}
-
 func (v *validator) areTangServersReachable(c *validationContext) (ValidationStatus, string) {
 	if c.host.TangConnectivity == "" {
 		return ValidationPending, ""
@@ -432,7 +408,7 @@ func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) (V
 		//day2 validation is taking the disk encryption data solely from
 		//the host inventory and set the diskEncryption field on the cluster
 		//according to that information
-		luks, err := v.getDiskEncryptionForDay2(c.host)
+		luks, err := hostutil.GetDiskEncryptionForDay2(v.log, c.host)
 		if err != nil {
 			return ValidationPending, "Missing ignition information"
 		}


### PR DESCRIPTION
The DB will store no information about the cluster disk encryption settings for imported clusters.

In such cases, the backend should attempt to get the Tang servers configuration directly from the host ignition for validation purposes.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
