### PR TITLE
MGMT-13210: Revert "Increase timeout waiting for image-service"

### DIFF
--- a/tools/wait_for_assisted_service.py
+++ b/tools/wait_for_assisted_service.py
@@ -10,7 +10,6 @@ from urllib.parse import urlunsplit, urlsplit
 from retry import retry
 
 TIMEOUT = 60 * 30
-IMAGE_SERVICE_TIMEOUT = 60 * 40
 REQUEST_TIMEOUT = 2
 SLEEP = 10
 
@@ -68,7 +67,7 @@ def main():
             domain=deploy_options.domain,
             namespace=deploy_options.namespace,
             disable_tls=deploy_options.disable_tls),
-        timeout_seconds=IMAGE_SERVICE_TIMEOUT,
+        timeout_seconds=TIMEOUT,
         expected_exceptions=(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout),
         sleep_seconds=SLEEP, waiting_for="assisted-image-service to be healthy")
 


### PR DESCRIPTION
Reverts openshift/assisted-service#4871

Now that we have https://github.com/openshift/assisted-test-infra/pull/1989 we don't need to wait longer for image-service.

/cc @adriengentil @gamli75 @eliorerz 