### PR TITLE
MGMT-15736: Align feature support level to support HighAvailabilityMode as filterable feature

### DIFF
--- a/client/installer/get_supported_features_parameters.go
+++ b/client/installer/get_supported_features_parameters.go
@@ -69,6 +69,12 @@ type GetSupportedFeaturesParams struct {
 	*/
 	CPUArchitecture *string
 
+	/* HighAvailabilityMode.
+
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	*/
+	HighAvailabilityMode *string
+
 	/* OpenshiftVersion.
 
 	   Version of the OpenShift cluster.
@@ -156,6 +162,17 @@ func (o *GetSupportedFeaturesParams) SetCPUArchitecture(cPUArchitecture *string)
 	o.CPUArchitecture = cPUArchitecture
 }
 
+// WithHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) WithHighAvailabilityMode(highAvailabilityMode *string) *GetSupportedFeaturesParams {
+	o.SetHighAvailabilityMode(highAvailabilityMode)
+	return o
+}
+
+// SetHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) SetHighAvailabilityMode(highAvailabilityMode *string) {
+	o.HighAvailabilityMode = highAvailabilityMode
+}
+
 // WithOpenshiftVersion adds the openshiftVersion to the get supported features params
 func (o *GetSupportedFeaturesParams) WithOpenshiftVersion(openshiftVersion string) *GetSupportedFeaturesParams {
 	o.SetOpenshiftVersion(openshiftVersion)
@@ -198,6 +215,23 @@ func (o *GetSupportedFeaturesParams) WriteToRequest(r runtime.ClientRequest, reg
 		if qCPUArchitecture != "" {
 
 			if err := r.SetQueryParam("cpu_architecture", qCPUArchitecture); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.HighAvailabilityMode != nil {
+
+		// query param high_availability_mode
+		var qrHighAvailabilityMode string
+
+		if o.HighAvailabilityMode != nil {
+			qrHighAvailabilityMode = *o.HighAvailabilityMode
+		}
+		qHighAvailabilityMode := qrHighAvailabilityMode
+		if qHighAvailabilityMode != "" {
+
+			if err := r.SetQueryParam("high_availability_mode", qHighAvailabilityMode); err != nil {
 				return err
 			}
 		}

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1569,7 +1569,7 @@ func (b *bareMetalInventory) GetClusterSupportedPlatformsInternal(
 	var supportedPlatforms []models.PlatformType
 	for _, platformType := range hostsSupportedPlatforms {
 		featureId := provider.GetPlatformFeatureID(platformType)
-		if featureId == "" || featuresupport.IsFeatureAvailable(featureId, cluster.OpenshiftVersion, &cluster.CPUArchitecture) {
+		if featureId == "" || featuresupport.IsFeatureAvailable(featureId, cluster.OpenshiftVersion, &cluster.CPUArchitecture, cluster.HighAvailabilityMode) {
 			supportedPlatforms = append(supportedPlatforms, platformType)
 		} else {
 			b.log.Debugf("The platform %s was removed from cluster %s supported-platforms because it is not compatible with "+
@@ -1590,7 +1590,13 @@ func (b *bareMetalInventory) GetClusterSupportedPlatforms(ctx context.Context, p
 }
 
 func (bm *bareMetalInventory) GetFeatureSupportLevelListInternal(_ context.Context, params installer.GetSupportedFeaturesParams) (models.SupportLevels, error) {
-	return featuresupport.GetFeatureSupportList(params.OpenshiftVersion, params.CPUArchitecture, (*models.PlatformType)(params.PlatformType)), nil
+	supportLevelFilters := featuresupport.SupportLevelFilters{
+		OpenshiftVersion:     params.OpenshiftVersion,
+		CPUArchitecture:      params.CPUArchitecture,
+		PlatformType:         (*models.PlatformType)(params.PlatformType),
+		HighAvailabilityMode: params.HighAvailabilityMode,
+	}
+	return featuresupport.GetFeatureSupportList(supportLevelFilters), nil
 }
 
 func (bm *bareMetalInventory) GetArchitecturesSupportLevelListInternal(_ context.Context, params installer.GetSupportedArchitecturesParams) (models.SupportLevels, error) {
@@ -1724,7 +1730,7 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 	}
 
 	installerReleaseImageOverride := ""
-	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster.CPUArchitecture, cluster.OpenshiftVersion, cluster.Platform.Type) {
+	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster) {
 		defaultArchImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, common.DefaultCPUArchitecture, cluster.PullSecret)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get image for installer image override "+
@@ -2596,7 +2602,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.V2UpdateCluste
 	if params.ClusterUpdateParams.UserManagedNetworking != nil && swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) != userManagedNetworking {
 		if !swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) &&
 			(cluster.CPUArchitecture != common.DefaultCPUArchitecture &&
-				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture))) {
+				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode)) {
 			err = errors.Errorf("disabling User Managed Networking is not allowed for clusters with non-x86_64 CPU architecture")
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
@@ -6455,10 +6461,11 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 // This flow does not affect the multiarch release images and is meant purely for using arm64 release image with the x86 hub.
 // Implementation of handling the multiarch images is done directly in the `oc` binary and relies on the fact that `oc adm release extract`
 // will automatically use the image matching the Hub's architecture.
-func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version string, platform *models.PlatformType) bool {
-	return cpuArchitecture != common.MultiCPUArchitecture &&
-		cpuArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
-		featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, version, swag.String(models.ClusterCPUArchitectureArm64))
+func isBaremetalBinaryFromAnotherReleaseImageRequired(cluster common.Cluster) bool {
+	return cluster.CPUArchitecture != common.MultiCPUArchitecture &&
+		cluster.CPUArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
+		featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion,
+			swag.String(models.ClusterCPUArchitectureArm64), cluster.HighAvailabilityMode)
 }
 
 // updateMonitoredOperators checks the content of the installer configuration and updates the list

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -448,7 +448,7 @@ func ValidateClusterCreateIPAddresses(ipV6Supported bool, clusterId strfmt.UUID,
 	}
 
 	if (len(params.APIVips) > 1 || len(params.IngressVips) > 1) &&
-		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, swag.StringValue(params.OpenshiftVersion), swag.String(params.CPUArchitecture)) {
+		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, swag.StringValue(params.OpenshiftVersion), swag.String(params.CPUArchitecture), params.HighAvailabilityMode) {
 
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s %s", "dual-stack VIPs are not supported in OpenShift", *params.OpenshiftVersion))
 	}
@@ -528,7 +528,7 @@ func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Clust
 	}
 
 	if (len(params.APIVips) > 1 || len(params.IngressVips) > 1) &&
-		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s %s", "dual-stack VIPs are not supported in OpenShift", cluster.OpenshiftVersion))
 	}

--- a/internal/featuresupport/architecture_support_level.go
+++ b/internal/featuresupport/architecture_support_level.go
@@ -30,25 +30,16 @@ func getArchitectureSupportList(features map[models.ArchitectureSupportLevelID]S
 	return featureSupportList
 }
 
-// Handle cases where a CPU architecture is not supported at for a given openshift version, in that case
-// return a list of unsupported features
-func overrideInvalidRequest(features map[models.FeatureSupportLevelID]SupportLevelFeature, cpuArchitecture, openshiftVersion string) models.SupportLevels {
-	supportLevels := models.SupportLevels{}
-	cpuArchID := cpuArchitectureFeatureIdMap[cpuArchitecture]
-	if !isArchitectureSupported(cpuArchID, openshiftVersion) {
-		for _, feature := range features {
-			supportLevels[string(feature.getId())] = models.SupportLevelUnavailable
-		}
-		return supportLevels
-	}
-	return nil
-}
-
 func GetCpuArchitectureSupportList(openshiftVersion string) models.SupportLevels {
 	return getArchitectureSupportList(cpuFeaturesList, openshiftVersion)
 }
 
-func isArchitectureSupported(featureId models.ArchitectureSupportLevelID, openshiftVersion string) bool {
-	supportLevel := GetSupportLevel(featureId, openshiftVersion)
+func isArchitectureSupported(filters SupportLevelFilters) bool {
+	if filters.CPUArchitecture == nil {
+		return true
+	}
+
+	featureId := cpuArchitectureFeatureIdMap[*filters.CPUArchitecture]
+	supportLevel := GetSupportLevel(featureId, filters.OpenshiftVersion)
 	return supportLevel != models.SupportLevelUnsupported && supportLevel != models.SupportLevelUnavailable
 }

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -40,50 +40,104 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		}
 	})
 
+	Context("isValidRequest", func() {
+		It("is baremetal platform supported with SNO", func() {
+			platformType := models.PlatformTypeBaremetal
+			filters := SupportLevelFilters{
+				OpenshiftVersion:     "4.14",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+				PlatformType:         &platformType,
+				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+			}
+			Expect(isPlatformSupported(filters)).To(Equal(false))
+		})
+		It("is vsphere platform supported with SNO", func() {
+			platformType := models.PlatformTypeVsphere
+			filters := SupportLevelFilters{
+				OpenshiftVersion:     "4.14",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+				PlatformType:         &platformType,
+				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+			}
+			Expect(isPlatformSupported(filters)).To(Equal(false))
+		})
+		It("is nutanix platform supported with SNO", func() {
+			platformType := models.PlatformTypeNutanix
+			filters := SupportLevelFilters{
+				OpenshiftVersion:     "4.14",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+				PlatformType:         &platformType,
+				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+			}
+			Expect(isPlatformSupported(filters)).To(Equal(false))
+		})
+		It("is vsphere platform supported with P arch", func() {
+			platformType := models.PlatformTypeVsphere
+			filters := SupportLevelFilters{
+				OpenshiftVersion: "4.14",
+				CPUArchitecture:  swag.String(models.ClusterCPUArchitecturePpc64le),
+				PlatformType:     &platformType,
+			}
+			Expect(isPlatformSupported(filters)).To(Equal(false))
+
+			filters.CPUArchitecture = swag.String(models.ClusterCPUArchitectureArm64)
+			Expect(isPlatformSupported(filters)).To(Equal(true))
+		})
+		It("is oci platform supported OCP version 4.13", func() {
+			platformType := models.PlatformTypeOci
+			filters := SupportLevelFilters{
+				OpenshiftVersion: "4.13",
+				PlatformType:     &platformType,
+			}
+			Expect(isPlatformSupported(filters)).To(Equal(false))
+		})
+
+	})
+
 	It("Test ARM64 is not supported under 4.10", func() {
-		feature := models.ArchitectureSupportLevelIDARM64ARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.7")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.8")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.9")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.10")).To(Equal(true))
-		Expect(isArchitectureSupported(feature, "4.11")).To(Equal(true))
-		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(true))
-		Expect(isArchitectureSupported(feature, "4.13")).To(Equal(true))
+		cpuArch := models.ClusterCPUArchitectureArm64
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.6", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.7", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.8", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.9", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.10", CPUArchitecture: &cpuArch})).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.11", CPUArchitecture: &cpuArch})).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.12", CPUArchitecture: &cpuArch})).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.13", CPUArchitecture: &cpuArch})).To(Equal(true))
 
 		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.30", CPUArchitecture: &cpuArch})).To(Equal(true))
 	})
 
 	It("Test s390x is not supported under 4.12", func() {
-		feature := models.ArchitectureSupportLevelIDS390XARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.7")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.8")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.9")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.10")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.11")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(true))
-		Expect(isArchitectureSupported(feature, "4.13")).To(Equal(true))
+		cpuArch := models.ClusterCPUArchitectureS390x
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.6", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.7", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.8", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.9", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.10", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.11", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.12", CPUArchitecture: &cpuArch})).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.13", CPUArchitecture: &cpuArch})).To(Equal(true))
 
 		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.30", CPUArchitecture: &cpuArch})).To(Equal(true))
 
 	})
 
 	It("Test PPC64LE is not supported under 4.12", func() {
-		feature := models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.7")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.8")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.9")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.10")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.11")).To(Equal(false))
-		Expect(isArchitectureSupported(feature, "4.12")).To(Equal(true))
-		Expect(isArchitectureSupported(feature, "4.13")).To(Equal(true))
+		cpuArch := models.ClusterCPUArchitecturePpc64le
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.6", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.7", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.8", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.9", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.10", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.11", CPUArchitecture: &cpuArch})).To(Equal(false))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.12", CPUArchitecture: &cpuArch})).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.13", CPUArchitecture: &cpuArch})).To(Equal(true))
 
 		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(Equal(true))
+		Expect(isArchitectureSupported(SupportLevelFilters{OpenshiftVersion: "4.30", CPUArchitecture: &cpuArch})).To(Equal(true))
 	})
 
 	Context("Test LVM/Nutanix are not supported under 4.11", func() {
@@ -92,22 +146,22 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			feature := f
 			It(fmt.Sprintf("%s test", feature), func() {
 				arch := "DoesNotMatter"
-				Expect(IsFeatureAvailable(feature, "4.6", swag.String(arch))).To(Equal(false))
-				Expect(IsFeatureAvailable(feature, "4.7", swag.String(arch))).To(Equal(false))
-				Expect(IsFeatureAvailable(feature, "4.8", swag.String(arch))).To(Equal(false))
-				Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch))).To(Equal(false))
-				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(Equal(true))
+				Expect(IsFeatureAvailable(feature, "4.6", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
+				Expect(IsFeatureAvailable(feature, "4.7", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
+				Expect(IsFeatureAvailable(feature, "4.8", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
+				Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
+				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 
 				featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.11", CPUArchitecture: swag.String(arch)}
 				Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelDevPreview))
 				featureSupportParams = SupportLevelFilters{OpenshiftVersion: "4.11.20", CPUArchitecture: swag.String(arch)}
 				Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelDevPreview))
 
-				Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch))).To(Equal(true))
-				Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch))).To(Equal(true))
+				Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+				Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 
 				// Check for feature release
-				Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch))).To(Equal(true))
+				Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 			})
 		}
 	})
@@ -115,10 +169,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	Context("Test LSO CPU compatibility", func() {
 		feature := models.FeatureSupportLevelIDLSO
 		It("LSO IsFeatureAvailable", func() {
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitecturePpc64le))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureX8664))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureS390x))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureArm64))).To(Equal(false))
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitecturePpc64le), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureX8664), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureS390x), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureArm64), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
 		})
 		It("LSO GetSupportLevel on architecture", func() {
 			featureSupportParams := SupportLevelFilters{OpenshiftVersion: "Any", CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664)}
@@ -139,20 +193,20 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		feature := models.FeatureSupportLevelIDMCE
 		It(fmt.Sprintf("%s test", feature), func() {
 			arch := "DoesNotMatter"
-			Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch))).To(Equal(false))
-			Expect(IsFeatureAvailable(feature, "4.10", swag.String(arch))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(false))
+			Expect(IsFeatureAvailable(feature, "4.10", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 
 			featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.9", CPUArchitecture: swag.String(arch)}
 			Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelUnavailable))
 			featureSupportParams = SupportLevelFilters{OpenshiftVersion: "4.11.20", CPUArchitecture: swag.String(arch)}
 			Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelSupported))
 
-			Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 
 			// Check for feature release
-			Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch), swag.String(models.ClusterHighAvailabilityModeFull))).To(Equal(true))
 		})
 	})
 
@@ -186,7 +240,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	})
 
 	Context("GetSupportList", func() {
-		It("GetFeatureSupportList 4.12 with Platform", func() {
+		It("GetFeatureSupportList 4.14 with Platform", func() {
 			platforms := []models.PlatformType{
 				models.PlatformTypeNutanix,
 				models.PlatformTypeVsphere,
@@ -196,18 +250,58 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			}
 			for _, platform := range platforms {
 				p := platform
-				list := GetFeatureSupportList("dummy", nil, &p)
+				list := GetFeatureSupportList(SupportLevelFilters{
+					OpenshiftVersion:     "4.14",
+					CPUArchitecture:      nil,
+					PlatformType:         &p,
+					HighAvailabilityMode: nil,
+				})
 				Expect(len(list)).To(Equal(16))
+			}
+		})
+		It("GetFeatureSupportList 4.12 with HighAvailabilityMode", func() {
+			list := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.12",
+				CPUArchitecture:      nil,
+				PlatformType:         nil,
+				HighAvailabilityMode: swag.String("does_not_matter_what_is_the_value"),
+			})
+			Expect(len(list)).To(Equal(19))
+		})
+		It("overrideInvalidRequest 4.12 vsphere with HighAvailabilityMode None", func() {
+			platform := models.PlatformTypeVsphere
+			list := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.10",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+				PlatformType:         &platform,
+				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+			})
+			for featureId, supportLevel := range list {
+				sl := supportLevel
+				By(fmt.Sprintf("Feature %s", featureId), func() {
+					// All features in that case should be unavailable
+					Expect(sl).To(Equal(models.SupportLevelUnavailable))
+				})
 			}
 		})
 
 		It("GetFeatureSupportList 4.12", func() {
-			list := GetFeatureSupportList("4.12", nil, nil)
+			list := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.12",
+				CPUArchitecture:      nil,
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
 			Expect(len(list)).To(Equal(20))
 		})
 
 		It("GetFeatureSupportList 4.13", func() {
-			list := GetFeatureSupportList("4.13", nil, nil)
+			list := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.13",
+				CPUArchitecture:      nil,
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
 			Expect(len(list)).To(Equal(20))
 		})
 
@@ -222,7 +316,12 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 
 		It("GetFeatureSupportList 4.11 with not supported architecture", func() {
-			featuresList := GetFeatureSupportList("4.11", swag.String(models.ClusterCPUArchitecturePpc64le), nil)
+			featuresList := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.11",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitecturePpc64le),
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
 
 			for _, supportLevel := range featuresList {
 				Expect(supportLevel).To(Equal(models.SupportLevelUnavailable))
@@ -230,15 +329,31 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
-			featuresList := GetFeatureSupportList("4.12", swag.String(models.ClusterCPUArchitecturePpc64le), nil)
+			featuresList := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.12",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitecturePpc64le),
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
+
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelUnavailable))
 
-			featuresList = GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitecturePpc64le), nil)
+			featuresList = GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.13",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitecturePpc64le),
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelDevPreview))
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
-			featuresList := GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitectureX8664), nil)
+			featuresList := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.13",
+				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+				PlatformType:         nil,
+				HighAvailabilityMode: nil,
+			})
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelSupported))
 		})
 	})
@@ -489,7 +604,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect((&MinimalIso{}).getFeatureActiveLevel(&cluster, &infraEnv, nil, nil)).To(Equal(activeLevelActive))
 
 				filters := SupportLevelFilters{OpenshiftVersion: "4.12", CPUArchitecture: &cpuArchitecture}
-				Expect((&MinimalIso{}).getSupportLevel(filters)).To(Equal(models.SupportLevelSupported))
+				Expect((&MinimalIso{}).getSupportLevel(filters, true)).To(Equal(models.SupportLevelSupported))
 			})
 			It("Empty support level - platforms", func() {
 				for _, platform := range []models.PlatformType{models.PlatformTypeOci, models.PlatformTypeVsphere, models.PlatformTypeNutanix, models.PlatformTypeBaremetal, models.PlatformTypeNone} {
@@ -501,10 +616,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 
 						By(fmt.Sprintf("Feature %s", f.GetName()), func() {
 							filters := SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: nil}
-							Expect(string(f.getSupportLevel(filters))).To(Not(Equal("")))
+							Expect(string(f.getSupportLevel(filters, true))).To(Not(Equal("ignore")))
 
 							filters = SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: &p}
-							Expect(string(f.getSupportLevel(filters))).To(Equal(""))
+							Expect(string(f.getSupportLevel(filters, true))).To(Equal("ignore"))
 						})
 					}
 				}
@@ -514,10 +629,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 					p := platform
 					feature := &PlatformManagedNetworkingFeature{}
 					filters := SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: nil}
-					Expect(string(feature.getSupportLevel(filters))).To(Equal(""))
+					Expect(string(feature.getSupportLevel(filters, true))).To(Equal("ignore"))
 
 					filters = SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: &p}
-					Expect(string(feature.getSupportLevel(filters))).To(Not(Equal("")))
+					Expect(string(feature.getSupportLevel(filters, true))).To(Not(Equal("ignore")))
 				}
 			})
 
@@ -531,7 +646,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect((&MinimalIso{}).getFeatureActiveLevel(&cluster, &infraEnv, nil, nil)).To(Equal(activeLevelActive))
 
 				filters := SupportLevelFilters{OpenshiftVersion: "4.12", CPUArchitecture: &cpuArchitecture}
-				Expect((&MinimalIso{}).getSupportLevel(filters)).To(Equal(models.SupportLevelUnavailable))
+				Expect((&MinimalIso{}).getSupportLevel(filters, true)).To(Equal(models.SupportLevelUnavailable))
 			})
 
 			It("s390x not supporting minimal-iso without cluster", func() {
@@ -541,7 +656,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect((&MinimalIso{}).getFeatureActiveLevel(nil, &infraEnv, nil, nil)).To(Equal(activeLevelActive))
 
 				filters := SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: &cpuArchitecture}
-				Expect((&MinimalIso{}).getSupportLevel(filters)).To(Equal(models.SupportLevelUnavailable))
+				Expect((&MinimalIso{}).getSupportLevel(filters, true)).To(Equal(models.SupportLevelUnavailable))
 			})
 
 			It("Disable olm operator activated features in cluster", func() {
@@ -575,7 +690,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				openshiftVersion := "4.13"
 				cpuArchitecture := models.ClusterCPUArchitectureS390x
 				filters := SupportLevelFilters{OpenshiftVersion: openshiftVersion, CPUArchitecture: &cpuArchitecture}
-				supportLevel := featureA.getSupportLevel(filters)
+				supportLevel := featureA.getSupportLevel(filters, true)
 				equalSupportLevel := GetSupportLevel(featureA.getId(), filters)
 				Expect(supportLevel).To(Equal(equalSupportLevel))
 			})

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -22,8 +22,12 @@ func (feature *VipAutoAllocFeature) GetName() string {
 	return "VIP Automatic Allocation"
 }
 
-func (feature *VipAutoAllocFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *VipAutoAllocFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if filters.PlatformType != nil && *filters.PlatformType == models.PlatformTypeOci {
+		return models.SupportLevelUnavailable
+	}
+
+	if swag.StringValue(filters.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
 		return models.SupportLevelUnavailable
 	}
 
@@ -75,7 +79,7 @@ func (feature *ClusterManagedNetworkingFeature) GetName() string {
 	return "Cluster Managed Networking"
 }
 
-func (feature *ClusterManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *ClusterManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -84,6 +88,10 @@ func (feature *ClusterManagedNetworkingFeature) getSupportLevel(filters SupportL
 		if isNotAvailable || err != nil {
 			return models.SupportLevelUnavailable
 		}
+	}
+
+	if swag.StringValue(filters.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
+		return models.SupportLevelUnavailable
 	}
 
 	if filters.PlatformType != nil && *filters.PlatformType == models.PlatformTypeOci {
@@ -145,7 +153,7 @@ func (feature *DualStackFeature) GetName() string {
 	return "Dual-Stack"
 }
 
-func (feature *DualStackFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *DualStackFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -195,7 +203,7 @@ func (feature *DualStackVipsFeature) GetName() string {
 	return "Dual-Stack VIPs"
 }
 
-func (feature *DualStackVipsFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *DualStackVipsFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -247,7 +255,7 @@ func (feature *UserManagedNetworkingFeature) GetName() string {
 	return "User Managed Networking"
 }
 
-func (feature *UserManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *UserManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if filters.PlatformType != nil && *filters.PlatformType == models.PlatformTypeNutanix {
 		return models.SupportLevelUnavailable
 	}
@@ -306,10 +314,10 @@ func (feature *PlatformManagedNetworkingFeature) GetName() string {
 	return "Platform managed networking"
 }
 
-func (feature *PlatformManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *PlatformManagedNetworkingFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	// PlatformManagedNetworking is not relevant without platform type - in this case remove disable this feature support-level
-	if !isPlatformSet(filters) {
-		return ""
+	if removeCollidingFeatures && !isPlatformSet(filters) {
+		return supportLevelIgnored
 	}
 
 	if filters.PlatformType != nil && (*filters.PlatformType == models.PlatformTypeOci || *filters.PlatformType == models.PlatformTypeNone) {

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -52,7 +52,7 @@ func (feature *LvmFeature) GetName() string {
 	return "Logical Volume Management"
 }
 
-func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -111,8 +111,12 @@ func (feature *OdfFeature) GetName() string {
 	return "OpenShift Data Foundation"
 }
 
-func (feature *OdfFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *OdfFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
+		return models.SupportLevelUnavailable
+	}
+
+	if swag.StringValue(filters.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
 		return models.SupportLevelUnavailable
 	}
 
@@ -154,7 +158,7 @@ func (feature *CnvFeature) GetName() string {
 	return "OpenShift Virtualization"
 }
 
-func (feature *CnvFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *CnvFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -196,7 +200,7 @@ func (feature *LsoFeature) GetName() string {
 	return "Local Storage Operator"
 }
 
-func (feature *LsoFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *LsoFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
@@ -236,7 +240,7 @@ func (feature *MceFeature) GetName() string {
 	return "multicluster engine"
 }
 
-func (feature *MceFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
+func (feature *MceFeature) getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}

--- a/internal/featuresupport/support_level_feature.go
+++ b/internal/featuresupport/support_level_feature.go
@@ -10,10 +10,10 @@ type SupportLevelFeature interface {
 	New() SupportLevelFeature
 	// getId - Get SupportLevelFeature unique ID
 	getId() models.FeatureSupportLevelID
-	// GetName - Get SupportLevelFeature user friendly name
+	// GetName - Get SupportLevelFeature user-friendly name
 	GetName() string
 	// getSupportLevel - Get feature support-level value, filtered by given filters (e.g. OpenshiftVersion, CpuArchitecture)
-	getSupportLevel(filters SupportLevelFilters) models.SupportLevel
+	getSupportLevel(filters SupportLevelFilters, removeCollidingFeatures bool) models.SupportLevel
 	// getIncompatibleFeatures - Get a list of features that cannot exist alongside this feature
 	getIncompatibleFeatures(openshiftVersion string) *[]models.FeatureSupportLevelID
 	// getIncompatibleArchitectures - Get a list of architectures which the given feature will not work on
@@ -23,9 +23,10 @@ type SupportLevelFeature interface {
 }
 
 type SupportLevelFilters struct {
-	OpenshiftVersion string
-	CPUArchitecture  *string
-	PlatformType     *models.PlatformType
+	OpenshiftVersion     string
+	CPUArchitecture      *string
+	PlatformType         *models.PlatformType
+	HighAvailabilityMode *string
 }
 
 type featureActiveLevel string

--- a/internal/provider/baremetal/installConfig.go
+++ b/internal/provider/baremetal/installConfig.go
@@ -90,7 +90,7 @@ func (p baremetalProvider) AddPlatformToInstallConfig(
 	}
 	p.Log.Infof("setting Baremetal.ProvisioningNetwork to %s", provNetwork)
 
-	if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+	if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 		cfg.Platform = installcfg.Platform{
 			Baremetal: &installcfg.BareMetalInstallConfigPlatform{
 				ProvisioningNetwork: provNetwork,

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -156,7 +156,7 @@ func getUpdateParamsForPlatformUMNMandatory(platform *models.Platform, userManag
 	if !swag.BoolValue(userManagedNetworking) {
 		if platform == nil || isPlatformBM(platform) {
 			if cluster.CPUArchitecture != common.X86CPUArchitecture &&
-				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 				return nil, nil, common.NewApiError(http.StatusBadRequest, errors.New("disabling User Managed Networking or setting Bare-Metal platform is not allowed for clusters with non-x86_64 CPU architecture"))
 			}
 

--- a/internal/provider/nutanix/installConfig.go
+++ b/internal/provider/nutanix/installConfig.go
@@ -50,7 +50,7 @@ func (p nutanixProvider) AddPlatformToInstallConfig(
 			return errors.New("invalid cluster parameters, IngressVip must be provided")
 		}
 
-		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 			nPlatform.APIVIPs = network.GetApiVips(cluster)
 			nPlatform.IngressVIPs = network.GetIngressVips(cluster)
 		} else {

--- a/internal/provider/vsphere/installConfig.go
+++ b/internal/provider/vsphere/installConfig.go
@@ -64,7 +64,7 @@ func (p vsphereProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerCon
 			return errors.New("invalid cluster parameters, IngressVip must be provided")
 		}
 
-		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 			vsPlatform.APIVIPs = network.GetApiVips(cluster)
 			vsPlatform.IngressVIPs = network.GetIngressVips(cluster)
 		} else {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5650,6 +5650,16 @@ func init() {
             "description": "The provider platform type.",
             "name": "platform_type",
             "in": "query"
+          },
+          {
+            "enum": [
+              "Full",
+              "None"
+            ],
+            "type": "string",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "name": "high_availability_mode",
+            "in": "query"
           }
         ],
         "responses": {
@@ -15899,6 +15909,16 @@ func init() {
             "type": "string",
             "description": "The provider platform type.",
             "name": "platform_type",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "Full",
+              "None"
+            ],
+            "type": "string",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "name": "high_availability_mode",
             "in": "query"
           }
         ],

--- a/restapi/operations/installer/get_supported_features_parameters.go
+++ b/restapi/operations/installer/get_supported_features_parameters.go
@@ -44,6 +44,10 @@ type GetSupportedFeaturesParams struct {
 	  Default: "x86_64"
 	*/
 	CPUArchitecture *string
+	/*Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	  In: query
+	*/
+	HighAvailabilityMode *string
 	/*Version of the OpenShift cluster.
 	  Required: true
 	  In: query
@@ -68,6 +72,11 @@ func (o *GetSupportedFeaturesParams) BindRequest(r *http.Request, route *middlew
 
 	qCPUArchitecture, qhkCPUArchitecture, _ := qs.GetOK("cpu_architecture")
 	if err := o.bindCPUArchitecture(qCPUArchitecture, qhkCPUArchitecture, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qHighAvailabilityMode, qhkHighAvailabilityMode, _ := qs.GetOK("high_availability_mode")
+	if err := o.bindHighAvailabilityMode(qHighAvailabilityMode, qhkHighAvailabilityMode, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -113,6 +122,38 @@ func (o *GetSupportedFeaturesParams) bindCPUArchitecture(rawData []string, hasKe
 func (o *GetSupportedFeaturesParams) validateCPUArchitecture(formats strfmt.Registry) error {
 
 	if err := validate.EnumCase("cpu_architecture", "query", *o.CPUArchitecture, []interface{}{"x86_64", "aarch64", "arm64", "ppc64le", "s390x", "multi"}, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// bindHighAvailabilityMode binds and validates parameter HighAvailabilityMode from query.
+func (o *GetSupportedFeaturesParams) bindHighAvailabilityMode(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.HighAvailabilityMode = &raw
+
+	if err := o.validateHighAvailabilityMode(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateHighAvailabilityMode carries on validations for parameter HighAvailabilityMode
+func (o *GetSupportedFeaturesParams) validateHighAvailabilityMode(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("high_availability_mode", "query", *o.HighAvailabilityMode, []interface{}{"Full", "None"}, true); err != nil {
 		return err
 	}
 

--- a/restapi/operations/installer/get_supported_features_urlbuilder.go
+++ b/restapi/operations/installer/get_supported_features_urlbuilder.go
@@ -13,9 +13,10 @@ import (
 
 // GetSupportedFeaturesURL generates an URL for the get supported features operation
 type GetSupportedFeaturesURL struct {
-	CPUArchitecture  *string
-	OpenshiftVersion string
-	PlatformType     *string
+	CPUArchitecture      *string
+	HighAvailabilityMode *string
+	OpenshiftVersion     string
+	PlatformType         *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -57,6 +58,14 @@ func (o *GetSupportedFeaturesURL) Build() (*url.URL, error) {
 	}
 	if cPUArchitectureQ != "" {
 		qs.Set("cpu_architecture", cPUArchitectureQ)
+	}
+
+	var highAvailabilityModeQ string
+	if o.HighAvailabilityMode != nil {
+		highAvailabilityModeQ = *o.HighAvailabilityMode
+	}
+	if highAvailabilityModeQ != "" {
+		qs.Set("high_availability_mode", highAvailabilityModeQ)
 	}
 
 	openshiftVersionQ := o.OpenshiftVersion

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3585,6 +3585,11 @@ paths:
           description: The provider platform type.
           type: string
           enum: [ 'baremetal', 'none', 'nutanix', 'vsphere', 'oci' ]
+        - in: query
+          name: high_availability_mode
+          type: string
+          enum: [ 'Full', 'None' ]
+          description: Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
       responses:
         "200":
           description: Success.

--- a/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
@@ -69,6 +69,12 @@ type GetSupportedFeaturesParams struct {
 	*/
 	CPUArchitecture *string
 
+	/* HighAvailabilityMode.
+
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	*/
+	HighAvailabilityMode *string
+
 	/* OpenshiftVersion.
 
 	   Version of the OpenShift cluster.
@@ -156,6 +162,17 @@ func (o *GetSupportedFeaturesParams) SetCPUArchitecture(cPUArchitecture *string)
 	o.CPUArchitecture = cPUArchitecture
 }
 
+// WithHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) WithHighAvailabilityMode(highAvailabilityMode *string) *GetSupportedFeaturesParams {
+	o.SetHighAvailabilityMode(highAvailabilityMode)
+	return o
+}
+
+// SetHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) SetHighAvailabilityMode(highAvailabilityMode *string) {
+	o.HighAvailabilityMode = highAvailabilityMode
+}
+
 // WithOpenshiftVersion adds the openshiftVersion to the get supported features params
 func (o *GetSupportedFeaturesParams) WithOpenshiftVersion(openshiftVersion string) *GetSupportedFeaturesParams {
 	o.SetOpenshiftVersion(openshiftVersion)
@@ -198,6 +215,23 @@ func (o *GetSupportedFeaturesParams) WriteToRequest(r runtime.ClientRequest, reg
 		if qCPUArchitecture != "" {
 
 			if err := r.SetQueryParam("cpu_architecture", qCPUArchitecture); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.HighAvailabilityMode != nil {
+
+		// query param high_availability_mode
+		var qrHighAvailabilityMode string
+
+		if o.HighAvailabilityMode != nil {
+			qrHighAvailabilityMode = *o.HighAvailabilityMode
+		}
+		qHighAvailabilityMode := qrHighAvailabilityMode
+		if qHighAvailabilityMode != "" {
+
+			if err := r.SetQueryParam("high_availability_mode", qHighAvailabilityMode); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Add parameter to `api/assisted-install/v2/support-levels/features` API so that the features could be filtered also by `high_availability_mod`, e.g.
```
api/assisted-install/v2/support-levels/features?openshift_version=4.10&cpu_architecture=x86_64?high_availability_mode=Full
```
## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

/cc @eliorerz 
