### PR TITLE
RHTAPBUGS-318: Fetch tag in RHTAP build

### DIFF
--- a/.tekton/assisted-service-q2vh-pull-request.yaml
+++ b/.tekton/assisted-service-q2vh-pull-request.yaml
@@ -143,6 +143,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "100"
+      - name: refspec
+        value: "refs/tags/*:refs/tags/* refs/heads/{{source_branch}}"
       runAfter:
       - init
       taskRef:

--- a/.tekton/assisted-service-q2vh-push.yaml
+++ b/.tekton/assisted-service-q2vh-push.yaml
@@ -140,6 +140,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "100"
+      - name: refspec
+        value: "refs/tags/*:refs/tags/* refs/heads/{{source_branch}}"
       runAfter:
       - init
       taskRef:


### PR DESCRIPTION
The build process requires tags to be presented (it runs git describe). Configure the pipeline to fetch the recent 100 commits and all the tags.