### PR TITLE
"MGMT-13133: MetalLB operator for assisted installer"

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
@@ -95,6 +95,9 @@ const (
 
 	// ClusterValidationIDNetworkTypeValid captures enum value "network-type-valid"
 	ClusterValidationIDNetworkTypeValid ClusterValidationID = "network-type-valid"
+
+	// ClusterValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	ClusterValidationIDMetallbRequirementsSatisfied ClusterValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -102,7 +105,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/api/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
@@ -146,6 +146,9 @@ const (
 
 	// HostValidationIDNoIPCollisionsInNetwork captures enum value "no-ip-collisions-in-network"
 	HostValidationIDNoIPCollisionsInNetwork HostValidationID = "no-ip-collisions-in-network"
+
+	// HostValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	HostValidationIDMetallbRequirementsSatisfied HostValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -153,7 +156,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/internal/operators"
+	"github.com/openshift/assisted-service/internal/operators/metallb"
 	"github.com/openshift/assisted-service/internal/provider/registry"
 	"github.com/openshift/assisted-service/internal/provider/vsphere"
 	"github.com/openshift/assisted-service/internal/usage"
@@ -2100,6 +2101,13 @@ var _ = Describe("cluster", func() {
 					}, nil).Times(1)
 			}
 
+			mockMetalLBGetOperatorByName := func(operatorName string) {
+				operator := metallb.Operator
+				operator.Properties = "{\"api_cidr\"=\"192.168.122.201/32\",\"ingress_cidr\"=\"192.168.122.202/32\"}"
+				mockOperatorManager.EXPECT().GetOperatorByName(operatorName).Return(
+					&operator, nil).Times(1)
+			}
+
 			Context("V2RegisterCluster", func() {
 				BeforeEach(func() {
 					bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
@@ -2780,10 +2788,11 @@ var _ = Describe("cluster", func() {
 					verifyApiErrorString(reply, http.StatusBadRequest, "Currently, you can not install OpenShift Data Foundation Logical Volume Manager operator at the same time as Virtualization operator")
 				})
 
-				It("enable cnv and lvm after 4.12 is allowed", func() {
+				It("enable cnv and lvm and metallb after 4.12 is allowed", func() {
 					mockClusterRegisterSuccess(true)
 					mockCNVGetOperatorByName("cnv")
 					mockCNVGetOperatorByName("lvm")
+					mockMetalLBGetOperatorByName(metallb.Operator.Name)
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
 						DoAndReturn(func(commonCluster *common.Cluster, operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
 							return operators, nil
@@ -2794,19 +2803,25 @@ var _ = Describe("cluster", func() {
 					clusterParams.OlmOperators = []*models.OperatorCreateParams{
 						{Name: "cnv"},
 						{Name: "lvm"},
+						{Name: metallb.Operator.Name},
 					}
 					mockOperatorManager.EXPECT().EnsureOperatorPrerequisite(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 					reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
 						NewClusterParams: clusterParams,
 					})
 
-					foundExpected := false
+					foundCNV := false
+					foundMetalLB := false
 					for _, monitoredOperator := range reply.(*installer.V2RegisterClusterCreated).Payload.MonitoredOperators {
 						if monitoredOperator.Name == "cnv" {
-							foundExpected = true
+							foundCNV = true
+						}
+						if monitoredOperator.Name == metallb.Operator.Name {
+							foundMetalLB = true
 						}
 					}
-					Expect(foundExpected).Should(BeTrue())
+					Expect(foundCNV).Should(BeTrue())
+					Expect(foundMetalLB).Should(BeTrue())
 				})
 
 				It("return cnv when cnv operator enabled", func() {
@@ -2861,6 +2876,32 @@ var _ = Describe("cluster", func() {
 					foundExpected := false
 					for _, monitoredOperator := range reply.(*installer.V2RegisterClusterCreated).Payload.MonitoredOperators {
 						if monitoredOperator.Name == "lvm" {
+							foundExpected = true
+						}
+					}
+					Expect(foundExpected).Should(BeTrue())
+				})
+
+				It("return metallb when metallb operator enabled", func() {
+					mockClusterRegisterSuccess(true)
+					mockMetalLBGetOperatorByName(metallb.Operator.Name)
+					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(commonCluster *common.Cluster, operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
+							return operators, nil
+						}).Times(1)
+
+					clusterParams := getDefaultClusterCreateParams()
+					clusterParams.OlmOperators = []*models.OperatorCreateParams{
+						{Name: metallb.Operator.Name},
+					}
+					mockOperatorManager.EXPECT().EnsureOperatorPrerequisite(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+					reply := bm.V2RegisterCluster(ctx, installer.V2RegisterClusterParams{
+						NewClusterParams: clusterParams,
+					})
+
+					foundExpected := false
+					for _, monitoredOperator := range reply.(*installer.V2RegisterClusterCreated).Payload.MonitoredOperators {
+						if monitoredOperator.Name == metallb.Operator.Name {
 							foundExpected = true
 						}
 					}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -87,6 +87,7 @@ var _ = Describe("stateMachine", func() {
 				{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 				{Status: api.Success, ValidationId: string(models.ClusterValidationIDCnvRequirementsSatisfied)},
 				{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+				{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 			}, nil)
 		})
 
@@ -150,6 +151,7 @@ var _ = Describe("TestClusterMonitoring", func() {
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDCnvRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 
@@ -732,6 +734,7 @@ var _ = Describe("lease timeout event", func() {
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 
@@ -848,6 +851,7 @@ var _ = Describe("Auto assign machine CIDR", func() {
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 
@@ -2218,6 +2222,7 @@ var _ = Describe("Majority groups", func() {
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 
@@ -2537,6 +2542,7 @@ var _ = Describe("ready_state", func() {
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 

--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -107,6 +107,7 @@ func NewClusterStateMachine(th TransitionHandler) stateswitch.StateMachine {
 		If(IsLsoRequirementsSatisfied),
 		If(IsCnvRequirementsSatisfied),
 		If(IsLvmRequirementsSatisfied),
+		If(IsMetalLBRequirementsSatisfied),
 		If(isNetworkTypeValid),
 		If(NetworksSameAddressFamilies),
 	)

--- a/internal/cluster/validation_id.go
+++ b/internal/cluster/validation_id.go
@@ -32,6 +32,7 @@ const (
 	IsLsoRequirementsSatisfied          = ValidationID(models.ClusterValidationIDLsoRequirementsSatisfied)
 	IsCnvRequirementsSatisfied          = ValidationID(models.ClusterValidationIDCnvRequirementsSatisfied)
 	IsLvmRequirementsSatisfied          = ValidationID(models.ClusterValidationIDLvmRequirementsSatisfied)
+	IsMetalLBRequirementsSatisfied      = ValidationID(models.ClusterValidationIDMetallbRequirementsSatisfied)
 )
 
 func (v ValidationID) Category() (string, error) {
@@ -44,7 +45,7 @@ func (v ValidationID) Category() (string, error) {
 		return "hosts-data", nil
 	case IsPullSecretSet:
 		return "configuration", nil
-	case IsOdfRequirementsSatisfied, IsLsoRequirementsSatisfied, IsCnvRequirementsSatisfied, IsLvmRequirementsSatisfied:
+	case IsOdfRequirementsSatisfied, IsLsoRequirementsSatisfied, IsCnvRequirementsSatisfied, IsLvmRequirementsSatisfied, IsMetalLBRequirementsSatisfied:
 		return "operators", nil
 	}
 	return "", common.NewApiError(http.StatusInternalServerError, errors.Errorf("Unexpected cluster validation id %s", string(v)))

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -1295,7 +1295,8 @@ func (m *Manager) canBeMaster(conditions map[string]bool) bool {
 		conditions[AreLsoRequirementsSatisfied.String()] &&
 		conditions[AreOdfRequirementsSatisfied.String()] &&
 		conditions[AreCnvRequirementsSatisfied.String()] &&
-		conditions[AreLvmRequirementsSatisfied.String()]
+		conditions[AreLvmRequirementsSatisfied.String()] &&
+		conditions[AreMetalLBRequirementsSatisfied.String()]
 }
 
 func (m *Manager) GetHostValidDisks(host *models.Host) ([]*models.Disk, error) {

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -2820,6 +2820,7 @@ var _ = Describe("AutoAssignRole", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 		masterRequirements := models.ClusterHostRequirementsDetails{
 			CPUCores:   4,
@@ -3007,6 +3008,7 @@ var _ = Describe("IsValidMasterCandidate", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 	})
 

--- a/internal/host/monitor_test.go
+++ b/internal/host/monitor_test.go
@@ -81,6 +81,7 @@ var _ = Describe("monitor_disconnection", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("abc").AnyTimes()
 	})
@@ -196,6 +197,7 @@ var _ = Describe("TestHostMonitoring - with cluster", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("abc").AnyTimes()
 	})
@@ -347,6 +349,7 @@ var _ = Describe("HostMonitoring - with infra-env", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil)
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("abc").AnyTimes()
 	})

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -748,6 +748,7 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		If(AreLsoRequirementsSatisfied),
 		If(AreCnvRequirementsSatisfied),
 		If(AreLvmRequirementsSatisfied),
+		If(AreMetalLBRequirementsSatisfied),
 		If(HasSufficientNetworkLatencyRequirementForRole),
 		If(HasSufficientPacketLossRequirementForRole),
 		If(HasDefaultRoute),

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -6204,6 +6204,7 @@ var allValidationIDs []validationID = []validationID{
 	AreOdfRequirementsSatisfied,
 	AreCnvRequirementsSatisfied,
 	AreLvmRequirementsSatisfied,
+	AreMetalLBRequirementsSatisfied,
 	SufficientOrUnknownInstallationDiskSpeed,
 	HasSufficientNetworkLatencyRequirementForRole,
 	HasSufficientPacketLossRequirementForRole,

--- a/internal/host/validation_id.go
+++ b/internal/host/validation_id.go
@@ -33,6 +33,7 @@ const (
 	AreOdfRequirementsSatisfied                    = validationID(models.HostValidationIDOdfRequirementsSatisfied)
 	AreCnvRequirementsSatisfied                    = validationID(models.HostValidationIDCnvRequirementsSatisfied)
 	AreLvmRequirementsSatisfied                    = validationID(models.HostValidationIDLvmRequirementsSatisfied)
+	AreMetalLBRequirementsSatisfied                = validationID(models.HostValidationIDMetallbRequirementsSatisfied)
 	SufficientOrUnknownInstallationDiskSpeed       = validationID(models.HostValidationIDSufficientInstallationDiskSpeed)
 	HasSufficientNetworkLatencyRequirementForRole  = validationID(models.HostValidationIDSufficientNetworkLatencyRequirementForRole)
 	HasSufficientPacketLossRequirementForRole      = validationID(models.HostValidationIDSufficientPacketLossRequirementForRole)
@@ -92,7 +93,8 @@ func (v validationID) category() (string, error) {
 	case AreLsoRequirementsSatisfied,
 		AreOdfRequirementsSatisfied,
 		AreCnvRequirementsSatisfied,
-		AreLvmRequirementsSatisfied:
+		AreLvmRequirementsSatisfied,
+		AreMetalLBRequirementsSatisfied:
 		return "operators", nil
 	}
 	return "", common.NewApiError(http.StatusInternalServerError, errors.Errorf("Unexpected validation id %s", string(v)))

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Validations test", func() {
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied)},
 			{Status: api.Success, ValidationId: string(models.HostValidationIDLvmRequirementsSatisfied)},
+			{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied)},
 		}, nil).AnyTimes()
 		err := m.RefreshStatus(ctx, h, db)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/operators/builder.go
+++ b/internal/operators/builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/cnv"
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/internal/operators/lvm"
+	"github.com/openshift/assisted-service/internal/operators/metallb"
 	"github.com/openshift/assisted-service/internal/operators/odf"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
@@ -32,7 +33,7 @@ type Options struct {
 
 // NewManager creates new instance of an Operator Manager
 func NewManager(log logrus.FieldLogger, manifestAPI manifestsapi.ManifestsAPI, options Options, objectHandler s3wrapper.API, extracter oc.Extracter) *Manager {
-	return NewManagerWithOperators(log, manifestAPI, options, objectHandler, lso.NewLSOperator(), odf.NewOcsOperator(log), odf.NewOdfOperator(log, extracter), cnv.NewCNVOperator(log, options.CNVConfig, extracter), lvm.NewLvmOperator(log, extracter))
+	return NewManagerWithOperators(log, manifestAPI, options, objectHandler, lso.NewLSOperator(), odf.NewOcsOperator(log), odf.NewOdfOperator(log, extracter), cnv.NewCNVOperator(log, options.CNVConfig, extracter), lvm.NewLvmOperator(log, extracter), metallb.NewMetalLBOperator(log, extracter))
 }
 
 // NewManagerWithOperators creates new instance of an Operator Manager and configures it with given operators

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/api"
 	"github.com/openshift/assisted-service/internal/operators/cnv"
 	"github.com/openshift/assisted-service/internal/operators/lso"
+	"github.com/openshift/assisted-service/internal/operators/metallb"
 	"github.com/openshift/assisted-service/internal/operators/odf"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
@@ -70,6 +71,11 @@ var _ = Describe("Operators manager", func() {
 	Context("GenerateManifests", func() {
 		It("Check YAMLs of all supported OLM operators", func() {
 			cluster.MonitoredOperators = manager.GetSupportedOperatorsByType(models.OperatorTypeOlm)
+			for _, operator := range cluster.MonitoredOperators {
+				if operator != nil && operator.Name == metallb.Operator.Name {
+					operator.Properties = "{\"api_ip\":\"192.168.122.201\",\"ingress_ip\":\"192.168.122.202\"}"
+				}
+			}
 
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -275,12 +281,13 @@ var _ = Describe("Operators manager", func() {
 			results, err := manager.ValidateCluster(context.TODO(), cluster)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(HaveLen(4))
+			Expect(results).To(HaveLen(5))
 			Expect(results).To(ContainElements(
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied), Reasons: []string{"lso is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied), Reasons: []string{"odf is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDCnvRequirementsSatisfied), Reasons: []string{"cnv is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied), Reasons: []string{"lvm is disabled"}},
+				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied), Reasons: []string{"metallb is disabled"}},
 			))
 		})
 
@@ -293,13 +300,14 @@ var _ = Describe("Operators manager", func() {
 			results, err := manager.ValidateCluster(context.TODO(), cluster)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(HaveLen(4))
+			Expect(results).To(HaveLen(5))
 			Expect(results).To(ContainElements(
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLsoRequirementsSatisfied), Reasons: []string{}},
 				api.ValidationResult{Status: api.Failure, ValidationId: string(models.ClusterValidationIDOdfRequirementsSatisfied),
 					Reasons: []string{"A minimum of 3 hosts is required to deploy ODF."}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDCnvRequirementsSatisfied), Reasons: []string{"cnv is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDLvmRequirementsSatisfied), Reasons: []string{"lvm is disabled"}},
+				api.ValidationResult{Status: api.Success, ValidationId: string(models.ClusterValidationIDMetallbRequirementsSatisfied), Reasons: []string{"metallb is disabled"}},
 			))
 		})
 	})
@@ -311,12 +319,13 @@ var _ = Describe("Operators manager", func() {
 			results, err := manager.ValidateHost(context.TODO(), cluster, clusterHost)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(HaveLen(4))
+			Expect(results).To(HaveLen(5))
 			Expect(results).To(ContainElements(
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied), Reasons: []string{"lso is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied), Reasons: []string{"odf is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied), Reasons: []string{"cnv is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDLvmRequirementsSatisfied), Reasons: []string{"lvm is disabled"}},
+				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied), Reasons: []string{"metallb is disabled"}},
 			))
 		})
 
@@ -328,13 +337,14 @@ var _ = Describe("Operators manager", func() {
 
 			results, err := manager.ValidateHost(context.TODO(), cluster, clusterHost)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(HaveLen(4))
+			Expect(results).To(HaveLen(5))
 
 			Expect(results).To(ContainElements(
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDLsoRequirementsSatisfied), Reasons: []string{}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDOdfRequirementsSatisfied), Reasons: []string{}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDCnvRequirementsSatisfied), Reasons: []string{"cnv is disabled"}},
 				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDLvmRequirementsSatisfied), Reasons: []string{"lvm is disabled"}},
+				api.ValidationResult{Status: api.Success, ValidationId: string(models.HostValidationIDMetallbRequirementsSatisfied), Reasons: []string{"metallb is disabled"}},
 			))
 		})
 	})
@@ -375,7 +385,7 @@ var _ = Describe("Operators manager", func() {
 		It("should provide list of supported operators", func() {
 			supportedOperators := manager.GetSupportedOperators()
 
-			Expect(supportedOperators).To(ConsistOf("odf", "lso", "cnv", "lvm"))
+			Expect(supportedOperators).To(ConsistOf("odf", "lso", "cnv", "lvm", "metallb"))
 		})
 
 		It("should provide properties of an operator", func() {

--- a/internal/operators/metallb/config.go
+++ b/internal/operators/metallb/config.go
@@ -1,0 +1,10 @@
+package metallb
+
+type Config struct {
+	MetalLBMinOpenshiftVersion string `envconfig:"METALLB_MIN_OPENSHIFT_VERSION" default:"4.11.0"`
+}
+
+type Properties struct {
+	ApiIP     string `json:"api_ip"`
+	IngressIP string `json:"ingress_ip"`
+}

--- a/internal/operators/metallb/manifest.go
+++ b/internal/operators/metallb/manifest.go
@@ -1,0 +1,201 @@
+package metallb
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/openshift/assisted-service/internal/common"
+)
+
+// Manifests returns manifests needed to deploy MetalLB
+func Manifests(cluster *common.Cluster) (map[string][]byte, []byte, error) {
+	metalLBSubscription, err := getSubscription()
+	if err != nil {
+		return nil, nil, err
+	}
+	metalLBNamespace, err := getNamespace()
+	if err != nil {
+		return nil, nil, err
+	}
+	metalLBOperatorGroup, err := getOperatorGroup()
+	if err != nil {
+		return nil, nil, err
+	}
+	metalLBConfigs, err := getMetalLBOperand(cluster)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	openshiftManifests := make(map[string][]byte)
+
+	openshiftManifests["50_openshift-metallb_ns.yaml"] = metalLBNamespace
+	openshiftManifests["50_openshift-metallb_operator_group.yaml"] = metalLBOperatorGroup
+	openshiftManifests["50_openshift-metallb_subscription.yaml"] = metalLBSubscription
+
+	return openshiftManifests, metalLBConfigs, nil
+}
+
+func getSubscription() ([]byte, error) {
+	data := map[string]string{
+		"OPERATOR_NAMESPACE":         Operator.Namespace,
+		"OPERATOR_SUBSCRIPTION_NAME": Operator.SubscriptionName,
+	}
+	return executeTemplate(data, "MetalLBSubscription", MetalLBSubscription)
+}
+
+func getNamespace() ([]byte, error) {
+	data := map[string]string{
+		"OPERATOR_NAMESPACE": Operator.Namespace,
+	}
+	return executeTemplate(data, "MetalLBNamespace", MetalLBNamespace)
+}
+
+func getOperatorGroup() ([]byte, error) {
+	data := map[string]string{
+		"OPERATOR_NAMESPACE":  Operator.Namespace,
+		"OPERATOR_GROUP_NAME": Operator.SubscriptionName,
+	}
+	return executeTemplate(data, "MetalLBOperatorGroup", MetalLBOperatorGroup)
+}
+
+func getMetalLBOperand(cluster *common.Cluster) ([]byte, error) {
+	properties, err := parsePropertiesField(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{
+		"OPERATOR_NAMESPACE": Operator.Namespace,
+		"API_IP":             properties.ApiIP,
+		"INGRESS_IP":         properties.IngressIP,
+	}
+	operand := MetalLBOperandPartA
+
+	if properties.ApiIP != "" {
+		operand += apiIpAddressPoolResource
+	}
+
+	if properties.IngressIP != "" {
+		operand += ingressIpAddressPoolResource
+	}
+
+	operand += MetalLBOperandPartB
+	return executeTemplate(data, "MetalLBOperand", operand)
+}
+
+func executeTemplate(data map[string]string, contentName, content string) ([]byte, error) {
+	tmpl, err := template.New(contentName).Parse(content)
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, data)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+const MetalLBSubscription = `apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: "{{.OPERATOR_SUBSCRIPTION_NAME}}"
+  namespace: "{{.OPERATOR_NAMESPACE}}"
+spec:
+  channel: "stable"
+  name: metallb-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace`
+
+const MetalLBNamespace = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{.OPERATOR_NAMESPACE}}"
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    workload.openshift.io/allowed: management
+spec: {}`
+
+const MetalLBOperatorGroup = `apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: "{{.OPERATOR_GROUP_NAME}}"
+  namespace: "{{.OPERATOR_NAMESPACE}}"`
+
+const MetalLBOperandPartA = `apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: "{{.OPERATOR_NAMESPACE}}"
+---
+`
+const apiIpAddressPoolResource = `apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb-api-vip
+  namespace: "{{.OPERATOR_NAMESPACE}}"
+spec:
+  autoAssign: false
+  addresses:
+    - {{.API_IP}}/32
+---
+`
+const ingressIpAddressPoolResource = `apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb-ingress-ip
+  namespace: "{{.OPERATOR_NAMESPACE}}"
+spec:
+  autoAssign: false
+  addresses:
+    - {{.INGRESS_IP}}/32
+---
+`
+const MetalLBOperandPartB = `apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: cluster-api-ingress
+  namespace: "{{.OPERATOR_NAMESPACE}}"
+spec:
+  ipAddressPools:
+    - metallb-ingress-ip
+    - metallb-api-vip
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: metallb-api-vip
+  name: metallb-api
+  namespace: openshift-kube-apiserver
+spec:
+  ports:
+  - name: http
+    protocol: TCP
+    port: 6443
+    targetPort: 6443
+  selector:
+    app: openshift-kube-apiserver
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: metallb-ingress-ip
+  name: metallb-ingress
+  namespace: openshift-ingress
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+  selector:
+    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+  type: LoadBalancer`

--- a/internal/operators/metallb/manifests_test.go
+++ b/internal/operators/metallb/manifests_test.go
@@ -1,0 +1,94 @@
+package metallb
+
+import (
+	"encoding/json"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("MetalLB manifest generation", func() {
+	operator := NewMetalLBOperator(common.GetTestLog(), nil)
+	var cluster common.Cluster
+
+	BeforeEach(func() {
+		cluster = common.Cluster{Cluster: models.Cluster{}}
+	})
+
+	It("valid properties", func() {
+		properties := Properties{
+			ApiIP:     "192.168.122.201",
+			IngressIP: "192.168.122.202",
+		}
+		propertiesBytes, err := json.Marshal(&properties)
+		Expect(err).NotTo(HaveOccurred())
+		propertiesStr := string(propertiesBytes)
+
+		metallbConfig := models.MonitoredOperator{
+			Name:       Operator.Name,
+			Properties: propertiesStr,
+		}
+
+		cluster.MonitoredOperators = append(cluster.MonitoredOperators, &metallbConfig)
+
+		openshiftManifests, manifest, err := operator.GenerateManifests(&cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(openshiftManifests).To(HaveLen(3))
+		Expect(openshiftManifests["50_openshift-metallb_ns.yaml"]).NotTo(HaveLen(0))
+		Expect(openshiftManifests["50_openshift-metallb_subscription.yaml"]).NotTo(HaveLen(0))
+		Expect(openshiftManifests["50_openshift-metallb_operator_group.yaml"]).NotTo(HaveLen(0))
+		Expect(manifest).NotTo(HaveLen(0))
+
+		for _, openshiftManifest := range openshiftManifests {
+			_, err = yaml.YAMLToJSON(openshiftManifest)
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+
+		_, err = yaml.YAMLToJSON(manifest)
+		Expect(err).NotTo(HaveOccurred(), "yamltojson err: %v", err)
+
+		Expect(strings.Contains(string(manifest), properties.ApiIP)).To(BeTrue())
+		Expect(strings.Contains(string(manifest), properties.IngressIP)).To(BeTrue())
+	})
+
+	It("empty properties", func() {
+		_, _, err := operator.GenerateManifests(&cluster)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("invalid properites - bad json", func() {
+		metallbConfig := models.MonitoredOperator{
+			Name:       Operator.Name,
+			Properties: "not json",
+		}
+
+		cluster.MonitoredOperators = append(cluster.MonitoredOperators, &metallbConfig)
+
+		_, _, err := operator.GenerateManifests(&cluster)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("invalid properites - bad cidr", func() {
+		properties := Properties{
+			ApiIP:     "192.168.122",
+			IngressIP: "192.168.122.202",
+		}
+		propertiesBytes, err := json.Marshal(&properties)
+		Expect(err).NotTo(HaveOccurred())
+		propertiesStr := string(propertiesBytes)
+
+		metallbConfig := models.MonitoredOperator{
+			Name:       Operator.Name,
+			Properties: propertiesStr,
+		}
+
+		cluster.MonitoredOperators = append(cluster.MonitoredOperators, &metallbConfig)
+
+		_, _, err = operator.GenerateManifests(&cluster)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/operators/metallb/metallb_operator.go
+++ b/internal/operators/metallb/metallb_operator.go
@@ -1,0 +1,189 @@
+package metallb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/kelseyhightower/envconfig"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/network"
+	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/models"
+	logutil "github.com/openshift/assisted-service/pkg/log"
+	"github.com/sirupsen/logrus"
+)
+
+// api.Operator implementation for MetalLB
+type operator struct {
+	log       logrus.FieldLogger
+	config    *Config
+	extracter oc.Extracter
+}
+
+var Operator = models.MonitoredOperator{
+	Name:             "metallb",
+	OperatorType:     models.OperatorTypeOlm,
+	Namespace:        "metallb-system",
+	SubscriptionName: "metallb-operator",
+	TimeoutSeconds:   30 * 60,
+}
+
+// NewMetalLBOperator creates new LvmOperator
+func NewMetalLBOperator(log logrus.FieldLogger, extracter oc.Extracter) *operator {
+	cfg := Config{}
+	err := envconfig.Process(common.EnvConfigPrefix, &cfg)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return newMetalLBOperatorWithConfig(log, &cfg, extracter)
+}
+
+// newMetalLBOperatorWithConfig creates new ODFOperator with given configuration
+func newMetalLBOperatorWithConfig(log logrus.FieldLogger, config *Config, extracter oc.Extracter) *operator {
+	return &operator{
+		log:       log,
+		config:    config,
+		extracter: extracter,
+	}
+}
+
+// GetName reports the name of an operator this Operator manages
+func (o *operator) GetName() string {
+	return Operator.Name
+}
+
+// GetFullName reports the full name of an operator this Operator manages
+func (o *operator) GetFullName() string {
+	return Operator.Name
+}
+
+// GetDependencies provides a list of dependencies of the Operator
+func (o *operator) GetDependencies(cluster *common.Cluster) ([]string, error) {
+	return make([]string, 0), nil
+}
+
+// GetClusterValidationID returns cluster validation ID for the Operator
+func (o *operator) GetClusterValidationID() string {
+	return string(models.ClusterValidationIDMetallbRequirementsSatisfied)
+}
+
+// GetHostValidationID returns host validation ID for the Operator
+func (o *operator) GetHostValidationID() string {
+	return string(models.HostValidationIDMetallbRequirementsSatisfied)
+}
+
+// ValidateCluster always return "valid" result
+func (o *operator) ValidateCluster(_ context.Context, cluster *common.Cluster) (api.ValidationResult, error) {
+	var ocpVersion, minOpenshiftVersionForMetalLB *version.Version
+	var err error
+
+	ocpVersion, err = version.NewVersion(cluster.OpenshiftVersion)
+	if err != nil {
+		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetHostValidationID(), Reasons: []string{err.Error()}}, nil
+	}
+	minOpenshiftVersionForMetalLB, err = version.NewVersion(o.config.MetalLBMinOpenshiftVersion)
+	if err != nil {
+		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{err.Error()}}, nil
+	}
+	if ocpVersion.LessThan(minOpenshiftVersionForMetalLB) {
+		message := fmt.Sprintf("MetalLB operator is only supported for openshift versions %s and above", o.config.MetalLBMinOpenshiftVersion)
+		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{message}}, nil
+	}
+
+	_, err = parsePropertiesField(cluster)
+	if err != nil {
+		return api.ValidationResult{Status: api.Failure, ValidationId: o.GetClusterValidationID(), Reasons: []string{err.Error()}}, nil
+	}
+
+	return api.ValidationResult{Status: api.Success, ValidationId: o.GetClusterValidationID()}, nil
+}
+
+// ValidateHost always return "valid" result
+func (o *operator) ValidateHost(ctx context.Context, cluster *common.Cluster, host *models.Host) (api.ValidationResult, error) {
+	return api.ValidationResult{Status: api.Success, ValidationId: o.GetHostValidationID()}, nil
+}
+
+// GenerateManifests generates manifests for the operator
+func (o *operator) GenerateManifests(cluster *common.Cluster) (map[string][]byte, []byte, error) {
+	return Manifests(cluster)
+}
+
+// GetProperties provides description of operator properties: none required
+func (o *operator) GetProperties() models.OperatorProperties {
+	return models.OperatorProperties{}
+}
+
+// GetMonitoredOperator returns MonitoredOperator corresponding to the LSO
+func (o *operator) GetMonitoredOperator() *models.MonitoredOperator {
+	return &Operator
+}
+
+// GetHostRequirements provides operator's requirements towards the host
+func (o *operator) GetHostRequirements(ctx context.Context, cluster *common.Cluster, _ *models.Host) (*models.ClusterHostRequirementsDetails, error) {
+	log := logutil.FromContext(ctx, o.log)
+	preflightRequirements, err := o.GetPreflightRequirements(ctx, cluster)
+	if err != nil {
+		log.WithError(err).Errorf("Cannot retrieve preflight requirements for cluster %s", cluster.ID)
+		return nil, err
+	}
+	return preflightRequirements.Requirements.Master.Quantitative, nil
+}
+
+// GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
+func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
+	dependecies, err := o.GetDependencies(cluster)
+	if err != nil {
+		return &models.OperatorHardwareRequirements{}, err
+	}
+	return &models.OperatorHardwareRequirements{
+		OperatorName: o.GetName(),
+		Dependencies: dependecies,
+		Requirements: &models.HostTypeHardwareRequirementsWrapper{
+			Master: &models.HostTypeHardwareRequirements{
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+			},
+			Worker: &models.HostTypeHardwareRequirements{
+				Quantitative: &models.ClusterHostRequirementsDetails{},
+			},
+		},
+	}, nil
+}
+
+func (o *operator) GetSupportedArchitectures() []string {
+	return []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture}
+}
+
+// parse and validate the operator's properties field
+func parsePropertiesField(cluster *common.Cluster) (Properties, error) {
+	propertiesObj := Properties{}
+	properties := ""
+
+	for _, mo := range cluster.MonitoredOperators {
+		if mo != nil && mo.Name == Operator.Name {
+			properties = mo.Properties
+			break
+		}
+	}
+
+	if properties == "" {
+		return propertiesObj, fmt.Errorf("Properties field for operator %s can not be empty", Operator.Name)
+	}
+
+	err := json.Unmarshal([]byte(properties), &propertiesObj)
+	if err != nil {
+		return propertiesObj, err
+	}
+
+	if !network.IsIPv4Addr(propertiesObj.ApiIP) {
+		return propertiesObj, fmt.Errorf("MetalLB API IP is not a valid IPv4 address")
+	}
+
+	if !network.IsIPv4Addr(propertiesObj.IngressIP) {
+		return propertiesObj, fmt.Errorf("MetalLB Ingress IP is not a valid IPv4 address")
+	}
+
+	return propertiesObj, nil
+}

--- a/internal/operators/metallb/metallb_operator_test.go
+++ b/internal/operators/metallb/metallb_operator_test.go
@@ -1,0 +1,50 @@
+package metallb
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("MetalLB Operator", func() {
+	ctx := context.TODO()
+	operator := NewMetalLBOperator(common.GetTestLog(), nil)
+	var cluster common.Cluster
+
+	BeforeEach(func() {
+		cluster = common.Cluster{Cluster: models.Cluster{}}
+	})
+
+	Context("ValidateCluster", func() {
+		It("valid cluster", func() {
+			properties := Properties{
+				ApiIP:     "192.168.122.201",
+				IngressIP: "192.168.122.202",
+			}
+			propertiesBytes, err := json.Marshal(&properties)
+			Expect(err).NotTo(HaveOccurred())
+			propertiesStr := string(propertiesBytes)
+
+			metallbConfig := models.MonitoredOperator{
+				Name:       Operator.Name,
+				Properties: propertiesStr,
+			}
+
+			cluster.MonitoredOperators = append(cluster.MonitoredOperators, &metallbConfig)
+
+			_, err = operator.ValidateCluster(ctx, &cluster)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("invalid properties", func() {
+			result, err := operator.ValidateCluster(ctx, &cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).To(Equal(api.Failure))
+		})
+	})
+})

--- a/internal/operators/metallb/metallb_suite_test.go
+++ b/internal/operators/metallb/metallb_suite_test.go
@@ -1,0 +1,13 @@
+package metallb
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MetalLB suite")
+}

--- a/models/cluster_validation_id.go
+++ b/models/cluster_validation_id.go
@@ -95,6 +95,9 @@ const (
 
 	// ClusterValidationIDNetworkTypeValid captures enum value "network-type-valid"
 	ClusterValidationIDNetworkTypeValid ClusterValidationID = "network-type-valid"
+
+	// ClusterValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	ClusterValidationIDMetallbRequirementsSatisfied ClusterValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -102,7 +105,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/models/host_validation_id.go
+++ b/models/host_validation_id.go
@@ -146,6 +146,9 @@ const (
 
 	// HostValidationIDNoIPCollisionsInNetwork captures enum value "no-ip-collisions-in-network"
 	HostValidationIDNoIPCollisionsInNetwork HostValidationID = "no-ip-collisions-in-network"
+
+	// HostValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	HostValidationIDMetallbRequirementsSatisfied HostValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -153,7 +156,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6233,7 +6233,8 @@ func init() {
         "odf-requirements-satisfied",
         "cnv-requirements-satisfied",
         "lvm-requirements-satisfied",
-        "network-type-valid"
+        "network-type-valid",
+        "metallb-requirements-satisfied"
       ]
     },
     "cluster_default_config": {
@@ -7680,7 +7681,8 @@ func init() {
         "compatible-agent",
         "no-skip-installation-disk",
         "no-skip-missing-disk",
-        "no-ip-collisions-in-network"
+        "no-ip-collisions-in-network",
+        "metallb-requirements-satisfied"
       ]
     },
     "host_network": {
@@ -16200,7 +16202,8 @@ func init() {
         "odf-requirements-satisfied",
         "cnv-requirements-satisfied",
         "lvm-requirements-satisfied",
-        "network-type-valid"
+        "network-type-valid",
+        "metallb-requirements-satisfied"
       ]
     },
     "cluster_default_config": {
@@ -17563,7 +17566,8 @@ func init() {
         "compatible-agent",
         "no-skip-installation-disk",
         "no-skip-missing-disk",
-        "no-ip-collisions-in-network"
+        "no-ip-collisions-in-network",
+        "metallb-requirements-satisfied"
       ]
     },
     "host_network": {

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/cnv"
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/internal/operators/lvm"
+	"github.com/openshift/assisted-service/internal/operators/metallb"
 	"github.com/openshift/assisted-service/internal/operators/odf"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
@@ -3643,6 +3644,8 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 			CPUCores: 6,
 			RAMMib:   conversions.GibToMib(19),
 		}
+		workerMetalLBRequirements = models.ClusterHostRequirementsDetails{}
+		masterMetalLBRequirements = models.ClusterHostRequirementsDetails{}
 	)
 
 	BeforeEach(func() {
@@ -3670,7 +3673,7 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 			},
 		}
 		Expect(*requirements.Ocp).To(BeEquivalentTo(expectedOcpRequirements))
-		Expect(requirements.Operators).To(HaveLen(4))
+		Expect(requirements.Operators).To(HaveLen(5))
 		for _, op := range requirements.Operators {
 			switch op.OperatorName {
 			case lso.Operator.Name:
@@ -3684,6 +3687,9 @@ var _ = Describe("Preflight Cluster Requirements", func() {
 				Expect(*op.Requirements.Worker.Quantitative).To(BeEquivalentTo(workerCNVRequirements))
 			case lvm.Operator.Name:
 				continue // lvm operator is tested separately
+			case metallb.Operator.Name:
+				Expect(*op.Requirements.Master.Quantitative).To(BeEquivalentTo(masterMetalLBRequirements))
+				Expect(*op.Requirements.Worker.Quantitative).To(BeEquivalentTo(workerMetalLBRequirements))
 			default:
 				Fail("Unexpected operator")
 			}

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/cnv"
 	"github.com/openshift/assisted-service/internal/operators/lso"
 	"github.com/openshift/assisted-service/internal/operators/lvm"
+	"github.com/openshift/assisted-service/internal/operators/metallb"
 	"github.com/openshift/assisted-service/internal/operators/odf"
 	"github.com/openshift/assisted-service/models"
 )
@@ -34,7 +35,7 @@ var _ = Describe("Operators endpoint tests", func() {
 			reply, err := userBMClient.Operators.V2ListSupportedOperators(context.TODO(), opclient.NewV2ListSupportedOperatorsParams())
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(reply.GetPayload()).To(ConsistOf(odf.Operator.Name, lso.Operator.Name, cnv.Operator.Name, lvm.Operator.Name))
+			Expect(reply.GetPayload()).To(ConsistOf(odf.Operator.Name, lso.Operator.Name, cnv.Operator.Name, lvm.Operator.Name, metallb.Operator.Name))
 		})
 
 		It("should provide operator properties", func() {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5983,6 +5983,7 @@ definitions:
       - 'no-skip-installation-disk'
       - 'no-skip-missing-disk'
       - 'no-ip-collisions-in-network'
+      - 'metallb-requirements-satisfied'
 
   dhcp_allocation_request:
     type: object
@@ -6340,6 +6341,7 @@ definitions:
       - 'cnv-requirements-satisfied'
       - 'lvm-requirements-satisfied'
       - 'network-type-valid'
+      - 'metallb-requirements-satisfied'
 
   logs_type:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
@@ -95,6 +95,9 @@ const (
 
 	// ClusterValidationIDNetworkTypeValid captures enum value "network-type-valid"
 	ClusterValidationIDNetworkTypeValid ClusterValidationID = "network-type-valid"
+
+	// ClusterValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	ClusterValidationIDMetallbRequirementsSatisfied ClusterValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -102,7 +105,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","network-type-valid","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
+++ b/vendor/github.com/openshift/assisted-service/models/host_validation_id.go
@@ -146,6 +146,9 @@ const (
 
 	// HostValidationIDNoIPCollisionsInNetwork captures enum value "no-ip-collisions-in-network"
 	HostValidationIDNoIPCollisionsInNetwork HostValidationID = "no-ip-collisions-in-network"
+
+	// HostValidationIDMetallbRequirementsSatisfied captures enum value "metallb-requirements-satisfied"
+	HostValidationIDMetallbRequirementsSatisfied HostValidationID = "metallb-requirements-satisfied"
 )
 
 // for schema
@@ -153,7 +156,7 @@ var hostValidationIdEnum []interface{}
 
 func init() {
 	var res []HostValidationID
-	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["connected","media-connected","has-inventory","has-min-cpu-cores","has-min-valid-disks","has-min-memory","machine-cidr-defined","has-cpu-cores-for-role","has-memory-for-role","hostname-unique","hostname-valid","belongs-to-machine-cidr","ignition-downloadable","belongs-to-majority-group","valid-platform-network-settings","ntp-synced","time-synced-between-host-and-service","container-images-available","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","lvm-requirements-satisfied","sufficient-installation-disk-speed","cnv-requirements-satisfied","sufficient-network-latency-requirement-for-role","sufficient-packet-loss-requirement-for-role","has-default-route","api-domain-name-resolved-correctly","api-int-domain-name-resolved-correctly","apps-domain-name-resolved-correctly","compatible-with-cluster-platform","dns-wildcard-not-configured","disk-encryption-requirements-satisfied","non-overlapping-subnets","vsphere-disk-uuid-enabled","compatible-agent","no-skip-installation-disk","no-skip-missing-disk","no-ip-collisions-in-network","metallb-requirements-satisfied"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
Add another optional operator during installation
https://github.com/openshift/assisted-service/pull/4708
https://issues.redhat.com/browse/MGMT-13133

## List all the issues related to this PR

- [ ] Enhancement

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
