### PR TITLE
MGMT-14634: Ensure that empty manifest may not be added.

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -412,6 +412,11 @@ func (m *Manifests) validateAllowedToModifyManifests(ctx context.Context, cluste
 }
 
 func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, manifestContent []byte, fileName string) error {
+	// If the manifest content size is zero then some of the content validations might pass when they should not
+	// We need to reject zero size content
+	if len(manifestContent) == 0 {
+		return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s should not be empty", fileName, string(clusterID)))
+	}
 	// etcd resources in k8s are limited to 1.5 MiB as indicated here https://etcd.io/docs/v3.5/dev-guide/limit/#request-size-limit
 	// however, one the the resource types that can be created from a manifest is a ConfigMap
 	// which has a size limit of 1MiB as cited here https://kubernetes.io/docs/concepts/configuration/configmap

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -437,6 +437,23 @@ spec:
 				Expect(err.Error()).To(ContainSubstring("Cluster manifest openshift/99-test.yaml for cluster " + clusterID.String() + " should not include a directory in its name."))
 			})
 
+			It("Creation fails for a manifest file that has no content", func() {
+				clusterID := registerCluster().ID
+				fileName := "99-test.json"
+				emptyContent := encodeToBase64("")
+				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &emptyContent,
+						FileName: &fileName,
+					},
+				})
+				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
+				err := response.(*common.ApiErrorResponse)
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+				Expect(err.Error()).To(ContainSubstring("Manifest content of file manifests/99-test.json for cluster ID " + clusterID.String() + " should not be empty"))
+			})
+
 			It("Creation fails for a manifest file that exceeds the maximum upload size", func() {
 				clusterID := registerCluster().ID
 				fileName := "99-test.json"


### PR DESCRIPTION
Presently, if a manifest has no content then it passes validation. This breaks bootkube when empty content is submitted.

This PR validates that manifest content is not empty before accepting it.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Submitted an empty file to the API endpoint and observed that validation now fails.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
