### PR TITLE
Revert "Fix DNS validation (#5371)"

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	baseDomainRegex          = `^[a-z\d][\-]*[a-z\d]+$`
-	dnsNameRegex             = `^([a-z\d]([\-]*[a-z\d]+)*\.)+[a-z\d]+[\-]*[a-z\d]+$`
+	baseDomainRegex          = "^([a-z0-9]+(-[a-z0-9]+)*)+$"
+	dnsNameRegex             = "^([a-z0-9]+(-[a-z0-9]+)*[.])+[a-z]{2,}$"
 	hostnameRegex            = `^[a-z0-9][a-z0-9\-\.]{0,61}[a-z0-9]$`
 	installerArgsValuesRegex = `^[A-Za-z0-9@!#$%*()_+-=//.,";':{}\[\]]+$`
 )

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -193,27 +193,7 @@ var _ = Describe("dns name", func() {
 			valid:      false,
 		},
 		{
-			domainName: "-",
-			valid:      false,
-		},
-		{
-			domainName: "a-",
-			valid:      false,
-		},
-		{
 			domainName: "co",
-			valid:      true,
-		},
-		{
-			domainName: "1c",
-			valid:      true,
-		},
-		{
-			domainName: "1-c",
-			valid:      true,
-		},
-		{
-			domainName: "1--c",
 			valid:      true,
 		},
 		{
@@ -234,10 +214,6 @@ var _ = Describe("dns name", func() {
 		},
 		{
 			domainName: "a-aa.com",
-			valid:      true,
-		},
-		{
-			domainName: "a--aa.com",
 			valid:      true,
 		},
 		{


### PR DESCRIPTION
This reverts commit d052c2cff55394be61e1219f230185ed10782f1b.

We discovered a few regressions in behavior that may or may not be critical to customers. At the time being we're reverting this code and releasing a patch version so we can concentrate on delivering 2.24. A future fix will be developed in parallel.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
