### PR TITLE
MGMT-14793: Assisted discovery core and root user shell should have proxy environment set

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1530,6 +1530,20 @@ func setEtcHostsInIgnition(role models.HostRole, path string, workDir string, co
 	return nil
 }
 
+func GetProfileProxyEntries(http_proxy string, https_proxy string, no_proxy string) string {
+	entries := []string{}
+	if len(http_proxy) > 0 {
+		entries = append(entries, fmt.Sprintf("export HTTP_PROXY=%[1]s\nexport http_proxy=%[1]s", http_proxy))
+	}
+	if len(https_proxy) > 0 {
+		entries = append(entries, fmt.Sprintf("export HTTPS_PROXY=%[1]s\nexport https_proxy=%[1]s", https_proxy))
+	}
+	if len(no_proxy) > 0 {
+		entries = append(entries, fmt.Sprintf("export NO_PROXY=%[1]s\nexport no_proxy=%[1]s", no_proxy))
+	}
+	return strings.Join(entries, "\n") + "\n"
+}
+
 func GetServiceIPHostnames(serviceIPs string) string {
 	ips := strings.Split(strings.TrimSpace(serviceIPs), ",")
 	content := ""
@@ -1669,6 +1683,7 @@ func (ib *ignitionBuilder) FormatDiscoveryIgnitionFile(ctx context.Context, infr
 		"AgentTimeoutStartSec": strconv.FormatInt(int64(cfg.AgentTimeoutStart.Seconds()), 10),
 		"SELINUX_POLICY":       base64.StdEncoding.EncodeToString([]byte(selinuxPolicy)),
 		"EnableAgentService":   infraEnv.InternalIgnitionConfigOverride == "",
+		"ProfileProxyExports":  dataurl.EncodeBytes([]byte(GetProfileProxyEntries(httpProxy, httpsProxy, noProxy))),
 	}
 	if safeForLogs {
 		for _, key := range []string{"userSshKey", "PullSecretToken", "PULL_SECRET", "RH_ROOT_CA"} {

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -191,6 +191,14 @@
         "name": "root"
       },
       "contents": { "source": "data:text/plain;base64,{{.OKDHoldAgent}}" }
+    }{{end}}{{if .PROXY_SETTINGS}},
+    {
+      "path": "/etc/profile.d/proxy.sh",
+      "mode": 644,
+      "user": {
+        "name": "root"
+      },
+      "contents": { "source": "{{.ProfileProxyExports}}" }
     }{{end}}]
   }
 }


### PR DESCRIPTION
**Background**

When we run our agent we set the proxy environment variables as can be seen here

When the user SSHs into the host, the shell does not have those environment variables set.

**Issue**

This means that when the user is trying to debug network connectivity (for example, in day-2 users often SSH to see why they can't reach the day-1 cluster's API), they will usually try to run curl to see whether they can reach the URL themselves, but it might behave differently than the agent because the shell, by default, doesn't use the proxy settings.

**Solution**

Set the default environment variables (through .profile) of the core and root shells to include the same proxy environment variables as the agent, so that when the user logs into the host to run commands, they would have the same proxy settings as the ones the agent.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
 Run a custom image of the service and then boot a host from an ISO generated by the image service, ensure that the proxy settings have been picked up.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
