### PR TITLE
NO-ISSUE: remove mocks from coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,9 @@ ifeq ($(CI), true)
 	./hack/publish-codecov.sh
 endif
 
+display-coverage:
+	./hack/display_cover_profile.sh
+
 run-db-container:
 	$(CONTAINER_COMMAND) ps -q --filter "name=postgres" | xargs -r $(CONTAINER_COMMAND) kill && sleep 3
 	$(CONTAINER_COMMAND) run -d  --rm --tmpfs /var/lib/pgsql/data --name postgres -e POSTGRESQL_ADMIN_PASSWORD=admin -e POSTGRESQL_MAX_CONNECTIONS=10000 -p 127.0.0.1:5432:5432 \

--- a/hack/display_cover_profile.sh
+++ b/hack/display_cover_profile.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${TMP_COVER_PROFILE:=/tmp/display_coverage.out}"
+
+exclude_patterns=("mock_.*")
+
+cp "${COVER_PROFILE}" "${TMP_COVER_PROFILE}"
+for pattern in $exclude_patterns; do
+    sed -i "/${pattern}/d" ${TMP_COVER_PROFILE}
+done
+
+go tool cover -html="${TMP_COVER_PROFILE}"
+rm -f "${TMP_COVER_PROFILE}"


### PR DESCRIPTION
Coverage include mocks, as they normally are included in the interface's package.
This hack removes them from the coverage profile before uploading or manual local analysis.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [X] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

Locally with `go tool cover -html=./reports/unit_coverage.out` and other cli utils

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
