### PR TITLE
MGMT-14165: `AgentClusterInstall` Webhooks improvements and fixes

### DIFF
--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -1,9 +1,20 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 )
+
+func PlatformTypeToPlatform(platformType hiveext.PlatformType) *models.Platform {
+	pType := strings.ToLower(string(platformType))
+	platform := &models.Platform{Type: PlatformTypePtr(models.PlatformType(pType))}
+	platform.IsExternal = swag.Bool(*platform.Type == models.PlatformTypeOci)
+	return platform
+}
 
 func PlatformTypePtr(p models.PlatformType) *models.PlatformType {
 	return &p

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
@@ -62,6 +62,83 @@ var _ = Describe("ACI mutator hook", func() {
 			patched:         false,
 		},
 		{
+			name: "ACI create with userManagedNetworking not set with multi Node --> patch to false",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 3, WorkerAgents: 3},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with Nutanix platform --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with VSphere platform --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform and multi node --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 3, WorkerAgents: 3},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform and SNO --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "Invalid Config: ACI create with userManagedNetworking not set with BareMetal platform and SNO --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
 			name: "ACI updated after install start --> no change",
 			oldSpec: hiveext.AgentClusterInstallSpec{
 				Networking:            hiveext.Networking{},

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
-	apiserver "github.com/openshift/generic-admission-server/pkg/apiserver"
+	"github.com/openshift/generic-admission-server/pkg/apiserver"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -315,6 +315,298 @@ var _ = Describe("ACI web validate", func() {
 				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
 			},
 			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Multi node ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "SNO ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with BareMetal platform and userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI create with BareMetal platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with VSpherePlatformType platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with VSpherePlatformType platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with NutanixPlatformType platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with NutanixPlatformType platform and userManagedNetworking set to true not is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update None platform with userManagedNetworking set to false not is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update None platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update None platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update BareMetalPlatformType platform with platform None is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				PlatformType: hiveext.NonePlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update BareMetalPlatformType platform with userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI update BareMetalPlatformType platform to SNO is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI update None platform to SNO is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "SNO ACI update None platform to Multi node is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       1,
+				},
+			},
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 	}


### PR DESCRIPTION
Not all Platform and `UserManageNetworking` configurations are valid.
In REST-API, assisted service will attempt to calculate either of the two
configs to handle misconfigurations. This behavior cannot work the same way
in KubeAPI, as the DB cannot be updated separately from the ACI spec.

This webhook is placed to prevent such updates, to begin with, while basing
on the same backend business logic as the REST-API does, excluding the
backend-driven "fixes".

Mutating webhook:
1. patching `userManagedNetworking` for cases where the `platform` is not set will stay the same.
2. SNO and / or None platform: `userManagedNetworking`  --> `true`
3. BareMetal platform: userManagedNetworking  --> `false`
4. Nutanix and VSphere platform: `userManagedNetworking` not patched.
5, In case of a mismatch between platform and topology (e.g. BareMetal + SNO):
   `userManagedNetworking` not patched.

Validation webhook:
This webhook will not look at updates to:
1. `Platform`
2. `userManagedNetworking`
3. `ControlPlaneAgents` + `WorkerAgents`

As stated above, in the case of any misconfiguration in ACI create or update, it
will reject the request without trying to change the cluster attributes to fix
it (which is why this bug got opened, to begin with).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
