### PR TITLE
MGMT-14510: Remove the validation for infraenv and preprov image CPU arch

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -448,16 +448,6 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(res).To(Equal(ctrl.Result{}))
 		})
 
-		It("sets a failure condition when the infraEnv arch doesn't match the preprovisioningimage", func() {
-			infraEnv.Spec.CpuArchitecture = "aarch64"
-			Expect(c.Create(ctx, infraEnv)).To(BeNil())
-
-			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
-			Expect(err).To(BeNil())
-			Expect(res).To(Equal(ctrl.Result{}))
-			checkImageConditionFailed(c, ppi, archMismatchReason, "does not match InfraEnv CPU architecture")
-		})
-
 		It("doesn't fail when the infraEnv image has not been created yet", func() {
 			infraEnv.Status = aiv1beta1.InfraEnvStatus{}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())


### PR DESCRIPTION
The intention of this validation was to ensure that a user didn't try to boot a machine with an incompatible image, but it turns out that BMO just always sets this architecture field to x86_64 which is blocking installs on any other architecture.

Removing the validation will allow these installs to proceed.

Reverts:
https://github.com/openshift/assisted-service/pull/4520
https://issues.redhat.com/browse/MGMT-10819

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-14510

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Will provide an image built form this branch to QE for validation

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
