### PR TITLE
[release-4.12] MGMT-15150: Use same installer binary for all platform types

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5899,7 +5899,7 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 	return b.hostApi.GetKnownApprovedHosts(clusterId)
 }
 
-// In case cpu architecture is not x86_64 and platform is baremetal, we should extract openshift-baremetal-installer
+// In case cpu architecture is not x86_64, we should extract openshift-baremetal-installer
 // from x86_64 release image as there is no x86_64 openshift-baremetal-installer executable in arm image.
 // This flow does not affect the multiarch release images and is meant purely for using arm64 release image with the x86 hub.
 // Implementation of handling the multiarch images is done directly in the `oc` binary and relies on the fact that `oc adm release extract`
@@ -5907,7 +5907,6 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version string, platform *models.PlatformType) bool {
 	return cpuArchitecture != common.MultiCPUArchitecture &&
 		cpuArchitecture != common.DefaultCPUArchitecture &&
-		common.PlatformTypeValue(platform) == models.PlatformTypeBaremetal &&
 		featuresupport.IsFeatureSupported(version,
 			models.FeatureSupportLevelFeaturesItems0FeatureIDARM64ARCHITECTUREWITHCLUSTERMANAGEDNETWORKING)
 }

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -336,15 +336,7 @@ func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseIm
 // extractFromRelease returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image.
 func (r *release) extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool, platformType models.PlatformType, icspFile string) (string, error) {
-	// Using platform type as an indication for which openshift install binary to use
-	// (e.g. as non-x86_64 clusters should use the openshift-install binary).
-	var binary string
-	if platformType == models.PlatformTypeNone {
-		binary = "openshift-install"
-	} else {
-		binary = "openshift-baremetal-install"
-	}
-
+	binary := "openshift-baremetal-install"
 	workdir := filepath.Join(cacheDir, releaseImage)
 	log.Infof("extracting %s binary to %s", binary, workdir)
 	err := os.MkdirAll(workdir, 0755)

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -29,7 +29,6 @@ var (
 	mcoImage               = "mco_image"
 	mustGatherImage        = "must_gather_image"
 	baremetalInstallBinary = "openshift-baremetal-install"
-	installBinary          = "openshift-install"
 )
 
 //go:embed test_skopeo_multiarch_image_output
@@ -421,18 +420,6 @@ var _ = Describe("oc", func() {
 			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeBaremetal, "")
 			Expect(path).To(Equal(""))
 			Expect(err).Should(HaveOccurred())
-		})
-
-		It("extract openshift-install from release image", func() {
-			command := fmt.Sprintf(templateExtract+" --registry-config=%s",
-				installBinary, filepath.Join(cacheDir, releaseImage), false, releaseImage, tempFilePath)
-			args := splitStringToInterfacesArray(command)
-			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
-
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, models.PlatformTypeNone, "")
-			filePath := filepath.Join(cacheDir+"/"+releaseImage, installBinary)
-			Expect(path).To(Equal(filePath))
-			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
There's nothing special about platform:none that requires it to use a different installer binary. This was originally done (in f9b2f3d324) to avoid a problem with the openshift-baremetal-install binary not being available for non-x86 targets, but this was resolved by 1d025b8108 ([MGMT-9206](https://issues.redhat.com//browse/MGMT-9206)).

(Backported from #5346)