### PR TITLE
[release-4.12] OCPBUGS-13529: Support by-path root device hints

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -436,6 +436,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "1",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sda",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 						SizeBytes:               int64(120) * 1000 * 1000 * 1000,
@@ -444,6 +445,7 @@ var _ = Describe("bmac reconcile", func() {
 						ID:                      "2",
 						InstallationEligibility: v1beta1.HostInstallationEligibility{Eligible: true},
 						Path:                    "/dev/sdb",
+						ByPath:                  "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:1:0",
 						DriveType:               string(models.DriveTypeSSD),
 						Bootable:                true,
 					},
@@ -595,6 +597,24 @@ var _ = Describe("bmac reconcile", func() {
 				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
 				Expect(err).To(BeNil())
 				updatedHost.Spec.RootDeviceHints.DeviceName = "/dev/sda"
+				updatedHost.Spec.RootDeviceHints.MinSizeGigabytes = 110
+				Expect(c.Update(ctx, updatedHost)).To(BeNil())
+
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				updatedAgent := &v1beta1.Agent{}
+				err = c.Get(ctx, types.NamespacedName{Name: agent.Name, Namespace: agent.Namespace}, updatedAgent)
+				Expect(err).To(BeNil())
+				Expect(updatedAgent.Spec.InstallationDiskID).To(Equal("1"))
+			})
+
+			It("should set the InstallationDiskID if the by-path RootDeviceHints were provided and match", func() {
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err := c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				updatedHost.Spec.RootDeviceHints.DeviceName = "/dev/disk/by-path/pci-0000:03:00.0-scsi-0:2:0:0"
 				updatedHost.Spec.RootDeviceHints.MinSizeGigabytes = 110
 				Expect(c.Update(ctx, updatedHost)).To(BeNil())
 

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -188,7 +188,7 @@ func GetAcceptableDisksWithHints(disks []*models.Disk, hints *bmh_v1alpha1.RootD
 		}
 
 		if hints != nil {
-			if hints.DeviceName != "" && hints.DeviceName != disk.Path {
+			if hints.DeviceName != "" && hints.DeviceName != disk.Path && hints.DeviceName != disk.ByPath {
 				continue
 			}
 


### PR DESCRIPTION
Backported from #5213/#5185 