### PR TITLE
[release-ocm-2.8] MGMT-15013: AgentClusterInstall Webhooks improvements and fixes

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/platform.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/platform.go
@@ -19,6 +19,10 @@ import (
 // swagger:model platform
 type Platform struct {
 
+	// Indicates if the underlying platform type is external.
+	// Read Only: true
+	IsExternal *bool `json:"is_external,omitempty"`
+
 	// type
 	// Required: true
 	Type *PlatformType `json:"type"`
@@ -66,6 +70,10 @@ func (m *Platform) validateType(formats strfmt.Registry) error {
 func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateIsExternal(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -73,6 +81,15 @@ func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry)
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Platform) contextValidateIsExternal(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "is_external", "body", m.IsExternal); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/api/vendor/github.com/openshift/assisted-service/models/platform_type.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/platform_type.go
@@ -41,6 +41,9 @@ const (
 
 	// PlatformTypeNone captures enum value "none"
 	PlatformTypeNone PlatformType = "none"
+
+	// PlatformTypeOci captures enum value "oci"
+	PlatformTypeOci PlatformType = "oci"
 )
 
 // for schema
@@ -48,7 +51,7 @@ var platformTypeEnum []interface{}
 
 func init() {
 	var res []PlatformType
-	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none","oci"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2535,6 +2535,7 @@ func (b *bareMetalInventory) updateNetworkTables(db *gorm.DB, cluster *common.Cl
 func (b *bareMetalInventory) updatePlatformParams(params installer.V2UpdateClusterParams, updates map[string]interface{}, usages map[string]models.Usage) error {
 	if params.ClusterUpdateParams.Platform != nil && common.PlatformTypeValue(params.ClusterUpdateParams.Platform.Type) != "" {
 		updates["platform_type"] = params.ClusterUpdateParams.Platform.Type
+		updates["platform_is_external"] = swag.BoolValue(params.ClusterUpdateParams.Platform.IsExternal)
 
 		err := b.providerRegistry.SetPlatformUsages(
 			common.PlatformTypeValue(params.ClusterUpdateParams.Platform.Type), usages, b.usageApi)

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4036,7 +4036,7 @@ var _ = Describe("cluster", func() {
 						},
 					})
 
-					verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none platform is not allowed in single node Openshift")
+					verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
 				})
 
 				It("Set Machine CIDR", func() {
@@ -5967,7 +5967,7 @@ var _ = Describe("cluster", func() {
 	})
 })
 
-var _ = Describe("[V2ClusterUpdate] cluster", func() {
+var _ = Describe("V2ClusterUpdate cluster", func() {
 
 	masterHostId1 := strfmt.UUID(uuid.New().String())
 	masterHostId3 := strfmt.UUID(uuid.New().String())
@@ -6080,7 +6080,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					},
 				})
 
-				verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none platform is not allowed in single node Openshift")
+				verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
 			})
 
 			It("Set Machine CIDR", func() {
@@ -6184,6 +6184,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6200,6 +6201,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6247,9 +6249,11 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					var result installcfg.InstallerConfigBaremetal
 					installConfig := createInstallConfigBuilder()
@@ -6280,6 +6284,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 
@@ -6296,6 +6301,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=true and vphsere platform while cluster platform already set to none - success", func() {
@@ -6311,6 +6317,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
@@ -6329,6 +6336,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=nil and baremetal platform while cluster platform is set to vsphere - success", func() {
@@ -6345,6 +6353,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
@@ -6360,6 +6369,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=nil and none platform while cluster platform is set to vsphere - success", func() {
@@ -6375,6 +6385,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeBaremetal, gomock.Any(), mockUsage)
@@ -6390,6 +6401,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=nil and baremetal platform while cluster platform is set to vsphere and umn true- failure", func() {
@@ -6406,6 +6418,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6449,7 +6462,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
 							},
 						})
-						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none platform is not allowed in single node Openshift")
+						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
 					})
 
 					It("Update to nutanix platform while single node cluster - failure", func() {
@@ -6459,7 +6472,24 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
 							},
 						})
-						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none platform is not allowed in single node Openshift")
+						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
+					})
+
+					It("Update to oci platform while single node cluster - success", func() {
+						mockSuccess()
+						mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeOci, gomock.Any(), mockUsage)
+
+						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							},
+						})
+						Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+						actual := reply.(*installer.V2UpdateClusterCreated).Payload
+						Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+						Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+						Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
 					})
 				})
 
@@ -6477,6 +6507,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					reply2 := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
@@ -6501,6 +6532,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
 					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
@@ -6518,6 +6550,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=false and vphsere platform while cluster platform already set to baremetal - success", func() {
@@ -6537,6 +6570,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=true and vphsere platform while cluster platform already set to baremetal - success", func() {
@@ -6558,6 +6592,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual2 := reply2.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual2.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual2.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual2.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update UMN=true - success", func() {
@@ -6601,6 +6636,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6629,7 +6665,145 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
+				})
+
+				It("Update platform=oci - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=false and platform=oci results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=true and platform=oci - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeOci, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=nutanix results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=false and platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=false and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 				})
 			})
 
@@ -6664,6 +6838,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 				})
 
 				It("Update platform=none - success", func() {
@@ -6678,6 +6853,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6694,6 +6870,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6711,6 +6888,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6738,6 +6916,7 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 
 				})
 
@@ -6766,6 +6945,692 @@ var _ = Describe("[V2ClusterUpdate] cluster", func() {
 					actual := reply.(*installer.V2UpdateClusterCreated).Payload
 					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
 					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=oci - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeOci, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+
+				})
+
+				It("Update UMN=false and platform=oci results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=true and platform=oci - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeOci, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update platform=nutanix - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=true and platform=nutanix results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=false and platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=false and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+			})
+			Context("Update Platform while Cluster platform is oci", func() {
+				var cluster *common.Cluster
+				BeforeEach(func() {
+					clusterID = strfmt.UUID(uuid.New().String())
+					cluster = &common.Cluster{Cluster: models.Cluster{
+						ID:                    &clusterID,
+						HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeFull),
+						UserManagedNetworking: swag.Bool(true),
+						Platform: &models.Platform{
+							Type:       common.PlatformTypePtr(models.PlatformTypeOci),
+							IsExternal: swag.Bool(true),
+						},
+						CPUArchitecture: common.X86CPUArchitecture,
+					}}
+					err := db.Create(cluster).Error
+					Expect(err).ShouldNot(HaveOccurred())
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
+				})
+
+				It("Update UMN=true - success", func() {
+					mockSuccess()
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update platform=oci - success", func() {
+					mockSuccess()
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update UMN=true and platform=oci - success", func() {
+					mockSuccess()
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update UMN=false and platform=oci results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update platform=baremetal - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set baremetal platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=true and platform=baremetal results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set baremetal platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=false and platform=baremetal - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeBaremetal, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=none - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+
+				})
+
+				It("Update UMN=false and platform=none results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set none platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=true and platform=none - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=nutanix - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=true and platform=nutanix results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=false and platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=false and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				Context("Single node cluster", func() {
+					BeforeEach(func() {
+						clusterID = strfmt.UUID(uuid.New().String())
+						err := db.Create(&common.Cluster{Cluster: models.Cluster{
+							ID:                    &clusterID,
+							HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeNone),
+							UserManagedNetworking: swag.Bool(true),
+							Platform: &models.Platform{
+								Type: common.PlatformTypePtr(models.PlatformTypeOci),
+							},
+						}}).Error
+						Expect(err).ShouldNot(HaveOccurred())
+					})
+
+					It("Update to vsphere platform while single node cluster - failure", func() {
+						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							},
+						})
+						verifyApiErrorString(reply, http.StatusBadRequest, "Single node cluster is not supported alongside vsphere platform")
+					})
+
+					It("Update to baremetal platform while single node cluster - failure", func() {
+						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							},
+						})
+						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
+					})
+
+					It("Update to nutanix platform while single node cluster - failure", func() {
+						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							},
+						})
+						verifyApiErrorString(reply, http.StatusBadRequest, "disabling User Managed Networking or setting platform different than none or oci platforms is not allowed in single node Openshift")
+					})
+
+					It("Update to none platform while single node cluster - success", func() {
+						mockSuccess()
+						mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+						reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+							},
+						})
+						Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+						actual := reply.(*installer.V2UpdateClusterCreated).Payload
+						Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+						Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+						Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+					})
+				})
+			})
+
+			Context("Update Platform while Cluster platform is nutanix", func() {
+				var cluster *common.Cluster
+				BeforeEach(func() {
+					clusterID = strfmt.UUID(uuid.New().String())
+					cluster = &common.Cluster{Cluster: models.Cluster{
+						ID:                    &clusterID,
+						HighAvailabilityMode:  swag.String(models.ClusterHighAvailabilityModeFull),
+						UserManagedNetworking: swag.Bool(false),
+						Platform: &models.Platform{
+							Type:       common.PlatformTypePtr(models.PlatformTypeNutanix),
+							IsExternal: swag.Bool(false),
+						},
+						CPUArchitecture: common.X86CPUArchitecture,
+					}}
+					err := db.Create(cluster).Error
+					Expect(err).ShouldNot(HaveOccurred())
+					mockClusterApi.EXPECT().VerifyClusterUpdatability(createClusterIdMatcher(cluster)).Return(nil).Times(1)
+				})
+				It("Update UMN=true - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set nutanix platform with user-managed-networking enabled")
+				})
+
+				It("Update platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=false and platform=nutanix - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNutanix, gomock.Any(), mockUsage)
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNutanix)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNutanix))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=oci - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=false and platform=oci results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set oci platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=true and platform=oci - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeOci, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeOci)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeOci))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeTrue())
+				})
+
+				It("Update platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeTrue())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=false and platform=vsphere - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeVsphere, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeVsphere)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(BeFalse())
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeVsphere))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+				It("Update platform=baremetal - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeBaremetal, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update UMN=true and platform=baremetal results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							UserManagedNetworking: swag.Bool(true)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set baremetal platform with user-managed-networking enabled")
+				})
+
+				It("Update UMN=false and platform=baremetal - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeBaremetal, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeBaremetal)},
+							UserManagedNetworking: swag.Bool(false),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(false))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeBaremetal))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
+				})
+
+				It("Update platform=none - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform: &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+						},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set none platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=false and platform=none results BadRequestError - failure", func() {
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+							UserManagedNetworking: swag.Bool(false)},
+					})
+					verifyApiErrorString(reply, http.StatusBadRequest, "Can't set none platform with user-managed-networking disabled")
+				})
+
+				It("Update UMN=true and platform=none - success", func() {
+					mockSuccess()
+					mockProviderRegistry.EXPECT().SetPlatformUsages(models.PlatformTypeNone, gomock.Any(), mockUsage)
+
+					reply := bm.V2UpdateCluster(ctx, installer.V2UpdateClusterParams{
+						ClusterID: clusterID,
+						ClusterUpdateParams: &models.V2ClusterUpdateParams{
+							Platform:              &models.Platform{Type: common.PlatformTypePtr(models.PlatformTypeNone)},
+							UserManagedNetworking: swag.Bool(true),
+						},
+					})
+					Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2UpdateClusterCreated()))
+					actual := reply.(*installer.V2UpdateClusterCreated).Payload
+					Expect(swag.BoolValue(actual.UserManagedNetworking)).To(Equal(true))
+					Expect(*actual.Platform.Type).To(Equal(models.PlatformTypeNone))
+					Expect(swag.BoolValue(actual.Platform.IsExternal)).To(BeFalse())
 				})
 			})
 		})
@@ -12224,6 +13089,7 @@ var _ = Describe("TestRegisterCluster", func() {
 						Platform: &models.Platform{
 							Type: common.PlatformTypePtr(models.PlatformTypeNutanix),
 						},
+						UserManagedNetworking: swag.Bool(false),
 					},
 				})
 				verifyApiErrorString(reply2, http.StatusBadRequest, "only x86-64 CPU architecture is supported on Nutanix clusters")
@@ -16458,6 +17324,7 @@ var _ = Describe("Platform tests", func() {
 			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
 			Expect(cluster.Platform).ShouldNot(BeNil())
 			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeBaremetal))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeFalse())
 		})
 
 		It("vsphere platform", func() {
@@ -16469,6 +17336,7 @@ var _ = Describe("Platform tests", func() {
 			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
 			Expect(cluster.Platform).ShouldNot(BeNil())
 			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeVsphere))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeFalse())
 		})
 
 		It("vsphere platform with credentials", func() {
@@ -16478,6 +17346,7 @@ var _ = Describe("Platform tests", func() {
 			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
 			Expect(cluster.Platform).ShouldNot(BeNil())
 			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeVsphere))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeFalse())
 		})
 
 		It("nutanix platform", func() {
@@ -16493,6 +17362,38 @@ var _ = Describe("Platform tests", func() {
 			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
 			Expect(cluster.Platform).ShouldNot(BeNil())
 			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeNutanix))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeFalse())
+		})
+
+		It("OCI platform - HA", func() {
+			registerParams.NewClusterParams.Platform = &models.Platform{
+				Type: common.PlatformTypePtr(models.PlatformTypeOci),
+			}
+			reply := bm.V2RegisterCluster(ctx, *registerParams)
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
+			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
+			Expect(cluster.Platform).ShouldNot(BeNil())
+			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeOci))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeTrue())
+			Expect(swag.BoolValue(cluster.UserManagedNetworking)).Should(BeTrue())
+		})
+
+		It("OCI platform - SNO", func() {
+			registerParams.NewClusterParams.Platform = &models.Platform{
+				Type: common.PlatformTypePtr(models.PlatformTypeOci),
+			}
+
+			MinimalOpenShiftVersionForSNO := "4.8.0"
+			registerParams.NewClusterParams.OpenshiftVersion = swag.String(MinimalOpenShiftVersionForSNO)
+			registerParams.NewClusterParams.HighAvailabilityMode = swag.String(models.ClusterCreateParamsHighAvailabilityModeNone)
+
+			reply := bm.V2RegisterCluster(ctx, *registerParams)
+			Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2RegisterClusterCreated()))
+			cluster := reply.(*installer.V2RegisterClusterCreated).Payload
+			Expect(cluster.Platform).ShouldNot(BeNil())
+			Expect(common.PlatformTypeValue(cluster.Platform.Type)).Should(BeEquivalentTo(models.PlatformTypeOci))
+			Expect(swag.BoolValue(cluster.Platform.IsExternal)).Should(BeTrue())
+			Expect(swag.BoolValue(cluster.UserManagedNetworking)).Should(BeTrue())
 		})
 	})
 
@@ -16512,6 +17413,21 @@ var _ = Describe("Platform tests", func() {
 			reply := bm.V2RegisterCluster(ctx, *registerParams)
 			verifyApiError(reply, http.StatusBadRequest)
 		})
+
+		It("OCI platform - fail if UMN is false", func() {
+			registerParams.NewClusterParams.Platform = &models.Platform{
+				Type: common.PlatformTypePtr(models.PlatformTypeOci),
+			}
+			registerParams.NewClusterParams.UserManagedNetworking = swag.Bool(false)
+			mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
+				eventstest.WithNameMatcher(eventgen.ClusterRegistrationFailedEventName),
+				eventstest.WithMessageContainsMatcher("Can't set oci platform with user-managed-networking disabled"),
+				eventstest.WithSeverityMatcher(models.EventSeverityError))).Times(1)
+
+			reply := bm.V2RegisterCluster(ctx, *registerParams)
+			verifyApiError(reply, http.StatusBadRequest)
+		})
+
 	})
 })
 

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -923,7 +923,7 @@ func ValidateDiskEncryptionParams(diskEncryptionParams *models.DiskEncryption, D
 
 func ValidateHighAvailabilityModeWithPlatform(highAvailabilityMode *string, platform *models.Platform) error {
 	if swag.StringValue(highAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
-		if platform != nil && platform.Type != nil && *platform.Type != models.PlatformTypeNone {
+		if platform != nil && platform.Type != nil && *platform.Type != models.PlatformTypeNone && !swag.BoolValue(platform.IsExternal) {
 			return errors.Errorf("Single node cluster is not supported alongside %s platform", *platform.Type)
 		}
 	}

--- a/internal/common/conversions.go
+++ b/internal/common/conversions.go
@@ -1,9 +1,20 @@
 package common
 
 import (
+	"strings"
+
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/models"
 )
+
+func PlatformTypeToPlatform(platformType hiveext.PlatformType) *models.Platform {
+	pType := strings.ToLower(string(platformType))
+	platform := &models.Platform{Type: PlatformTypePtr(models.PlatformType(pType))}
+	platform.IsExternal = swag.Bool(*platform.Type == models.PlatformTypeOci)
+	return platform
+}
 
 func PlatformTypePtr(p models.PlatformType) *models.PlatformType {
 	return &p

--- a/internal/provider/external/base.go
+++ b/internal/provider/external/base.go
@@ -1,0 +1,33 @@
+package external
+
+import (
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+type externalProvider struct {
+	Log          logrus.FieldLogger
+	platformType models.PlatformType
+}
+
+// NewExternalProvider creates a new none platform provider.
+func NewExternalProvider(log logrus.FieldLogger, platformType models.PlatformType) provider.Provider {
+	return &externalProvider{
+		Log:          log,
+		platformType: platformType,
+	}
+}
+
+// Name returns the name of the provider
+func (p *externalProvider) Name() models.PlatformType {
+	return p.platformType
+}
+
+func (p *externalProvider) IsHostSupported(_ *models.Host) (bool, error) {
+	return true, nil
+}
+
+func (p *externalProvider) AreHostsSupported(_ []*models.Host) (bool, error) {
+	return true, nil
+}

--- a/internal/provider/external/consts.go
+++ b/internal/provider/external/consts.go
@@ -1,0 +1,1 @@
+package external

--- a/internal/provider/external/ignition.go
+++ b/internal/provider/external/ignition.go
@@ -1,0 +1,53 @@
+package external
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/assisted-service/internal/common"
+)
+
+// Workaround as openshift installer does not support the external platform.
+// The trick is to generate the manifests with platform=none and patch
+// the insfrastructure object with the external platform.
+const (
+	clusterInfraPatchTemplate = `---
+	- op: replace
+	  path: /spec/platformSpec
+	  value:
+		type: External
+		external:
+		  platformName: %s
+	- op: replace
+	  path: /status/platform
+	  value: External
+	- op: replace
+	  path: /status/platformStatus
+	  value:
+		type: External
+		external:
+		  cloudControllerManager:
+			state: External
+	`
+)
+
+func (p externalProvider) PreCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error {
+	return nil
+}
+
+func (p externalProvider) PostCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error {
+	p.Log.Info("Patching infrastructure object")
+
+	platformName := string(p.platformType)
+	clusterInfraPatch := fmt.Sprintf(clusterInfraPatchTemplate, platformName)
+
+	clusterInfraPatchPath := filepath.Join(workDir, "manifests", "cluster-infrastructure-02-config.yml.patch_01_configure_external_platform")
+	err := os.WriteFile(clusterInfraPatchPath, []byte(clusterInfraPatch), 0600)
+	if err != nil {
+		p.Log.Error("Couldn't write infrastructure patch %v", clusterInfraPatchPath)
+		return err
+	}
+
+	return nil
+}

--- a/internal/provider/external/installConfig.go
+++ b/internal/provider/external/installConfig.go
@@ -1,0 +1,36 @@
+package external
+
+import (
+	"github.com/go-openapi/swag"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/host/hostutil"
+	"github.com/openshift/assisted-service/internal/installcfg"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+)
+
+func (p externalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
+	// workaround until openshift installer supports external platform
+	cfg.Platform = installcfg.Platform{
+		None: &installcfg.PlatformNone{},
+	}
+
+	cfg.Networking.MachineNetwork = provider.GetMachineNetworkForUserManagedNetworking(p.Log, cluster)
+	if cluster.NetworkType != nil {
+		cfg.Networking.NetworkType = swag.StringValue(cluster.NetworkType)
+	}
+
+	if common.IsSingleNodeCluster(cluster) {
+
+		if cfg.Networking.NetworkType == "" {
+			cfg.Networking.NetworkType = models.ClusterNetworkTypeOVNKubernetes
+		}
+
+		bootstrap := common.GetBootstrapHost(cluster)
+		if bootstrap != nil {
+			cfg.BootstrapInPlace = installcfg.BootstrapInPlace{InstallationDisk: hostutil.GetHostInstallationPath(bootstrap)}
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/external/inventory.go
+++ b/internal/provider/external/inventory.go
@@ -1,0 +1,19 @@
+package external
+
+import (
+	"github.com/openshift/assisted-service/internal/usage"
+	"github.com/openshift/assisted-service/models"
+)
+
+func (p *externalProvider) CleanPlatformValuesFromDBUpdates(_ map[string]interface{}) error {
+	return nil
+}
+
+func (p *externalProvider) SetPlatformUsages(
+	usages map[string]models.Usage,
+	usageApi usage.API) error {
+	props := &map[string]interface{}{
+		"platform_type": p.Name()}
+	usageApi.Add(usages, usage.PlatformSelectionUsage, props)
+	return nil
+}

--- a/internal/provider/registry/registry.go
+++ b/internal/provider/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/assisted-service/internal/installcfg"
 	"github.com/openshift/assisted-service/internal/provider"
 	"github.com/openshift/assisted-service/internal/provider/baremetal"
+	"github.com/openshift/assisted-service/internal/provider/external"
 	"github.com/openshift/assisted-service/internal/provider/none"
 	"github.com/openshift/assisted-service/internal/provider/nutanix"
 	"github.com/openshift/assisted-service/internal/provider/vsphere"
@@ -165,5 +166,6 @@ func InitProviderRegistry(log logrus.FieldLogger) ProviderRegistry {
 	providerRegistry.Register(baremetal.NewBaremetalProvider(log))
 	providerRegistry.Register(none.NewNoneProvider(log))
 	providerRegistry.Register(nutanix.NewNutanixProvider(log))
+	providerRegistry.Register(external.NewExternalProvider(log, models.PlatformTypeOci))
 	return providerRegistry
 }

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -85,16 +85,16 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, bmInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
+		Expect(len(platforms)).Should(Equal(3))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone, models.PlatformTypeOci))
 	})
 	It("single vsphere host", func() {
 		hosts := make([]*models.Host, 0)
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(3))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone}
+		Expect(len(platforms)).Should(Equal(4))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone, models.PlatformTypeOci}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("5 vsphere hosts - 3 masters, 2 workers", func() {
@@ -106,8 +106,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(3))
-		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone}
+		Expect(len(platforms)).Should(Equal(4))
+		supportedPlatforms := []models.PlatformType{models.PlatformTypeBaremetal, models.PlatformTypeVsphere, models.PlatformTypeNone, models.PlatformTypeOci}
 		Expect(platforms).Should(ContainElements(supportedPlatforms))
 	})
 	It("2 vsphere hosts 1 generic host", func() {
@@ -117,8 +117,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(true, models.HostStatusKnown, vsphereInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
+		Expect(len(platforms)).Should(Equal(3))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone, models.PlatformTypeOci))
 	})
 	It("3 vsphere masters 2 generic workers", func() {
 		hosts := make([]*models.Host, 0)
@@ -129,8 +129,8 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 		hosts = append(hosts, createHost(false, models.HostStatusKnown, bmInventory))
 		platforms, err := providerRegistry.GetSupportedProvidersByHosts(hosts)
 		Expect(err).To(BeNil())
-		Expect(len(platforms)).Should(Equal(2))
-		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone))
+		Expect(len(platforms)).Should(Equal(3))
+		Expect(platforms).Should(ContainElements(models.PlatformTypeBaremetal, models.PlatformTypeNone, models.PlatformTypeOci))
 	})
 	It("host with an invalid inventory", func() {
 		hosts := make([]*models.Host, 0)
@@ -394,6 +394,22 @@ var _ = Describe("Test AddPlatformToInstallConfig", func() {
 			Expect(string(installConfigByte)).To(Equal(expectedNutanixInstallConfig411))
 		})
 	})
+
+	Context("external", func() {
+		It("should set platform to none", func() {
+			cfg := getInstallerConfigBaremetal()
+			hosts := make([]*models.Host, 0)
+			hosts = append(hosts, createHost(true, models.HostStatusKnown, getBaremetalInventoryStr("hostname0", "bootMode", true, false)))
+			hosts = append(hosts, createHost(true, models.HostStatusKnown, getBaremetalInventoryStr("hostname1", "bootMode", true, false)))
+			hosts = append(hosts, createHost(true, models.HostStatusKnown, getBaremetalInventoryStr("hostname2", "bootMode", true, false)))
+			hosts = append(hosts, createHost(false, models.HostStatusKnown, getBaremetalInventoryStr("hostname3", "bootMode", true, false)))
+			hosts = append(hosts, createHost(false, models.HostStatusKnown, getBaremetalInventoryStr("hostname4", "bootMode", true, false)))
+			cluster := createClusterFromHosts(hosts)
+			err := providerRegistry.AddPlatformToInstallConfig(models.PlatformTypeNone, &cfg, &cluster)
+			Expect(err).To(BeNil())
+			Expect(cfg.Platform.None).ToNot(BeNil())
+		})
+	})
 })
 
 var _ = Describe("Test SetPlatformUsages", func() {
@@ -423,6 +439,13 @@ var _ = Describe("Test SetPlatformUsages", func() {
 		It("success", func() {
 			usageApi.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			err := providerRegistry.SetPlatformUsages(models.PlatformTypeVsphere, nil, usageApi)
+			Expect(err).To(BeNil())
+		})
+	})
+	Context("oci", func() {
+		It("success", func() {
+			usageApi.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			err := providerRegistry.SetPlatformUsages(models.PlatformTypeOci, nil, usageApi)
 			Expect(err).To(BeNil())
 		})
 	})
@@ -519,9 +542,11 @@ func createVspherePlatformParams() *models.Platform {
 }
 
 func createClusterFromHosts(hosts []*models.Host) common.Cluster {
+	clusterID := strfmt.UUID(uuid.New().String())
 	return common.Cluster{
 		Cluster: models.Cluster{
 			Name:             "cluster",
+			ID:               &clusterID,
 			APIVip:           "192.168.10.10",
 			APIVips:          []*models.APIVip{{IP: "192.168.10.10"}},
 			Hosts:            hosts,

--- a/models/platform.go
+++ b/models/platform.go
@@ -19,6 +19,10 @@ import (
 // swagger:model platform
 type Platform struct {
 
+	// Indicates if the underlying platform type is external.
+	// Read Only: true
+	IsExternal *bool `json:"is_external,omitempty"`
+
 	// type
 	// Required: true
 	Type *PlatformType `json:"type"`
@@ -66,6 +70,10 @@ func (m *Platform) validateType(formats strfmt.Registry) error {
 func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateIsExternal(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -73,6 +81,15 @@ func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry)
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Platform) contextValidateIsExternal(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "is_external", "body", m.IsExternal); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/models/platform_type.go
+++ b/models/platform_type.go
@@ -41,6 +41,9 @@ const (
 
 	// PlatformTypeNone captures enum value "none"
 	PlatformTypeNone PlatformType = "none"
+
+	// PlatformTypeOci captures enum value "oci"
+	PlatformTypeOci PlatformType = "oci"
 )
 
 // for schema
@@ -48,7 +51,7 @@ var platformTypeEnum []interface{}
 
 func init() {
 	var res []PlatformType
-	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none","oci"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_mutating_hook_test.go
@@ -62,6 +62,83 @@ var _ = Describe("ACI mutator hook", func() {
 			patched:         false,
 		},
 		{
+			name: "ACI create with userManagedNetworking not set with multi Node --> patch to false",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 3, WorkerAgents: 3},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with Nutanix platform --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with VSphere platform --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform and multi node --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 3, WorkerAgents: 3},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "ACI create with userManagedNetworking not set with None platform and SNO --> patch to true",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         true,
+			patchedValue:    true,
+		},
+		{
+			name: "Invalid Config: ACI create with userManagedNetworking not set with BareMetal platform and SNO --> no change",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:            hiveext.Networking{},
+				PlatformType:          hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+			patched:         false,
+		},
+		{
 			name: "ACI updated after install start --> no change",
 			oldSpec: hiveext.AgentClusterInstallSpec{
 				Networking:            hiveext.Networking{},

--- a/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
+++ b/pkg/webhooks/hiveextension/v1beta1/agentclusterinstall_validation_hook_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
-	apiserver "github.com/openshift/generic-admission-server/pkg/apiserver"
+	"github.com/openshift/generic-admission-server/pkg/apiserver"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -315,6 +315,298 @@ var _ = Describe("ACI web validate", func() {
 				ProvisionRequirements: hiveext.ProvisionRequirements{ControlPlaneAgents: 1},
 			},
 			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Multi node ACI create with None platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "SNO ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with None platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with BareMetal platform and userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "SNO ACI create with BareMetal platform and userManagedNetworking set to false is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI create with BareMetal platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with VSpherePlatformType platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with VSpherePlatformType platform and userManagedNetworking set to true is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.VSpherePlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with NutanixPlatformType platform and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI create with NutanixPlatformType platform and userManagedNetworking set to true not is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NutanixPlatformType,
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update None platform with userManagedNetworking set to false not is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update None platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update None platform with platform BareMetalPlatformType and userManagedNetworking set to false is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "ACI update BareMetalPlatformType platform with platform None is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				PlatformType: hiveext.NonePlatformType,
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ACI update BareMetalPlatformType platform with userManagedNetworking set to true is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				Networking: hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI update BareMetalPlatformType platform to SNO is not allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(false)},
+				PlatformType: hiveext.BareMetalPlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Multi node ACI update None platform to SNO is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       0,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			operation:       admissionv1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "SNO ACI update None platform to Multi node is allowed",
+			newSpec: hiveext.AgentClusterInstallSpec{
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 3,
+					WorkerAgents:       3,
+				},
+			},
+			oldSpec: hiveext.AgentClusterInstallSpec{
+				Networking:   hiveext.Networking{UserManagedNetworking: swag.Bool(true)},
+				PlatformType: hiveext.NonePlatformType,
+				ProvisionRequirements: hiveext.ProvisionRequirements{
+					ControlPlaneAgents: 1,
+					WorkerAgents:       1,
+				},
+			},
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9390,6 +9390,11 @@ func init() {
         "type"
       ],
       "properties": {
+        "is_external": {
+          "description": "Indicates if the underlying platform type is external.",
+          "type": "boolean",
+          "readOnly": true
+        },
         "type": {
           "$ref": "#/definitions/platform_type"
         }
@@ -9402,7 +9407,8 @@ func init() {
         "baremetal",
         "nutanix",
         "vsphere",
-        "none"
+        "none",
+        "oci"
       ]
     },
     "preflight-hardware-requirements": {
@@ -19675,6 +19681,11 @@ func init() {
         "type"
       ],
       "properties": {
+        "is_external": {
+          "description": "Indicates if the underlying platform type is external.",
+          "type": "boolean",
+          "readOnly": true
+        },
         "type": {
           "$ref": "#/definitions/platform_type"
         }
@@ -19687,7 +19698,8 @@ func init() {
         "baremetal",
         "nutanix",
         "vsphere",
-        "none"
+        "none",
+        "oci"
       ]
     },
     "preflight-hardware-requirements": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2474,7 +2474,7 @@ paths:
     post:
       tags:
         - installer
-      description: Deprecated, maintained for legacy purposes. Does the same thing as allow-add-hosts. Use allow-add-hosts instead. 
+      description: Deprecated, maintained for legacy purposes. Does the same thing as allow-add-hosts. Use allow-add-hosts instead.
       deprecated: true
       operationId: TransformClusterToDay2
       parameters:
@@ -3760,7 +3760,7 @@ paths:
         "201":
           description: Success.
           schema:
-            $ref: '#/definitions/ignored-validations' 
+            $ref: '#/definitions/ignored-validations'
         "400":
           description: Error.
           schema:
@@ -5317,6 +5317,10 @@ definitions:
     properties:
       type:
         $ref: '#/definitions/platform_type'
+      is_external:
+        description: Indicates if the underlying platform type is external.
+        readOnly: true
+        type: boolean
 
   image_info:
     type: object
@@ -5473,7 +5477,7 @@ definitions:
         type: string
       data:
         type: object
-        description: additional data from the cluster 
+        description: additional data from the cluster
         additionalProperties:
           type: object
 
@@ -6117,6 +6121,7 @@ definitions:
       - nutanix
       - vsphere
       - none
+      - oci
 
   memory_method:
     type: string

--- a/vendor/github.com/openshift/assisted-service/models/platform.go
+++ b/vendor/github.com/openshift/assisted-service/models/platform.go
@@ -19,6 +19,10 @@ import (
 // swagger:model platform
 type Platform struct {
 
+	// Indicates if the underlying platform type is external.
+	// Read Only: true
+	IsExternal *bool `json:"is_external,omitempty"`
+
 	// type
 	// Required: true
 	Type *PlatformType `json:"type"`
@@ -66,6 +70,10 @@ func (m *Platform) validateType(formats strfmt.Registry) error {
 func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateIsExternal(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateType(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -73,6 +81,15 @@ func (m *Platform) ContextValidate(ctx context.Context, formats strfmt.Registry)
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *Platform) contextValidateIsExternal(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "is_external", "body", m.IsExternal); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/openshift/assisted-service/models/platform_type.go
+++ b/vendor/github.com/openshift/assisted-service/models/platform_type.go
@@ -41,6 +41,9 @@ const (
 
 	// PlatformTypeNone captures enum value "none"
 	PlatformTypeNone PlatformType = "none"
+
+	// PlatformTypeOci captures enum value "oci"
+	PlatformTypeOci PlatformType = "oci"
 )
 
 // for schema
@@ -48,7 +51,7 @@ var platformTypeEnum []interface{}
 
 func init() {
 	var res []PlatformType
-	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["baremetal","nutanix","vsphere","none","oci"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
**:warning: Note: this cherry-pick includes https://github.com/openshift/assisted-service/pull/5143, as it changed the code in a way that we have to include it. Otherwise, it leads to a lot of manual git conflicts.**

Not all Platform and UserManageNetworking configurations are valid.
In REST-API, assisted service will attempt to calculate either of the two
configs to handle misconfigurations. This behavior cannot work the same way
in KubeAPI, as the DB cannot be updated separately from the ACI spec.

This webhook is placed to prevent such updates, to begin with, while basing
on the same backend business logic as the REST-API does, excluding the
backend-driven "fixes".

Mutating webhook:

    patching userManagedNetworking for cases where the platform is not set will stay the same.
    SNO and / or None platform: userManagedNetworking --> true
    BareMetal platform: userManagedNetworking --> false
    Nutanix and VSphere platform: userManagedNetworking not patched.
    5, In case of a mismatch between platform and topology (e.g. BareMetal + SNO):
    userManagedNetworking not patched.

Validation webhook:
This webhook will not look at updates to:

    Platform
    userManagedNetworking
    ControlPlaneAgents + WorkerAgents

As stated above, in the case of any misconfiguration in ACI create or update, it
will reject the request without trying to change the cluster attributes to fix
it (which is why this bug got opened, to begin with).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
