### PR TITLE
MGMT-15128: Nutanix: Remove control plane machine set on OCP greater or equal to 4.14

### DIFF
--- a/internal/provider/nutanix/consts.go
+++ b/internal/provider/nutanix/consts.go
@@ -3,10 +3,10 @@ package nutanix
 const (
 	PhUsername   = "username_placeholder"
 	PhPassword   = "password_placeholder"
-	PhPCAddress  = "1.1.1.1"
-	PhPCPort     = int32(8080)
-	PhPEAddress  = "1.1.1.1"
-	PhPEPort     = int32(8080)
+	PhPCAddress  = "prism.central.placeholder.address"
+	PhPCPort     = int32(9440)
+	PhPEAddress  = "prism.element.placeholder.address"
+	PhPEPort     = int32(9440)
 	PhEName      = "prism_endpoint_name_placeholder"
 	PhPUUID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	PhSubnetUUID = "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"

--- a/internal/provider/nutanix/ignition.go
+++ b/internal/provider/nutanix/ignition.go
@@ -35,6 +35,15 @@ func (p nutanixProvider) PostCreateManifestsHook(_ *common.Cluster, _ *[]string,
 		return fmt.Errorf("error deleting machineset: %w", err)
 	}
 
+	// Delete control-plane-machine-set
+	p.Log.Info("Deleting control-plane machine set")
+	files, _ = filepath.Glob(path.Join(workDir, "openshift", "*_openshift-machine-api_master-control-plane-machine-set*.yaml"))
+	err = p.deleteAllFiles(files)
+
+	if err != nil {
+		return fmt.Errorf("error deleting control-plane machineset: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/provider/registry/registry_test.go
+++ b/internal/provider/registry/registry_test.go
@@ -31,14 +31,14 @@ const expectedNutanixInstallConfig411 = `apiVIP: 192.168.10.10
 ingressVIP: 192.168.10.11
 prismCentral:
   endpoint:
-    address: 1.1.1.1
-    port: 8080
+    address: prism.central.placeholder.address
+    port: 9440
   username: username_placeholder
   password: password_placeholder
 prismElements:
 - endpoint:
-    address: 1.1.1.1
-    port: 8080
+    address: prism.element.placeholder.address
+    port: 9440
   uuid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   name: prism_endpoint_name_placeholder
 subnetUUIDs:
@@ -50,14 +50,14 @@ ingressVIPs:
 - 192.168.10.11
 prismCentral:
   endpoint:
-    address: 1.1.1.1
-    port: 8080
+    address: prism.central.placeholder.address
+    port: 9440
   username: username_placeholder
   password: password_placeholder
 prismElements:
 - endpoint:
-    address: 1.1.1.1
-    port: 8080
+    address: prism.element.placeholder.address
+    port: 9440
   uuid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   name: prism_endpoint_name_placeholder
 subnetUUIDs:


### PR DESCRIPTION
- Prevent from the control-plane-machine-set operator from being degraded due to placeholder credentials on installation.
- Update prism central and prism element address placeholder, so it won't be confusing on post installation steps.

/ cc @eliorerz 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed
