### PR TITLE
OCPBUGS-17992 day2 skip install config overrides

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1098,7 +1098,10 @@ func selectClusterNetworkType(params *models.V2ClusterUpdateParams, cluster *com
 
 func (r *ClusterDeploymentsReconciler) updateInstallConfigOverrides(ctx context.Context, log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall,
 	cluster *common.Cluster) error {
-	// handle InstallConfigOverrides
+	// not relevant for day2 cluster - install config is not used
+	if common.IsDay2Cluster(cluster) {
+		return nil
+	}
 	update := false
 	annotations := clusterInstall.ObjectMeta.GetAnnotations()
 	installConfigOverrides := annotations[InstallConfigOverrides]

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -3949,3 +3949,129 @@ var _ = Describe("unbindAgents", func() {
 		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 })
+
+var _ = Describe("day2 cluster", func() {
+	var (
+		c                              client.Client
+		ctx                            = context.Background()
+		imageSetName                   = "openshift-v4.8.0"
+		releaseImageUrl                = "quay.io/openshift-release-dev/ocp-release:4.8.0-x86_64"
+		clusterKey                     types.NamespacedName
+		clusterName                    = "test-cluster"
+		agentClusterInstallName        = "test-cluster-aci"
+		defaultClusterSpec             hivev1.ClusterDeploymentSpec
+		pullSecretName                 = "pull-secret"
+		defaultAgentClusterInstallSpec hiveext.AgentClusterInstallSpec
+		mockCtrl                       *gomock.Controller
+		mockInstallerInternal          *bminventory.MockInstallerInternals
+		cr                             *ClusterDeploymentsReconciler
+		mockVersions                   *versions.MockHandler
+		dbCluster                      *common.Cluster
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
+		mockVersions = versions.NewMockHandler(mockCtrl)
+
+		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+		cr = &ClusterDeploymentsReconciler{
+			Client:            c,
+			APIReader:         c,
+			Scheme:            scheme.Scheme,
+			Log:               common.GetTestLog(),
+			Installer:         mockInstallerInternal,
+			PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
+			VersionsHandler:   mockVersions,
+		}
+
+		clusterKey = types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      clusterName,
+		}
+
+		pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
+		Expect(c.Create(ctx, pullSecret)).To(BeNil())
+
+		imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
+		Expect(c.Create(ctx, imageSet)).To(BeNil())
+
+		secretName := fmt.Sprintf(adminKubeConfigStringTemplate, clusterName)
+		adminKubeconfigSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"kubeconfig": []byte("somekubeconfig"),
+			},
+		}
+		Expect(c.Create(ctx, adminKubeconfigSecret)).To(Succeed())
+
+		defaultClusterSpec = getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName)
+		defaultClusterSpec.Installed = true
+		defaultClusterSpec.ClusterMetadata = &hivev1.ClusterMetadata{}
+		defaultClusterSpec.ClusterMetadata.AdminKubeconfigSecretRef.Name = secretName
+		defaultClusterSpec.ClusterMetadata.ClusterID = ""
+		defaultClusterSpec.ClusterMetadata.InfraID = ""
+
+		defaultAgentClusterInstallSpec = getDefaultAgentClusterInstallSpec(clusterName)
+		defaultAgentClusterInstallSpec.ClusterMetadata = &hivev1.ClusterMetadata{}
+		defaultAgentClusterInstallSpec.ClusterMetadata.AdminKubeconfigSecretRef.Name = secretName
+		defaultAgentClusterInstallSpec.ClusterMetadata.ClusterID = ""
+		defaultAgentClusterInstallSpec.ClusterMetadata.InfraID = ""
+
+		id := strfmt.UUID(uuid.New().String())
+		dbCluster = &common.Cluster{
+			PullSecret: testPullSecretVal,
+			Cluster: models.Cluster{
+				Kind:            swag.String(models.ClusterKindAddHostsCluster),
+				ID:              &id,
+				Status:          swag.String(models.ClusterStatusInstalled),
+				APIVip:          common.TestIPv4Networking.APIVip,
+				APIVips:         common.TestIPv4Networking.APIVips,
+				IngressVip:      common.TestIPv4Networking.IngressVip,
+				IngressVips:     common.TestIPv4Networking.IngressVips,
+				ClusterNetworks: common.TestIPv4Networking.ClusterNetworks,
+				ServiceNetworks: common.TestIPv4Networking.ServiceNetworks,
+				SSHPublicKey:    defaultAgentClusterInstallSpec.SSHPublicKey,
+				BaseDNSDomain:   defaultClusterSpec.BaseDomain,
+				Name:            defaultClusterSpec.ClusterName,
+				Hyperthreading:  models.ClusterHyperthreadingAll,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	It("install config overrides not relevant for day2", func() {
+		cd := newClusterDeployment(clusterKey.Name, clusterKey.Namespace, defaultClusterSpec)
+		Expect(c.Create(ctx, cd)).To(BeNil())
+
+		aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cd)
+		aci.ObjectMeta.SetAnnotations(map[string]string{InstallConfigOverrides: `{"networking":{"networkType":"OVNKubernetes"}}`})
+		Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
+		mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+
+		By("first time will create the cluster")
+		request := newClusterDeploymentRequest(cd)
+		result, err := cr.Reconcile(ctx, request)
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
+
+		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(dbCluster, nil)
+		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		mockInstallerInternal.EXPECT().GetKnownApprovedHosts(gomock.Any()).Return(nil, nil)
+		// expected not to be called
+		mockInstallerInternal.EXPECT().UpdateClusterInstallConfigInternal(gomock.Any(), gomock.Any()).Times(0)
+		By("second time will update the cluster by the spec")
+		result, err = cr.Reconcile(ctx, request)
+		Expect(err).To(BeNil())
+		Expect(result).To(Equal(ctrl.Result{}))
+	})
+})


### PR DESCRIPTION
Updating or setting install config is not relevant for day2 clusters because install config is not used in day2, the installer is not invoked in day2.

the issue that this change comes to resolve is when user is using backup restore on a multi node baremetal cluster that use install config overrides without specifying machine network that is calculated automatically from the hosts, it will mean that it will not be set in the spec and not going to be restored, in this case the controller will try to update the install config and get and error that machine network is not set for a baremetal cluster

This change  was tested in test-infra by creating an installed day2 cluster with install config overrides annotation, i saw that the spec was synced and had no errors
In addition i added a manifests to see that it have no affect on the cluster as well.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
