### PR TITLE
MGMT-14075: Fix register cluster won't fail when creating cluster with P or Z architectures on 4.12

### DIFF
--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -93,10 +93,10 @@ func isFeatureCompatible(feature SupportLevelFeature, features ...SupportLevelFe
 	return nil
 }
 
-func ValidateIncompatibleFeatures(cluster common.Cluster, updateParams *models.V2ClusterUpdateParams) error {
+func ValidateIncompatibleFeatures(cpuArchitecture string, cluster common.Cluster, updateParams *models.V2ClusterUpdateParams) error {
 	var activatedFeatures []SupportLevelFeature
 
-	if cluster.CPUArchitecture == "" || cluster.OpenshiftVersion == "" {
+	if cpuArchitecture == "" || cluster.OpenshiftVersion == "" {
 		return nil
 	}
 
@@ -106,11 +106,11 @@ func ValidateIncompatibleFeatures(cluster common.Cluster, updateParams *models.V
 		}
 	}
 
-	if isSupported := isArchitectureSupported(cpuArchitectureFeatureIdMap[cluster.CPUArchitecture], cluster.OpenshiftVersion); !isSupported {
-		return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cluster.CPUArchitecture, cluster.OpenshiftVersion)
+	if isSupported := isArchitectureSupported(cpuArchitectureFeatureIdMap[cpuArchitecture], cluster.OpenshiftVersion); !isSupported {
+		return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cpuArchitecture, cluster.OpenshiftVersion)
 	}
 
-	if err := isFeaturesCompatibleWIthArchitecture(cluster.OpenshiftVersion, cluster.CPUArchitecture, activatedFeatures); err != nil {
+	if err := isFeaturesCompatibleWIthArchitecture(cluster.OpenshiftVersion, cpuArchitecture, activatedFeatures); err != nil {
 		return err
 	}
 	if err := isFeaturesCompatibleWIthFeatures(activatedFeatures); err != nil {

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -187,7 +187,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				OpenshiftVersion: "4.6",
 				CPUArchitecture:  models.ClusterCPUArchitectureX8664,
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
 		})
 		It("Single compatible feature is activated", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
@@ -197,7 +197,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
 		})
 		It("SNO feature is activated with incompatible architecture ppc64le", func() {
 			expectedError := "cannot use Single Node OpenShift because it's not compatible with the ppc64le architecture on version 4.13 of OpenShift"
@@ -208,7 +208,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitecturePpc64le, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("SNO feature is activated with incompatible architecture s390x", func() {
 			expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.13 of OpenShift"
@@ -219,7 +219,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureS390x, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("Nutanix feature is activated with incompatible architecture", func() {
 			expectedError := "cannot use arm64 architecture because it's not compatible on version 4.8 of OpenShift"
@@ -230,7 +230,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureArm64, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("ClusterManagedNetworking feature is activated with compatible architecture on 4.11", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
@@ -240,7 +240,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 				UserManagedNetworking: swag.Bool(false),
 			}}
-			Expect(ValidateIncompatibleFeatures(cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureArm64, cluster, nil)).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Returning bad request on feature-support validation is colliding with multi platform feature. 

Whenever the user set the CPU architecture to P or Z the platform changed to multi causing loose of information and not failing the cluster registration/update

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @eliorerz 