### PR TITLE
MGMT-14315: Allow to install P and Z architectures with Single Node Openshift on 4.13

### DIFF
--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -10,19 +10,19 @@ import (
 )
 
 var featuresList = map[models.FeatureSupportLevelID]SupportLevelFeature{
-	models.FeatureSupportLevelIDSNO:                      &SnoFeature{},
-	models.FeatureSupportLevelIDVIPAUTOALLOC:             &VipAutoAllocFeature{},
-	models.FeatureSupportLevelIDCUSTOMMANIFEST:           &CustomManifestFeature{},
-	models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING: &ClusterManagedNetworkingFeature{},
-	models.FeatureSupportLevelIDUSERMANAGEDNETWORKING:    &UserManagedNetworkingFeature{},
-	models.FeatureSupportLevelIDSINGLENODEEXPANSION:      &SingleNodeExpansionFeature{},
-	models.FeatureSupportLevelIDDUALSTACKVIPS:            &DualStackVipsFeature{},
-	models.FeatureSupportLevelIDLVM:                      &LvmFeature{},
-	models.FeatureSupportLevelIDNUTANIXINTEGRATION:       &NutanixIntegrationFeature{},
-	models.FeatureSupportLevelIDVSPHEREINTEGRATION:       &VsphereIntegrationFeature{},
-	models.FeatureSupportLevelIDCNV:                      &CnvFeature{},
-	models.FeatureSupportLevelIDODF:                      &OdfFeature{},
-	models.FeatureSupportLevelIDMINIMALISO:               &MinimalIso{},
+	models.FeatureSupportLevelIDSNO:                      (&SnoFeature{}).New(),
+	models.FeatureSupportLevelIDVIPAUTOALLOC:             (&VipAutoAllocFeature{}).New(),
+	models.FeatureSupportLevelIDCUSTOMMANIFEST:           (&CustomManifestFeature{}).New(),
+	models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING: (&ClusterManagedNetworkingFeature{}).New(),
+	models.FeatureSupportLevelIDUSERMANAGEDNETWORKING:    (&UserManagedNetworkingFeature{}).New(),
+	models.FeatureSupportLevelIDSINGLENODEEXPANSION:      (&SingleNodeExpansionFeature{}).New(),
+	models.FeatureSupportLevelIDDUALSTACKVIPS:            (&DualStackVipsFeature{}).New(),
+	models.FeatureSupportLevelIDLVM:                      (&LvmFeature{}).New(),
+	models.FeatureSupportLevelIDNUTANIXINTEGRATION:       (&NutanixIntegrationFeature{}).New(),
+	models.FeatureSupportLevelIDVSPHEREINTEGRATION:       (&VsphereIntegrationFeature{}).New(),
+	models.FeatureSupportLevelIDCNV:                      (&CnvFeature{}).New(),
+	models.FeatureSupportLevelIDODF:                      (&OdfFeature{}).New(),
+	models.FeatureSupportLevelIDMINIMALISO:               (&MinimalIso{}).New(),
 }
 
 func getFeatureSupportList(features map[models.FeatureSupportLevelID]SupportLevelFeature, filters SupportLevelFilters) models.SupportLevels {

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -172,8 +172,11 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
-			featuresList := GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitecturePpc64le))
+			featuresList := GetFeatureSupportList("4.12", swag.String(models.ClusterCPUArchitecturePpc64le))
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelUnavailable))
+
+			featuresList = GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitecturePpc64le))
+			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelDevPreview))
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
@@ -239,10 +242,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(ContainSubstring("cannot use Minimal ISO because it's not compatible with the s390x architecture on version 4.13 of OpenShift"))
 		})
-		It("SNO feature is activated with incompatible architecture ppc64le", func() {
-			expectedError := "cannot use Single Node OpenShift because it's not compatible with the ppc64le architecture on version 4.13 of OpenShift"
+		It("SNO feature is activated with incompatible architecture ppc64le on 4.12", func() {
+			expectedError := "cannot use Single Node OpenShift because it's not compatible with the ppc64le architecture on version 4.12 of OpenShift"
 			cluster := common.Cluster{Cluster: models.Cluster{
-				OpenshiftVersion:      "4.13",
+				OpenshiftVersion:      "4.12",
 				CPUArchitecture:       models.ClusterCPUArchitecturePpc64le,
 				HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeNone),
 				UserManagedNetworking: swag.Bool(true),
@@ -250,8 +253,28 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			}}
 			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitecturePpc64le, &cluster, nil, nil).Error()).To(Equal(expectedError))
 		})
-		It("SNO feature is activated with incompatible architecture s390x", func() {
-			expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.13 of OpenShift"
+		It("SNO feature is compatible on ppc64le architecture at 4.13", func() {
+			cluster := common.Cluster{Cluster: models.Cluster{
+				OpenshiftVersion:      "4.13",
+				CPUArchitecture:       models.ClusterCPUArchitecturePpc64le,
+				HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeNone),
+				UserManagedNetworking: swag.Bool(true),
+				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+			}}
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitecturePpc64le, &cluster, nil, nil)).To(BeNil())
+		})
+		It("SNO feature is activated with incompatible architecture s390x on 4.12", func() {
+			expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.12 of OpenShift"
+			cluster := common.Cluster{Cluster: models.Cluster{
+				OpenshiftVersion:      "4.12",
+				CPUArchitecture:       models.ClusterCPUArchitectureS390x,
+				HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeNone),
+				UserManagedNetworking: swag.Bool(true),
+				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+			}}
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureS390x, &cluster, nil, nil).Error()).To(Equal(expectedError))
+		})
+		It("SNO feature is activated with compatible architecture s390x on 4.13", func() {
 			cluster := common.Cluster{Cluster: models.Cluster{
 				OpenshiftVersion:      "4.13",
 				CPUArchitecture:       models.ClusterCPUArchitectureS390x,
@@ -259,7 +282,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				UserManagedNetworking: swag.Bool(true),
 				Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 			}}
-			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureS390x, &cluster, nil, nil).Error()).To(Equal(expectedError))
+			Expect(ValidateIncompatibleFeatures(log, models.ClusterCPUArchitectureS390x, &cluster, nil, nil)).To(BeNil())
 		})
 		It("Nutanix feature is activated with incompatible architecture", func() {
 			expectedError := "cannot use arm64 architecture because it's not compatible on version 4.8 of OpenShift"

--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -197,9 +197,16 @@ var _ = Describe("Feature support levels API", func() {
 				err2 := err.(*installer.V2RegisterClusterBadRequest)
 				ExpectWithOffset(1, *err2.Payload.Reason).To(ContainSubstring(expectedError))
 			})
-			It("SNO with s390x fails on SNO isn't compatible with architecture - failure", func() {
-				expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.13"
-				_, err := registerNewCluster("4.13", "s390x", models.ClusterHighAvailabilityModeNone, swag.Bool(true))
+			It("SNO with s390x fails on SNO isn't compatible with architecture success on 4.13", func() {
+				cluster, err := registerNewCluster("4.13", "s390x", models.ClusterHighAvailabilityModeNone, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cluster.Payload.CPUArchitecture).To(Equal("multi"))
+				Expect(swag.StringValue(cluster.Payload.HighAvailabilityMode)).To(Equal(models.ClusterHighAvailabilityModeNone))
+
+			})
+			It("SNO with s390x fails on SNO isn't compatible with architecture on 4.12 - failure", func() {
+				expectedError := "cannot use Single Node OpenShift because it's not compatible with the s390x architecture on version 4.12"
+				_, err := registerNewCluster("4.12", "s390x", models.ClusterHighAvailabilityModeNone, swag.Bool(true))
 				Expect(err).To(HaveOccurred())
 				err2 := err.(*installer.V2RegisterClusterBadRequest)
 				ExpectWithOffset(1, *err2.Payload.Reason).To(ContainSubstring(expectedError))


### PR DESCRIPTION
Updating that SNO is dev preview on OCP 4.13 with P or Z architecture.
Also changing the way we initialize `SupportLevelFeature` - now allowing to link between 2 opposite (`CMN` or `UMN`) or related (`SNO` and `SingleNodeExpention`) features 

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eliorerz 
