### PR TITLE
MGMT-14883: Fix feature-support validation fail to validate openshift version

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1958,12 +1958,19 @@ func (b *bareMetalInventory) validateUpdateClusterIncompatibleFeatures(ctx conte
 		return params, err
 	}
 
+	// Validate with infra-envs architecture
 	for _, infraEnv := range infraEnvs {
 		if err = featuresupport.ValidateIncompatibleFeatures(b.log, infraEnv.CPUArchitecture, cluster, infraEnv, params.ClusterUpdateParams); err != nil {
 			b.log.Error(err)
 			return params, common.NewApiError(http.StatusBadRequest, err)
 		}
 	}
+	// Validate with cluster architecture - CPUArchitecture can be multi when multi cpu architecture is selected
+	if err = featuresupport.ValidateIncompatibleFeatures(b.log, cluster.CPUArchitecture, cluster, nil, params.ClusterUpdateParams); err != nil {
+		b.log.Error(err)
+		return params, common.NewApiError(http.StatusBadRequest, err)
+	}
+
 	return params, nil
 }
 
@@ -5970,7 +5977,7 @@ func (b *bareMetalInventory) V2UpdateHostInternal(ctx context.Context, params in
 	log := logutil.FromContext(ctx, b.log)
 	var c *models.Cluster
 	var cluster *common.Cluster
-	var usages usage.FeatureUsage = make(usage.FeatureUsage)
+	var usages = make(usage.FeatureUsage)
 	var clusterID strfmt.UUID
 	var err error
 

--- a/internal/featuresupport/common.go
+++ b/internal/featuresupport/common.go
@@ -30,7 +30,7 @@ func ValidateIncompatibleFeatures(log logrus.FieldLogger, cpuArchitecture string
 			return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cpuArchitecture, cluster.OpenshiftVersion)
 		}
 
-		if err := isFeaturesCompatibleWithArchitecture(swag.StringValue(openshiftVersion), cpuArchitecture, activatedFeatures); err != nil {
+		if err := isFeaturesCompatible(swag.StringValue(openshiftVersion), cpuArchitecture, activatedFeatures); err != nil {
 			return err
 		}
 

--- a/internal/featuresupport/feature_support_level.go
+++ b/internal/featuresupport/feature_support_level.go
@@ -102,10 +102,11 @@ func isFeaturesCompatibleWithFeatures(openshiftVersion string, activatedFeatures
 	return nil
 }
 
-// isFeaturesCompatibleWithArchitecture Determine if feature is compatible with CPU architecture in a given openshift-version
-func isFeaturesCompatibleWithArchitecture(openshiftVersion, cpuArchitecture string, activatedFeatures []SupportLevelFeature) error {
+// isFeaturesCompatible Determine if feature is compatible with CPU architecture in a given openshift-version
+func isFeaturesCompatible(openshiftVersion, cpuArchitecture string, activatedFeatures []SupportLevelFeature) error {
 	for _, feature := range activatedFeatures {
-		if !isFeatureCompatibleWithArchitecture(feature, openshiftVersion, cpuArchitecture) {
+		if !isFeatureCompatibleWithArchitecture(feature, openshiftVersion, cpuArchitecture) ||
+			!IsFeatureAvailable(feature.getId(), openshiftVersion, swag.String(cpuArchitecture)) {
 			return fmt.Errorf("cannot use %s because it's not compatible with the %s architecture "+
 				"on version %s of OpenShift", feature.getName(), cpuArchitecture, openshiftVersion)
 		}

--- a/internal/featuresupport/features.go
+++ b/internal/featuresupport/features.go
@@ -290,9 +290,6 @@ func (feature *DualStackFeature) getSupportLevel(filters SupportLevelFilters) mo
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
-	if isNotSupported, err := common.BaseVersionLessThan("4.12", filters.OpenshiftVersion); isNotSupported || err != nil {
-		return models.SupportLevelUnavailable
-	}
 
 	return models.SupportLevelSupported
 }


### PR DESCRIPTION
It shouldn't be possible to create a cluster with platform = OCI and OCP < 4.14

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [  ] No tests needed

/cc @adriengentil 