### PR TITLE
MGMT-11805: `docs/change-iso-password.sh` lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ endif
 
 lint:
 	golangci-lint run -v
-	shellcheck internal/ignition/boot-reporter/assisted-boot-reporter.sh 
+	shellcheck internal/ignition/boot-reporter/assisted-boot-reporter.sh docs/change-iso-password.sh 
 
 $(BUILD_FOLDER):
 	mkdir -p $(BUILD_FOLDER)

--- a/docs/change-iso-password.sh
+++ b/docs/change-iso-password.sh
@@ -3,19 +3,19 @@
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <path to discovery .iso>"
-    exit 1
+	echo "Usage: $0 <path to discovery .iso>"
+	exit 1
 fi
 
 if [[ ! -f $1 ]]; then
-    echo "ERROR: Discovery ISO not found at $1"
-    exit 1
+	echo "ERROR: Discovery ISO not found at $1"
+	exit 1
 fi
 
 DISCOVERY_ISO_HOST_PATH="$1"
 DISCOVERY_ISO_HOST_DIR=$(dirname "$DISCOVERY_ISO_HOST_PATH")
 function COREOS_INSTALLER() {
-    podman run -v "$DISCOVERY_ISO_HOST_DIR":/data --rm quay.io/coreos/coreos-installer:release "$@"
+	podman run -v "$DISCOVERY_ISO_HOST_DIR":/data --rm quay.io/coreos/coreos-installer:release "$@"
 }
 
 ISO_NAME=$(basename "$DISCOVERY_ISO_HOST_PATH" .iso)
@@ -28,24 +28,24 @@ DISCOVERY_ISO_WITH_PASSWORD=/data/${ISO_NAME}_with_password.iso
 DISCOVERY_ISO_WITH_PASSWORD_HOST=$(dirname "$DISCOVERY_ISO_HOST_PATH")/$(basename "$DISCOVERY_ISO_WITH_PASSWORD")
 
 # Prompt
-read -sp 'Please enter the password to be used by the "core" user: ' pw
+read -rsp 'Please enter the password to be used by the "core" user: ' pw
 echo ''
-USER_PASSWORD=$(openssl passwd -6 --stdin <<< $pw)
+USER_PASSWORD=$(openssl passwd -6 --stdin <<<"$pw")
 unset pw
 
 # Transform original ignition
 TRANSFORMED_IGNITION_PATH=$(mktemp --tmpdir="$DISCOVERY_ISO_HOST_DIR")
 TRANSFORMED_IGNITION_NAME=$(basename "$TRANSFORMED_IGNITION_PATH")
-COREOS_INSTALLER iso ignition show "$DISCOVERY_ISO_PATH" | jq --arg pass "$USER_PASSWORD" '.passwd.users[0].passwordHash = $pass' > "$TRANSFORMED_IGNITION_PATH"
+COREOS_INSTALLER iso ignition show "$DISCOVERY_ISO_PATH" | jq --arg pass "$USER_PASSWORD" '.passwd.users[0].passwordHash = $pass' >"$TRANSFORMED_IGNITION_PATH"
 
-if [[ -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST" ]] ; then
-    echo "ERROR: $DISCOVERY_ISO_WITH_PASSWORD_HOST already exists"
-    echo "Would you like to overwrite it? [y/N]"
-    read -r SHOULD_OVERWRITE
-    if [[ "$SHOULD_OVERWRITE" != "y" ]]; then
-        echo "Exiting"
-        exit 1
-    fi
+if [[ -f "$DISCOVERY_ISO_WITH_PASSWORD_HOST" ]]; then
+	echo "ERROR: $DISCOVERY_ISO_WITH_PASSWORD_HOST already exists"
+	echo "Would you like to overwrite it? [y/N]"
+	read -r SHOULD_OVERWRITE
+	if [[ "$SHOULD_OVERWRITE" != "y" ]]; then
+		echo "Exiting"
+		exit 1
+	fi
 fi
 
 # Generate new ISO


### PR DESCRIPTION
- Added shellcheck lint for docs/change-iso-password.sh
- Formatted it more nicely
- Fixed shellcheck complaints
- Changed mode to +x

/cc nmagnezi

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md