### PR TITLE
MGMT-14136: Reload NM config after creation - ACM 2.7

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -160,6 +160,7 @@ function copy_nmconnection_files_to_nm_config_dir() {
   done
 
   cp ${host_dir}/*.nmconnection ${ETC_NETWORK_MANAGER}/
+  type nmcli > /dev/null 2>&1 && nmcli connection reload
 }
 
 map_host_macs_to_interfaces


### PR DESCRIPTION
This is a backport of [MGMT-14074](https://issues.redhat.com//browse/MGMT-14074), #5066 and #5087 to the ACM 2.7 branch.

Apparently in versions of RHCOS based on RHEL 9 when the `99-assisted-pre-static-network-config.sh` script is executed the NetworkManager service is already running and will not automatically reload the connection configuration files that we create. When using the minimal ISO that may prevent the dowload of the rootfs, as the network settings may not be correct. To avoid that this patch changes the script so that it explicitly runs `nmcli connection reload` after creating the files.

Related: https://issues.redhat.com/browse/MGMT-14136
Related: https://issues.redhat.com/browse/MGMT-14074
Related: https://github.com/openshift/assisted-service/pull/5066
Related: https://github.com/openshift/assisted-service/pull/5087

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
