### PR TITLE
MGMT-14137: Create test flow for ZTP for node labeling and avoiding reboot for custom role

### DIFF
--- a/deploy/operator/README.md
+++ b/deploy/operator/README.md
@@ -105,7 +105,19 @@ export ASSISTED_AGENT_CLUSTER_INSTALL_NAME=assisted-agent-cluster-install
 export ASSISTED_INFRAENV_NAME=assisted-infra-env
 export ASSISTED_PULLSECRET_NAME=assisted-pull-secret
 export ASSISTED_PRIVATEKEY_NAME=assisted-ssh-private-key
-export SPOKE_CONTROLPLANE_AGENTS=1  # currently only single-node is supported
+export SPOKE_CONTROLPLANE_AGENTS=1  # either 1 (single-node) or 3 is supported
+export SPOKE_WORKER_AGENTS=0 # Number of worker nodes
+
+# JSON encoded dictionary of machine config pool per host.  Example: '{"ostest-extraworker-5":"infra","ostest-extraworker-3":"storage"}'
+export MACHINE_CONFIG_POOLS=<machine-config-pools>
+
+# JSON encoded dictionary of node-labels per host. Example: '{"ostest-extraworker-3":{"node-role.kubernetes.io/infra":""}, "ostest-extraworker-5":{"node-role.kubernetes.io/infra":""}}'
+export NODE_LABELS=<node-labels>
+
+# JSON encoded dictionary of manifests to be applied on day1 cluster.
+# Every value in this dictionary points to a file which contains the manifest content. 
+# Example: '{"mc.json":"/workerdir/mc.json", "mcp.yaml", "/workerdir/mcp.yaml"}'
+export MANIFEST_FILES=<manifest_files>  
 ```
 
 ## Running None Platform ZTP Flow (Testing only)

--- a/deploy/operator/ztp/add-remote-nodes-playbook.yaml
+++ b/deploy/operator/ztp/add-remote-nodes-playbook.yaml
@@ -13,6 +13,8 @@
     - day2: "true"
     - day2_masters: "{{ lookup('env', 'DAY2_MASTERS') }}"
     - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
+    - machine_config_pools: "{{ lookup('env', 'MACHINE_CONFIG_POOLS') }}"
+    - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
 
   tasks:
   - name: optional-latebinding

--- a/deploy/operator/ztp/agentClusterInstall.j2
+++ b/deploy/operator/ztp/agentClusterInstall.j2
@@ -39,4 +39,25 @@ spec:
 {% endif %}
   provisionRequirements:
     controlPlaneAgents: {{ spoke_controlplane_agents }}
+{% if spoke_worker_agents is defined and spoke_worker_agents|int > 0 %}
+    workerAgents: {{ spoke_worker_agents }}
+{% endif %}
   sshPublicKey: '{{ ssh_public_key }}'
+{% if manifests is defined and manifests %}
+  manifestsConfigMapRefs:
+    - name: '{{ agent_cluster_install_name }}'
+{% endif %}
+
+{% if manifests is defined and manifests %}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ agent_cluster_install_name }}'
+  namespace: '{{ spoke_namespace }}'
+data:
+{% for key, value in manifests.items() %}
+  {{ key }}: |
+{{ value }}
+{% endfor %}
+{% endif %}

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -6,6 +6,7 @@
   vars:
     - spoke_namespace: "{{ lookup('env', 'SPOKE_NAMESPACE') }}"
     - spoke_controlplane_agents: "{{ lookup('env', 'SPOKE_CONTROLPLANE_AGENTS') }}"
+    - spoke_worker_agents: "{{ lookup('env', 'SPOKE_WORKER_AGENTS', default='0') }}"
     - spoke_api_vip: "{{ lookup('env', 'SPOKE_API_VIP') }}"
     - spoke_ingress_vip: "{{ lookup('env', 'SPOKE_INGRESS_VIP') }}"
     - cluster_name: "{{ lookup('env', 'ASSISTED_CLUSTER_NAME') }}"
@@ -31,6 +32,9 @@
     - user_managed_networking: "{{ lookup('env', 'USER_MANAGED_NETWORKING') }}"
     - day2: "false"
     - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
+    - machine_config_pools: "{{ lookup('env', 'MACHINE_CONFIG_POOLS') }}"
+    - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
+    - manifests: "{{ lookup('env', 'MANIFESTS') }}"
 
   tasks:
   - name: create directory for generated CRDs

--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -13,8 +13,11 @@
       {% set bmhs = baremetalhosts %}
 {% endif %}
 {% endif %}
+{% if day2|string != "true" %}
+{% set limit = spoke_controlplane_agents|int + spoke_worker_agents|int %}
+{% endif %}
 {% for host in bmhs %}
-{% if day2|string == "true"  or ns.counter <= spoke_controlplane_agents|int%}
+{% if day2|string == "true"  or ns.counter <= limit %}
 
 ---
 apiVersion: v1
@@ -40,8 +43,17 @@ metadata:
 {% if baremetalhosts_ignition_override|string | length > 0 %}
     bmac.agent-install.openshift.io/ignition-config-overrides: '{{ baremetalhosts_ignition_override | tojson }}'
 {% endif %}
-{% if day2_masters is defined and day2_masters|string == "True" %}
+{% if day2|string != "true" and ns.counter <= 3 or day2_masters is defined and day2_masters|string == "True" %}
     bmac.agent-install.openshift.io/role: master
+{% endif %}
+{% set hostname = host["name"] %}
+{% if machine_config_pools is defined and machine_config_pools and hostname in machine_config_pools  %}
+    bmac.agent-install.openshift.io/machine-config-pool: '{{ machine_config_pools[hostname] }}'
+{% endif %}
+{% if node_labels is defined and node_labels and hostname in node_labels %}
+{% for node_key, node_value in node_labels[hostname].items() %}
+    bmac.agent-install.openshift.io.node-label.{{node_key}} : '{{ node_value }}'
+{% endfor %}
 {% endif %}
 spec:
   online: true

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -65,6 +65,17 @@ if [ "${DISCONNECTED}" = "true" ]; then
     ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE="${LOCAL_REGISTRY}/$(get_image_without_registry ${ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE})"
 fi
 
+if [ -n "${MANIFEST_FILES+x}" ] ; then
+  MANIFESTS=$(elements=$(echo "${MANIFEST_FILES}" |\
+      jq -r  'to_entries|to_entries|.[]| (length|tostring) + " " + (.key|tostring) + " " + .value.key + " " + .value.value' |\
+      while read len index name path ; do \
+        content=$(awk '{print "      " $0}' $path | jq -Rsa .) && echo "{\"${name}\":$content}" || exit 1  ;\
+        [[ $(( $index + 1 )) == $len ]] || echo , ;\
+      done) && \
+      echo '[' "$elements" ']' | jq -c add) || exit 1
+  export MANIFESTS
+fi
+
 # TODO: make SSH public key configurable
 
 set -o nounset


### PR DESCRIPTION


Modify the scripts in assisted-service/deploy/operator/ztp. The following environment variables will be added:

MANIFESTS: JSON containing the manifests to be added for day1 flow.  The key is the file name, and the value is the content.

NODE_LABELS: Dictionary of dictionaries.  The Outer dictionary key is the node name and the value is the node labels (key, value) to be applied.

MACHINE_CONFIG_POOL: Dictionary of strings.  The key is the node name and the value is machine config pool name.

SPOKE_WORKER_AGENTS: Number of worker nodes to be added as part of day1 installation.  Default 0

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @filanov 
