### PR TITLE
MGMT-15349: Don't attempt to contact spoke while unbinding a day2 host

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -758,7 +758,8 @@ func (r *AgentReconciler) updateStatus(ctx context.Context, log logrus.FieldLogg
 		if h.Progress != nil && h.Progress.CurrentStage != "" {
 			// In case the node didn't reboot yet, we get the stage from the host (else)
 			if swag.StringValue(h.Kind) == models.HostKindAddToExistingClusterHost &&
-				funk.Contains([]models.HostStage{models.HostStageRebooting, models.HostStageJoined, models.HostStageConfiguring}, h.Progress.CurrentStage) {
+				funk.Contains([]models.HostStage{models.HostStageRebooting, models.HostStageJoined, models.HostStageConfiguring}, h.Progress.CurrentStage) &&
+				agent.Spec.ClusterDeploymentName != nil {
 
 				spokeClient, err = r.spokeKubeClient(ctx, agent.Spec.ClusterDeploymentName)
 				if err != nil {

--- a/internal/controller/controllers/agent_controller_test.go
+++ b/internal/controller/controllers/agent_controller_test.go
@@ -1148,6 +1148,40 @@ var _ = Describe("agent reconcile", func() {
 		Expect(result).To(Equal(ctrl.Result{}))
 	})
 
+	It("Agent status update does not panic when running unbind during day2 install", func() {
+		hostId := strfmt.UUID(uuid.New().String())
+		infraEnvId := strfmt.UUID(uuid.New().String())
+		logCollectionTime, _ := strfmt.ParseDateTime("2022-02-17T21:41:51Z")
+		hostKind := models.HostKindAddToExistingClusterHost
+		host := &common.Host{
+			Host: models.Host{
+				ID:              &hostId,
+				Kind:            &hostKind,
+				ClusterID:       &sId,
+				InfraEnvID:      infraEnvId,
+				Inventory:       common.GenerateTestDefaultInventory(),
+				Status:          swag.String(models.HostStatusInstallingInProgress),
+				StatusInfo:      swag.String("Some status info"),
+				LogsCollectedAt: logCollectionTime,
+				Progress: &models.HostProgressInfo{
+					CurrentStage:           models.HostStageConfiguring,
+					InstallationPercentage: 44,
+				},
+			},
+		}
+		agent := newAgent(hostId.String(), testNamespace, v1beta1.AgentSpec{ClusterDeploymentName: nil})
+		Expect(c.Create(ctx, agent)).To(BeNil())
+
+		mockInstallerInternal.EXPECT().GetHostByKubeKey(gomock.Any()).Return(host, nil).AnyTimes()
+		mockInstallerInternal.EXPECT().GetClusterInternal(gomock.Any(), installer.V2GetClusterParams{ClusterID: sId}).Return(backEndCluster, nil).AnyTimes()
+		mockInstallerInternal.EXPECT().UnbindHostInternal(gomock.Any(), gomock.Any(), false, bminventory.NonInteractive).Return(host, fmt.Errorf("no condition found to run transition"))
+		allowGetInfraEnvInternal(mockInstallerInternal, infraEnvId, "infraEnvName")
+
+		result, err := hr.Reconcile(ctx, newHostRequest(agent))
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}))
+	})
+
 	It("Agent bind", func() {
 		hostId := strfmt.UUID(uuid.New().String())
 		infraEnvId := strfmt.UUID(uuid.New().String())


### PR DESCRIPTION
If an agent is unbound while it is installing the transition will fail, but the agent spec will still have no cluster deployment reference. The agent controller should not attempt to contact the spoke cluster in this case.

Previously unbinding a day-2 host that was installing could cause a panic. This patch guards against that situation.

Additionally this should be covered by the agent validating webhook which prevents agents from being unbound while they are installing, but we still shouldn't crash if this does happen to slip through somehow.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-15349

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
