### PR TITLE
MGMT-14026: Add validation to ensure ignored validation ID exists

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -600,6 +600,21 @@ func (b *bareMetalInventory) validateIgnoredValidations(problems []string, ignor
 	if err != nil {
 		problems = append(problems, fmt.Sprintf("error during unmarshal of json for ignored %s validations", validationType))
 	} else {
+		for _, v := range ignoredValidationsArr {
+			var err error
+			if validationType == common.ValidationTypeCluster {
+				validation := models.NewClusterValidationID(models.ClusterValidationID(v))
+				err = validation.Validate(nil)
+			} else if validationType == common.ValidationTypeHost {
+				validation := models.NewHostValidationID(models.HostValidationID(v))
+				err = validation.Validate(nil)
+			} else {
+				problems = append(problems, fmt.Sprintf("Unable to validate %s the type %s is invalid", v, validationType))
+			}
+			if err != nil {
+				problems = append(problems, fmt.Sprintf("Validation ID '%s' is not a known %s validation", v, validationType))
+			}
+		}
 		mayIgnoreValidations, cantBeIgnored := common.MayIgnoreValidations(ignoredValidationsArr, nonIgnorableValidations)
 		if !mayIgnoreValidations {
 			problems = append(problems, fmt.Sprintf("unable to ignore the following %s validations (%s)", validationType, strings.Join(cantBeIgnored, ",")))
@@ -638,8 +653,9 @@ func (b *bareMetalInventory) V2SetIgnoredValidations(ctx context.Context, params
 	problems := []string{}
 	cluster.IgnoredClusterValidations = params.IgnoredValidations.ClusterValidationIds
 	cluster.IgnoredHostValidations = params.IgnoredValidations.HostValidationIds
-	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, common.NonIgnorableClusterValidations, "cluster")
-	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, common.NonIgnorableHostValidations, "host")
+
+	problems = b.validateIgnoredValidations(problems, cluster.IgnoredClusterValidations, common.NonIgnorableClusterValidations, common.ValidationTypeCluster)
+	problems = b.validateIgnoredValidations(problems, cluster.IgnoredHostValidations, common.NonIgnorableHostValidations, common.ValidationTypeHost)
 	if len(problems) > 0 {
 		return b.setIgnoredValidationsBadRequest("cannot proceed due to the following errors: " + strings.Join(problems, "\n"))
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -100,6 +100,9 @@ const NMDebugModeConf = `
 domains=ALL:DEBUG
 `
 
+const ValidationTypeHost = "host"
+const ValidationTypeCluster = "cluster"
+
 func GetIgnoredValidations(validationsJSON string, clusterID string) ([]string, bool) {
 	ignoredValidations := []string{}
 	if validationsJSON != "" {


### PR DESCRIPTION
During QA it was discovered that the ignored validations feature does not validate the supplied validation ID's to ensure they are valid. This PR fixes that by validating the supplied validation ID's

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
