### PR TITLE
MGMT-13903: Select IP inside machine CIDR for BMH

### DIFF
--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	bmh_v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
@@ -63,6 +64,9 @@ var _ = BeforeEach(func() {
 		PullSecret: "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}",
 		Cluster: models.Cluster{
 			ID: &clusterID,
+			MachineNetworks: []*models.MachineNetwork{{
+				Cidr: "192.168.126.11/24",
+			}},
 		},
 	}
 	cluster.ImageInfo = &models.ImageInfo{}
@@ -2219,4 +2223,81 @@ var _ = Describe("OKD overrides", func() {
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, defaultCfg, false, auth.TypeRHSSO, string(models.ImageTypeMinimalIso))
 		checkOKDFiles(text, err, true)
 	})
+})
+
+var _ = Describe("Bare metal host generation", func() {
+	DescribeTable(
+		"Selects IP addresse within cluster machine network",
+		func(firstAddress, secondAddress string) {
+			// Create the generator:
+			generator := NewGenerator(
+				"",
+				workDir,
+				installerCacheDir,
+				cluster,
+				"",
+				"",
+				"",
+				"",
+				nil,
+				log,
+				mockOperatorManager,
+				mockProviderRegistry,
+				"",
+				"",
+			).(*installerGenerator)
+
+			// The default host inventory used by these tests has two NICs, each with
+			// one IP address, but for this test we need one NIC with two IP addresses,
+			// so we need to update the inventory accordingly.
+			var inventoryObject models.Inventory
+			err := json.Unmarshal([]byte(hostInventory), &inventoryObject)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(inventoryObject.Interfaces).ToNot(BeEmpty())
+			interfaceObject := inventoryObject.Interfaces[0]
+			interfaceObject.IPV4Addresses = []string{
+				firstAddress,
+				secondAddress,
+			}
+			inventoryObject.Interfaces = []*models.Interface{
+				interfaceObject,
+			}
+			inventoryJSON, err := json.Marshal(inventoryObject)
+			Expect(err).ToNot(HaveOccurred())
+			host := &models.Host{
+				Inventory: string(inventoryJSON),
+			}
+
+			// Generate the bare metal hosts:
+			inputObject := &bmh_v1alpha1.BareMetalHost{}
+			outputFile := &config_32_types.File{}
+			err = generator.modifyBMHFile(outputFile, inputObject, host)
+			Expect(err).ToNot(HaveOccurred())
+			outputObject, err := fileToBMH(outputFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Extract the content of the status annotation:
+			Expect(outputObject.Annotations).To(HaveKey(bmh_v1alpha1.StatusAnnotation))
+			statusAnnotation := outputObject.Annotations[bmh_v1alpha1.StatusAnnotation]
+			var outputStatus bmh_v1alpha1.BareMetalHostStatus
+			err = json.Unmarshal([]byte(statusAnnotation), &outputStatus)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that the IP address of the bare metal host is within the machine
+			// network of the cluster:
+			Expect(outputStatus.HardwareDetails).ToNot(BeNil())
+			Expect(outputStatus.HardwareDetails.NIC).To(HaveLen(1))
+			Expect(outputStatus.HardwareDetails.NIC[0].IP).To(Equal("192.168.126.11"))
+		},
+		Entry(
+			"Lucky order in inventory",
+			"192.168.126.11/24",
+			"192.168.140.133/24",
+		),
+		Entry(
+			"Unlucky oder in inventory",
+			"192.168.140.133/24",
+			"192.168.126.11/24",
+		),
+	)
 })


### PR DESCRIPTION
Currently when the service generates the bare metal hosts for the installed cluster it selects the first IP address of each NIC. But if there are multiple IP addresses in the same interface this may end up selecting an IP address that isn't inside the machine CIDR of the cluster. If that happens then there will be a missmatch between the IP addresses of machines and nodes. As a result machine will not be linked to nodes and machines will never reach the `Running` phase, and therefore the corresponding machine pool will never have the minium number of replicas, which makes the installation fail.

Related: https://issues.redhat.com/browse/MGMT-13903

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
