### PR TITLE
MGMT-13708: allow overriding image service image in subscription

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -43,6 +43,13 @@ cat <<EOF
 EOF
     fi
 
+    if [ -n "${IMAGE_SERVICE_IMAGE:-}" ]; then
+cat <<EOF
+    - name: IMAGE_SERVICE_IMAGE
+      value: '${IMAGE_SERVICE_IMAGE}'
+EOF
+    fi
+
     if [ -n "${INSTALLER_IMAGE:-}" ]; then
 cat <<EOF
     - name: INSTALLER_IMAGE


### PR DESCRIPTION
Allow overriding image service image in subscription, that way we can
inject it as CI artifact when deploying AI through the subscription using the
index image.

x-ref: https://github.com/openshift/release/pull/36470
