### PR TITLE
MGMT-15559: Change detached annotation condition in non-converged flow

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller_test.go
+++ b/internal/controller/controllers/bmh_agent_controller_test.go
@@ -1331,14 +1331,8 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations).To(HaveKey(BMH_DETACHED_ANNOTATION))
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("some-other-value"))
 			})
-			It("should set the detached annotation if agent is installed", func() {
-				agent.Status.Conditions = []conditionsv1.Condition{
-					{
-						Type:   v1beta1.InstalledCondition,
-						Status: corev1.ConditionTrue,
-						Reason: v1beta1.InstalledReason,
-					},
-				}
+			It("should set the detached annotation if agent started rebooting", func() {
+				agent.Status.Progress.CurrentStage = models.HostStageRebooting
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
 				for range [3]int{} {
@@ -1354,14 +1348,9 @@ var _ = Describe("bmac reconcile", func() {
 				Expect(updatedHost.ObjectMeta.Annotations[BMH_DETACHED_ANNOTATION]).To(Equal("assisted-service-controller"))
 			})
 
-			It("should set the detached annotation if agent is installation is progressing", func() {
-				agent.Status.Conditions = []conditionsv1.Condition{
-					{
-						Type:   v1beta1.InstalledCondition,
-						Status: corev1.ConditionFalse,
-						Reason: v1beta1.InstallationInProgressReason,
-					},
-				}
+			It("should set the detached annotation if agent has joined cluster", func() {
+				agent.Status.Progress.CurrentStage = models.HostStageJoined
+
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
 				for range [3]int{} {
@@ -1378,13 +1367,7 @@ var _ = Describe("bmac reconcile", func() {
 			})
 
 			It("should set the detached annotation if agent is installation has failed", func() {
-				agent.Status.Conditions = []conditionsv1.Condition{
-					{
-						Type:   v1beta1.InstalledCondition,
-						Status: corev1.ConditionFalse,
-						Reason: v1beta1.InstallationFailedReason,
-					},
-				}
+				agent.Status.Progress.CurrentStage = models.HostStageFailed
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
 				for range [3]int{} {
@@ -1436,13 +1419,7 @@ var _ = Describe("bmac reconcile", func() {
 
 		Context("when BMH is detached", func() {
 			It("should not change the URL when it changes in the InfraEnv", func() {
-				agent.Status.Conditions = []conditionsv1.Condition{
-					{
-						Type:   v1beta1.InstalledCondition,
-						Status: corev1.ConditionFalse,
-						Reason: v1beta1.InstallationFailedReason,
-					},
-				}
+				agent.Status.Progress.CurrentStage = models.HostStageFailed
 				Expect(c.Update(ctx, agent)).To(BeNil())
 
 				for range [3]int{} {


### PR DESCRIPTION
[MGMT-15559](https://issues.redhat.com/browse/MGMT-15559)
Day 2 workers create BMH and Machine CRs on the spoke cluster when the host starts installing. The non-converged flow initially added the detached annotation for the BMH when the host starts installing too. This causes the BMH to stop being reconciled so the BMH and Machine CRs aren't created in the spoke cluster.

This change adds the detached annotation when the host reaches rebooting, joined, or failed instead of installing so that it doesn't conflict with adding the BMH/Machine to the spoke cluster.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR
[MGMT-15639](https://issues.redhat.com/browse/MGMT-15639)

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @ori-amizur 