### PR TITLE
MGMT-13668: Ensure that full ISO is always used for S390x and PowerCPU architectures

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4898,6 +4898,13 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 		return nil, common.NewApiError(http.StatusNotFound, err)
 	}
 
+	if params.InfraEnvUpdateParams.ImageType == models.ImageTypeMinimalIso && infraEnv.CPUArchitecture == common.S390xCPUArchitecture {
+			msg := fmt.Sprintf("architecture %s does not support minimal ISO ", infraEnv.CPUArchitecture)
+			err := errors.New(msg)
+			log.Error(msg)
+			return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
 	if params.InfraEnvUpdateParams.Proxy != nil {
 		if err = validateProxySettings(params.InfraEnvUpdateParams.Proxy.HTTPProxy,
 			params.InfraEnvUpdateParams.Proxy.HTTPSProxy,

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -185,6 +185,11 @@ func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.Fiel
 
 	updateParams.InfraEnvUpdateParams.ImageType = r.Config.ImageType
 
+	if infraEnv.Spec.CpuArchitecture == models.ClusterCPUArchitectureS390x && updateParams.InfraEnvUpdateParams.ImageType == models.ImageTypeMinimalIso {
+		log.Warnf("[updateInfraEnv] Infra env type forced to full ISO for infra env with ID %s as S390x architecture does not support minimal ISO", updateParams.InfraEnvID)
+		updateParams.InfraEnvUpdateParams.ImageType = models.ImageTypeFullIso
+	}
+
 	existingKargs, err := kubeKernelArgs(internalInfraEnv)
 	if err != nil {
 		return nil, err
@@ -437,6 +442,11 @@ func (r *InfraEnvReconciler) createInfraEnv(ctx context.Context, log logrus.Fiel
 	}
 
 	createParams := CreateInfraEnvParams(infraEnv, r.Config.ImageType, pullSecret, clusterID, openshiftVersion)
+
+	if createParams.InfraenvCreateParams.ImageType == models.ImageTypeMinimalIso && createParams.InfraenvCreateParams.CPUArchitecture == common.S390xCPUArchitecture {
+		log.Warnf("[createInfraEnv] Infra env type forced to full ISO for infra env with name %s as S390x architecture does not support minimal ISO", *createParams.InfraenvCreateParams.Name)
+		createParams.InfraenvCreateParams.ImageType = models.ImageTypeFullIso
+	}
 
 	staticNetworkConfig, err := r.processNMStateConfig(ctx, log, infraEnv)
 	if err != nil {


### PR DESCRIPTION
When generating the ISO URL, presently we just take the value straight from the infraenv. In the case of S390x and PowerCPU architectures, there is no support for minimal-iso. If we encounter these platforms, this PR will ensure that the full ISO link is always returned.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
