### PR TITLE
OCPBUGS-13310 support setting CPUPartitioningMode with install config…

### DIFF
--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -601,6 +601,18 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(data.Compute[0].Hyperthreading).Should(Equal("Disabled"))
 	})
 
+	It("CPUPartitioningMode config overrides", func() {
+		var result installcfg.InstallerConfigBaremetal
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)
+		cluster.InstallConfigOverrides = `{"cpuPartitioningMode":"AllNodes"}`
+		data, err := installConfig.GetInstallConfig(&cluster, clusterInfraenvs, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		err = yaml.Unmarshal(data, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		// test that overrides worked
+		Expect(string(result.CPUPartitioning)).Should(Equal("AllNodes"))
+	})
+
 	Context("networking", func() {
 		It("Single network fields", func() {
 			var result installcfg.InstallerConfigBaremetal
@@ -783,7 +795,7 @@ var _ = Describe("Generate NoProxy", func() {
 	})
 })
 
-func TestSubsystem(t *testing.T) {
+func TestBuilder(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "installcfg tests")
 }

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -162,6 +162,13 @@ type Capabilities struct {
 	AdditionalEnabledCapabilities []ClusterVersionCapability  `yaml:"additionalEnabledCapabilities,omitempty"`
 }
 
+type CPUPartitioningMode string
+
+const (
+	CPUPartitioningNone     CPUPartitioningMode = "None"
+	CPUPartitioningAllNodes CPUPartitioningMode = "AllNodes"
+)
+
 type InstallerConfigBaremetal struct {
 	APIVersion string `yaml:"apiVersion"`
 	BaseDomain string `yaml:"baseDomain"`
@@ -188,6 +195,7 @@ type InstallerConfigBaremetal struct {
 	Platform              Platform             `yaml:"platform"`
 	BootstrapInPlace      BootstrapInPlace     `yaml:"bootstrapInPlace,omitempty"`
 	FIPS                  bool                 `yaml:"fips"`
+	CPUPartitioning       CPUPartitioningMode  `json:"cpuPartitioningMode,omitempty"`
 	PullSecret            string               `yaml:"pullSecret"`
 	SSHKey                string               `yaml:"sshKey"`
 	AdditionalTrustBundle string               `yaml:"additionalTrustBundle,omitempty"`


### PR DESCRIPTION
… overrides

A feature that is being intoduced in https://github.com/openshift/installer/commit/206c7b88af92fe19b48fa33372dd89ed4a9cf02d Required for ZTP installation

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [X] Cloud
- [X] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
