### PR TITLE
MGMT-14937: Deprecate `user_managed_networking` attribute

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -265,7 +265,7 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// user name

--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -132,7 +132,7 @@ type ClusterCreateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.

--- a/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -120,7 +120,7 @@ type V2ClusterUpdateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -265,7 +265,7 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// user name

--- a/models/cluster_create_params.go
+++ b/models/cluster_create_params.go
@@ -132,7 +132,7 @@ type ClusterCreateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.

--- a/models/v2_cluster_update_params.go
+++ b/models/v2_cluster_update_params.go
@@ -120,7 +120,7 @@ type V2ClusterUpdateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6227,7 +6227,7 @@ func init() {
           }
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "x-nullable": true
         },
@@ -6440,7 +6440,7 @@ func init() {
           "x-nullable": true
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "default": false,
           "x-nullable": true
@@ -10066,7 +10066,7 @@ func init() {
           "x-nullable": true
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "x-nullable": true
         },
@@ -16622,7 +16622,7 @@ func init() {
           }
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "x-nullable": true
         },
@@ -16835,7 +16835,7 @@ func init() {
           "x-nullable": true
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "default": false,
           "x-nullable": true
@@ -20348,7 +20348,7 @@ func init() {
           "x-nullable": true
         },
         "user_managed_networking": {
-          "description": "Indicate if the networking is managed by the user.",
+          "description": "(DEPRECATED) Indicate if the networking is managed by the user.",
           "type": "boolean",
           "x-nullable": true
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3990,8 +3990,8 @@ definitions:
       - 'NUTANIX_INTEGRATION'
       - 'VSPHERE_INTEGRATION'
       - 'DUAL_STACK_VIPS'
-      - 'CLUSTER_MANAGED_NETWORKING'
-      - 'USER_MANAGED_NETWORKING'
+      - 'CLUSTER_MANAGED_NETWORKING' # DEPRECATED
+      - 'USER_MANAGED_NETWORKING' # DEPRECATED
       - 'MINIMAL_ISO'
       - 'FULL_ISO'
       - 'EXTERNAL_PLATFORM_OCI'
@@ -4689,7 +4689,7 @@ definitions:
         x-nullable: true
       user_managed_networking:
         type: boolean
-        description: Indicate if the networking is managed by the user.
+        description: (DEPRECATED) Indicate if the networking is managed by the user.
         x-nullable: true
         default: false
       additional_ntp_source:
@@ -4881,7 +4881,7 @@ definitions:
         x-nullable: true
       user_managed_networking:
         type: boolean
-        description: Indicate if the networking is managed by the user.
+        description: (DEPRECATED) Indicate if the networking is managed by the user.
         x-nullable: true
       additional_ntp_source:
         type: string
@@ -5229,7 +5229,7 @@ definitions:
       user_managed_networking:
         type: boolean
         x-nullable: true
-        description: Indicate if the networking is managed by the user.
+        description: (DEPRECATED) Indicate if the networking is managed by the user.
       additional_ntp_source:
         type: string
         description: A comma-separated list of NTP sources (name or IP) going to be added to all the hosts.

--- a/vendor/github.com/openshift/assisted-service/models/cluster.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster.go
@@ -265,7 +265,7 @@ type Cluster struct {
 	// Format: date-time
 	UpdatedAt timeext.Time `json:"updated_at,omitempty" gorm:"type:timestamp with time zone"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// user name

--- a/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_create_params.go
@@ -132,7 +132,7 @@ type ClusterCreateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.

--- a/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/v2_cluster_update_params.go
@@ -120,7 +120,7 @@ type V2ClusterUpdateParams struct {
 	// A comma-separated list of tags that are associated to the cluster.
 	Tags *string `json:"tags,omitempty"`
 
-	// Indicate if the networking is managed by the user.
+	// (DEPRECATED) Indicate if the networking is managed by the user.
 	UserManagedNetworking *bool `json:"user_managed_networking,omitempty"`
 
 	// Indicate if virtual IP DHCP allocation mode is enabled.


### PR DESCRIPTION
Deprecate user managed networking - use platform to determine the network configuration instead.
This PR only deprecate `user_managed_networking` attribute

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Deprecate feature
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

/cc @avishayt @gamli75 