### PR TITLE
 MGMT-15715: Allow handling multi-document YAML custom manifests

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -691,9 +691,15 @@ func (g *installerGenerator) bootstrapInPlaceIgnitionsCreate(ctx context.Context
 func (g *installerGenerator) expandUserMultiDocYamls(ctx context.Context) error {
 	log := logutil.FromContext(ctx, g.log)
 
-	userManifests, err := manifests.GetUserManifestSuffixes(ctx, g.cluster.ID, g.s3Client)
+	metadata, err := manifests.GetManifestMetadata(ctx, g.cluster.ID, g.s3Client)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to retrieve user manifests")
+		return errors.Wrapf(err, "Failed to retrieve manifest matadata")
+	}
+	userManifests, err := manifests.ResolveManifestNamesFromMetadata(
+		manifests.FilterMetadataOnManifestSource(metadata, constants.ManifestSourceUserSupplied),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to resolve manifest names from metadata")
 	}
 
 	// pass a random token to expandMultiDocYaml in order to prevent name

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -460,16 +460,16 @@ func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID 
 	}
 	extension := filepath.Ext(fileName)
 	if extension == ".yaml" || extension == ".yml" {
-		if !isValidYaml(manifestContent) {
-			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s has an invalid YAML format", fileName, string(clusterID)))
+		if err := isValidYaml(manifestContent); err != nil {
+			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s has an invalid YAML format: %s", fileName, string(clusterID), err))
 		}
 	} else if extension == ".json" {
 		if !json.Valid(manifestContent) {
 			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s has an illegal JSON format", fileName, string(clusterID)))
 		}
 	} else if strings.HasPrefix(extension, ".patch") && (strings.Contains(fileName, ".yaml.patch") || strings.Contains(fileName, ".yml.patch")) {
-		if !isValidYaml(manifestContent) {
-			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Patch content of file %s for cluster ID %s has an invalid YAML format", fileName, string(clusterID)))
+		if err := isValidYaml(manifestContent); err != nil {
+			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Patch content of file %s for cluster ID %s has an invalid YAML format: %s", fileName, string(clusterID), err))
 		}
 	} else {
 		return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest filename of file %s for cluster ID %s is invalid. Only json, yaml and yml extensions are supported", fileName, string(clusterID)))
@@ -478,7 +478,7 @@ func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID 
 }
 
 // isValidYaml checks if all yaml documents are valid, in the case of multi-doc yaml this may be more than one document.
-func isValidYaml(manifestContent []byte) bool {
+func isValidYaml(manifestContent []byte) error {
 	dec := yaml.NewDecoder(bytes.NewReader(manifestContent))
 
 	for {
@@ -488,11 +488,11 @@ func isValidYaml(manifestContent []byte) bool {
 			break
 		}
 		if err != nil {
-			return false
+			return err
 		}
 	}
 
-	return true
+	return nil
 }
 
 func (m *Manifests) decodeUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, manifest string) ([]byte, error) {

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -361,27 +361,52 @@ func GetClusterManifests(ctx context.Context, clusterID *strfmt.UUID, s3Client s
 	return manifestFiles, nil
 }
 
-// Return the list of the manifests provided by the user into a list of "{folder}/{filename}"
-func GetUserManifestSuffixes(ctx context.Context, clusterID *strfmt.UUID, s3Client s3wrapper.API) ([]string, error) {
+// GetManifestMetadata returns the paths of manifest metadata for a given cluster
+func GetManifestMetadata(ctx context.Context, clusterID *strfmt.UUID, s3Client s3wrapper.API) ([]string, error) {
 	prefix := getManifestMetadataPrefix(*clusterID)
 	metadataList, err := s3Client.ListObjectsByPrefix(ctx, prefix)
 	if err != nil {
 		return []string{}, err
 	}
 
-	userManifests := []string{}
-	for _, metadata := range metadataList {
-		fileDir, metadataKey := filepath.Split(metadata)
+	return metadataList, nil
+}
 
-		if metadataKey == constants.ManifestSourceUserSupplied {
-			manifestDir, manifestFilename := filepath.Split(filepath.Clean(fileDir))
-			_, manifestFolder := filepath.Split(filepath.Clean(manifestDir))
-			manifestSuffix := filepath.Join(manifestFolder, manifestFilename)
-			userManifests = append(userManifests, manifestSuffix)
+// FilterMetadataOnManifestSource filters a list of metadata paths filtered on manifest source
+func FilterMetadataOnManifestSource(metadataList []string, manifestSource string) []string {
+	filteredMetadata := []string{}
+
+	for _, metadata := range metadataList {
+		_, metadataKey := filepath.Split(metadata)
+		if metadataKey == manifestSource {
+			filteredMetadata = append(filteredMetadata, metadata)
 		}
 	}
 
-	return userManifests, err
+	return filteredMetadata
+}
+
+// ResolveManifestNamesFromMetadata resolves metadata paths like
+// "{clusterID}/{ManifestMetadataFolder}/manifests/first.yaml/{manifestSource}" into
+// "manifests/first.yaml"
+func ResolveManifestNamesFromMetadata(metadataList []string) ([]string, error) {
+	manifestList := []string{}
+
+	for _, metadata := range metadataList {
+		fileDir, _ := filepath.Split(metadata)
+		manifestDir, manifestFilename := filepath.Split(filepath.Clean(fileDir))
+		metadataDir, manifestFolder := filepath.Split(filepath.Clean(manifestDir))
+
+		if fileDir == "" || manifestDir == "" || metadataDir == "" {
+			err := errors.Errorf("Failed to extract manifest name from metadata path %s", metadata)
+			return []string{}, err
+		}
+
+		manifestName := filepath.Join(manifestFolder, manifestFilename)
+		manifestList = append(manifestList, manifestName)
+	}
+
+	return manifestList, nil
 }
 
 func listManifests(ctx context.Context, clusterID *strfmt.UUID, folder string, s3Client s3wrapper.API) ([]string, error) {

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -477,7 +477,7 @@ func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID 
 	return nil
 }
 
-// isValidYaml checks if one or more (in case of multi-doc yaml) yaml documents are valid
+// isValidYaml checks if all yaml documents are valid, in the case of multi-doc yaml this may be more than one document.
 func isValidYaml(manifestContent []byte) bool {
 	dec := yaml.NewDecoder(bytes.NewReader(manifestContent))
 

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -402,7 +402,7 @@ spec:
 				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
 				err := response.(*common.ApiErrorResponse)
 				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
-				Expect(err.Error()).To(ContainSubstring("Manifest content of file manifests/99-test.yml for cluster ID " + clusterID.String() + " has an invalid YAML format"))
+				Expect(err.Error()).To(Equal("Manifest content of file manifests/99-test.yml for cluster ID " + clusterID.String() + " has an invalid YAML format: yaml: line 1: did not find expected node content"))
 			})
 
 			It("fails for manifest with unsupported extension", func() {
@@ -516,7 +516,7 @@ invalid YAML content: {
 				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
 				err := response.(*common.ApiErrorResponse)
 				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
-				Expect(err.Error()).To(ContainSubstring("Manifest content of file manifests/99-test.yml for cluster ID " + clusterID.String() + " has an invalid YAML format"))
+				Expect(err.Error()).To(Equal("Manifest content of file manifests/99-test.yml for cluster ID " + clusterID.String() + " has an invalid YAML format: yaml: line 4: did not find expected node content"))
 			})
 		})
 	})

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -995,8 +995,8 @@ invalid YAML content: {
 		})
 	})
 
-	Context("GetUserManifestSuffixes", func() {
-		It("Should be able to list only user manifests if user and non user manifests are present", func() {
+	Context("GetManifestMetadata", func() {
+		It("Should be able to list manifest metadata", func() {
 			clusterId := registerCluster().ID
 			s3Metadata := []string{
 				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "first.yaml", constants.ManifestSourceUserSupplied),
@@ -1004,10 +1004,66 @@ invalid YAML content: {
 				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "third.yaml", "some-other-manifest-source"),
 			}
 			mockS3Client.EXPECT().ListObjectsByPrefix(ctx, filepath.Join(clusterId.String(), constants.ManifestMetadataFolder)).Return(s3Metadata, nil).Times(1)
-			userManifests, err := manifests.GetUserManifestSuffixes(ctx, clusterId, mockS3Client)
+			userManifests, err := manifests.GetManifestMetadata(ctx, clusterId, mockS3Client)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(userManifests).To(ConsistOf("manifests/first.yaml", "openshift/second.yaml"))
+			Expect(userManifests).To(ConsistOf(s3Metadata))
 		})
+	})
+	Context("FilterMetadataOnManifestSource", func() {
+		It("returns metadata paths when matching manifest source", func() {
+			clusterId := registerCluster().ID
+			firstMetadata := filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "first.yaml", constants.ManifestSourceUserSupplied)
+			secondMetadata := filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "openshift", "second.yaml", constants.ManifestSourceUserSupplied)
+			s3Metadata := []string{
+				firstMetadata,
+				secondMetadata,
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "third.yaml", "some-other-manifest-source"),
+			}
+			filteredMetadata := manifests.FilterMetadataOnManifestSource(s3Metadata, constants.ManifestSourceUserSupplied)
+			Expect(filteredMetadata).To(ConsistOf(firstMetadata, secondMetadata))
+		})
+		It("returns an empty list when no metadata have matched the manifest seource", func() {
+			clusterId := registerCluster().ID
+			s3Metadata := []string{
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "first.yaml", constants.ManifestSourceUserSupplied),
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "openshift", "second.yaml", constants.ManifestSourceUserSupplied),
+			}
+			filteredMetadata := manifests.FilterMetadataOnManifestSource(s3Metadata, "some-other-manifest-source")
+			Expect(filteredMetadata).To(ConsistOf())
+		})
+		It("returns an empty list when metadata are malformed", func() {
+			s3Metadata := []string{
+				"first.yaml",
+				"",
+			}
+			filteredMetadata := manifests.FilterMetadataOnManifestSource(s3Metadata, "some-other-manifest-source")
+			Expect(filteredMetadata).To(ConsistOf())
+		})
+	})
+	Context("ResolveManifestNamesFromMetadata", func() {
+		It("returns manifest names when metadata paths are valid", func() {
+			clusterId := registerCluster().ID
+			s3Metadata := []string{
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "first.yaml", constants.ManifestSourceUserSupplied),
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "openshift", "second.yaml", constants.ManifestSourceUserSupplied),
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "third.yaml", "some-other-manifest-source"),
+			}
+			manifestNames, err := manifests.ResolveManifestNamesFromMetadata(s3Metadata)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(manifestNames).To(ConsistOf("manifests/first.yaml", "openshift/second.yaml", "manifests/third.yaml"))
+		})
+
+		for _, invalidMetadata := range []string{"foo.yaml", "foo/bar", ""} {
+			invalidMetadata_ := invalidMetadata
+			It("returns an error when metadata are malformed", func() {
+				_, err := manifests.ResolveManifestNamesFromMetadata([]string{invalidMetadata_})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(
+					fmt.Sprintf("Failed to extract manifest name from metadata path %s", invalidMetadata_),
+				))
+			})
+		}
+
 	})
 })
 

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -473,7 +473,7 @@ spec:
 				Expect(err.Error()).To(ContainSubstring("Manifest content of file 99-openshift-machineconfig-master-kargs.json for cluster ID " + clusterID.String() + " exceeds the maximum file size of 1MiB"))
 			})
 
-			It("accept muti-doc yaml file", func() {
+			It("Upload succeeds when each yaml in multi-doc yaml file is valid", func() {
 				clusterID := registerCluster().ID
 				fileName := "99-test.yaml"
 				content := encodeToBase64(`---

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -1001,7 +1001,7 @@ invalid YAML content: {
 			s3Metadata := []string{
 				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "first.yaml", constants.ManifestSourceUserSupplied),
 				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "openshift", "second.yaml", constants.ManifestSourceUserSupplied),
-				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "third.yaml", "other-metadata"),
+				filepath.Join(clusterId.String(), constants.ManifestMetadataFolder, "manifests", "third.yaml", "some-other-manifest-source"),
 			}
 			mockS3Client.EXPECT().ListObjectsByPrefix(ctx, filepath.Join(clusterId.String(), constants.ManifestMetadataFolder)).Return(s3Metadata, nil).Times(1)
 			userManifests, err := manifests.GetUserManifestSuffixes(ctx, clusterId, mockS3Client)

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -391,7 +391,7 @@ spec:
 			It("fails for manifest with invalid yaml format", func() {
 				clusterID := registerCluster().ID
 				fileName := "99-test.yml"
-				invalidYAMLContent := encodeToBase64("not a valid YAML: {{ content }}")
+				invalidYAMLContent := encodeToBase64("invalid YAML content: {")
 				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
 					ClusterID: *clusterID,
 					CreateManifestParams: &models.CreateManifestParams{
@@ -504,7 +504,7 @@ first: one
 				content := encodeToBase64(`---
 first: one
 ---
-not a valid YAML: {{ content }}
+invalid YAML content: {
 `)
 				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
 					ClusterID: *clusterID,


### PR DESCRIPTION
Multi document yamls are not supported during installation.

This change looks into the custom manifests files uploaded by the user,
and splits multi document yaml files into several ones.