### PR TITLE
MGMT-15762 - fix odf validation failing where is one small disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __pycache__/
 deploy/olm-catalog/**/tests/**
 
 reports
-
+**/junit_unit_test.xml
 # Files used for onprem testing
 coreos-installer
 livecd.iso

--- a/internal/operators/odf/odf_operator.go
+++ b/internal/operators/odf/odf_operator.go
@@ -222,13 +222,13 @@ func (o *operator) GetHostRequirements(_ context.Context, cluster *common.Cluste
 
 // GetPreflightRequirements returns operator hardware requirements that can be determined with cluster data only
 func (o *operator) GetPreflightRequirements(context context.Context, cluster *common.Cluster) (*models.OperatorHardwareRequirements, error) {
-	dependecies, err := o.GetDependencies(cluster)
+	dependencies, err := o.GetDependencies(cluster)
 	if err != nil {
 		return &models.OperatorHardwareRequirements{}, err
 	}
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
-		Dependencies: dependecies,
+		Dependencies: dependencies,
 		Requirements: &models.HostTypeHardwareRequirementsWrapper{
 			Master: &models.HostTypeHardwareRequirements{
 				Quantitative: &models.ClusterHostRequirementsDetails{

--- a/internal/operators/odf/odf_operator_test.go
+++ b/internal/operators/odf/odf_operator_test.go
@@ -39,12 +39,17 @@ var _ = Describe("Odf Operator", func() {
 			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 32 * conversions.GiB,
 				Disks: []*models.Disk{
 					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeHDD, ID: diskID1}}})}
+		masterWithTwoSmallDisk = &models.Host{Role: models.HostRoleMaster, InstallationDiskID: diskID1,
+			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 32 * conversions.GiB,
+				Disks: []*models.Disk{
+					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID1},
+					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeHDD, ID: diskID2}}})}
 		masterWithLessDiskSize = &models.Host{Role: models.HostRoleMaster, InstallationDiskID: diskID1,
 			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 32 * conversions.GiB,
 				Disks: []*models.Disk{
 					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeHDD, ID: diskID1},
 					{SizeBytes: 40 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID2},
-					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID2},
+					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID3},
 				}})}
 		workerWithOneDisk = &models.Host{Role: models.HostRoleWorker, InstallationDiskID: diskID1,
 			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 64 * conversions.GiB,
@@ -78,7 +83,7 @@ var _ = Describe("Odf Operator", func() {
 				Disks: []*models.Disk{
 					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeHDD, ID: diskID1},
 					{SizeBytes: 40 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID2},
-					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID2},
+					{SizeBytes: 20 * conversions.GB, DriveType: models.DriveTypeSSD, ID: diskID3},
 				}})}
 		autoAssignHost = &models.Host{Role: models.HostRoleAutoAssign, SuggestedRole: models.HostRoleAutoAssign, InstallationDiskID: diskID1,
 			Inventory: Inventory(&InventoryResources{Cpus: 12, Ram: 32 * conversions.GiB,
@@ -280,6 +285,13 @@ var _ = Describe("Odf Operator", func() {
 					masterWithThreeDisk, masterWithNoDisk, masterWithLessDiskSize,
 				}}},
 				masterWithLessDiskSize,
+				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID(), Reasons: []string{}},
+			),
+			table.Entry("there is no disk with sufficient size",
+				&common.Cluster{Cluster: models.Cluster{Hosts: []*models.Host{
+					masterWithThreeDisk, masterWithNoDisk, masterWithTwoSmallDisk,
+				}}},
+				masterWithTwoSmallDisk,
 				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Insufficient resources to deploy ODF in compact mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of 25 GB minimum and an installation disk."}},
 			),
 		)
@@ -328,7 +340,7 @@ var _ = Describe("Odf Operator", func() {
 					masterWithThreeDisk, masterWithNoDisk, masterWithOneDisk, workerWithTwoDisk, workerWithThreeDisk, workerWithLessDiskSize,
 				}}},
 				workerWithLessDiskSize,
-				api.ValidationResult{Status: api.Failure, ValidationId: operator.GetHostValidationID(), Reasons: []string{"Insufficient resources to deploy ODF in standard mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of 25 GB minimum and an installation disk."}},
+				api.ValidationResult{Status: api.Success, ValidationId: operator.GetHostValidationID(), Reasons: []string{}},
 			),
 			table.Entry("worker with disk of size zero",
 				&common.Cluster{Cluster: models.Cluster{Hosts: []*models.Host{
@@ -339,5 +351,4 @@ var _ = Describe("Odf Operator", func() {
 			),
 		)
 	})
-
 })

--- a/internal/operators/odf/validations.go
+++ b/internal/operators/odf/validations.go
@@ -167,20 +167,20 @@ func (o *operator) setStatusInsufficientResources(odfClusterResources *odfCluste
 
 // count all disks of drive type ssd or hdd
 func (o *operator) getValidDiskCount(disks []*models.Disk, installationDiskID string, mode odfDeploymentMode) (int64, error) {
-	var countDisks int64
-	var smallDisks int64
+	var countEligibleDisks int64
+	var countRegularDisks int64
 
 	for _, disk := range disks {
 		if (disk.DriveType == models.DriveTypeSSD || disk.DriveType == models.DriveTypeHDD) && installationDiskID != disk.ID && disk.SizeBytes != 0 {
 			if disk.SizeBytes >= conversions.GbToBytes(o.config.ODFMinDiskSizeGB) {
-				countDisks++
+				countEligibleDisks++
 			} else {
-				smallDisks++
+				countRegularDisks++
 			}
 		}
 	}
-	if countDisks == 0 && smallDisks != 0 {
-		return countDisks, fmt.Errorf("Insufficient resources to deploy ODF in %s mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of %d GB minimum and an installation disk.", strings.ToLower(string(mode)), o.config.ODFMinDiskSizeGB)
+	if countEligibleDisks == 0 && countRegularDisks > 0 {
+		return countEligibleDisks, fmt.Errorf("Insufficient resources to deploy ODF in %s mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of %d GB minimum and an installation disk.", strings.ToLower(string(mode)), o.config.ODFMinDiskSizeGB)
 	}
-	return countDisks, nil
+	return countEligibleDisks, nil
 }

--- a/internal/operators/odf/validations.go
+++ b/internal/operators/odf/validations.go
@@ -168,16 +168,19 @@ func (o *operator) setStatusInsufficientResources(odfClusterResources *odfCluste
 // count all disks of drive type ssd or hdd
 func (o *operator) getValidDiskCount(disks []*models.Disk, installationDiskID string, mode odfDeploymentMode) (int64, error) {
 	var countDisks int64
-	var err error
+	var smallDisks int64
 
 	for _, disk := range disks {
 		if (disk.DriveType == models.DriveTypeSSD || disk.DriveType == models.DriveTypeHDD) && installationDiskID != disk.ID && disk.SizeBytes != 0 {
-			if disk.SizeBytes < conversions.GbToBytes(o.config.ODFMinDiskSizeGB) {
-				err = fmt.Errorf("Insufficient resources to deploy ODF in %s mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of %d GB minimum and an installation disk.", strings.ToLower(string(mode)), o.config.ODFMinDiskSizeGB)
-			} else {
+			if disk.SizeBytes >= conversions.GbToBytes(o.config.ODFMinDiskSizeGB) {
 				countDisks++
+			} else {
+				smallDisks++
 			}
 		}
 	}
-	return countDisks, err
+	if countDisks == 0 && smallDisks != 0 {
+		return countDisks, fmt.Errorf("Insufficient resources to deploy ODF in %s mode. ODF requires a minimum of 3 hosts. Each host must have at least 1 additional disk of %d GB minimum and an installation disk.", strings.ToLower(string(mode)), o.config.ODFMinDiskSizeGB)
+	}
+	return countDisks, nil
 }


### PR DESCRIPTION
This PR fixing issue where if one of the disk is small it will fail the validation even if there is sufficient disks 

* add new test cases for this scenario 
* return test disk to random UUID 


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
