### PR TITLE
AGENT-557: Split register into registerCluster and registerInfraEnv

### DIFF
--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -193,6 +193,40 @@ func RegisterExtraManifests(fsys fs.FS, ctx context.Context, log *log.Logger, cl
 	return nil
 }
 
+func GetCluster(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall) (cluster *models.Cluster, err error) {
+	list, err := bmInventory.Installer.V2ListClusters(ctx, &installer.V2ListClustersParams{})
+	if err != nil {
+		return nil, err
+	}
+	clusterList := list.Payload
+	numClusters := len(clusterList)
+	if numClusters > 1 {
+		errorMessage := "found multiple clusters registered in assisted-service"
+		return nil, errors.New(errorMessage)
+	}
+	if numClusters == 0 {
+		return nil, errors.New("No clusters registered in assisted-service")
+	}
+	return clusterList[0], nil
+}
+
+func GetInfraEnv(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall) (infraEnv *models.InfraEnv, err error) {
+	list, err := bmInventory.Installer.ListInfraEnvs(ctx, &installer.ListInfraEnvsParams{})
+	if err != nil {
+		return nil, err
+	}
+	infraEnvList := list.Payload
+	numInfraEnvs := len(infraEnvList)
+	if numInfraEnvs > 1 {
+		errorMessage := "found multiple infraenvs registered in assisted-service"
+		return nil, errors.New(errorMessage)
+	}
+	if numInfraEnvs == 0 {
+		return nil, errors.New("No infraenvs registered in assisted-service")
+	}
+	return infraEnvList[0], nil
+}
+
 // Read a Yaml file and unmarshal the contents
 func getFileData(filePath string, output interface{}) error {
 


### PR DESCRIPTION
The split is desired to enable the interactive flow. Users will register the cluster through the GUI instead of including the cluster information in the ignition/agent ISO.

registerCluster is able to detect if a cluster has already been registered with the REST-API and exits with status 0, skipping cluster registration from manifest files.

registerInfraEnv requires and checks that a cluster has been registered with the REST-API. It also skips infraenv registration if it detects one has already been created.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
