### PR TITLE
MGMT-14242: MGMT-14017:  MGMT-14239: MGMT-14300: Fix multiple bugs (feature support and feature usage)

### DIFF
--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -16583,14 +16583,18 @@ var _ = Describe("Update cluster - feature usage flags", func() {
 		It("Add feature usage of ARM64 when cluster arch match", func() {
 			mockUsage.EXPECT().Add(usages, usage.CPUArchitectureARM64, nil).Times(1)
 			mockUsage.EXPECT().Remove(usages, usage.CPUArchitectureARM64).Times(0)
+			mockUsage.EXPECT().Remove(usages, usage.CPUArchitectureS390x).Times(1)
+			mockUsage.EXPECT().Remove(usages, usage.CPUArchitecturePpc64le).Times(1)
 			cluster.CPUArchitecture = "arm64"
-			bm.updateClusterCPUFeatureUsage(cluster, usages)
+			bm.updateClusterCPUFeatureUsage(cluster.CPUArchitecture, usages)
 		})
 
 		It("Remove feature usage of ARM64 when cluster arch match", func() {
 			mockUsage.EXPECT().Add(usages, usage.CPUArchitectureARM64, nil).Times(0)
 			mockUsage.EXPECT().Remove(usages, usage.CPUArchitectureARM64).Times(1)
-			bm.updateClusterCPUFeatureUsage(cluster, usages)
+			mockUsage.EXPECT().Remove(usages, usage.CPUArchitectureS390x).Times(1)
+			mockUsage.EXPECT().Remove(usages, usage.CPUArchitecturePpc64le).Times(1)
+			bm.updateClusterCPUFeatureUsage(cluster.CPUArchitecture, usages)
 		})
 	})
 

--- a/internal/featuresupport/common.go
+++ b/internal/featuresupport/common.go
@@ -24,18 +24,17 @@ func ValidateIncompatibleFeatures(log logrus.FieldLogger, cpuArchitecture string
 	}
 
 	activatedFeatures := getActivatedFeatures(log, cluster, infraEnv, updateParams)
-	if cpuArchitecture != "" {
-		if openshiftVersion != nil {
-			if isSupported := isArchitectureSupported(cpuArchitectureFeatureIdMap[cpuArchitecture], swag.StringValue(openshiftVersion)); !isSupported {
-				return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cpuArchitecture, cluster.OpenshiftVersion)
-			}
+	if cpuArchitecture != "" && swag.StringValue(openshiftVersion) != "" {
+		if isSupported := isArchitectureSupported(cpuArchitectureFeatureIdMap[cpuArchitecture], swag.StringValue(openshiftVersion)); !isSupported {
+			return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cpuArchitecture, cluster.OpenshiftVersion)
 		}
 
 		if err := isFeaturesCompatibleWithArchitecture(swag.StringValue(openshiftVersion), cpuArchitecture, activatedFeatures); err != nil {
 			return err
 		}
+
 	} else {
-		log.Warn("Cannot validate incompatible CPU architecture due to empty value")
+		log.Warn("Cannot validate incompatible CPU architecture due to empty CPU architecture or empty OpenshiftVersion")
 	}
 
 	if err := isFeaturesCompatibleWithFeatures(activatedFeatures); err != nil {

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -282,15 +282,16 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			}}
 			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureArm64, &cluster, nil, nil)).To(BeNil())
 		})
-		It("Ppc64le with CMN and minimal iso - success", func() {
+		It("Ppc64le with CMN - fail", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
 				OpenshiftVersion: "4.12",
 				CPUArchitecture:  models.ClusterCPUArchitecturePpc64le,
 			}}
-			infraEnv := models.InfraEnv{CPUArchitecture: models.ClusterCPUArchitecturePpc64le, Type: common.ImageTypePtr(models.ImageTypeMinimalIso)}
+			infraEnv := models.InfraEnv{CPUArchitecture: models.ClusterCPUArchitecturePpc64le, Type: common.ImageTypePtr(models.ImageTypeFullIso)}
 
 			err := ValidateIncompatibleFeatures(log, models.ClusterCPUArchitecturePpc64le, &cluster, nil, nil)
-			Expect(err).To(BeNil())
+			Expect(err).To(Not(BeNil()))
+			cluster.UserManagedNetworking = swag.Bool(true)
 			err = ValidateIncompatibleFeatures(log, models.ClusterCPUArchitecturePpc64le, &cluster, &infraEnv, nil)
 			Expect(err).To(BeNil())
 		})

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -192,6 +192,16 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			}}
 			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureX8664, &cluster, nil, nil)).To(BeNil())
 		})
+
+		It("No OCP version with CPU architecture that depends on OCP version", func() {
+			cluster := common.Cluster{Cluster: models.Cluster{
+				CPUArchitecture:       models.ClusterCPUArchitectureArm64,
+				HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeNone),
+				UserManagedNetworking: swag.Bool(true),
+				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+			}}
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureArm64, &cluster, nil, nil)).To(BeNil())
+		})
 		It("Single compatible feature is activated", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
 				OpenshiftVersion:      "4.8",

--- a/internal/featuresupport/features.go
+++ b/internal/featuresupport/features.go
@@ -220,6 +220,7 @@ func (feature *ClusterManagedNetworkingFeature) getFeatureActiveLevel(cluster *c
 func (feature *ClusterManagedNetworkingFeature) getIncompatibleArchitectures(openshiftVersion *string) *[]models.ArchitectureSupportLevelID {
 	incompatibilities := []models.ArchitectureSupportLevelID{
 		models.ArchitectureSupportLevelIDS390XARCHITECTURE,
+		models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE,
 	}
 
 	if openshiftVersion != nil {


### PR DESCRIPTION
This PR fixes 4 issues:

- https://issues.redhat.com/browse/MGMT-14242 - Installation of day2 arm worker in a day1 x86 cluster is blocked by assisted service due to missing OCP version
- https://issues.redhat.com/browse/MGMT-14017 -  Feature usage for power and z  not working on 2.18.0
- https://issues.redhat.com/browse/MGMT-14239 - Disable `Cluster Managed Network` support for Power(ppc64le)
- https://issues.redhat.com/browse/MGMT-14300 - Create infraenv failed for day2 add host for Power

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 