### PR TITLE
OCPBUGS-13738 enforce additional ntp sources added into chrony

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -382,7 +382,7 @@ func main() {
 	hostApi := host.NewManager(log.WithField("pkg", "host-state"), db, notificationStream, eventsHandler, hwValidator,
 		instructionApi, &Options.HWValidatorConfig, metricsManager, &Options.HostConfig, lead, operatorsManager, providerRegistry, Options.EnableKubeAPI, objectHandler, versionHandler)
 	dnsApi := dns.NewDNSHandler(Options.BMConfig.BaseDNSDomains, log)
-	manifestsGenerator := network.NewManifestsGenerator(manifestsApi, Options.ManifestsGeneratorConfig)
+	manifestsGenerator := network.NewManifestsGenerator(manifestsApi, Options.ManifestsGeneratorConfig, db)
 	clusterApi := cluster.NewManager(Options.ClusterConfig, log.WithField("pkg", "cluster-state"), db,
 		notificationStream, eventsHandler, uploadClient, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager, ocmClient, objectHandler, dnsApi, authHandler)
 	infraEnvApi := infraenv.NewManager(log.WithField("pkg", "host-state"), db, objectHandler)


### PR DESCRIPTION
Chrony configuration applied into machine config manifest based on the reply from the agent, meaning that when user add additional ntp source first the service will ask the agent to add it then return the reply to the service it will be stored in the DB and used to create the machine config chrony configuration

Because NTP is a soft validation, in ZTP flow there are cases that the installation will start before the agent return a reply to the service, it will mean that those sources will not be applied, to avoid that when building the manifests in addition to taking the agent reply the additional ntp sources will be added directly from the DB

The downside of this solution is that if the source is incorrect it will appear in /etc/chrony.conf but not in `chronyc sources` and it will not be resolved as the regular reply from the agent

It will not harm the cluster installation or affect the cluster after the installation if the source is incorrect


Example i added `harta,barta` in additional ntp sources
They didn't return from the agent so without this code they will not be added to the installation event if there is no race 
After installation 
```
cat /etc/chrony.conf 
...
server harta iburst
server barta iburst

chronyc sources
MS Name/IP address         Stratum Poll Reach LastRx Last sample               
===============================================================================
^? ntp.wdc2.us.leaseweb.net      0   9     0     -     +0ns[   +0ns] +/-    0ns
^? 152.70.159.102                0   9     0     -     +0ns[   +0ns] +/-    0ns
^? time.cloudflare.com           0   9     0     -     +0ns[   +0ns] +/-    0ns
^? haka.ruselabs.com             0   9     0     -     +0ns[   +0ns] +/-    0ns
^? ip229.ip-51-81-226.us         0   9     0     -     +0ns[   +0ns] +/-    0ns
^? 108.175.15.67                 0   9     0     -     +0ns[   +0ns] +/-    0ns
^? connected.by.freedominte>     0   9     0     -     +0ns[   +0ns] +/-    0ns
^? 168.61.215.74                 0   9     0     -     +0ns[   +0ns] +/-    0ns
^? tick.srs1.ntfo.org            0   9     0     -     +0ns[   +0ns] +/-    0ns
^? pacific.latt.net              0   9     0     -     +0ns[   +0ns] +/-    0ns
^? shaka.ruselabs.com            0   9     0     -     +0ns[   +0ns] +/-    0ns
^? 198.30.92.2                   0   9     0     -     +0ns[   +0ns] +/-    0ns
^? pi3.rellim.com                0   9     0     -     +0ns[   +0ns] +/-    0ns
^? srcf-ntp.stanford.edu         0   9     0     -     +0ns[   +0ns] +/-    0ns
^? time.cloudflare.com           0   9     0     -     +0ns[   +0ns] +/-    0ns
^* ntp1.ntp-001.prod.iad2.d>     2   8   377   121   +162us[ +215us] +/-   27ms
```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
