### PR TITLE
OCPBUGS-18455: Add CloudControllerManager field for external platform

### DIFF
--- a/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -376,9 +376,16 @@ const (
 	WorkerAgentMachinePool string = "worker"
 )
 
-// PlatformType is a specific supported infrastructure provider.
-// +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
-type PlatformType string
+// CloudControllerManager describes the type of cloud controller manager to be enabled.
+type CloudControllerManager string
+
+const (
+	// CloudControllerManagerTypeExternal specifies that an external cloud provider is to be configured.
+	CloudControllerManagerTypeExternal = "External"
+
+	// CloudControllerManagerTypeNone specifies that no cloud provider is to be configured.
+	CloudControllerManagerTypeNone = ""
+)
 
 // ExternalPlatformSpec holds the desired state for the generic External infrastructure provider.
 type ExternalPlatformSpec struct {
@@ -389,7 +396,17 @@ type ExternalPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'Unknown' || self == oldSelf",message="platform name cannot be changed once set"
 	// +optional
 	PlatformName string `json:"platformName,omitempty"`
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	// +kubebuilder:default:=""
+	// +default=""
+	// +kubebuilder:validation:Enum="";External
+	// +optional
+	CloudControllerManager CloudControllerManager `json:"cloudControllerManager,omitempty"`
 }
+
+// PlatformType is a specific supported infrastructure provider.
+// +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
+type PlatformType string
 
 const (
 	// BareMetalPlatformType represents managed bare metal infrastructure.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/openshift/assisted-service
 go 1.18
 
 require (
-    github.com/hashicorp/go-multierror v1.1.1
 	github.com/IBM/netaddr v1.5.0
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -376,9 +376,16 @@ const (
 	WorkerAgentMachinePool string = "worker"
 )
 
-// PlatformType is a specific supported infrastructure provider.
-// +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
-type PlatformType string
+// CloudControllerManager describes the type of cloud controller manager to be enabled.
+type CloudControllerManager string
+
+const (
+	// CloudControllerManagerTypeExternal specifies that an external cloud provider is to be configured.
+	CloudControllerManagerTypeExternal = "External"
+
+	// CloudControllerManagerTypeNone specifies that no cloud provider is to be configured.
+	CloudControllerManagerTypeNone = ""
+)
 
 // ExternalPlatformSpec holds the desired state for the generic External infrastructure provider.
 type ExternalPlatformSpec struct {
@@ -389,7 +396,17 @@ type ExternalPlatformSpec struct {
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'Unknown' || self == oldSelf",message="platform name cannot be changed once set"
 	// +optional
 	PlatformName string `json:"platformName,omitempty"`
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	// +kubebuilder:default:=""
+	// +default=""
+	// +kubebuilder:validation:Enum="";External
+	// +optional
+	CloudControllerManager CloudControllerManager `json:"cloudControllerManager,omitempty"`
 }
+
+// PlatformType is a specific supported infrastructure provider.
+// +kubebuilder:validation:Enum="";BareMetal;None;VSphere;Nutanix;External
+type PlatformType string
 
 const (
 	// BareMetalPlatformType represents managed bare metal infrastructure.


### PR DESCRIPTION
Introduces a new configuration to the platform external platform spec which allows an external cloud provider to be enabled.

Ref: 
https://github.com/openshift/installer/pull/7533
https://github.com/openshift/installer/pull/7457 

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
