### PR TITLE
Fix setup_env.sh failure handling

### DIFF
--- a/hack/setup_env.sh
+++ b/hack/setup_env.sh
@@ -5,11 +5,6 @@ set -o pipefail
 set -o errexit
 set -o xtrace
 
-function get_package_manager() {
-    PACKAGE_MANAGER=$( command -v dnf &> /dev/null && echo "dnf" || echo "yum")
-    echo $PACKAGE_MANAGER
-}
-
 function print_help() {
   ALL_FUNCS="golang|assisted_service|hive_from_upstream|print_help"
   echo "Usage: bash ${0} (${ALL_FUNCS})"
@@ -42,20 +37,22 @@ function jq() {
 
 function awscli() {
   echo "Installing aws-cli..."
-  curl --retry 5 --connect-timeout 30 -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" && unzip /tmp/awscliv2.zip && \
-  ./aws/install && rm -f /tmp/awscliv2.zip
+  curl --retry 5 --connect-timeout 30 -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+  unzip -q /tmp/awscliv2.zip
+  ./aws/install
+  rm -f /tmp/awscliv2.zip
 }
 
 function podman_remote() {
   # podman-remote 4 cannot run against podman server 3 so installing them both side by side
-  curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v3.4.4/podman-remote-static.tar.gz -o "podman-remote3.tar.gz" && \
-  tar -zxvf podman-remote3.tar.gz && \
-  mv podman-remote-static /usr/local/bin/podman-remote3 && \
+  curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v3.4.4/podman-remote-static.tar.gz -o "podman-remote3.tar.gz"
+  tar -zxvf podman-remote3.tar.gz
+  mv podman-remote-static /usr/local/bin/podman-remote3
   rm -f podman-remote3.tar.gz
 
-  curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz -o "podman-remote4.tar.gz" && \
-  tar -zxvf podman-remote4.tar.gz && \
-  mv podman-remote-static /usr/local/bin/podman-remote4 && \
+  curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz -o "podman-remote4.tar.gz"
+  tar -zxvf podman-remote4.tar.gz
+  mv podman-remote-static /usr/local/bin/podman-remote4
   rm -f podman-remote4.tar.gz
 }
 
@@ -72,12 +69,13 @@ function assisted_service() {
   ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac)
 
   latest_kubectl_version=$(curl --retry 5 --connect-timeout 30 -L -s https://dl.k8s.io/release/stable.txt)
-  curl --retry 5 --connect-timeout 30 -L "https://dl.k8s.io/release/${latest_kubectl_version}/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
-    install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl && \
-    rm -f /tmp/kubectl
+  curl --retry 5 --connect-timeout 30 -L "https://dl.k8s.io/release/${latest_kubectl_version}/bin/linux/amd64/kubectl" -o /tmp/kubectl
+  install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+  rm -f /tmp/kubectl
 
-  $(get_package_manager) install -y --setopt=skip_missing_names_on_install=False \
-    unzip diffutils python3-pip genisoimage skopeo && dnf clean all && rm -rf /var/cache/yum
+  dnf install -y unzip diffutils python3-pip genisoimage skopeo
+  dnf clean all
+  rm -rf /var/cache/yum
 
   jq
 


### PR DESCRIPTION
Even when using ``set -o errexit``, bash ignores exit codes when they are part of an explicitly tested command. Commands using ``&&`` are considered tested and therefore are not being checked.

For example, in the following job we eventually got to the following error:
```
./setup_env.sh: line 45: unzip: command not found
```
(see
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/5439/pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted/1694619719769788416)

But looking a few lines above, it shows that:
```
dnf install -y --setopt=skip_missing_names_on_install=False unzip
diffutils python3-pip genisoimage skopeo
Main config did not have a skip_missing_names_on_install attr. before
setopt
Main config did not have a skip_missing_names_on_install attr. before
setopt
CentOS Stream 8 - AppStream                      55 MB/s |  33 MB
00:00
CentOS Stream 8 - BaseOS                         23 MB/s |  41 MB
00:01
CentOS Stream 8 - Extras                         68 kB/s |  18 kB
00:00
CentOS Stream 8 - Extras common packages         71 kB/s | 6.8 kB
00:00
Docker CE Stable - x86_64                       766 kB/s |  49 kB
00:00
Package genisoimage-1.1.11-39.el8.x86_64 is already installed.
Error:
 Problem: cannot install the best candidate for the job
  - nothing provides platform-python-pip = 9.0.3-23.el8 needed by
    python3-pip-9.0.3-23.el8.noarch from appstream
(try to add '--skip-broken' to skip uninstallable packages or '--nobest'
to use not only best candidate packages)
```

which means we didn't install any of those dependencies (including ``unzip``) and went on for the other instructions.

This removes anywhere with the ``&&`` condition (as either way it's not needed, each line should pass to continue with the other ones) and also removes ``get_package_manager`` as we should only use ``dnf`` anywhere.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
