### PR TITLE
MGMT-15525: Use go 1.18 when setting up environment

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -19,7 +19,7 @@ function golang() {
   echo "Installing golang..."
   curl --retry 5 --connect-timeout 30 -L https://storage.googleapis.com/golang/getgo/installer_linux -o /tmp/golang_installer
   chmod u+x /tmp/golang_installer
-  /tmp/golang_installer
+  /tmp/golang_installer -version 1.18
   rm /tmp/golang_installer
 
   echo "Activating go command on current shell..."


### PR DESCRIPTION
Without this this command was failing with the following output:

```
[2023-08-09 17:01:25] + /tmp/golang_installer
[2023-08-09 17:01:25] Welcome to the Go installer!
[2023-08-09 17:01:26] Downloading Go version go1.21.0
[2023-08-09 17:01:26] time 2023-08-04T20:14:06Z to /root/.go
[2023-08-09 17:01:26] This may take a bit of time...
[2023-08-09 17:01:26] Downloading Go from 400 Bad Request failed with HTTP status %!s(MISSING)
```

Also correct a minor typo in a function name.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
