### PR TITLE
MGMT-10534: Create an override annotation for the ironic agent image

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -55,7 +55,7 @@ More details on conditions is available [here](kube-api-conditions.md)
 #### Debug Information
 
 The `DebugInfo` field under `Status` provides additional information for debugging installation process:
-- `EventsURL` specifies an HTTP/S URL that contains events occured during cluster installation process
+- `EventsURL` specifies an HTTP/S URL that contains events occurred during cluster installation process
 
 
 
@@ -213,6 +213,9 @@ The environment var for the ironicAgent image to be used on X86_64 CPU architect
 `IRONIC_AGENT_IMAGE`
 The environment var for the ironicAgent image to be used on arm64 CPU architecture:
 `IRONIC_AGENT_IMAGE_ARM`
+
+The ironic agent image can also be overridden using the InfraEnv annotation `infraenv.agent-install.openshift.io/ironic-agent-image-override`
+If this field is set this image will be used instead of the hub or default image.
 
 **NOTE**
 Ensure the correct images are mirrored if installing in a disconnected environment.

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -61,6 +61,7 @@ import (
 const defaultRequeueAfterPerRecoverableError = 2 * bminventory.WindowBetweenRequestsInSeconds
 const InfraEnvFinalizerName = "infraenv." + aiv1beta1.Group + "/ai-deprovision"
 const EnableIronicAgentAnnotation = "infraenv." + aiv1beta1.Group + "/enable-ironic-agent"
+const ironicAgentImageOverrideAnnotation = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override"
 
 type InfraEnvConfig struct {
 	ImageType models.ImageType `envconfig:"ISO_IMAGE_TYPE" default:"minimal-iso"`

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -409,9 +409,14 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 		log.WithError(err).Error("failed to get corresponding infraEnv")
 		return false, err
 	}
-	ironicAgentImage, err := r.getIronicAgentImageByRelease(ctx, log, infraEnvInternal)
-	if err != nil {
-		log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
+	ironicAgentImage, ok := infraEnv.GetAnnotations()[ironicAgentImageOverrideAnnotation]
+	if !ok || ironicAgentImage == "" {
+		ironicAgentImage, err = r.getIronicAgentImageByRelease(ctx, log, infraEnvInternal)
+		if err != nil {
+			log.WithError(err).Warningf("Failed to get ironic agent image by release for infraEnv: %s", infraEnv.Name)
+		}
+	} else {
+		log.Infof("Using override ironic agent image (%s) for infraEnv %s", ironicAgentImage, infraEnv.Name)
 	}
 
 	// if ironicAgentImage can't be found by version use the default


### PR DESCRIPTION
If the override annotation (`infraenv.agent-install.openshift.io/ironic-agent-image-override`) is set in the infraEnv use it instead of pulling the image from the hub cluster or using the default image.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-10534

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Unit and subsystem tests should be sufficient for this.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) - updated
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
