### PR TITLE
MGMT-14923: add OSImageVersion to InfraEnvSpec

### DIFF
--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -110,6 +110,13 @@ type InfraEnvSpec struct {
 	// certificates in this bundle.
 	// +optional
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
+
+	// OSImageVersion is the version of OS image to use when generating the InfraEnv.
+	// The version should refer to an OSImage specified in the AgentServiceConfig
+	// (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+	// Note: OSImageVersion can't be specified along with ClusterRef. 
+	// +optional
+	OSImageVersion string `json:"osImageVersion,omitempty"`
 }
 
 type KernelArgument struct {

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -170,6 +170,13 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+              osImageVersion:
+                description: 'OSImageVersion is the version of OS image to use when
+                  generating the InfraEnv. The version should refer to an OSImage
+                  specified in the AgentServiceConfig (i.e. OSImageVersion should
+                  equal to an OpenshiftVersion in OSImages list). Note: OSImageVersion
+                  can''t be specified along with ClusterRef.'
+                type: string
               proxy:
                 description: Proxy defines the proxy settings for agents and clusters
                   that use the InfraEnv. If unset, the agents and clusters will not

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -2573,6 +2573,13 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+              osImageVersion:
+                description: 'OSImageVersion is the version of OS image to use when
+                  generating the InfraEnv. The version should refer to an OSImage
+                  specified in the AgentServiceConfig (i.e. OSImageVersion should
+                  equal to an OpenshiftVersion in OSImages list). Note: OSImageVersion
+                  can''t be specified along with ClusterRef.'
+                type: string
               proxy:
                 description: Proxy defines the proxy settings for agents and clusters
                   that use the InfraEnv. If unset, the agents and clusters will not

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
@@ -168,6 +168,13 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+              osImageVersion:
+                description: 'OSImageVersion is the version of OS image to use when
+                  generating the InfraEnv. The version should refer to an OSImage
+                  specified in the AgentServiceConfig (i.e. OSImageVersion should
+                  equal to an OpenshiftVersion in OSImages list). Note: OSImageVersion
+                  can''t be specified along with ClusterRef.'
+                type: string
               proxy:
                 description: Proxy defines the proxy settings for agents and clusters
                   that use the InfraEnv. If unset, the agents and clusters will not

--- a/pkg/webhooks/agentinstall/v1beta1/infraenv_admission_hook_test.go
+++ b/pkg/webhooks/agentinstall/v1beta1/infraenv_admission_hook_test.go
@@ -204,6 +204,37 @@ var _ = Describe("infraenv web validate", func() {
 			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
+		{
+			name: "Test can't specify both Spec.ClusterRef and Spec.OSImageVersion",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "newName",
+				},
+				OSImageVersion: "4.14",
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test InfraEnv create does not fail when only Spec.ClusterRef is specified",
+			newSpec: v1beta1.InfraEnvSpec{
+				ClusterRef: &v1beta1.ClusterReference{
+					Name:      "newName",
+					Namespace: "newName",
+				},
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test InfraEnv create does not fail when only Spec.OSImageVersion is specified",
+			newSpec: v1beta1.InfraEnvSpec{
+				OSImageVersion: "4.14",
+			},
+			operation:       admissionv1.Create,
+			expectedAllowed: true,
+		},
 	}
 
 	for i := range cases {

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -110,6 +110,12 @@ type InfraEnvSpec struct {
 	// certificates in this bundle.
 	// +optional
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
+
+	// OSImageVersion is the version of OS image to use when generating the InfraEnv.
+	// The version should refer to an OSImage specified th AgentServiceConfig
+	// (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+	// +optional
+	OSImageVersion string `json:"osImageVersion,omitempty"`
 }
 
 type KernelArgument struct {


### PR DESCRIPTION
Introduced a new property to InfraEnvSpec: `OSImageVersion`.
The property can be used for creating an InfraEnv through kube-api with a specific OS image version.

The `OSImageVersion` is useful for HyperShift flows which use late binding, hence, the InfraEnv isn't created according to a cluster version (thus, the latest OS image is used as a fallback).

Notes:
* The specified version should refer to an OSImage from the list in AgentServiceConfig, otherwise the condition is set to failure.
* When a ClusterRef is provided, we still use the cluster's version for creating the InfraEnv. Thus, The property should not be provided along with OSImageVersion to avoid a conflict (validated with a WebHook).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
