### PR TITLE
MGMT-14734: Fix failed to update Nutanix provider cluster when on multi architecture

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -445,9 +445,6 @@ func (b *bareMetalInventory) validateRegisterClusterInternalParams(params *insta
 		if err := validations.ValidateHighAvailabilityModeWithPlatform(params.NewClusterParams.HighAvailabilityMode, params.NewClusterParams.Platform); err != nil {
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
-		if err := validations.ValidateArchitectureWithPlatform(&params.NewClusterParams.CPUArchitecture, params.NewClusterParams.Platform); err != nil {
-			return common.NewApiError(http.StatusBadRequest, err)
-		}
 	}
 
 	return nil
@@ -1940,10 +1937,6 @@ func (b *bareMetalInventory) validateUpdateCluster(
 	}
 
 	if err = validations.ValidateHighAvailabilityModeWithPlatform(cluster.HighAvailabilityMode, platform); err != nil {
-		return params, common.NewApiError(http.StatusBadRequest, err)
-	}
-
-	if err = validations.ValidateArchitectureWithPlatform(&cluster.CPUArchitecture, platform); err != nil {
 		return params, common.NewApiError(http.StatusBadRequest, err)
 	}
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -6269,7 +6269,7 @@ var _ = Describe("V2ClusterUpdate cluster", func() {
 						HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeFull),
 						UserManagedNetworking: swag.Bool(false),
 						OpenshiftVersion:      "4.12",
-						CPUArchitecture:       common.DefaultCPUArchitecture,
+						CPUArchitecture:       models.ClusterCPUArchitectureMulti,
 						Platform: &models.Platform{
 							Type: common.PlatformTypePtr(models.PlatformTypeBaremetal),
 						},
@@ -6831,6 +6831,26 @@ var _ = Describe("V2ClusterUpdate cluster", func() {
 				})
 
 				It("Update platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=nutanix with multi cpu architecture - success", func() {
+					err := db.Model(&common.Cluster{}).Where("id = ?", clusterID).Update("cpu_architecture", models.ClusterCPUArchitectureMulti).Error
+					Expect(err).ShouldNot(HaveOccurred())
 					mockSuccess()
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
 
@@ -12957,7 +12977,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		Expect(cfg.DiskEncryptionSupport).Should(BeTrue())
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -13192,8 +13212,19 @@ var _ = Describe("TestRegisterCluster", func() {
 			It("Nutanix platform and arm64 - failed", func() {
 				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
-					eventstest.WithMessageContainsMatcher("only x86-64 CPU architecture is supported on Nutanix clusters"),
+					eventstest.WithMessageContainsMatcher("cannot use Nutanix Platform Integration because it's not compatible with the arm64 architecture on version 4.11"),
 					eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
+
+				mockOSImages.EXPECT().GetCPUArchitectures(gomock.Any()).Return(
+					[]string{minimalOpenShiftVersionForNutanix, common.ARM64CPUArchitecture}).Times(1)
+				mockVersions.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&models.ReleaseImage{
+					CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+					OpenshiftVersion: swag.String("4.11.1"),
+					URL:              swag.String("release_4.11.1"),
+					Version:          swag.String("4.11.1-multi"),
+				}, nil).Times(1)
+				mockOperatorManager.EXPECT().GetSupportedOperatorsByType(models.OperatorTypeBuiltin).Return([]*models.MonitoredOperator{&common.TestDefaultConfig.MonitoredOperator}).Times(1)
 
 				params := getClusterCreateParams(nil)
 				params.Platform = &models.Platform{
@@ -13225,6 +13256,14 @@ var _ = Describe("TestRegisterCluster", func() {
 				Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
 				c := reply.(*installer.V2RegisterClusterCreated).Payload
 
+				infraEnvID := strfmt.UUID(uuid.New().String())
+				err := db.Create(&common.InfraEnv{InfraEnv: models.InfraEnv{
+					ID:              &infraEnvID,
+					ClusterID:       *c.ID,
+					CPUArchitecture: models.InfraEnvCPUArchitectureArm64,
+				}}).Error
+				Expect(err).ShouldNot(HaveOccurred())
+
 				reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
 					ClusterID: *c.ID,
 					ClusterUpdateParams: &models.V2ClusterUpdateParams{
@@ -13234,7 +13273,7 @@ var _ = Describe("TestRegisterCluster", func() {
 						UserManagedNetworking: swag.Bool(false),
 					},
 				})
-				verifyApiErrorString(reply2, http.StatusBadRequest, "only x86-64 CPU architecture is supported on Nutanix clusters")
+				verifyApiErrorString(reply2, http.StatusBadRequest, "cannot use Nutanix Platform Integration because it's not compatible with the arm64 architecture on version 4.11 of OpenShift")
 			})
 
 			It("None platform type", func() {


### PR DESCRIPTION
Cluster fails to update Nutanix with multi platform architecture

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 