### PR TITLE
Add private SELinux label for volume mount content

### DIFF
--- a/docs/change-iso-password.sh
+++ b/docs/change-iso-password.sh
@@ -15,7 +15,7 @@ fi
 DISCOVERY_ISO_HOST_PATH="$1"
 DISCOVERY_ISO_HOST_DIR=$(dirname "$DISCOVERY_ISO_HOST_PATH")
 function COREOS_INSTALLER() {
-	podman run -v "$DISCOVERY_ISO_HOST_DIR":/data --rm quay.io/coreos/coreos-installer:release "$@"
+	podman run -v "$DISCOVERY_ISO_HOST_DIR":/data:Z --rm quay.io/coreos/coreos-installer:release "$@"
 }
 
 ISO_NAME=$(basename "$DISCOVERY_ISO_HOST_PATH" .iso)


### PR DESCRIPTION
This merge request changes the `change-iso-password.sh` script, which is used to add a password to the discovery ISO, slightly. It adds a private SELinux label for the volume mount content by adding the `:Z` suffix to the volume mount in the podman run command. Without it, the podman run command fails because of permissions.

## List all the issues related to this PR

- [ ] New Feature
- [ ] Enhancement
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

Successfully executed script on a system (Fedora 37) with enforced SELinux and on a Windows machine using WSL without SELinux.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
