### PR TITLE
MGMT-11424: added validations for ignition cert

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -1,6 +1,8 @@
 package validations
 
 import (
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/http"
@@ -172,4 +174,19 @@ func ValidateTags(tags string) error {
 func IsValidTag(tag string) bool {
 	tagRegex := `^\w+( \w+)*$` // word characters and whitespace
 	return regexp.MustCompile(tagRegex).MatchString(tag)
+}
+
+// ValidateCaCertificate ensures the specified base64 CA certificate
+// is valid by trying to decode and parse it.
+func ValidateCaCertificate(certificate string) error {
+	decodedCaCert, err := base64.StdEncoding.DecodeString(certificate)
+	if err != nil {
+		return errors.Wrap(err, "failed to decode certificate")
+	}
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(decodedCaCert); !ok {
+		return errors.Errorf("unable to parse certificate")
+	}
+
+	return nil
 }


### PR DESCRIPTION
On create/update cluster, a CA certificate can be specified in the ignition endpoint.
Added validations to ensure the validity of the certificate. I.e. it should be encoded to base64 and parsable.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
