### PR TITLE
manifests: Add a shebang to NM dispatcher script

### DIFF
--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -88,7 +88,7 @@ const unmanagedResolvConf = `
 rc-manager=unmanaged
 `
 
-const forceDnsDispatcherScript = `
+const forceDnsDispatcherScript = `#!/bin/bash
 export IP="{{.HOST_IP}}"
 export BASE_RESOLV_CONF=/run/NetworkManager/resolv.conf
 if [ "$2" = "dhcp4-change" ] || [ "$2" = "dhcp6-change" ] || [ "$2" = "up" ] || [ "$2" = "connectivity-change" ]; then


### PR DESCRIPTION
This will reportedly fix a SELinux issue that happens with the RHEL 9 rebase for OCP 4.13, where the dispatcher policy is a bit tighter for scripts by default.

See also https://github.com/fedora-selinux/selinux-policy/issues/778 which is highly related to this - the policy is stricter for bash versus executables.
