### PR TITLE
MGMT-14973: Fix misleading logs showing wrong platform and user_managed_networking combination

### DIFF
--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-openapi/strfmt"
@@ -65,4 +66,11 @@ func StrFmtUUIDPtr(u strfmt.UUID) *strfmt.UUID {
 
 func VipVerificationPtr(v models.VipVerification) *models.VipVerification {
 	return &v
+}
+
+func BoolPtrForLog(b *bool) string {
+	if b == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%t", *b)
 }


### PR DESCRIPTION
When patching platform and leaving umn without change, than umn in the logs shows "false" instead of nil, causing us to think that the cluster is not in a valid state (e.g. none + umn disabled)
 
```
time="2023-06-15T09:59:54Z" level=info msg="Platform verification completed, setting platform type to none and user-managed-networking to false" func="github.com/openshift/assisted-service/internal/bminventory.(*bareMetalInventory).validateUpdateCluster" file="/assisted-service/internal/bminventory/inventory.go:1928" cluster_id=468bffe8-ce24-400e-a104-b0aab378eb75 go-id=94310 pkg=Inventory request_id=2fbb74ba-4390-4f27-b6fd-ee11ac1a7895 
 ```

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Logs
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @adriengentil @gamli75 @nmagnezi 