### PR TITLE
MGMT-13505: allow to edit ignition url in kube-api

### DIFF
--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	mutableFields = []string{"ClusterMetadata"}
+	mutableFields = []string{"ClusterMetadata", "IgnitionEndpoint"}
 )
 
 // AgentClusterInstallValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -186,6 +186,27 @@ var _ = Describe("ACI web validate", func() {
 			expectedAllowed: true,
 		},
 		{
+			name: "Test AgentClusterInstall.Spec update allowed for ignition endpoint field when Install finished",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				IgnitionEndpoint: &hiveext.IgnitionEndpoint{
+					Url: "http://endpoint-2",
+				},
+			},
+			conditions: []hivev1.ClusterInstallCondition{
+				{
+					Type:   hiveext.ClusterCompletedCondition,
+					Reason: hiveext.ClusterInstalledReason,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				IgnitionEndpoint: &hiveext.IgnitionEndpoint{
+					Url: "http://endpoint-1",
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
 			name: "Test AgentClusterInstall.Spec is immutable (updates not allowed) Install failed",
 			newSpec: hiveext.AgentClusterInstallSpec{
 				SSHPublicKey: "somekey",


### PR DESCRIPTION
Following a customer incident, we would like to allow the user to provide ignition overrides after the installation has started/failed for the day2. This supports fixing limitations/bugs in the main flow.

The full details are provided in the thread attached to the corresponding Jira ticket.

This PR allows editing the IgnitionEndpoint field in agent cluster install cr to facilitate the above.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
