### PR TITLE
MGMT-14526: Possible issue with validateNoWildcardDNS resolution validation

### DIFF
--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -124,7 +124,8 @@ var TestImageStatusesFailure = &models.ContainerImageAvailability{
 var DomainAPI = "api.test-cluster.example.com"
 var DomainAPIInternal = "api-int.test-cluster.example.com"
 var DomainApps = fmt.Sprintf("%s.apps.test-cluster.example.com", constants.AppsSubDomainNameHostDNSValidation)
-var WildcardDomain = fmt.Sprintf("%s.test-cluster.example.com", constants.DNSWildcardFalseDomainName)
+var UndottedWildcardDomain = fmt.Sprintf("%s.test-cluster.example.com", constants.DNSWildcardFalseDomainName)
+var WildcardDomain = UndottedWildcardDomain + "."
 var ReleaseDomain = "quay.io"
 
 var DomainResolutions = []*models.DomainResolutionResponseDomain{
@@ -153,11 +154,34 @@ var DomainResolutions = []*models.DomainResolutionResponseDomain{
 		IPV4Addresses: []strfmt.IPv4{},
 		IPV6Addresses: []strfmt.IPv6{},
 	},
+	{
+		DomainName:    &UndottedWildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{},
+		IPV6Addresses: []strfmt.IPv6{},
+	},
 }
 
 var WildcardResolved = []*models.DomainResolutionResponseDomain{
 	{
 		DomainName:    &WildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
+		IPV6Addresses: []strfmt.IPv6{"1003:db8::40/120"},
+	},
+	{
+		DomainName:    &UndottedWildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
+		IPV6Addresses: []strfmt.IPv6{"1003:db8::40/120"},
+	},
+}
+
+var SubDomainWildcardResolved = []*models.DomainResolutionResponseDomain{
+	{
+		DomainName:    &WildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{},
+		IPV6Addresses: []strfmt.IPv6{},
+	},
+	{
+		DomainName:    &UndottedWildcardDomain,
 		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
 		IPV6Addresses: []strfmt.IPv6{"1003:db8::40/120"},
 	},
@@ -171,6 +195,11 @@ var DomainResolutionNoAPI = []*models.DomainResolutionResponseDomain{
 	},
 	{
 		DomainName:    &WildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{},
+		IPV6Addresses: []strfmt.IPv6{},
+	},
+	{
+		DomainName:    &UndottedWildcardDomain,
 		IPV4Addresses: []strfmt.IPv4{},
 		IPV6Addresses: []strfmt.IPv6{},
 	},
@@ -202,12 +231,18 @@ var DomainResolutionAllEmpty = []*models.DomainResolutionResponseDomain{
 		IPV4Addresses: []strfmt.IPv4{},
 		IPV6Addresses: []strfmt.IPv6{},
 	},
+	{
+		DomainName:    &UndottedWildcardDomain,
+		IPV4Addresses: []strfmt.IPv4{},
+		IPV6Addresses: []strfmt.IPv6{},
+	},
 }
 
 var TestDomainNameResolutionsSuccess = &models.DomainResolutionResponse{Resolutions: DomainResolutions}
 var TestDomainResolutionsNoAPI = &models.DomainResolutionResponse{Resolutions: DomainResolutionNoAPI}
 var TestDomainResolutionsAllEmpty = &models.DomainResolutionResponse{Resolutions: DomainResolutionAllEmpty}
 var TestDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: WildcardResolved}
+var TestSubDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: SubDomainWildcardResolved}
 
 var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "1.2.3.10", Destination: "0.0.0.0", Metric: 600}}
 
@@ -415,14 +450,21 @@ func GenerateTestDefaultVmwareInventory() string {
 
 func CreateWildcardDomainNameResolutionReply(name string, baseDomain string) *models.DomainResolutionResponse {
 
-	domain := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, name, baseDomain)
+	undottedDomain := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, name, baseDomain)
+	domain := undottedDomain + "."
 
 	var domainNameWildcardConfig = []*models.DomainResolutionResponseDomain{
+		{
+			DomainName:    &undottedDomain,
+			IPV4Addresses: []strfmt.IPv4{},
+			IPV6Addresses: []strfmt.IPv6{},
+		},
 		{
 			DomainName:    &domain,
 			IPV4Addresses: []strfmt.IPv4{},
 			IPV6Addresses: []strfmt.IPv6{},
-		}}
+		},
+	}
 
 	var testDomainNameResolutionWildcard = &models.DomainResolutionResponse{
 		Resolutions: domainNameWildcardConfig}

--- a/internal/host/hostcommands/domain_name_resolution_cmd.go
+++ b/internal/host/hostcommands/domain_name_resolution_cmd.go
@@ -49,7 +49,8 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	apiDomainName := fmt.Sprintf("api.%s.%s", clusterName, baseDNSDomain)
 	apiInternalDomainName := fmt.Sprintf("api-int.%s.%s", clusterName, baseDNSDomain)
 	appsDomainName := fmt.Sprintf("%s.apps.%s.%s", constants.AppsSubDomainNameHostDNSValidation, clusterName, baseDNSDomain)
-	wildcardDomainName := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
+	wildcardDomainNameWithDot := fmt.Sprintf("%s.%s.%s.", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
+	wildcardDomainNameNoDot := fmt.Sprintf("%s.%s.%s", constants.DNSWildcardFalseDomainName, clusterName, baseDNSDomain)
 
 	apiDomain := models.DomainResolutionRequestDomain{
 		DomainName: &apiDomainName,
@@ -60,12 +61,16 @@ func (f *domainNameResolutionCmd) prepareParam(host *models.Host, cluster *commo
 	appsDomain := models.DomainResolutionRequestDomain{
 		DomainName: &appsDomainName,
 	}
-	wildcardDomain := models.DomainResolutionRequestDomain{
-		DomainName: &wildcardDomainName,
+	wildcardDomainWithDot := models.DomainResolutionRequestDomain{
+		DomainName: &wildcardDomainNameWithDot,
+	}
+
+	wildcardDomainNoDot := models.DomainResolutionRequestDomain{
+		DomainName: &wildcardDomainNameNoDot,
 	}
 
 	var domains []*models.DomainResolutionRequestDomain
-	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain, &wildcardDomain)
+	domains = append(domains, &apiDomain, &apiInternalDomain, &appsDomain, &wildcardDomainWithDot, &wildcardDomainNoDot)
 
 	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {
 		releaseHost, err := versions.GetReleaseImageHost(cluster, f.versionHandler)

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -433,6 +433,7 @@ var _ = Describe("Validations test", func() {
 			successMessage := "DNS wildcard check was successful"
 			successMessageDay2 := "DNS wildcard check is not required for day2"
 			failureMessage := "DNS wildcard configuration was detected for domain *.test-cluster.example.com - the installation will not be able to complete while this record exists. Please remove it to proceed. The domain resolves to addresses 7.8.9.10/24, 1003:db8::40/120"
+			subDomainFailureMessage := "Unexpected domain name resolution was detected for the relative domain name with the sub-domain *.test-cluster.example.com despite the fact that no resolution exists for a Fully Qualified Domain Name (FQDN) with same sub-domain. This is usually a sign of DHCP-provided domain-search configuration. The installation will not be able to complete with this configuration in place. Please remove it to proceed. The relative domain name resolves to addresses 7.8.9.10/24, 1003:db8::40/120"
 			errorMessage := "Error while parsing DNS resolution response"
 			pendingMessage := "DNS wildcard check cannot be performed yet because the host has not yet performed DNS resolution"
 
@@ -442,6 +443,7 @@ var _ = Describe("Validations test", func() {
 			var DNSResponseStateCorruptResponse DNSResponseState = "corrupt-response"
 			var DNSResponseStateDidntResolveIllegalWildcard DNSResponseState = "didnt-resolve-illegal-wildcard"
 			var DNSResponseStateResolvedIllegalWildcard DNSResponseState = "resolved-illegal-wildcard"
+			var DNSSubDomainResponseStateResolvedIllegalWildcard DNSResponseState = "sub-domain-resolved-illegal-wildcard"
 
 			for _, dnsWildcardTestCase := range []struct {
 				// Inputs
@@ -470,6 +472,12 @@ var _ = Describe("Validations test", func() {
 
 					expectedValidationStatus: ValidationFailure,
 					expectedMessage:          failureMessage,
+				},
+				{
+					testCaseName:             "day 1 cluster - sub domain resolved wildcard",
+					dnsResponse:              DNSSubDomainResponseStateResolvedIllegalWildcard,
+					expectedValidationStatus: ValidationFailure,
+					expectedMessage:          subDomainFailureMessage,
 				},
 				{
 					testCaseName: "day 1 cluster - no resolutions",
@@ -554,6 +562,8 @@ var _ = Describe("Validations test", func() {
 						setHostDomainResolutions(testHost, common.TestDomainNameResolutionsSuccess)
 					case DNSResponseStateResolvedIllegalWildcard:
 						setHostDomainResolutions(testHost, common.TestDomainNameResolutionsWildcardResolved)
+					case DNSSubDomainResponseStateResolvedIllegalWildcard:
+						setHostDomainResolutions(testHost, common.TestSubDomainNameResolutionsWildcardResolved)
 					case DNSResponseStateCorruptResponse:
 						setHostCorruptDomainResolutions(testHost)
 					case DNSResponseStateNoResponse:

--- a/subsystem/utils_test.go
+++ b/subsystem/utils_test.go
@@ -546,6 +546,11 @@ func generateCommonDomainReply(ctx context.Context, h *models.Host, clusterName,
 			IPV4Addresses: []strfmt.IPv4{},
 			IPV6Addresses: []strfmt.IPv6{},
 		},
+		{
+			DomainName:    fqdn(constants.DNSWildcardFalseDomainName, clusterName, baseDomain+"."),
+			IPV4Addresses: []strfmt.IPv4{},
+			IPV6Addresses: []strfmt.IPv6{},
+		},
 	}
 	var domainResolutionResponse = models.DomainResolutionResponse{
 		Resolutions: domainResolutions,


### PR DESCRIPTION


There was a case that a user set up their DHCP to have domain-search entry for the *.apps.cluster-name.cluster-domain. suffix, our wildcard validation failed even though the user never set up a *.cluster-name.cluster-domain. wildcard (validation false positive)

The reason for the failure is that with search domain the actual resolution was to validateNoWildcardDNS.cluster-name.cluster-domain.apps.cluster-name.cluster-domain.

The solution to avoid it is to append a dot "." to the domain name to resolve.

Since such a problem might happen (OCP does not append dot), we need to verify that such case doesn't happen.  So the failure was recognized but with different error message in order not to confuse the end user.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
