### PR TITLE
MGMT-14636: Don't panic on BMH delete when agents are unbound

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -1914,6 +1914,16 @@ var _ = Describe("handleBMHFinalizer", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 
+			It("deletes an unbound agent and removes the finalizer", func() {
+				agent.Spec.ClusterDeploymentName = nil
+				mockClient.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&v1beta1.Agent{})).Return(nil)
+
+				res := bmhr.handleBMHFinalizer(ctx, bmhr.Log, bmh, agent)
+				Expect(bmh.GetFinalizers()).NotTo(ContainElement(BMH_FINALIZER_NAME))
+				_, err := res.Result()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
 			It("drains the node", func() {
 				setupSpokeClient()
 				node := &corev1.Node{


### PR DESCRIPTION
Now BMAC only attempts to drain and clean agents that are currently bound to a cluster

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-14636

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
