### PR TITLE
No-ISSUE: Revert "MGMT-14634: Ensure that empty manifest may not be added. (#5348)"

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -423,11 +423,6 @@ func (m *Manifests) validateAllowedToModifyManifests(ctx context.Context, cluste
 }
 
 func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, manifestContent []byte, fileName string) error {
-	// If the manifest content size is zero then some of the content validations might pass when they should not
-	// We need to reject zero size content
-	if len(manifestContent) == 0 {
-		return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s should not be empty", fileName, string(clusterID)))
-	}
 	// etcd resources in k8s are limited to 1.5 MiB as indicated here https://etcd.io/docs/v3.5/dev-guide/limit/#request-size-limit
 	// however, one the the resource types that can be created from a manifest is a ConfigMap
 	// which has a size limit of 1MiB as cited here https://kubernetes.io/docs/concepts/configuration/configmap

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -437,23 +437,6 @@ spec:
 				Expect(err.Error()).To(ContainSubstring("Cluster manifest openshift/99-test.yaml for cluster " + clusterID.String() + " should not include a directory in its name."))
 			})
 
-			It("Creation fails for a manifest file that has no content", func() {
-				clusterID := registerCluster().ID
-				fileName := "99-test.json"
-				emptyContent := encodeToBase64("")
-				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
-					ClusterID: *clusterID,
-					CreateManifestParams: &models.CreateManifestParams{
-						Content:  &emptyContent,
-						FileName: &fileName,
-					},
-				})
-				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
-				err := response.(*common.ApiErrorResponse)
-				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
-				Expect(err.Error()).To(ContainSubstring("Manifest content of file manifests/99-test.json for cluster ID " + clusterID.String() + " should not be empty"))
-			})
-
 			It("Creation fails for a manifest file that exceeds the maximum upload size", func() {
 				clusterID := registerCluster().ID
 				fileName := "99-test.json"


### PR DESCRIPTION
This reverts commit 10a88f557b971c66e2734d08b1e7526ed356f6df.

It was found that this validation is causing issues for the UI. We have some mitigations planned for the issues, however this commit needs to be rolled back for now to prevent ongoing breakage while the issues are addressed.
