### PR TITLE
Mgmt 13607: Use 4.13 hypershift operator and the payload hostedcontrolplane operator

### DIFF
--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -25,6 +25,7 @@ export ADD_NONE_PLATFORM_LIBVIRT_DNS="${ADD_NONE_PLATFORM_LIBVIRT_DNS:-false}"
 export LIBVIRT_NONE_PLATFORM_NETWORK="${LIBVIRT_NONE_PLATFORM_NETWORK:-ostestbm}"
 export LOAD_BALANCER_IP="${LOAD_BALANCER_IP:-192.168.111.1}"
 export HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
+export HYPERSHIFT_OPERATOR_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
 export PROVIDER_IMAGE="${PROVIDER_IMAGE:-}"
 
 if [[ ${SPOKE_CONTROLPLANE_AGENTS} -eq 1 ]]; then
@@ -112,11 +113,11 @@ oc patch storageclass assisted-service -p '{"metadata": {"annotations":{"storage
 
 ### Hypershift CLI needs access to the kubeconfig, pull-secret and public SSH key
 function hypershift() {
-  podman run -it --net host --rm --entrypoint /usr/bin/hypershift -v $KUBECONFIG:/root/.kube/config -v $ASSISTED_PULLSECRET_JSON:/root/pull-secret.json -v /root/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub $HYPERSHIFT_IMAGE "$@"
+  podman run -it --net host --rm --entrypoint /usr/bin/hypershift -v $KUBECONFIG:/root/.kube/config -v $ASSISTED_PULLSECRET_JSON:/root/pull-secret.json -v /root/.ssh/id_rsa.pub:/root/.ssh/id_rsa.pub $HYPERSHIFT_OPERATOR_IMAGE "$@"
 }
 
 echo "Installing HyperShift using upstream image"
-hypershift install --hypershift-image $HYPERSHIFT_IMAGE --namespace hypershift
+hypershift install --hypershift-image $HYPERSHIFT_OPERATOR_IMAGE --namespace hypershift
 wait_for_pods "hypershift"
 
 if [ -z "$PROVIDER_IMAGE" ]


### PR DESCRIPTION
When creating hosted cluster using hypershift from 4.11 release the hostedcontrolplane fail to start the cluster-api pod because it is using hardcoded registry.ci.openshift.org/hypershift/cluster-api:v1.0.0 image that no longer exists (since Jan 25) 

This PR update the test setup to install hypershift operator from a different env var than the control plane operator (default is: `quay.io/hypershift/hypershift-operator:latest`)
 
- Should this PR be tested by the reviewer? no
- Is this PR relying on CI for an e2e test run? no
- Should this PR be tested in a specific environment? hypershift + capi
- Any logs, screenshots, etc that can help with the review process? no

-->

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-13607

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
