### PR TITLE
MGMT-13793: Do not remove host default configuration unless network configuration is provided for it

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -58,11 +58,6 @@ else
 fi
 echo "Info: ETC_NETWORK_MANAGER was set to $ETC_NETWORK_MANAGER"
 
-# remove default connection file create by NM(nm-initrd-generator). This is a WA until
-# NM is back to supporting priority between nmconnections
-rm -f ${ETC_NETWORK_MANAGER}/*
-echo "Info: Removing default connection files in $ETC_NETWORK_MANAGER"
-
 # Create a map of host mac addresses to their network interfaces
 function map_host_macs_to_interfaces() {
   SYS_CLASS_NET_DIR='/sys/class/net'
@@ -107,7 +102,7 @@ function find_host_directory_by_mac_address() {
   if [ -z "$host_dir" ]
   then
     echo "Error: None of the host directories contained a mac-address to host mapping for the current host"
-    exit 0
+    // We should not exit the script here in any fashion as the Dracut initqueue handler will not run any subsequent scripts if there is an exit.
   fi
 }
 
@@ -186,8 +181,17 @@ function copy_nmconnection_files_to_nm_config_dir() {
 echo "PreNetworkConfig Start"
 map_host_macs_to_interfaces
 find_host_directory_by_mac_address
-set_logical_nic_mac_mapping
-update_interface_names_by_mapping_file
-copy_nmconnection_files_to_nm_config_dir
+
+// Make sure we do not run any of the following functions if there was no matching config.
+if [ "$host_dir" ]
+  then
+    # remove default connection file create by NM(nm-initrd-generator). This is a WA until
+    # NM is back to supporting priority between nmconnections
+    rm -f ${ETC_NETWORK_MANAGER}/*
+    echo "Removing default connection files in '$ETC_NETWORK_MANAGER'"
+    set_logical_nic_mac_mapping
+    update_interface_names_by_mapping_file
+    copy_nmconnection_files_to_nm_config_dir
+fi
 echo "PreNetworkConfig End"
 `


### PR DESCRIPTION
Presently, in the PreNetworkConfig script, we are removing the default network manager configuration for a host in every case. This should be altered so that the default configuration is deleted only if custom nmstate configuration has been provided for the host.

This PR also addresses a breaking issue with the way in which  Dracut Initqueue scripts are handled. Consider the following directory on a given host.

```
ls /usr/lib/dracut/hooks/initqueue/settled
90-assisted-pre-static-network-config.sh 99-nm-run.sh
```

if we inject a script between the two scripts with the sole purpose of using an exit statement...
```
echo "exit 0" > /usr/lib/dracut/hooks/initqueue/settled/91-test-exit.sh && chmod +x /usr/lib/dracut/hooks/initqueue/settled/91-test-exit.sh
```
Then the script `99-nm-run.sh` will not be executed. It appears that an `exit` in any of the `.sh` scripts is considered to be a "fatal" error.

I notice that there is an interesting section of code here

https://github.com/redhat-plumbers/dracut-rhel8/blob/a7eaedb1679d871c213753fad872d65b23070240/modules.d/98dracut-systemd/dracut-initqueue.sh#L34-L46

```
    udevadm settle --timeout=0 >/dev/null 2>&1 || continue

    for job in $hookdir/initqueue/settled/*.sh; do
        [ -e "$job" ] || break
        job=$job . $job
        check_finished && break 2
    done
```
The behaviour of which is proven to prevent the execution of further scripts if an exit is found in any of the scripts.

To correct this, the code of the Pre Network Config has been adjusted to avoid using `exit`

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
