### PR TITLE
MGMT-14830: Enable TechPreviewNoUpgrade when platform is external

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -2,6 +2,7 @@ package installcfg
 
 import (
 	"github.com/go-openapi/strfmt"
+	configv1 "github.com/openshift/api/config/v1"
 	cluster_validations "github.com/openshift/assisted-service/internal/cluster/validations"
 )
 
@@ -201,6 +202,7 @@ type InstallerConfigBaremetal struct {
 	AdditionalTrustBundle string               `yaml:"additionalTrustBundle,omitempty"`
 	ImageContentSources   []ImageContentSource `yaml:"imageContentSources,omitempty"`
 	Capabilities          *Capabilities        `yaml:"capabilities,omitempty"`
+	FeatureSet            configv1.FeatureSet  `yaml:"featureSet,omitempty"`
 }
 
 func (c *InstallerConfigBaremetal) Validate() error {

--- a/internal/provider/external/installConfig.go
+++ b/internal/provider/external/installConfig.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"github.com/go-openapi/swag"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/installcfg"
@@ -14,6 +15,9 @@ func (p externalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerCo
 	cfg.Platform = installcfg.Platform{
 		None: &installcfg.PlatformNone{},
 	}
+
+	// Enable feature set "TechPreviewNoUpgrade" in order to access External platform feature
+	cfg.FeatureSet = configv1.TechPreviewNoUpgrade
 
 	cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
 	if cluster.NetworkType != nil {

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider/vsphere"
@@ -395,8 +396,8 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 		})
 	})
 
-	Context("external", func() {
-		It("should set platform to none", func() {
+	Context("oci", func() {
+		It("should set platform to none and featureset to TechPreviewNoUpgrade", func() {
 			cfg := getInstallerConfigBaremetal()
 			hosts := make([]*models.Host, 0)
 			hosts = append(hosts, createHost(true, models.HostStatusKnown, getBaremetalInventoryStr("hostname0", "bootMode", true, false)))
@@ -405,9 +406,10 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			hosts = append(hosts, createHost(false, models.HostStatusKnown, getBaremetalInventoryStr("hostname3", "bootMode", true, false)))
 			hosts = append(hosts, createHost(false, models.HostStatusKnown, getBaremetalInventoryStr("hostname4", "bootMode", true, false)))
 			cluster := createClusterFromHosts(hosts)
-			err := providerRegistry.AddPlatformToInstallConfig(models.PlatformTypeNone, &cfg, &cluster)
+			err := providerRegistry.AddPlatformToInstallConfig(models.PlatformTypeOci, &cfg, &cluster)
 			Expect(err).To(BeNil())
 			Expect(cfg.Platform.None).ToNot(BeNil())
+			Expect(cfg.FeatureSet).To(Equal(configv1.TechPreviewNoUpgrade))
 		})
 	})
 })


### PR DESCRIPTION
External platform will only be available behind the `TechPreviewNoUpgrade`
feature set. This change enables it automatically when an external
platform is selected (e.g.: oci).
