### PR TITLE
MGMT-11805: Dedicated `.sh` file for the `docs/change-iso-password.sh` script

### DIFF
--- a/docs/change-iso-password.sh
+++ b/docs/change-iso-password.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path to discovery .iso>"
+    exit 1
+fi
+
+if [[ ! -f $1 ]]; then
+    echo "ERROR: Discovery ISO not found at $1"
+    exit 1
+fi
+
+DISCOVERY_ISO_HOST_PATH="$1"
+DISCOVERY_ISO_HOST_DIR=$(dirname "$DISCOVERY_ISO_HOST_PATH")
+function COREOS_INSTALLER() {
+    podman run -v "$DISCOVERY_ISO_HOST_DIR":/data --rm quay.io/coreos/coreos-installer:release "$@"
+}
+
+ISO_NAME=$(basename "$DISCOVERY_ISO_HOST_PATH" .iso)
+
+# Container paths
+DISCOVERY_ISO_PATH=/data/${ISO_NAME}.iso
+DISCOVERY_ISO_WITH_PASSWORD=/data/${ISO_NAME}_with_password.iso
+
+# Host output path
+DISCOVERY_ISO_WITH_PASSWORD_HOST=$(dirname "$DISCOVERY_ISO_HOST_PATH")/$(basename "$DISCOVERY_ISO_WITH_PASSWORD")
+
+# Prompt
+read -sp 'Please enter the password to be used by the "core" user: ' pw
+echo ''
+USER_PASSWORD=$(openssl passwd -6 --stdin <<< $pw)
+unset pw
+
+# Transform original ignition
+TRANSFORMED_IGNITION_PATH=$(mktemp --tmpdir="$DISCOVERY_ISO_HOST_DIR")
+TRANSFORMED_IGNITION_NAME=$(basename "$TRANSFORMED_IGNITION_PATH")
+COREOS_INSTALLER iso ignition show "$DISCOVERY_ISO_PATH" | jq --arg pass "$USER_PASSWORD" '.passwd.users[0].passwordHash = $pass' > "$TRANSFORMED_IGNITION_PATH"
+
+if [[ -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST" ]] ; then
+    echo "ERROR: $DISCOVERY_ISO_WITH_PASSWORD_HOST already exists"
+    echo "Would you like to overwrite it? [y/N]"
+    read -r SHOULD_OVERWRITE
+    if [[ "$SHOULD_OVERWRITE" != "y" ]]; then
+        echo "Exiting"
+        exit 1
+    fi
+fi
+
+# Generate new ISO
+rm -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST"
+COREOS_INSTALLER iso customize --output "$DISCOVERY_ISO_WITH_PASSWORD" --force "$DISCOVERY_ISO_PATH" --live-ignition /data/"$TRANSFORMED_IGNITION_NAME"
+echo 'Created ISO with your password in "'"$DISCOVERY_ISO_WITH_PASSWORD_HOST"'", the login username is "core"'

--- a/docs/set-discovery-password.md
+++ b/docs/set-discovery-password.md
@@ -14,64 +14,7 @@ ISO's ignition file core user with a password
 
 # Change ISO `core` user password script
 
-The following script takes the path of the downloaded discovery ISO file as its
-first argument, prompts the user to enter a password, and creates a similarly
-named ISO file in the same folder as the original one but with password login
+[This](change-iso-password.sh) script takes the path of the downloaded discovery ISO file as its first
+argument, prompts the user to enter a password, and creates a similarly named
+ISO file in the same folder as the original one but with password login
 enabled.
-
-```bash
-#!/bin/bash
-
-set -euo pipefail
-
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <path to discovery .iso>"
-    exit 1
-fi
-
-if [[ ! -f $1 ]]; then
-    echo "ERROR: Discovery ISO not found at $1"
-    exit 1
-fi
-
-DISCOVERY_ISO_HOST_PATH="$1"
-DISCOVERY_ISO_HOST_DIR=$(dirname "$DISCOVERY_ISO_HOST_PATH")
-function COREOS_INSTALLER() {
-    podman run -v "$DISCOVERY_ISO_HOST_DIR":/data --rm quay.io/coreos/coreos-installer:release "$@"
-}
-
-ISO_NAME=$(basename "$DISCOVERY_ISO_HOST_PATH" .iso)
-
-# Container paths
-DISCOVERY_ISO_PATH=/data/${ISO_NAME}.iso
-DISCOVERY_ISO_WITH_PASSWORD=/data/${ISO_NAME}_with_password.iso
-
-# Host output path
-DISCOVERY_ISO_WITH_PASSWORD_HOST=$(dirname "$DISCOVERY_ISO_HOST_PATH")/$(basename "$DISCOVERY_ISO_WITH_PASSWORD")
-
-# Prompt
-read -sp 'Please enter the password to be used by the "core" user: ' pw
-echo ''
-USER_PASSWORD=$(openssl passwd -6 --stdin <<< $pw)
-unset pw
-
-# Transform original ignition
-TRANSFORMED_IGNITION_PATH=$(mktemp --tmpdir="$DISCOVERY_ISO_HOST_DIR")
-TRANSFORMED_IGNITION_NAME=$(basename "$TRANSFORMED_IGNITION_PATH")
-COREOS_INSTALLER iso ignition show "$DISCOVERY_ISO_PATH" | jq --arg pass "$USER_PASSWORD" '.passwd.users[0].passwordHash = $pass' > "$TRANSFORMED_IGNITION_PATH"
-
-if [[ -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST" ]] ; then
-    echo "ERROR: $DISCOVERY_ISO_WITH_PASSWORD_HOST already exists"
-    echo "Would you like to overwrite it? [y/N]"
-    read -r SHOULD_OVERWRITE
-    if [[ "$SHOULD_OVERWRITE" != "y" ]]; then
-        echo "Exiting"
-        exit 1
-    fi
-fi
-
-# Generate new ISO
-rm -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST"
-COREOS_INSTALLER iso customize --output "$DISCOVERY_ISO_WITH_PASSWORD" --force "$DISCOVERY_ISO_PATH" --live-ignition /data/"$TRANSFORMED_IGNITION_NAME"
-echo 'Created ISO with your password in "'"$DISCOVERY_ISO_WITH_PASSWORD_HOST"'", the login username is "core"'
-```


### PR DESCRIPTION
The UI team [asked](https://issues.redhat.com/browse/MGMT-11805?focusedCommentId=21692724&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21692724) us to provide a dedicated file they can use as a
download link instead of embedding the script file inside the markdown
file.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md