### PR TITLE
NO-ISSUE: Wait for hostedcontrolplane to be created

### DIFF
--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -138,6 +138,7 @@ hypershift create cluster agent --name $ASSISTED_CLUSTER_NAME --base-domain redh
   $PROVIDER_FLAG_FOR_CREATE_COMMAND
 
 # Wait for a hypershift hostedcontrolplane to report ready status
+wait_for_resource "hostedcontrolplane/${ASSISTED_CLUSTER_NAME}" "${SPOKE_NAMESPACE}-${ASSISTED_CLUSTER_NAME}"
 wait_for_boolean_field "hostedcontrolplane/${ASSISTED_CLUSTER_NAME}" status.ready "${SPOKE_NAMESPACE}-${ASSISTED_CLUSTER_NAME}"
 wait_for_condition "nodepool/$ASSISTED_CLUSTER_NAME" "Ready" "10m" "$SPOKE_NAMESPACE"
 wait_for_condition "hostedcluster/$ASSISTED_CLUSTER_NAME" "Available" "10m" "$SPOKE_NAMESPACE"

--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -133,6 +133,25 @@ function wait_for_boolean_field() {
     return 1
 }
 
+function wait_for_resource() {
+    object="$1"
+    namespace="$2"
+    interval="${4:-10}"
+    set +e
+    for i in {1..50}; do
+        date --rfc-3339=seconds
+        value=$(oc get -n ${namespace} ${object} --no-headers | wc -l)
+        if [ "${value}" -ne 0 ]; then
+            return 0
+        fi
+        sleep ${interval}
+    done
+    set -e
+
+    echo "The object ${object} under namespace ${namespace} not found!"
+    return 1
+}
+
 function get_image_without_tag() {
     # given "<registry>/<repository>/<project>:<tag>" or
     #       "<registry>/<repository>/<project>@sha256:<sha>" or


### PR DESCRIPTION
The the status check may fail if we try to check it before the hostedcontrolplane got created

## List all the issues related to this PR
https://issues.redhat.com/browse/MGMT-14610
- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
