### PR TITLE
MGMT-14074: Reload NM config after creation

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -180,6 +180,7 @@ function copy_nmconnection_files_to_nm_config_dir() {
   done
 
   cp ${host_dir}/*.nmconnection ${ETC_NETWORK_MANAGER}/
+  nmcli connection reload
   echo "Info: Copied all nmconnection files from $host_dir to $ETC_NETWORK_MANAGER"
 }
 


### PR DESCRIPTION
Apparently in versions of RHCOS based on RHEL 9 when the `99-assisted-pre-static-network-config.sh` script is executed the NetworkManager service is already running and will not automatically reload the connection configuration files that we create. When using the minimal ISO that may prevent the dowload of the rootfs, as the network settings may not be correct. To avoid that this patch changes the script so that it explicitly runs `nmcli connection reload` after creating the files.

Related: https://issues.redhat.com/browse/MGMT-14074

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Tested running a 9.2 minimal ISO in a virtual machine. Interrupted the boot adding `rd.break=initqueue` to the kernel command line. Then modified the shell script manually, and exited the shell to continue the boot. With the change the boot continues and the rootfs is downloaded. Without change the boot fails to download the rootfs.

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
