### PR TITLE
MGMT-13685: Make sure ingress and api vip are not broadcast address.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/assisted-service
 go 1.18
 
 require (
+	github.com/IBM/netaddr v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/IBM/netaddr v1.5.0 h1:IJlFZe1+nFs09TeMB/HOP4+xBnX2iM/xgiDOgZgTJq0=
+github.com/IBM/netaddr v1.5.0/go.mod h1:DDBPeYgbFzoXHjSz9Jwk7K8wmWV4+a/Kv0LqRnb8we4=
 github.com/InVisionApp/go-health v2.1.0+incompatible/go.mod h1:/+Gv1o8JUsrjC6pi6MN6/CgKJo4OqZ6x77XAnImrzhg=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -1736,6 +1738,7 @@ github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/vendor/github.com/IBM/netaddr/.travis.yml
+++ b/vendor/github.com/IBM/netaddr/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go_import_path: github.com/IBM/netaddr
+
+go:
+- "1.15"
+- "1.16"
+
+script:
+- go test -cover ./...

--- a/vendor/github.com/IBM/netaddr/LICENSE
+++ b/vendor/github.com/IBM/netaddr/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   

--- a/vendor/github.com/IBM/netaddr/README.md
+++ b/vendor/github.com/IBM/netaddr/README.md
@@ -1,0 +1,54 @@
+# netaddr package for go
+
+This repo contains a library to complement the [go net library][net] and
+provides containers and utilities like in python's [netaddr].
+
+Please see the [api documentation] for details. [The authoritative source for
+this library is found on github][source]. We encourage importing this code
+using the stable, versioned URL provided by [gopkg.in][gopkg]. Once imported,
+refer to it as `netaddr` in your code (without the version).
+
+    import "gopkg.in/netaddr.v1"
+
+## comparison with python's netaddr
+
+This netaddr library was written to complement the existing [net] package in go
+just filling in a few gaps that existed. See the table below for a side-by-side
+comparison of python netaddr features and the corresponding features in this
+library or elsewhere in go packages.
+
+| Python netaddr | Go                                |
+|----------------|-----------------------------------|
+| EUI            | ???                               |
+| IPAddress      | Use [IP] from [net]\*             |
+| IPNetwork      | Use [IPNet] from [net]\*\*        |
+| IPSet          | Use [IPSet]                       |
+| IPRange        | Use [IPRange]                     |
+| IPGlob         | Not yet implemented               |
+
+\* The [net] package in golang parses IPv4 address as IPv4 encoded IPv6
+addresses. I found this design choice frustrating. Hence, there is a [ParseIP]
+in this package that always parses IPv4 as 4 byte addresses.
+
+\*\* This package provides a few extra convenience utilities for [IPNet]. See
+[ParseNet], [NetSize], [BroadcastAddr], and [NetworkAddr].
+
+## help
+
+This needs a lot of work. Help if you can!
+
+- More test coverage
+
+[netaddr]: https://netaddr.readthedocs.io/en/latest/installation.html
+[net]: https://golang.org/pkg/net/
+[api documentation]: https://godoc.org/gopkg.in/netaddr.v1
+[source]: https://github.com/IBM/netaddr/
+[gopkg]: https://gopkg.in/netaddr.v1
+[IP]: https://golang.org/pkg/net/#IP
+[IPNet]: https://golang.org/pkg/net/#IPNet
+[IPSet]: https://godoc.org/gopkg.in/netaddr.v1#IPSet
+[ParseIP]: https://godoc.org/gopkg.in/netaddr.v1#ParseIP
+[ParseNet]: https://godoc.org/gopkg.in/netaddr.v1#ParseNet
+[NetSize]: https://godoc.org/gopkg.in/netaddr.v1#NetSize
+[BroadcastAddr]: https://godoc.org/gopkg.in/netaddr.v1#BroadcastAddr
+[NetworkAddr]: https://godoc.org/gopkg.in/netaddr.v1#NetworkAddr

--- a/vendor/github.com/IBM/netaddr/iprange.go
+++ b/vendor/github.com/IBM/netaddr/iprange.go
@@ -1,0 +1,45 @@
+package netaddr
+
+import (
+	"fmt"
+	"net"
+)
+
+// IPRange range of ips not necessarily aligned to a power of 2
+type IPRange struct {
+	First, Last net.IP
+}
+
+func (r *IPRange) String() string {
+	return fmt.Sprintf("[%s,%s]", r.First, r.Last)
+}
+
+// IPRangeFromIPNet get an IPRange from an *ip.Net
+func IPRangeFromIPNet(cidr *net.IPNet) *IPRange {
+	return &IPRange{
+		First: NetworkAddr(cidr),
+		Last:  BroadcastAddr(cidr),
+	}
+}
+
+// Minus returns the ranges in r that are not in b
+func (r *IPRange) Minus(b *IPRange) []*IPRange {
+	diff := []*IPRange{}
+	if IPLessThan(r.First, b.First) {
+		diff = append(diff, &IPRange{First: r.First, Last: IPMin(r.Last, decrementIP(b.First))})
+	}
+
+	if IPLessThan(b.Last, r.Last) {
+		diff = append(diff, &IPRange{First: IPMax(r.First, incrementIP(b.Last)), Last: r.Last})
+	}
+	return diff
+}
+
+// Contains returns true if b is contained in r
+func (r *IPRange) Contains(b *IPRange) bool {
+	if (IPLessThan(r.First, b.First) || r.First.Equal(b.First)) &&
+		(IPLessThan(b.Last, r.Last) || r.Last.Equal(b.Last)) {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/IBM/netaddr/ipset.go
+++ b/vendor/github.com/IBM/netaddr/ipset.go
@@ -1,0 +1,149 @@
+package netaddr
+
+import (
+	"net"
+)
+
+// IPSet is a set of IP addresses
+type IPSet struct {
+	tree *ipTree
+}
+
+// InsertNet ensures this IPSet has the entire given IP network
+func (s *IPSet) InsertNet(net *net.IPNet) {
+	if net == nil {
+		return
+	}
+
+	newNet := net
+	for {
+		newNode := &ipTree{net: newNet}
+		s.tree = s.tree.insert(newNode)
+
+		if s.tree != newNode && newNode.up == nil {
+			break
+		}
+
+		// The new node was inserted. See if it can be combined with the previous and/or next ones
+		prev := newNode.prev()
+		if prev != nil {
+			if ok, n := canCombineNets(prev.net, newNet); ok {
+				newNet = n
+			}
+		}
+		next := newNode.next()
+		if next != nil {
+			if ok, n := canCombineNets(newNet, next.net); ok {
+				newNet = n
+			}
+		}
+		if newNet == newNode.net {
+			break
+		}
+	}
+}
+
+// RemoveNet ensures that all of the IPs in the given network are removed from
+// the set if present.
+func (s *IPSet) RemoveNet(net *net.IPNet) {
+	if net == nil {
+		return
+	}
+
+	s.tree = s.tree.removeNet(net)
+}
+
+// ContainsNet returns true iff this IPSet contains all IPs in the given network
+func (s *IPSet) ContainsNet(net *net.IPNet) bool {
+	if s == nil || net == nil {
+		return false
+	}
+	return s.tree.contains(&ipTree{net: net})
+}
+
+// Insert ensures this IPSet has the given IP
+func (s *IPSet) Insert(ip net.IP) {
+	s.InsertNet(ipToNet(ip))
+}
+
+// Remove ensures this IPSet does not contain the given IP
+func (s *IPSet) Remove(ip net.IP) {
+	s.RemoveNet(ipToNet(ip))
+}
+
+// Contains returns true iff this IPSet contains the the given IP address
+func (s *IPSet) Contains(ip net.IP) bool {
+	return s.ContainsNet(ipToNet(ip))
+}
+
+// Union computes the union of this IPSet and another set. It returns the
+// result as a new set.
+func (s *IPSet) Union(other *IPSet) (newSet *IPSet) {
+	newSet = &IPSet{}
+	s.tree.walk(func(node *ipTree) {
+		newSet.InsertNet(node.net)
+	})
+	other.tree.walk(func(node *ipTree) {
+		newSet.InsertNet(node.net)
+	})
+	return
+}
+
+// Difference computes the set difference between this IPSet and another one
+// It returns the result as a new set.
+func (s *IPSet) Difference(other *IPSet) (newSet *IPSet) {
+	newSet = &IPSet{}
+	s.tree.walk(func(node *ipTree) {
+		newSet.InsertNet(node.net)
+	})
+	other.tree.walk(func(node *ipTree) {
+		newSet.RemoveNet(node.net)
+	})
+	return
+}
+
+// GetIPs retrieves a slice of the first IPs in the set ordered by address up
+// to the given limit.
+func (s *IPSet) GetIPs(limit int) (ips []net.IP) {
+	if limit == 0 {
+		limit = int(^uint(0) >> 1) // MaxInt
+	}
+	for node := s.tree.first(); node != nil; node = node.next() {
+		ips = append(ips, expandNet(node.net, limit-len(ips))...)
+	}
+	return
+}
+
+// GetNetworks retrieves a list of all networks included in the ipTree
+func (s *IPSet) GetNetworks() []*net.IPNet {
+	networks := []*net.IPNet{}
+	s.tree.walk(func(node *ipTree) {
+		networks = append(networks, node.net)
+	})
+	return networks
+}
+
+// Intersection computes the set intersect between this IPSet and another one
+// It returns a new set which is the intersection.
+func (s *IPSet) Intersection(set1 *IPSet) (interSect *IPSet) {
+	interSect = &IPSet{}
+	s.tree.walk(func(node *ipTree) {
+		if set1.ContainsNet(node.net) {
+			interSect.InsertNet(node.net)
+		}
+	})
+	set1.tree.walk(func(node *ipTree) {
+		if s.ContainsNet(node.net) {
+			interSect.InsertNet(node.net)
+		}
+	})
+	return
+}
+
+// String returns a list of IP Networks
+func (s *IPSet) String() (str []string) {
+	for node := s.tree.first(); node != nil; node = node.next() {
+		str = append(str, node.net.String())
+	}
+	return
+}

--- a/vendor/github.com/IBM/netaddr/iptree.go
+++ b/vendor/github.com/IBM/netaddr/iptree.go
@@ -1,0 +1,315 @@
+package netaddr
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+	"net"
+)
+
+type ipTree struct {
+	net             *net.IPNet
+	left, right, up *ipTree
+}
+
+// setLeft helps maintain the bidirectional relationships in the tree. Always
+// use it to set the left child of a node.
+func (t *ipTree) setLeft(child *ipTree) {
+	if t.left != nil && t == t.left.up {
+		t.left.up = nil
+	}
+	t.left = child
+	if child != nil {
+		child.up = t
+	}
+}
+
+// setRight helps maintain the bidirectional relationships in the tree. Always
+// use it to set the right child of a node.
+func (t *ipTree) setRight(child *ipTree) {
+	if t.right != nil && t == t.right.up {
+		t.right.up = nil
+	}
+	t.right = child
+	if child != nil {
+		child.up = t
+	}
+}
+
+// trimLeft trims CIDRs that overlap top from the left child
+func (t *ipTree) trimLeft(top *ipTree) *ipTree {
+	if t == nil {
+		return nil
+	}
+
+	if ContainsNet(top.net, t.net) {
+		return t.left.trimLeft(top)
+	}
+	t.setRight(t.right.trimLeft(top))
+	return t
+}
+
+// trimRight trims CIDRs that overlap top from the right child
+func (t *ipTree) trimRight(top *ipTree) *ipTree {
+	if t == nil {
+		return nil
+	}
+
+	if ContainsNet(top.net, t.net) {
+		return t.right.trimRight(top)
+	}
+	t.setLeft(t.left.trimRight(top))
+	return t
+}
+
+// insert adds the given node to the tree if its CIDR is not already in the
+// set. The new node's CIDR is added in the correct spot and any existing
+// subsets are removed from the tree. This method does not optimize the tree by
+// adding CIDRs that can be combined.
+func (t *ipTree) insert(newNode *ipTree) *ipTree {
+	if t == nil {
+		return newNode
+	}
+
+	if ContainsNet(t.net, newNode.net) {
+		return t
+	}
+
+	if ContainsNet(newNode.net, t.net) {
+		// Replace the current top node and trim the tree
+		newNode.setLeft(t.left.trimLeft(newNode))
+		newNode.setRight(t.right.trimRight(newNode))
+
+		// Check the left-most leaf to see if it can be combined with this one
+		return newNode
+	}
+
+	if bytes.Compare(newNode.net.IP, t.net.IP) < 0 {
+		t.setLeft(t.left.insert(newNode))
+	} else {
+		t.setRight(t.right.insert(newNode))
+	}
+	return t
+}
+
+// contains returns true if the given IP is in the set.
+func (t *ipTree) contains(newNode *ipTree) bool {
+	if t == nil || newNode == nil {
+		return false
+	}
+
+	if ContainsNet(t.net, newNode.net) {
+		return true
+	}
+	if ContainsNet(newNode.net, t.net) {
+		return false
+	}
+	if bytes.Compare(newNode.net.IP, t.net.IP) < 0 {
+		return t.left.contains(newNode)
+	}
+	return t.right.contains(newNode)
+}
+
+// remove takes out the node and adjusts the tree recursively
+func (t *ipTree) remove() *ipTree {
+	replaceMe := func(newChild *ipTree) *ipTree {
+		if t.up != nil {
+			if t == t.up.left {
+				t.up.setLeft(newChild)
+			} else {
+				t.up.setRight(newChild)
+			}
+		} else if newChild != nil {
+			newChild.up = t.up
+		}
+		return newChild
+	}
+
+	if t.left != nil && t.right != nil {
+		next := t.next()
+		t.net = next.net
+		next.remove()
+		return t
+	}
+	if t.left != nil {
+		return replaceMe(t.left)
+	}
+	if t.right != nil {
+		return replaceMe(t.right)
+	}
+	return replaceMe(nil)
+}
+
+// removeNet removes all of the IPs in the given net from the set
+func (t *ipTree) removeNet(net *net.IPNet) (top *ipTree) {
+	if t == nil {
+		return
+	}
+	// If net starts before me.net, recursively remove net from the left
+	if bytes.Compare(net.IP, t.net.IP) < 0 {
+		t.left = t.left.removeNet(net)
+	}
+
+	// If any CIDRs in `net - me.net` come after me.net, remove net from
+	// the right
+	diff := netDifference(net, t.net)
+	for _, n := range diff {
+		if bytes.Compare(t.net.IP, n.IP) < 0 {
+			t.right = t.right.removeNet(net)
+			break
+		}
+	}
+
+	top = t
+	if ContainsNet(net, t.net) {
+		// Remove the current node
+		top = t.remove()
+	} else if ContainsNet(t.net, net) {
+		diff = netDifference(t.net, net)
+		t.net = diff[0]
+		for _, n := range diff[1:] {
+			top = top.insert(&ipTree{net: n})
+		}
+	}
+	return
+}
+
+// first returns the first node in the tree or nil if there are none. It is
+// always the left-most node.
+func (t *ipTree) first() *ipTree {
+	if t == nil {
+		return nil
+	}
+	if t.left == nil {
+		return t
+	}
+	return t.left.first()
+}
+
+// next returns the node following the given one in order or nil if it is the last.
+func (t *ipTree) next() *ipTree {
+	if t.right != nil {
+		next := t.right
+		for next.left != nil {
+			next = next.left
+		}
+		return next
+	}
+
+	next := t
+	for next.up != nil {
+		if next.up.left == next {
+			return next.up
+		}
+		next = next.up
+	}
+	return nil
+}
+
+// prev returns the node preceding the given one in order or nil if it is the first.
+func (t *ipTree) prev() *ipTree {
+	if t.left != nil {
+		prev := t.left
+		for prev.right != nil {
+			prev = prev.right
+		}
+		return prev
+	}
+
+	prev := t
+	for prev.up != nil {
+		if prev.up.right == prev {
+			return prev.up
+		}
+		prev = prev.up
+	}
+	return nil
+}
+
+// walk visits all of the nodes in order by passing each node, in turn, to the
+// given visit function.
+func (t *ipTree) walk(visit func(*ipTree)) {
+	if t == nil {
+		return
+	}
+	t.left.walk(visit)
+	visit(t)
+	t.right.walk(visit)
+}
+
+// size returns the number of IPs in the set.
+// It isn't efficient and only meant for testing.
+func (t *ipTree) size() *big.Int {
+	s := big.NewInt(0)
+	if t != nil {
+		ones, bits := t.net.Mask.Size()
+		s.Lsh(big.NewInt(1), uint(bits-ones))
+		s.Add(s, t.left.size())
+		s.Add(s, t.right.size())
+	}
+	return s
+}
+
+// height returns the length of the maximum path from top node to leaf
+// It isn't efficient and only meant for testing.
+func (t *ipTree) height() uint {
+	if t == nil {
+		return 0
+	}
+
+	s := t.left.height()
+	if s < t.right.height() {
+		s = t.right.height()
+	}
+	return s + 1
+}
+
+// numNodes Return the number of nodes in the underlying tree It isn't
+// efficient and only meant for testing.
+func (t *ipTree) numNodes() int {
+	if t == nil {
+		return 0
+	}
+	return 1 + t.left.numNodes() + t.right.numNodes()
+}
+
+func (t *ipTree) validate() []error {
+	errs := []error{}
+
+	// if tree is nil, then it is valid
+	if t == nil {
+		return errs
+	}
+
+	// assert root's up is nil
+	if t.up != nil {
+		errs = append(errs, errors.New("root up must be nil"))
+	}
+
+	// validate each node
+	var lastNode *ipTree
+	t.walk(func(n *ipTree) {
+		// assert that the node's are linked properly
+		if n.left != nil && n.left.up != n {
+			errs = append(errs, errors.New("linkage error: left.up node must equal node"))
+		}
+		if n.right != nil && n.right.up != n {
+			errs = append(errs, errors.New("linkage error: right.up node must equal node"))
+		}
+
+		if n.net == nil {
+			errs = append(errs, errors.New("each node in tree must have a network"))
+		} else if !n.net.IP.Mask(n.net.Mask).Equal(n.net.IP) {
+			// verify that the network is valid
+			errs = append(errs, errors.New("cidr invalid: "+n.net.String()))
+		}
+
+		// assert order is correct
+		if lastNode != nil && bytes.Compare(lastNode.net.IP, n.net.IP) >= 0 {
+			errs = append(errs, errors.New("nodes must be in order: "+lastNode.net.IP.String()+" !< "+n.net.IP.String()))
+		}
+		lastNode = n
+	})
+
+	return errs
+}

--- a/vendor/github.com/IBM/netaddr/net_utils.go
+++ b/vendor/github.com/IBM/netaddr/net_utils.go
@@ -1,0 +1,307 @@
+package netaddr
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"net"
+	"strings"
+)
+
+// NetSize returns the size of the given IPNet in terms of the number of
+// addresses. It always includes the network and broadcast addresses.
+func NetSize(n *net.IPNet) *big.Int {
+	ones, bits := n.Mask.Size()
+	return big.NewInt(0).Lsh(big.NewInt(1), uint(bits-ones))
+}
+
+// ParseIP is like net.ParseIP except that it parses IPv4 addresses as 4 byte
+// addresses instead of 16-byte mapped IPv6 addresses. This has been one of my
+// biggest gripes against the net package.
+func ParseIP(address string) net.IP {
+	if strings.Contains(address, ":") {
+		return net.ParseIP(address)
+	}
+	return net.ParseIP(address).To4()
+}
+
+// ParseCIDR is like net.ParseCIDR except that it parses IPv4 addresses as 4
+// byte addresses instead of 16-byte mapped IPv6 addresses. Much like ParseIP.
+func ParseCIDR(cidr string) (net.IP, *net.IPNet, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return net.IP{}, nil, err
+	}
+
+	if strings.Contains(cidr, ":") {
+		return ip, ipNet, nil
+	}
+	return ip.To4(), ipNet, nil
+}
+
+// ParseCIDRToNet is like ParseCIDR except that it only returns one *net.IPNet
+// that unifies the IP address and the mask. It leaves out the network address
+// which ParseCIDR returns. This may be considered an abuse of the IPNet
+// construct as it is documented that IP is supposed to be the "network
+// number". However, the public IPNet interface does not dissallow it and this
+// usage has been spotted in the wild.
+func ParseCIDRToNet(cidr string) (*net.IPNet, error) {
+	ip, ipNet, err := ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}, nil
+}
+
+// ParseNet parses an IP network from a CIDR. Unlike net.ParseCIDR, it does not
+// allow a CIDR where the host part is non-zero. For example, the following
+// CIDRs will result in an error: 203.0.113.1/24, 2001:db8::1/64, 10.0.20.0/20
+func ParseNet(cidr string) (parsed *net.IPNet, err error) {
+	ip, parsed, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	if !ip.Equal(parsed.IP) {
+		err = fmt.Errorf("Host part is not zero")
+		return nil, err
+	}
+	return
+}
+
+// NewIP returns a new IP with the given size. The size must be 4 for IPv4 and
+// 16 for IPv6.
+func NewIP(size int) net.IP {
+	if size == 4 {
+		return net.ParseIP("0.0.0.0").To4()
+	}
+	if size == 16 {
+		return net.ParseIP("::")
+	}
+	panic("Bad value for size")
+}
+
+// NetworkAddr returns the first address in the given network, or the network address.
+func NetworkAddr(n *net.IPNet) net.IP {
+	network := NewIP(len(n.IP))
+	for i := 0; i < len(n.IP); i++ {
+		network[i] = n.IP[i] & n.Mask[i]
+	}
+	return network
+}
+
+// BroadcastAddr returns the last address in the given network, or the broadcast address.
+func BroadcastAddr(n *net.IPNet) net.IP {
+	// The golang net package doesn't make it easy to calculate the broadcast address. :(
+	broadcast := NewIP(len(n.IP))
+	for i := 0; i < len(n.IP); i++ {
+		broadcast[i] = n.IP[i] | ^n.Mask[i]
+	}
+	return broadcast
+}
+
+// ContainsNet returns true if net2 is a subset of net1. To be clear, it
+// returns true if net1 == net2 also.
+func ContainsNet(net1, net2 *net.IPNet) bool {
+	// If the two networks are different IP versions, return false
+	if len(net1.IP) != len(net2.IP) {
+		return false
+	}
+	if !net1.Contains(net2.IP) {
+		return false
+	}
+	if !net1.IP.Equal(net2.IP) {
+		return true
+	}
+	return bytes.Compare(net1.Mask, net2.Mask) <= 0
+}
+
+// netDifference returns the set difference a - b. It returns the list of CIDRs
+// in order from largest to smallest. They are *not* sorted by network IP.
+func netDifference(a, b *net.IPNet) (result []*net.IPNet) {
+	// If the two networks are different IP versions, return a
+	if len(a.IP) != len(b.IP) {
+		return []*net.IPNet{a}
+	}
+
+	// If b contains a then the difference is empty
+	if ContainsNet(b, a) {
+		return
+	}
+	// If a doesn't contain b then the difference is equal to a
+	if !ContainsNet(a, b) {
+		return []*net.IPNet{a}
+	}
+
+	// If two nets overlap then one must contain the other. At this point, we
+	// know a contains b and b is smaller than a. Cut a in half and recurse on
+	// the one that overlaps
+	first, second := divideNetInHalf(a)
+	if bytes.Compare(b.IP, second.IP) < 0 {
+		return append([]*net.IPNet{second}, netDifference(first, b)...)
+	}
+	return append([]*net.IPNet{first}, netDifference(second, b)...)
+}
+
+// divideNetInHalf returns the given net as two equally sized halves
+func divideNetInHalf(n *net.IPNet) (a, b *net.IPNet) {
+	// Get the size of the original netmask
+	ones, bits := n.Mask.Size()
+
+	// Netmask has one more 1. Net is half the size of original.
+	mask := net.CIDRMask(ones+1, bits)
+
+	// Create a new IP to fill in for the second half
+	ip := net.ParseIP("::")
+	if bits == 32 {
+		ip = net.ParseIP("0.0.0.0").To4()
+	}
+	// Fill in the new IP
+	for i := 0; i < bits/8; i++ {
+		// Puts a 1 in the new bit since this is the second half
+		extraOne := mask[i] ^ n.Mask[i]
+		// New IP is the same as old IP with the extra one at the end
+		ip[i] = mask[i] & (n.IP[i] | extraOne)
+	}
+
+	a = &net.IPNet{IP: n.IP, Mask: mask}
+	b = &net.IPNet{IP: ip, Mask: mask}
+	return
+}
+
+// canCombineNets returns true if the two networks, a and b, can be combined
+// into one larger cidr twice the size. If true, it returns the combined
+// network.
+func canCombineNets(a, b *net.IPNet) (ok bool, newNet *net.IPNet) {
+	if a.IP.Equal(b.IP) {
+		return
+	}
+	if bytes.Compare(a.Mask, b.Mask) != 0 {
+		return
+	}
+	ones, bits := a.Mask.Size()
+	newNet = &net.IPNet{IP: a.IP, Mask: net.CIDRMask(ones-1, bits)}
+	if newNet.Contains(b.IP) {
+		ok = true
+		return
+	}
+	return
+}
+
+// ipToNet converts the given IP to a /32 or /128 network depending on the type
+// of address.
+func ipToNet(ip net.IP) *net.IPNet {
+	size := 8 * len(ip)
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(size, size)}
+}
+
+// incrementIP returns the given IP + 1
+func incrementIP(ip net.IP) (result net.IP) {
+	result = make([]byte, len(ip)) // start off with a nice empty ip of proper length
+
+	carry := true
+	for i := len(ip) - 1; i >= 0; i-- {
+		result[i] = ip[i]
+		if carry {
+			result[i]++
+			if result[i] != 0 {
+				carry = false
+			}
+		}
+	}
+	return
+}
+
+// decrementIP returns the given IP - 1
+func decrementIP(ip net.IP) (result net.IP) {
+	result = make([]byte, len(ip)) // start off with a nice empty ip of proper length
+
+	borrow := true
+	for i := len(ip) - 1; i >= 0; i-- {
+		result[i] = ip[i]
+		if borrow {
+			result[i]--
+			if result[i] != 255 { // if we overflowed, we'd end up here
+				borrow = false
+			}
+		}
+	}
+	return
+}
+
+// expandNet returns a slice containing all of the IPs in the given net up to
+// the given limit
+func expandNet(n *net.IPNet, limit int) []net.IP {
+	ones, bits := n.Mask.Size()
+
+	size := limit
+	max := 1 << 30
+	if bits-ones < 30 {
+		max = 1 << uint(bits-ones)
+	}
+	if max < size {
+		size = max
+	}
+	result := make([]net.IP, size)
+	next := n.IP
+	for i := 0; i < size; i++ {
+		result[i] = next[:]
+		next = incrementIP(next)
+	}
+	return result
+}
+
+// IPLessThan compare two ip addresses true
+// ordered by ipv4 first, then ipv6 later
+// then by section left-most is most significant
+// e.g.
+// 10.0.0.0
+// 10.0.0.1
+// 192.169.0.1
+// 2001:db8::
+func IPLessThan(a, b net.IP) bool {
+	if len(a) != len(b) { // ipv6 comes after ipv4
+		return len(a) < len(b)
+	}
+	for i := range a { // go left to right and compare each one
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false // they are equal
+}
+
+// IPMin returns the minimum of a and b
+func IPMin(a, b net.IP) net.IP {
+	if IPLessThan(a, b) {
+		return a
+	}
+	return b
+}
+
+// IPMax returns the maximum of a and b
+func IPMax(a, b net.IP) net.IP {
+	if IPLessThan(a, b) {
+		return b
+	}
+	return a
+}
+
+// IPv4 returns the IP address (in 4-byte form) of the
+// IPv4 address a.b.c.d.
+func IPv4(a, b, c, d byte) net.IP {
+	p := make(net.IP, net.IPv4len)
+	p[0] = a
+	p[1] = b
+	p[2] = c
+	p[3] = d
+	return p
+}
+
+// IPv4Net returns the IPNet (in 4-byte form) of the
+// IPv4 address a.b.c.d/p.
+func IPv4Net(a, b, c, d byte, p int) net.IPNet {
+	return net.IPNet{
+		IP:   IPv4(a, b, c, d),
+		Mask: net.CIDRMask(p, 8*net.IPv4len),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,9 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
+# github.com/IBM/netaddr v1.5.0
+## explicit; go 1.16
+github.com/IBM/netaddr
 # github.com/MakeNowJust/heredoc v1.0.0
 ## explicit; go 1.12
 github.com/MakeNowJust/heredoc


### PR DESCRIPTION
This change is to ensure that the API VIP and the Ingress VIP  are checked against the broadcast address of the machine network to ensure that they are not the broadcast address.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
