### PR TITLE
MGMT-15950:  Fix DNS wilcard domain validation

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -18,7 +18,7 @@ import (
 const (
 	baseDomainRegex          = `^[a-z\d]+[\-]*[a-z\d]+$`
 	dnsNameRegex             = `^([a-z\d]([\-]*[a-z\d]+)*\.)+[a-z\d]+[\-]*[a-z\d]+$`
-	wildCardDomainRegex      = `^(validateNoWildcardDNS\.).+\.$`
+	wildCardDomainRegex      = `^(validateNoWildcardDNS\.).+\.?$`
 	hostnameRegex            = `^[a-z0-9][a-z0-9\-\.]{0,61}[a-z0-9]$`
 	installerArgsValuesRegex = `^[A-Za-z0-9@!#$%*()_+-=//.,";':{}\[\]]+$`
 )

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -265,6 +265,14 @@ var _ = Describe("dns name", func() {
 			valid:      true,
 		},
 		{
+			domainName: "validateNoWildcardDNS.test.com",
+			valid:      true,
+		},
+		{
+			domainName: "validateNoWildcardDNS.test.com.",
+			valid:      true,
+		},
+		{
 			domainName: "a.c",
 			valid:      false,
 		},


### PR DESCRIPTION
DNS wildcard domain starts with validateNoWildcardDNS. The domain may have an optional trailing dot. Currently the assumption is that the trailing dot is mandatory for the domain name.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @tsorya 