### PR TITLE
MGMT-14852: Allow AutomatedCleaningMode to be set by user

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -868,16 +868,11 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	}
 
 	dirty := false
-	// in case of converged flow set the custom deploy and cleaning mode instead of the annotations
+	// in case of converged flow set the custom deploy instead of the annotations
 	if r.ConvergedFlowEnabled {
 		if bmh.Spec.CustomDeploy == nil || bmh.Spec.CustomDeploy.Method != ASSISTED_DEPLOY_METHOD {
 			log.Infof("Updating BMH CustomDeploy to %s", ASSISTED_DEPLOY_METHOD)
 			bmh.Spec.CustomDeploy = &bmh_v1alpha1.CustomDeploy{Method: ASSISTED_DEPLOY_METHOD}
-			dirty = true
-		}
-		if bmh.Spec.AutomatedCleaningMode != bmh_v1alpha1.CleaningModeDisabled {
-			log.Infof("Updating BMH AutomatedCleaningMode to %s", bmh_v1alpha1.CleaningModeDisabled)
-			bmh.Spec.AutomatedCleaningMode = bmh_v1alpha1.CleaningModeDisabled
 			dirty = true
 		}
 		return reconcileComplete{dirty: dirty, stop: false}
@@ -886,11 +881,8 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	annotations := bmh.ObjectMeta.GetAnnotations()
 	// Set the following parameters regardless of the state
 	// of the InfraEnv and the BMH. There is no need for
-	// inspection and cleaning to happen out of assisted
-	// service's loop.
-	if _, ok := annotations[BMH_INSPECT_ANNOTATION]; !ok || bmh.Spec.AutomatedCleaningMode != bmh_v1alpha1.CleaningModeDisabled {
-		bmh.Spec.AutomatedCleaningMode = bmh_v1alpha1.CleaningModeDisabled
-
+	// inspection to happen out of assisted service's loop.
+	if _, ok := annotations[BMH_INSPECT_ANNOTATION]; !ok {
 		// Let's make sure inspection is disabled for BMH resources
 		// that are associated with an agent-based deployment.
 		//


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-14852
Epic: https://issues.redhat.com/browse/MGMT-13017
Removes setting automated cleaning mode to disabled by default, which lets the user set the field.
Part of the larger epic to allow wiping disks before installing by using Ironic's automated cleaning feature.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
