### PR TITLE
MGMT-15243: Skip any zero size manifests when applying

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1574,6 +1574,12 @@ func (g *installerGenerator) downloadManifest(ctx context.Context, manifest stri
 	if err != nil {
 		return err
 	}
+
+	if len(content) == 0 {
+		// Ignore any empty files.
+		return nil
+	}
+
 	// manifest has full path as object-key on s3: clusterID/manifests/[manifests|openshift]/filename
 	// clusterID/manifests should be trimmed
 	prefix := manifests.GetManifestObjectName(*g.cluster.ID, "")


### PR DESCRIPTION
When applying manifests when installation is started, we should skip any
manifests that are of zero size to prevent them from causing bootstrap
problems later.

We can't validate zero size at the point of file upload as the UI is
presently using an approach where it uploads an empty manifest file to
track that the user wishes to add user defined manifests.

Discussions are underway to change this but for now we need to take this
alternative approach.

This PR implements this.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
