### PR TITLE
MGMT-13913: Fix empty features list when calling GET v2/support-levels/features

### DIFF
--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -45,10 +45,8 @@ func getFeatureSupportList(features map[models.FeatureSupportLevelID]SupportLeve
 	featureSupportList := models.SupportLevels{}
 
 	for _, feature := range features {
-		if reflect.TypeOf(feature).Name() == "SupportLevelFeature" {
-			featureID := feature.GetId()
-			featureSupportList[string(featureID)] = feature.GetSupportLevel(filters)
-		}
+		featureID := feature.GetId()
+		featureSupportList[string(featureID)] = feature.GetSupportLevel(filters)
 	}
 	return featureSupportList
 }
@@ -69,7 +67,7 @@ func GetFeatureSupportList(openshiftVersion string, cpuArchitecture *string) mod
 		CPUArchitecture:  cpuArchitecture,
 	}
 
-	if swag.StringValue(filters.CPUArchitecture) == "" {
+	if cpuArchitecture == nil {
 		filters.CPUArchitecture = swag.String(common.DefaultCPUArchitecture)
 	}
 

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -155,6 +155,29 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 	})
 
+	Context("GetSupportList", func() {
+		It("GetFeatureSupportList 4.12", func() {
+			list := GetFeatureSupportList("4.12", nil)
+			Expect(len(list)).To(Equal(22))
+		})
+
+		It("GetFeatureSupportList 4.13", func() {
+			list := GetFeatureSupportList("4.13", nil)
+			Expect(len(list)).To(Equal(22))
+		})
+
+		It("GetCpuArchitectureSupportList 4.12", func() {
+			list := GetCpuArchitectureSupportList("4.12")
+			Expect(len(list)).To(Equal(5))
+		})
+
+		It("GetCpuArchitectureSupportList 4.13", func() {
+			list := GetCpuArchitectureSupportList("4.13")
+			Expect(len(list)).To(Equal(5))
+		})
+
+	})
+
 })
 
 func TestOperators(t *testing.T) {


### PR DESCRIPTION
Description of the problem:
GetFeatureSupportList returning empty object when calling GET v2/support-levels/features?openshift_version=X


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 