### PR TITLE
MGMT-12397: Add pre install error validation

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
@@ -101,6 +101,9 @@ const (
 
 	// ClusterValidationIDPlatformRequirementsSatisfied captures enum value "platform-requirements-satisfied"
 	ClusterValidationIDPlatformRequirementsSatisfied ClusterValidationID = "platform-requirements-satisfied"
+
+	// ClusterValidationIDInstallationPreparationSucceeded captures enum value "installation-preparation-succeeded"
+	ClusterValidationIDInstallationPreparationSucceeded ClusterValidationID = "installation-preparation-succeeded"
 )
 
 // for schema
@@ -108,7 +111,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied","installation-preparation-succeeded"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -988,6 +988,7 @@ func (m *Manager) HandlePreInstallError(ctx context.Context, c *common.Cluster, 
 	log.WithError(installErr).Warnf("Failed to prepare installation of cluster %s", c.ID.String())
 	err := m.db.Model(&common.Cluster{}).Where("id = ?", c.ID.String()).Updates(&common.Cluster{
 		InstallationPreparationCompletionStatus: common.InstallationPreparationFailed,
+		InstallationPreparationCompletionStatusText: installErr.Error(),
 	}).Error
 	if err != nil {
 		log.WithError(err).Errorf("Failed to handle pre installation error for cluster %s", c.ID.String())

--- a/internal/cluster/refresh_status_preprocessor.go
+++ b/internal/cluster/refresh_status_preprocessor.go
@@ -205,6 +205,10 @@ func newValidations(v *clusterValidator) []validation {
 			id:        PlatformRequirementsSatisfied,
 			condition: v.platformRequirementsSatisfied,
 		},
+		{
+			id:        PreparationSucceeded,
+			condition: v.preparationSucceded,
+		},
 	}
 	return ret
 }

--- a/internal/cluster/validation_id.go
+++ b/internal/cluster/validation_id.go
@@ -34,6 +34,7 @@ const (
 	IsLvmRequirementsSatisfied          = ValidationID(models.ClusterValidationIDLvmRequirementsSatisfied)
 	IsMceRequirementsSatisfied          = ValidationID(models.ClusterValidationIDMceRequirementsSatisfied)
 	PlatformRequirementsSatisfied       = ValidationID(models.ClusterValidationIDPlatformRequirementsSatisfied)
+	PreparationSucceeded                = ValidationID(models.ClusterValidationIDInstallationPreparationSucceeded)
 )
 
 func (v ValidationID) Category() (string, error) {
@@ -48,6 +49,8 @@ func (v ValidationID) Category() (string, error) {
 		return "configuration", nil
 	case IsOdfRequirementsSatisfied, IsLsoRequirementsSatisfied, IsCnvRequirementsSatisfied, IsLvmRequirementsSatisfied, IsMceRequirementsSatisfied:
 		return "operators", nil
+	case PreparationSucceeded:
+		return "installation-preparation", nil
 	}
 	return "", common.NewApiError(http.StatusInternalServerError, errors.Errorf("Unexpected cluster validation id %s", string(v)))
 }

--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -422,6 +422,18 @@ func (v *clusterValidator) platformRequirementsSatisfied(c *clusterPreprocessCon
 	return ValidationFailure, "The custom manifest required for Oracle Cloud Infrastructure platform integration has not been added. Add a custom manifest to continue."
 }
 
+// preparationSucceded
+
+func (v *clusterValidator) preparationSucceded(c *clusterPreprocessContext) (ValidationStatus, string) {
+	// Check to see if the preparation failure has been indicated
+	// If so then report the failure
+	if c.cluster.InstallationPreparationCompletionStatus == "failed" {
+		return ValidationFailure, fmt.Sprintf("The cluster preparation failed with the following error: %s", c.cluster.InstallationPreparationCompletionStatusText)
+	}
+	return ValidationSuccess, "Cluster preparation succeeded"
+}
+
+
 func (v *clusterValidator) isDNSDomainDefined(c *clusterPreprocessContext) (ValidationStatus, string) {
 	if c.cluster.BaseDNSDomain != "" {
 		return ValidationSuccess, "The base domain is defined."

--- a/internal/common/db.go
+++ b/internal/common/db.go
@@ -65,6 +65,9 @@ type Cluster struct {
 	// Indication if installation preparation succeeded or failed
 	InstallationPreparationCompletionStatus string
 
+	// Any status text associated with InstallationPreparationCompletionStatus should be stored here
+	InstallationPreparationCompletionStatusText string
+
 	// ImageGenerated indicates if the discovery image was generated successfully. It will be used internally
 	// when an image needs to be generated. In case the user request to generate an image with custom parameters,
 	// and the generation failed, the value of ImageGenerated will be set to 'false'. In that case, providing the

--- a/models/cluster_validation_id.go
+++ b/models/cluster_validation_id.go
@@ -101,6 +101,9 @@ const (
 
 	// ClusterValidationIDPlatformRequirementsSatisfied captures enum value "platform-requirements-satisfied"
 	ClusterValidationIDPlatformRequirementsSatisfied ClusterValidationID = "platform-requirements-satisfied"
+
+	// ClusterValidationIDInstallationPreparationSucceeded captures enum value "installation-preparation-succeeded"
+	ClusterValidationIDInstallationPreparationSucceeded ClusterValidationID = "installation-preparation-succeeded"
 )
 
 // for schema
@@ -108,7 +111,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied","installation-preparation-succeeded"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -6692,7 +6692,8 @@ func init() {
         "lvm-requirements-satisfied",
         "mce-requirements-satisfied",
         "network-type-valid",
-        "platform-requirements-satisfied"
+        "platform-requirements-satisfied",
+        "installation-preparation-succeeded"
       ]
     },
     "cluster_default_config": {
@@ -17209,7 +17210,8 @@ func init() {
         "lvm-requirements-satisfied",
         "mce-requirements-satisfied",
         "network-type-valid",
-        "platform-requirements-satisfied"
+        "platform-requirements-satisfied",
+        "installation-preparation-succeeded"
       ]
     },
     "cluster_default_config": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6697,6 +6697,7 @@ definitions:
       - 'mce-requirements-satisfied'
       - 'network-type-valid'
       - 'platform-requirements-satisfied'
+      - 'installation-preparation-succeeded'
 
   logs_type:
     type: string

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -112,8 +112,9 @@ type InfraEnvSpec struct {
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
 	// OSImageVersion is the version of OS image to use when generating the InfraEnv.
-	// The version should refer to an OSImage specified th AgentServiceConfig
+	// The version should refer to an OSImage specified in the AgentServiceConfig
 	// (i.e. OSImageVersion should equal to an OpenshiftVersion in OSImages list).
+	// Note: OSImageVersion can't be specified along with ClusterRef. 
 	// +optional
 	OSImageVersion string `json:"osImageVersion,omitempty"`
 }

--- a/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
+++ b/vendor/github.com/openshift/assisted-service/models/cluster_validation_id.go
@@ -101,6 +101,9 @@ const (
 
 	// ClusterValidationIDPlatformRequirementsSatisfied captures enum value "platform-requirements-satisfied"
 	ClusterValidationIDPlatformRequirementsSatisfied ClusterValidationID = "platform-requirements-satisfied"
+
+	// ClusterValidationIDInstallationPreparationSucceeded captures enum value "installation-preparation-succeeded"
+	ClusterValidationIDInstallationPreparationSucceeded ClusterValidationID = "installation-preparation-succeeded"
 )
 
 // for schema
@@ -108,7 +111,7 @@ var clusterValidationIdEnum []interface{}
 
 func init() {
 	var res []ClusterValidationID
-	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["machine-cidr-defined","cluster-cidr-defined","service-cidr-defined","no-cidrs-overlapping","networks-same-address-families","network-prefix-valid","machine-cidr-equals-to-calculated-cidr","api-vips-defined","api-vips-valid","ingress-vips-defined","ingress-vips-valid","all-hosts-are-ready-to-install","sufficient-masters-count","dns-domain-defined","pull-secret-set","ntp-server-configured","lso-requirements-satisfied","ocs-requirements-satisfied","odf-requirements-satisfied","cnv-requirements-satisfied","lvm-requirements-satisfied","mce-requirements-satisfied","network-type-valid","platform-requirements-satisfied","installation-preparation-succeeded"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
We need a validation that shows whether or not the previous attempt to
prepare for installation failed. This can have benefits for both UI
users and KubeAPI users.

This PR makes use of an existing cluster database field `InstallationPreparationCompletionStatus` to determine whether or not the preparation phase failed and adds `InstallationPreparationCompletionStatusText` to allow us to track the reason for the failure.

The new validation `installation-preparation-succeeded` is then added to a new category `installation-preparation` and exposed with all of
the other cluster validators.

When plugged into the UI as it stands now, there will need to be a UX
change to allow this information to be displayed with an error.

For KubeAPI, the plan is to couple this functionality with the "limited retry"
mechanism being proposed in https://issues.redhat.com/browse/MGMT-12397

```
...
    {
      "id": "sufficient-masters-count",
      "status": "success",
      "message": "The cluster has the exact amount of dedicated control plane nodes."
    }
  ],
  "installation-preparation": [
    {
      "id": "installation-preparation-succeeded",
      "status": "failure",
      "message": "The cluster preparation failed with the following error: failed generating install config for cluster 3837f834-aaa7-4ee8-b3cc-7fd24396c65a: error running openshift-install ignition-configs,  level=fatal msg=failed to fetch Bootstrap Ignition Config: failed to fetch dependency of \"Bootstrap Ignition Config\": failed to generate asset \"CVO Ignore\": could not unmarshal \"manifests/test.yaml\": error unmarshaling JSON: while decoding JSON: Object 'Kind' is missing in '{\"test\":{\"k\":\"v\"}}'\n: exit status 1"
    }
  ],
  "network": [
    {
      "id": "api-vips-defined",
      "status": "success",
      "message": "API virtual IPs are not required: User Managed Networking"
    },
...
```