### PR TITLE
Add skopeo to OCP build

### DIFF
--- a/Dockerfile.assisted-service.ocp
+++ b/Dockerfile.assisted-service.ocp
@@ -19,9 +19,10 @@ FROM registry.ci.openshift.org/ocp/4.14:base
 
 LABEL io.openshift.release.operator=true
 
+# multiarch images need skopeo until WRKLDS-222 and https://bugzilla.redhat.com/show_bug.cgi?id=2111537 are fixed
 # ToDo: Replace postgres with SQLite DB
 # https://issues.redhat.com/browse/AGENT-223
-RUN dnf install -y postgresql-server libvirt-libs nmstate nmstate-libs && dnf clean all
+RUN dnf install -y postgresql-server libvirt-libs nmstate nmstate-libs skopeo && dnf clean all
 
 RUN dnf update libksba libxml2 -y && dnf clean all
 


### PR DESCRIPTION
Skopeo is missing from the ocp build of assisted-service, causing this error when using the 'multi' payload with agent installer:
```
'skopeo inspect --raw --no-tags docker://quay.io/openshift-release-dev/ocp-release:4.15.0-ec.0-multi --authfile /tmp/registry-config1256292744' 
exited with non-zero exit code -1: \nexec: \"skopeo\": executable file not found in $PATH"
```
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual (Elaborate on how it was tested)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
