### PR TITLE
ACM-4127: Cache release images even if there is no matching OS image

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -850,7 +850,7 @@ func createVersionHandlers(log logrus.FieldLogger, ctrlMgr manager.Manager, rele
 			return nil, nil, errors.Wrapf(err, "Failed to parse feature must-gather images JSON %s", Options.MustGatherImages)
 		}
 	}
-	versionsHandler, err := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler, osImages,
+	versionsHandler, err := versions.NewHandler(log.WithField("pkg", "versions"), releaseHandler,
 		releaseImagesArray, mustGatherVersionsMap, Options.ReleaseImageMirror, versionsClient)
 	if err != nil {
 		return nil, nil, err

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	go.elastic.co/apm/module/apmhttp v1.15.0
 	go.elastic.co/apm/module/apmlogrus v1.15.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
-	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.3.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/square/go-jose.v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -1985,6 +1985,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde h1:ejfdSekXMDxDLbRrJMwUk6KnSLZ2McaUCVcIKM+N6jc=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -206,6 +206,7 @@ func toMac(macStr string) *strfmt.MAC {
 func mockClusterRegisterSteps() {
 	mockSecretValidator.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 	mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+	mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 	mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 	mockProviderRegistry.EXPECT().SetPlatformUsages(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
@@ -2743,6 +2744,7 @@ var _ = Describe("cluster", func() {
 						eventstest.WithMessageContainsMatcher("error"),
 						eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
 					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().GetOperatorByName(newOperatorName).Return(nil, errors.Errorf("error")).Times(1)
 
@@ -2758,6 +2760,7 @@ var _ = Describe("cluster", func() {
 
 				It("should return error when both cnv and lvm operator enabled", func() {
 					mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+					mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 					mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
 						DoAndReturn(func(commonCluster *common.Cluster, operators []*models.MonitoredOperator) ([]*models.MonitoredOperator, error) {
@@ -12967,6 +12970,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			Return(errors.New("error")).Times(1)
 		mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{}).Times(1)
 		mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil).Times(1)
+		mockOSImages.EXPECT().GetOsImage(gomock.Any(), gomock.Any()).Return(common.TestDefaultConfig.OsImage, nil).Times(1)
 
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.PullSecret = swag.String("")

--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -108,7 +108,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 		err = json.Unmarshal(bytes, releaseImages)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, *releaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, *releaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 		return versionsHandler
 	}
@@ -182,7 +182,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 
 	It("missing release images", func() {
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, models.ReleaseImages{}, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, models.ReleaseImages{}, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 		reply := h.V2ListSupportedOpenshiftVersions(context.Background(), operations.V2ListSupportedOpenshiftVersionsParams{})
@@ -206,7 +206,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 		}
 
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -232,7 +232,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 			},
 		}
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -276,7 +276,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 			},
 		}
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -307,7 +307,7 @@ var _ = Describe("ListSupportedOpenshiftVersions", func() {
 			},
 		}
 		osImages := readDefaultOsImages()
-		versionsHandler, err := NewHandler(logger, mockRelease, osImages, releaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(logger, mockRelease, releaseImages, nil, "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		h := NewAPIHandler(logger, versions, authzHandler, versionsHandler, osImages)
 
@@ -362,7 +362,7 @@ var _ = Describe("Test list versions with capability restrictions", func() {
 
 		osImages, err := NewOSImages(defaultOsImages)
 		Expect(err).ShouldNot(HaveOccurred())
-		versionsHandler, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "", nil)
+		versionsHandler, err := NewHandler(common.GetTestLog(), nil, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		return NewAPIHandler(common.GetTestLog(), Versions{}, authzHandler, versionsHandler, osImages)

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -30,12 +30,11 @@ type Handler interface {
 	ValidateReleaseImageForRHCOS(rhcosVersion, cpuArch string) error
 }
 
-func NewHandler(log logrus.FieldLogger, releaseHandler oc.Release, osImages OSImages, releaseImages models.ReleaseImages,
+func NewHandler(log logrus.FieldLogger, releaseHandler oc.Release, releaseImages models.ReleaseImages,
 	mustGatherVersions MustGatherVersions, releaseImageMirror string, kubeClient client.Client) (*handler, error) {
 
 	h := &handler{
 		mustGatherVersions: mustGatherVersions,
-		osImages:           osImages,
 		releaseImages:      releaseImages,
 		releaseHandler:     releaseHandler,
 		releaseImageMirror: releaseImageMirror,
@@ -52,7 +51,6 @@ func NewHandler(log logrus.FieldLogger, releaseHandler oc.Release, osImages OSIm
 
 type handler struct {
 	mustGatherVersions MustGatherVersions
-	osImages           OSImages
 	releaseImages      models.ReleaseImages
 	releaseHandler     oc.Release
 	releaseImageMirror string

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -242,13 +242,6 @@ func (h *handler) addReleaseImage(releaseImageUrl, pullSecret string) (*models.R
 	var cpuArchitecture string
 	if len(cpuArchitectures) == 1 {
 		cpuArchitecture = cpuArchitectures[0]
-
-		// Ensure a relevant OsImage exists. For multiarch we disabling the code below because we don't know yet
-		// what is going to be the architecture of InfraEnv and Agent.
-		osImage, err := h.osImages.GetOsImage(ocpReleaseVersion, cpuArchitecture)
-		if err != nil || osImage.URL == nil {
-			return nil, errors.Errorf("No OS images are available for version %s and architecture %s", ocpReleaseVersion, cpuArchitecture)
-		}
 	} else {
 		cpuArchitecture = common.MultiCPUArchitecture
 	}

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -169,7 +169,7 @@ var _ = Describe("GetReleaseImage", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
-		h, err = NewHandler(common.GetTestLog(), mockRelease, osImages, defaultReleaseImages, nil, "", nil)
+		h, err = NewHandler(common.GetTestLog(), mockRelease, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -358,9 +358,8 @@ var _ = Describe("ValidateReleaseImageForRHCOS", func() {
 				Version:          swag.String("4.12"),
 			},
 		}
-		osImages, err := NewOSImages(defaultOsImages)
-		Expect(err).ShouldNot(HaveOccurred())
-		h, err = NewHandler(common.GetTestLog(), nil, osImages, releaseImages, nil, "", nil)
+		var err error
+		h, err = NewHandler(common.GetTestLog(), nil, releaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -390,16 +389,8 @@ var _ = Describe("ValidateReleaseImageForRHCOS", func() {
 })
 
 var _ = Describe("GetDefaultReleaseImage", func() {
-	var osImages OSImages
-
-	BeforeEach(func() {
-		var err error
-		osImages, err = NewOSImages(defaultOsImages)
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-
 	It("Default release image exists", func() {
-		h, err := NewHandler(common.GetTestLog(), nil, osImages, defaultReleaseImages, nil, "", nil)
+		h, err := NewHandler(common.GetTestLog(), nil, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		releaseImage, err := h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
@@ -410,7 +401,7 @@ var _ = Describe("GetDefaultReleaseImage", func() {
 	})
 
 	It("Missing default release image", func() {
-		h, err := NewHandler(common.GetTestLog(), nil, osImages, models.ReleaseImages{}, nil, "", nil)
+		h, err := NewHandler(common.GetTestLog(), nil, models.ReleaseImages{}, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		_, err = h.GetDefaultReleaseImage(common.TestDefaultConfig.CPUArchitecture)
@@ -441,7 +432,7 @@ var _ = Describe("GetMustGatherImages", func() {
 		var err error
 		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
-		h, err = NewHandler(common.GetTestLog(), mockRelease, nil, defaultReleaseImages, mustgatherImages, mirror, nil)
+		h, err = NewHandler(common.GetTestLog(), mockRelease, defaultReleaseImages, mustgatherImages, mirror, nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -504,9 +495,8 @@ var _ = Describe("GetReleaseImageByURL", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockRelease = oc.NewMockRelease(ctrl)
 
-		osImages, err := NewOSImages(defaultOsImages)
-		Expect(err).ShouldNot(HaveOccurred())
-		h, err = NewHandler(common.GetTestLog(), mockRelease, osImages, defaultReleaseImages, nil, "", nil)
+		var err error
+		h, err = NewHandler(common.GetTestLog(), mockRelease, defaultReleaseImages, nil, "", nil)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -647,7 +637,7 @@ var _ = Describe("GetReleaseImageByURL", func() {
 
 var _ = Describe("NewHandler", func() {
 	validateNewHandler := func(releaseImages models.ReleaseImages) error {
-		_, err := NewHandler(common.GetTestLog(), nil, nil, releaseImages, nil, "", nil)
+		_, err := NewHandler(common.GetTestLog(), nil, releaseImages, nil, "", nil)
 		return err
 	}
 

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -2,7 +2,6 @@ package versions
 
 import (
 	context "context"
-	"fmt"
 	"testing"
 
 	"github.com/go-openapi/swag"
@@ -551,7 +550,7 @@ var _ = Describe("GetReleaseImageByURL", func() {
 			Expect(releaseImage.Version).Should(Equal(releaseImageFromCache.(*models.ReleaseImage).Version))
 		})
 
-		It("fails when missing OS image", func() {
+		It("succeeds for missing OS image", func() {
 			ocpVersion := "4.7"
 			mockRelease.EXPECT().GetOpenshiftVersion(
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(ocpVersion, nil).AnyTimes()
@@ -559,8 +558,7 @@ var _ = Describe("GetReleaseImageByURL", func() {
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{cpuArchitecture}, nil).AnyTimes()
 
 			_, err := h.GetReleaseImageByURL(ctx, "invalidRelease", pullSecret)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(Equal(fmt.Sprintf("No OS images are available for version %s and architecture %s", ocpVersion, cpuArchitecture)))
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,136 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			isFront := s.waiters.Front() == elem
+			s.waiters.Remove(elem)
+			// If we're at the front and there're extra tokens left, notify other waiters.
+			if isFront && s.size > s.cur {
+				s.notifyWaiters()
+			}
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	s.notifyWaiters()
+	s.mu.Unlock()
+}
+
+func (s *Weighted) notifyWaiters() {
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+}

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -52,10 +52,6 @@ type call struct {
 	val interface{}
 	err error
 
-	// forgotten indicates whether Forget was called with this call's key
-	// while the call was still in flight.
-	forgotten bool
-
 	// These fields are read and written with the singleflight
 	// mutex held before the WaitGroup is done, and are read but
 	// not written after the WaitGroup is done.
@@ -148,10 +144,10 @@ func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
 			c.err = errGoexit
 		}
 
-		c.wg.Done()
 		g.mu.Lock()
 		defer g.mu.Unlock()
-		if !c.forgotten {
+		c.wg.Done()
+		if g.m[key] == c {
 			delete(g.m, key)
 		}
 
@@ -204,9 +200,6 @@ func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
 // an earlier call to complete.
 func (g *Group) Forget(key string) {
 	g.mu.Lock()
-	if c, ok := g.m[key]; ok {
-		c.forgotten = true
-	}
 	delete(g.m, key)
 	g.mu.Unlock()
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1104,9 +1104,10 @@ golang.org/x/oauth2/google/internal/externalaccount
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
-# golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
+# golang.org/x/sync v0.1.0
 ## explicit
 golang.org/x/sync/errgroup
+golang.org/x/sync/semaphore
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.3.0
 ## explicit; go 1.17


### PR DESCRIPTION
This reduces the amount of work we have to do every time we encounter a cache miss.

Before this change a cache miss would re-evaluate all of the cluster image sets in the cluster and would require us to pull and inspect all of the images that we don't already have cache entries for. If we had a limited set of OS images this could mean a lot of additional processing time.

In some cases there were as many as 40 cluster image sets that didn't have OS images. Processing these caused requests to time out in some cases.

Additionally, these images were all being processed serially which also slowed everything down. This PR adds concurrency to the cluster image set processing to allow the first request to download an ISO to succeed even when it needs to process all (~80 in my testing) cluster image sets.

While just adding this concurrency would also have solved this issue I think the API (cluster create in this case) is the better place to validate the match between release image and OS version. Especially now that the release image handler and OS image handler are separated.

https://issues.redhat.com/browse/ACM-4127

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Reproduced the issue using the information from the JIRA and the current latest image, deployed an image built from this PR and observed that the issue was resolved.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?