### PR TITLE
MGMT-14530: Changing event message filtering to escape wildcards and not be case sensetive

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -272,7 +272,7 @@ func filterEvents(tx *gorm.DB, clusterID *strfmt.UUID, hostIds []strfmt.UUID, in
 
 		// filter by event message
 		if message != nil {
-			tx = tx.Where("events.message LIKE ?", fmt.Sprintf("%%%s%%", *message))
+			tx = tx.Where("LOWER(events.message) LIKE ?", fmt.Sprintf("%%%s%%", strings.ToLower(escapePlaceHolders(*message))))
 		}
 
 		tx = tx.Where(buildDisjunctiveQuery(cleanQuery, hostIds, deletedHosts, clusterLevel))
@@ -416,6 +416,12 @@ func isDescending(order *string) (*bool, error) {
 		return swag.Bool(true), nil
 	}
 	return nil, errors.New("incompatible order parameter")
+}
+
+func escapePlaceHolders(message string) string {
+	escapedPercent := strings.ReplaceAll(message, "%", "\\%")
+	return strings.ReplaceAll(escapedPercent, "_", "\\_")
+
 }
 
 func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParams) ([]*common.Event, *common.EventSeverityCount, *int64, error) {


### PR DESCRIPTION
To obtain accurate results in `SQL`, we need to escape the letters `%` and `_ `as they are considered wildcards. Also, we aim to retrieve messages that correspond to events regardless of the letter case.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
