### PR TITLE
OCPBUGS-13081: Support by-path root device hints

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -623,9 +623,13 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 
 	// Add storage
 	for _, d := range inventory.Disks {
+		device := d.Path
+		if d.ByPath != "" {
+			device = d.ByPath
+		}
 		// missing WWNVendorExtension, WWNWithExtension
 		disk := bmh_v1alpha1.Storage{
-			Name:         d.Path,
+			Name:         device,
 			HCTL:         d.Hctl,
 			Model:        d.Model,
 			SizeBytes:    bmh_v1alpha1.Capacity(d.SizeBytes),

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -467,6 +467,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "1",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sda",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 						SizeBytes:               int64(120) * 1000 * 1000 * 1000,
@@ -475,6 +476,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "2",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sdb",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:1:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 					},
@@ -708,6 +710,23 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedAgent.Spec.InstallationDiskID).To(Equal("1"))
 			})
 
+			It("should set the InstallationDiskID if the by-path RootDeviceHints were provided and match", func() {
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				updatedHost.Spec.RootDeviceHints.DeviceName = "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0"
+				updatedHost.Spec.RootDeviceHints.MinSizeGigabytes = 110
+				Expect(c.Update(ctx, updatedHost)).To(BeNil())
+
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				updatedAgent := &v1beta1.Agent{}
+				err = c.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, updatedAgent)
+				Expect(err).To(BeNil())
+				Expect(updatedAgent.Spec.InstallationDiskID).To(Equal("1"))
+			})
 			It("should not touch InstallationDiskID if the RootDeviceHints were not provided", func() {
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
 				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -190,7 +190,7 @@ func GetAcceptableDisksWithHints(disks []*models.Disk, hints *bmh_v1alpha1.RootD
 		}
 
 		if hints != nil {
-			if hints.DeviceName != "" && hints.DeviceName != disk.Path {
+			if hints.DeviceName != "" && hints.DeviceName != disk.Path && hints.DeviceName != disk.ByPath {
 				continue
 			}
 

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -939,8 +939,12 @@ func (g *installerGenerator) modifyBMHFile(file *config_latest_types.File, bmh *
 		}
 	}
 	for i, disk := range inventory.Disks {
+		device := disk.Path
+		if disk.ByPath != "" {
+			device = disk.ByPath
+		}
 		hw.Storage[i] = bmh_v1alpha1.Storage{
-			Name:         disk.Path,
+			Name:         device,
 			Vendor:       disk.Vendor,
 			SizeBytes:    bmh_v1alpha1.Capacity(disk.SizeBytes),
 			Model:        disk.Model,


### PR DESCRIPTION
In many cases, the /dev/disk/by-path symlink is the only way to stably identify a disk without having prior knowledge of the hardware from some external source (e.g. a spreadsheet of disk serial numbers). It should be possible to specify this path in the root device hints.

Metal³ is also changing to allow this, and both uses of the Metal³ root device hints (i.e. in the baremetal-operator and in assisted-service) should behave consistently.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [x] Ephemeral installer
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
