### PR TITLE
MGMT-14133: Fix P/Z support level allows cluster with OLM operators.

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6634,7 +6634,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 		Context("Feature compatibility", func() {
 			Context("OCP Version 4.13", func() {
 
-				createClusterWithInfraEnv := func(clusterId strfmt.UUID, cpuArchitecture, openshiftVersion string, platformType models.PlatformType, umn bool, highAvailabilityMode string) {
+				createCluster := func(clusterId strfmt.UUID, cpuArchitecture, openshiftVersion string, platformType models.PlatformType, umn bool, highAvailabilityMode string) {
 					err := db.Create(&common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterId,
 						HighAvailabilityMode:  swag.String(highAvailabilityMode),
@@ -6647,7 +6647,9 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					}}).Error
 					Expect(err).ShouldNot(HaveOccurred())
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				}
 
+				createInfraEnv := func(clusterId strfmt.UUID, cpuArchitecture string) {
 					infraEnvID := strfmt.UUID(uuid.New().String())
 					infraEnv := &common.InfraEnv{
 						InfraEnv: models.InfraEnv{
@@ -6657,6 +6659,11 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						},
 					}
 					Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+				}
+
+				createClusterWithInfraEnv := func(clusterId strfmt.UUID, cpuArchitecture, openshiftVersion string, platformType models.PlatformType, umn bool, highAvailabilityMode string) {
+					createCluster(clusterID, cpuArchitecture, openshiftVersion, platformType, umn, highAvailabilityMode)
+					createInfraEnv(clusterID, cpuArchitecture)
 				}
 
 				It("s390x with SNO - incompatible", func() {

--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 )
 
@@ -93,16 +94,18 @@ func isFeatureCompatible(feature SupportLevelFeature, features ...SupportLevelFe
 	return nil
 }
 
-func ValidateIncompatibleFeatures(cpuArchitecture string, cluster common.Cluster, updateParams *models.V2ClusterUpdateParams) error {
+func ValidateIncompatibleFeatures(log logrus.FieldLogger, cpuArchitecture string, cluster common.Cluster, updateParams *models.V2ClusterUpdateParams) error {
 	var activatedFeatures []SupportLevelFeature
 
 	if cpuArchitecture == "" || cluster.OpenshiftVersion == "" {
+		log.Warnf("Cannot validate incompatible features, CpuArchitecture='%s', OpenshiftVersion='%s'", cpuArchitecture, cluster.OpenshiftVersion)
 		return nil
 	}
 
 	for _, feature := range featuresList {
 		if feature.getFeatureActiveLevel(cluster, updateParams) == activeLevelActive {
 			activatedFeatures = append(activatedFeatures, feature)
+			log.Debugf("%s feature is activated", feature.GetName())
 		}
 	}
 

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("V2ListFeatureSupportLevels API", func() {
@@ -182,12 +183,14 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	})
 
 	Context("ValidateIncompatibleFeatures", func() {
+		log := logrus.New()
+
 		It("No feature is activated", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
 				OpenshiftVersion: "4.6",
 				CPUArchitecture:  models.ClusterCPUArchitectureX8664,
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
 		})
 		It("Single compatible feature is activated", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
@@ -197,7 +200,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureX8664, cluster, nil)).To(BeNil())
 		})
 		It("SNO feature is activated with incompatible architecture ppc64le", func() {
 			expectedError := "cannot use Single Node OpenShift because it's not compatible with the ppc64le architecture on version 4.13 of OpenShift"
@@ -208,7 +211,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitecturePpc64le, cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitecturePpc64le, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("SNO feature is activated with incompatible architecture s390x", func() {
 			expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.13 of OpenShift"
@@ -219,7 +222,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureS390x, cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureS390x, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("Nutanix feature is activated with incompatible architecture", func() {
 			expectedError := "cannot use arm64 architecture because it's not compatible on version 4.8 of OpenShift"
@@ -230,7 +233,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureArm64, cluster, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureArm64, cluster, nil).Error()).To(Equal(expectedError))
 		})
 		It("ClusterManagedNetworking feature is activated with compatible architecture on 4.11", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
@@ -240,7 +243,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 				UserManagedNetworking: swag.Bool(false),
 			}}
-			Expect(ValidateIncompatibleFeatures(models.ClusterCPUArchitectureArm64, cluster, nil)).To(BeNil())
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureArm64, cluster, nil)).To(BeNil())
 		})
 	})
 
@@ -350,7 +353,6 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 					models.FeatureSupportLevelIDCUSTOMMANIFEST,
 					models.FeatureSupportLevelIDDUALSTACKVIPS,
 					models.FeatureSupportLevelIDSINGLENODEEXPANSION,
-					models.FeatureSupportLevelIDLVM,
 					models.FeatureSupportLevelIDCNV,
 				}
 				for _, featureId := range features {

--- a/internal/featuresupport/features.go
+++ b/internal/featuresupport/features.go
@@ -84,6 +84,7 @@ func (feature *SnoFeature) GetIncompatibleFeatures() *[]models.FeatureSupportLev
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+		models.FeatureSupportLevelIDVIPAUTOALLOC,
 	}
 }
 
@@ -315,7 +316,10 @@ func (feature *SingleNodeExpansionFeature) GetIncompatibleFeatures() *[]models.F
 }
 
 func (feature *SingleNodeExpansionFeature) GetIncompatibleArchitectures(_ string) *[]models.ArchitectureSupportLevelID {
-	return nil
+	return &[]models.ArchitectureSupportLevelID{
+		models.ArchitectureSupportLevelIDS390XARCHITECTURE,
+		models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE,
+	}
 }
 
 // LvmFeature
@@ -353,7 +357,13 @@ func (feature *LvmFeature) getFeatureActiveLevel(cluster common.Cluster, updateP
 }
 
 func (feature *LvmFeature) GetIncompatibleFeatures() *[]models.FeatureSupportLevelID {
-	return nil
+	return &[]models.FeatureSupportLevelID{
+		models.FeatureSupportLevelIDVIPAUTOALLOC,
+		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+		models.FeatureSupportLevelIDODF,
+	}
 }
 
 func (feature *LvmFeature) GetIncompatibleArchitectures(_ string) *[]models.ArchitectureSupportLevelID {
@@ -404,6 +414,7 @@ func (feature *NutanixIntegrationFeature) GetIncompatibleFeatures() *[]models.Fe
 	return &[]models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDSNO,
 		models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
+		models.FeatureSupportLevelIDLVM,
 	}
 }
 
@@ -445,6 +456,7 @@ func (feature *VsphereIntegrationFeature) getFeatureActiveLevel(cluster common.C
 func (feature *VsphereIntegrationFeature) GetIncompatibleFeatures() *[]models.FeatureSupportLevelID {
 	return &[]models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDSNO,
+		models.FeatureSupportLevelIDLVM,
 	}
 }
 
@@ -483,6 +495,7 @@ func (feature *OdfFeature) GetIncompatibleArchitectures(_ string) *[]models.Arch
 func (feature *OdfFeature) GetIncompatibleFeatures() *[]models.FeatureSupportLevelID {
 	return &[]models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDSNO,
+		models.FeatureSupportLevelIDLVM,
 	}
 }
 


### PR DESCRIPTION
Apparently `GetClusterFromDB` is not returning the cluster monitored operators causing the infraenv not to fail when there is incompatible feature/architecture,
Also add missing feature incompatibilities

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 