### PR TITLE
MGMT-15388: Remove unsupported platforms from the supported-platforms endpoint

### DIFF
--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -242,3 +242,16 @@ func GetActualCreateClusterPlatformParams(platform *models.Platform, userManaged
 	}
 	return GetClusterPlatformByHighAvailabilityMode(platform, userManagedNetworking, highAvailabilityMode)
 }
+
+func GetPlatformFeatureID(platformType models.PlatformType) models.FeatureSupportLevelID {
+	switch platformType {
+	case models.PlatformTypeOci:
+		return models.FeatureSupportLevelIDEXTERNALPLATFORMOCI
+	case models.PlatformTypeVsphere:
+		return models.FeatureSupportLevelIDVSPHEREINTEGRATION
+	case models.PlatformTypeNutanix:
+		return models.FeatureSupportLevelIDNUTANIXINTEGRATION
+	default:
+		return "" // Return empty string on platform without a feature support ID
+	}
+}


### PR DESCRIPTION
Currently we check for the hosts supported platforms and return it without taking in any consideration if the platform is supported in the cluster openshift version or CPU architecture.
This PR uses feature support to remove the not supported platforms before returning the actual value to the user.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eliorerz 