### PR TITLE
MGMT-15015 Provider IsHostSupported panic if platform is not found

### DIFF
--- a/internal/provider/registry/registry.go
+++ b/internal/provider/registry/registry.go
@@ -103,7 +103,7 @@ func (r *registry) IsHostSupported(p models.PlatformType, host *models.Host) (bo
 	currentProvider, err := r.Get(string(p))
 	if err != nil {
 		return false, fmt.Errorf("error while checking if hosts are supported by platform %s, error %w",
-			currentProvider.Name(), err)
+			string(p), err)
 	}
 	return currentProvider.IsHostSupported(host)
 }

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -142,6 +142,15 @@ var _ = Describe("Test GetSupportedProvidersByHosts", func() {
 	})
 })
 
+var _ = Describe("IsHostSupported", func() {
+	It("platform not found", func() {
+		providerRegistry = InitProviderRegistry(common.GetTestLog())
+		found, err := providerRegistry.IsHostSupported("none-existing-platform-type", &models.Host{})
+		Expect(err).NotTo(Succeed())
+		Expect(found).To(BeFalse())
+	})
+})
+
 var _ = Describe("Test AddPlatformToInstallConfig", func() {
 	BeforeEach(func() {
 		providerRegistry = InitProviderRegistry(common.GetTestLog())


### PR DESCRIPTION
Print the platform from the arguments and not the reply from the get function to avoid using nil reply

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
