### PR TITLE
Mgmt 13607:  Get CAPI image from the release

### DIFF
--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -128,15 +128,15 @@ else
   export PROVIDER_FLAG_FOR_CREATE_COMMAND=" --annotations hypershift.openshift.io/capi-provider-agent-image=$PROVIDER_IMAGE"
 fi
 
-# Since the default registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 image no longer exists, we get the CAPI image from the release
-CLUSTER_API_IMAGE=oc adm release info --image-for=cluster-capi-controllers ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-${RELEASE_IMAGE}}
+# Since the default registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 image no longer exists, we use this hardcoded image instead
+CLUSTER_API_IMAGE="quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5cbebdd15b363b4d582e82a46a890fa43086176038e76467743aabb15289a8b2"
 
 echo "Creating HostedCluster"
 hypershift create cluster agent --name $ASSISTED_CLUSTER_NAME --base-domain redhat.example --pull-secret /root/pull-secret.json \
  --ssh-key /root/.ssh/id_rsa.pub --agent-namespace $SPOKE_NAMESPACE --namespace $SPOKE_NAMESPACE \
  --control-plane-operator-image $HYPERSHIFT_IMAGE \
  --release-image ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-${RELEASE_IMAGE}} \
-  --annotations hypershift.openshift.io/capi-manager-image=$CLUSTER_API_IMAGE" \
+  --annotations hypershift.openshift.io/capi-manager-image=${CLUSTER_API_IMAGE} \
   $PROVIDER_FLAG_FOR_CREATE_COMMAND
 
 # Wait for a running hypershift cluster with no worker nodes

--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -128,11 +128,15 @@ else
   export PROVIDER_FLAG_FOR_CREATE_COMMAND=" --annotations hypershift.openshift.io/capi-provider-agent-image=$PROVIDER_IMAGE"
 fi
 
+# Since the default registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 image no longer exists, we get the CAPI image from the release
+CLUSTER_API_IMAGE=oc adm release info --image-for=cluster-capi-controllers ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-${RELEASE_IMAGE}}
+
 echo "Creating HostedCluster"
 hypershift create cluster agent --name $ASSISTED_CLUSTER_NAME --base-domain redhat.example --pull-secret /root/pull-secret.json \
  --ssh-key /root/.ssh/id_rsa.pub --agent-namespace $SPOKE_NAMESPACE --namespace $SPOKE_NAMESPACE \
  --control-plane-operator-image $HYPERSHIFT_IMAGE \
  --release-image ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE:-${RELEASE_IMAGE}} \
+  --annotations hypershift.openshift.io/capi-manager-image=$CLUSTER_API_IMAGE" \
   $PROVIDER_FLAG_FOR_CREATE_COMMAND
 
 # Wait for a running hypershift cluster with no worker nodes


### PR DESCRIPTION
When creating hosted cluster using hypershift from 4.11 release the hostedcontrolplane fail to start the cluster-api pod because it is using hardcoded registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 image that no longer exists (since Jan 25) 

This PR update the test setup to get the CAPI image from the release

- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? hypershift + capi
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-13607

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
