### PR TITLE
Add BMH annotation keys to docs

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -160,10 +160,17 @@ In case that the Bare Metal Operator is installed, the Baremetal Agent Controlle
 
 - Find the right pairs of BMH/Agent using their MAC addresses
 - Set the Image.URL in the BMH copying it from the InfraEnv's status.
-- Reconcile the Agent's spec by copying the following attributes from the BMH's annotations:
+- Reconcile the Agent's spec by copying the following fields from the BMH's annotations:
     - Role: master/worker
+      - `bmac.agent-install.openshift.io/role`
     - Hostname (optional for user to set)
+      - `bmac.agent-install.openshift.io/hostname`
     - MachineConfigPool (optional for user to set)
+      - `bmac.agent-install.openshift.io/machine-config-pool`
+    - InstallerArgs (optional for user to set)
+      - `bmac.agent-install.openshift.io/installer-args`
+    - IgnitionConfigOverrides (optional for user to set)
+      - `bmac.agent-install.openshift.io/ignition-config-overrides`
 - Reconcile the BareMetalHost hardware details by copying the Agent's inventory data to the BMH's `hardwaredetails` annotation.
 - Disable ironic inspection
 


### PR DESCRIPTION
Previously we said which fields could be set using annotations, but didn't document the annotation keys

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?