### PR TITLE
MGMT-13643: added MaxLength to additional_trust_bundle

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -28,6 +28,7 @@ type InfraEnvCreateParams struct {
 	// infra-env will trust the certificates in this bundle. Clusters formed
 	// from the hosts discovered by this infra-env will also trust the
 	// certificates in this bundle.
+	// Max Length: 65535
 	AdditionalTrustBundle string `json:"additional_trust_bundle,omitempty"`
 
 	// If set, all hosts that register will be associated with the specified cluster.
@@ -72,6 +73,10 @@ type InfraEnvCreateParams struct {
 func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateClusterID(formats); err != nil {
 		res = append(res, err)
 	}
@@ -107,6 +112,18 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // InfraEnvUpdateParams infra env update params
@@ -23,6 +24,7 @@ type InfraEnvUpdateParams struct {
 	AdditionalNtpSources *string `json:"additional_ntp_sources,omitempty"`
 
 	// Allows users to change the additional_trust_bundle infra-env field
+	// Max Length: 65535
 	AdditionalTrustBundle *string `json:"additional_trust_bundle,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -51,6 +53,10 @@ type InfraEnvUpdateParams struct {
 func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -70,6 +76,18 @@ func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvUpdateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", *m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -7699,6 +7699,16 @@ var _ = Describe("infraEnvs", func() {
 			err = reply.(*common.ApiErrorResponse)
 			Expect(err.Error()).To(ContainSubstring("over the maximum allowable size"))
 		})
+
+		It("Invalid additional trust bundle - too long", func() {
+			bytes := make([]byte, 65536)
+			longString := string(bytes)
+			params := &models.InfraEnvCreateParams{
+				AdditionalTrustBundle: longString,
+			}
+			err := params.Validate(nil)
+			Expect(err.Error()).To(ContainSubstring("should be at most 65535 chars long"))
+		})
 	})
 
 	Context("Create InfraEnv - with rhsso auth", func() {
@@ -8136,6 +8146,15 @@ var _ = Describe("infraEnvs", func() {
 				i, err = bm.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *i.ID})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(i.AdditionalTrustBundle).To(Equal(""))
+			})
+			It("Update additional trust bundle - too long", func() {
+				bytes := make([]byte, 65536)
+				longString := string(bytes)
+				params := &models.InfraEnvUpdateParams{
+					AdditionalTrustBundle: swag.String(longString),
+				}
+				err := params.Validate(nil)
+				Expect(err.Error()).To(ContainSubstring("should be at most 65535 chars long"))
 			})
 			It("updates proxy when http and https are the same", func() {
 				var err error

--- a/models/infra_env_create_params.go
+++ b/models/infra_env_create_params.go
@@ -28,6 +28,7 @@ type InfraEnvCreateParams struct {
 	// infra-env will trust the certificates in this bundle. Clusters formed
 	// from the hosts discovered by this infra-env will also trust the
 	// certificates in this bundle.
+	// Max Length: 65535
 	AdditionalTrustBundle string `json:"additional_trust_bundle,omitempty"`
 
 	// If set, all hosts that register will be associated with the specified cluster.
@@ -72,6 +73,10 @@ type InfraEnvCreateParams struct {
 func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateClusterID(formats); err != nil {
 		res = append(res, err)
 	}
@@ -107,6 +112,18 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/models/infra_env_update_params.go
+++ b/models/infra_env_update_params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // InfraEnvUpdateParams infra env update params
@@ -23,6 +24,7 @@ type InfraEnvUpdateParams struct {
 	AdditionalNtpSources *string `json:"additional_ntp_sources,omitempty"`
 
 	// Allows users to change the additional_trust_bundle infra-env field
+	// Max Length: 65535
 	AdditionalTrustBundle *string `json:"additional_trust_bundle,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -51,6 +53,10 @@ type InfraEnvUpdateParams struct {
 func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -70,6 +76,18 @@ func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvUpdateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", *m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8386,6 +8386,7 @@ func init() {
         "additional_trust_bundle": {
           "description": "PEM-encoded X.509 certificate bundle. Hosts discovered by this\ninfra-env will trust the certificates in this bundle. Clusters formed\nfrom the hosts discovered by this infra-env will also trust the\ncertificates in this bundle.",
           "type": "string",
+          "maxLength": 65535,
           "x-nullable": false
         },
         "cluster_id": {
@@ -8462,6 +8463,7 @@ func init() {
         "additional_trust_bundle": {
           "description": "Allows users to change the additional_trust_bundle infra-env field",
           "type": "string",
+          "maxLength": 65535,
           "x-nullable": true
         },
         "ignition_config_override": {
@@ -18687,6 +18689,7 @@ func init() {
         "additional_trust_bundle": {
           "description": "PEM-encoded X.509 certificate bundle. Hosts discovered by this\ninfra-env will trust the certificates in this bundle. Clusters formed\nfrom the hosts discovered by this infra-env will also trust the\ncertificates in this bundle.",
           "type": "string",
+          "maxLength": 65535,
           "x-nullable": false
         },
         "cluster_id": {
@@ -18763,6 +18766,7 @@ func init() {
         "additional_trust_bundle": {
           "description": "Allows users to change the additional_trust_bundle infra-env field",
           "type": "string",
+          "maxLength": 65535,
           "x-nullable": true
         },
         "ignition_config_override": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7055,6 +7055,7 @@ definitions:
       additional_trust_bundle:
         type: string
         x-nullable: false
+        maxLength: 65535
         description: |-
           PEM-encoded X.509 certificate bundle. Hosts discovered by this
           infra-env will trust the certificates in this bundle. Clusters formed
@@ -7091,6 +7092,7 @@ definitions:
         type: string
         description: Allows users to change the additional_trust_bundle infra-env field
         x-nullable: true
+        maxLength: 65535
 
   ip:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_create_params.go
@@ -28,6 +28,7 @@ type InfraEnvCreateParams struct {
 	// infra-env will trust the certificates in this bundle. Clusters formed
 	// from the hosts discovered by this infra-env will also trust the
 	// certificates in this bundle.
+	// Max Length: 65535
 	AdditionalTrustBundle string `json:"additional_trust_bundle,omitempty"`
 
 	// If set, all hosts that register will be associated with the specified cluster.
@@ -72,6 +73,10 @@ type InfraEnvCreateParams struct {
 func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateClusterID(formats); err != nil {
 		res = append(res, err)
 	}
@@ -107,6 +112,18 @@ func (m *InfraEnvCreateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvCreateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/infra_env_update_params.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // InfraEnvUpdateParams infra env update params
@@ -23,6 +24,7 @@ type InfraEnvUpdateParams struct {
 	AdditionalNtpSources *string `json:"additional_ntp_sources,omitempty"`
 
 	// Allows users to change the additional_trust_bundle infra-env field
+	// Max Length: 65535
 	AdditionalTrustBundle *string `json:"additional_trust_bundle,omitempty"`
 
 	// JSON formatted string containing the user overrides for the initial ignition config.
@@ -51,6 +53,10 @@ type InfraEnvUpdateParams struct {
 func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAdditionalTrustBundle(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateImageType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -70,6 +76,18 @@ func (m *InfraEnvUpdateParams) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InfraEnvUpdateParams) validateAdditionalTrustBundle(formats strfmt.Registry) error {
+	if swag.IsZero(m.AdditionalTrustBundle) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("additional_trust_bundle", "body", *m.AdditionalTrustBundle, 65535); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
As the max length of a string in postgres is 65,535 bytes, additional_trust_bundle property length should be limited on: infra-env-create-params and infra-env-update-params.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
