### PR TITLE
MGMT-15034: Fix patch of infrastructure CR with external platform

### DIFF
--- a/internal/provider/external/external_suite_test.go
+++ b/internal/provider/external/external_suite_test.go
@@ -1,0 +1,13 @@
+package external
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProviderRegistry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ProviderExternal test")
+}

--- a/internal/provider/external/ignition.go
+++ b/internal/provider/external/ignition.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/pkg/errors"
 )
 
 // Workaround as openshift installer does not support the external platform.
@@ -13,23 +14,22 @@ import (
 // the insfrastructure object with the external platform.
 const (
 	clusterInfraPatchTemplate = `---
-	- op: replace
-	  path: /spec/platformSpec
-	  value:
-		type: External
-		external:
-		  platformName: %s
-	- op: replace
-	  path: /status/platform
-	  value: External
-	- op: replace
-	  path: /status/platformStatus
-	  value:
-		type: External
-		external:
-		  cloudControllerManager:
-			state: External
-	`
+- op: replace
+  path: /spec/platformSpec
+  value:
+    type: External
+    external:
+      platformName: %s
+- op: replace
+  path: /status/platform
+  value: External
+- op: replace
+  path: /status/platformStatus
+  value:
+    type: External
+    external:
+      cloudControllerManager:
+        state: External`
 )
 
 func (p externalProvider) PreCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error {
@@ -37,17 +37,30 @@ func (p externalProvider) PreCreateManifestsHook(cluster *common.Cluster, envVar
 }
 
 func (p externalProvider) PostCreateManifestsHook(cluster *common.Cluster, envVars *[]string, workDir string) error {
-	p.Log.Info("Patching infrastructure object")
 
 	platformName := string(p.platformType)
 	clusterInfraPatch := fmt.Sprintf(clusterInfraPatchTemplate, platformName)
 
-	clusterInfraPatchPath := filepath.Join(workDir, "manifests", "cluster-infrastructure-02-config.yml.patch_01_configure_external_platform")
-	err := os.WriteFile(clusterInfraPatchPath, []byte(clusterInfraPatch), 0600)
+	p.Log.Infof("Patching Infrastructure CR with external platform: platformName=%s", platformName)
+
+	infraManifest := filepath.Join(workDir, "manifests", "cluster-infrastructure-02-config.yml")
+	data, err := os.ReadFile(infraManifest)
 	if err != nil {
-		p.Log.Error("Couldn't write infrastructure patch %v", clusterInfraPatchPath)
-		return err
+		return errors.Wrapf(err, "failed to read Infrastructure Manifest \"%s\"", infraManifest)
 	}
+	p.Log.Infof("read the infrastructure manifest at %s", infraManifest)
+
+	data, err = common.ApplyYamlPatch(data, []byte(clusterInfraPatch))
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch Infrastructure Manifest \"%s\"", infraManifest)
+	}
+	p.Log.Infof("applied the yaml patch to the infrastructure manifest at %s: \n %s", infraManifest, string(data[:]))
+
+	err = os.WriteFile(infraManifest, data, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write Infrastructure Manifest \"%s\"", infraManifest)
+	}
+	p.Log.Infof("wrote the resulting infrastructure manifest at %s", infraManifest)
 
 	return nil
 }

--- a/internal/provider/external/ignition_test.go
+++ b/internal/provider/external/ignition_test.go
@@ -1,0 +1,114 @@
+package external
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/provider"
+	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	cluster *common.Cluster
+	log     = logrus.New()
+	workDir string
+)
+
+var _ = BeforeEach(func() {
+	// setup temp workdir
+	var err error
+	workDir, err = os.MkdirTemp("", "assisted-install-test-")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterEach(func() {
+	os.RemoveAll(workDir)
+})
+
+var _ = Describe("Infrastructure CR", func() {
+	When("platform is OCI", func() {
+		var (
+			provider provider.Provider
+		)
+
+		BeforeEach(func() {
+			provider = NewExternalProvider(log, models.PlatformTypeOci)
+		})
+
+		It("should be patched", func() {
+			base := `apiVersion: config.openshift.io/v1
+kind: Infrastructure
+metadata:
+  creationTimestamp: "2023-06-19T13:49:07Z"
+  generation: 1
+  name: cluster
+  resourceVersion: "553"
+  uid: 240dc176-566e-4471-b9db-fb25c676ba33
+spec:
+  cloudConfig:
+    name: ""
+  platformSpec:
+    type: None
+status:
+  apiServerInternalURI: https://api-int.test-infra-cluster-97ef21c5.assisted-ci.oci-rhelcert.edge-sro.rhecoeng.com:6443
+  apiServerURL: https://api.test-infra-cluster-97ef21c5.assisted-ci.oci-rhelcert.edge-sro.rhecoeng.com:6443
+  controlPlaneTopology: HighlyAvailable
+  cpuPartitioning: None
+  etcdDiscoveryDomain: ""
+  infrastructureName: test-infra-cluster-97-w6b42
+  infrastructureTopology: HighlyAvailable
+  platform: None
+  platformStatus:
+    type: None
+`
+
+			expected := `apiVersion: config.openshift.io/v1
+kind: Infrastructure
+metadata:
+  creationTimestamp: "2023-06-19T13:49:07Z"
+  generation: 1
+  name: cluster
+  resourceVersion: "553"
+  uid: 240dc176-566e-4471-b9db-fb25c676ba33
+spec:
+  cloudConfig:
+    name: ""
+  platformSpec:
+    external:
+      platformName: oci
+    type: External
+status:
+  apiServerInternalURI: https://api-int.test-infra-cluster-97ef21c5.assisted-ci.oci-rhelcert.edge-sro.rhecoeng.com:6443
+  apiServerURL: https://api.test-infra-cluster-97ef21c5.assisted-ci.oci-rhelcert.edge-sro.rhecoeng.com:6443
+  controlPlaneTopology: HighlyAvailable
+  cpuPartitioning: None
+  etcdDiscoveryDomain: ""
+  infrastructureName: test-infra-cluster-97-w6b42
+  infrastructureTopology: HighlyAvailable
+  platform: External
+  platformStatus:
+    external:
+      cloudControllerManager:
+        state: External
+    type: External
+`
+
+			manifestsDir := filepath.Join(workDir, "manifests")
+			Expect(os.Mkdir(manifestsDir, 0755)).To(Succeed())
+
+			err := os.WriteFile(filepath.Join(manifestsDir, "cluster-infrastructure-02-config.yml"), []byte(base), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(provider.PostCreateManifestsHook(cluster, nil, workDir)).To(Succeed())
+
+			content, err := os.ReadFile(filepath.Join(manifestsDir, "cluster-infrastructure-02-config.yml"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(content)).To(Equal(expected))
+		})
+	})
+})


### PR DESCRIPTION
Patch directly the Infrastructure CR from PostCreateManifestsHook
function which makes it easier to test.

This part of the code is a workaround until the openshift installer
supports external platform.
