### PR TITLE
MGMT-14750: Allow FC, ECKD, FBA drive types on s390x

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -62,6 +62,15 @@ const (
 
 	// DriveTypeRAID captures enum value "RAID"
 	DriveTypeRAID DriveType = "RAID"
+
+	// DriveTypeECKD captures enum value "ECKD"
+	DriveTypeECKD DriveType = "ECKD"
+
+	// DriveTypeECKDESE captures enum value "ECKD (ESE)"
+	DriveTypeECKDESE DriveType = "ECKD (ESE)"
+
+	// DriveTypeFBA captures enum value "FBA"
+	DriveTypeFBA DriveType = "FBA"
 )
 
 // for schema
@@ -69,7 +78,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID","ECKD","ECKD (ESE)","FBA"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -319,6 +319,9 @@ func IncrementCidrMask(subnet string) string {
 
 func GenerateTestDefaultInventory() string {
 	inventory := &models.Inventory{
+		CPU: &models.CPU{
+			Architecture: models.ClusterCPUArchitectureX8664,
+		},
 		Interfaces: []*models.Interface{
 			{
 				Name: "eth0",
@@ -363,6 +366,9 @@ func GenerateTestInventoryWithVirtualInterface(physicalInterfaces, virtualInterf
 	interfaces := generateInterfaces(physicalInterfaces, "physical")
 	interfaces = append(interfaces, generateInterfaces(virtualInterfaces, "device")...)
 	inventory := &models.Inventory{
+		CPU: &models.CPU{
+			Architecture: models.ClusterCPUArchitectureX8664,
+		},
 		Interfaces: interfaces,
 		Disks: []*models.Disk{
 			TestDefaultConfig.Disks,

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -37,18 +37,18 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 }
 
 // DiskIsEligible mocks base method.
-func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, infraEnv *common.InfraEnv, cluster *common.Cluster, host *models.Host, allDisks []*models.Disk) ([]string, error) {
+func (m *MockValidator) DiskIsEligible(ctx context.Context, disk *models.Disk, infraEnv *common.InfraEnv, cluster *common.Cluster, host *models.Host, hostArchitecture string, allDisks []*models.Disk) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DiskIsEligible", ctx, disk, infraEnv, cluster, host, allDisks)
+	ret := m.ctrl.Call(m, "DiskIsEligible", ctx, disk, infraEnv, cluster, host, hostArchitecture, allDisks)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DiskIsEligible indicates an expected call of DiskIsEligible.
-func (mr *MockValidatorMockRecorder) DiskIsEligible(ctx, disk, infraEnv, cluster, host, allDisks interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) DiskIsEligible(ctx, disk, infraEnv, cluster, host, hostArchitecture, allDisks interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), ctx, disk, infraEnv, cluster, host, allDisks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskIsEligible", reflect.TypeOf((*MockValidator)(nil).DiskIsEligible), ctx, disk, infraEnv, cluster, host, hostArchitecture, allDisks)
 }
 
 // GetClusterHostRequirements mocks base method.
@@ -156,17 +156,17 @@ func (mr *MockValidatorMockRecorder) GetPreflightInfraEnvHardwareRequirements(ct
 }
 
 // IsValidStorageDeviceType mocks base method.
-func (m *MockValidator) IsValidStorageDeviceType(disk *models.Disk) bool {
+func (m *MockValidator) IsValidStorageDeviceType(disk *models.Disk, hostArchitecture string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValidStorageDeviceType", disk)
+	ret := m.ctrl.Call(m, "IsValidStorageDeviceType", disk, hostArchitecture)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsValidStorageDeviceType indicates an expected call of IsValidStorageDeviceType.
-func (mr *MockValidatorMockRecorder) IsValidStorageDeviceType(disk interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) IsValidStorageDeviceType(disk, hostArchitecture interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidStorageDeviceType", reflect.TypeOf((*MockValidator)(nil).IsValidStorageDeviceType), disk)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidStorageDeviceType", reflect.TypeOf((*MockValidator)(nil).IsValidStorageDeviceType), disk, hostArchitecture)
 }
 
 // ListEligibleDisks mocks base method.

--- a/internal/hardware/validator_test.go
+++ b/internal/hardware/validator_test.go
@@ -130,13 +130,13 @@ var _ = Describe("Disk eligibility", func() {
 	It("Check if SSD is eligible", func() {
 		testDisk.DriveType = models.DriveTypeSSD
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
 
 		By("Check infra env SSD is eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
@@ -145,13 +145,13 @@ var _ = Describe("Disk eligibility", func() {
 	It("Check if HDD is eligible", func() {
 		testDisk.DriveType = models.DriveTypeHDD
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
 
 		By("Check infra env HDD is eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
@@ -162,13 +162,13 @@ var _ = Describe("Disk eligibility", func() {
 		testDisk.DriveType = models.DriveTypeMultipath
 		allDisks := []*models.Disk{&testDisk, {Name: "sda", DriveType: models.DriveTypeFC, Holders: "dm-0"}, {Name: "sdb", DriveType: models.DriveTypeFC, Holders: "dm-0"}}
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, allDisks)
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, allDisks)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
 
 		By("Check infra env FC multipath is eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, allDisks)
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, allDisks)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
@@ -179,43 +179,118 @@ var _ = Describe("Disk eligibility", func() {
 		testDisk.DriveType = models.DriveTypeMultipath
 		allDisks := []*models.Disk{&testDisk, {Name: "sda", DriveType: models.DriveTypeISCSI, Holders: "dm-0"}, {Name: "sdb", DriveType: models.DriveTypeISCSI, Holders: "dm-0"}}
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, allDisks)
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, allDisks)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 
 		By("Check infra env iSCSI multipath is not eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, allDisks)
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, allDisks)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 	})
 
-	It("Check if FC is not eligible", func() {
+	It("Check if FC is not eligible on non-s390x", func() {
 		testDisk.DriveType = models.DriveTypeFC
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 
-		By("Check infra env FC is not eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		By("Check infra env FC is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
+	})
+
+	It("Check if FC is eligible for s390x", func() {
+		testDisk.DriveType = models.DriveTypeFC
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+
+		By("Check infra env FC is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+	})
+
+	It("Check if ECKD is not eligible on non-s390x", func() {
+		testDisk.DriveType = models.DriveTypeECKD
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).ToNot(BeEmpty())
+
+		By("Check infra env ECKD is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).ToNot(BeEmpty())
+	})
+
+	It("Check if ECKD is eligible for s390x", func() {
+		testDisk.DriveType = models.DriveTypeECKD
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+
+		By("Check infra env ECKD is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+	})
+
+	It("Check if FBA is not eligible on non-s390x", func() {
+		testDisk.DriveType = models.DriveTypeFBA
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).ToNot(BeEmpty())
+
+		By("Check infra env FBA is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).ToNot(BeEmpty())
+	})
+
+	It("Check if FBA is eligible for s390x", func() {
+		testDisk.DriveType = models.DriveTypeFBA
+
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
+
+		By("Check infra env FBA is only eligible for s390x")
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureS390x, []*models.Disk{&testDisk})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eligible).To(BeEmpty())
 	})
 
 	It("Check that ODD is not eligible", func() {
 		testDisk.DriveType = models.DriveTypeODD
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 
 		By("Check infra-env ODD is not eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
@@ -224,13 +299,13 @@ var _ = Describe("Disk eligibility", func() {
 	It("Check that a big enough size is eligible", func() {
 		testDisk.SizeBytes = bigEnoughSize
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
 
 		By("Check infra-env a big enough size is eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
@@ -239,7 +314,7 @@ var _ = Describe("Disk eligibility", func() {
 		versionRequirements["default"].MasterRequirements.DiskSizeGb = minDiskSizeGb - 2
 		tooSmallSizeForWorker := conversions.GbToBytes(minDiskSizeGb) - 1
 		testDisk.SizeBytes = tooSmallSizeForWorker
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(BeEmpty())
@@ -250,13 +325,13 @@ var _ = Describe("Disk eligibility", func() {
 	It("Check that a small size is not eligible", func() {
 		testDisk.SizeBytes = tooSmallSize
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
 
 		By("Check infra-env a small size is not eligible")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).ToNot(BeEmpty())
@@ -266,13 +341,13 @@ var _ = Describe("Disk eligibility", func() {
 		existingReasons := []string{"Reason 1", "Reason 2"}
 		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ConsistOf(existingReasons))
 
 		By("Check infra-env existing non-eligibility reasons are preserved")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ConsistOf(existingReasons))
 	})
@@ -283,14 +358,14 @@ var _ = Describe("Disk eligibility", func() {
 
 		testDisk.SizeBytes = tooSmallSize
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ContainElements(existingReasons))
 		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
 
 		By("Check infra env a small size reason is added to existing reasons")
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, nil, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ContainElements(existingReasons))
@@ -304,13 +379,13 @@ var _ = Describe("Disk eligibility", func() {
 
 		testDisk.SizeBytes = tooSmallSize
 
-		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err := hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ContainElements(existingReasons))
 		Expect(eligible).To(HaveLen(len(existingReasons) + 1))
 
 		testDisk.InstallationEligibility.NotEligibleReasons = existingReasons
-		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, []*models.Disk{&testDisk})
+		eligible, err = hwvalidator.DiskIsEligible(ctx, &testDisk, infraEnv, &cluster, &host, models.ClusterCPUArchitectureX8664, []*models.Disk{&testDisk})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(eligible).To(ContainElements(existingReasons))
 		Expect(eligible).To(HaveLen(len(existingReasons) + 1))

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -252,7 +252,7 @@ func (m *Manager) populateDisksEligibility(ctx context.Context, inventory *model
 		}
 
 		// Append to the existing reasons already filled in by the agent
-		reasons, err := m.hwValidator.DiskIsEligible(ctx, disk, infraEnv, cluster, host, inventory.Disks)
+		reasons, err := m.hwValidator.DiskIsEligible(ctx, disk, infraEnv, cluster, host, inventory.CPU.Architecture, inventory.Disks)
 		if err != nil {
 			return err
 		}

--- a/internal/host/hostutil/test_utils.go
+++ b/internal/host/hostutil/test_utils.go
@@ -271,7 +271,7 @@ func GenerateMasterInventoryWithHostnameDualStack(hostname string) string {
 
 func GenerateMasterInventoryWithHostnameAndCpuFlags(hostname string, cpuflags []string, systemPlatform string) string {
 	inventory := models.Inventory{
-		CPU: &models.CPU{Count: 8, Flags: cpuflags},
+		CPU: &models.CPU{Count: 8, Flags: cpuflags, Architecture: models.ClusterCPUArchitectureX8664},
 		Disks: []*models.Disk{
 			{
 				SizeBytes: 128849018880,

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1561,7 +1561,7 @@ var _ = Describe("Refresh Host", func() {
 				)).AnyTimes()
 
 				mockDefaultClusterHostRequirements(mockHwValidator)
-				mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any()).Return(true).AnyTimes()
+				mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 				mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return([]*models.Disk{}).AnyTimes()
 				mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 			}

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Validations test", func() {
 
 	mockAndRefreshStatusWithoutEvents := func(h *models.Host) {
 		mockDefaultClusterHostRequirements(mockHwValidator)
-		mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any()).Return(true).AnyTimes()
+		mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return([]*models.Disk{}).AnyTimes()
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 		mockOperators.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any()).Return([]api.ValidationResult{
@@ -1545,7 +1545,7 @@ var _ = Describe("Validations test", func() {
 			updateClusterPlatform()
 			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
 
-			mockHwValidator.EXPECT().IsValidStorageDeviceType(CDROM).Return(false).Times(1)
+			mockHwValidator.EXPECT().IsValidStorageDeviceType(CDROM, models.ClusterCPUArchitectureX8664).Return(false).Times(1)
 			mockAndRefreshStatus(&host)
 			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
 			status, _, _ := getValidationResult(host.ValidationsInfo, hostUUIDValidation)

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1682,7 +1682,7 @@ func (v *validator) isVSphereDiskUUIDEnabled(c *validationContext) (ValidationSt
 		// if any of them doesn't have that flag, it's likely because the user has forgotten to
 		// enable `disk.EnableUUID` for this virtual machine
 		// See https://access.redhat.com/solutions/4606201
-		if v.hwValidator.IsValidStorageDeviceType(disk) && !disk.HasUUID {
+		if v.hwValidator.IsValidStorageDeviceType(disk, c.inventory.CPU.Architecture) && !disk.HasUUID {
 			return ValidationFailure, "VSphere disk.EnableUUID isn't enabled for this virtual machine, it's necessary for disks to be mounted properly"
 		}
 	}

--- a/models/drive_type.go
+++ b/models/drive_type.go
@@ -62,6 +62,15 @@ const (
 
 	// DriveTypeRAID captures enum value "RAID"
 	DriveTypeRAID DriveType = "RAID"
+
+	// DriveTypeECKD captures enum value "ECKD"
+	DriveTypeECKD DriveType = "ECKD"
+
+	// DriveTypeECKDESE captures enum value "ECKD (ESE)"
+	DriveTypeECKDESE DriveType = "ECKD (ESE)"
+
+	// DriveTypeFBA captures enum value "FBA"
+	DriveTypeFBA DriveType = "FBA"
 )
 
 // for schema
@@ -69,7 +78,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID","ECKD","ECKD (ESE)","FBA"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7249,7 +7249,10 @@ func init() {
         "iSCSI",
         "FC",
         "LVM",
-        "RAID"
+        "RAID",
+        "ECKD",
+        "ECKD (ESE)",
+        "FBA"
       ]
     },
     "error": {
@@ -17600,7 +17603,10 @@ func init() {
         "iSCSI",
         "FC",
         "LVM",
-        "RAID"
+        "RAID",
+        "ECKD",
+        "ECKD (ESE)",
+        "FBA"
       ]
     },
     "error": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5763,6 +5763,9 @@ definitions:
       - FC
       - LVM
       - RAID
+      - ECKD        # IBM
+      - ECKD (ESE)  # IBM
+      - FBA         # IBM
 
   io_perf:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/drive_type.go
+++ b/vendor/github.com/openshift/assisted-service/models/drive_type.go
@@ -62,6 +62,15 @@ const (
 
 	// DriveTypeRAID captures enum value "RAID"
 	DriveTypeRAID DriveType = "RAID"
+
+	// DriveTypeECKD captures enum value "ECKD"
+	DriveTypeECKD DriveType = "ECKD"
+
+	// DriveTypeECKDESE captures enum value "ECKD (ESE)"
+	DriveTypeECKDESE DriveType = "ECKD (ESE)"
+
+	// DriveTypeFBA captures enum value "FBA"
+	DriveTypeFBA DriveType = "FBA"
 )
 
 // for schema
@@ -69,7 +78,7 @@ var driveTypeEnum []interface{}
 
 func init() {
 	var res []DriveType
-	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Unknown","HDD","FDD","ODD","SSD","virtual","Multipath","iSCSI","FC","LVM","RAID","ECKD","ECKD (ESE)","FBA"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
Multipath cannot be enabled in day1 on s390x, so we will allow installing directly on an FC path only for this arch.  In addition, there are two new drive types for IBM DASDs (direct access storage devices).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
