### PR TITLE
MGMT-14396: Get correct path for binary from mirror

### DIFF
--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -100,7 +100,7 @@ func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 	return &Release{link}, nil
 }
 
-//	Walk through the cacheDir and list the files recursively.
+// Walk through the cacheDir and list the files recursively.
 // If the total volume of the files reaches the capacity, delete
 // the oldest ones.
 //

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -71,7 +71,11 @@ func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 	var workdir, binary, path string
 	var err error
 
-	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseID, i.cacheDir, platformType)
+	releaseImageLocation := releaseID
+	if releaseIDMirror != "" {
+		releaseImageLocation = releaseIDMirror
+	}
+	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir, platformType)
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		//evict older files if necessary
 		i.evict()

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -115,6 +115,46 @@ var _ = Describe("installer cache", func() {
 		Expect(os.IsNotExist(err)).To(BeFalse())
 
 	})
+
+	It("extracts from the mirror", func() {
+		releaseID := "4.10-orig"
+		releaseMirrorID := "4.10-mirror"
+		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
+		fname := filepath.Join(workdir, releaseID)
+
+		mockRelease.EXPECT().GetReleaseBinaryPath(
+			releaseMirrorID, gomock.Any(), gomock.Any()).
+			Return(workdir, releaseID, fname)
+		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
+			gomock.Any(), cacheDir, gomock.Any(),
+			gomock.Any(), gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType, icspFile string) (string, error) {
+				err := os.WriteFile(fname, []byte("abcde"), 0600)
+				return "", err
+			})
+		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, models.PlatformTypeBaremetal, "icsp")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("extracts without a mirror", func() {
+		releaseID := "4.10-orig"
+		releaseMirrorID := ""
+		workdir := filepath.Join(cacheDir, "quay.io", "release-dev")
+		fname := filepath.Join(workdir, releaseID)
+
+		mockRelease.EXPECT().GetReleaseBinaryPath(
+			releaseID, gomock.Any(), gomock.Any()).
+			Return(workdir, releaseID, fname)
+		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
+			gomock.Any(), cacheDir, gomock.Any(),
+			gomock.Any(), gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType, icspFile string) (string, error) {
+				err := os.WriteFile(fname, []byte("abcde"), 0600)
+				return "", err
+			})
+		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, models.PlatformTypeBaremetal, "icsp")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
 })
 
 func TestInstallerCache(t *testing.T) {


### PR DESCRIPTION
If a release image mirror is specified, the binary will get extracted to a location reflecting the mirror's pullspec, not the original release pullspec.

## List all the issues related to this PR

[MGMT-14396](https://issues.redhat.com/browse/MGMT-14396)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] Ephemeral installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
