### PR TITLE
MGMT-13274: Update time-synced-between-host-and-service message to remove bad advice

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -843,10 +843,10 @@ func (v *validator) isTimeSyncedBetweenHostAndService(c *validationContext) (Val
 	diff := time.Now().UTC().Sub(time.Unix(c.host.Timestamp, 0).UTC())
 	if diff > maxServiceAheadOfHostTimeDiff {
 		return ValidationFailure, fmt.Sprintf("Host clock is not synchronized, service time is ahead of host's at least for %.1f minutes, "+
-			"please configure an NTP server via DHCP or set clock manually. Service time: %s", maxServiceAheadOfHostTimeDiff.Minutes(), time.Now().UTC())
+			"please configure an NTP server via DHCP. Service time: %s", maxServiceAheadOfHostTimeDiff.Minutes(), time.Now().UTC())
 	} else if diff < -maxHostAheadOfServiceTimeDiff {
 		return ValidationFailure, fmt.Sprintf("Host clock is not synchronized, host time is ahead of service at least for %.1f minutes, "+
-			"please configure an NTP server via DHCP or set clock manually. Service time: %s", maxHostAheadOfServiceTimeDiff.Minutes(), time.Now().UTC())
+			"please configure an NTP server via DHCP. Service time: %s", maxHostAheadOfServiceTimeDiff.Minutes(), time.Now().UTC())
 	}
 
 	return ValidationSuccess, "Host clock is synchronized with service"


### PR DESCRIPTION
The message "please configure an NTP server via DHCP or set clock manually" from the time-synced-between-host-and-service validation is problematic because we are advising the end user to manually set their clock; an unsuppored operation.

Therefore, we are going to remove that part of the message to have it read

"please configure an NTP server via DHCP" instead


## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

This is a simple text change, there is not much to test.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
