### PR TITLE
MGMT-15808: change base image to stream9

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -14,9 +14,9 @@ RUN cd /assisted-service/build && python3 ../tools/client_package_initializer.py
 # TODO: Currently, the Python package is included in the service image for testing purposes. It conveniently allows matching a service version to a specific Python client version. In the future, once the Python package is published on pip, it should (probably) be removed from the Assisted Service image (this dockerfile).
 
 # Build binaries
-FROM quay.io/centos/centos:stream8 as builder
+FROM quay.io/centos/centos:stream9 as builder
 
-RUN dnf install --enablerepo=powertools -y gcc git nmstate-devel && dnf clean all
+RUN dnf install --enablerepo=crb -y gcc git nmstate-devel && dnf clean all
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.18 /usr/local/go /usr/local/go
 
 ENV GOROOT=/usr/local/go
@@ -40,7 +40,7 @@ RUN cd ./cmd/webadmission && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o
 RUN cd ./cmd/agentbasedinstaller/client && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=on go build -o /build/agent-installer-client
 
 # Create final image
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 # multiarch images need it till WRKLDS-222 and https://bugzilla.redhat.com/show_bug.cgi?id=2111537 are fixed
 RUN dnf install -y --setopt=install_weak_deps=False skopeo

--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS golang
 RUN chmod g+xw -R /usr/local/go
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 ENV GOPATH=/go
 ENV GOROOT=/usr/local/go
@@ -37,7 +37,7 @@ COPY --from=quay.io/coreos/shellcheck-alpine:v0.5.0 /bin/shellcheck /usr/bin/she
 
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-    dnf install -y --enablerepo=powertools \
+    dnf install -y --enablerepo=crb \
         openssl postgresql nmstate-devel sqlite gcc genisoimage git docker-ce-cli libvirt-client libvirt-devel java && \
     dnf clean all
 

--- a/ci-images/Dockerfile.base
+++ b/ci-images/Dockerfile.base
@@ -1,8 +1,7 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y 'dnf-command(config-manager)' && \
-    dnf config-manager --set-enabled powertools && \
-    dnf install -y git unzip make gcc which nmstate-devel python3
+RUN dnf install --enablerepo=crb -y \
+    git unzip make gcc which nmstate-devel python3
 
 # Git checks if the user that owns the files on the filesystem match the
 # current user.  We need to disable this check because tests in Prow are


### PR DESCRIPTION
Now that D/S building system fully supports RHEL-9 base images (and allows easy installation of nmstate and other libs that were previously unsupported) we can move U/S to stream9 and D/S to ubi9-minimal.

It doesn't seem possible to easily use ubi9-minimal U/S, because installation of nmstate packages (and libvirt-libs) either requires entitlements running on a RHEL node, or maybe alternatively an access to RedHat's internal network (which can be a major problem for development U/S).

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
