### PR TITLE
MGMT-15572 Hold installation when reconcile-pause annotation is set on cluster deployment

### DIFF
--- a/internal/controller/controllers/agent_controller.go
+++ b/internal/controller/controllers/agent_controller.go
@@ -1422,7 +1422,7 @@ func setAgentLabel(log logrus.FieldLogger, agent *aiv1beta1.Agent, key string, v
 	// If the value still doesn't match the regex, skip it because it will cause the update to fail
 	re = regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`)
 	if !re.MatchString(value) {
-		log.Info("Skipping setting of label %s=%s because the value contains illegal characters", key, value)
+		log.Infof("Skipping setting of label %s=%s because the value contains illegal characters", key, value)
 		return false
 	}
 

--- a/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/hiveextension/v1beta1/agentclusterinstall_types.go
@@ -59,7 +59,7 @@ const (
 	ClusterInstallationNotStartedReason string = "InstallationNotStarted"
 	ClusterInstallationNotStartedMsg    string = "The installation has not yet started"
 	ClusterInstallationOnHoldReason     string = "InstallationOnHold"
-	ClusterInstallationOnHoldMsg        string = "The installation is on hold. To unhold set holdInstallation to false"
+	ClusterInstallationOnHoldMsg        string = "The installation is on hold. To unhold set holdInstallation and hive.openshift.io/reconcile-pause annotaiton in cluster deployment to false"
 	ClusterInstallationInProgressReason string = "InstallationInProgress"
 	ClusterInstallationInProgressMsg    string = "The installation is in progress:"
 	ClusterUnknownStatusReason          string = "UnknownStatus"


### PR DESCRIPTION
Assisted service will watch for hive.openshift.io/reconcile-pause annotation on cluster deployment in addition to the existing hold installation field in agent cluster install, the reason for the duplication is and integration with Ansible in ACM product that is not longer maintained so the implementation is done in Assisted

The logic will check both fields on day1 installation and if one of them is set the installation will be paused


## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
