### PR TITLE
MGMT-14728: Escape the escape char (\)

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -419,9 +419,10 @@ func isDescending(order *string) (*bool, error) {
 }
 
 func escapePlaceHolders(message string) string {
-	escapedPercent := strings.ReplaceAll(message, "%", "\\%")
-	return strings.ReplaceAll(escapedPercent, "_", "\\_")
-
+	message = strings.ReplaceAll(message, "\\", "\\\\")
+	message = strings.ReplaceAll(message, "_", "\\_")
+	message = strings.ReplaceAll(message, "%", "\\%")
+	return message
 }
 
 func (e Events) queryEvents(ctx context.Context, params *common.V2GetEventsParams) ([]*common.Event, *common.EventSeverityCount, *int64, error) {

--- a/internal/events/event_test.go
+++ b/internal/events/event_test.go
@@ -1723,6 +1723,57 @@ var _ = Describe("Events library", func() {
 			Expect(events).To(HaveLen(0))
 		})
 
+		It("Filter by message with escape char ('\\')", func() {
+			theEvents.V2AddEvent(
+				ctx,
+				&cluster1,
+				nil,
+				nil,
+				eventgen.ClusterInstallationCompletedEventName,
+				models.EventSeverityInfo,
+				"Host: test-infra-cluster-bd49f89a-worker-1, reached installation stage Writing image to disk: 97%",
+				time.Date(2023, 2, 25, 50, 0, 0, 0, time.UTC),
+			)
+
+			response, err := theEvents.V2GetEvents(
+				ctx,
+				&common.V2GetEventsParams{
+					ClusterID: &cluster1,
+					Message:   swag.String("\\"),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			events := response.GetEvents()
+			eventSeverityCount := response.GetEventSeverityCount()
+			eventCount := response.GetEventCount()
+			Expect(*eventCount).To(Equal(int64(0)))
+			Expect(int((*eventSeverityCount)[models.EventSeverityInfo])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityWarning])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityError])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityCritical])).To(Equal(0))
+			Expect(events).To(HaveLen(0))
+
+			response, err = theEvents.V2GetEvents(
+				ctx,
+				&common.V2GetEventsParams{
+					ClusterID: &cluster1,
+					Message:   swag.String("%35C"),
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			events = response.GetEvents()
+			eventSeverityCount = response.GetEventSeverityCount()
+			eventCount = response.GetEventCount()
+			Expect(*eventCount).To(Equal(int64(0)))
+			Expect(int((*eventSeverityCount)[models.EventSeverityInfo])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityWarning])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityError])).To(Equal(0))
+			Expect(int((*eventSeverityCount)[models.EventSeverityCritical])).To(Equal(0))
+			Expect(events).To(HaveLen(0))
+		})
+
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
A fix to a bug in which searching for events with message `\` retrieves all messages with `%` as it escapes the next char (`%`) instead of being escaped
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
