### PR TITLE
MGMT-15073:Cluster reset - only system generated manifests to be deleted

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -385,7 +385,7 @@ func main() {
 	dnsApi := dns.NewDNSHandler(Options.BMConfig.BaseDNSDomains, log)
 	manifestsGenerator := network.NewManifestsGenerator(manifestsApi, Options.ManifestsGeneratorConfig, db)
 	clusterApi := cluster.NewManager(Options.ClusterConfig, log.WithField("pkg", "cluster-state"), db,
-		notificationStream, eventsHandler, uploadClient, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager, ocmClient, objectHandler, dnsApi, authHandler)
+		notificationStream, eventsHandler, uploadClient, hostApi, metricsManager, manifestsGenerator, lead, operatorsManager, ocmClient, objectHandler, dnsApi, authHandler, manifestsApi)
 	infraEnvApi := infraenv.NewManager(log.WithField("pkg", "host-state"), db, objectHandler)
 
 	clusterEventsUploader := thread.New(

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -1557,7 +1557,7 @@ var _ = Describe("cluster", func() {
 	}
 	setResetClusterSuccess := func() {
 		mockS3Client.EXPECT().DeleteObject(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
-		mockClusterApi.EXPECT().DeleteClusterFiles(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockClusterApi.EXPECT().ResetClusterFiles(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mockClusterApi.EXPECT().ResetCluster(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		mockHostApi.EXPECT().ResetHost(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	}
@@ -1883,7 +1883,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("happy flow", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, mockStream, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, mockStream, mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -1901,7 +1901,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, release version is lower than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7"
 			clusterParams.OpenshiftVersion = swag.String(insufficientOpenShiftVersionForNoneHA)
@@ -1913,7 +1913,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, release version is pre-release and lower than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			insufficientOpenShiftVersionForNoneHA := "4.7.0-fc.1"
 			clusterParams.OpenshiftVersion = swag.String(insufficientOpenShiftVersionForNoneHA)
@@ -1925,7 +1925,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -1943,7 +1943,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster success, release version is pre-release and greater than minimal", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 			noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -1962,7 +1962,7 @@ var _ = Describe("cluster", func() {
 		It("create non ha cluster fail, explicitly disabled UserManagedNetworking", func() {
 			errStr := "Can't set none platform with user-managed-networking disabled"
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams.OpenshiftVersion = swag.String(openShiftVersionForNoneHA)
@@ -1975,7 +1975,7 @@ var _ = Describe("cluster", func() {
 		})
 		It("create non ha cluster fail, explicitly enabled VipDhcpAllocation", func() {
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			noneHaMode := models.ClusterHighAvailabilityModeNone
 			openShiftVersionForNoneHA := "4.8.0-fc.2"
 			clusterParams.OpenshiftVersion = swag.String(openShiftVersionForNoneHA)
@@ -1990,7 +1990,7 @@ var _ = Describe("cluster", func() {
 	})
 	It("create non ha cluster success, release version is ci-release and greater than minimal", func() {
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		mockClusterRegisterSuccessWithVersion(models.ClusterCPUArchitectureX8664, "4.8")
 		noneHaMode := models.ClusterHighAvailabilityModeNone
@@ -2086,7 +2086,7 @@ var _ = Describe("cluster", func() {
 
 		It("update cluster day1 with APIVipDNSName failed", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 
@@ -2164,7 +2164,7 @@ var _ = Describe("cluster", func() {
 			Context("V2RegisterCluster", func() {
 				BeforeEach(func() {
 					bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-						db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+						db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 				})
 				Context("RegisterCluster - Multiple-VIPs Support", func() {
 					var openshiftVersion = "4.12.0"
@@ -10659,7 +10659,7 @@ var _ = Describe("V2UploadClusterIngressCert test", func() {
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), nil, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+			db, commontesting.GetDummyNotificationStream(ctrl), nil, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 		c = common.Cluster{Cluster: models.Cluster{
 			ID:               &clusterID,
 			OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
@@ -12466,7 +12466,7 @@ var _ = Describe("GetSupportedPlatformsFromInventory", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 		mockClusterRegisterSuccess(true)
 		mockAMSSubscription(ctx)
@@ -13028,7 +13028,7 @@ var _ = Describe("TestRegisterCluster", func() {
 		Expect(cfg.DiskEncryptionSupport).Should(BeTrue())
 		bm = createInventory(db, cfg)
 		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil)
+			db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -14249,7 +14249,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			var c *models.Cluster
 			diskEncryptionBm := createInventory(db, cfg)
 			diskEncryptionBm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperatorManager, nil, nil, nil, nil, nil)
 
 			By("Register cluster", func() {
 
@@ -14329,7 +14329,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			mockUsageReports()
 		})
 
@@ -14552,7 +14552,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			cfg.DiskEncryptionSupport = false
 			bm = createInventory(db, cfg)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			mockUsageReports()
 		})
 
@@ -15009,7 +15009,7 @@ var _ = Describe("TestRegisterCluster", func() {
 			db, dbName = common.PrepareTestDB()
 			bm = createInventory(db, Config{})
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		})
 
 		Context("with EnableOrgBasedFeatureGates true", func() {
@@ -15130,7 +15130,7 @@ var _ = Describe("AMS subscriptions", func() {
 		Expect(envconfig.Process("test", &cfg)).ShouldNot(HaveOccurred())
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		mockUsageReports()
 	})
 
@@ -15191,7 +15191,7 @@ var _ = Describe("AMS subscriptions", func() {
 		It("deregister cluster that don't have 'Reserved' subscriptions", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil)
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
 
@@ -15213,7 +15213,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name happy flow", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -15246,7 +15246,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster name with same name", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -15276,7 +15276,7 @@ var _ = Describe("AMS subscriptions", func() {
 
 		It("update cluster without name field", func() {
 			mockOperators := operators.NewMockAPI(ctrl)
-			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 
 			mockClusterRegisterSuccess(true)
 			mockAMSSubscription(ctx)
@@ -15385,7 +15385,7 @@ var _ = Describe("AMS subscriptions", func() {
 		It("register and deregister cluster happy flow - nil OCM client", func() {
 			mockS3Client = s3wrapper.NewMockAPI(ctrl)
 			bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog().WithField("pkg", "cluster-monitor"),
-				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil)
+				db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, nil, nil, mockS3Client, nil, nil, nil)
 			bm.ocmClient = nil
 			mockClusterRegisterSuccess(true)
 
@@ -17414,7 +17414,7 @@ var _ = Describe("Platform tests", func() {
 		db, dbName = common.PrepareTestDB()
 		bm = createInventory(db, cfg)
 		mockOperators := operators.NewMockAPI(ctrl)
-		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil)
+		bm.clusterApi = cluster.NewManager(cluster.Config{}, common.GetTestLog(), db, commontesting.GetDummyNotificationStream(ctrl), mockEvents, nil, nil, nil, nil, nil, mockOperators, nil, nil, nil, nil, nil)
 		bm.ocmClient = nil
 		clusterParams := getDefaultClusterCreateParams()
 		clusterParams.Name = swag.String("cluster")

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -230,7 +230,7 @@ func (b *bareMetalInventory) V2ResetCluster(ctx context.Context, params installe
 		b.customizeHost(&cluster.Cluster, h)
 	}
 
-	if err := b.clusterApi.DeleteClusterFiles(ctx, cluster, b.objectHandler); err != nil {
+	if err := b.clusterApi.ResetClusterFiles(ctx, cluster, b.objectHandler); err != nil {
 		return common.NewApiError(http.StatusInternalServerError, err)
 	}
 	if err := b.deleteDNSRecordSets(ctx, *cluster); err != nil {

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -263,20 +263,6 @@ func (mr *MockAPIMockRecorder) CompleteInstallation(ctx, db, cluster, successful
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockAPI)(nil).CompleteInstallation), ctx, db, cluster, successfullyFinished, reason)
 }
 
-// DeleteClusterFiles mocks base method.
-func (m *MockAPI) DeleteClusterFiles(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteClusterFiles", ctx, c, objectHandler)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteClusterFiles indicates an expected call of DeleteClusterFiles.
-func (mr *MockAPIMockRecorder) DeleteClusterFiles(ctx, c, objectHandler interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterFiles", reflect.TypeOf((*MockAPI)(nil).DeleteClusterFiles), ctx, c, objectHandler)
-}
-
 // DeleteClusterLogs mocks base method.
 func (m *MockAPI) DeleteClusterLogs(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
 	m.ctrl.T.Helper()
@@ -599,6 +585,20 @@ func (m *MockAPI) ResetCluster(ctx context.Context, c *common.Cluster, reason st
 func (mr *MockAPIMockRecorder) ResetCluster(ctx, c, reason, db interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetCluster", reflect.TypeOf((*MockAPI)(nil).ResetCluster), ctx, c, reason, db)
+}
+
+// ResetClusterFiles mocks base method.
+func (m *MockAPI) ResetClusterFiles(ctx context.Context, c *common.Cluster, objectHandler s3wrapper.API) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetClusterFiles", ctx, c, objectHandler)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResetClusterFiles indicates an expected call of ResetClusterFiles.
+func (mr *MockAPIMockRecorder) ResetClusterFiles(ctx, c, objectHandler interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetClusterFiles", reflect.TypeOf((*MockAPI)(nil).ResetClusterFiles), ctx, c, objectHandler)
 }
 
 // SetConnectivityMajorityGroupsForCluster mocks base method.

--- a/internal/cluster/progress_test.go
+++ b/internal/cluster/progress_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Progress bar test", func() {
 		mockOperatorApi = operators.NewMockAPI(ctrl)
 		mockDnsApi = dns.NewMockDNSApi(ctrl)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, mockOperatorApi, nil, nil, mockDnsApi, nil, nil)
 	})
 
 	AfterEach(func() {

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Transition tests", func() {
 
 	Context("cancel_installation", func() {
 		BeforeEach(func() {
-			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+			capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 		})
 
 		It("cancel_installation", func() {
@@ -366,7 +366,7 @@ var _ = Describe("Transition tests", func() {
 					mockMetric.EXPECT().ClusterInstallationFinished(gomock.Any(), models.ClusterStatusInstalled, models.ClusterStatusFinalizing, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 				}
 
-				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil)
+				capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), eventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil)
 
 				// Test
 				clusterAfterRefresh, err := capi.RefreshStatus(ctx, &c, db)
@@ -414,7 +414,7 @@ var _ = Describe("Cancel cluster installation", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		uploadClient = uploader.NewClient(&uploader.Config{EnableDataCollection: false}, nil, logrus.New(), nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEventsHandler, uploadClient, nil, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 	})
 
 	AfterEach(func() {
@@ -488,7 +488,7 @@ var _ = Describe("Reset cluster", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = eventsapi.NewMockHandler(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
-		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEventsHandler, nil, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil)
+		capi = NewManager(getDefaultConfig(), common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEventsHandler, nil, nil, nil, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 	})
 
 	AfterEach(func() {
@@ -660,7 +660,7 @@ var _ = Describe("Refresh Cluster - No DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1457,7 +1457,7 @@ var _ = Describe("Refresh Cluster - Same networks", func() {
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -1736,7 +1736,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil)
 
 		mockHostAPI.EXPECT().IsValidMasterCandidate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		hid1 = strfmt.UUID(uuid.New().String())
@@ -1979,7 +1979,7 @@ var _ = Describe("Refresh Cluster - Advanced networking validations", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3041,7 +3041,7 @@ var _ = Describe("Refresh Cluster - With DHCP", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		mockS3Api.EXPECT().DoesObjectExist(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -3682,7 +3682,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 		mockS3Api = s3wrapper.NewMockAPI(ctrl)
 		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, mockS3Api, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -4018,7 +4018,7 @@ var _ = Describe("Refresh Cluster - Installing Cases", func() {
 					mockAccountsMgmt = ocm.NewMockOCMAccountsMgmt(ctrl)
 					ocmClient := &ocm.Client{AccountsMgmt: mockAccountsMgmt, Config: &ocm.Config{}}
 					clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-						mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil)
+						mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, ocmClient, mockS3Api, nil, nil, nil)
 					if !t.requiresAMSUpdate {
 						cluster.IsAmsSubscriptionConsoleUrlSet = true
 					}
@@ -4117,7 +4117,7 @@ var _ = Describe("Log Collection - refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(logTimeoutConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 		clusterId = strfmt.UUID(uuid.New().String())
 	})
 
@@ -4259,7 +4259,7 @@ var _ = Describe("NTP refresh cluster", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
@@ -4564,7 +4564,7 @@ var _ = Describe("Single node", func() {
 		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
 		dnsApi := dns.NewDNSHandler(nil, common.GetTestLog())
 		clusterApi = NewManager(getDefaultConfig(), common.GetTestLog().WithField("pkg", "cluster-monitor"), db, testing.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, dnsApi, nil, nil)
 		hid1 = strfmt.UUID(uuid.New().String())
 		hid2 = strfmt.UUID(uuid.New().String())
 		hid3 = strfmt.UUID(uuid.New().String())

--- a/internal/manifests/api/interface.go
+++ b/internal/manifests/api/interface.go
@@ -17,7 +17,7 @@ type ManifestsAPI interface {
 
 //go:generate mockgen --build_flags=--mod=mod -package api -destination mock_manifests_internal.go . ClusterManifestsInternals
 type ClusterManifestsInternals interface {
-	IsUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (error, bool)
+	IsUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (bool, error)
 	CreateClusterManifestInternal(ctx context.Context, params operations.V2CreateClusterManifestParams, isCustomManifest bool) (*models.Manifest, error)
 	ListClusterManifestsInternal(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error)
 	DeleteClusterManifestInternal(ctx context.Context, params operations.V2DeleteClusterManifestParams) error

--- a/internal/manifests/api/interface.go
+++ b/internal/manifests/api/interface.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/restapi"
 	operations "github.com/openshift/assisted-service/restapi/operations/manifests"
@@ -16,6 +17,7 @@ type ManifestsAPI interface {
 
 //go:generate mockgen --build_flags=--mod=mod -package api -destination mock_manifests_internal.go . ClusterManifestsInternals
 type ClusterManifestsInternals interface {
+	IsUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (error, bool)
 	CreateClusterManifestInternal(ctx context.Context, params operations.V2CreateClusterManifestParams, isCustomManifest bool) (*models.Manifest, error)
 	ListClusterManifestsInternal(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error)
 	DeleteClusterManifestInternal(ctx context.Context, params operations.V2DeleteClusterManifestParams) error

--- a/internal/manifests/api/mock_manifests_api.go
+++ b/internal/manifests/api/mock_manifests_api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	middleware "github.com/go-openapi/runtime/middleware"
+	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	manifests "github.com/openshift/assisted-service/restapi/operations/manifests"
@@ -64,6 +65,21 @@ func (m *MockManifestsAPI) DeleteClusterManifestInternal(arg0 context.Context, a
 func (mr *MockManifestsAPIMockRecorder) DeleteClusterManifestInternal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterManifestInternal", reflect.TypeOf((*MockManifestsAPI)(nil).DeleteClusterManifestInternal), arg0, arg1)
+}
+
+// IsUserManifest mocks base method.
+func (m *MockManifestsAPI) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (error, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// IsUserManifest indicates an expected call of IsUserManifest.
+func (mr *MockManifestsAPIMockRecorder) IsUserManifest(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUserManifest", reflect.TypeOf((*MockManifestsAPI)(nil).IsUserManifest), arg0, arg1, arg2, arg3)
 }
 
 // ListClusterManifestsInternal mocks base method.

--- a/internal/manifests/api/mock_manifests_api.go
+++ b/internal/manifests/api/mock_manifests_api.go
@@ -68,11 +68,11 @@ func (mr *MockManifestsAPIMockRecorder) DeleteClusterManifestInternal(arg0, arg1
 }
 
 // IsUserManifest mocks base method.
-func (m *MockManifestsAPI) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (error, bool) {
+func (m *MockManifestsAPI) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	ret1, _ := ret[1].(bool)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/internal/manifests/api/mock_manifests_internal.go
+++ b/internal/manifests/api/mock_manifests_internal.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	strfmt "github.com/go-openapi/strfmt"
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/openshift/assisted-service/models"
 	manifests "github.com/openshift/assisted-service/restapi/operations/manifests"
@@ -63,6 +64,21 @@ func (m *MockClusterManifestsInternals) DeleteClusterManifestInternal(arg0 conte
 func (mr *MockClusterManifestsInternalsMockRecorder) DeleteClusterManifestInternal(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterManifestInternal", reflect.TypeOf((*MockClusterManifestsInternals)(nil).DeleteClusterManifestInternal), arg0, arg1)
+}
+
+// IsUserManifest mocks base method.
+func (m *MockClusterManifestsInternals) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (error, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// IsUserManifest indicates an expected call of IsUserManifest.
+func (mr *MockClusterManifestsInternalsMockRecorder) IsUserManifest(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUserManifest", reflect.TypeOf((*MockClusterManifestsInternals)(nil).IsUserManifest), arg0, arg1, arg2, arg3)
 }
 
 // ListClusterManifestsInternal mocks base method.

--- a/internal/manifests/api/mock_manifests_internal.go
+++ b/internal/manifests/api/mock_manifests_internal.go
@@ -67,11 +67,11 @@ func (mr *MockClusterManifestsInternalsMockRecorder) DeleteClusterManifestIntern
 }
 
 // IsUserManifest mocks base method.
-func (m *MockClusterManifestsInternals) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (error, bool) {
+func (m *MockClusterManifestsInternals) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	ret1, _ := ret[1].(bool)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/openshift/assisted-service/internal/cluster"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/constants"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
@@ -63,7 +62,7 @@ func (m *Manifests) CreateClusterManifestInternal(ctx context.Context, params op
 	// In OCM, this is validated at the authorization layer. In other
 	// authorization scheme, it does not and therefore should be checked
 	// at the application level.
-	if !cluster.ClusterExists(m.db, params.ClusterID) {
+	if _, err := common.GetClusterFromDB(m.db, params.ClusterID, false); err != nil {
 		return nil, common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
 	}
 
@@ -138,7 +137,7 @@ func (m *Manifests) ListClusterManifestsInternal(ctx context.Context, params ope
 	// In OCM, this is validated at the authorization layer. In other
 	// authorization scheme, it does not and therefore should be checked
 	// at the application level.
-	if !cluster.ClusterExists(m.db, params.ClusterID) {
+	if _, err := common.GetClusterFromDB(m.db, params.ClusterID, false); err != nil {
 		return nil, common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
 	}
 
@@ -275,8 +274,8 @@ func (m *Manifests) V2DownloadClusterManifest(ctx context.Context, params operat
 	// In OCM, this is validated at the authorization layer. In other
 	// authorization scheme, it does not and therefore should be checked
 	// at the application level.
-	if !cluster.ClusterExists(m.db, params.ClusterID) {
-		return common.NewApiError(http.StatusNotFound, fmt.Errorf("object Not Found"))
+	if _, err := common.GetClusterFromDB(m.db, params.ClusterID, false); err != nil {
+		return common.NewApiError(http.StatusNotFound, fmt.Errorf("Object Not Found"))
 	}
 
 	objectName := GetManifestObjectName(params.ClusterID, path)

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -100,7 +100,7 @@ func (m *Manifests) CreateClusterManifestInternal(ctx context.Context, params op
 	return &manifest, nil
 }
 
-func (m *Manifests) isUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (error, bool) {
+func (m *Manifests) IsUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (error, bool) {
 	path := filepath.Join(folder, fileName)
 	isCustomManifest, err := m.objectHandler.DoesObjectExist(ctx, GetManifestMetadataObjectName(clusterID, path, constants.ManifestSourceUserSupplied))
 	return err, isCustomManifest
@@ -154,7 +154,7 @@ func (m *Manifests) ListClusterManifestsInternal(ctx context.Context, params ope
 		if len(parts) > 2 {
 			fileName := filepath.Join(parts[3:]...)
 			folder := parts[2]
-			err, isUserManifest := m.isUserManifest(ctx, params.ClusterID, folder, fileName)
+			err, isUserManifest := m.IsUserManifest(ctx, params.ClusterID, folder, fileName)
 			if err != nil {
 				return nil, common.NewApiError(http.StatusInternalServerError, errors.Wrapf(err, "Unable to determine the source of manifest for cluster %s at path %s/%s", params.ClusterID, folder, fileName))
 			}
@@ -242,7 +242,7 @@ func (m *Manifests) UpdateClusterManifestInternal(ctx context.Context, params op
 		return nil, err
 	}
 
-	err, isCustomManifest := m.isUserManifest(ctx, params.ClusterID, srcFolder, srcFileName)
+	err, isCustomManifest := m.IsUserManifest(ctx, params.ClusterID, srcFolder, srcFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -791,6 +791,73 @@ spec:
 			Expect(responsePayload.Payload.Folder).To(Equal(defaultFolder))
 		})
 	})
+
+	Describe("ParsePath", func() {
+		It("Should parse a full manifest path into folder and filename", func() {
+			folder, filename, err := manifests.ParsePath("2716d677-8052-463e-be12-d45e3aa05db0/manifests/openshift/file-1.yaml")
+			Expect(err).Should(BeNil())
+			Expect(folder).Should(Equal("openshift"))
+			Expect(filename).Should(Equal("file-1.yaml"))
+		})
+
+		It("Should return an error if supplied a non-manifest path", func() {
+			folder, filename, err := manifests.ParsePath("2716d677-8052-463e-be12-d45e3aa05db0/something.ign")
+			Expect(err.Error()).Should(Equal("Filepath 2716d677-8052-463e-be12-d45e3aa05db0/something.ign is not a manifest path"))
+			Expect(folder).Should(Equal(""))
+			Expect(filename).Should(Equal(""))
+		})
+	})
+
+	Describe("IsManifest", func() {
+		It("Should be able to determine if a given manifest path is a manifest path", func() {
+			Expect(manifests.IsManifest("2716d677-8052-463e-be12-d45e3aa05db0/manifests/openshift/file-1.yaml")).To(BeTrue())
+		})
+
+		It("Should be able to determine if a given manifest path is not a manifest path", func() {
+			Expect(manifests.IsManifest("2716d677-8052-463e-be12-d45e3aa05db0/something.ign")).To(BeFalse())
+		})
+	})
+
+	Describe("IsUserManifest", func() {
+		var (
+			manifestsAPI *manifests.Manifests
+			db           *gorm.DB
+			ctx          = context.Background()
+			ctrl         *gomock.Controller
+			mockS3Client *s3wrapper.MockAPI
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			mockS3Client = s3wrapper.NewMockAPI(ctrl)
+			mockUsageAPI = usage.NewMockAPI(ctrl)
+			manifestsAPI = manifests.NewManifestsAPI(db, common.GetTestLog(), mockS3Client, mockUsageAPI)
+		})
+
+		It("Should determine that a manifest is user generated if there is a metadata file for it", func() {
+			clusterId := strfmt.UUID(uuid.New().String())
+			mockS3Client.EXPECT().DoesObjectExist(
+				ctx,
+				filepath.Join(
+					clusterId.String(),
+					constants.ManifestMetadataFolder,
+					"openshift",
+					"user-defined-manifest.yaml", "user-supplied")).Return(true, nil).Times(1)
+			Expect(manifestsAPI.IsUserManifest(ctx, clusterId, "openshift", "user-defined-manifest.yaml")).To(BeTrue())
+		})
+
+		It("Should determine that a manifest is not user generated if there is no metadata file for it", func() {
+			clusterId := strfmt.UUID(uuid.New().String())
+			mockS3Client.EXPECT().DoesObjectExist(
+				ctx,
+				filepath.Join(
+					clusterId.String(),
+					constants.ManifestMetadataFolder,
+					"openshift",
+					"system-generated-manifest.yaml", "user-supplied")).Return(false, nil).Times(1)
+			Expect(manifestsAPI.IsUserManifest(ctx, clusterId, "openshift", "system-generated-manifest.yaml")).To(BeFalse())
+		})
+	})
 })
 
 type VoidReadCloser struct {

--- a/internal/operators/odf/validation_test.go
+++ b/internal/operators/odf/validation_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		var cfg clust.Config
 		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		clusterApi = clust.NewManager(cfg, common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),
-			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil)
+			mockEvents, nil, mockHostAPI, mockMetric, nil, nil, operatorsManager, nil, nil, nil, nil, nil)
 
 		hid1 = strfmt.UUID("054e0100-f50e-4be7-874d-73861179e40d")
 		hid2 = strfmt.UUID("514c8480-cda5-46e5-afce-e146def2066f")

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -2808,21 +2808,22 @@ var _ = Describe("cluster install", func() {
 				waitForHostState(ctx, models.HostStatusResettingPendingUserAction, defaultWaitForHostStateTimeout, c.Hosts...)
 			})
 
-			It("reset cluster doesn't delete manifests", func() {
+			It("reset cluster doesn't delete user generated manifests", func() {
 				content := `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: master
-  name: 99-openshift-machineconfig-master-kargs
+  name: 01-user-generated-manifest
 spec:
   kernelArguments:
   - 'loglevel=7'`
 				base64Content := base64.StdEncoding.EncodeToString([]byte(content))
 				manifest := models.Manifest{
-					FileName: "99-openshift-machineconfig-master-kargs.yaml",
+					FileName: "01-user-generated-manifest.yaml",
 					Folder:   "openshift",
 				}
+				// All manifests created via the API are considered to be "user generated"
 				response, err := userBMClient.Manifests.V2CreateClusterManifest(ctx, &manifests.V2CreateClusterManifestParams{
 					ClusterID: clusterID,
 					CreateManifestParams: &models.CreateManifestParams{


### PR DESCRIPTION
Presently when a cluster is reset, we perform all sorts of awkward workarounds to exclude files from deletion, when in reality all we should do is delete only the system generated manifests, leaving all other files and logs intact.

Moreover, when performing a permenant deletion, ALL files should be deleted.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
