### PR TITLE
 OCPBUGS-13621: Fix singular Ingress and API cluster VIPs removal

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2365,12 +2365,19 @@ func (b *bareMetalInventory) updateClusterData(_ context.Context, cluster *commo
 	return nil
 }
 
-func wereClusterVipsUpdated(clusterVips []string, paramsVips []string) bool {
-	if len(clusterVips) != len(paramsVips) {
+func wereClusterVipsUpdated(clusterVip string, paramVip *string, clusterVips []string, paramVips []string) bool {
+	if paramVip != nil && clusterVip != swag.StringValue(paramVip) {
+		return true
+	}
+
+	if paramVips == nil {
+		return false
+	}
+	if len(clusterVips) != len(paramVips) {
 		return true
 	}
 	for i := range clusterVips {
-		if clusterVips[i] != paramsVips[i] {
+		if clusterVips[i] != paramVips[i] {
 			return true
 		}
 	}
@@ -2388,17 +2395,16 @@ func (b *bareMetalInventory) updateVips(db *gorm.DB, params installer.V2UpdateCl
 		},
 	}
 
-	if params.ClusterUpdateParams.APIVips != nil && len(params.ClusterUpdateParams.APIVips) > 0 {
-		if wereClusterVipsUpdated(network.GetApiVips(cluster), network.GetApiVips(&paramVips)) {
-			apiVipUpdated = true
-			cluster.APIVips = params.ClusterUpdateParams.APIVips
-		}
+	if wereClusterVipsUpdated(cluster.APIVip, params.ClusterUpdateParams.APIVip, network.GetApiVips(cluster), network.GetApiVips(&paramVips)) {
+		apiVipUpdated = true
+		cluster.APIVip = swag.StringValue(params.ClusterUpdateParams.APIVip)
+		cluster.APIVips = params.ClusterUpdateParams.APIVips
 	}
-	if params.ClusterUpdateParams.IngressVips != nil && len(params.ClusterUpdateParams.IngressVips) > 0 {
-		if wereClusterVipsUpdated(network.GetIngressVips(cluster), network.GetIngressVips(&paramVips)) {
-			ingressVipUpdated = true
-			cluster.IngressVips = params.ClusterUpdateParams.IngressVips
-		}
+
+	if wereClusterVipsUpdated(cluster.IngressVip, params.ClusterUpdateParams.IngressVip, network.GetIngressVips(cluster), network.GetIngressVips(&paramVips)) {
+		ingressVipUpdated = true
+		cluster.IngressVip = swag.StringValue(params.ClusterUpdateParams.IngressVip)
+		cluster.IngressVips = params.ClusterUpdateParams.IngressVips
 	}
 
 	if apiVipUpdated || ingressVipUpdated {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -386,7 +386,6 @@ func handleIngressVipUpdateBackwardsCompatibility(cluster *common.Cluster, param
 	if cluster.IngressVip != "" {
 		// IngressVip was cleared and IngressVips were not provided, clear both fields.
 		if swag.StringValue(params.IngressVip) == "" && len(params.IngressVips) == 0 {
-			params.IngressVip = nil
 			params.IngressVips = nil
 		}
 		// IngressVip was changed (but not cleared), IngressVips will be forcefully set to the value of IngressVips as a one-element list.
@@ -404,7 +403,6 @@ func handleApiVipUpdateBackwardsCompatibility(cluster *common.Cluster, params *m
 	if cluster.APIVip != "" {
 		// APIVip was cleared and APIVips were not provided, clear both fields.
 		if swag.StringValue(params.APIVip) == "" && len(params.APIVips) == 0 {
-			params.APIVip = nil
 			params.APIVips = nil
 		}
 		// APIVip was changed (but not cleared), APIVips will be forcefully set to the value of APIVip as a one-element list.

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -200,6 +200,13 @@ var _ = Describe("Operators endpoint tests", func() {
 		registerNewCluster := func(openshiftVersion string, highAvailabilityMode string, operators []*models.OperatorCreateParams, cpuArchitecture *string) *installer.V2RegisterClusterCreated {
 			var err error
 			var cluster *installer.V2RegisterClusterCreated
+			clusterCIDR := "10.128.0.0/14"
+			serviceCIDR := "172.30.0.0/16"
+
+			vipDhcpAllocation := swag.Bool(true)
+			if highAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+				vipDhcpAllocation = swag.Bool(false)
+			}
 
 			cluster, err = user2BMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
@@ -209,6 +216,12 @@ var _ = Describe("Operators endpoint tests", func() {
 					PullSecret:           swag.String(fmt.Sprintf(psTemplate, FakePS2)),
 					CPUArchitecture:      swag.StringValue(cpuArchitecture),
 					OlmOperators:         operators,
+					BaseDNSDomain:        "example.com",
+					ClusterNetworks:      []*models.ClusterNetwork{{Cidr: models.Subnet(clusterCIDR), HostPrefix: 23}},
+					ServiceNetworks:      []*models.ServiceNetwork{{Cidr: models.Subnet(serviceCIDR)}},
+					SSHPublicKey:         sshPublicKey,
+					VipDhcpAllocation:    vipDhcpAllocation,
+					NetworkType:          swag.String(models.ClusterNetworkTypeOVNKubernetes),
 				},
 			})
 


### PR DESCRIPTION
This change fixes a case where the user attempts to remove Ingress and API VIPs. Cleanup used to fail due to a missing deletion as a part of the deletion db transaction.

Added unit tests to verify all deletion combination works for singular, plural, and a combination of VIP params.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
