### PR TITLE
MGMT-13977: Disallow single character base domain

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -49,7 +49,7 @@ func ValidateDomainNameFormat(dnsDomainName string) (int32, error) {
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "Single DNS base domain validation for %s", dnsDomainName)
 	}
-	if matched {
+	if matched && len(dnsDomainName) > 1 {
 		return 0, nil
 	}
 	matched, err = regexp.MatchString(dnsNameRegex, dnsDomainName)

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -190,7 +190,7 @@ var _ = Describe("dns name", func() {
 		},
 		{
 			domainName: "a",
-			valid:      true,
+			valid:      false,
 		},
 		{
 			domainName: "co",
@@ -215,6 +215,14 @@ var _ = Describe("dns name", func() {
 		{
 			domainName: "a-aa.com",
 			valid:      true,
+		},
+		{
+			domainName: "a.c",
+			valid:      false,
+		},
+		{
+			domainName: "aaa.c",
+			valid:      false,
 		},
 	}
 	for _, t := range tests {


### PR DESCRIPTION
[MGMT-13977](https://issues.redhat.com/browse/MGMT-13977)
Previously, the service allowed base domains
with a single character, which is not valid.

A top-level domain (TLD) aka base domain
must have at least two characters. This change
ensures that the base domain for a cluster has
at least two characters and fits the standards
for DNS:
https://datatracker.ietf.org/doc/html/rfc1123#page-13 
https://datatracker.ietf.org/doc/html/rfc952

Slack thread discussion for reference: https://redhat-internal.slack.com/archives/C68TNFWA2/p1681860903326989
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed
Using test-infra environment: deployed three different clusters with three different base domains and ensured the domains that had one character for their base domain did not pass the validation:
```bash
$ export IPv4=true; export NUM_MASTERS=1; export ENABLE_KUBE_API=true
$ export TEST_TEARDOWN=no; export TEST=./src/tests/test_kube_api.py ; export TEST_FUNC=test_kubeapi

$ skipper make -i BASE_DOMAIN=redhat.co _test
$ skipper make -i BASE_DOMAIN=redhat.c _test
$ skipper make -i BASE_DOMAIN=c _test
```

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
