### PR TITLE
MGMT-15150: Use same installer binary for all platform types

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -6443,7 +6443,7 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 	return b.hostApi.GetKnownApprovedHosts(clusterId)
 }
 
-// In case cpu architecture is not x86_64 and platform is baremetal, we should extract openshift-baremetal-installer
+// In case cpu architecture is not x86_64, we should extract openshift-baremetal-installer
 // from x86_64 release image as there is no x86_64 openshift-baremetal-installer executable in arm image.
 // This flow does not affect the multiarch release images and is meant purely for using arm64 release image with the x86 hub.
 // Implementation of handling the multiarch images is done directly in the `oc` binary and relies on the fact that `oc adm release extract`
@@ -6451,7 +6451,6 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version string, platform *models.PlatformType) bool {
 	return cpuArchitecture != common.MultiCPUArchitecture &&
 		cpuArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
-		common.PlatformTypeValue(platform) == models.PlatformTypeBaremetal &&
 		featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, version, swag.String(models.ClusterCPUArchitectureArm64))
 }
 

--- a/internal/ignition/dummy.go
+++ b/internal/ignition/dummy.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
-	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
 	"github.com/sirupsen/logrus"
@@ -33,7 +32,7 @@ func NewDummyGenerator(serviceBaseURL string, workDir string, cluster *common.Cl
 }
 
 // Generate creates the expected ignition and related files but with nonsense content
-func (g *dummyGenerator) Generate(_ context.Context, installConfig []byte, platformType models.PlatformType, authType auth.AuthType) error {
+func (g *dummyGenerator) Generate(_ context.Context, installConfig []byte, authType auth.AuthType) error {
 	toUpload := fileNames[:]
 	for _, host := range g.cluster.Hosts {
 		toUpload = append(toUpload, hostutil.IgnitionFileName(host))

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -202,7 +202,7 @@ var fileNames = [...]string{
 
 // Generator can generate ignition files and upload them to an S3-like service
 type Generator interface {
-	Generate(ctx context.Context, installConfig []byte, platformType models.PlatformType, authType auth.AuthType) error
+	Generate(ctx context.Context, installConfig []byte, authType auth.AuthType) error
 	UploadToS3(ctx context.Context) error
 	UpdateEtcHosts(string) error
 }
@@ -307,7 +307,7 @@ func (g *installerGenerator) UploadToS3(ctx context.Context) error {
 }
 
 // Generate generates ignition files and applies modifications.
-func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte, platformType models.PlatformType, authType auth.AuthType) error {
+func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte, authType auth.AuthType) error {
 	var err error
 	log := logutil.FromContext(ctx, g.log)
 
@@ -328,7 +328,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 		MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay}, mirrorRegistriesBuilder)
 
 	release, err := g.installerCache.Get(g.installerReleaseImageOverride, g.releaseImageMirror,
-		g.cluster.PullSecret, ocRelease, platformType)
+		g.cluster.PullSecret, ocRelease)
 	if err != nil {
 		return errors.Wrap(err, "failed to get installer path")
 	}

--- a/internal/ignition/mock_ignition.go
+++ b/internal/ignition/mock_ignition.go
@@ -38,17 +38,17 @@ func (m *MockGenerator) EXPECT() *MockGeneratorMockRecorder {
 }
 
 // Generate mocks base method.
-func (m *MockGenerator) Generate(ctx context.Context, installConfig []byte, platformType models.PlatformType, authType auth.AuthType) error {
+func (m *MockGenerator) Generate(ctx context.Context, installConfig []byte, authType auth.AuthType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", ctx, installConfig, platformType, authType)
+	ret := m.ctrl.Call(m, "Generate", ctx, installConfig, authType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Generate indicates an expected call of Generate.
-func (mr *MockGeneratorMockRecorder) Generate(ctx, installConfig, platformType, authType interface{}) *gomock.Call {
+func (mr *MockGeneratorMockRecorder) Generate(ctx, installConfig, authType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockGenerator)(nil).Generate), ctx, installConfig, platformType, authType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockGenerator)(nil).Generate), ctx, installConfig, authType)
 }
 
 // UpdateEtcHosts mocks base method.

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/openshift/assisted-service/internal/oc"
-	"github.com/openshift/assisted-service/models"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -64,7 +63,7 @@ func New(cacheDir string, storageCapacity int64, log logrus.FieldLogger) *Instal
 // Get returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image. Tries the mirror release image first if it's set. It is safe for concurrent use. A cache of
 // binaries is maintained to reduce re-downloading of the same release.
-func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocRelease oc.Release, platformType models.PlatformType) (*Release, error) {
+func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocRelease oc.Release) (*Release, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -75,13 +74,13 @@ func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 	if releaseIDMirror != "" {
 		releaseImageLocation = releaseIDMirror
 	}
-	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir, platformType)
+	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir)
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		//evict older files if necessary
 		i.evict()
 
 		//extract the binary
-		_, err = ocRelease.Extract(i.log, releaseID, releaseIDMirror, i.cacheDir, pullSecret, platformType)
+		_, err = ocRelease.Extract(i.log, releaseID, releaseIDMirror, i.cacheDir, pullSecret)
 		if err != nil {
 			return &Release{}, err
 		}

--- a/internal/installercache/installercache_test.go
+++ b/internal/installercache/installercache_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/oc"
-	"github.com/openshift/assisted-service/models"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,16 +45,15 @@ var _ = Describe("installer cache", func() {
 		fname := filepath.Join(workdir, releaseID)
 
 		mockRelease.EXPECT().GetReleaseBinaryPath(
-			gomock.Any(), gomock.Any(), gomock.Any()).
+			gomock.Any(), gomock.Any()).
 			Return(workdir, releaseID, fname)
 		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
-			gomock.Any(), cacheDir, gomock.Any(),
-			gomock.Any()).
-			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType) (string, error) {
+			gomock.Any(), cacheDir, gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		l, err := manager.Get(releaseID, "mirror", "pull-secret", mockRelease, models.PlatformTypeBaremetal)
+		l, err := manager.Get(releaseID, "mirror", "pull-secret", mockRelease)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		time.Sleep(1 * time.Second)
@@ -123,16 +121,15 @@ var _ = Describe("installer cache", func() {
 		fname := filepath.Join(workdir, releaseID)
 
 		mockRelease.EXPECT().GetReleaseBinaryPath(
-			releaseMirrorID, gomock.Any(), gomock.Any()).
+			releaseMirrorID, gomock.Any()).
 			Return(workdir, releaseID, fname)
 		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
-			gomock.Any(), cacheDir, gomock.Any(),
-			gomock.Any()).
-			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType) (string, error) {
+			gomock.Any(), cacheDir, gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, models.PlatformTypeBaremetal)
+		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -143,16 +140,15 @@ var _ = Describe("installer cache", func() {
 		fname := filepath.Join(workdir, releaseID)
 
 		mockRelease.EXPECT().GetReleaseBinaryPath(
-			releaseID, gomock.Any(), gomock.Any()).
+			releaseID, gomock.Any()).
 			Return(workdir, releaseID, fname)
 		mockRelease.EXPECT().Extract(gomock.Any(), releaseID,
-			gomock.Any(), cacheDir, gomock.Any(),
-			gomock.Any()).
-			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, platformType models.PlatformType) (string, error) {
+			gomock.Any(), cacheDir, gomock.Any()).
+			DoAndReturn(func(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
 				err := os.WriteFile(fname, []byte("abcde"), 0600)
 				return "", err
 			})
-		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease, models.PlatformTypeBaremetal)
+		_, err := manager.Get(releaseID, releaseMirrorID, "pull-secret", mockRelease)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 })

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	models "github.com/openshift/assisted-service/models"
 	logrus "github.com/sirupsen/logrus"
 )
 
@@ -36,18 +35,18 @@ func (m *MockRelease) EXPECT() *MockReleaseMockRecorder {
 }
 
 // Extract mocks base method.
-func (m *MockRelease) Extract(log logrus.FieldLogger, releaseImage, releaseImageMirror, cacheDir, pullSecret string, platformType models.PlatformType) (string, error) {
+func (m *MockRelease) Extract(log logrus.FieldLogger, releaseImage, releaseImageMirror, cacheDir, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Extract", log, releaseImage, releaseImageMirror, cacheDir, pullSecret, platformType)
+	ret := m.ctrl.Call(m, "Extract", log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Extract indicates an expected call of Extract.
-func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret, platformType interface{}) *gomock.Call {
+func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, platformType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 }
 
 // GetIronicAgentImage mocks base method.
@@ -156,9 +155,9 @@ func (mr *MockReleaseMockRecorder) GetReleaseArchitecture(log, releaseImage, rel
 }
 
 // GetReleaseBinaryPath mocks base method.
-func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir string, platformType models.PlatformType) (string, string, string) {
+func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir string) (string, string, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReleaseBinaryPath", releaseImage, cacheDir, platformType)
+	ret := m.ctrl.Call(m, "GetReleaseBinaryPath", releaseImage, cacheDir)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -166,7 +165,7 @@ func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir string, platfo
 }
 
 // GetReleaseBinaryPath indicates an expected call of GetReleaseBinaryPath.
-func (mr *MockReleaseMockRecorder) GetReleaseBinaryPath(releaseImage, cacheDir, platformType interface{}) *gomock.Call {
+func (mr *MockReleaseMockRecorder) GetReleaseBinaryPath(releaseImage, cacheDir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseBinaryPath", reflect.TypeOf((*MockRelease)(nil).GetReleaseBinaryPath), releaseImage, cacheDir, platformType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseBinaryPath", reflect.TypeOf((*MockRelease)(nil).GetReleaseBinaryPath), releaseImage, cacheDir)
 }

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -345,15 +345,8 @@ func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseIm
 }
 
 func (r *release) GetReleaseBinaryPath(releaseImage string, cacheDir string, platformType models.PlatformType) (workdir string, binary string, path string) {
-	// Using platform type as an indication for which openshift install binary to use
-	// (e.g. as non-x86_64 clusters should use the openshift-install binary).
-	if platformType == models.PlatformTypeNone {
-		binary = "openshift-install"
-	} else {
-		binary = "openshift-baremetal-install"
-	}
-
 	workdir = filepath.Join(cacheDir, releaseImage)
+	binary = "openshift-baremetal-install"
 	path = filepath.Join(workdir, binary)
 	return
 }

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -29,7 +29,6 @@ var (
 	mcoImage               = "mco_image"
 	mustGatherImage        = "must_gather_image"
 	baremetalInstallBinary = "openshift-baremetal-install"
-	installBinary          = "openshift-install"
 )
 
 //go:embed test_skopeo_multiarch_image_output
@@ -421,18 +420,6 @@ var _ = Describe("oc", func() {
 			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeBaremetal)
 			Expect(path).To(Equal(""))
 			Expect(err).Should(HaveOccurred())
-		})
-
-		It("extract openshift-install from release image", func() {
-			command := fmt.Sprintf(templateExtract+" --registry-config=%s",
-				installBinary, filepath.Join(cacheDir, releaseImage), false, releaseImage, tempFilePath)
-			args := splitStringToInterfacesArray(command)
-			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
-
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeNone)
-			filePath := filepath.Join(cacheDir+"/"+releaseImage, installBinary)
-			Expect(path).To(Equal(filePath))
-			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
-	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/executer"
 	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	logrus "github.com/sirupsen/logrus"
@@ -375,7 +374,7 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeBaremetal)
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImage, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
@@ -387,14 +386,14 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret, models.PlatformTypeBaremetal)
+			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImageMirror, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("extract baremetal-install with no release image or mirror", func() {
-			path, err := oc.Extract(log, "", "", cacheDir, pullSecret, models.PlatformTypeBaremetal)
+			path, err := oc.Extract(log, "", "", cacheDir, pullSecret)
 			Expect(path).Should(BeEmpty())
 			Expect(err).Should(HaveOccurred())
 		})
@@ -405,7 +404,7 @@ var _ = Describe("oc", func() {
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "Failed to extract the installer", 1).Times(1)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeBaremetal)
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImage, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
@@ -417,7 +416,7 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "Failed to extract the installer", 1).Times(5)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeBaremetal)
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			Expect(path).To(Equal(""))
 			Expect(err).Should(HaveOccurred())
 		})

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -5,12 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-openapi/swag"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/ignition"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/provider/registry"
-	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/auth"
 	logutil "github.com/openshift/assisted-service/pkg/log"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
@@ -104,7 +102,7 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 		generator = ignition.NewGenerator(k.ServiceBaseURL, clusterWorkDir, installerCacheDir, &cluster, releaseImage, k.Config.ReleaseImageMirror,
 			k.Config.ServiceCACertPath, k.Config.InstallInvoker, k.s3Client, log, k.operatorsApi, k.providerRegistry, installerReleaseImageOverride, k.clusterTLSCertOverrideDir, k.InstallerCacheCapacity)
 	}
-	err = generator.Generate(ctx, cfg, k.getClusterPlatformType(cluster), k.authHandler.AuthType())
+	err = generator.Generate(ctx, cfg, k.authHandler.AuthType())
 	if err != nil {
 		return err
 	}
@@ -123,12 +121,4 @@ func (k *installGenerator) GenerateInstallConfig(ctx context.Context, cluster co
 	}
 
 	return nil
-}
-
-func (k *installGenerator) getClusterPlatformType(cluster common.Cluster) models.PlatformType {
-	// Enabled UserManagedNetworking implies none platform.
-	if swag.BoolValue(cluster.UserManagedNetworking) {
-		return models.PlatformTypeNone
-	}
-	return common.PlatformTypeValue(cluster.Platform.Type)
 }


### PR DESCRIPTION
There's nothing special about platform:none that requires it to use a different installer binary. This was originally done to avoid a problem with the openshift-baremetal-install binary not being available for non-x86 targets, but this was resolved by 1d025b8108 ([MGMT-9206](https://issues.redhat.com//browse/MGMT-9206)). We no longer need all this complexity.

This partially reverts commit f9b2f3d3246f91f7e80eab0b85eb9c34742eaa46.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
