### PR TITLE
Docs fix: ensure kubeconfig secret is created with a kubeconfig key.

### DIFF
--- a/docs/hive-integration/import-installed-cluster.md
+++ b/docs/hive-integration/import-installed-cluster.md
@@ -54,7 +54,7 @@ oc get secret -n openshift-kube-apiserver node-kubeconfigs -ojson | jq '.data["l
 
 Then _make sure that KUBECONFIG is set to the hub_ and use:
 ```
-oc -n spoke-cluster create secret generic some-other-cluster-admin-kubeconfig --from-file=/tmp/kubeconfig.some-other-cluster
+oc -n spoke-cluster create secret generic some-other-cluster-admin-kubeconfig --from-file=kubeconfig=/tmp/kubeconfig.some-other-cluster
 ```
 
 #### 5: Create an AgentClusterInstall and a ClusterDeployment, these should reference each other.


### PR DESCRIPTION
Update docs/hive-integration/import-installed-cluster.md. When creating the kubeconfig secret for the imported ClusterDeployment, ensure that the kubeconfig is stored within a `kubeconfig` key within the secret data.

The previous example command would result in the kubeconfig being stored within a `kubeconfig.some-other-cluster` key within secret data if followed verbatim and eventually Hive would populate a `kubeconfig` key within the secret with an empty string value. client-go within Hive will fail to be able to use the kubeconfig as empty or missing within the secret resulting in conditions like the following set on the ClusterDeployment,

```
    - lastProbeTime: '2023-05-23T13:33:43Z'
      lastTransitionTime: '2023-05-23T13:33:01Z'
      message: >-
        invalid configuration: no configuration has been provided, try setting
        KUBERNETES_MASTER environment variable
      reason: ErrorConnectingToCluster
      status: 'True'
      type: Unreachable
```

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
