### PR TITLE
Podman README-disconnected requires 4.2 and not 3.3

### DIFF
--- a/deploy/podman/README-disconnected.md
+++ b/deploy/podman/README-disconnected.md
@@ -8,7 +8,7 @@ These instructions detail how to deploy the assisted installer service in a disc
 * A container registry to mirror an OpenShift release
 * A web server to hold the Red Hat CoreOS (RHCOS) boot ISO
 
-Make sure you have [podman](https://podman.io) version 3.3+ installed. If you must use an older version of podman, reference the [previous documentation and procedure](https://github.com/openshift/assisted-service/tree/v2.0.11#deploy-without-a-kubernetes-cluster) to avoid a [podman bug](https://github.com/containers/podman/issues/9609).
+Make sure you have [podman](https://podman.io) version 4.2+ installed. If you must use an older version of podman, reference the [previous documentation and procedure](https://github.com/openshift/assisted-service/tree/v2.0.11#deploy-without-a-kubernetes-cluster) to avoid a [podman bug](https://github.com/containers/podman/issues/9609).
 
 If you do not have a web server to host the ISO and a container registry available you can co-locate all these services on the same host that you run the Assisted Installer from. This host will be referred to as the "assisted installer host" in the rest of the document.
 


### PR DESCRIPTION
The previous versions seems to have been a mistake.

4.2 is required for configmap volume sources

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md