### PR TITLE
MGMT-15598: Add a parameter to manifest list to disable filter

### DIFF
--- a/client/manifests/v2_list_cluster_manifests_parameters.go
+++ b/client/manifests/v2_list_cluster_manifests_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2ListClusterManifestsParams creates a new V2ListClusterManifestsParams object,
@@ -69,6 +70,12 @@ type V2ListClusterManifestsParams struct {
 	*/
 	ClusterID strfmt.UUID
 
+	/* IncludeSystemGenerated.
+
+	   Include system generated manifests in results? Default is false.
+	*/
+	IncludeSystemGenerated *bool
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -86,7 +93,18 @@ func (o *V2ListClusterManifestsParams) WithDefaults() *V2ListClusterManifestsPar
 //
 // All values with no default are reset to their zero value.
 func (o *V2ListClusterManifestsParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		includeSystemGeneratedDefault = bool(false)
+	)
+
+	val := V2ListClusterManifestsParams{
+		IncludeSystemGenerated: &includeSystemGeneratedDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the v2 list cluster manifests params
@@ -133,6 +151,17 @@ func (o *V2ListClusterManifestsParams) SetClusterID(clusterID strfmt.UUID) {
 	o.ClusterID = clusterID
 }
 
+// WithIncludeSystemGenerated adds the includeSystemGenerated to the v2 list cluster manifests params
+func (o *V2ListClusterManifestsParams) WithIncludeSystemGenerated(includeSystemGenerated *bool) *V2ListClusterManifestsParams {
+	o.SetIncludeSystemGenerated(includeSystemGenerated)
+	return o
+}
+
+// SetIncludeSystemGenerated adds the includeSystemGenerated to the v2 list cluster manifests params
+func (o *V2ListClusterManifestsParams) SetIncludeSystemGenerated(includeSystemGenerated *bool) {
+	o.IncludeSystemGenerated = includeSystemGenerated
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2ListClusterManifestsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -144,6 +173,23 @@ func (o *V2ListClusterManifestsParams) WriteToRequest(r runtime.ClientRequest, r
 	// path param cluster_id
 	if err := r.SetPathParam("cluster_id", o.ClusterID.String()); err != nil {
 		return err
+	}
+
+	if o.IncludeSystemGenerated != nil {
+
+		// query param include_system_generated
+		var qrIncludeSystemGenerated bool
+
+		if o.IncludeSystemGenerated != nil {
+			qrIncludeSystemGenerated = *o.IncludeSystemGenerated
+		}
+		qIncludeSystemGenerated := swag.FormatBool(qrIncludeSystemGenerated)
+		if qIncludeSystemGenerated != "" {
+
+			if err := r.SetQueryParam("include_system_generated", qIncludeSystemGenerated); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -176,7 +176,7 @@ func (m *Manifests) ListClusterManifestsInternal(ctx context.Context, params ope
 		if err != nil {
 			return nil, err
 		}
-		if isUserManifest {
+		if isUserManifest || swag.BoolValue(params.IncludeSystemGenerated) {
 			manifests = append(manifests, &models.Manifest{FileName: filename, Folder: folder})
 		}
 	}

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -2038,6 +2038,13 @@ func init() {
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Include system generated manifests in results? Default is false.",
+            "name": "include_system_generated",
+            "in": "query"
           }
         ],
         "responses": {
@@ -12283,6 +12290,13 @@ func init() {
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "description": "Include system generated manifests in results? Default is false.",
+            "name": "include_system_generated",
+            "in": "query"
           }
         ],
         "responses": {

--- a/restapi/operations/manifests/v2_list_cluster_manifests_parameters.go
+++ b/restapi/operations/manifests/v2_list_cluster_manifests_parameters.go
@@ -9,17 +9,26 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
 // NewV2ListClusterManifestsParams creates a new V2ListClusterManifestsParams object
-//
-// There are no default values defined in the spec.
+// with the default values initialized.
 func NewV2ListClusterManifestsParams() V2ListClusterManifestsParams {
 
-	return V2ListClusterManifestsParams{}
+	var (
+		// initialize parameters with default values
+
+		includeSystemGeneratedDefault = bool(false)
+	)
+
+	return V2ListClusterManifestsParams{
+		IncludeSystemGenerated: &includeSystemGeneratedDefault,
+	}
 }
 
 // V2ListClusterManifestsParams contains all the bound params for the v2 list cluster manifests operation
@@ -36,6 +45,11 @@ type V2ListClusterManifestsParams struct {
 	  In: path
 	*/
 	ClusterID strfmt.UUID
+	/*Include system generated manifests in results? Default is false.
+	  In: query
+	  Default: false
+	*/
+	IncludeSystemGenerated *bool
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -47,8 +61,15 @@ func (o *V2ListClusterManifestsParams) BindRequest(r *http.Request, route *middl
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rClusterID, rhkClusterID, _ := route.Params.GetOK("cluster_id")
 	if err := o.bindClusterID(rClusterID, rhkClusterID, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qIncludeSystemGenerated, qhkIncludeSystemGenerated, _ := qs.GetOK("include_system_generated")
+	if err := o.bindIncludeSystemGenerated(qIncludeSystemGenerated, qhkIncludeSystemGenerated, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -87,5 +108,29 @@ func (o *V2ListClusterManifestsParams) validateClusterID(formats strfmt.Registry
 	if err := validate.FormatOf("cluster_id", "path", "uuid", o.ClusterID.String(), formats); err != nil {
 		return err
 	}
+	return nil
+}
+
+// bindIncludeSystemGenerated binds and validates parameter IncludeSystemGenerated from query.
+func (o *V2ListClusterManifestsParams) bindIncludeSystemGenerated(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewV2ListClusterManifestsParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("include_system_generated", "query", "bool", raw)
+	}
+	o.IncludeSystemGenerated = &value
+
 	return nil
 }

--- a/restapi/operations/manifests/v2_list_cluster_manifests_urlbuilder.go
+++ b/restapi/operations/manifests/v2_list_cluster_manifests_urlbuilder.go
@@ -12,11 +12,14 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // V2ListClusterManifestsURL generates an URL for the v2 list cluster manifests operation
 type V2ListClusterManifestsURL struct {
 	ClusterID strfmt.UUID
+
+	IncludeSystemGenerated *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -56,6 +59,18 @@ func (o *V2ListClusterManifestsURL) Build() (*url.URL, error) {
 		_basePath = "/api/assisted-install"
 	}
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var includeSystemGeneratedQ string
+	if o.IncludeSystemGenerated != nil {
+		includeSystemGeneratedQ = swag.FormatBool(*o.IncludeSystemGenerated)
+	}
+	if includeSystemGeneratedQ != "" {
+		qs.Set("include_system_generated", includeSystemGeneratedQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2846,6 +2846,12 @@ paths:
           type: string
           format: uuid
           required: true
+        - in: query
+          name: include_system_generated
+          description: Include system generated manifests in results? Default is false.
+          type: boolean
+          required: false
+          default: false
       responses:
         "200":
           description: Success.

--- a/vendor/github.com/openshift/assisted-service/client/manifests/v2_list_cluster_manifests_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/manifests/v2_list_cluster_manifests_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewV2ListClusterManifestsParams creates a new V2ListClusterManifestsParams object,
@@ -69,6 +70,12 @@ type V2ListClusterManifestsParams struct {
 	*/
 	ClusterID strfmt.UUID
 
+	/* IncludeSystemGenerated.
+
+	   Include system generated manifests in results? Default is false.
+	*/
+	IncludeSystemGenerated *bool
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -86,7 +93,18 @@ func (o *V2ListClusterManifestsParams) WithDefaults() *V2ListClusterManifestsPar
 //
 // All values with no default are reset to their zero value.
 func (o *V2ListClusterManifestsParams) SetDefaults() {
-	// no default values defined for this parameter
+	var (
+		includeSystemGeneratedDefault = bool(false)
+	)
+
+	val := V2ListClusterManifestsParams{
+		IncludeSystemGenerated: &includeSystemGeneratedDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the v2 list cluster manifests params
@@ -133,6 +151,17 @@ func (o *V2ListClusterManifestsParams) SetClusterID(clusterID strfmt.UUID) {
 	o.ClusterID = clusterID
 }
 
+// WithIncludeSystemGenerated adds the includeSystemGenerated to the v2 list cluster manifests params
+func (o *V2ListClusterManifestsParams) WithIncludeSystemGenerated(includeSystemGenerated *bool) *V2ListClusterManifestsParams {
+	o.SetIncludeSystemGenerated(includeSystemGenerated)
+	return o
+}
+
+// SetIncludeSystemGenerated adds the includeSystemGenerated to the v2 list cluster manifests params
+func (o *V2ListClusterManifestsParams) SetIncludeSystemGenerated(includeSystemGenerated *bool) {
+	o.IncludeSystemGenerated = includeSystemGenerated
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *V2ListClusterManifestsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -144,6 +173,23 @@ func (o *V2ListClusterManifestsParams) WriteToRequest(r runtime.ClientRequest, r
 	// path param cluster_id
 	if err := r.SetPathParam("cluster_id", o.ClusterID.String()); err != nil {
 		return err
+	}
+
+	if o.IncludeSystemGenerated != nil {
+
+		// query param include_system_generated
+		var qrIncludeSystemGenerated bool
+
+		if o.IncludeSystemGenerated != nil {
+			qrIncludeSystemGenerated = *o.IncludeSystemGenerated
+		}
+		qIncludeSystemGenerated := swag.FormatBool(qrIncludeSystemGenerated)
+		if qIncludeSystemGenerated != "" {
+
+			if err := r.SetQueryParam("include_system_generated", qIncludeSystemGenerated); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {


### PR DESCRIPTION
Recently we made a change to the manifest list to filter out the system generated manifests when listing them.

This has led to issues with data gathering for triage which requires full access to all manifests, system generated or otherwise.

I have introduced a boolean parameter IncludeSystemGenerated which defaults to false. When set to true, the manifest list endpoint will show all manifests, irrespective of how they were created.

It is intended that we will make a change in assisted-test-infra that will send this parameter.
## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
