### PR TITLE
MGMT-14582: Set OCI platform behind a capability

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -540,6 +540,9 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	if err = validations.ValidateDualStackNetworks(params.NewClusterParams, false); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
+	if err = validations.ValidatePlatformCapability(params.NewClusterParams.Platform, ctx, b.authzHandler, log); err != nil {
+		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
 
 	params, err = b.setDefaultRegisterClusterParams(ctx, params, id)
 	if err != nil {
@@ -1860,6 +1863,10 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 	}
 
 	if err := b.validateIgnitionEndpoint(params.ClusterUpdateParams.IgnitionEndpoint, log); err != nil {
+		return installer.V2UpdateClusterParams{}, err
+	}
+
+	if err := validations.ValidatePlatformCapability(params.ClusterUpdateParams.Platform, ctx, b.authzHandler, log); err != nil {
 		return installer.V2UpdateClusterParams{}, err
 	}
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -540,7 +540,7 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 	if err = validations.ValidateDualStackNetworks(params.NewClusterParams, false); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
-	if err = validations.ValidatePlatformCapability(params.NewClusterParams.Platform, ctx, b.authzHandler, log); err != nil {
+	if err = validations.ValidatePlatformCapability(params.NewClusterParams.Platform, ctx, b.authzHandler); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
 	}
 
@@ -575,9 +575,6 @@ func (b *bareMetalInventory) RegisterClusterInternal(
 		//              with multiarch in order to get access to that release payload.
 		var multiarchAllowed bool
 		multiarchAllowed, err = b.authzHandler.HasOrgBasedCapability(ctx, ocm.MultiarchCapabilityName)
-		if err != nil {
-			log.WithError(err).Errorf("error getting user %s capability", ocm.MultiarchCapabilityName)
-		}
 		if err != nil || !multiarchAllowed {
 			err = common.NewApiError(http.StatusBadRequest, errors.New("multiarch clusters are not available"))
 			return nil, err
@@ -1866,7 +1863,7 @@ func (b *bareMetalInventory) validateAndUpdateClusterParams(ctx context.Context,
 		return installer.V2UpdateClusterParams{}, err
 	}
 
-	if err := validations.ValidatePlatformCapability(params.ClusterUpdateParams.Platform, ctx, b.authzHandler, log); err != nil {
+	if err := validations.ValidatePlatformCapability(params.ClusterUpdateParams.Platform, ctx, b.authzHandler); err != nil {
 		return installer.V2UpdateClusterParams{}, err
 	}
 

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -572,15 +572,8 @@ func (b *bareMetalInventory) V2ImportCluster(ctx context.Context, params install
 }
 
 func (b *bareMetalInventory) allowedToIgnoreValidations(ctx context.Context) bool {
-	log := logutil.FromContext(ctx, b.log)
 	allowedToIgnoreValidations, err := b.authzHandler.HasOrgBasedCapability(ctx, ocm.IgnoreValidationsCapabilityName)
-	if err != nil {
-		log.WithError(err).Errorf("error getting user %s capability", ocm.IgnoreValidationsCapabilityName)
-	}
-	if err != nil || !allowedToIgnoreValidations {
-		return false
-	}
-	return true
+	return err == nil && allowedToIgnoreValidations
 }
 
 func (b *bareMetalInventory) setIgnoredValidationsBadRequest(message string) *installer.V2SetIgnoredValidationsBadRequest {

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openshift/assisted-service/pkg/tang"
 	"github.com/openshift/assisted-service/pkg/validations"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 	"golang.org/x/crypto/ssh"
 )
@@ -979,7 +978,7 @@ func ValidateArchitectureWithPlatform(architecture *string, platform *models.Pla
 	return nil
 }
 
-func ValidatePlatformCapability(platform *models.Platform, ctx context.Context, authzHandler auth.Authorizer, log logrus.FieldLogger) error {
+func ValidatePlatformCapability(platform *models.Platform, ctx context.Context, authzHandler auth.Authorizer) error {
 	if platform == nil {
 		return nil
 	}
@@ -997,10 +996,6 @@ func ValidatePlatformCapability(platform *models.Platform, ctx context.Context, 
 	available, err := authzHandler.HasOrgBasedCapability(ctx, *capabilityName)
 	if err == nil && available {
 		return nil
-	}
-
-	if err != nil {
-		log.WithError(err).Errorf("error getting user %s capability", *capabilityName)
 	}
 
 	return common.NewApiError(http.StatusBadRequest, errors.Errorf("Platform %s is not available", *platform.Type))

--- a/pkg/auth/rhsso_authz_handler.go
+++ b/pkg/auth/rhsso_authz_handler.go
@@ -186,6 +186,11 @@ func (a *AuthzHandler) HasOrgBasedCapability(ctx context.Context, capability str
 	isAllowed, err := a.client.Authorization.CapabilityReview(context.Background(), fmt.Sprint(username), capability, ocm.OrganizationCapabilityType)
 	a.log.Debugf("queried AMS API with CapabilityReview for username: %s about capability: %s, capability type: %s. Result: %t",
 		fmt.Sprint(username), capability, ocm.OrganizationCapabilityType, isAllowed)
+
+	if err != nil {
+		a.log.WithError(err).Errorf("error getting user %s capability", capability)
+	}
+
 	return isAllowed, err
 }
 

--- a/pkg/ocm/utils.go
+++ b/pkg/ocm/utils.go
@@ -17,6 +17,7 @@ const (
 	AMSActionDelete                 string = "delete"
 	BareMetalCapabilityName         string = "bare_metal_installer_admin"
 	MultiarchCapabilityName         string = "bare_metal_installer_multiarch"
+	PlatformOciCapabilityName       string = "bare_metal_installer_platform_oci"
 	AccountCapabilityType           string = "Account"
 	OrganizationCapabilityType      string = "Organization"
 	Subscription                    string = "Subscription"


### PR DESCRIPTION
Ensure OCI platform cannot be set if user's organization doesn't
have `bare_metal_installer_platform_oci` capability.
