### PR TITLE
MGMT-13083: limit the size of release binaries

### DIFF
--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Bootstrap Ignition Update", func() {
 		}
 		db, dbName = common.PrepareTestDB()
 		g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", mockS3Client, log,
-			mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+			mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 		err = g.updateBootstrap(context.Background(), examplePath)
 
@@ -291,7 +291,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 	Describe("update ignitions", func() {
 		It("with ca cert file", func() {
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", caCertPath, "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -314,7 +314,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		It("with no ca cert file", func() {
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			err := g.updateIgnitions()
 			Expect(err).NotTo(HaveOccurred())
@@ -333,7 +333,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		It("with service ips", func() {
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			err := g.UpdateEtcHosts("10.10.10.1,10.10.10.2")
 			Expect(err).NotTo(HaveOccurred())
@@ -356,7 +356,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		It("with no service ips", func() {
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			err := g.UpdateEtcHosts("")
 			Expect(err).NotTo(HaveOccurred())
@@ -386,7 +386,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		Context("DHCP generation", func() {
 			It("Definitions only", func() {
 				g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-					mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+					mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 				g.encodedDhcpFileContents = "data:,abc"
 				err := g.updateIgnitions()
@@ -405,7 +405,7 @@ SV4bRR9i0uf+xQ/oYRvugQ25Q7EahO5hJIWRf4aULbk36Zpw3++v2KFnF26zqwB6
 		})
 		It("Definitions+leases", func() {
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			g.encodedDhcpFileContents = "data:,abc"
 			cluster.ApiVipLease = "api"
@@ -543,7 +543,7 @@ var _ = Describe("createHostIgnitions", func() {
 			}
 
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 			err := g.createHostIgnitions("http://www.example.com:6008", auth.TypeRHSSO)
 			Expect(err).NotTo(HaveOccurred())
@@ -590,7 +590,7 @@ var _ = Describe("createHostIgnitions", func() {
 		}}
 
 		g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-			mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+			mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 
 		err := g.createHostIgnitions("http://www.example.com:6008", auth.TypeNone)
 		Expect(err).NotTo(HaveOccurred())
@@ -662,7 +662,7 @@ spec:
 			}}
 
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", mockS3Client, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 			mockS3Client.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return([]string{"mcp.yaml"}, nil)
 			mockS3Client.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return(nil, nil)
 			mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader(mcp)), int64(0), nil)
@@ -689,7 +689,7 @@ spec:
 			}}
 
 			g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", mockS3Client, log,
-				mockOperatorManager, mockProviderRegistry, "", "").(*installerGenerator)
+				mockOperatorManager, mockProviderRegistry, "", "", 5).(*installerGenerator)
 			mockS3Client.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return([]string{"mcp.yaml"}, nil)
 			mockS3Client.EXPECT().ListObjectsByPrefix(gomock.Any(), gomock.Any()).Return(nil, nil)
 			mockS3Client.EXPECT().Download(gomock.Any(), gomock.Any()).Return(io.NopCloser(strings.NewReader(mc)), int64(0), nil)
@@ -1736,7 +1736,7 @@ var _ = Describe("Import Cluster TLS Certs for ephemeral installer", func() {
 
 	It("copies the tls cert files", func() {
 		g := NewGenerator("", workDir, installerCacheDir, cluster, "", "", "", "", nil, log,
-			mockOperatorManager, mockProviderRegistry, "", certDir).(*installerGenerator)
+			mockOperatorManager, mockProviderRegistry, "", certDir, 5).(*installerGenerator)
 
 		err := g.importClusterTLSCerts(context.Background())
 		Expect(err).NotTo(HaveOccurred())
@@ -2229,6 +2229,7 @@ var _ = Describe("Bare metal host generation", func() {
 				mockProviderRegistry,
 				"",
 				"",
+				5,
 			).(*installerGenerator)
 
 			// The default host inventory used by these tests has two NICs, each with

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -1,61 +1,189 @@
 package installercache
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
-	"github.com/openshift/assisted-service/pkg/executer"
-	"github.com/openshift/assisted-service/pkg/mirrorregistries"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
-type installers struct {
+var (
+	DeleteGracePeriod   time.Duration = -5 * time.Minute
+	CacheLimitThreshold               = 0.8
+)
+
+// Installers implements a thread safe LRU cache for ocp install binaries
+// on the pod's ephermal file system. The number of binaries stored is
+// limited by the storageCapacity parameter.
+type Installers struct {
 	sync.Mutex
-	releases map[string]*release
+	log logrus.FieldLogger
+	// total capcity of the allowed storage (in bytes)
+	storageCapacity int64
+	// parent directory of the binary cache
+	cacheDir string
 }
 
-type release struct {
-	sync.Mutex
+type fileInfo struct {
 	path string
+	info os.FileInfo
 }
 
-var cache installers = installers{
-	releases: make(map[string]*release),
+func (fi *fileInfo) Compare(other *fileInfo) bool {
+	//oldest file will be first in queue
+	return fi.info.ModTime().Unix() < other.info.ModTime().Unix()
 }
 
-// Get returns a release resource for the given release ID
-func (i *installers) Get(releaseID string) *release {
-	i.Lock()
-	defer i.Unlock()
+type Release struct {
+	Path string
+}
 
-	r, present := i.releases[releaseID]
-	if !present {
-		r = &release{}
-		i.releases[releaseID] = r
+func (rl *Release) Release() {
+	if err := os.Remove(rl.Path); err != nil {
+		logrus.New().WithError(err).Errorf("Failed to delete release link %s", rl.Path)
 	}
-	return r
+}
+
+// New constructs an installer cache with a given storage capacity
+func New(cacheDir string, storageCapacity int64, log logrus.FieldLogger) *Installers {
+	return &Installers{
+		log:             log,
+		storageCapacity: storageCapacity,
+		cacheDir:        cacheDir,
+	}
 }
 
 // Get returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image. Tries the mirror release image first if it's set. It is safe for concurrent use. A cache of
 // binaries is maintained to reduce re-downloading of the same release.
-func Get(releaseID, releaseIDMirror, cacheDir, pullSecret string, platformType models.PlatformType, icspFile string, log logrus.FieldLogger) (string, error) {
-	r := cache.Get(releaseID)
-	r.Lock()
-	defer r.Unlock()
+func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocRelease oc.Release, platformType models.PlatformType, icspFile string) (*Release, error) {
+	i.Lock()
+	defer i.Unlock()
 
-	var path string
+	var workdir, binary, path string
 	var err error
-	//cache miss
-	if r.path == "" {
-		mirrorRegistriesBuilder := mirrorregistries.New()
-		path, err = oc.NewRelease(&executer.CommonExecuter{}, oc.Config{
-			MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay}, mirrorRegistriesBuilder).Extract(log, releaseID, releaseIDMirror, cacheDir, pullSecret, platformType, icspFile)
+
+	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseID, i.cacheDir, platformType)
+	if _, err = os.Stat(path); os.IsNotExist(err) {
+		//evict older files if necessary
+		i.evict()
+
+		//extract the binary
+		_, err = ocRelease.Extract(i.log, releaseID, releaseIDMirror, i.cacheDir, pullSecret, platformType, icspFile)
 		if err != nil {
-			return "", err
+			return &Release{}, err
 		}
-		r.path = path
+	} else {
+		//update the file mtime to signal it was recently used
+		err = os.Chtimes(path, time.Now(), time.Now())
+		if err != nil {
+			return &Release{}, errors.Wrap(err, fmt.Sprintf("Failed to update release binary %s", path))
+		}
 	}
-	return r.path, nil
+	// return a new hard link to the binary file
+	// the caller should delete the hard link when
+	// it finishes working with the file
+	link := filepath.Join(workdir, "ln_"+fmt.Sprint(time.Now().Unix())+
+		"_"+binary)
+	err = os.Link(path, link)
+	if err != nil {
+		return &Release{}, errors.Wrap(err, fmt.Sprintf("Failed to create hard link to binary %s", path))
+	}
+	return &Release{link}, nil
+}
+
+//	Walk through the cacheDir and list the files recursively.
+// If the total volume of the files reaches the capacity, delete
+// the oldest ones.
+//
+// Locking must be done outside evict() to avoid contentions.
+func (i *Installers) evict() {
+	//if cache limit is undefined skip eviction
+	if i.storageCapacity == 0 {
+		return
+	}
+
+	// store the file paths
+	files := NewPriorityQueue(&fileInfo{})
+	links := make([]*fileInfo, 0)
+	var totalSize int64
+
+	// visit process the file/dir pointed by path and store relevant
+	// paths in a priority queue
+	visit := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		//find hard links
+		if strings.HasPrefix(info.Name(), "ln_") {
+			links = append(links, &fileInfo{path, info})
+			return nil
+		}
+
+		//save the other files based on their mod time
+		files.Add(&fileInfo{path, info})
+		totalSize += info.Size()
+		return nil
+	}
+
+	err := filepath.Walk(i.cacheDir, visit)
+	if err != nil {
+		if !os.IsNotExist(err) { //ignore first invocation where the cacheDir does not exist
+			i.log.WithError(err).Errorf("release binary eviction failed to inspect directory %s", i.cacheDir)
+		}
+		return
+	}
+
+	//prune the hard links just in case the deletion of resources
+	//in ignition.go did not succeeded as expected
+	for idx := 0; idx < len(links); idx++ {
+		finfo := links[idx]
+		//Allow a grace period of 5 minutes from the link creation time
+		//to ensure the link is not being used.
+		grace := time.Now().Add(DeleteGracePeriod).Unix()
+		if finfo.info.ModTime().Unix() < grace {
+			os.Remove(finfo.path)
+		}
+	}
+
+	//delete the oldest file if necessary
+	for totalSize >= int64(float64(i.storageCapacity)*CacheLimitThreshold) {
+		finfo, _ := files.Pop()
+		totalSize -= finfo.info.Size()
+		//remove the file
+		if err := i.evictFile(finfo.path); err != nil {
+			i.log.WithError(err).Errorf("failed to evict file %s", finfo.path)
+		}
+	}
+}
+
+func (i *Installers) evictFile(filePath string) error {
+	i.log.Infof("evicting binary file %s due to storage pressure", filePath)
+	err := os.Remove(filePath)
+	if err != nil {
+		return err
+	}
+	// if the parent directory was left empty,
+	// remove it to avoid dangling directories
+	parentDir := path.Dir(filePath)
+	entries, err := os.ReadDir(parentDir)
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return os.Remove(parentDir)
+	}
+	return nil
 }

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -1,0 +1,123 @@
+package installercache
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/oc"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("installer cache", func() {
+	var (
+		ctrl        *gomock.Controller
+		mockRelease *oc.MockRelease
+		manager     *Installers
+		cacheDir    string
+	)
+
+	BeforeEach(func() {
+		DeleteGracePeriod = 1 * time.Millisecond
+
+		ctrl = gomock.NewController(GinkgoT())
+		mockRelease = oc.NewMockRelease(ctrl)
+
+		var err error
+		cacheDir, err = ioutil.TempDir("/tmp", "cacheDir")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Mkdir(filepath.Join(cacheDir, "quay.io"), 0755)).To(Succeed())
+		Expect(os.Mkdir(filepath.Join(filepath.Join(cacheDir, "quay.io"), "release-dev"), 0755)).To(Succeed())
+		manager = New(cacheDir, 12, logrus.New())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(cacheDir)
+	})
+
+	testGet := func(releaseID string) (string, string) {
+		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
+		fname := filepath.Join(workdir, releaseID)
+
+		mockRelease.EXPECT().GetReleaseBinaryPath(
+			gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(workdir, releaseID, fname)
+		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
+			gomock.Any(), cacheDir, gomock.Any(),
+			gomock.Any(), gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType, icspFile string) (string, error) {
+				err := os.WriteFile(fname, []byte("abcde"), 0600)
+				return "", err
+			})
+		l, err := manager.Get(releaseID, "mirror", "pull-secret", mockRelease, models.PlatformTypeBaremetal, "icsp")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		time.Sleep(1 * time.Second)
+		return fname, l.Path
+	}
+	It("evicts the oldest file", func() {
+		r1, l1 := testGet("4.8")
+		r2, l2 := testGet("4.9")
+		r3, l3 := testGet("4.10")
+
+		By("verify that the oldest file was deleted")
+		_, err := os.Stat(r1)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(r2)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+		_, err = os.Stat(r3)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+
+		By("verify that the links were purged")
+		manager.evict()
+		_, err = os.Stat(l1)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(l2)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(l3)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+	})
+
+	It("exising files access time is updated", func() {
+		_, _ = testGet("4.8")
+		r2, _ := testGet("4.9")
+		r1, _ := testGet("4.8")
+		r3, _ := testGet("4.10")
+
+		By("verify that the oldest file was deleted")
+		_, err := os.Stat(r1)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+		_, err = os.Stat(r2)
+		Expect(os.IsNotExist(err)).To(BeTrue())
+		_, err = os.Stat(r3)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+	})
+
+	It("when cache limit is not set eviction is skipped", func() {
+		manager.storageCapacity = 0
+
+		r1, _ := testGet("4.8")
+		r2, _ := testGet("4.9")
+		r3, _ := testGet("4.10")
+
+		By("verify that the no file was deleted")
+		_, err := os.Stat(r1)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+		_, err = os.Stat(r2)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+		_, err = os.Stat(r3)
+		Expect(os.IsNotExist(err)).To(BeFalse())
+
+	})
+})
+
+func TestInstallerCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "installercache tests")
+}

--- a/internal/installercache/priorityqueue.go
+++ b/internal/installercache/priorityqueue.go
@@ -1,0 +1,66 @@
+package installercache
+
+import "container/heap"
+
+type Comparable[E any] interface {
+	Compare(E) bool
+}
+
+// heapitems implements heap.Interface
+type heapItems[E Comparable[E]] []E
+
+func (hi heapItems[E]) Len() int { return len(hi) }
+func (hi heapItems[E]) Less(i, j int) bool {
+	return hi[i].Compare(hi[j])
+}
+
+func (hi heapItems[E]) Swap(i, j int) {
+	hi[i], hi[j] = hi[j], hi[i]
+}
+
+func (hi *heapItems[E]) Push(item any) {
+	*hi = append(*hi, item.(E))
+}
+
+func (hi *heapItems[E]) Pop() any {
+	item := (*hi)[hi.Len()-1]
+	*hi = (*hi)[0 : hi.Len()-1]
+	return item
+}
+
+// PriorityQueue implements a non-thread safe priority queue
+// Each item implmenets the Comparable interface. The priority
+// is determined by the Compare function of that interface
+type PriorityQueue[T Comparable[T]] struct {
+	items heapItems[T]
+	empty T
+}
+
+func NewPriorityQueue[T Comparable[T]](empty T) *PriorityQueue[T] {
+	pq := &PriorityQueue[T]{
+		items: make([]T, 0),
+		empty: empty,
+	}
+	heap.Init(&pq.items)
+	return pq
+}
+
+// Returns the size of the queue
+func (pq *PriorityQueue[T]) Len() int {
+	return pq.items.Len()
+}
+
+// Add the specified item into this priority queue.
+func (pq *PriorityQueue[T]) Add(item T) {
+	heap.Push(&pq.items, item)
+}
+
+// Retrieves and removes the head of this queue,
+// If the queue is empty, it returns an empty value
+// ok indicates whether value was found in the queue.
+func (pq *PriorityQueue[T]) Pop() (value T, ok bool) {
+	if pq.items.Len() > 0 {
+		return heap.Pop(&pq.items).(T), true
+	}
+	return pq.empty, false
+}

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -154,3 +154,19 @@ func (mr *MockReleaseMockRecorder) GetReleaseArchitecture(log, releaseImage, rel
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseArchitecture", reflect.TypeOf((*MockRelease)(nil).GetReleaseArchitecture), log, releaseImage, releaseImageMirror, pullSecret)
 }
+
+// GetReleaseBinaryPath mocks base method.
+func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir string, platformType models.PlatformType) (string, string, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReleaseBinaryPath", releaseImage, cacheDir, platformType)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	return ret0, ret1, ret2
+}
+
+// GetReleaseBinaryPath indicates an expected call of GetReleaseBinaryPath.
+func (mr *MockReleaseMockRecorder) GetReleaseBinaryPath(releaseImage, cacheDir, platformType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseBinaryPath", reflect.TypeOf((*MockRelease)(nil).GetReleaseBinaryPath), releaseImage, cacheDir, platformType)
+}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -181,6 +181,9 @@ parameters:
 - name: ENABLE_DATA_COLLECTION
   value: "false"
   required: false
+- name: INSTALLER_CACHE_CAPACITY
+  value: "6442450944"
+  required: false
 apiVersion: v1
 kind: Template
 metadata:
@@ -434,6 +437,8 @@ objects:
                 value: ${ENABLE_REJECT_UNKNOWN_FIELDS}
               - name: ENABLE_DATA_COLLECTION
                 value: ${ENABLE_DATA_COLLECTION}
+              - name: INSTALLER_CACHE_CAPACITY
+                value: ${INSTALLER_CACHE_CAPACITY}
             volumeMounts:
               - name: route53-creds
                 mountPath: "/etc/.aws"

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -27,12 +27,13 @@ type ISOInstallConfigGenerator interface {
 }
 
 type Config struct {
-	ServiceCACertPath  string `envconfig:"SERVICE_CA_CERT_PATH" default:""`
-	ServiceIPs         string `envconfig:"SERVICE_IPS" default:""`
-	ReleaseImageMirror string
-	DummyIgnition      bool   `envconfig:"DUMMY_IGNITION"`
-	InstallInvoker     string `envconfig:"INSTALL_INVOKER" default:"assisted-installer"`
-	ServiceBaseURL     string `envconfig:"SERVICE_BASE_URL"`
+	ServiceCACertPath      string `envconfig:"SERVICE_CA_CERT_PATH" default:""`
+	ServiceIPs             string `envconfig:"SERVICE_IPS" default:""`
+	ReleaseImageMirror     string
+	DummyIgnition          bool   `envconfig:"DUMMY_IGNITION"`
+	InstallInvoker         string `envconfig:"INSTALL_INVOKER" default:"assisted-installer"`
+	ServiceBaseURL         string `envconfig:"SERVICE_BASE_URL"`
+	InstallerCacheCapacity int64  `envconfig:"INSTALLER_CACHE_CAPACITY"`
 }
 
 type installGenerator struct {
@@ -101,7 +102,7 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 		generator = ignition.NewDummyGenerator(k.ServiceBaseURL, clusterWorkDir, &cluster, k.s3Client, log)
 	} else {
 		generator = ignition.NewGenerator(k.ServiceBaseURL, clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror,
-			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi, k.providerRegistry, installerReleaseImageOverride, k.clusterTLSCertOverrideDir)
+			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi, k.providerRegistry, installerReleaseImageOverride, k.clusterTLSCertOverrideDir, k.InstallerCacheCapacity)
 	}
 	err = generator.Generate(ctx, cfg, k.getClusterPlatformType(cluster), k.authHandler.AuthType())
 	if err != nil {


### PR DESCRIPTION
with lru policies

The single source of truth is the file system, so no delete failures are retried.

instead of locking in memory, the caller receives a hard link to the file and deletes it after the processing is completed.

There is also a GC logic for links if they are left behind.

The hard link makes sure that the file is always available to the caller, even if eviction is taking place in parallel (in the rare event of a request storm)

A priority queue is used to keep track of the oldest file. Whenever a file is accessed its mtime is updated so it won't get evicted.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
