### PR TITLE
MGMT-14195: Use clusterIdMatcher instead of gomock.Any() in inventory_test

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -2014,12 +2014,13 @@ var _ = Describe("cluster", func() {
 
 		It("update_cluster_while_installing", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
-			err := db.Create(&common.Cluster{Cluster: models.Cluster{
+			cluster := &common.Cluster{Cluster: models.Cluster{
 				ID: &clusterID,
-			}}).Error
+			}}
+			err := db.Create(cluster).Error
 			Expect(err).ShouldNot(HaveOccurred())
 
-			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(errors.Errorf("wrong state")).Times(1)
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(errors.Errorf("wrong state")).Times(1)
 
 			apiVip := "8.8.8.8"
 			ingressVip := "1.1.1.1"
@@ -2055,16 +2056,17 @@ var _ = Describe("cluster", func() {
 				pullSecret := "{\"auths\":{\"cloud.openshift.com\":{\"auth\":\"dG9rZW46dGVzdAo=\",\"email\":\"coyote@acme.com\"}}}" // #nosec
 				pullSecretWithNewline := pullSecret + " \n"
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster := &common.Cluster{Cluster: models.Cluster{
 					ID: &clusterID,
 					Platform: &models.Platform{
 						Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 					},
 					OpenshiftVersion: "4.12",
 					CPUArchitecture:  common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockSuccess()
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3027,8 +3029,7 @@ var _ = Describe("cluster", func() {
 						for _, operator := range test.expectedOperators {
 							operator.ClusterID = clusterID
 						}
-
-						err := db.Create(&common.Cluster{Cluster: models.Cluster{
+						cluster := &common.Cluster{Cluster: models.Cluster{
 							ID:                 &clusterID,
 							MonitoredOperators: test.originalOperators,
 							OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
@@ -3036,11 +3037,12 @@ var _ = Describe("cluster", func() {
 								Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 							},
 							CPUArchitecture: common.DefaultCPUArchitecture,
-						}}).Error
+						}}
+						err := db.Create(cluster).Error
 						Expect(err).ShouldNot(HaveOccurred())
 
 						// Update
-						mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+						mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 						mockSuccess()
 
 						for _, updateOperator := range test.updateOperators {
@@ -3083,7 +3085,7 @@ var _ = Describe("cluster", func() {
 							Properties:     "",
 						},
 					}
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster := &common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterID,
 						MonitoredOperators:    originalOperators,
 						OpenshiftVersion:      "4.12",
@@ -3091,11 +3093,12 @@ var _ = Describe("cluster", func() {
 						UserManagedNetworking: swag.Bool(true),
 						Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
 						CPUArchitecture:       common.DefaultCPUArchitecture,
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Update
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockSuccess()
 					mockLVMGetOperatorByName("lvm")
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
@@ -3126,7 +3129,7 @@ var _ = Describe("cluster", func() {
 							Properties:     "",
 						},
 					}
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster := &common.Cluster{Cluster: models.Cluster{
 						ID:                 &clusterID,
 						MonitoredOperators: originalOperators,
 						OpenshiftVersion:   common.TestDefaultConfig.OpenShiftVersion,
@@ -3134,11 +3137,12 @@ var _ = Describe("cluster", func() {
 							Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 						},
 						CPUArchitecture: common.DefaultCPUArchitecture,
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
 
 					// Update
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockCNVGetOperatorByName("cnv")
 					mockLVMGetOperatorByName("lvm")
 					mockOperatorManager.EXPECT().ResolveDependencies(gomock.Any(), gomock.Any()).
@@ -3163,6 +3167,8 @@ var _ = Describe("cluster", func() {
 
 			Context("UpdateCluster - Multiple-VIPs Support ", func() {
 
+				var cluster *common.Cluster
+
 				BeforeEach(func() {
 					Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 					db, dbName = common.PrepareTestDB()
@@ -3173,14 +3179,15 @@ var _ = Describe("cluster", func() {
 					clusterID = strfmt.UUID(uuid.New().String())
 					infraEnvID = strfmt.UUID(uuid.New().String())
 
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster = &common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterID,
 						OpenshiftVersion:      "4.12.0",
 						Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 						UserManagedNetworking: swag.Bool(false),
 						CPUArchitecture:       common.X86CPUArchitecture,
 						MachineNetworks:       []*models.MachineNetwork{{Cidr: "1.3.4.0/24"}},
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
 					addHost(masterHostId1, models.HostRoleMaster, "known", models.HostKindHost, infraEnvID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 					addHost(masterHostId2, models.HostRoleMaster, "known", models.HostKindHost, infraEnvID, clusterID, getInventoryStr("hostname1", "bootMode", "1.2.3.5/24", "10.11.50.80/16"), db)
@@ -3196,7 +3203,7 @@ var _ = Describe("cluster", func() {
 
 					It("API VIP and Ingress VIP populated in APIVips and ingressVips", func() {
 						mockDetectAndStoreCollidingIPsForCluster(mockClusterApi, 1)
-						mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+						mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 						mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 						mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
@@ -3213,7 +3220,7 @@ var _ = Describe("cluster", func() {
 							},
 						})
 						Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-						cluster := &common.Cluster{Cluster: *reply.(*installer.V2UpdateClusterCreated).Payload}
+						cluster = &common.Cluster{Cluster: *reply.(*installer.V2UpdateClusterCreated).Payload}
 						Expect(cluster.APIVip).To(Equal(apiVip))
 						Expect(network.GetApiVipById(cluster, 0)).To(Equal(apiVip))
 						Expect(cluster.IngressVip).To(Equal(ingressVip))
@@ -3222,7 +3229,7 @@ var _ = Describe("cluster", func() {
 
 					It("API VIP match APIVips first element", func() {
 						mockDetectAndStoreCollidingIPsForCluster(mockClusterApi, 1)
-						mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+						mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 						mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 						mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
@@ -3244,7 +3251,7 @@ var _ = Describe("cluster", func() {
 							},
 						})
 						Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-						cluster := &common.Cluster{Cluster: *reply.(*installer.V2UpdateClusterCreated).Payload}
+						cluster = &common.Cluster{Cluster: *reply.(*installer.V2UpdateClusterCreated).Payload}
 						Expect(cluster.APIVip).To(Equal(apiVip))
 						Expect(cluster.APIVips).To(Equal(apiVips))
 						Expect(cluster.IngressVip).To(Equal(ingressVip))
@@ -3253,7 +3260,7 @@ var _ = Describe("cluster", func() {
 
 					It("Ingress VIP match ingressVips first element", func() {
 						mockDetectAndStoreCollidingIPsForCluster(mockClusterApi, 1)
-						mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+						mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 						mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 						mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 						mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
@@ -3389,7 +3396,7 @@ var _ = Describe("cluster", func() {
 
 				It("Two APIVips and Two ingressVips - IPv4 first and IPv6 second - positive", func() {
 					mockDetectAndStoreCollidingIPsForCluster(mockClusterApi, 1)
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockClusterApi.EXPECT().SetConnectivityMajorityGroupsForCluster(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 					mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 					mockHostApi.EXPECT().RefreshInventory(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
@@ -3631,18 +3638,19 @@ var _ = Describe("cluster", func() {
 
 			It("Resolve OLM dependencies", func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster := &common.Cluster{Cluster: models.Cluster{
 					ID:               &clusterID,
 					OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
 					Platform: &models.Platform{
 						Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 					},
 					CPUArchitecture: common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Update
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockSuccess()
 
 				newOperatorName := testOLMOperators[1].Name
@@ -3694,19 +3702,20 @@ var _ = Describe("cluster", func() {
 
 			It("OLM invalid name", func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster := &common.Cluster{Cluster: models.Cluster{
 					ID:               &clusterID,
 					OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
 					Platform: &models.Platform{
 						Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 					},
 					CPUArchitecture: common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 
 				newOperatorName := "invalid-name"
 
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockOperatorManager.EXPECT().GetOperatorByName(newOperatorName).Return(nil, errors.Errorf("error")).Times(1)
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
@@ -3722,14 +3731,15 @@ var _ = Describe("cluster", func() {
 
 		It("ssh key with newline", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
-			err := db.Create(&common.Cluster{Cluster: models.Cluster{
+			cluster := &common.Cluster{Cluster: models.Cluster{
 				ID:               &clusterID,
 				OpenshiftVersion: "4.12",
 				CPUArchitecture:  common.DefaultCPUArchitecture,
 				Platform: &models.Platform{
 					Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 				},
-			}}).Error
+			}}
+			err := db.Create(cluster).Error
 			Expect(err).ShouldNot(HaveOccurred())
 			sshKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDi8KHZYGyPQjECHwytquI3rmpgoUn6M+lkeOD2nEKvYElLE5mPIeqF0izJIl56u" +
 				"ar2wda+3z107M9QkatE+dP4S9/Ltrlm+/ktAf4O6UoxNLUzv/TGHasb9g3Xkt8JTkohVzVK36622Sd8kLzEc61v1AonLWIADtpwq6/GvH" +
@@ -3739,7 +3749,7 @@ var _ = Describe("cluster", func() {
 				"IfNyDiU2JR50r1jCxj5H76QxIuM= root@ocp-edge34.lab.eng.tlv2.redhat.com"
 			sshKeyWithNewLine := sshKey + " \n"
 
-			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 			mockSuccess()
 			reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 				ClusterID: clusterID,
@@ -3748,7 +3758,6 @@ var _ = Describe("cluster", func() {
 				},
 			})
 			Expect(reply).To(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
-			var cluster common.Cluster
 			err = db.First(&cluster, "id = ?", clusterID).Error
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(cluster.SSHPublicKey).Should(Equal(sshKey))
@@ -3767,16 +3776,17 @@ var _ = Describe("cluster", func() {
 
 		It("Update SchedulableMasters", func() {
 			clusterID = strfmt.UUID(uuid.New().String())
-			err := db.Create(&common.Cluster{Cluster: models.Cluster{
+			cluster := &common.Cluster{Cluster: models.Cluster{
 				ID:               &clusterID,
 				OpenshiftVersion: "4.12",
 				CPUArchitecture:  common.DefaultCPUArchitecture,
 				Platform: &models.Platform{
 					Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 				},
-			}}).Error
+			}}
+			err := db.Create(cluster).Error
 			Expect(err).ShouldNot(HaveOccurred())
-			mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+			mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 			mockSuccess()
 			reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 				ClusterID: clusterID,
@@ -3793,7 +3803,7 @@ var _ = Describe("cluster", func() {
 
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{
+				cluster := &common.Cluster{
 					Cluster: models.Cluster{
 						ID:               &clusterID,
 						OpenshiftVersion: "4.8.0-fc.4",
@@ -3804,9 +3814,10 @@ var _ = Describe("cluster", func() {
 							Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 						},
 						CPUArchitecture: common.DefaultCPUArchitecture,
-					}}).Error
+					}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockClusterUpdateSuccess(1, 0)
 			})
 
@@ -3851,7 +3862,7 @@ var _ = Describe("cluster", func() {
 		Context("Day2 api vip dnsname/ip", func() {
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster := &common.Cluster{Cluster: models.Cluster{
 					ID:   &clusterID,
 					Kind: swag.String(models.ClusterKindAddHostsCluster),
 					Platform: &models.Platform{
@@ -3859,9 +3870,10 @@ var _ = Describe("cluster", func() {
 					},
 					OpenshiftVersion: "4.12",
 					CPUArchitecture:  common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 			})
 			It("update api vip dnsname success", func() {
 				mockSuccess()
@@ -3926,16 +3938,17 @@ var _ = Describe("cluster", func() {
 		Context("Update Cluster Tags", func() {
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster := &common.Cluster{Cluster: models.Cluster{
 					ID:   &clusterID,
 					Kind: swag.String(models.ClusterKindAddHostsCluster),
 					Platform: &models.Platform{
 						Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 					},
 					CPUArchitecture: common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 			})
 
 			It("Update tags success", func() {
@@ -3964,17 +3977,19 @@ var _ = Describe("cluster", func() {
 		})
 
 		Context("Update Network", func() {
+			var cluster *common.Cluster
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
 				infraEnvID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster = &common.Cluster{Cluster: models.Cluster{
 					ID:                    &clusterID,
 					OpenshiftVersion:      common.TestDefaultConfig.OpenShiftVersion,
 					Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 					UserManagedNetworking: swag.Bool(false),
 					CPUArchitecture:       common.X86CPUArchitecture,
 					HighAvailabilityMode:  swag.String(models.ClusterCreateParamsHighAvailabilityModeFull),
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 				addHost(masterHostId1, models.HostRoleMaster, "known", models.HostKindHost, infraEnvID, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 				addHost(masterHostId2, models.HostRoleMaster, "known", models.HostKindHost, infraEnvID, clusterID, getInventoryStr("hostname1", "bootMode", "1.2.3.5/24", "10.11.50.80/16"), db)
@@ -3989,11 +4004,11 @@ var _ = Describe("cluster", func() {
 			}
 
 			mockClusterUpdatability := func(times int) {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(times)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(times)
 			}
 
 			mockClusterUpdatabilityAnyTimes := func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).AnyTimes()
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).AnyTimes()
 			}
 
 			Context("Single node", func() {
@@ -5948,18 +5963,20 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 		})
 
 		Context("Single node", func() {
+			var cluster *common.Cluster
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster = &common.Cluster{Cluster: models.Cluster{
 					ID:       &clusterID,
 					Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 				addHost(masterHostId1, models.HostRoleMaster, "known", models.HostKindHost, clusterID, getInventoryStr("hostname0", "bootMode", "1.2.3.4/24", "10.11.50.90/16"), db)
 				err = db.Model(&models.Host{ID: &masterHostId3, ClusterID: &clusterID}).UpdateColumn("free_addresses",
 					makeFreeNetworksAddressesStr(makeFreeAddresses("10.11.0.0/16", "10.11.12.15", "10.11.12.16"))).Error
 				Expect(err).ToNot(HaveOccurred())
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 			})
 
 			mockSuccess := func(times int) {
@@ -6041,9 +6058,10 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 		})
 		Context("Platform", func() {
 			Context("Update Platform while Cluster platform is baremetal", func() {
+				var cluster *common.Cluster
 				BeforeEach(func() {
 					clusterID = strfmt.UUID(uuid.New().String())
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster = &common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterID,
 						HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeFull),
 						UserManagedNetworking: swag.Bool(false),
@@ -6052,9 +6070,10 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 						Platform: &models.Platform{
 							Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 						},
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				})
 
 				It("Update UMN=false - success", func() {
@@ -6182,7 +6201,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
@@ -6213,7 +6232,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
 
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6247,7 +6266,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
 
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6277,7 +6296,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeBaremetal, gomock.Any(), mockUsage)
 
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6308,7 +6327,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -6379,7 +6398,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 						ClusterID: clusterID,
 						ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -6403,7 +6422,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
 
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
 
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6535,9 +6554,10 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 			})
 
 			Context("Update Platform while Cluster platform is none", func() {
+				var cluster *common.Cluster
 				BeforeEach(func() {
 					clusterID = strfmt.UUID(uuid.New().String())
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster = &common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterID,
 						HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeFull),
 						UserManagedNetworking: swag.Bool(true),
@@ -6545,9 +6565,10 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							Type: common.PlatformTypePtr(models.PlatformTypeNone),
 						},
 						CPUArchitecture: common.X86CPUArchitecture,
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				})
 
 				It("Update UMN=true - success", func() {
@@ -6673,7 +6694,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 			Context("OCP Version 4.13", func() {
 
 				createCluster := func(clusterId strfmt.UUID, cpuArchitecture, openshiftVersion string, platformType models.PlatformType, umn bool, highAvailabilityMode string) {
-					err := db.Create(&common.Cluster{Cluster: models.Cluster{
+					cluster := &common.Cluster{Cluster: models.Cluster{
 						ID:                    &clusterId,
 						HighAvailabilityMode:  swag.String(highAvailabilityMode),
 						UserManagedNetworking: swag.Bool(umn),
@@ -6682,9 +6703,10 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 							Type: common.PlatformTypePtr(platformType),
 						},
 						CPUArchitecture: cpuArchitecture,
-					}}).Error
+					}}
+					err := db.Create(cluster).Error
 					Expect(err).ShouldNot(HaveOccurred())
-					mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				}
 
 				createInfraEnv := func(clusterId strfmt.UUID, cpuArchitecture string) {
@@ -13163,17 +13185,18 @@ var _ = Describe("TestRegisterCluster", func() {
 
 		Context("V2 Update cluster", func() {
 			var clusterID strfmt.UUID
-
+			var cluster *common.Cluster
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster = &common.Cluster{Cluster: models.Cluster{
 					ID:                    &clusterID,
 					Kind:                  swag.String(models.ClusterKindAddHostsCluster),
 					Status:                swag.String(models.ClusterStatusInsufficient),
 					Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 					UserManagedNetworking: swag.Bool(false),
 					CPUArchitecture:       models.ClusterCPUArchitectureX8664,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 				bm = createInventory(db, cfg)
 			})
@@ -13182,7 +13205,7 @@ var _ = Describe("TestRegisterCluster", func() {
 				mockSetConnectivityMajorityGroupsForCluster(mockClusterApi)
 				mockUsageReports()
 				mockClusterApi.EXPECT().RefreshStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockDetectAndStoreCollidingIPsForCluster(mockClusterApi, 1)
 				apiVip := "1.2.3.5"
 				ingressVip := "1.2.3.6"
@@ -13308,9 +13331,11 @@ var _ = Describe("TestRegisterCluster", func() {
 				mockClusterUpdateSuccess(1, 0)
 			}
 
+			var cluster *common.Cluster
+
 			BeforeEach(func() {
 				clusterID = strfmt.UUID(uuid.New().String())
-				err := db.Create(&common.Cluster{Cluster: models.Cluster{
+				cluster = &common.Cluster{Cluster: models.Cluster{
 					ID:     &clusterID,
 					Kind:   swag.String(models.ClusterKindAddHostsCluster),
 					Status: swag.String(models.ClusterStatusInsufficient),
@@ -13318,13 +13343,14 @@ var _ = Describe("TestRegisterCluster", func() {
 						Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 					},
 					CPUArchitecture: common.DefaultCPUArchitecture,
-				}}).Error
+				}}
+				err := db.Create(cluster).Error
 				Expect(err).ShouldNot(HaveOccurred())
 				bm = createInventory(db, cfg)
 			})
 
 			It("Update cluster disk encryption configuration enable on all", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
 					ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -13338,7 +13364,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			})
 
 			It("Update cluster disk encryption configuration enable on masters", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
 					ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -13352,7 +13378,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			})
 
 			It("Update cluster disk encryption configuration enable on workers", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: clusterID,
 					ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -13366,7 +13392,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			})
 
 			It("Update cluster disk encryption configuration enable on none", func() {
-				mockClusterApi.EXPECT().VerifyClusterUpdatability(gomock.Any()).Return(nil).Times(1)
+				mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 				mockSuccess()
 				mockUsageReports()
 				reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{


### PR DESCRIPTION
The current implementation of the inventory test uses gomock.Any() as a matcher for the cluster, this is not very accurate. This PR changes that by ensuring each cluster matches on at least ID.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
