### PR TITLE
MGMT-15489: Don't set detached for BMHs without infraenv label

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -838,6 +838,15 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 	log.Debugf("Started BMH reconcile")
 	log.Debugf("BMH value %v", bmh)
 
+	infraEnv, err := r.findInfraEnvForBMH(ctx, log, bmh)
+	if err != nil {
+		return reconcileError{err: err}
+	}
+	// Stop `Reconcile` if BMH does not have an InfraEnv.
+	if infraEnv == nil {
+		return reconcileComplete{stop: true}
+	}
+
 	// A detached BMH is considered to be unmanaged by the hub
 	// cluster and, therefore, BMAC reconciles on this BMH should
 	// not happen.
@@ -854,17 +863,6 @@ func (r *BMACReconciler) reconcileBMH(ctx context.Context, log logrus.FieldLogge
 		}
 		log.Debugf("Stopped BMH reconcile because it has been detached")
 		return result
-	}
-
-	infraEnv, err := r.findInfraEnvForBMH(ctx, log, bmh)
-
-	if err != nil {
-		return reconcileError{err: err}
-	}
-
-	// Stop `Reconcile` if BMH does not have an InfraEnv.
-	if infraEnv == nil {
-		return reconcileComplete{stop: true}
 	}
 
 	dirty := false

--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -1315,6 +1315,21 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations).NotTo(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).NotTo(Equal("assisted-service-controller"))
 			})
+			It("should not set the detached annotation value for BMHs not labeled with an infraenv", func() {
+				host.SetAnnotations(map[string]string{BMH_DETACHED_ANNOTATION: "some-other-value"})
+				delete(host.Labels, BMH_INFRA_ENV_LABEL)
+				Expect(c.Update(ctx, host)).To(BeNil())
+
+				result, err := bmhr.Reconcile(ctx, newBMHRequest(host))
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{}))
+
+				updatedHost := &bmh_v1alpha1.BareMetalHost{}
+				err = c.Get(ctx, types.NamespacedName{Name: host.Name, Namespace: testNamespace}, updatedHost)
+				Expect(err).To(BeNil())
+				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
+				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("some-other-value"))
+			})
 			It("should set the detached annotation if agent is installed", func() {
 				agent.Status.Conditions = []conditionsv1.Condition{
 					{


### PR DESCRIPTION
Before this, if a BMH existed in the cluster where BMAC was running and was both provisioned and deteched BMAC would set the detached annotation value to "assisted-service-controller" even if the BMH didn't have an infraenv label.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-15489

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?