### PR TITLE
MGMT-14395: Day-2 domain name resolution step shouldn't include release image domain

### DIFF
--- a/internal/host/hostcommands/domain_name_resolution_cmd.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd.go
@@ -67,15 +67,19 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	var domains []*models.DomainResolutionRequestDomain
 	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain, &wildcardDomain)
 
-	releaseHost, err := versions.GetReleaseImageHost(cluster, f.versionHandler)
-	if err != nil {
-		return "", err
-	}
-	if net.ParseIP(releaseHost) == nil {
-		releaseDomain := models.DomainResolutionRequestDomain{
-			DomainName: swag.String(releaseHost),
+	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
+		releaseHost, err := versions.GetReleaseImageHost(cluster, f.versionHandler)
+
+		if err != nil {
+			return "", err
 		}
-		domains = append(domains, &releaseDomain)
+
+		if net.ParseIP(releaseHost) == nil {
+			releaseDomain := models.DomainResolutionRequestDomain{
+				DomainName: swag.String(releaseHost),
+			}
+			domains = append(domains, &releaseDomain)
+		}
 	}
 
 	request := models.DomainResolutionRequest{


### PR DESCRIPTION
Solves [MGMT-14395](https://issues.redhat.com//browse/MGMT-14395)

# Change

Don't request domain resolution for the cluster release image domain on
day-2 clusters

# Why

Fixes a bug where day-2 hosts get stuck in insufficient due to error
creating DNS resolution step.

# Info

We can avoid requesting DNS resolution for this domain on day-2 cluster
hosts, because we don't run the DNS validation on the release image
domain on day-2 clusters anyway (see [1]).

This bug affects only some day-2 clusters that don't have the release
image set (imported clusters). See example failure here [2].

[1] https://github.com/openshift/assisted-service/blob/654a835dd1298a727a490ba1cfa33a96e7a468b0/internal/host/validator.go#L1527

[2] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-day2-single-node-periodic/1648884250834898944

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md