### PR TITLE
MGMT-14449: change creation time for hosts to one minute ago instead of now

### DIFF
--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -85,7 +85,8 @@ func GenerateTestHostAddedToCluster(hostID, infraEnvID, clusterID strfmt.UUID, s
 }
 
 func GenerateTestHostByKind(hostID, infraEnvID strfmt.UUID, clusterID *strfmt.UUID, state, kind string, role models.HostRole) models.Host {
-	now := strfmt.DateTime(time.Now())
+	aMinuteAgoTime := time.Now().Add(-time.Minute)
+	aMinuteAgo := strfmt.DateTime(aMinuteAgoTime)
 	return models.Host{
 		ID:              &hostID,
 		InfraEnvID:      infraEnvID,
@@ -95,22 +96,23 @@ func GenerateTestHostByKind(hostID, infraEnvID strfmt.UUID, clusterID *strfmt.UU
 		Role:            role,
 		SuggestedRole:   role,
 		Kind:            swag.String(kind),
-		CheckedInAt:     now,
-		RegisteredAt:    now,
-		StatusUpdatedAt: now,
+		CheckedInAt:     aMinuteAgo,
+		RegisteredAt:    aMinuteAgo,
+		StatusUpdatedAt: aMinuteAgo,
 		Progress: &models.HostProgressInfo{
-			StageStartedAt: now,
-			StageUpdatedAt: now,
+			StageStartedAt: aMinuteAgo,
+			StageUpdatedAt: aMinuteAgo,
 		},
 		APIVipConnectivity:    GenerateTestAPIConnectivityResponseSuccessString(""),
 		Connectivity:          GenerateTestConnectivityReport(),
 		DiscoveryAgentVersion: defaultAgentImage,
-		Timestamp:             time.Now().Unix(),
+		Timestamp:             aMinuteAgoTime.Unix(),
 	}
 }
 
 func GenerateTestHostWithInfraEnv(hostID, infraEnvID strfmt.UUID, state string, role models.HostRole) models.Host {
-	now := strfmt.DateTime(time.Now())
+	aMinuteAgoTime := time.Now().Add(-time.Minute)
+	aMinuteAgo := strfmt.DateTime(aMinuteAgoTime)
 	return models.Host{
 		ID:                    &hostID,
 		InfraEnvID:            infraEnvID,
@@ -118,18 +120,19 @@ func GenerateTestHostWithInfraEnv(hostID, infraEnvID strfmt.UUID, state string, 
 		Inventory:             common.GenerateTestDefaultInventory(),
 		Role:                  role,
 		Kind:                  swag.String(models.HostKindHost),
-		CheckedInAt:           now,
-		RegisteredAt:          now,
-		StatusUpdatedAt:       now,
+		CheckedInAt:           aMinuteAgo,
+		RegisteredAt:          aMinuteAgo,
+		StatusUpdatedAt:       aMinuteAgo,
 		APIVipConnectivity:    GenerateTestAPIConnectivityResponseSuccessString(""),
 		Connectivity:          GenerateTestConnectivityReport(),
 		DiscoveryAgentVersion: defaultAgentImage,
-		Timestamp:             time.Now().Unix(),
+		Timestamp:             aMinuteAgoTime.Unix(),
 	}
 }
 
 func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUID, role models.HostRole, status string, netAddr common.NetAddress) *models.Host {
-	now := strfmt.DateTime(time.Now())
+	aMinuteAgoTime := time.Now().Add(-time.Minute)
+	aMinuteAgo := strfmt.DateTime(aMinuteAgoTime)
 	h := models.Host{
 		ID:                &hostID,
 		RequestedHostname: netAddr.Hostname,
@@ -139,16 +142,16 @@ func GenerateTestHostWithNetworkAddress(hostID, infraEnvID, clusterID strfmt.UUI
 		Inventory:         common.GenerateTestInventoryWithNetwork(netAddr),
 		Role:              role,
 		Kind:              swag.String(models.HostKindHost),
-		CheckedInAt:       now,
-		RegisteredAt:      now,
-		StatusUpdatedAt:   now,
+		CheckedInAt:       aMinuteAgo,
+		RegisteredAt:      aMinuteAgo,
+		StatusUpdatedAt:   aMinuteAgo,
 		Progress: &models.HostProgressInfo{
-			StageStartedAt: now,
-			StageUpdatedAt: now,
+			StageStartedAt: aMinuteAgo,
+			StageUpdatedAt: aMinuteAgo,
 		},
 		APIVipConnectivity:    GenerateTestAPIConnectivityResponseSuccessString(""),
 		DiscoveryAgentVersion: defaultAgentImage,
-		Timestamp:             time.Now().Unix(),
+		Timestamp:             aMinuteAgoTime.Unix(),
 	}
 	return &h
 }


### PR DESCRIPTION
This PR aims to reduce race conditions in tests by creating hosts in the past.

For instance, if we check updated at timestamp to be updated and the host got updated too fast, it would seem unchanged.

This change should fix this case.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
