### PR TITLE
MGMT-14110: MGMT-14109: Set P and Z architectures support label as tech-preview on 4.12

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -341,7 +341,7 @@ func (b *bareMetalInventory) setDefaultRegisterClusterParams(ctx context.Context
 	}
 
 	log.Infof("Verifying cluster platform and user-managed-networking, got platform=%s and userManagedNetworking=%t", getPlatformType(params.NewClusterParams.Platform), swag.BoolValue(params.NewClusterParams.UserManagedNetworking))
-	platform, userManagedNetworking, err := provider.GetActualCreateClusterPlatformParams(params.NewClusterParams.Platform, params.NewClusterParams.UserManagedNetworking, params.NewClusterParams.HighAvailabilityMode)
+	platform, userManagedNetworking, err := provider.GetActualCreateClusterPlatformParams(params.NewClusterParams.Platform, params.NewClusterParams.UserManagedNetworking, params.NewClusterParams.HighAvailabilityMode, params.NewClusterParams.CPUArchitecture)
 	if err != nil {
 		log.Error(err)
 		return params, err

--- a/internal/featuresupport/architectures.go
+++ b/internal/featuresupport/architectures.go
@@ -45,9 +45,12 @@ func (feature *S390xArchitectureFeature) GetId() models.ArchitectureSupportLevel
 }
 
 func (feature *S390xArchitectureFeature) GetSupportLevel(openshiftVersion string) models.SupportLevel {
-	isNotSupported, err := common.BaseVersionLessThan("4.13", openshiftVersion)
+	isNotSupported, err := common.BaseVersionLessThan("4.12", openshiftVersion)
 	if isNotSupported || err != nil {
 		return models.SupportLevelUnsupported
+	}
+	if isEqual, _ := common.BaseVersionEqual("4.12", openshiftVersion); isEqual {
+		return models.SupportLevelTechPreview
 	}
 
 	return models.SupportLevelSupported
@@ -61,9 +64,12 @@ func (feature *PPC64LEArchitectureFeature) GetId() models.ArchitectureSupportLev
 }
 
 func (feature *PPC64LEArchitectureFeature) GetSupportLevel(openshiftVersion string) models.SupportLevel {
-	isNotSupported, err := common.BaseVersionLessThan("4.13", openshiftVersion)
+	isNotSupported, err := common.BaseVersionLessThan("4.12", openshiftVersion)
 	if isNotSupported || err != nil {
 		return models.SupportLevelUnsupported
+	}
+	if isEqual, _ := common.BaseVersionEqual("4.12", openshiftVersion); isEqual {
+		return models.SupportLevelTechPreview
 	}
 
 	return models.SupportLevelSupported

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -54,7 +54,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Expect(isArchitectureSupported(feature, "4.30")).To(Equal(true))
 	})
 
-	It("Test s390x is not supported under 4.13", func() {
+	It("Test s390x is not supported under 4.12", func() {
 		feature := models.ArchitectureSupportLevelIDS390XARCHITECTURE
 		Expect(isArchitectureSupported(feature, "4.6")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.7")).To(Equal(false))
@@ -62,7 +62,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Expect(isArchitectureSupported(feature, "4.9")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.10")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.11")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(false))
+		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(true))
 		Expect(isArchitectureSupported(feature, "4.13")).To(Equal(true))
 
 		// Check for feature release
@@ -70,7 +70,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 
 	})
 
-	It("Test PPC64LE is not supported under 4.13", func() {
+	It("Test PPC64LE is not supported under 4.12", func() {
 		feature := models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE
 		Expect(isArchitectureSupported(feature, "4.6")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.7")).To(Equal(false))
@@ -78,7 +78,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Expect(isArchitectureSupported(feature, "4.9")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.10")).To(Equal(false))
 		Expect(isArchitectureSupported(feature, "4.11")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(false))
+		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(true))
 		Expect(isArchitectureSupported(feature, "4.13")).To(Equal(true))
 
 		// Check for feature release
@@ -162,8 +162,8 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			Expect(len(list)).To(Equal(5))
 		})
 
-		It("GetFeatureSupportList 4.12 with not supported architecture", func() {
-			featuresList := GetFeatureSupportList("4.12", swag.String(models.ClusterCPUArchitecturePpc64le))
+		It("GetFeatureSupportList 4.11 with not supported architecture", func() {
+			featuresList := GetFeatureSupportList("4.11", swag.String(models.ClusterCPUArchitecturePpc64le))
 
 			for _, supportLevel := range featuresList {
 				Expect(supportLevel).To(Equal(models.SupportLevelUnsupported))


### PR DESCRIPTION
- [MGMT-14109](https://issues.redhat.com//browse/MGMT-14109): Set P and Z architectures support label as tech-preview on 4.12
- [MGMT-14110](https://issues.redhat.com//browse/MGMT-14110): Set UserManagedNetworking default value for P and Z architectures

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
