### PR TITLE
MGMT-13664: Don't wait for console if it is disabled - ACM 2.7

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -300,7 +300,7 @@ func mockGenerateInstallConfigSuccess(mockGenerator *generator.MockISOInstallCon
 }
 
 func mockGetInstallConfigSuccess(mockInstallConfigBuilder *installcfg_builder.MockInstallConfigBuilder) {
-	mockInstallConfigBuilder.EXPECT().GetInstallConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("some string"), nil).Times(1)
+	mockInstallConfigBuilder.EXPECT().GetInstallConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return([]byte("{}"), nil).AnyTimes()
 }
 
 func addVMToCluster(cluster *common.Cluster, db *gorm.DB) {
@@ -9850,6 +9850,7 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			eventstest.WithNameMatcher(eventgen.InstallConfigAppliedEventName),
 			eventstest.WithClusterIdMatcher(params.ClusterID.String())))
 		mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), params.InstallConfigParams).Return(nil).Times(1)
+		mockGetInstallConfigSuccess(mockInstallConfigBuilder)
 		mockUsageReports()
 		response := bm.V2UpdateClusterInstallConfig(ctx, params)
 		Expect(response).To(BeAssignableToTypeOf(&installer.V2UpdateClusterInstallConfigCreated{}))
@@ -9896,6 +9897,7 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			eventstest.WithNameMatcher(eventgen.InstallConfigAppliedEventName),
 			eventstest.WithClusterIdMatcher(params.ClusterID.String())))
 		mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), params.InstallConfigParams).Return(nil).Times(1)
+		mockGetInstallConfigSuccess(mockInstallConfigBuilder)
 		bm.V2UpdateClusterInstallConfig(ctx, params)
 	})
 
@@ -9910,11 +9912,117 @@ var _ = Describe("UpdateClusterInstallConfig", func() {
 			eventstest.WithNameMatcher(eventgen.InstallConfigAppliedEventName),
 			eventstest.WithClusterIdMatcher(params.ClusterID.String())))
 		mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), params.InstallConfigParams).Return(nil).Times(1)
+		mockGetInstallConfigSuccess(mockInstallConfigBuilder)
 		bm.V2UpdateClusterInstallConfig(ctx, params)
 		var updated common.Cluster
 		err := db.First(&updated, "id = ?", clusterID).Error
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated.Cluster.FeatureUsage).To(Equal(""))
+	})
+
+	DescribeTable(
+		"Removes the console from the list of monitored operators for 4.12 or newer",
+		func(version string) {
+			err := db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update("openshift_version", version).Error
+			Expect(err).ToNot(HaveOccurred())
+			operator := &models.MonitoredOperator{
+				ClusterID: clusterID,
+				Name:      "console",
+			}
+			err = db.FirstOrCreate(operator).Error
+			Expect(err).ToNot(HaveOccurred())
+			installConfig := installcfg.InstallerConfigBaremetal{
+				Capabilities: &installcfg.Capabilities{
+					BaselineCapabilitySet: "None",
+					AdditionalEnabledCapabilities: []installcfg.ClusterVersionCapability{
+						"baremetal",
+					},
+				},
+			}
+			installConfigData, err := yaml.Marshal(installConfig)
+			Expect(err).ToNot(HaveOccurred())
+			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).AnyTimes()
+			mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockInstallConfigBuilder.EXPECT().GetInstallConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(installConfigData, nil).AnyTimes()
+			params := installer.V2UpdateClusterInstallConfigParams{
+				ClusterID:           clusterID,
+				InstallConfigParams: "{}",
+			}
+			bm.V2UpdateClusterInstallConfig(ctx, params)
+			err = db.First(&operator).Error
+			Expect(err).To(Equal(gorm.ErrRecordNotFound))
+		},
+		Entry("Release 4.12", "4.12.7"),
+		Entry("Release 4.13", "4.13.0"),
+		Entry("Prerelease 4.13", "4.13.0-ec.5"),
+	)
+
+	DescribeTable(
+		"Doesn't remove the console from the list of monitored operators for 4.11 or older",
+		func(version string) {
+			err := db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update("openshift_version", version).Error
+			Expect(err).ToNot(HaveOccurred())
+			operator := &models.MonitoredOperator{
+				ClusterID: clusterID,
+				Name:      "console",
+			}
+			err = db.FirstOrCreate(operator).Error
+			Expect(err).ToNot(HaveOccurred())
+			installConfig := installcfg.InstallerConfigBaremetal{
+				Capabilities: &installcfg.Capabilities{
+					BaselineCapabilitySet: "None",
+					AdditionalEnabledCapabilities: []installcfg.ClusterVersionCapability{
+						"baremetal",
+					},
+				},
+			}
+			installConfigData, err := yaml.Marshal(installConfig)
+			Expect(err).ToNot(HaveOccurred())
+			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).AnyTimes()
+			mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			mockInstallConfigBuilder.EXPECT().GetInstallConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(installConfigData, nil).AnyTimes()
+			params := installer.V2UpdateClusterInstallConfigParams{
+				ClusterID:           clusterID,
+				InstallConfigParams: "{}",
+			}
+			bm.V2UpdateClusterInstallConfig(ctx, params)
+			err = db.First(&operator).Error
+			Expect(err).ToNot(HaveOccurred())
+		},
+		Entry("Release 4.10", "4.10.2"),
+		Entry("Release 4.11", "4.11.3"),
+		Entry("Prerelease 4.11", "4.11.0-ec.2"),
+	)
+
+	It("Adds the console from the list of monitored operators", func() {
+		err := db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update("openshift_version", "4.12.7").Error
+		Expect(err).ToNot(HaveOccurred())
+		operator := &models.MonitoredOperator{
+			ClusterID: clusterID,
+			Name:      "console",
+		}
+		err = db.Delete(operator).Error
+		Expect(err).ToNot(HaveOccurred())
+		installConfig := installcfg.InstallerConfigBaremetal{
+			Capabilities: &installcfg.Capabilities{
+				BaselineCapabilitySet: "None",
+				AdditionalEnabledCapabilities: []installcfg.ClusterVersionCapability{
+					"Console",
+				},
+			},
+		}
+		installConfigData, err := yaml.Marshal(installConfig)
+		Expect(err).ToNot(HaveOccurred())
+		mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).AnyTimes()
+		mockInstallConfigBuilder.EXPECT().ValidateInstallConfigPatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockInstallConfigBuilder.EXPECT().GetInstallConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(installConfigData, nil).AnyTimes()
+		params := installer.V2UpdateClusterInstallConfigParams{
+			ClusterID:           clusterID,
+			InstallConfigParams: "{}",
+		}
+		bm.V2UpdateClusterInstallConfig(ctx, params)
+		err = db.First(&operator).Error
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
This is a backport of [MGMT-12471](https://issues.redhat.com//browse/MGMT-12471) for ACM 2.7. It contains the changes in pull request #4594.

Currently the service keeps for each cluster a list of the operators that it will wait for before considering the cluster installed. This list includes the console operator. But since version 4.11 that can be disabled via the `capabilities` section of the installer configuration file. For example:

```yaml
capabilities:
  baselineCapabilitySet: None
  additionalEnabledCapabilities:
  - baremetal
```

That will configure the cluster so that only the `baremetal` optional capability will be installed, which effectively disables the `Console` capability.

This patch changes the service so that it removes the console operator from that list when this kind of update is made to the installer configuration.

Related: https://issues.redhat.com/browse/MGMT-13664
Related: https://issues.redhat.com/browse/MGMT-12471
Related: https://github.com/openshift/assisted-service/pull/4594

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested with the included unit tests.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
