### PR TITLE
MGMT-14096: Don't wait for console if disabled - ACM 2.6

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3462,10 +3462,14 @@ func (b *bareMetalInventory) GetCredentialsInternal(ctx context.Context, params 
 		log.WithError(err).Errorf("failed to find cluster %s", params.ClusterID)
 		return nil, err
 	}
-	if !b.clusterApi.IsOperatorAvailable(&cluster, operators.OperatorConsole.Name) {
-		err := errors.New("console-url isn't available yet, it will be once console operator is ready as part of cluster finalizing stage")
-		log.WithError(err)
-		return nil, common.NewApiError(http.StatusConflict, err)
+	var consoleURL string
+	if b.clusterApi.IsOperatorMonitored(&cluster, operators.OperatorConsole.Name) {
+		if !b.clusterApi.IsOperatorAvailable(&cluster, operators.OperatorConsole.Name) {
+			err := errors.New("console-url isn't available yet, it will be once console operator is ready as part of cluster finalizing stage")
+			log.WithError(err)
+			return nil, common.NewApiError(http.StatusConflict, err)
+		}
+		consoleURL = common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain)
 	}
 	objectName := fmt.Sprintf("%s/%s", params.ClusterID, "kubeadmin-password")
 	r, _, err := b.objectHandler.Download(ctx, objectName)
@@ -3482,7 +3486,7 @@ func (b *bareMetalInventory) GetCredentialsInternal(ctx context.Context, params 
 	return &models.Credentials{
 		Username:   DefaultUser,
 		Password:   string(password),
-		ConsoleURL: common.GetConsoleUrl(cluster.Name, cluster.BaseDNSDomain),
+		ConsoleURL: consoleURL,
 	}, nil
 }
 

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -97,6 +97,7 @@ type API interface {
 	// Refresh state in case of hosts update
 	RefreshStatus(ctx context.Context, c *common.Cluster, db *gorm.DB) (*common.Cluster, error)
 	ClusterMonitoring()
+	IsOperatorMonitored(c *common.Cluster, operatorName string) bool
 	IsOperatorAvailable(c *common.Cluster, operatorName string) bool
 	UploadIngressCert(c *common.Cluster) (err error)
 	VerifyClusterUpdatability(c *common.Cluster) (err error)
@@ -624,6 +625,15 @@ func CanDownloadKubeconfig(c *common.Cluster) (err error) {
 	}
 
 	return err
+}
+
+func (m *Manager) IsOperatorMonitored(c *common.Cluster, operatorName string) bool {
+	for _, o := range c.MonitoredOperators {
+		if o.Name == operatorName {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) IsOperatorAvailable(c *common.Cluster, operatorName string) bool {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -400,6 +400,20 @@ func (mr *MockAPIMockRecorder) IsOperatorAvailable(c, operatorName interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOperatorAvailable", reflect.TypeOf((*MockAPI)(nil).IsOperatorAvailable), c, operatorName)
 }
 
+// IsOperatorMonitored mocks base method.
+func (m *MockAPI) IsOperatorMonitored(c *common.Cluster, operatorName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsOperatorMonitored", c, operatorName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsOperatorMonitored indicates an expected call of IsOperatorMonitored.
+func (mr *MockAPIMockRecorder) IsOperatorMonitored(c, operatorName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOperatorMonitored", reflect.TypeOf((*MockAPI)(nil).IsOperatorMonitored), c, operatorName)
+}
+
 // IsReadyForInstallation mocks base method.
 func (m *MockAPI) IsReadyForInstallation(c *common.Cluster) (bool, string) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Currently the cluster deployment controller waits for the console to be available before marking the cluster deployment as completed. This fails when the console capability is disabled. To avoid that this patch changes the controller so that it doesn't wait when the console is disabled.

Note that this is a clone of [MGMT-14096](https://issues.redhat.com//browse/MGMT-14096) (which in turn is a clone of OCPBUGS-8335) for ACM 2.6.

Related: https://issues.redhat.com/browse/OCPBUGS-8335
Related: https://issues.redhat.com/browse/MGMT-14096
Related: https://github.com/openshift/assisted-service/pull/5022

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
