### PR TITLE
MGMT-13487: handle day2 cluster authz

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -14950,7 +14950,8 @@ var _ = Describe("V2UpdateHostInstallerArgs - with rhsso auth", func() {
 		bm.authzHandler = auth.NewAuthzHandler(cfg, mockOcmClient, common.GetTestLog().WithField("pkg", "auth"), db)
 		payload = &ocm.AuthPayload{Role: ocm.UserRole}
 
-		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID, UserName: userName1}}).Error
+		clusterKind := models.ClusterKindCluster
+		err := db.Create(&common.Cluster{Cluster: models.Cluster{ID: &clusterID, UserName: userName1, Kind: &clusterKind}}).Error
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// add a host


### PR DESCRIPTION
When organization tenancy is enabled, we check whether users can manipulate an object based on the AMS subscription which is stored on the cluster.

When a user creates a day2 cluster, it gets a new ID (which is different form day1 cluster), and has no AMS subscription ID. Hence, checking AccessReview on the day2 cluster fails for a non-owner user.

To mitigate this issue, 'hasSubscriptionAccess' func now searches for the day1 cluster when trying to manipulate a day2 cluster. I.e. fetching the subscription ID from the day1 cluster in order to use AccessReview.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
