### PR TITLE
OCPBUGS-17992 day2 skip install config overrides

### DIFF
--- a/internal/controller/controllers/clusterdeployments_controller.go
+++ b/internal/controller/controllers/clusterdeployments_controller.go
@@ -1034,7 +1034,10 @@ func selectClusterNetworkType(params *models.V2ClusterUpdateParams, cluster *com
 
 func (r *ClusterDeploymentsReconciler) updateInstallConfigOverrides(ctx context.Context, log logrus.FieldLogger, clusterInstall *hiveext.AgentClusterInstall,
 	cluster *common.Cluster) error {
-	// handle InstallConfigOverrides
+	// not relevant for day2 cluster - install config is not used
+	if common.IsDay2Cluster(cluster) {
+		return nil
+	}
 	update := false
 	annotations := clusterInstall.ObjectMeta.GetAnnotations()
 	installConfigOverrides := annotations[InstallConfigOverrides]


### PR DESCRIPTION
opened a manual PR because the original one had tests with interfaces that didn't exist in this version https://github.com/openshift/assisted-service/pull/5464

Updating or setting install config is not relevant for day2 clusters because install config is not used in day2, the installer is not invoked in day2.

The issue that this change comes to resolve is when user is using backup restore on a multi node baremetal cluster that use install config overrides without specifying machine network that is calculated automatically from the hosts, it will mean that it will not be set in the spec and not going to be restored, in this case the controller will try to update the install config and get and error that machine network is not set for a baremetal cluster

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
