### PR TITLE
MGMT-13657: Don't wait for console if it is disabled - ACM 2.6

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -40,6 +40,7 @@ import (
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/infraenv"
+	installcfgdata "github.com/openshift/assisted-service/internal/installcfg"
 	installcfg "github.com/openshift/assisted-service/internal/installcfg/builder"
 	"github.com/openshift/assisted-service/internal/isoeditor"
 	"github.com/openshift/assisted-service/internal/manifests"
@@ -67,6 +68,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
+	"gopkg.in/yaml.v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
@@ -127,6 +129,7 @@ type Config struct {
 }
 
 const minimalOpenShiftVersionForSingleNode = "4.8.0-0.0"
+const minimalOpenShiftVersionForConsoleCapability = "4.12.0-0.0"
 
 type Interactivity bool
 
@@ -1463,11 +1466,19 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 		log.WithError(err).Errorf("failed to set install config overrides feature usage for cluster %s", params.ClusterID)
 	}
 
+	cluster.InstallConfigOverrides = params.InstallConfigParams
 	err = tx.Model(&common.Cluster{}).Where(query, params.ClusterID).Update("install_config_overrides", params.InstallConfigParams).Error
 	if err != nil {
 		log.WithError(err).Errorf("failed to update install config overrides")
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
+
+	err = b.updateMonitoredOperators(tx, cluster)
+	if err != nil {
+		log.WithError(err).Error("failed to update monitored operators")
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
+	}
+
 	err = tx.Commit().Error
 	if err != nil {
 		log.Error(err)
@@ -1476,6 +1487,7 @@ func (b *bareMetalInventory) UpdateClusterInstallConfigInternal(ctx context.Cont
 	txSuccess = true
 	eventgen.SendInstallConfigAppliedEvent(ctx, b.eventsHandler, params.ClusterID)
 	log.Infof("Custom install config was applied to cluster %s", params.ClusterID)
+
 	return cluster, nil
 }
 
@@ -5607,4 +5619,89 @@ func (b *bareMetalInventory) HostWithCollectedLogsExists(clusterId strfmt.UUID) 
 
 func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*common.Host, error) {
 	return b.hostApi.GetKnownApprovedHosts(clusterId)
+}
+
+// updateMonitoredOperators checks the content of the installer configuration and updates the list
+// of monitored operators accordingly. For example, if the installer configuration uses the
+// capabilities mechanism to disable the console then the console operator is removed from the list
+// of monitored operators.
+func (b *bareMetalInventory) updateMonitoredOperators(tx *gorm.DB, cluster *common.Cluster) error {
+	// Get the complete installer configuration, including the overrides:
+	installConfigData, err := b.installConfigBuilder.GetInstallConfig(cluster, false, "")
+	if err != nil {
+		return err
+	}
+	var installConfig installcfgdata.InstallerConfigBaremetal
+	err = yaml.Unmarshal(installConfigData, &installConfig)
+	if err != nil {
+		return err
+	}
+
+	// Since version 4.12 it is possible to disable the console via the capabilities section of
+	// the installer configuration. The way to do it is to set the base capability set to `None`
+	// and then explicitly list all the enabled capabilities.
+	consoleEnabled := true
+	logFields := logrus.Fields{
+		"cluster_id":      cluster.ID,
+		"cluster_version": cluster.OpenshiftVersion,
+		"minimal_version": minimalOpenShiftVersionForConsoleCapability,
+	}
+	consoleCapabilitySupported, err := common.VersionGreaterOrEqual(
+		cluster.OpenshiftVersion,
+		minimalOpenShiftVersionForConsoleCapability,
+	)
+	if err != nil {
+		return err
+	}
+	if consoleCapabilitySupported {
+		capabilities := installConfig.Capabilities
+		if capabilities != nil {
+			logFields["baseline_capability_set"] = capabilities.BaselineCapabilitySet
+			logFields["additional_enabled_capabilities"] = capabilities.AdditionalEnabledCapabilities
+			if capabilities.BaselineCapabilitySet == "None" {
+				consoleEnabled = false
+				for _, capability := range capabilities.AdditionalEnabledCapabilities {
+					if capability == "Console" {
+						consoleEnabled = true
+						break
+					}
+				}
+			}
+		}
+		if consoleEnabled {
+			b.log.WithFields(logFields).Info(
+				"Console is enabled because the cluster version supports the " +
+					"capability and it has been explicitly enabled by " +
+					"the user",
+			)
+		} else {
+			b.log.WithFields(logFields).Info(
+				"Console is disabled because the cluster version supports the " +
+					"capability and it hasn't been explicitly enabled by " +
+					"the user",
+			)
+		}
+	} else {
+		consoleEnabled = true
+		b.log.WithFields(logFields).Info(
+			"Console is enabled because the cluster version doesn't support " +
+				"the capability",
+		)
+	}
+
+	// Add or remove the console operator to the list of monitored operators:
+	consoleOperator := operators.OperatorConsole
+	consoleOperator.ClusterID = *cluster.ID
+	if consoleEnabled {
+		b.log.WithFields(logFields).Info(
+			"Adding the console to the set of monitored operators",
+		)
+		err = tx.FirstOrCreate(&consoleOperator).Error
+	} else {
+		b.log.WithFields(logFields).Info(
+			"Removing the console from the set of monitored operators",
+		)
+		err = tx.Delete(&consoleOperator).Error
+	}
+	return err
 }


### PR DESCRIPTION
This is a backport of [MGMT-12471](https://issues.redhat.com//browse/MGMT-12471) for ACM 2.6. It includes the changes from pull request #4594.

Currently the service keeps for each cluster a list of the operators that it will wait for before considering the cluster installed. This list includes the console operator. But since version 4.11 that can be disabled via the `capabilities` section of the installer configuration file. For example:

```yaml
capabilities:
  baselineCapabilitySet: None
  additionalEnabledCapabilities:
  - baremetal
```

That will configure the cluster so that only the `baremetal` optional capability will be installed, which effectively disables the `Console` capability.

This patch changes the service so that it removes the console operator from that list when this kind of update is made to the installer configuration.

Related: https://issues.redhat.com/browse/MGMT-13657
Related: https://issues.redhat.com/browse/MGMT-12471
Related: https://github.com/openshift/assisted-service/pull/4594

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested with the included unit tests.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
