### PR TITLE
MGMT-14283: Ignored validations - validation id "all" does not work

### DIFF
--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -601,6 +601,10 @@ func (b *bareMetalInventory) validateIgnoredValidations(problems []string, ignor
 		problems = append(problems, fmt.Sprintf("error during unmarshal of json for ignored %s validations", validationType))
 	} else {
 		for _, v := range ignoredValidationsArr {
+			// Don't check to see if "all" is a valid host or cluster validation, because it isn't, but it's allowed!
+			if strings.ToLower(v) == "all" {
+				continue
+			}
 			var err error
 			if validationType == common.ValidationTypeCluster {
 				validation := models.NewClusterValidationID(models.ClusterValidationID(v))

--- a/subsystem/authz_test.go
+++ b/subsystem/authz_test.go
@@ -361,13 +361,15 @@ var _ = Describe("test authorization", func() {
 			_, err := user2BMClient.Installer.V2SetIgnoredValidations(ctx, &installer.V2SetIgnoredValidationsParams{
 				ClusterID: *cluster.ID,
 				IgnoredValidations: &models.IgnoredValidations{
-					ClusterValidationIds: "[\"dns-domain-defined\", \"does-not-exist\"]",
-					HostValidationIds:    "[\"has-cpu-cores-for-role\", \"also-does-not-exist\",\"has-memory-for-role\"]",
+					ClusterValidationIds: "[\"all\", \"dns-domain-defined\", \"does-not-exist\"]",
+					HostValidationIds:    "[\"all\", \"has-cpu-cores-for-role\", \"also-does-not-exist\",\"has-memory-for-role\"]",
 				},
 			})
 			Expect(err).Should(HaveOccurred())
 			Expect(marshalError(err)).To(ContainSubstring("Validation ID 'does-not-exist' is not a known cluster validation"))
 			Expect(marshalError(err)).To(ContainSubstring("Validation ID 'also-does-not-exist' is not a known host validation"))
+			Expect(marshalError(err)).ToNot(ContainSubstring("Validation ID 'all' is not a known host validation"))
+			Expect(marshalError(err)).ToNot(ContainSubstring("Validation ID 'all' is not a known cluster validation"))
 			c, err := common.GetClusterFromDB(db, *cluster.ID, common.SkipEagerLoading)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(c.IgnoredClusterValidations).To(Equal(""))


### PR DESCRIPTION
Presently when you attempt to ignore "all" validations then a validation error will be returned. This is a bug.

This PR addresses the bug.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
