### PR TITLE
Delete the spoke BMH before removing the finalizer

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -248,15 +248,15 @@ func deleteBMHForMachine(ctx context.Context, spokeClient client.Client, machine
 		return errors.Wrapf(err, "failed to get BMH %s", bmhNSName)
 	}
 
+	if err = spokeClient.Delete(ctx, bmh); err != nil {
+		return errors.Wrapf(err, "failed to delete BMH %s", bmhNSName)
+	}
+
 	// TODO: remove this once OCPBUGS-7581 is fixed
 	patch := client.MergeFrom(bmh.DeepCopy())
 	bmh.ObjectMeta.Finalizers = nil
-	if err = spokeClient.Patch(ctx, bmh, patch); err != nil {
+	if err = client.IgnoreNotFound(spokeClient.Patch(ctx, bmh, patch)); err != nil {
 		return errors.Wrapf(err, "failed to remove BMH %s finalizers", bmhNSName)
-	}
-
-	if err = spokeClient.Delete(ctx, bmh); err != nil {
-		return errors.Wrapf(err, "failed to delete BMH %s", bmhNSName)
 	}
 
 	return nil


### PR DESCRIPTION
This avoids a race condition where assisted-service deletes the BMH finalizer on the spoke cluster, then BMO on the spoke cluster adds the finalizer back before we can mark the BMH to be deleted.

Previously the BMH would not be fully deleted in the spoke cluster due to OCPBUGS-7581

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-14667

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

In progress

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests) - Covered by existing tests

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
