### PR TITLE
MGMT-15738: Support for E2E test, make sure we have an infraenv for adding a node to the local cluster.

### DIFF
--- a/deploy/operator/utils.sh
+++ b/deploy/operator/utils.sh
@@ -9,6 +9,22 @@ function wait_for_crd() {
     wait_for_condition "crd/${crd}" "Established" "60s" "${namespace}"
 }
 
+function remote_agents() {
+	namespace="$1"
+	hostnames="$2"
+	oc get agent -n ${namespace} --no-headers -l "agent-install.openshift.io/bmh in ( ${hostnames} )"
+}
+
+export -f remote_agents
+
+function installed_remote_agents() {
+        namespace="$1"
+        hostnames="$2"
+        remote_agents ${namespace} ${hostnames} | grep Done
+}
+
+export -f installed_remote_agents
+
 function wait_for_operator() {
     subscription="$1"
     namespace="${2:-}"

--- a/deploy/operator/ztp/add-worker-nodes-to-local-cluster-playbook.yaml
+++ b/deploy/operator/ztp/add-worker-nodes-to-local-cluster-playbook.yaml
@@ -1,0 +1,39 @@
+- name: Add worker nodes to a local cluster
+  hosts: localhost
+  collections:
+   - community.general
+  gather_facts: no
+  vars:
+    - baremetalhosts: "{{ lookup('file', lookup('env', 'REMOTE_BAREMETALHOSTS_FILE')) | from_json }}"
+    - infraenv_name: "{{ lookup('env', 'LOCAL_CLUSTER_NAMESPACE', default='') }}-day2-infraenv"
+    # Note: We are reusing the variable name `spoke_namespace` as it is broadly used in templates
+    # however, we are setting this to the local-cluster namespace instead
+    - spoke_namespace: "{{ lookup('env', 'LOCAL_CLUSTER_NAMESPACE', default='') }}"
+    - cluster_deployment_name: "{{ lookup('env', 'LOCAL_CLUSTER_NAMESPACE', default='') }}-cluster-deployment"
+    - pull_secret_name: "pull-secret"
+    - ssh_public_key: "{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+    - day2: "true"
+    - baremetalhosts_ignition_override: "{{ lookup('env', 'BAREMETALHOSTS_IGNITION_OVERRIDE', default='') }}"
+    - machine_config_pools: "{{ lookup('env', 'MACHINE_CONFIG_POOLS') }}"
+    - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
+    - infraenv_label: "{{ lookup('env', 'LOCAL_CLUSTER_INFRAENV_LABEL', default='local-cluster') }}"
+
+  tasks:
+  - name: generate-crs-and-apply
+    block:
+    - name: create directory for generated CRs
+      file:
+        name: local-cluster-generated
+        state: directory
+    - name: write local-cluster day2 infraenv
+      template:
+        src: "infraEnv.j2"
+        dest: "local-cluster-generated/infraEnv-local-cluster.yaml"
+    - name: apply infraenv with oc
+      ansible.builtin.command: "oc apply -f local-cluster-generated/infraEnv-local-cluster.yaml"
+    - name: write the remote baremetalHost crds
+      template:
+        src: "baremetalHost.j2"
+        dest: "local-cluster-generated/remote-baremetal-host.yaml"
+    - name: apply local cluster manifests
+      ansible.builtin.command: "oc apply -f local-cluster-generated/remote-baremetal-host.yaml"

--- a/deploy/operator/ztp/add_day2_local_cluster_nodes.sh
+++ b/deploy/operator/ztp/add_day2_local_cluster_nodes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -x
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${__dir}/../common.sh"
+source "${__dir}/../utils.sh"
+
+export REMOTE_BAREMETALHOSTS_FILE="${REMOTE_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/remote_baremetalhosts.json}"
+export LOCAL_CLUSTER_NAMESPACE="${LOCAL_CLUSTER_NAMESPACE:-local-agent-cluster}"
+
+echo "Adding day2 local cluster nodes"
+ansible-playbook "${__dir}/add-worker-nodes-to-local-cluster-playbook.yaml"
+
+comma_sep_host_names=$(jq -r '[.[].name] | join(",")' "${REMOTE_BAREMETALHOSTS_FILE}")
+export comma_sep_host_names
+
+if [ -z "${comma_sep_host_names}" ] ; then
+  echo "Missing bmhs names"
+  exit 1
+fi
+
+export -f wait_for_cmd_amount
+
+node_count=$(jq -r '[.[].name] | length' "${REMOTE_BAREMETALHOSTS_FILE}")
+
+timeout 20m bash -c "wait_for_cmd_amount ${node_count} 30 remote_agents ${LOCAL_CLUSTER_NAMESPACE} ${comma_sep_host_names}"
+echo "Remote worker agents were discovered!"
+
+timeout 60m bash -c "wait_for_cmd_amount ${node_count} 30 installed_remote_agents ${LOCAL_CLUSTER_NAMESPACE} ${comma_sep_host_names}"
+
+echo "Local cluster agents installation completed successfully!"

--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -31,20 +31,11 @@ if [ -z "${comma_sep_host_names}" ] ; then
   exit 1
 fi
 
-function remote_agents() {
-	oc get agent -n ${SPOKE_NAMESPACE} --no-headers -l "agent-install.openshift.io/bmh in ( ${comma_sep_host_names} )"
-}
-
-function remote_done_agents() {
-        remote_agents | grep Done
-}
-
 export -f wait_for_cmd_amount
-export -f remote_agents
 
 node_count=$(jq -r '[.[].name] | length' "${REMOTE_BAREMETALHOSTS_FILE}")
 
-timeout 20m bash -c "wait_for_cmd_amount ${node_count} 30 remote_agents"
+timeout 20m bash -c "wait_for_cmd_amount ${node_count} 30 remote_agents  ${SPOKE_NAMESPACE} ${comma_sep_host_names}"
 echo "Remote worker agents were discovered!"
 
 # If we are performing late binding then we to bind the discovered agents by setting their clusterRef
@@ -73,7 +64,6 @@ PATCH
 
 fi
 
-export -f remote_done_agents
-timeout 60m bash -c "wait_for_cmd_amount ${node_count} 30 remote_done_agents"
+timeout 60m bash -c "wait_for_cmd_amount ${node_count} 30 installed_remote_agents  ${SPOKE_NAMESPACE} ${comma_sep_host_names}"
 
 echo "Remote worker agents installation completed successfully!"

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -35,6 +35,7 @@
     - machine_config_pools: "{{ lookup('env', 'MACHINE_CONFIG_POOLS') }}"
     - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
     - manifests: "{{ lookup('env', 'MANIFESTS') }}"
+    - infraenv_label: ""
 
   tasks:
   - name: create directory for generated CRDs

--- a/deploy/operator/ztp/infraEnv.j2
+++ b/deploy/operator/ztp/infraEnv.j2
@@ -12,3 +12,7 @@ spec:
   pullSecretRef:
     name: '{{ pull_secret_name }}'
   sshAuthorizedKey: '{{ ssh_public_key }}'
+  {% if infraenv_label|string | length > 0 %}
+  agentLabels:
+    infraenv: '{{ infraenv_label }}'
+  {% endif %}


### PR DESCRIPTION
In [MGMT-15704](https://issues.redhat.com//browse/MGMT-15704) we introduced functionality to automatically import the local cluster into the infrastructure operator, this would make it possible to add nodes to the local cluster.

This commit is part of an effort (using the openshift/release project) to perform an E2E test. To support the test, we need to add an infraenv to support the addition of a node to the local cluster.

Most of the fields in this infraenv are intentionally preset to known defaults used by assisted-service with only the `ssh_public_key` field being injected by ansible.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
