### PR TITLE
MGMT-14409: generate short image URL

### DIFF
--- a/internal/gencrypto/token.go
+++ b/internal/gencrypto/token.go
@@ -90,20 +90,26 @@ func ParseExpirationFromURL(urlString string) (*strfmt.DateTime, error) {
 	}
 
 	if tokenString := parsedURL.Query().Get("image_token"); tokenString != "" {
-		token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
-		if err != nil {
-			return nil, err
-		}
-		claims, ok := token.Claims.(jwt.MapClaims)
-		if !ok {
-			return nil, errors.Errorf("malformed token claims in url")
-		}
-		exp, ok := claims["exp"].(float64)
-		if !ok {
-			return nil, errors.Errorf("token missing 'exp' claim")
-		}
-		expTime := time.Unix(int64(exp), 0)
-		expiresAt = strfmt.DateTime(expTime)
+		return ParseExpirationFromToken(tokenString)
 	}
+	return &expiresAt, nil
+}
+
+func ParseExpirationFromToken(tokenString string) (*strfmt.DateTime, error) {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.Errorf("malformed token claims in url")
+	}
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return nil, errors.Errorf("token missing 'exp' claim")
+	}
+	expTime := time.Unix(int64(exp), 0)
+	expiresAt := strfmt.DateTime(expTime)
+
 	return &expiresAt, nil
 }

--- a/internal/imageservice/url_test.go
+++ b/internal/imageservice/url_test.go
@@ -102,6 +102,17 @@ var _ = Describe("URL building", func() {
 		Expect(parsed.Query().Get("type")).To(Equal(isoType))
 	})
 
+	It("builds an image short URL", func() {
+		u, err := ShortImageURL(baseURL, ByAPIKeyPath, id, version, arch, isoType)
+		Expect(err).NotTo(HaveOccurred())
+
+		parsed, err := url.Parse(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed.Scheme).To(Equal("https"))
+		Expect(parsed.Host).To(Equal("image-service.example.com"))
+		Expect(parsed.Path).To(Equal(fmt.Sprintf("/v3/byapikey/%s/%s/%s/full.iso", id, version, arch)))
+	})
+
 	It("successfully builds all boot artifact URLs", func() {
 		osImage := models.OsImage{CPUArchitecture: &arch, OpenshiftVersion: &version}
 		bootArtifacts, err := GetBootArtifactURLs(baseURL, id, &osImage, false)
@@ -112,6 +123,43 @@ var _ = Describe("URL building", func() {
 		checkURL(bootArtifacts.KernelURL, scheme, host, "/v3/boot-artifacts/kernel", version, arch)
 		checkURL(bootArtifacts.RootFSURL, scheme, host, "/v3/boot-artifacts/rootfs", version, arch)
 		checkURL(bootArtifacts.InitrdURL, scheme, host, fmt.Sprintf("/v3/images/%s/pxe-initrd", id), version, arch)
+	})
+})
+
+var _ = Describe("URL parsing", func() {
+	var (
+		baseURL = "https://image-service.example.com/v3"
+		version = "4.10"
+		arch    = "x86_64"
+		isoType = "full-iso"
+		id      = "2bf4b68e-c6cd-4603-9d79-1d05e5aa0665"
+	)
+
+	It("successfully parse /images/ URLs", func() {
+		u, err := ImageURL(baseURL, id, version, arch, isoType)
+		Expect(err).NotTo(HaveOccurred())
+
+		parsedISOType, parsedArch, parsedVersion, err := ParseDownloadURL(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsedISOType).To(Equal(isoType))
+		Expect(parsedArch).To(Equal(arch))
+		Expect(parsedVersion).To(Equal(version))
+	})
+
+	It("successfully parse shorter URLs", func() {
+		u, err := ShortImageURL(baseURL, ByAPIKeyPath, id, version, arch, isoType)
+		Expect(err).NotTo(HaveOccurred())
+
+		parsedISOType, parsedArch, parsedVersion, err := ParseDownloadURL(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsedISOType).To(Equal(isoType))
+		Expect(parsedArch).To(Equal(arch))
+		Expect(parsedVersion).To(Equal(version))
+	})
+
+	It("successfully parse malformed URL", func() {
+		_, _, _, err := ParseDownloadURL("http://host/malformed/path/")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/internal/imageservice/url_test.go
+++ b/internal/imageservice/url_test.go
@@ -157,8 +157,8 @@ var _ = Describe("URL parsing", func() {
 		Expect(parsedVersion).To(Equal(version))
 	})
 
-	It("successfully parse malformed URL", func() {
-		_, _, _, err := ParseDownloadURL("http://host/malformed/path/")
+	It("successfully parse non-infraenv URL", func() {
+		_, _, _, err := ParseDownloadURL("http://host/non/infraenv/")
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/internal/imageservice/urls.go
+++ b/internal/imageservice/urls.go
@@ -120,6 +120,7 @@ func buildURL(baseURL string, suffix string, insecure bool, params map[string]st
 
 // ParseDownloadURL parse an image service download URL and returns the image type, the arch and the version.
 // This function can parse /images/ URLs and shorter /by.../ URLs.
+// The parsing is best effort, no validation is performed on the retuned values.
 func ParseDownloadURL(downloadURL string) (string, string, string, error) {
 	var imageType, version, arch string
 

--- a/internal/imageservice/urls.go
+++ b/internal/imageservice/urls.go
@@ -17,6 +17,15 @@ type BootArtifactURLs struct {
 
 const BootArtifactsPath = "/boot-artifacts"
 
+type ShortImageURLPrefix string
+
+const ByAPIKeyPath ShortImageURLPrefix = "byapikey"
+const ByIDPath ShortImageURLPrefix = "byid"
+const ByTokenPath ShortImageURLPrefix = "bytoken"
+
+const MinimalISOFilename string = "minimal.iso"
+const FullISOFilename string = "full.iso"
+
 func KernelURL(baseURL, version, arch string, insecure bool) (string, error) {
 	return buildURL(baseURL, fmt.Sprintf("%s/kernel", BootArtifactsPath), insecure, map[string]string{
 		"version": version,
@@ -46,6 +55,22 @@ func ImageURL(baseURL, imageID, version, arch, isoType string) (string, error) {
 		"version": version,
 		"arch":    arch,
 	})
+}
+
+func ShortImageURL(baseURL string, prefix ShortImageURLPrefix, token, version, arch, isoType string) (string, error) {
+	var isoFilename string
+
+	switch isoType {
+	case string(models.ImageTypeFullIso):
+		isoFilename = FullISOFilename
+	case string(models.ImageTypeMinimalIso):
+		isoFilename = MinimalISOFilename
+	default:
+		return "", fmt.Errorf("failed generating image url: %s iso type does not exist", isoType)
+	}
+
+	path := fmt.Sprintf("%s/%s/%s/%s/%s", prefix, token, version, arch, isoFilename)
+	return buildURL(baseURL, path, false, map[string]string{})
 }
 
 func GetBootArtifactURLs(baseURL, imageID string, osImage *models.OsImage, insecure bool) (*BootArtifactURLs, error) {
@@ -91,4 +116,39 @@ func buildURL(baseURL string, suffix string, insecure bool, params map[string]st
 		downloadURL.Scheme = "http"
 	}
 	return downloadURL.String(), nil
+}
+
+// ParseDownloadURL parse an image service download URL and returns the image type, the arch and the version.
+// This function can parse /images/ URLs and shorter /by.../ URLs.
+func ParseDownloadURL(downloadURL string) (string, string, string, error) {
+	var imageType, version, arch string
+
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return "", "", "", errors.Wrap(err, "failed to parse download URL")
+	}
+
+	// The URL contains a query string
+	// then it's a long image URL
+	vals := u.Query()
+	if len(vals) > 0 {
+		imageType = vals.Get("type")
+		version = vals.Get("version")
+		arch = vals.Get("arch")
+		return imageType, arch, version, nil
+	}
+
+	// shorter URL
+	rest, isoFilename := path.Split(u.Path)
+	rest, arch = path.Split(path.Clean(rest))
+	_, version = path.Split(path.Clean(rest))
+
+	switch isoFilename {
+	case FullISOFilename:
+		imageType = string(models.ImageTypeFullIso)
+	case MinimalISOFilename:
+		imageType = string(models.ImageTypeMinimalIso)
+	}
+
+	return imageType, arch, version, nil
 }


### PR DESCRIPTION
Generate short URL in the infraenv to download discovery ISO, see the [enhancement](https://github.com/openshift/assisted-service/blob/master/docs/enhancements/short-url-enhancement.md) for more details.

Test locally if there are no issues updating an infraenv from the former URL to the short URL. Tested also the opposite if we do a rollback.