### PR TITLE
MGMT-13178: Adding order parameter and changing the count of events by severity to apply only after the filtering

### DIFF
--- a/client/events/v2_list_events_parameters.go
+++ b/client/events/v2_list_events_parameters.go
@@ -128,6 +128,14 @@ type V2ListEventsParams struct {
 	*/
 	Offset *int64
 
+	/* Order.
+
+	   Order by event_time of events retrieved.
+
+	   Default: "ascending"
+	*/
+	Order *string
+
 	/* Severities.
 
 	   Retrieved events severities.
@@ -151,7 +159,18 @@ func (o *V2ListEventsParams) WithDefaults() *V2ListEventsParams {
 //
 // All values with no default are reset to their zero value.
 func (o *V2ListEventsParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		orderDefault = string("ascending")
+	)
+
+	val := V2ListEventsParams{
+		Order: &orderDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the v2 list events params
@@ -295,6 +314,17 @@ func (o *V2ListEventsParams) WithOffset(offset *int64) *V2ListEventsParams {
 // SetOffset adds the offset to the v2 list events params
 func (o *V2ListEventsParams) SetOffset(offset *int64) {
 	o.Offset = offset
+}
+
+// WithOrder adds the order to the v2 list events params
+func (o *V2ListEventsParams) WithOrder(order *string) *V2ListEventsParams {
+	o.SetOrder(order)
+	return o
+}
+
+// SetOrder adds the order to the v2 list events params
+func (o *V2ListEventsParams) SetOrder(order *string) {
+	o.Order = order
 }
 
 // WithSeverities adds the severities to the v2 list events params
@@ -469,6 +499,23 @@ func (o *V2ListEventsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		if qOffset != "" {
 
 			if err := r.SetQueryParam("offset", qOffset); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Order != nil {
+
+		// query param order
+		var qrOrder string
+
+		if o.Order != nil {
+			qrOrder = *o.Order
+		}
+		qOrder := qrOrder
+		if qOrder != "" {
+
+			if err := r.SetQueryParam("order", qOrder); err != nil {
 				return err
 			}
 		}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -488,44 +488,52 @@ func ApplyYamlPatch(src []byte, ops []byte) ([]byte, error) {
 type EventSeverityCount map[string]int64
 
 type V2GetEventsParams struct {
-	/*A comma-separated list of event categories.
-	  In: query
+	/*
+	   A comma-separated list of event categories.
 	*/
 	Categories []string
-	/*The cluster to return events for.
-	  In: query
+	/*
+	   The cluster to return events for.
+	   Format: uuid
 	*/
 	ClusterID *strfmt.UUID
-	/*Cluster level events flag.
-	  In: query
+	/*
+	   Cluster level events flag.
 	*/
 	ClusterLevel *bool
-	/*Deleted hosts flag.
-	  In: query
+	/*
+	   Deleted hosts flag.
 	*/
 	DeletedHosts *bool
-	/*Hosts in the specified cluster to return events for.
-	  In: query
+	/*
+	   Hosts in the specified cluster to return events for.
 	*/
 	HostIds []strfmt.UUID
-	/*The infra-env to return events for.
-	  In: query
+	/*
+	   The infra-env to return events for.
+	   Format: uuid
 	*/
 	InfraEnvID *strfmt.UUID
-	/*The maximum number of records to retrieve.
-	  In: query
+	/*
+	   The maximum number of records to retrieve.
 	*/
 	Limit *int64
-	/*Retrieved events message pattern.
-	  In: query
+	/*
+	   Retrieved events message pattern.
 	*/
 	Message *string
-	/*Number of records to skip before starting to return the records.
-	  In: query
+	/*
+	   Number of records to skip before starting to return the records.
 	*/
 	Offset *int64
-	/*Retrieved events severities.
-	  In: query
+
+	/*
+	   Order by event_time of events retrieved.
+	   Default: "ascending"
+	*/
+	Order *string
+	/*
+	   Retrieved events severities.
 	*/
 	Severities []string
 }

--- a/internal/events/events_api.go
+++ b/internal/events/events_api.go
@@ -38,6 +38,7 @@ func (a *Api) V2ListEvents(ctx context.Context, params events.V2ListEventsParams
 		InfraEnvID:   params.InfraEnvID,
 		Limit:        params.Limit,
 		Offset:       params.Offset,
+		Order:        params.Order,
 		Severities:   params.Severities,
 		Message:      params.Message,
 		DeletedHosts: params.DeletedHosts,

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2904,6 +2904,17 @@ func init() {
             "in": "query"
           },
           {
+            "enum": [
+              "ascending",
+              "descending"
+            ],
+            "type": "string",
+            "default": "ascending",
+            "description": "Order by event_time of events retrieved.",
+            "name": "order",
+            "in": "query"
+          },
+          {
             "type": "array",
             "items": {
               "enum": [
@@ -13088,6 +13099,17 @@ func init() {
             "type": "integer",
             "description": "Number of records to skip before starting to return the records.",
             "name": "offset",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "ascending",
+              "descending"
+            ],
+            "type": "string",
+            "default": "ascending",
+            "description": "Order by event_time of events retrieved.",
+            "name": "order",
             "in": "query"
           },
           {

--- a/restapi/operations/events/v2_list_events_parameters.go
+++ b/restapi/operations/events/v2_list_events_parameters.go
@@ -18,11 +18,18 @@ import (
 )
 
 // NewV2ListEventsParams creates a new V2ListEventsParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewV2ListEventsParams() V2ListEventsParams {
 
-	return V2ListEventsParams{}
+	var (
+		// initialize parameters with default values
+
+		orderDefault = string("ascending")
+	)
+
+	return V2ListEventsParams{
+		Order: &orderDefault,
+	}
 }
 
 // V2ListEventsParams contains all the bound params for the v2 list events operation
@@ -74,6 +81,11 @@ type V2ListEventsParams struct {
 	  In: query
 	*/
 	Offset *int64
+	/*Order by event_time of events retrieved.
+	  In: query
+	  Default: "ascending"
+	*/
+	Order *string
 	/*Retrieved events severities.
 	  In: query
 	*/
@@ -138,6 +150,11 @@ func (o *V2ListEventsParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	qOffset, qhkOffset, _ := qs.GetOK("offset")
 	if err := o.bindOffset(qOffset, qhkOffset, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qOrder, qhkOrder, _ := qs.GetOK("order")
+	if err := o.bindOrder(qOrder, qhkOrder, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -430,6 +447,39 @@ func (o *V2ListEventsParams) bindOffset(rawData []string, hasKey bool, formats s
 		return errors.InvalidType("offset", "query", "int64", raw)
 	}
 	o.Offset = &value
+
+	return nil
+}
+
+// bindOrder binds and validates parameter Order from query.
+func (o *V2ListEventsParams) bindOrder(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewV2ListEventsParams()
+		return nil
+	}
+	o.Order = &raw
+
+	if err := o.validateOrder(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateOrder carries on validations for parameter Order
+func (o *V2ListEventsParams) validateOrder(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("order", "query", *o.Order, []interface{}{"ascending", "descending"}, true); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/events/v2_list_events_urlbuilder.go
+++ b/restapi/operations/events/v2_list_events_urlbuilder.go
@@ -26,6 +26,7 @@ type V2ListEventsURL struct {
 	Limit        *int64
 	Message      *string
 	Offset       *int64
+	Order        *string
 	Severities   []string
 
 	_basePath string
@@ -158,6 +159,14 @@ func (o *V2ListEventsURL) Build() (*url.URL, error) {
 	}
 	if offsetQ != "" {
 		qs.Set("offset", offsetQ)
+	}
+
+	var orderQ string
+	if o.Order != nil {
+		orderQ = *o.Order
+	}
+	if orderQ != "" {
+		qs.Set("order", orderQ)
 	}
 
 	var severitiesIR []string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3477,6 +3477,12 @@ paths:
           type: integer
           required: false
         - in: query
+          name: order
+          description: Order by event_time of events retrieved.
+          type: string
+          enum: [ascending, descending]
+          default: ascending
+        - in: query
           name: severities
           description: Retrieved events severities.
           type: array


### PR DESCRIPTION
As part of events pagination epic, this PR is about adding `order` parameter so the client can request the events in the desired order, and changing the counting of events by severity to apply after the filtering

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
