### PR TITLE
[release-4.13] OCPBUGS-13083: Support by-path root device hints

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -572,9 +572,13 @@ func (r *BMACReconciler) reconcileAgentInventory(log logrus.FieldLogger, bmh *bm
 
 	// Add storage
 	for _, d := range inventory.Disks {
+		device := d.Path
+		if d.ByPath != "" {
+			device = d.ByPath
+		}
 		// missing WWNVendorExtension, WWNWithExtension
 		disk := bmh_v1alpha1.Storage{
-			Name:         d.Path,
+			Name:         device,
 			HCTL:         d.Hctl,
 			Model:        d.Model,
 			SizeBytes:    bmh_v1alpha1.Capacity(d.SizeBytes),

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -436,6 +436,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "1",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sda",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 						SizeBytes:               int64(120) * 1000 * 1000 * 1000,
@@ -444,6 +445,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "2",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sdb",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:1:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 					},
@@ -677,6 +679,23 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedAgent.Spec.InstallationDiskID).To(Equal("1"))
 			})
 
+			It("should set the InstallationDiskID if the by-path RootDeviceHints were provided and match", func() {
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				updatedHost.Spec.RootDeviceHints.DeviceName = "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0"
+				updatedHost.Spec.RootDeviceHints.MinSizeGigabytes = 110
+				Expect(c.Update(ctx, updatedHost)).To(BeNil())
+
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				updatedAgent := &v1beta1.Agent{}
+				err = c.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, updatedAgent)
+				Expect(err).To(BeNil())
+				Expect(updatedAgent.Spec.InstallationDiskID).To(Equal("1"))
+			})
 			It("should not touch InstallationDiskID if the RootDeviceHints were not provided", func() {
 				updatedHost := &bmh_v1alpha1.BareMetalHost{}
 				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -190,7 +190,7 @@ func GetAcceptableDisksWithHints(disks []*models.Disk, hints *bmh_v1alpha1.RootD
 		}
 
 		if hints != nil {
-			if hints.DeviceName != "" && hints.DeviceName != disk.Path {
+			if hints.DeviceName != "" && hints.DeviceName != disk.Path && hints.DeviceName != disk.ByPath {
 				continue
 			}
 

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -956,7 +956,7 @@ func (g *installerGenerator) modifyBMHFile(file *config_latest_types.File, bmh *
 	}
 	for i, disk := range inventory.Disks {
 		hw.Storage[i] = bmh_v1alpha1.Storage{
-			Name:         disk.Name,
+			Name:         disk.Path,
 			Vendor:       disk.Vendor,
 			SizeBytes:    bmh_v1alpha1.Capacity(disk.SizeBytes),
 			Model:        disk.Model,

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -955,8 +955,12 @@ func (g *installerGenerator) modifyBMHFile(file *config_latest_types.File, bmh *
 		}
 	}
 	for i, disk := range inventory.Disks {
+		device := disk.Path
+		if disk.ByPath != "" {
+			device = disk.ByPath
+		}
 		hw.Storage[i] = bmh_v1alpha1.Storage{
-			Name:         disk.Path,
+			Name:         device,
 			Vendor:       disk.Vendor,
 			SizeBytes:    bmh_v1alpha1.Capacity(disk.SizeBytes),
 			Model:        disk.Model,


### PR DESCRIPTION
Backport of #5185.