### PR TITLE
Fix cpu partitioning struct tag/field

### DIFF
--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -610,7 +610,7 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		err = yaml.Unmarshal(data, &result)
 		Expect(err).ShouldNot(HaveOccurred())
 		// test that overrides worked
-		Expect(string(result.CPUPartitioning)).Should(Equal("AllNodes"))
+		Expect(string(result.CPUPartitioningMode)).Should(Equal("AllNodes"))
 	})
 
 	Context("networking", func() {

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -195,7 +195,7 @@ type InstallerConfigBaremetal struct {
 	Platform              Platform             `yaml:"platform"`
 	BootstrapInPlace      BootstrapInPlace     `yaml:"bootstrapInPlace,omitempty"`
 	FIPS                  bool                 `yaml:"fips"`
-	CPUPartitioning       CPUPartitioningMode  `json:"cpuPartitioningMode,omitempty"`
+	CPUPartitioningMode   CPUPartitioningMode  `yaml:"cpuPartitioningMode,omitempty"`
 	PullSecret            string               `yaml:"pullSecret"`
 	SSHKey                string               `yaml:"sshKey"`
 	AdditionalTrustBundle string               `yaml:"additionalTrustBundle,omitempty"`


### PR DESCRIPTION
The struct tag for cpu partitioning was using but in order for the
install config to be rendered correctly in all cases it need the yaml
tag like the other fields.

Without the yaml tag cpu partitioning was being included in the install
config even if it was empty with an invlid name.

This meant that all 4.10 installs always failed to prepare for
installation with an event like:

```
Failed to prepare the installation due to an unexpected error: failed
generating install config for cluster
1583dc9b-e059-48fc-96b9-5e711d1de6b1: error running openshift-install
manifests, level=fatal msg=failed to fetch Master Machines: failed to
load asset "Install Config": failed to unmarshal install-config.yaml:
failed to parse first occurence of unknown field: error unmarshaling
JSON: while decoding JSON: json: unknown field "cpupartitioning" : exit
status 1. Please retry later
```

To correct this while also maintaining the current overrides behavior
the field name is updated to match the API name (cpuPartitioningMode)
and the json struct tag is changed to yaml.

This allows for overrides to work in a case-insensitive way (as is
supported currently for all other fields) as well as for the install
config yaml to render properly.

NOTE:

This field name is intentionally different than the one in the openshift
installer repo. This allows for us to take advantage of the
case-insensitive matching allowed by json unmarshaling while also using
the correct name.

Originally committed in https://github.com/openshift/assisted-service/pull/5207

## List all the issues related to this PR

https://issues.redhat.com/browse/OCPBUGS-13310

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
