### PR TITLE
NO-ISSUE: Extend waiting time to test DB container to be ready

### DIFF
--- a/internal/common/common_unitest_db.go
+++ b/internal/common/common_unitest_db.go
@@ -407,7 +407,7 @@ func openTestDB(dbName string) (*gorm.DB, error) {
 		})
 	}
 
-	for attempts := 0; attempts < 5; attempts++ {
+	for attempts := 0; attempts < 30; attempts++ {
 		db, err := open()
 		if err == nil {
 			return db, nil


### PR DESCRIPTION
Sometimes when debugging unittest without skipper the 5 seconds timeout is not enough and will fail if the test start before DB container is ready.
This PR extend the waiting to 30 seconds which is most of the time is enough.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed


/cc @osherdp @adriengentil 