### PR TITLE
MGMT-14704: Provide info on custom/vs non custom manifest in manifest endpoint.

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3630,7 +3630,7 @@ func (b *bareMetalInventory) V2GetPresignedForClusterFiles(ctx context.Context, 
 	var err error
 	fullFileName := fmt.Sprintf("%s/%s", params.ClusterID.String(), params.FileName)
 	downloadFilename := params.FileName
-	if params.FileName == manifests.ManifestFolder {
+	if params.FileName == constants.ManifestFolder {
 		if params.AdditionalName != nil {
 			additionalName := *params.AdditionalName
 			fullFileName = manifests.GetManifestObjectName(params.ClusterID, additionalName)
@@ -3752,7 +3752,7 @@ func (b *bareMetalInventory) checkFileForDownload(ctx context.Context, clusterID
 	log := logutil.FromContext(ctx, b.log)
 	log.Infof("Checking cluster file for download: %s for cluster %s", fileName, clusterID)
 
-	if !funk.Contains(clusterPkg.S3FileNames, fileName) && fileName != manifests.ManifestFolder {
+	if !funk.Contains(clusterPkg.S3FileNames, fileName) && fileName != constants.ManifestFolder {
 		err := errors.Errorf("invalid cluster file %s", fileName)
 		log.WithError(err).Errorf("failed download file: %s from cluster: %s", fileName, clusterID)
 		return common.NewApiError(http.StatusBadRequest, err)
@@ -3766,7 +3766,7 @@ func (b *bareMetalInventory) checkFileForDownload(ctx context.Context, clusterID
 	switch fileName {
 	case constants.Kubeconfig:
 		err = clusterPkg.CanDownloadKubeconfig(cluster)
-	case manifests.ManifestFolder:
+	case constants.ManifestFolder:
 		// do nothing. manifests can be downloaded at any given cluster state
 	default:
 		err = clusterPkg.CanDownloadFiles(cluster)

--- a/internal/constants/manifests.go
+++ b/internal/constants/manifests.go
@@ -1,0 +1,6 @@
+package constants
+
+// ManifestFolder represents the manifests folder on s3 per cluster
+const ManifestFolder = "manifests"
+const ManifestMetadataFolder = "manifest-attributes"
+const ManifestSourceUserSupplied = "user-supplied"

--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1149,6 +1149,7 @@ func (r *ClusterDeploymentsReconciler) syncManifests(ctx context.Context, log lo
 
 	// create/update all manifests provided by configmap data
 	for filename, manifest := range manifestsFromConfigMap {
+		isUserManifest := true
 		log.Infof("Creating cluster deployment %s manifest %s", cluster.KubeKeyName, filename)
 		_, err := r.Manifests.CreateClusterManifestInternal(ctx, operations.V2CreateClusterManifestParams{
 			ClusterID: *cluster.ID,
@@ -1156,7 +1157,8 @@ func (r *ClusterDeploymentsReconciler) syncManifests(ctx context.Context, log lo
 				Content:  swag.String(base64.StdEncoding.EncodeToString([]byte(manifest))),
 				FileName: swag.String(filename),
 				Folder:   swag.String(models.ManifestFolderOpenshift),
-			}})
+			}},
+			isUserManifest)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to create cluster deployment %s manifest %s", cluster.KubeKeyName, filename)
 			return err

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -1975,7 +1975,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(2)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("error")).Times(1)
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, errors.Errorf("error")).Times(1)
 			request := newClusterDeploymentRequest(cluster)
 			aci = getTestClusterInstall()
 			aci.Spec.ManifestsConfigMapRef = ref
@@ -2039,7 +2039,7 @@ var _ = Describe("cluster reconcile", func() {
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, nil).Times(1)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)
@@ -2164,7 +2164,7 @@ var _ = Describe("cluster reconcile", func() {
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(backEndCluster, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(2)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), true).Return(nil, nil).Times(2)
 			mockClusterApi.EXPECT().IsReadyForInstallation(gomock.Any()).Return(true, "").Times(1)
 			mockManifestsApi.EXPECT().ListClusterManifestsInternal(gomock.Any(), gomock.Any()).Return(models.ListManifests{}, nil).Times(1)
 			mockInstallerInternal.EXPECT().GetKnownHostApprovedCounts(gomock.Any()).Return(5, 5, nil).Times(1)

--- a/internal/manifests/api/interface.go
+++ b/internal/manifests/api/interface.go
@@ -16,7 +16,7 @@ type ManifestsAPI interface {
 
 //go:generate mockgen --build_flags=--mod=mod -package api -destination mock_manifests_internal.go . ClusterManifestsInternals
 type ClusterManifestsInternals interface {
-	CreateClusterManifestInternal(ctx context.Context, params operations.V2CreateClusterManifestParams) (*models.Manifest, error)
+	CreateClusterManifestInternal(ctx context.Context, params operations.V2CreateClusterManifestParams, isCustomManifest bool) (*models.Manifest, error)
 	ListClusterManifestsInternal(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error)
 	DeleteClusterManifestInternal(ctx context.Context, params operations.V2DeleteClusterManifestParams) error
 }

--- a/internal/manifests/api/mock_manifests_api.go
+++ b/internal/manifests/api/mock_manifests_api.go
@@ -38,18 +38,18 @@ func (m *MockManifestsAPI) EXPECT() *MockManifestsAPIMockRecorder {
 }
 
 // CreateClusterManifestInternal mocks base method.
-func (m *MockManifestsAPI) CreateClusterManifestInternal(arg0 context.Context, arg1 manifests.V2CreateClusterManifestParams) (*models.Manifest, error) {
+func (m *MockManifestsAPI) CreateClusterManifestInternal(arg0 context.Context, arg1 manifests.V2CreateClusterManifestParams, arg2 bool) (*models.Manifest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateClusterManifestInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateClusterManifestInternal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*models.Manifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateClusterManifestInternal indicates an expected call of CreateClusterManifestInternal.
-func (mr *MockManifestsAPIMockRecorder) CreateClusterManifestInternal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockManifestsAPIMockRecorder) CreateClusterManifestInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterManifestInternal", reflect.TypeOf((*MockManifestsAPI)(nil).CreateClusterManifestInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterManifestInternal", reflect.TypeOf((*MockManifestsAPI)(nil).CreateClusterManifestInternal), arg0, arg1, arg2)
 }
 
 // DeleteClusterManifestInternal mocks base method.

--- a/internal/manifests/api/mock_manifests_internal.go
+++ b/internal/manifests/api/mock_manifests_internal.go
@@ -37,18 +37,18 @@ func (m *MockClusterManifestsInternals) EXPECT() *MockClusterManifestsInternalsM
 }
 
 // CreateClusterManifestInternal mocks base method.
-func (m *MockClusterManifestsInternals) CreateClusterManifestInternal(arg0 context.Context, arg1 manifests.V2CreateClusterManifestParams) (*models.Manifest, error) {
+func (m *MockClusterManifestsInternals) CreateClusterManifestInternal(arg0 context.Context, arg1 manifests.V2CreateClusterManifestParams, arg2 bool) (*models.Manifest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateClusterManifestInternal", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateClusterManifestInternal", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*models.Manifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateClusterManifestInternal indicates an expected call of CreateClusterManifestInternal.
-func (mr *MockClusterManifestsInternalsMockRecorder) CreateClusterManifestInternal(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClusterManifestsInternalsMockRecorder) CreateClusterManifestInternal(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterManifestInternal", reflect.TypeOf((*MockClusterManifestsInternals)(nil).CreateClusterManifestInternal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterManifestInternal", reflect.TypeOf((*MockClusterManifestsInternals)(nil).CreateClusterManifestInternal), arg0, arg1, arg2)
 }
 
 // DeleteClusterManifestInternal mocks base method.

--- a/internal/manifests/manifests_v2.go
+++ b/internal/manifests/manifests_v2.go
@@ -12,7 +12,7 @@ import (
 
 func (m *Manifests) V2CreateClusterManifest(ctx context.Context, params operations.V2CreateClusterManifestParams) middleware.Responder {
 	log := logutil.FromContext(ctx, m.log)
-	manifest, err := m.CreateClusterManifestInternal(ctx, params)
+	manifest, err := m.CreateClusterManifestInternal(ctx, params, true)
 	if err != nil {
 		return common.GenerateErrorResponder(err)
 	}

--- a/internal/network/manifests_generator.go
+++ b/internal/network/manifests_generator.go
@@ -331,6 +331,7 @@ func (m *ManifestsGenerator) AddDiskEncryptionManifest(ctx context.Context, log 
 
 func (m *ManifestsGenerator) createManifests(ctx context.Context, cluster *common.Cluster, filename string, content []byte) error {
 	// all relevant logs of creating manifest will be inside CreateClusterManifest
+	// Mark internally created manifests as "non custom", i.e. not uploaded by a user.
 	_, err := m.manifestsApi.CreateClusterManifestInternal(ctx, operations.V2CreateClusterManifestParams{
 		ClusterID: *cluster.ID,
 		CreateManifestParams: &models.CreateManifestParams{
@@ -338,7 +339,7 @@ func (m *ManifestsGenerator) createManifests(ctx context.Context, cluster *commo
 			FileName: &filename,
 			Folder:   swag.String(models.ManifestFolderOpenshift),
 		},
-	})
+	}, false)
 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create manifest %s", filename)

--- a/internal/network/manifests_generator_test.go
+++ b/internal/network/manifests_generator_test.go
@@ -147,11 +147,11 @@ var _ = Describe("chrony manifest", func() {
 		})
 
 		It("CreateClusterManifest success", func() {
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: "50-masters-chrony-configuration.yaml",
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(1)
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: "50-workers-chrony-configuration.yaml",
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(1)
@@ -161,7 +161,7 @@ var _ = Describe("chrony manifest", func() {
 
 		It("CreateClusterManifest failure", func() {
 			fileName := "50-masters-chrony-configuration.yaml"
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("Failed to create manifest %s", fileName)).Times(1)
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(nil, errors.Errorf("Failed to create manifest %s", fileName)).Times(1)
 			Expect(ntpUtils.AddChronyManifest(ctx, log, &cluster)).Should(HaveOccurred())
 		})
 	})
@@ -321,7 +321,7 @@ var _ = Describe("dnsmasq manifest", func() {
 
 			ctrl := gomock.NewController(GinkgoT())
 			mockManifestsApi := manifestsapi.NewMockManifestsAPI(ctrl)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: "dnsmasq-bootstrap-in-place.yaml",
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(0)
@@ -341,7 +341,7 @@ var _ = Describe("dnsmasq manifest", func() {
 
 			ctrl := gomock.NewController(GinkgoT())
 			mockManifestsApi := manifestsapi.NewMockManifestsAPI(ctrl)
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: "dnsmasq-bootstrap-in-place.yaml",
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(1)
@@ -416,7 +416,7 @@ var _ = Describe("telemeter manifest", func() {
 			fileName := "redirect-telemeter.yaml"
 			It("happy flow", func() {
 				if test.envName == "Stage env" || test.envName == "Integration env" {
-					mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any()).Return(&models.Manifest{
+					mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any(), false).Return(&models.Manifest{
 						FileName: fileName,
 						Folder:   models.ManifestFolderOpenshift,
 					},
@@ -430,7 +430,7 @@ var _ = Describe("telemeter manifest", func() {
 				if test.envName != "Stage env" && test.envName != "Integration env" {
 					Skip("We don't create any additional manifest in prod")
 				}
-				mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any()).Return(nil, errors.Errorf("Failed to create manifest %s", fileName))
+				mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any(), false).Return(nil, errors.Errorf("Failed to create manifest %s", fileName))
 				err := manifestsGeneratorApi.AddTelemeterManifest(ctx, log, &cluster)
 				Expect(err).Should(HaveOccurred())
 			})
@@ -476,7 +476,7 @@ var _ = Describe("schedulable masters manifest", func() {
 	Context("CreateClusterManifest success", func() {
 		fileName := "cluster-scheduler-02-config.yml.patch_ai_set_masters_schedulable"
 		It("CreateClusterManifest success", func() {
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: fileName,
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(1)
@@ -484,7 +484,7 @@ var _ = Describe("schedulable masters manifest", func() {
 		})
 
 		It("CreateClusterManifest failure", func() {
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("Failed to create manifest %s", fileName)).Times(1)
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(nil, errors.Errorf("Failed to create manifest %s", fileName)).Times(1)
 			Expect(manifestsGeneratorApi.AddSchedulableMastersManifest(ctx, log, &cluster)).Should(HaveOccurred())
 		})
 	})
@@ -596,7 +596,7 @@ var _ = Describe("disk encryption manifest", func() {
 		It(t.name, func() {
 			c.DiskEncryption = t.diskEncryption
 			Expect(db.Create(&c).Error).NotTo(HaveOccurred())
-			mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any()).Times(t.numOfManifests)
+			mockManifestsApi.EXPECT().CreateClusterManifestInternal(ctx, gomock.Any(), false).Times(t.numOfManifests)
 			err := manifestsGeneratorApi.AddDiskEncryptionManifest(ctx, log, &c)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -649,7 +649,7 @@ var _ = Describe("node ip hint", func() {
 		fileName := "node-ip-hint.yaml"
 		It("CreateClusterManifest success", func() {
 			cluster := clusterCreate("3.3.3.0/24")
-			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&models.Manifest{
+			manifestsApi.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&models.Manifest{
 				FileName: fileName,
 				Folder:   models.ManifestFolderOpenshift,
 			}, nil).Times(2)

--- a/internal/operators/manager.go
+++ b/internal/operators/manager.go
@@ -182,7 +182,7 @@ func (mgr *Manager) createManifests(ctx context.Context, cluster *common.Cluster
 			FileName: &filename,
 			Folder:   swag.String(folder),
 		},
-	})
+	}, false)
 
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create manifest %s for cluster %s", filename, cluster.ID)

--- a/internal/operators/manager_test.go
+++ b/internal/operators/manager_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Operators manager", func() {
 			cluster.MonitoredOperators = manager.GetSupportedOperatorsByType(models.OperatorTypeOlm)
 
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(ctx context.Context, params operations.V2CreateClusterManifestParams) (*models.Manifest, error) {
+			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).DoAndReturn(
+				func(ctx context.Context, params operations.V2CreateClusterManifestParams, isCustomManifest bool) (*models.Manifest, error) {
 					manifestContent, err := base64.StdEncoding.DecodeString(*params.CreateManifestParams.Content)
 					if err != nil {
 						return nil, err
@@ -96,7 +96,7 @@ var _ = Describe("Operators manager", func() {
 			m := models.Manifest{}
 
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&m, nil).Times(6)
+			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&m, nil).Times(6)
 			Expect(manager.GenerateManifests(ctx, cluster)).ShouldNot(HaveOccurred())
 		})
 
@@ -110,7 +110,7 @@ var _ = Describe("Operators manager", func() {
 			m := models.Manifest{}
 
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&m, nil).Times(6)
+			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&m, nil).Times(6)
 			Expect(manager.GenerateManifests(ctx, cluster)).ShouldNot(HaveOccurred())
 		})
 
@@ -120,7 +120,7 @@ var _ = Describe("Operators manager", func() {
 			}
 			m := models.Manifest{}
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&m, nil).Times(3)
+			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&m, nil).Times(3)
 			Expect(manager.GenerateManifests(ctx, cluster)).ShouldNot(HaveOccurred())
 		})
 
@@ -131,7 +131,7 @@ var _ = Describe("Operators manager", func() {
 			}
 			m := models.Manifest{}
 			mockS3Api.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
-			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any()).Return(&m, nil).Times(6)
+			manifestsAPI.EXPECT().CreateClusterManifestInternal(gomock.Any(), gomock.Any(), false).Return(&m, nil).Times(6)
 			Expect(manager.GenerateManifests(ctx, cluster)).ShouldNot(HaveOccurred())
 		})
 	})

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -108,7 +108,7 @@ spec:
 
 			var found bool = false
 			for _, manifest := range response.Payload {
-				if *manifest == manifestFile {
+				if manifest.FileName == manifestFile.FileName && manifest.Folder == manifestFile.Folder {
 					found = true
 					break
 				}
@@ -151,7 +151,7 @@ spec:
 
 			var found bool = false
 			for _, manifest := range response.Payload {
-				if *manifest == manifestFile {
+				if manifest.FileName == manifestFile.FileName && manifest.Folder == manifestFile.Folder {
 					found = true
 					break
 				}


### PR DESCRIPTION
It has been reported that users have no way to determine whether or not a manifest is a custom manifest or one generated by the assisted-service. This PR introduces a change that uses the file system to store additional metadata about a manifest to indicate whether or not the manifest is a custom one.

For example, if the original file is stored in

```
"e09df13f-6f31-42c2-8361-2b5605f80e77/manifests/openshift/99-openshift-machineconfig-master-kargs.yaml"
```

Then, if an only if the manifest is custom -  a corresponding metadata file will be created in the following path.

```
"e09df13f-6f31-42c2-8361-2b5605f80e77/manifest-attributes/openshift/99-openshift-machineconfig-master-kargs.yaml/user-defined"
```

Any internally generated manifests are considered to be "non custom" and are created as such. All other manifests are considered to be custom and will follow the scheme above.

When the user retrieves the manifest list, an additional parameter will be supplied for each manifest to indicate the custom/non custom status of the manifest.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Building a custom version of the service, creating a cluster and uploading manifests
Fetching the manifest list
Observing that behaviour is as expected.
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
