### PR TITLE
[release-ocm-2.8] MGMT-15306: Fix UpdateCluster for requests that include VIPS and UMA

### DIFF
--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -379,8 +379,8 @@ func HandleApiVipBackwardsCompatibility(clusterId strfmt.UUID, apiVip string, ap
 func handleIngressVipUpdateBackwardsCompatibility(cluster *common.Cluster, params *models.V2ClusterUpdateParams) error {
 	if cluster.IngressVip != "" {
 		// IngressVip was cleared and IngressVips were not provided, clear both fields.
-		if swag.StringValue(params.IngressVip) == "" && len(params.IngressVips) == 0 {
-			params.IngressVips = nil
+		if params.IngressVip != nil && swag.StringValue(params.IngressVip) == "" && params.IngressVips == nil {
+			params.IngressVips = []*models.IngressVip{}
 		}
 		// IngressVip was changed (but not cleared), IngressVips will be forcefully set to the value of IngressVips as a one-element list.
 		if params.IngressVip != nil && swag.StringValue(params.IngressVip) != "" && swag.StringValue(params.IngressVip) != cluster.IngressVip {
@@ -396,8 +396,8 @@ func handleIngressVipUpdateBackwardsCompatibility(cluster *common.Cluster, param
 func handleApiVipUpdateBackwardsCompatibility(cluster *common.Cluster, params *models.V2ClusterUpdateParams) error {
 	if cluster.APIVip != "" {
 		// APIVip was cleared and APIVips were not provided, clear both fields.
-		if swag.StringValue(params.APIVip) == "" && len(params.APIVips) == 0 {
-			params.APIVips = nil
+		if params.APIVip != nil && swag.StringValue(params.APIVip) == "" && params.APIVips == nil {
+			params.APIVips = []*models.APIVip{}
 		}
 		// APIVip was changed (but not cleared), APIVips will be forcefully set to the value of APIVip as a one-element list.
 		if params.APIVip != nil && swag.StringValue(params.APIVip) != "" && swag.StringValue(params.APIVip) != cluster.APIVip {
@@ -470,6 +470,43 @@ func ValidateClusterCreateIPAddresses(ipV6Supported bool, clusterId strfmt.UUID,
 	return validateVIPAddresses(ipV6Supported, targetConfiguration)
 }
 
+func validateVIPsWithUMA(cluster *common.Cluster, params *models.V2ClusterUpdateParams, vipDhcpAllocation bool) error {
+	var (
+		apiVip      string
+		ingressVip  string
+		apiVips     []*models.APIVip
+		ingressVips []*models.IngressVip
+	)
+
+	if swag.BoolValue(cluster.VipDhcpAllocation) {
+		return ValidateVIPsWereNotSetUserManagedNetworking(
+			apiVip, ingressVip, apiVips, ingressVips, vipDhcpAllocation,
+		)
+	}
+
+	apiVip = cluster.APIVip
+	ingressVip = cluster.IngressVip
+	apiVips = cluster.APIVips
+	ingressVips = cluster.IngressVips
+
+	if params.APIVip != nil {
+		apiVip = swag.StringValue(params.APIVip)
+	}
+	if params.IngressVip != nil {
+		ingressVip = swag.StringValue(params.IngressVip)
+	}
+	if params.APIVips != nil {
+		apiVips = params.APIVips
+	}
+	if params.IngressVips != nil {
+		ingressVips = params.IngressVips
+	}
+
+	return ValidateVIPsWereNotSetUserManagedNetworking(
+		apiVip, ingressVip, apiVips, ingressVips, vipDhcpAllocation,
+	)
+}
+
 func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Cluster, params *models.V2ClusterUpdateParams) error {
 	var err error
 	targetConfiguration := common.Cluster{}
@@ -501,38 +538,34 @@ func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Clust
 		return common.NewApiError(http.StatusBadRequest, err)
 	}
 
-	targetConfiguration.UserManagedNetworking = swag.Bool(false)
-	if params.UserManagedNetworking != nil {
-		if swag.BoolValue(params.UserManagedNetworking) {
-			err = ValidateVIPsWereNotSetUserManagedNetworking(cluster.APIVip, cluster.IngressVip,
-				cluster.APIVips, cluster.IngressVips, swag.BoolValue(cluster.VipDhcpAllocation))
-			if err != nil {
-				// reformat error to match order of actions
-				errParts := strings.Split(err.Error(), " cannot be set with ")
-				err = errors.Errorf("%s cannot be set with %s", errParts[1], errParts[0])
-				return common.NewApiError(http.StatusBadRequest, err)
-			}
+	if params.UserManagedNetworking != nil && swag.BoolValue(params.UserManagedNetworking) {
+		vipDhcpAllocation := swag.BoolValue(cluster.VipDhcpAllocation)
+		if params.VipDhcpAllocation != nil { // VipDhcpAllocation from update params should take precedence
+			vipDhcpAllocation = swag.BoolValue(params.VipDhcpAllocation)
 		}
-		targetConfiguration.UserManagedNetworking = params.UserManagedNetworking
-	}
-	targetConfiguration.VipDhcpAllocation = swag.Bool(false)
-	if params.VipDhcpAllocation != nil {
-		targetConfiguration.VipDhcpAllocation = params.VipDhcpAllocation
+
+		if err = validateVIPsWithUMA(cluster, params, vipDhcpAllocation); err != nil {
+			// reformat error to match order of actions
+			errParts := strings.Split(err.Error(), " cannot be set with ")
+			err = errors.Errorf("%s cannot be set with %s", errParts[1], errParts[0])
+			return common.NewApiError(http.StatusBadRequest, err)
+		}
+
+		if cluster.VipDhcpAllocation != nil && swag.BoolValue(cluster.VipDhcpAllocation) { // override VIPs that were allocated via DHCP
+			params.APIVip = swag.String("")
+			params.IngressVip = swag.String("")
+			params.APIVips = []*models.APIVip{}
+			params.IngressVips = []*models.IngressVip{}
+		}
 	}
 
 	targetConfiguration.ID = cluster.ID
-	if params.APIVip != nil {
-		targetConfiguration.APIVip = *params.APIVip
-	}
-
-	if params.IngressVip != nil {
-		targetConfiguration.IngressVip = *params.IngressVip
-	}
-
+	targetConfiguration.VipDhcpAllocation = params.VipDhcpAllocation
+	targetConfiguration.APIVip = swag.StringValue(params.APIVip)
 	targetConfiguration.APIVips = params.APIVips
+	targetConfiguration.IngressVip = swag.StringValue(params.IngressVip)
 	targetConfiguration.IngressVips = params.IngressVips
 	targetConfiguration.UserManagedNetworking = params.UserManagedNetworking
-	targetConfiguration.VipDhcpAllocation = params.VipDhcpAllocation
 	targetConfiguration.HighAvailabilityMode = cluster.HighAvailabilityMode
 	targetConfiguration.ClusterNetworks = params.ClusterNetworks
 	targetConfiguration.ServiceNetworks = params.ServiceNetworks
@@ -787,7 +820,7 @@ func ValidateVIPsWereNotSetDhcpMode(apiVip string, ingressVip string, apiVips []
 		err := errors.New("Setting API VIP is forbidden when cluster is in vip-dhcp-allocation mode")
 		return err
 	}
-	if apiVips != nil {
+	if len(apiVips) > 0 {
 		err := errors.New("Setting API VIPs is forbidden when cluster is in vip-dhcp-allocation mode")
 		return err
 	}
@@ -795,7 +828,7 @@ func ValidateVIPsWereNotSetDhcpMode(apiVip string, ingressVip string, apiVips []
 		err := errors.New("Setting Ingress VIP is forbidden when cluster is in vip-dhcp-allocation mode")
 		return err
 	}
-	if ingressVips != nil {
+	if len(ingressVips) > 0 {
 		err := errors.New("Setting Ingress VIPs is forbidden when cluster is in vip-dhcp-allocation mode")
 		return err
 	}


### PR DESCRIPTION
This is a combination of 2 commits.

This is the 1st commit message:

**[MGMT-14416](https://issues.redhat.com//browse/MGMT-14416): VipDhcpAllocation from update params should take precedence (https://github.com/openshift/assisted-service/pull/5209)**

This change fixes a case where UserManagedNetworking and
VipDhcpAllocation are being changed at the same API update.

The ValidateClusterUpdateVIPAddresses func will now use VipDhcpAllocation
from update params, if relevant, before taking the DB cluster
VipDhcpAllocation into account.

Additionally, an additional error surfaced while fixing the aforementioned
issue, displaying a "User Managed Networking cannot be set with API VIP" to the user.

This change will also handle such a scenario by clearing up API and Ingress VIPs
that were set by DHCP, in case the user switched to 'User Managed Networking'.

This is the commit message https://github.com/openshift/assisted-service/pull/2:

**[MGMT-15306](https://issues.redhat.com//browse/MGMT-15306): Fix UpdateCluster for requests that include VIPS and UMA (https://github.com/openshift/assisted-service/pull/5547)**

This fix handles cluster updates that patch UMN and VIPs at the same request.
There was an issue in which the code overrode an empty VIPs array (which is
how VIPs should get deleted) with a nil, indicating no update to this field.

This change also includes tests that validate those exact scenarios.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
