### PR TITLE
MGMT-14338: add missing stream notifications

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -260,15 +260,15 @@ func main() {
 	ctrlMgr, err := createControllerManager()
 	failOnError(err, "failed to create controller manager")
 
-	usageManager := usage.NewManager(log)
+	notificationStream := getNotificationStream(log)
+	defer notificationStream.Close()
+
+	usageManager := usage.NewManager(log, notificationStream)
 	ocmClient := getOCMClient(log)
 
 	authHandler, err := auth.NewAuthenticator(&Options.Auth, ocmClient, log.WithField("pkg", "auth"), db)
 	failOnError(err, "failed to create authenticator")
 	authzHandler := auth.NewAuthzHandler(&Options.Auth, ocmClient, log.WithField("pkg", "authz"), db)
-
-	notificationStream := getNotificationStream(log)
-	defer notificationStream.Close()
 
 	crdEventsHandler := createCRDEventsHandler()
 	eventsHandler := createEventsHandler(crdEventsHandler, db, authzHandler, notificationStream, log)

--- a/internal/usage/manager_test.go
+++ b/internal/usage/manager_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
+	commontesting "github.com/openshift/assisted-service/internal/common/testing"
 	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -26,11 +28,13 @@ var _ = Describe("Feature Usage", func() {
 		dbName    string
 		manager   *UsageManager
 		clusterID strfmt.UUID
+		ctrl      *gomock.Controller
 	)
 
 	var _ = BeforeSuite(func() {
+		ctrl = gomock.NewController(GinkgoT())
 		db, dbName = common.PrepareTestDB()
-		manager = NewManager(logrus.WithField("pkg", "usage"))
+		manager = NewManager(logrus.WithField("pkg", "usage"), commontesting.GetDummyNotificationStream(ctrl))
 		clusterID = strfmt.UUID(uuid.New().String())
 		cluster := common.Cluster{Cluster: models.Cluster{
 			ID: &clusterID,


### PR DESCRIPTION
In this PR we add notifications for:
* infraenv registration
* feature usage updates

Unfortunately we do not have centralized updates, so this could happen in other parts of the code as well.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
