### PR TITLE
Make get_image_without_tag work when registry has a port

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -134,9 +134,11 @@ function wait_for_boolean_field() {
 }
 
 function get_image_without_tag() {
-    # given "<registry>/<repository>/<project>:<tag>"
-    # return "<registry>/<repository>/<project>"
-    echo "${1}" | cut -d':' -f1 | cut -d'@' -f1
+    # given "<registry>/<repository>/<project>:<tag>" or
+    #       "<registry>/<repository>/<project>@sha256:<sha>" or
+    #       "<registry>:<port>/<repository>/<project>:<tag>"
+    # return "<registry>:<port>/<repository>/<project>"
+    echo "${1%:*}" | cut -d@ -f1
 }
 
 function get_image_namespace() {


### PR DESCRIPTION
Another try to get the disconnected stuff to work. I promise I'll look more closely at the test results this time :sweat_smile: 

Previously `get_image_without_tag` would return just the registry hostname for an image with a port:

```
$ get_image_without_tag_old 'virthost.ostest.test.metalkube.org:5000/localimages/local-release-image:latest'
virthost.ostest.test.metalkube.org
```

This change makes the function work for all cases:

```
$ get_image_without_tag 'quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:51ad3c2b7792f2a0c551282b6c0650d8eb80c5cfd5fc912a6b7e79e088ad67e0'
quay.io/openshift-release-dev/ocp-v4.0-art-dev
$ get_image_without_tag 'virthost.ostest.test.metalkube.org:5000/localimages/local-release-image:latest'
virthost.ostest.test.metalkube.org:5000/localimages/local-release-image
$ get_image_without_tag 'quay.io/edge-infrastructure/assisted-service:latest'
quay.io/edge-infrastructure/assisted-service
```

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-11998

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

See examples in description

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?