### PR TITLE
MGMT-15507: Add adriengentil as approver in ocm-2.9

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,3 +8,4 @@ aliases:
     - gamli75
     - eliorerz
     - osherdp
+    - adriengentil


### PR DESCRIPTION
Add adriengentil in order to align the configuration with other assisted repos.
