### PR TITLE
MGMT-14384: Set restricted list of approvers for the new branch

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,34 +3,7 @@
 aliases:
   approvers:
     - romfreiman
-    - avishayt
-    - eranco74
     - filanov
     - gamli75
-    - ori-amizur
-    - tsorya
-    - nmagnezi
-    - carbonin
-    - danielerez
-    - slaviered
-    - omertuc
-    - eliorerz
     - osherdp
-    - flaper87
-    - mkowalski
-    - vrutkovs
-    - paul-maidment
-    - jhernand
-    - rccrdpccl
-    - adriengentil
-    - CrystalChun
-    - javipolo
-    - danmanor
-  emeritus_approvers:
-    - empovit
-    - yevgeny-shnaidman
-    - rwsu
-    - lranjbar
-    - pawanpinjarkar
-    - sagidayan
-    - ybettan
+    - eliorerz


### PR DESCRIPTION
Since there are (currently) no label restrictions on attached Jira bugs, we don't have a good way to enforce people are only merging bug-fixes / security-patches.
Setting a smaller approvers list can help us enforce this kind of restriction (list might change later on, if needed)

/cc @filanov @gamli75 @romfreiman