### PR TITLE
MGMT-13521: Clearer messaging when non-overlapping-subnets validation is pending.

### DIFF
--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -1958,4 +1958,25 @@ var _ = Describe("Validations test", func() {
 			Expect(ok).To(BeTrue())
 		})
 	})
+
+	Context("Validator", func() {
+
+		hostValidator := validator{}
+
+		It("should return appropriate message for pending non-overlapping-subnets with inventory not received", func() {
+			status, message := hostValidator.nonOverlappingSubnets(&validationContext{
+				inventory: nil,
+			})
+			Expect(status).To(Equal(ValidationPending))
+			Expect(message).To(Equal("inventory not yet received"))
+		})
+
+		It("Should return an appropriate message for pending non-overlapping-subnets with cluster unbound", func() {
+			status, message := hostValidator.nonOverlappingSubnets(&validationContext{
+				inventory: &models.Inventory{},
+			})
+			Expect(status).To(Equal(ValidationPending))
+			Expect(message).To(Equal("host is not bound to a cluster"))
+		})
+	})
 })


### PR DESCRIPTION
If the non-overlapping-subnets validation is pending, the message is "Missing inventory, or missing cluster." This message is confusing.  The message should either be "inventory not yet received" or "host is not bound to a cluster" depending on the case.

This has been modified in this PR to return the message "host is not bound to a cluster" when the cluster is not defined and "inventory not yet received" when the inventory is not defined.

This PR includes unit tests to ensure that the messaging has been correctly altered.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

cc @avishayt
