### PR TITLE
MGMT-15070: Unable to change machine-network with dual stack

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2112,6 +2112,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 	// We need to do it because updateNonDhcpNetworkParams is called before updateNetworks, so
 	// inside this function here cluster object has still values before applying requested changes.
 	targetConfiguration := common.Cluster{}
+	targetConfiguration.ID = cluster.ID
 	targetConfiguration.ClusterNetworks = cluster.ClusterNetworks
 	targetConfiguration.ServiceNetworks = cluster.ServiceNetworks
 	targetConfiguration.MachineNetworks = cluster.MachineNetworks
@@ -2171,7 +2172,6 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 		// require that user explicitly provides all the Machine Networks.
 		if reqDualStack {
 			if params.ClusterUpdateParams.MachineNetworks != nil {
-				cluster.MachineNetworks = params.ClusterUpdateParams.MachineNetworks
 				primaryMachineNetworkCidr = string(params.ClusterUpdateParams.MachineNetworks[0].Cidr)
 			} else {
 				primaryMachineNetworkCidr = network.GetPrimaryMachineCidrForUserManagedNetwork(cluster, log)
@@ -2182,7 +2182,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(updates map[string]inter
 				log.WithError(err).Warnf("Verify dual-stack machine networks")
 				return common.NewApiError(http.StatusBadRequest, err)
 			}
-			secondaryMachineNetworkCidr, err = network.GetSecondaryMachineCidr(cluster)
+			secondaryMachineNetworkCidr, err = network.GetSecondaryMachineCidr(&targetConfiguration)
 			if err != nil {
 				return common.NewApiError(http.StatusBadRequest, err)
 			}


### PR DESCRIPTION
When working with dual stack, and there is an attempt to update the machine networks only, they are not updated.  This change fixes it.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @filanov 