### PR TITLE
Add registry config for ironic agent image

### DIFF
--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -253,6 +253,8 @@ function deploy_mirror_config_map() {
   # The mirror should point all the release images and not just the OpenShift release image itself.
   # An arbitrary image (cli) is chosen to retreive its pull spec, in order to mirror its repository.
   cli_image=$(podman run --quiet --rm --net=none "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}" image cli)
+  # Ensure the repo for the ironic agent image is also mirrored
+  ironic_agent_image=$(oc adm release info --image-for=ironic-agent "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}")
 
   assisted_index_image=$(get_image_without_registry $(get_image_repository_only ${INDEX_IMAGE}))
 
@@ -270,6 +272,7 @@ data:
 
     $(registry_config "$(get_image_without_tag ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
     $(registry_config "$(get_image_without_tag ${cli_image})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
+    $(registry_config "$(get_image_without_tag ${ironic_agent_image})" "${LOCAL_REGISTRY}/$(get_image_repository_only ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})")
     $(for row in $(kubectl get imagecontentsourcepolicy -o json |
         jq -rc ".items[] | select(.metadata.name | test(\"${assisted_index_image}\")).spec.repositoryDigestMirrors[] | [.mirrors[0], .source]"); do
       row=$(echo ${row} | tr -d '[]"');

--- a/deploy/operator/setup_assisted_operator.sh
+++ b/deploy/operator/setup_assisted_operator.sh
@@ -253,8 +253,8 @@ function deploy_mirror_config_map() {
   # The mirror should point all the release images and not just the OpenShift release image itself.
   # An arbitrary image (cli) is chosen to retreive its pull spec, in order to mirror its repository.
   cli_image=$(podman run --quiet --rm --net=none "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}" image cli)
-  # Ensure the repo for the ironic agent image is also mirrored
-  ironic_agent_image=$(oc adm release info --image-for=ironic-agent "${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE}")
+  # Ensure the repo for the ironic agent image from the hub release is also mirrored
+  ironic_agent_image=$(oc adm release info --image-for=ironic-agent "${OPENSHIFT_RELEASE_IMAGE}")
 
   assisted_index_image=$(get_image_without_registry $(get_image_repository_only ${INDEX_IMAGE}))
 


### PR DESCRIPTION
When using the converged ZTP flow in a disconnected environment we need to ensure that the agent gets registry configuration for both the in-prow image repos as well as the internal images which will still likely be using quay.io

Specifically this is a problem for the ironic agent image which previously couldn't be pulled by the host during discovery despite being mirrored properly by dev-scripts.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-11998

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

Will be tested as a part of https://github.com/openshift/release/pull/36093

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?