### PR TITLE
MGMT-13746: validate discovery ignition size

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -4634,12 +4634,6 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 		kernelArguments = swag.String(string(b))
 	}
 
-	if params.InfraenvCreateParams.IgnitionConfigOverride != "" {
-		if err = validations.ValidateIgnitionImageSize(params.InfraenvCreateParams.IgnitionConfigOverride); err != nil {
-			return nil, common.NewApiError(http.StatusBadRequest, err)
-		}
-	}
-
 	imageType := b.getActualImageType(params.InfraenvCreateParams.CPUArchitecture, params.InfraenvCreateParams.ImageType)
 	infraEnv = common.InfraEnv{
 		Generated: false,
@@ -4701,6 +4695,20 @@ func (b *bareMetalInventory) RegisterInfraEnvInternal(
 
 	if err = updateSSHAuthorizedKey(&infraEnv); err != nil {
 		return nil, common.NewApiError(http.StatusBadRequest, err)
+	}
+
+	if params.InfraenvCreateParams.IgnitionConfigOverride != "" {
+		var discoveryIgnition string
+		discoveryIgnition, err = b.IgnitionBuilder.FormatDiscoveryIgnitionFile(
+			ctx, &infraEnv, b.IgnitionConfig,
+			false, b.authHandler.AuthType(), string(params.InfraenvCreateParams.ImageType))
+		if err != nil {
+			log.WithError(err).Error("Failed to format discovery ignition config")
+			return nil, common.NewApiError(http.StatusInternalServerError, err)
+		}
+		if err = validations.ValidateIgnitionImageSize(discoveryIgnition); err != nil {
+			return nil, common.NewApiError(http.StatusBadRequest, err)
+		}
 	}
 
 	if err = tx.Create(&infraEnv).Error; err != nil {
@@ -4988,6 +4996,11 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 		return nil, err
 	}
 
+	// Validate discovery ignition after updating InfraEnv data
+	if err = b.validateDiscoveryIgnitionImageSize(ctx, infraEnv, params, tx, log); err != nil {
+		return nil, err
+	}
+
 	tx.Commit()
 	success = true
 
@@ -5007,6 +5020,27 @@ func (b *bareMetalInventory) UpdateInfraEnvInternal(ctx context.Context, params 
 	}
 
 	return b.GetInfraEnvInternal(ctx, installer.GetInfraEnvParams{InfraEnvID: *infraEnv.ID})
+}
+
+func (b *bareMetalInventory) validateDiscoveryIgnitionImageSize(ctx context.Context, infraEnv *common.InfraEnv, params installer.UpdateInfraEnvParams, db *gorm.DB, log logrus.FieldLogger) error {
+	if params.InfraEnvUpdateParams.IgnitionConfigOverride != "" && params.InfraEnvUpdateParams.IgnitionConfigOverride != infraEnv.IgnitionConfigOverride {
+		infraEnvAfterUpdate, err := common.GetInfraEnvFromDB(db, params.InfraEnvID)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to get infraEnv: %s", params.InfraEnvID)
+			return err
+		}
+		discoveryIgnition, err := b.IgnitionBuilder.FormatDiscoveryIgnitionFile(
+			ctx, infraEnvAfterUpdate, b.IgnitionConfig,
+			false, b.authHandler.AuthType(), string(common.ImageTypeValue(infraEnvAfterUpdate.Type)))
+		if err != nil {
+			log.WithError(err).Error("Failed to format discovery ignition config")
+			return err
+		}
+		if err := validations.ValidateIgnitionImageSize(discoveryIgnition); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (b *bareMetalInventory) updateInfraEnvData(ctx context.Context, infraEnv *common.InfraEnv, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string, db *gorm.DB, log logrus.FieldLogger) error {
@@ -5050,10 +5084,6 @@ func (b *bareMetalInventory) updateInfraEnvData(ctx context.Context, infraEnv *c
 	}
 
 	if params.InfraEnvUpdateParams.IgnitionConfigOverride != "" && params.InfraEnvUpdateParams.IgnitionConfigOverride != infraEnv.IgnitionConfigOverride {
-		if err := validations.ValidateIgnitionImageSize(params.InfraEnvUpdateParams.IgnitionConfigOverride); err != nil {
-			return common.NewApiError(http.StatusBadRequest, err)
-		}
-
 		updates["ignition_config_override"] = params.InfraEnvUpdateParams.IgnitionConfigOverride
 		// Set the feature usage for ignition config overrides since it changed
 		if err := b.setIgnitionConfigOverrideUsage(infraEnv.ClusterID, params.InfraEnvUpdateParams.IgnitionConfigOverride, "infra-env", db); err != nil {


### PR DESCRIPTION
Currently, when IgnitionConfigOverride is specified on InfraEnv creation/update, we ensure its size isn't larger than 256KiB. This validation is done since the size of the padding for ignition in discovery image is limited.

Thus, in order to accurately validate the size, we need to calc the size of the entire discovery ignition (i.e. instead of only the 'IgnitionConfigOverride' property).

Note that this change still performs the validation only if IgnitionConfigOverride is specified, since it should still contain the substantial amount of data to reach the limitation. The other potentially large property is AdditionalTrustBundle but it's already limited to 64KiB.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
