### PR TITLE
MGMT-15074: Use the latest stable LSO operator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -316,7 +316,7 @@ func main() {
 	createS3Bucket(objectHandler, log)
 
 	manifestsApi := manifests.NewManifestsAPI(db, log.WithField("pkg", "manifests"), objectHandler, usageManager)
-	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler, extracterHandler)
+	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler, extracterHandler, versionHandler)
 	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
 	Options.InstructionConfig.HostFSMountDir = hostFSMountDir

--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -27,12 +27,28 @@ func VersionGreaterOrEqual(version1, version2 string) (bool, error) {
 	return v1.GreaterThanOrEqual(v2), nil
 }
 
+func IsVersionGreater(version1, version2 string) (bool, error) {
+	v1, v2, err := createTwoVersions(version1, version2)
+	if err != nil {
+		return false, err
+	}
+	return v1.GreaterThan(v2), nil
+}
+
 func BaseVersionGreaterOrEqual(version, versionMayGreaterThan string) (bool, error) {
 	// return version >= versionMayGreaterThan
 	version = strings.Split(version, "-")[0]
 	versionMayGreaterThan = strings.Split(versionMayGreaterThan, "-")[0]
 
 	return VersionGreaterOrEqual(versionMayGreaterThan, version)
+}
+
+func BaseVersionIsGreater(version, versionMayGreaterThan string) (bool, error) {
+	// return version > versionMayGreaterThan
+	version = strings.Split(version, "-")[0]
+	versionMayGreaterThan = strings.Split(versionMayGreaterThan, "-")[0]
+
+	return IsVersionGreater(versionMayGreaterThan, version)
 }
 
 func BaseVersionLessThan(version, versionMayLessThan string) (bool, error) {
@@ -45,15 +61,17 @@ func BaseVersionLessThan(version, versionMayLessThan string) (bool, error) {
 
 // BaseVersionEqual Compare Major and Minor of 2 different versions
 func BaseVersionEqual(version1, versionMayEqual string) (bool, error) {
-	version1 = strings.Split(version1, "-")[0]
-	versionMayEqual = strings.Split(versionMayEqual, "-")[0]
-
-	v1 := strings.Split(version1, ".")
-	v2 := strings.Split(versionMayEqual, ".")
+	v1 := GetParsedVersion(version1)
+	v2 := GetParsedVersion(versionMayEqual)
 
 	if len(v1) < 2 || len(v2) < 2 {
 		return false, errors.New("invalid version")
 	}
 
 	return v1[0] == v2[0] && v1[1] == v2[1], nil
+}
+
+func GetParsedVersion(version string) []string {
+	v := strings.Split(version, "-")[0]
+	return strings.Split(v, ".")
 }

--- a/internal/host/hostrole_test.go
+++ b/internal/host/hostrole_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Suggested-Role on Refresh", func() {
 		mockHwValidator       *hardware.MockValidator
 		validatorCfg          *hardware.ValidatorCfg
 		operatorsManager      *operators.Manager
+		mockVersionHandler    *versions.MockHandler
 	)
 
 	initHwValidator := func() {
@@ -67,7 +68,8 @@ var _ = Describe("Suggested-Role on Refresh", func() {
 		clusterId = strfmt.UUID(uuid.New().String())
 		infraEnvId = strfmt.UUID(uuid.New().String())
 		mockEvents = eventsapi.NewMockHandler(ctrl)
-		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		initHwValidator()
 		pr := registry.NewMockProviderRegistry(ctrl)
 		pr.EXPECT().IsHostSupported(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -99,6 +99,7 @@ var _ = Describe("RegisterHost", func() {
 		mockEvents                    *eventsapi.MockHandler
 		hostId, clusterId, infraEnvId strfmt.UUID
 		dbName                        string
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -106,7 +107,8 @@ var _ = Describe("RegisterHost", func() {
 		db, dbName = common.PrepareTestDB()
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		hapi = NewManager(common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager, nil, false, nil, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
@@ -632,6 +634,7 @@ var _ = Describe("HostInstallationFailed", func() {
 		mockMetric                    *metrics.MockAPI
 		mockEvents                    *eventsapi.MockHandler
 		dbName                        string
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -640,7 +643,8 @@ var _ = Describe("HostInstallationFailed", func() {
 		mockMetric = metrics.NewMockAPI(ctrl)
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		hapi = NewManager(common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEvents, mockHwValidator, nil, createValidatorCfg(), mockMetric, defaultConfig, nil, operatorsManager, nil, false, nil, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
@@ -679,6 +683,7 @@ var _ = Describe("Cancel host installation", func() {
 		host                          models.Host
 		ctrl                          *gomock.Controller
 		mockEventsHandler             *eventsapi.MockHandler
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -686,7 +691,8 @@ var _ = Describe("Cancel host installation", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEventsHandler = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		hapi = NewManager(common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEventsHandler, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager, nil, false, nil, nil)
 	})
 
@@ -772,6 +778,7 @@ var _ = Describe("Install", func() {
 		cluster                       common.Cluster
 		mockHwValidator               *hardware.MockValidator
 		dbName                        string
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -779,7 +786,8 @@ var _ = Describe("Install", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator = hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		pr := registry.NewMockProviderRegistry(ctrl)
 		pr.EXPECT().IsHostSupported(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 		mockVersions := versions.NewMockHandler(ctrl)
@@ -923,6 +931,7 @@ var _ = Describe("Unbind", func() {
 		hostId, clusterId, infraEnvId strfmt.UUID
 		host                          models.Host
 		dbName                        string
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -930,7 +939,8 @@ var _ = Describe("Unbind", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator := hardware.NewMockValidator(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		hapi = NewManager(common.GetTestLog(), db, testing.GetDummyNotificationStream(ctrl), mockEvents, mockHwValidator, nil, createValidatorCfg(), nil, defaultConfig, nil, operatorsManager, nil, false, nil, nil)
 		hostId = strfmt.UUID(uuid.New().String())
 		clusterId = strfmt.UUID(uuid.New().String())
@@ -1297,6 +1307,7 @@ var _ = Describe("Refresh Host", func() {
 		validatorCfg                  *hardware.ValidatorCfg
 		operatorsManager              *operators.Manager
 		pr                            *registry.MockProviderRegistry
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -1318,7 +1329,8 @@ var _ = Describe("Refresh Host", func() {
 				fmt.Sprintf("%s:%s", supportedGPU.VendorID, supportedGPU.DeviceID): true,
 			}},
 		}
-		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operatorsOptions, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager = operators.NewManager(common.GetTestLog(), nil, operatorsOptions, nil, nil, mockVersionHandler)
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 		pr = registry.NewMockProviderRegistry(ctrl)
 		pr.EXPECT().IsHostSupported(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
@@ -6008,6 +6020,7 @@ var _ = Describe("Upgrade agent feature", func() {
 		dbName                        string
 		mockHwValidator               *hardware.MockValidator
 		pr                            *registry.MockProviderRegistry
+		mockVersionHandler            *versions.MockHandler
 	)
 
 	BeforeEach(func() {
@@ -6015,12 +6028,14 @@ var _ = Describe("Upgrade agent feature", func() {
 		db, dbName = common.PrepareTestDB()
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHwValidator = hardware.NewMockValidator(ctrl)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
 		operatorsManager := operators.NewManager(
 			common.GetTestLog(),
 			nil,
 			operators.Options{},
 			nil,
 			nil,
+			mockVersionHandler,
 		)
 		pr = registry.NewMockProviderRegistry(ctrl)
 		mockVersions := versions.NewMockHandler(ctrl)

--- a/internal/operators/builder.go
+++ b/internal/operators/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/lvm"
 	"github.com/openshift/assisted-service/internal/operators/mce"
 	"github.com/openshift/assisted-service/internal/operators/odf"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/s3wrapper"
 	"github.com/sirupsen/logrus"
@@ -32,8 +33,8 @@ type Options struct {
 }
 
 // NewManager creates new instance of an Operator Manager
-func NewManager(log logrus.FieldLogger, manifestAPI manifestsapi.ManifestsAPI, options Options, objectHandler s3wrapper.API, extracter oc.Extracter) *Manager {
-	return NewManagerWithOperators(log, manifestAPI, options, objectHandler, lso.NewLSOperator(), odf.NewOcsOperator(log), odf.NewOdfOperator(log, extracter), cnv.NewCNVOperator(log, options.CNVConfig, extracter), lvm.NewLvmOperator(log, extracter), mce.NewMceOperator(log))
+func NewManager(log logrus.FieldLogger, manifestAPI manifestsapi.ManifestsAPI, options Options, objectHandler s3wrapper.API, extracter oc.Extracter, versionsHandler versions.Handler) *Manager {
+	return NewManagerWithOperators(log, manifestAPI, options, objectHandler, lso.NewLSOperator(log, versionsHandler), odf.NewOcsOperator(log), odf.NewOdfOperator(log, extracter), cnv.NewCNVOperator(log, options.CNVConfig, extracter), lvm.NewLvmOperator(log, extracter), mce.NewMceOperator(log))
 }
 
 // NewManagerWithOperators creates new instance of an Operator Manager and configures it with given operators

--- a/internal/operators/lso/ls_operator.go
+++ b/internal/operators/lso/ls_operator.go
@@ -5,11 +5,15 @@ import (
 
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/operators/api"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
+	"github.com/sirupsen/logrus"
 )
 
 // lsOperator is an LSO OLM operator plugin; it implements api.Operator
 type lsOperator struct {
+	Log            logrus.FieldLogger
+	versionHandler versions.Handler
 }
 
 var Operator = models.MonitoredOperator{
@@ -21,8 +25,8 @@ var Operator = models.MonitoredOperator{
 }
 
 // New LSOperator creates new instance of a Local Storage Operator installation plugin
-func NewLSOperator() *lsOperator {
-	return &lsOperator{}
+func NewLSOperator(log logrus.FieldLogger, versionHandler versions.Handler) *lsOperator {
+	return &lsOperator{log, versionHandler}
 }
 
 // GetName reports the name of an operator this Operator manages
@@ -62,7 +66,7 @@ func (l *lsOperator) ValidateHost(_ context.Context, _ *common.Cluster, _ *model
 // GenerateManifests generates manifests for the operator
 
 func (l *lsOperator) GenerateManifests(c *common.Cluster) (map[string][]byte, []byte, error) {
-	return Manifests()
+	return Manifests(l.Log, c, l.versionHandler)
 }
 
 // GetProperties provides description of operator properties: none required

--- a/internal/operators/lso/manifest.go
+++ b/internal/operators/lso/manifest.go
@@ -2,13 +2,56 @@ package lso
 
 import (
 	"bytes"
+	"fmt"
 	"text/template"
+
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/versions"
+	"github.com/sirupsen/logrus"
 )
 
-func lsoSubscription() ([]byte, error) {
+func getCatalogSource(openshiftVersion string) ([]byte, string, error) {
+	v := common.GetParsedVersion(openshiftVersion)
+	catalogSourceName := fmt.Sprintf("redhat-operators-v%s-%s", v[0], v[1])
+	data := map[string]string{
+		"MAJOR":               v[0],
+		"MINOR":               v[1],
+		"CATALOG_SOURCE_NAME": catalogSourceName,
+	}
+
+	const catalogSource = `kind: CatalogSource
+apiVersion: operators.coreos.com/v1alpha1
+metadata:
+  name: {{.CATALOG_SOURCE_NAME}}
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat Operators v{{.MAJOR}}.{{.MINOR}}
+  description: This additional catalog source is added by the assisted-installer when LSO is deployed alongside pre-release OCP installations.
+  image: registry.redhat.io/redhat/redhat-operator-index:v{{.MAJOR}}.{{.MINOR}}
+  priority: -100
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 10m0s`
+
+	tmpl, err := template.New("catalogSource").Parse(catalogSource)
+	if err != nil {
+		return nil, "", err
+	}
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, data)
+	if err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), catalogSourceName, nil
+}
+
+func lsoSubscription(catalogSourceName string) ([]byte, error) {
 	data := map[string]string{
 		"OPERATOR_NAMESPACE":         Operator.Namespace,
 		"OPERATOR_SUBSCRIPTION_NAME": Operator.SubscriptionName,
+		"CATALOG_SOURCE_NAME":        catalogSourceName,
 	}
 
 	const lsoSubscription = `apiVersion: operators.coreos.com/v1alpha1
@@ -19,7 +62,7 @@ metadata:
 spec:
   installPlanApproval: Automatic
   name: local-storage-operator
-  source: redhat-operators
+  source: {{.CATALOG_SOURCE_NAME}}
   sourceNamespace: openshift-marketplace`
 
 	tmpl, err := template.New("lsoSubscription").Parse(lsoSubscription)
@@ -34,15 +77,46 @@ spec:
 	return buf.Bytes(), nil
 }
 
-func Manifests() (map[string][]byte, []byte, error) {
-	lsoSubs, err := lsoSubscription()
+func addDynamicManifests(log logrus.FieldLogger, c *common.Cluster, handler versions.Handler, openshiftManifests map[string][]byte) error {
+	catalogSourceName := "redhat-operators"
+
+	// Use the latest stable LSO operator instead of the pre-release ones because the former is
+	// usually not published in the beta releases' Red Hat Operators catalog.
+	// Therefore, this patch enforces the usage of the previous stable version.
+	defaultReleaseImage, err := handler.GetDefaultReleaseImage(c.CPUArchitecture)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
+	if isGreater, _ := common.BaseVersionIsGreater(*defaultReleaseImage.OpenshiftVersion, c.OpenshiftVersion); isGreater {
+		log.Infof("Found pre-release OCP version %s, adding %s CatalogSource", c.OpenshiftVersion, *defaultReleaseImage.OpenshiftVersion)
+		catalogSource, csName, err2 := getCatalogSource(*defaultReleaseImage.OpenshiftVersion)
+		if err2 != nil {
+			return err2
+		}
+		catalogSourceName = csName
+		openshiftManifests["50_openshift-lso_catalog_source.yaml"] = catalogSource
+	}
+
+	// Add LSO subscription with the given CatalogSource name
+	lsoSubs, err := lsoSubscription(catalogSourceName)
+	if err != nil {
+		return err
+	}
+	openshiftManifests["50_openshift-lso_subscription.yaml"] = lsoSubs
+	return nil
+}
+
+func Manifests(log logrus.FieldLogger, c *common.Cluster, handler versions.Handler) (map[string][]byte, []byte, error) {
+	log.Infof("Generating cluster %s LSO manifests", c.ID.String())
 	openshiftManifests := make(map[string][]byte)
 	openshiftManifests["50_openshift-lso_ns.yaml"] = []byte(localStorageNamespace)
 	openshiftManifests["50_openshift-lso_operator_group.yaml"] = []byte(lsoOperatorGroup)
-	openshiftManifests["50_openshift-lso_subscription.yaml"] = lsoSubs
+
+	if err := addDynamicManifests(log, c, handler, openshiftManifests); err != nil {
+		return nil, nil, err
+	}
+
+	log.Infof("Generated %d cluster %s LSO manifests successfully", len(openshiftManifests), c.ID.String())
 	return openshiftManifests, []byte(localVolumeSet), nil
 }
 

--- a/internal/operators/lso/manifests_test.go
+++ b/internal/operators/lso/manifests_test.go
@@ -1,34 +1,75 @@
 package lso
 
 import (
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("LSO manifest generation", func() {
-	operator := NewLSOperator()
+	var (
+		mockCtrl           *gomock.Controller
+		mockVersionHandler *versions.MockHandler
+	)
+
+	mockCtrl = gomock.NewController(GinkgoT())
+	mockVersionHandler = versions.NewMockHandler(mockCtrl)
+	operator := NewLSOperator(common.GetTestLog(), mockVersionHandler)
+	clusterId := strfmt.UUID(uuid.New().String())
 	cluster := common.Cluster{Cluster: models.Cluster{
 		OpenshiftVersion: common.TestDefaultConfig.OpenShiftVersion,
+		CPUArchitecture:  common.X86CPUArchitecture,
+		ID:               &clusterId,
 	}}
 
-	Context("Create LSO Manifest", func() {
+	Context("LSO Manifest", func() {
+		It("Create LSO Manifests", func() {
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil)
 
-		openshiftManifests, manifest, err := operator.GenerateManifests(&cluster)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(openshiftManifests).To(HaveLen(3))
-		Expect(openshiftManifests["50_openshift-lso_ns.yaml"]).NotTo(HaveLen(0))
-		Expect(openshiftManifests["50_openshift-lso_operator_group.yaml"]).NotTo(HaveLen(0))
-		Expect(openshiftManifests["50_openshift-lso_subscription.yaml"]).NotTo(HaveLen(0))
+			openshiftManifests, manifest, err := operator.GenerateManifests(&cluster)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(openshiftManifests).To(HaveLen(3))
+			Expect(openshiftManifests["50_openshift-lso_ns.yaml"]).NotTo(HaveLen(0))
+			Expect(openshiftManifests["50_openshift-lso_operator_group.yaml"]).NotTo(HaveLen(0))
+			Expect(openshiftManifests["50_openshift-lso_subscription.yaml"]).NotTo(HaveLen(0))
 
-		for _, manifest := range openshiftManifests {
+			for _, manifest := range openshiftManifests {
+				_, err = yaml.YAMLToJSON(manifest)
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+
 			_, err = yaml.YAMLToJSON(manifest)
 			Expect(err).ShouldNot(HaveOccurred())
-		}
+		})
 
-		_, err = yaml.YAMLToJSON(manifest)
-		Expect(err).ShouldNot(HaveOccurred())
+		It("Extra manifest on pre release", func() {
+			cluster.OpenshiftVersion = "4.14"
+			releaseImage := &models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				OpenshiftVersion: swag.String("4.13"),
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.13.4-x86_64"),
+				Version:          swag.String("4.13.4"),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+			}
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(releaseImage, nil)
+			openshiftManifests, manifest, err := operator.GenerateManifests(&cluster)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(openshiftManifests).To(HaveLen(4))
+
+			Expect(yaml.YAMLToJSON(openshiftManifests["50_openshift-lso_catalog_source.yaml"])).NotTo(HaveLen(0))
+			Expect(yaml.YAMLToJSON(openshiftManifests["50_openshift-lso_ns.yaml"])).NotTo(HaveLen(0))
+			Expect(yaml.YAMLToJSON(openshiftManifests["50_openshift-lso_operator_group.yaml"])).NotTo(HaveLen(0))
+			Expect(yaml.YAMLToJSON(openshiftManifests["50_openshift-lso_subscription.yaml"])).NotTo(HaveLen(0))
+
+			_, err = yaml.YAMLToJSON(manifest)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })

--- a/internal/operators/odf/validation_test.go
+++ b/internal/operators/odf/validation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/openshift/assisted-service/internal/operators"
 	"github.com/openshift/assisted-service/internal/operators/odf"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 	"github.com/openshift/assisted-service/pkg/conversions"
 	"gorm.io/gorm"
@@ -94,6 +95,7 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		diskID1                                       = "/dev/disk/by-id/test-disk-1"
 		diskID2                                       = "/dev/disk/by-id/test-disk-2"
 		diskID3                                       = "/dev/disk/by-id/test-disk-3"
+		mockVersionHandler                            *versions.MockHandler
 	)
 
 	mockHostAPIIsRequireUserActionResetFalse := func() {
@@ -109,7 +111,8 @@ var _ = Describe("Ocs Operator use-cases", func() {
 		mockEvents = eventsapi.NewMockHandler(ctrl)
 		mockHostAPI = host.NewMockAPI(ctrl)
 		mockMetric = metrics.NewMockAPI(ctrl)
-		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil)
+		mockVersionHandler = versions.NewMockHandler(ctrl)
+		operatorsManager := operators.NewManager(common.GetTestLog(), nil, operators.Options{}, nil, nil, mockVersionHandler)
 		var cfg clust.Config
 		Expect(envconfig.Process(common.EnvConfigPrefix, &cfg)).ShouldNot(HaveOccurred())
 		clusterApi = clust.NewManager(cfg, common.GetTestLog().WithField("pkg", "cluster-monitor"), db, commontesting.GetDummyNotificationStream(ctrl),

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/client/installer"
@@ -21,13 +22,16 @@ import (
 	"github.com/openshift/assisted-service/internal/operators/lvm"
 	"github.com/openshift/assisted-service/internal/operators/mce"
 	"github.com/openshift/assisted-service/internal/operators/odf"
+	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
 )
 
 var _ = Describe("Operators endpoint tests", func() {
 
 	var (
-		clusterID strfmt.UUID
+		clusterID          strfmt.UUID
+		mockVersionHandler *versions.MockHandler
+		ctrl               *gomock.Controller
 	)
 
 	Context("supported-operators", func() {
@@ -61,7 +65,10 @@ var _ = Describe("Operators endpoint tests", func() {
 			cluster := reply.GetPayload()
 			c := &common.Cluster{Cluster: *cluster}
 
-			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVersionHandler = versions.NewMockHandler(ctrl)
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil)
+			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil, mockVersionHandler).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
 				Expect(operators.IsEnabled(c.MonitoredOperators, builtinOperator.Name)).Should(BeTrue())
 			}
 		})
@@ -283,7 +290,10 @@ var _ = Describe("Operators endpoint tests", func() {
 			}
 
 			// Builtin
-			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVersionHandler = versions.NewMockHandler(ctrl)
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil)
+			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil, mockVersionHandler).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
 				Expect(operatorNames).To(ContainElements(builtinOperator.Name))
 			}
 
@@ -362,7 +372,10 @@ var _ = Describe("Operators endpoint tests", func() {
 			}
 
 			// Builtin
-			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVersionHandler = versions.NewMockHandler(ctrl)
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil)
+			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil, mockVersionHandler).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
 				Expect(operatorNames).To(ContainElements(builtinOperator.Name))
 			}
 
@@ -453,7 +466,10 @@ var _ = Describe("Operators endpoint tests", func() {
 			}
 
 			// Builtin
-			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
+			ctrl = gomock.NewController(GinkgoT())
+			mockVersionHandler = versions.NewMockHandler(ctrl)
+			mockVersionHandler.EXPECT().GetDefaultReleaseImage(gomock.Any()).Return(common.TestDefaultConfig.ReleaseImage, nil)
+			for _, builtinOperator := range operators.NewManager(log, nil, operators.Options{}, nil, nil, mockVersionHandler).GetSupportedOperatorsByType(models.OperatorTypeBuiltin) {
 				Expect(operatorNames).To(ContainElements(builtinOperator.Name))
 			}
 


### PR DESCRIPTION
Use the latest stable LSO operator instead of the pre-release ones because the former is usually not published in the beta releases' Red Hat Operators catalog. Therefore, this patch enforces the usage of the previous stable version.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eliorerz 