### PR TITLE
MGMT-13958: MGMT-13862: Return bed request on wrong feature-feature or feature-architecture combination

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/feature_support_level_id.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/feature_support_level_id.go
@@ -30,47 +30,14 @@ func (m FeatureSupportLevelID) Pointer() *FeatureSupportLevelID {
 
 const (
 
-	// FeatureSupportLevelIDADDITIONALNTPSOURCE captures enum value "ADDITIONAL_NTP_SOURCE"
-	FeatureSupportLevelIDADDITIONALNTPSOURCE FeatureSupportLevelID = "ADDITIONAL_NTP_SOURCE"
-
-	// FeatureSupportLevelIDREQUESTEDHOSTNAME captures enum value "REQUESTED_HOSTNAME"
-	FeatureSupportLevelIDREQUESTEDHOSTNAME FeatureSupportLevelID = "REQUESTED_HOSTNAME"
-
-	// FeatureSupportLevelIDPROXY captures enum value "PROXY"
-	FeatureSupportLevelIDPROXY FeatureSupportLevelID = "PROXY"
-
 	// FeatureSupportLevelIDSNO captures enum value "SNO"
 	FeatureSupportLevelIDSNO FeatureSupportLevelID = "SNO"
-
-	// FeatureSupportLevelIDDAY2HOSTS captures enum value "DAY2_HOSTS"
-	FeatureSupportLevelIDDAY2HOSTS FeatureSupportLevelID = "DAY2_HOSTS"
 
 	// FeatureSupportLevelIDVIPAUTOALLOC captures enum value "VIP_AUTO_ALLOC"
 	FeatureSupportLevelIDVIPAUTOALLOC FeatureSupportLevelID = "VIP_AUTO_ALLOC"
 
-	// FeatureSupportLevelIDDISKSELECTION captures enum value "DISK_SELECTION"
-	FeatureSupportLevelIDDISKSELECTION FeatureSupportLevelID = "DISK_SELECTION"
-
-	// FeatureSupportLevelIDOVNNETWORKTYPE captures enum value "OVN_NETWORK_TYPE"
-	FeatureSupportLevelIDOVNNETWORKTYPE FeatureSupportLevelID = "OVN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSDNNETWORKTYPE captures enum value "SDN_NETWORK_TYPE"
-	FeatureSupportLevelIDSDNNETWORKTYPE FeatureSupportLevelID = "SDN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSCHEDULABLEMASTERS captures enum value "SCHEDULABLE_MASTERS"
-	FeatureSupportLevelIDSCHEDULABLEMASTERS FeatureSupportLevelID = "SCHEDULABLE_MASTERS"
-
-	// FeatureSupportLevelIDAUTOASSIGNROLE captures enum value "AUTO_ASSIGN_ROLE"
-	FeatureSupportLevelIDAUTOASSIGNROLE FeatureSupportLevelID = "AUTO_ASSIGN_ROLE"
-
 	// FeatureSupportLevelIDCUSTOMMANIFEST captures enum value "CUSTOM_MANIFEST"
 	FeatureSupportLevelIDCUSTOMMANIFEST FeatureSupportLevelID = "CUSTOM_MANIFEST"
-
-	// FeatureSupportLevelIDDISKENCRYPTION captures enum value "DISK_ENCRYPTION"
-	FeatureSupportLevelIDDISKENCRYPTION FeatureSupportLevelID = "DISK_ENCRYPTION"
-
-	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS captures enum value "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
-	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
 
 	// FeatureSupportLevelIDSINGLENODEEXPANSION captures enum value "SINGLE_NODE_EXPANSION"
 	FeatureSupportLevelIDSINGLENODEEXPANSION FeatureSupportLevelID = "SINGLE_NODE_EXPANSION"
@@ -84,9 +51,6 @@ const (
 	// FeatureSupportLevelIDCNV captures enum value "CNV"
 	FeatureSupportLevelIDCNV FeatureSupportLevelID = "CNV"
 
-	// FeatureSupportLevelIDDUALSTACKNETWORKING captures enum value "DUAL_STACK_NETWORKING"
-	FeatureSupportLevelIDDUALSTACKNETWORKING FeatureSupportLevelID = "DUAL_STACK_NETWORKING"
-
 	// FeatureSupportLevelIDNUTANIXINTEGRATION captures enum value "NUTANIX_INTEGRATION"
 	FeatureSupportLevelIDNUTANIXINTEGRATION FeatureSupportLevelID = "NUTANIX_INTEGRATION"
 
@@ -96,11 +60,11 @@ const (
 	// FeatureSupportLevelIDDUALSTACKVIPS captures enum value "DUAL_STACK_VIPS"
 	FeatureSupportLevelIDDUALSTACKVIPS FeatureSupportLevelID = "DUAL_STACK_VIPS"
 
-	// FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE captures enum value "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-	FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE FeatureSupportLevelID = "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-
 	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING captures enum value "CLUSTER_MANAGED_NETWORKING"
 	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING"
+
+	// FeatureSupportLevelIDUSERMANAGEDNETWORKING captures enum value "USER_MANAGED_NETWORKING"
+	FeatureSupportLevelIDUSERMANAGEDNETWORKING FeatureSupportLevelID = "USER_MANAGED_NETWORKING"
 )
 
 // for schema
@@ -108,7 +72,7 @@ var featureSupportLevelIdEnum []interface{}
 
 func init() {
 	var res []FeatureSupportLevelID
-	if err := json.Unmarshal([]byte(`["ADDITIONAL_NTP_SOURCE","REQUESTED_HOSTNAME","PROXY","SNO","DAY2_HOSTS","VIP_AUTO_ALLOC","DISK_SELECTION","OVN_NETWORK_TYPE","SDN_NETWORK_TYPE","SCHEDULABLE_MASTERS","AUTO_ASSIGN_ROLE","CUSTOM_MANIFEST","DISK_ENCRYPTION","CLUSTER_MANAGED_NETWORKING_WITH_VMS","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","DUAL_STACK_NETWORKING","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","USER_MANAGED_NETWORKING_WITH_MULTI_NODE","CLUSTER_MANAGED_NETWORKING"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["SNO","VIP_AUTO_ALLOC","CUSTOM_MANIFEST","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","CLUSTER_MANAGED_NETWORKING","USER_MANAGED_NETWORKING"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -620,6 +620,10 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	}
 	cluster.MonitoredOperators = append(monitoredOperators, newOLMOperators...)
 
+	if err = featuresupport.ValidateIncompatibleFeatures(*cluster, nil); err != nil {
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
 	pullSecret := swag.StringValue(params.NewClusterParams.PullSecret)
 	err = b.ValidatePullSecret(pullSecret, ocm.UserNameFromContext(ctx))
 	if err != nil {
@@ -1949,6 +1953,10 @@ func (b *bareMetalInventory) v2UpdateClusterInternal(ctx context.Context, params
 	}
 
 	if err = validations.ValidateArchitectureWithPlatform(&cluster.CPUArchitecture, platform); err != nil {
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
+	if err = featuresupport.ValidateIncompatibleFeatures(*cluster, params.ClusterUpdateParams); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 

--- a/internal/featuresupport/architecture_support_level.go
+++ b/internal/featuresupport/architecture_support_level.go
@@ -1,0 +1,76 @@
+package featuresupport
+
+import (
+	"fmt"
+
+	"github.com/openshift/assisted-service/models"
+	"github.com/thoas/go-funk"
+)
+
+var cpuFeaturesList = map[models.ArchitectureSupportLevelID]SupportLevelArchitecture{
+	models.ArchitectureSupportLevelIDX8664ARCHITECTURE:     &X8664ArchitectureFeature{},
+	models.ArchitectureSupportLevelIDARM64ARCHITECTURE:     &Arm64ArchitectureFeature{},
+	models.ArchitectureSupportLevelIDS390XARCHITECTURE:     &S390xArchitectureFeature{},
+	models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE:   &PPC64LEArchitectureFeature{},
+	models.ArchitectureSupportLevelIDMULTIARCHRELEASEIMAGE: &MultiArchReleaseImageFeature{},
+}
+
+var cpuArchitectureFeatureIdMap = map[string]models.ArchitectureSupportLevelID{
+	models.ClusterCPUArchitectureX8664:   models.ArchitectureSupportLevelIDX8664ARCHITECTURE,
+	models.ClusterCPUArchitectureArm64:   models.ArchitectureSupportLevelIDARM64ARCHITECTURE,
+	models.ClusterCPUArchitectureS390x:   models.ArchitectureSupportLevelIDS390XARCHITECTURE,
+	models.ClusterCPUArchitecturePpc64le: models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE,
+	models.ClusterCPUArchitectureMulti:   models.ArchitectureSupportLevelIDMULTIARCHRELEASEIMAGE,
+}
+
+func isFeatureCompatibleWithArchitecture(feature SupportLevelFeature, openshiftVersion, cpuArchitecture string) bool {
+	architectureID := cpuArchitectureFeatureIdMap[cpuArchitecture]
+	incompatibilitiesArchitectures := feature.GetIncompatibleArchitectures(openshiftVersion)
+	if incompatibilitiesArchitectures != nil && funk.Contains(*incompatibilitiesArchitectures, architectureID) {
+		return false
+	}
+	return true
+}
+
+func getArchitectureSupportList(features map[models.ArchitectureSupportLevelID]SupportLevelArchitecture, openshiftVersion string) models.SupportLevels {
+	featureSupportList := models.SupportLevels{}
+
+	for _, feature := range features {
+		featureID := feature.GetId()
+		featureSupportList[string(featureID)] = feature.GetSupportLevel(openshiftVersion)
+	}
+	return featureSupportList
+}
+
+// Handle cases where a CPU architecture is not supported at for a given openshift version, in that case
+// return a list of unsupported features
+func overrideInvalidRequest(features map[models.FeatureSupportLevelID]SupportLevelFeature, cpuArchitecture, openshiftVersion string) models.SupportLevels {
+	supportLevels := models.SupportLevels{}
+	cpuArchID := cpuArchitectureFeatureIdMap[cpuArchitecture]
+	if !isArchitectureSupported(cpuArchID, openshiftVersion) {
+		for _, feature := range features {
+			supportLevels[string(feature.GetId())] = models.SupportLevelUnsupported
+		}
+		return supportLevels
+	}
+	return nil
+}
+
+func GetCpuArchitectureSupportList(openshiftVersion string) models.SupportLevels {
+	return getArchitectureSupportList(cpuFeaturesList, openshiftVersion)
+}
+
+func isArchitectureSupported(featureId models.ArchitectureSupportLevelID, openshiftVersion string) bool {
+	return GetSupportLevel(featureId, openshiftVersion) != models.SupportLevelUnsupported
+}
+
+// isFeaturesCompatibleWIthArchitecture Determine if feature is compatible with CPU architecture in a given openshift-version
+func isFeaturesCompatibleWIthArchitecture(openshiftVersion, cpuArchitecture string, activatedFeatures []SupportLevelFeature) error {
+	for _, feature := range activatedFeatures {
+		if !isFeatureCompatibleWithArchitecture(feature, openshiftVersion, cpuArchitecture) {
+			return fmt.Errorf("cannot use %s because it's not compatible with the %s architecture "+
+				"on version %s of OpenShift", feature.GetName(), cpuArchitecture, openshiftVersion)
+		}
+	}
+	return nil
+}

--- a/models/feature_support_level_id.go
+++ b/models/feature_support_level_id.go
@@ -30,47 +30,14 @@ func (m FeatureSupportLevelID) Pointer() *FeatureSupportLevelID {
 
 const (
 
-	// FeatureSupportLevelIDADDITIONALNTPSOURCE captures enum value "ADDITIONAL_NTP_SOURCE"
-	FeatureSupportLevelIDADDITIONALNTPSOURCE FeatureSupportLevelID = "ADDITIONAL_NTP_SOURCE"
-
-	// FeatureSupportLevelIDREQUESTEDHOSTNAME captures enum value "REQUESTED_HOSTNAME"
-	FeatureSupportLevelIDREQUESTEDHOSTNAME FeatureSupportLevelID = "REQUESTED_HOSTNAME"
-
-	// FeatureSupportLevelIDPROXY captures enum value "PROXY"
-	FeatureSupportLevelIDPROXY FeatureSupportLevelID = "PROXY"
-
 	// FeatureSupportLevelIDSNO captures enum value "SNO"
 	FeatureSupportLevelIDSNO FeatureSupportLevelID = "SNO"
-
-	// FeatureSupportLevelIDDAY2HOSTS captures enum value "DAY2_HOSTS"
-	FeatureSupportLevelIDDAY2HOSTS FeatureSupportLevelID = "DAY2_HOSTS"
 
 	// FeatureSupportLevelIDVIPAUTOALLOC captures enum value "VIP_AUTO_ALLOC"
 	FeatureSupportLevelIDVIPAUTOALLOC FeatureSupportLevelID = "VIP_AUTO_ALLOC"
 
-	// FeatureSupportLevelIDDISKSELECTION captures enum value "DISK_SELECTION"
-	FeatureSupportLevelIDDISKSELECTION FeatureSupportLevelID = "DISK_SELECTION"
-
-	// FeatureSupportLevelIDOVNNETWORKTYPE captures enum value "OVN_NETWORK_TYPE"
-	FeatureSupportLevelIDOVNNETWORKTYPE FeatureSupportLevelID = "OVN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSDNNETWORKTYPE captures enum value "SDN_NETWORK_TYPE"
-	FeatureSupportLevelIDSDNNETWORKTYPE FeatureSupportLevelID = "SDN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSCHEDULABLEMASTERS captures enum value "SCHEDULABLE_MASTERS"
-	FeatureSupportLevelIDSCHEDULABLEMASTERS FeatureSupportLevelID = "SCHEDULABLE_MASTERS"
-
-	// FeatureSupportLevelIDAUTOASSIGNROLE captures enum value "AUTO_ASSIGN_ROLE"
-	FeatureSupportLevelIDAUTOASSIGNROLE FeatureSupportLevelID = "AUTO_ASSIGN_ROLE"
-
 	// FeatureSupportLevelIDCUSTOMMANIFEST captures enum value "CUSTOM_MANIFEST"
 	FeatureSupportLevelIDCUSTOMMANIFEST FeatureSupportLevelID = "CUSTOM_MANIFEST"
-
-	// FeatureSupportLevelIDDISKENCRYPTION captures enum value "DISK_ENCRYPTION"
-	FeatureSupportLevelIDDISKENCRYPTION FeatureSupportLevelID = "DISK_ENCRYPTION"
-
-	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS captures enum value "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
-	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
 
 	// FeatureSupportLevelIDSINGLENODEEXPANSION captures enum value "SINGLE_NODE_EXPANSION"
 	FeatureSupportLevelIDSINGLENODEEXPANSION FeatureSupportLevelID = "SINGLE_NODE_EXPANSION"
@@ -84,9 +51,6 @@ const (
 	// FeatureSupportLevelIDCNV captures enum value "CNV"
 	FeatureSupportLevelIDCNV FeatureSupportLevelID = "CNV"
 
-	// FeatureSupportLevelIDDUALSTACKNETWORKING captures enum value "DUAL_STACK_NETWORKING"
-	FeatureSupportLevelIDDUALSTACKNETWORKING FeatureSupportLevelID = "DUAL_STACK_NETWORKING"
-
 	// FeatureSupportLevelIDNUTANIXINTEGRATION captures enum value "NUTANIX_INTEGRATION"
 	FeatureSupportLevelIDNUTANIXINTEGRATION FeatureSupportLevelID = "NUTANIX_INTEGRATION"
 
@@ -96,11 +60,11 @@ const (
 	// FeatureSupportLevelIDDUALSTACKVIPS captures enum value "DUAL_STACK_VIPS"
 	FeatureSupportLevelIDDUALSTACKVIPS FeatureSupportLevelID = "DUAL_STACK_VIPS"
 
-	// FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE captures enum value "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-	FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE FeatureSupportLevelID = "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-
 	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING captures enum value "CLUSTER_MANAGED_NETWORKING"
 	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING"
+
+	// FeatureSupportLevelIDUSERMANAGEDNETWORKING captures enum value "USER_MANAGED_NETWORKING"
+	FeatureSupportLevelIDUSERMANAGEDNETWORKING FeatureSupportLevelID = "USER_MANAGED_NETWORKING"
 )
 
 // for schema
@@ -108,7 +72,7 @@ var featureSupportLevelIdEnum []interface{}
 
 func init() {
 	var res []FeatureSupportLevelID
-	if err := json.Unmarshal([]byte(`["ADDITIONAL_NTP_SOURCE","REQUESTED_HOSTNAME","PROXY","SNO","DAY2_HOSTS","VIP_AUTO_ALLOC","DISK_SELECTION","OVN_NETWORK_TYPE","SDN_NETWORK_TYPE","SCHEDULABLE_MASTERS","AUTO_ASSIGN_ROLE","CUSTOM_MANIFEST","DISK_ENCRYPTION","CLUSTER_MANAGED_NETWORKING_WITH_VMS","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","DUAL_STACK_NETWORKING","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","USER_MANAGED_NETWORKING_WITH_MULTI_NODE","CLUSTER_MANAGED_NETWORKING"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["SNO","VIP_AUTO_ALLOC","CUSTOM_MANIFEST","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","CLUSTER_MANAGED_NETWORKING","USER_MANAGED_NETWORKING"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7259,30 +7259,18 @@ func init() {
     "feature-support-level-id": {
       "type": "string",
       "enum": [
-        "ADDITIONAL_NTP_SOURCE",
-        "REQUESTED_HOSTNAME",
-        "PROXY",
         "SNO",
-        "DAY2_HOSTS",
         "VIP_AUTO_ALLOC",
-        "DISK_SELECTION",
-        "OVN_NETWORK_TYPE",
-        "SDN_NETWORK_TYPE",
-        "SCHEDULABLE_MASTERS",
-        "AUTO_ASSIGN_ROLE",
         "CUSTOM_MANIFEST",
-        "DISK_ENCRYPTION",
-        "CLUSTER_MANAGED_NETWORKING_WITH_VMS",
         "SINGLE_NODE_EXPANSION",
         "LVM",
         "ODF",
         "CNV",
-        "DUAL_STACK_NETWORKING",
         "NUTANIX_INTEGRATION",
         "VSPHERE_INTEGRATION",
         "DUAL_STACK_VIPS",
-        "USER_MANAGED_NETWORKING_WITH_MULTI_NODE",
-        "CLUSTER_MANAGED_NETWORKING"
+        "CLUSTER_MANAGED_NETWORKING",
+        "USER_MANAGED_NETWORKING"
       ]
     },
     "feature-support-levels": {
@@ -17351,30 +17339,18 @@ func init() {
     "feature-support-level-id": {
       "type": "string",
       "enum": [
-        "ADDITIONAL_NTP_SOURCE",
-        "REQUESTED_HOSTNAME",
-        "PROXY",
         "SNO",
-        "DAY2_HOSTS",
         "VIP_AUTO_ALLOC",
-        "DISK_SELECTION",
-        "OVN_NETWORK_TYPE",
-        "SDN_NETWORK_TYPE",
-        "SCHEDULABLE_MASTERS",
-        "AUTO_ASSIGN_ROLE",
         "CUSTOM_MANIFEST",
-        "DISK_ENCRYPTION",
-        "CLUSTER_MANAGED_NETWORKING_WITH_VMS",
         "SINGLE_NODE_EXPANSION",
         "LVM",
         "ODF",
         "CNV",
-        "DUAL_STACK_NETWORKING",
         "NUTANIX_INTEGRATION",
         "VSPHERE_INTEGRATION",
         "DUAL_STACK_VIPS",
-        "USER_MANAGED_NETWORKING_WITH_MULTI_NODE",
-        "CLUSTER_MANAGED_NETWORKING"
+        "CLUSTER_MANAGED_NETWORKING",
+        "USER_MANAGED_NETWORKING"
       ]
     },
     "feature-support-levels": {

--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/featuresupport"
 	"github.com/openshift/assisted-service/models"
 )
@@ -60,7 +61,7 @@ var _ = Describe("Feature support levels API", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for featureID, supportLevel := range response.Payload.Features {
-						filters := featuresupport.SupportLevelFilters{OpenshiftVersion: version}
+						filters := featuresupport.SupportLevelFilters{OpenshiftVersion: version, CPUArchitecture: swag.String(common.DefaultCPUArchitecture)}
 						featureSupportLevel := featuresupport.GetSupportLevel(models.FeatureSupportLevelID(featureID), filters)
 						Expect(featureSupportLevel).To(BeEquivalentTo(supportLevel))
 					}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3856,30 +3856,18 @@ definitions:
   feature-support-level-id:
     type: string
     enum:
-      - 'ADDITIONAL_NTP_SOURCE'
-      - 'REQUESTED_HOSTNAME'
-      - 'PROXY'
       - 'SNO'
-      - 'DAY2_HOSTS'
       - 'VIP_AUTO_ALLOC'
-      - 'DISK_SELECTION'
-      - 'OVN_NETWORK_TYPE'
-      - 'SDN_NETWORK_TYPE'
-      - 'SCHEDULABLE_MASTERS'
-      - 'AUTO_ASSIGN_ROLE'
       - 'CUSTOM_MANIFEST'
-      - 'DISK_ENCRYPTION'
-      - 'CLUSTER_MANAGED_NETWORKING_WITH_VMS'
       - 'SINGLE_NODE_EXPANSION'
       - 'LVM'
       - 'ODF'
       - 'CNV'
-      - 'DUAL_STACK_NETWORKING'
       - 'NUTANIX_INTEGRATION'
       - 'VSPHERE_INTEGRATION'
       - 'DUAL_STACK_VIPS'
-      - 'USER_MANAGED_NETWORKING_WITH_MULTI_NODE'
       - 'CLUSTER_MANAGED_NETWORKING'
+      - 'USER_MANAGED_NETWORKING'
 
   architecture-support-level-id:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/feature_support_level_id.go
+++ b/vendor/github.com/openshift/assisted-service/models/feature_support_level_id.go
@@ -30,47 +30,14 @@ func (m FeatureSupportLevelID) Pointer() *FeatureSupportLevelID {
 
 const (
 
-	// FeatureSupportLevelIDADDITIONALNTPSOURCE captures enum value "ADDITIONAL_NTP_SOURCE"
-	FeatureSupportLevelIDADDITIONALNTPSOURCE FeatureSupportLevelID = "ADDITIONAL_NTP_SOURCE"
-
-	// FeatureSupportLevelIDREQUESTEDHOSTNAME captures enum value "REQUESTED_HOSTNAME"
-	FeatureSupportLevelIDREQUESTEDHOSTNAME FeatureSupportLevelID = "REQUESTED_HOSTNAME"
-
-	// FeatureSupportLevelIDPROXY captures enum value "PROXY"
-	FeatureSupportLevelIDPROXY FeatureSupportLevelID = "PROXY"
-
 	// FeatureSupportLevelIDSNO captures enum value "SNO"
 	FeatureSupportLevelIDSNO FeatureSupportLevelID = "SNO"
-
-	// FeatureSupportLevelIDDAY2HOSTS captures enum value "DAY2_HOSTS"
-	FeatureSupportLevelIDDAY2HOSTS FeatureSupportLevelID = "DAY2_HOSTS"
 
 	// FeatureSupportLevelIDVIPAUTOALLOC captures enum value "VIP_AUTO_ALLOC"
 	FeatureSupportLevelIDVIPAUTOALLOC FeatureSupportLevelID = "VIP_AUTO_ALLOC"
 
-	// FeatureSupportLevelIDDISKSELECTION captures enum value "DISK_SELECTION"
-	FeatureSupportLevelIDDISKSELECTION FeatureSupportLevelID = "DISK_SELECTION"
-
-	// FeatureSupportLevelIDOVNNETWORKTYPE captures enum value "OVN_NETWORK_TYPE"
-	FeatureSupportLevelIDOVNNETWORKTYPE FeatureSupportLevelID = "OVN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSDNNETWORKTYPE captures enum value "SDN_NETWORK_TYPE"
-	FeatureSupportLevelIDSDNNETWORKTYPE FeatureSupportLevelID = "SDN_NETWORK_TYPE"
-
-	// FeatureSupportLevelIDSCHEDULABLEMASTERS captures enum value "SCHEDULABLE_MASTERS"
-	FeatureSupportLevelIDSCHEDULABLEMASTERS FeatureSupportLevelID = "SCHEDULABLE_MASTERS"
-
-	// FeatureSupportLevelIDAUTOASSIGNROLE captures enum value "AUTO_ASSIGN_ROLE"
-	FeatureSupportLevelIDAUTOASSIGNROLE FeatureSupportLevelID = "AUTO_ASSIGN_ROLE"
-
 	// FeatureSupportLevelIDCUSTOMMANIFEST captures enum value "CUSTOM_MANIFEST"
 	FeatureSupportLevelIDCUSTOMMANIFEST FeatureSupportLevelID = "CUSTOM_MANIFEST"
-
-	// FeatureSupportLevelIDDISKENCRYPTION captures enum value "DISK_ENCRYPTION"
-	FeatureSupportLevelIDDISKENCRYPTION FeatureSupportLevelID = "DISK_ENCRYPTION"
-
-	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS captures enum value "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
-	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKINGWITHVMS FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING_WITH_VMS"
 
 	// FeatureSupportLevelIDSINGLENODEEXPANSION captures enum value "SINGLE_NODE_EXPANSION"
 	FeatureSupportLevelIDSINGLENODEEXPANSION FeatureSupportLevelID = "SINGLE_NODE_EXPANSION"
@@ -84,9 +51,6 @@ const (
 	// FeatureSupportLevelIDCNV captures enum value "CNV"
 	FeatureSupportLevelIDCNV FeatureSupportLevelID = "CNV"
 
-	// FeatureSupportLevelIDDUALSTACKNETWORKING captures enum value "DUAL_STACK_NETWORKING"
-	FeatureSupportLevelIDDUALSTACKNETWORKING FeatureSupportLevelID = "DUAL_STACK_NETWORKING"
-
 	// FeatureSupportLevelIDNUTANIXINTEGRATION captures enum value "NUTANIX_INTEGRATION"
 	FeatureSupportLevelIDNUTANIXINTEGRATION FeatureSupportLevelID = "NUTANIX_INTEGRATION"
 
@@ -96,11 +60,11 @@ const (
 	// FeatureSupportLevelIDDUALSTACKVIPS captures enum value "DUAL_STACK_VIPS"
 	FeatureSupportLevelIDDUALSTACKVIPS FeatureSupportLevelID = "DUAL_STACK_VIPS"
 
-	// FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE captures enum value "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-	FeatureSupportLevelIDUSERMANAGEDNETWORKINGWITHMULTINODE FeatureSupportLevelID = "USER_MANAGED_NETWORKING_WITH_MULTI_NODE"
-
 	// FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING captures enum value "CLUSTER_MANAGED_NETWORKING"
 	FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING FeatureSupportLevelID = "CLUSTER_MANAGED_NETWORKING"
+
+	// FeatureSupportLevelIDUSERMANAGEDNETWORKING captures enum value "USER_MANAGED_NETWORKING"
+	FeatureSupportLevelIDUSERMANAGEDNETWORKING FeatureSupportLevelID = "USER_MANAGED_NETWORKING"
 )
 
 // for schema
@@ -108,7 +72,7 @@ var featureSupportLevelIdEnum []interface{}
 
 func init() {
 	var res []FeatureSupportLevelID
-	if err := json.Unmarshal([]byte(`["ADDITIONAL_NTP_SOURCE","REQUESTED_HOSTNAME","PROXY","SNO","DAY2_HOSTS","VIP_AUTO_ALLOC","DISK_SELECTION","OVN_NETWORK_TYPE","SDN_NETWORK_TYPE","SCHEDULABLE_MASTERS","AUTO_ASSIGN_ROLE","CUSTOM_MANIFEST","DISK_ENCRYPTION","CLUSTER_MANAGED_NETWORKING_WITH_VMS","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","DUAL_STACK_NETWORKING","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","USER_MANAGED_NETWORKING_WITH_MULTI_NODE","CLUSTER_MANAGED_NETWORKING"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["SNO","VIP_AUTO_ALLOC","CUSTOM_MANIFEST","SINGLE_NODE_EXPANSION","LVM","ODF","CNV","NUTANIX_INTEGRATION","VSPHERE_INTEGRATION","DUAL_STACK_VIPS","CLUSTER_MANAGED_NETWORKING","USER_MANAGED_NETWORKING"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
[MGMT-13862](https://issues.redhat.com//browse/MGMT-13862): Return bed request on wrong feature-feature or feature-architecture combination.
[MGMT-13958](https://issues.redhat.com//browse/MGMT-13958): Delete unused feature IDs from /v2/support-levels/features

Features that are being used by the UI:
![image](https://user-images.githubusercontent.com/16567084/225399100-3355db22-0bfe-496b-a6fb-4430cd0bf2b6.png)

Note: `CLUSTER_MANAGED_NETWORKING_WITH_VMS` has been removed due to that we are returning `Supported` statically regardless of cpu architecture or openshift version 


## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 