### PR TITLE
MGMT-14306: Update host role validation to accept AutoAssign in Day2

### DIFF
--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -101,7 +101,7 @@ func ValidateHostname(hostname string) error {
 func IsRoleValid(requestedRole models.HostRole, isDay2Host bool) bool {
 	roleSet := map[models.HostRole]struct{}{models.HostRoleAutoAssign: {}, models.HostRoleBootstrap: {}, models.HostRoleMaster: {}, models.HostRoleWorker: {}}
 	if isDay2Host {
-		roleSet = map[models.HostRole]struct{}{models.HostRoleMaster: {}, models.HostRoleWorker: {}}
+		roleSet = map[models.HostRole]struct{}{models.HostRoleAutoAssign: {}, models.HostRoleMaster: {}, models.HostRoleWorker: {}}
 	}
 
 	_, exists := roleSet[requestedRole]

--- a/internal/host/hostutil/host_utils_test.go
+++ b/internal/host/hostutil/host_utils_test.go
@@ -190,6 +190,15 @@ var _ = Describe("Ignition endpoint URL generation", func() {
 	})
 })
 
+var _ = Describe("Validations", func() {
+	Context("Role validity", func() {
+		It("Day2 host should accept AutoAssign role", func() {
+			isDay2Host := true
+			Expect(IsRoleValid(models.HostRoleAutoAssign, isDay2Host)).Should(BeTrue())
+		})
+	})
+})
+
 func TestHostUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	common.InitializeDBTest()


### PR DESCRIPTION
Presently there is a bug where the UI will not accept the host role "Auto Assign" for Day 2 hosts. This is a valid status and should be permitted. This change updates the validation to permit this.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Installed a day 1 cluster, added a day 2 host and observed that it will now accept "auto assign"
Validated that the day 2 host correctly gets added as a "worker"
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
