### PR TITLE
MGMT-14723: Fix randomly failing subsystem test

### DIFF
--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -116,7 +116,6 @@ var _ = Describe("Feature support levels API", func() {
 						OlmOperators: []*models.OperatorCreateParams{
 							{Name: "odf"},
 							{Name: "cnv"},
-							{Name: "lso"},
 						},
 					},
 					ClusterID: *cluster.Payload.ID,


### PR DESCRIPTION
This bug is appearing randomly depending on which operator is validated first.
Fixing the error:

```
Feature support levels API
/assisted-service/subsystem/feature_support_levels_test.go:29
  Support Level
  /assisted-service/subsystem/feature_support_levels_test.go:35
    Update cluster
    /assisted-service/subsystem/feature_support_levels_test.go:72
      Create infra-env after updating OLM operators on s390x architecture  [It]
      /assisted-service/subsystem/feature_support_levels_test.go:108
      Expected
              
          <string>: cannot use Local Storage Operator because it's not compatible with the s390x architecture on version 4.13.0-rc.8-multi of OpenShift
      to contain substring
          <string>: cannot use OpenShift Virtualization because it's not compatible with the s390x architecture on version 4.13
```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 