### PR TITLE
MGMT-15796: set CloudControllerManager to External for OCI

### DIFF
--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -128,8 +128,23 @@ type NutanixPrismElement struct {
 	Name                           string          `yaml:"name"`
 }
 
+// CloudControllerManager describes the type of cloud controller manager to be enabled.
+type CloudControllerManager string
+
+const (
+	// CloudControllerManagerTypeExternal specifies that an external cloud provider is to be configured.
+	CloudControllerManagerTypeExternal = "External"
+
+	// CloudControllerManagerTypeNone specifies that no cloud provider is to be configured.
+	CloudControllerManagerTypeNone = ""
+)
+
 type ExternalInstallConfigPlatform struct {
+	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
 	PlatformName string `yaml:"platformName"`
+
+	// CloudControllerManager when set to external, this property will enable an external cloud provider.
+	CloudControllerManager CloudControllerManager `yaml:"cloudControllerManager"`
 }
 
 type PlatformNone struct {

--- a/internal/provider/external/installConfig.go
+++ b/internal/provider/external/installConfig.go
@@ -12,7 +12,8 @@ import (
 func (p baseExternalProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerConfigBaremetal, cluster *common.Cluster) error {
 	cfg.Platform = installcfg.Platform{
 		External: &installcfg.ExternalInstallConfigPlatform{
-			PlatformName: string(p.Name()),
+			PlatformName:           string(p.Name()),
+			CloudControllerManager: installcfg.CloudControllerManagerTypeExternal,
 		},
 	}
 


### PR DESCRIPTION
The installer indroduces a breaking change in the definition of the external
platform through https://github.com/openshift/installer/pull/7581. Previously,
the CCM was enabled without a way to disable it, now it will be disabled by
default with a way to enable it.

This change ensure the CCM is enabled when platform is oci in order to keep the
current behaviour.
