### PR TITLE
MGMT-14975: Update MCE operator installation to use stable-2.3 channel

### DIFF
--- a/internal/operators/mce/config.go
+++ b/internal/operators/mce/config.go
@@ -2,7 +2,7 @@ package mce
 
 const (
 	MceMinOpenshiftVersion string = "4.10.0"
-	MceChannel             string = "stable-2.2"
+	MceChannel             string = "stable-2.3"
 
 	// Memory value provided in GiB
 	MinimumMemory int64 = 16


### PR DESCRIPTION
MCE 2.2 will not be available in OCP 4.14. Only MCE 2.3+, for that MCE operator subscription manifest channel need to be updated to `stable-2.3`.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @gamli75 