### PR TITLE
MGMT-14509 return 404 if cluster not found when host try to register

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5227,7 +5227,7 @@ func (b *bareMetalInventory) V2RegisterHost(ctx context.Context, params installe
 	cluster, err = b.getBoundClusterForUpdate(tx, infraEnv, params.InfraEnvID, *params.NewHostParams.HostID)
 	if err != nil {
 		log.WithError(err).Errorf("Bound Cluster get")
-		return common.NewApiError(http.StatusInternalServerError, err)
+		return common.GenerateErrorResponder(err)
 	}
 
 	_, err = common.GetHostFromDB(transaction.AddForUpdateQueryOption(tx), params.InfraEnvID.String(), params.NewHostParams.HostID.String())

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -508,6 +508,22 @@ var _ = Describe("RegisterHost", func() {
 		Expect(apiErr.StatusCode()).Should(Equal(int32(http.StatusNotFound)))
 	})
 
+	It("register host with non-existing cluster", func() {
+		clusterID := strfmt.UUID(uuid.New().String())
+		infraEnv := createInfraEnv(db, clusterID, clusterID)
+
+		reply := bm.V2RegisterHost(ctx, installer.V2RegisterHostParams{
+			InfraEnvID: *infraEnv.ID,
+			NewHostParams: &models.HostCreateParams{
+				DiscoveryAgentVersion: "v1",
+				HostID:                &hostID,
+			},
+		})
+		apiErr, ok := reply.(*common.ApiErrorResponse)
+		Expect(ok).Should(BeTrue())
+		Expect(apiErr.StatusCode()).Should(Equal(int32(http.StatusNotFound)))
+	})
+
 	It("register host to a cluster while installation is in progress", func() {
 		By("creating the cluster")
 		cluster := createCluster(db, models.ClusterStatusInstalling)


### PR DESCRIPTION
When host try to register if the clsuter is not exist the service should return 404, if it return 500 the host will continue to try and register again and again, it will csae the api rate to spike.

The root cause is not clear yet, meaning that we don't understand why infra-env still exist when cluster was deleted, it can probably happen if there is a bug in delete logic.

Eventailly the infra-env sohuld be deleted by GC bug we would like to avoid api skipes

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] Unit tests

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
