### PR TITLE
NO-ISSUE: Fix console output in ZTP jobs

### DIFF
--- a/deploy/operator/ztp/baremetalHost.j2
+++ b/deploy/operator/ztp/baremetalHost.j2
@@ -40,7 +40,9 @@ metadata:
     infraenvs.agent-install.openshift.io: '{{ infraenv_name }}'
   annotations:
     bmac.agent-install.openshift.io/hostname: '{{ host["name"] }}'
-    bmac.agent-install.openshift.io/installer-args: '["--console", "ttyS0"]'
+    # enable serial console when installing core os
+    # the console output will be logged by libvirt in order to ease debugging
+    bmac.agent-install.openshift.io/installer-args: '["--append-karg", "console=ttyS0"]'
 {% if baremetalhosts_ignition_override|string | length > 0 %}
     bmac.agent-install.openshift.io/ignition-config-overrides: '{{ baremetalhosts_ignition_override | tojson }}'
 {% endif %}

--- a/deploy/operator/ztp/infraEnv-latebinding.j2
+++ b/deploy/operator/ztp/infraEnv-latebinding.j2
@@ -9,6 +9,8 @@ spec:
   pullSecretRef:
     name: '{{ pull_secret_name }}'
   sshAuthorizedKey: '{{ ssh_public_key }}'
+  # enable serial console when booting on the disccovery ISO
+  # the console output will be logged by libvirt in order to ease debugging
   kernelArguments:
     - operation: append
       value: console=ttyS0

--- a/deploy/operator/ztp/infraEnv.j2
+++ b/deploy/operator/ztp/infraEnv.j2
@@ -12,6 +12,8 @@ spec:
   pullSecretRef:
     name: '{{ pull_secret_name }}'
   sshAuthorizedKey: '{{ ssh_public_key }}'
+  # enable serial console when booting on the disccovery ISO
+  # the console output will be logged by libvirt in order to ease debugging
   kernelArguments:
     - operation: append
       value: console=ttyS0


### PR DESCRIPTION
https://github.com/openshift/assisted-service/pull/5550 was merged by mistake.

The installer params don't allow `--console` flags, using `--append-karg`
instead.
