### PR TITLE
MGMT-14074: Don't run `nmcli` if not available

### DIFF
--- a/internal/constants/scripts.go
+++ b/internal/constants/scripts.go
@@ -180,7 +180,7 @@ function copy_nmconnection_files_to_nm_config_dir() {
   done
 
   cp ${host_dir}/*.nmconnection ${ETC_NETWORK_MANAGER}/
-  nmcli connection reload
+  type nmcli > /dev/null 2>&1 && nmcli connection reload
   echo "Info: Copied all nmconnection files from $host_dir to $ETC_NETWORK_MANAGER"
 }
 


### PR DESCRIPTION
A recent commit introduced the use of `nmcli connection reload` in the network configuration script `99-assisted-pre-static-network-config.sh`. But the `nmcli` tool is not avaiable in the RHEL 8 initramfs. Using it in that environment will generate an error message but not cause any other noticeable effect: the script will continue running. To avoid that error message this patch changes the script so that if checks if the command exists before executing it.

Related: https://issues.redhat.com/browse/MGMT-14074
Related: https://github.com/openshift/assisted-service/pull/5066

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
