### PR TITLE
actually use the ENABLE_DATA_COLLECTION parameter

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -432,6 +432,8 @@ objects:
                 value: ${WORK_DIR}
               - name: ENABLE_REJECT_UNKNOWN_FIELDS
                 value: ${ENABLE_REJECT_UNKNOWN_FIELDS}
+              - name: ENABLE_DATA_COLLECTION
+                value: ${ENABLE_DATA_COLLECTION}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"


### PR DESCRIPTION
Back in https://github.com/openshift/assisted-service/pull/5048 this parameter was only defined, but not used for the deployment definition.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
