### PR TITLE
MGMT-15878: Ensure that hosts emit event showing why preparation failed.

### DIFF
--- a/cmd/graphstatemachine/main.go
+++ b/cmd/graphstatemachine/main.go
@@ -35,6 +35,10 @@ func hostStateMachine() stateswitch.StateMachine {
 		func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
 	).AnyTimes()
 
+	mockTransitionHandler.EXPECT().PostHostPreparationTimeout().Return(
+		func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
+	).AnyTimes()
+
 	mockTransitionHandler.EXPECT().PostRefreshLogsProgress(gomock.Any()).Return(
 		func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
 	).AnyTimes()
@@ -65,6 +69,10 @@ func poolHostStateMachine() stateswitch.StateMachine {
 	}).AnyTimes()
 
 	mockTransitionHandler.EXPECT().PostRefreshHost(gomock.Any()).Return(
+		func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
+	).AnyTimes()
+
+	mockTransitionHandler.EXPECT().PostHostPreparationTimeout().Return(
 		func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
 	).AnyTimes()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -313,6 +313,8 @@ func main() {
 	// Make sure that prepare for installation timeout is more than the timeouts of all underlying tools + 2m extra
 	Options.ClusterConfig.PrepareConfig.PrepareForInstallationTimeout = maxDuration(Options.ClusterConfig.PrepareConfig.PrepareForInstallationTimeout,
 		maxDuration(Options.InstructionConfig.DiskCheckTimeout, Options.InstructionConfig.ImageAvailabilityTimeout)+2*time.Minute)
+	Options.HostConfig.PrepareConfig.PrepareForInstallationTimeout = maxDuration(Options.HostConfig.PrepareConfig.PrepareForInstallationTimeout,
+		maxDuration(Options.InstructionConfig.DiskCheckTimeout, Options.InstructionConfig.ImageAvailabilityTimeout)+1*time.Minute)
 	var lead leader.ElectorInterface
 	var k8sClient *kubernetes.Clientset
 	var autoMigrationLeader leader.ElectorInterface

--- a/internal/cluster/statemachine.go
+++ b/internal/cluster/statemachine.go
@@ -207,7 +207,7 @@ func NewClusterStateMachine(th TransitionHandler) stateswitch.StateMachine {
 	sm.AddTransitionRule(stateswitch.TransitionRule{
 		TransitionType:   TransitionTypeRefreshStatus,
 		SourceStates:     []stateswitch.State{stateswitch.State(models.ClusterStatusPreparingForInstallation)},
-		Condition:        th.IsPreparingTimedOut,
+		Condition:        stateswitch.And(th.IsPreparingTimedOut, stateswitch.Not(If(FailedPreparingtHostsExist))),
 		DestinationState: stateswitch.State(models.ClusterStatusReady),
 		PostTransition:   th.PostPreparingTimedOut,
 		Documentation: stateswitch.TransitionRuleDoc{

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -17,12 +17,16 @@ import (
 )
 
 const (
-	statusInfoMediaDisconnected                                = "Unable to read from the discovery media. It was either disconnected or poor network conditions prevented it from being read. Try using the minimal ISO option and be sure to keep the media connected until the installation is completed"
-	statusInfoDisconnected                                     = "Host has stopped communicating with the installation service"
-	statusInfoDiscovering                                      = "Waiting for host to send hardware details"
-	statusInfoInsufficientHardware                             = "Host does not meet the minimum hardware requirements: $FAILING_VALIDATIONS"
-	statusInfoPendingForInput                                  = "Waiting for user input: $FAILING_VALIDATIONS"
-	statusInfoNotReadyForInstall                               = "Host cannot be installed due to following failing validation(s): $FAILING_VALIDATIONS"
+	statusInfoMediaDisconnected                   = "Unable to read from the discovery media. It was either disconnected or poor network conditions prevented it from being read. Try using the minimal ISO option and be sure to keep the media connected until the installation is completed"
+	statusInfoDisconnected                        = "Host has stopped communicating with the installation service"
+	statusInfoDiscovering                         = "Waiting for host to send hardware details"
+	statusInfoInsufficientHardware                = "Host does not meet the minimum hardware requirements: $FAILING_VALIDATIONS"
+	statusInfoPendingForInput                     = "Waiting for user input: $FAILING_VALIDATIONS"
+	statusInfoNotReadyForInstall                  = "Host cannot be installed due to following failing validation(s): $FAILING_VALIDATIONS"
+	statusInfoPreparationTimeout                  = "The host has encountered a preparation timeout, the following conditions failed: $FAILING_CONDITIONS"
+	statusInfoPreparationTimeoutDiskSpeed         = "the installation disk speed check did not complete within the timeout."
+	statusInfoPreparationTimeoutImageAvailability = "container availability was not determined within the timeout."
+
 	statusInfoKnown                                            = "Host is ready to be installed"
 	statusInfoInstalling                                       = "Installation is in progress"
 	statusInfoResettingPendingUserAction                       = "Host requires booting into the discovery image to complete resetting the installation"

--- a/internal/host/config.go
+++ b/internal/host/config.go
@@ -10,7 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+type PrepareConfig struct {
+	PrepareForInstallationTimeout time.Duration `envconfig:"PREPARE_FOR_INSTALLATION_HOST_TIMEOUT" default:"8m"`
+}
+
 type Config struct {
+	PrepareConfig PrepareConfig
 	LogTimeoutConfig
 	EnableAutoAssign         bool                    `envconfig:"ENABLE_AUTO_ASSIGN" default:"true"`
 	ResetTimeout             time.Duration           `envconfig:"RESET_CLUSTER_TIMEOUT" default:"3m"`

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -154,6 +154,21 @@ func (mr *MockTransitionHandlerMockRecorder) IsLogCollectionTimedOut(sw, args in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLogCollectionTimedOut", reflect.TypeOf((*MockTransitionHandler)(nil).IsLogCollectionTimedOut), sw, args)
 }
 
+// IsPreparingTimedOut mocks base method.
+func (m *MockTransitionHandler) IsPreparingTimedOut(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPreparingTimedOut", sw, args)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsPreparingTimedOut indicates an expected call of IsPreparingTimedOut.
+func (mr *MockTransitionHandlerMockRecorder) IsPreparingTimedOut(sw, args interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPreparingTimedOut", reflect.TypeOf((*MockTransitionHandler)(nil).IsPreparingTimedOut), sw, args)
+}
+
 // IsUnboundHost mocks base method.
 func (m *MockTransitionHandler) IsUnboundHost(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) (bool, error) {
 	m.ctrl.T.Helper()
@@ -238,6 +253,20 @@ func (m *MockTransitionHandler) PostHostMediaDisconnected(sw stateswitch.StateSw
 func (mr *MockTransitionHandlerMockRecorder) PostHostMediaDisconnected(sw, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostHostMediaDisconnected", reflect.TypeOf((*MockTransitionHandler)(nil).PostHostMediaDisconnected), sw, args)
+}
+
+// PostHostPreparationTimeout mocks base method.
+func (m *MockTransitionHandler) PostHostPreparationTimeout() stateswitch.PostTransition {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostHostPreparationTimeout")
+	ret0, _ := ret[0].(stateswitch.PostTransition)
+	return ret0
+}
+
+// PostHostPreparationTimeout indicates an expected call of PostHostPreparationTimeout.
+func (mr *MockTransitionHandlerMockRecorder) PostHostPreparationTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostHostPreparationTimeout", reflect.TypeOf((*MockTransitionHandler)(nil).PostHostPreparationTimeout))
 }
 
 // PostHostProgress mocks base method.

--- a/internal/host/monitor.go
+++ b/internal/host/monitor.go
@@ -239,7 +239,6 @@ func (m *Manager) HostMonitoring() {
 		m.log.Debugf("Not a leader, exiting HostMonitoring")
 		return
 	}
-	m.log.Debugf("Running HostMonitoring")
 	defer commonutils.MeasureOperation("HostMonitoring", m.log, m.metricApi)()
 	m.initMonitoringQueryGenerator()
 	monitored += m.clusterHostMonitoring()

--- a/internal/host/statemachine.go
+++ b/internal/host/statemachine.go
@@ -554,6 +554,20 @@ func NewHostStateMachine(sm stateswitch.StateMachine, th TransitionHandler) stat
 		SourceStates: []stateswitch.State{
 			stateswitch.State(models.HostStatusPreparingForInstallation),
 		},
+		Condition:        stateswitch.And(If(IsConnected), If(IsMediaConnected), th.IsPreparingTimedOut, stateswitch.Or(installationDiskSpeedUnknown, imagesAvailabilityUnknown), allConditionsSuccessfulOrUnknown),
+		DestinationState: stateswitch.State(models.HostStatusPreparingFailed),
+		PostTransition:   th.PostHostPreparationTimeout(),
+		Documentation: stateswitch.TransitionRuleDoc{
+			Name:        "Preparing timed out host move to known",
+			Description: "TODO: Document this transition rule",
+		},
+	})
+
+	sm.AddTransitionRule(stateswitch.TransitionRule{
+		TransitionType: TransitionTypeRefresh,
+		SourceStates: []stateswitch.State{
+			stateswitch.State(models.HostStatusPreparingForInstallation),
+		},
 		Condition:        stateswitch.And(If(IsConnected), If(IsMediaConnected), stateswitch.Not(If(SucessfullOrUnknownContainerImagesAvailability))),
 		DestinationState: stateswitch.State(models.HostStatusPreparingFailed),
 		PostTransition:   th.PostRefreshHost(statusInfoHostPreparationFailure),


### PR DESCRIPTION
When preparation fails for a host, we do not implement any kind of a timeout for the host to indicate that this has occurred.

This means that it is sometimes not possible for the user to determine the cause of a cluster timeout (which will inevitably be caused by the timeout of a host during preparation.)

Presently, there are two ways in which a host may time out (no result received within the cluster timeout)

- An inconclusive result from the pulling of cluster images
- An inconclusive result from the disk speed check

This PR introduces a timeout to detect these scenarios and report on them in a host timeout event so that the user may have a clue as to what has happened. 

This PR is in addition to [MGMT-15814](https://issues.redhat.com//browse/MGMT-15814) which introduces a cluster condition to track a cluster timeout when there is a failure to configure the preparation of a cluster within a given time frame (for example if the assisted pod crashes)

Together these PR's should improve the overall quality of error reporting.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
