### PR TITLE
MGMT-14237: Remove all spoke resources when deleting the node

### DIFF
--- a/api/v1beta1/agent_types.go
+++ b/api/v1beta1/agent_types.go
@@ -89,6 +89,9 @@ const (
 	UnbindingMsg                     string                     = "The agent is currently unbinding from a cluster deployment"
 	UnbindingPendingUserActionReason string                     = "UnbindingPendingUserAction"
 	UnbindingPendingUserActionMsg    string                     = "The agent is currently unbinding; Pending host reboot from infraenv image"
+
+	CleanupCondition    conditionsv1.ConditionType = "Cleanup"
+	CleanupFailedReason string                     = "CleanupFailed"
 )
 
 type HostMemory struct {

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agent_types.go
@@ -89,6 +89,9 @@ const (
 	UnbindingMsg                     string                     = "The agent is currently unbinding from a cluster deployment"
 	UnbindingPendingUserActionReason string                     = "UnbindingPendingUserAction"
 	UnbindingPendingUserActionMsg    string                     = "The agent is currently unbinding; Pending host reboot from infraenv image"
+
+	CleanupCondition    conditionsv1.ConditionType = "Cleanup"
+	CleanupFailedReason string                     = "CleanupFailed"
 )
 
 type HostMemory struct {


### PR DESCRIPTION
This commit deletes the spoke machine and BMH when removing the node if
the entire cluster is not being removed (indicated by the existence of the cluster deployment).

Removing the machine will allow the same host to be cleanly added back as a node in the future.

The machine and BMH are removed directly and separately if the machine is not part of a machine set.
If the machine is part of a set the machine is annotated to indicate it is the one which should be removed and the machineset is configured for autoscaling. Once this is done the BMH is removed. This triggers the machine set to scale down, removing the previously annotated machine.

Due to OCPBUGS-7581 the BMH will likely not be removed cleanly so we also remove the finalizers before attempting the delete.

In the case of a none-platform cluster we won't find the machine and will delete the node directly.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-14237

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed


1.  Deployed a 5 node spoke
2. Removed the worker nodes one at a time by deleting the hub BMH
3. Observed that the machineset was scaled correctly and the machines and BMHs were removed.
4. Added the workers back as day-2 nodes
5. Removed a single worker
6. Observed that the machine, bmh and node were removed successfully
7. Deleted all remaining BMHs in the hub
8. Observed that hosts were all deprovisioned successfully and agents were removed from the hub

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
