### PR TITLE
OCPBUGS-19823: Ignore hostPrefix validation for plugins other than OVN/SDN

### DIFF
--- a/internal/cluster/validator.go
+++ b/internal/cluster/validator.go
@@ -536,9 +536,14 @@ func (v *clusterValidator) networkPrefixValid(c *clusterPreprocessContext) (Vali
 		return ValidationPending, "The Cluster Network CIDR is undefined."
 	}
 	validClusterNetworks := funk.Filter(c.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
-		return clusterNetwork != nil && (v.skipNetworkHostPrefixCheck(c, clusterNetwork.HostPrefix) ||
-			network.VerifyNetworkHostPrefix(clusterNetwork.HostPrefix) == nil &&
-				network.VerifyClusterCidrSize(int(clusterNetwork.HostPrefix), string(clusterNetwork.Cidr), len(c.cluster.Hosts)) == nil)
+		if clusterNetwork == nil {
+			return false
+		}
+		if v.skipNetworkHostPrefixCheck(c, clusterNetwork.HostPrefix) {
+			return true
+		}
+		return network.VerifyNetworkHostPrefix(clusterNetwork.HostPrefix) == nil &&
+			network.VerifyClusterCidrSize(int(clusterNetwork.HostPrefix), string(clusterNetwork.Cidr), len(c.cluster.Hosts)) == nil
 	}).([]*models.ClusterNetwork)
 
 	if len(validClusterNetworks) == len(c.cluster.ClusterNetworks) {

--- a/internal/cluster/validator_test.go
+++ b/internal/cluster/validator_test.go
@@ -627,23 +627,6 @@ var _ = Describe("skipNetworkHostPrefixCheck", func() {
 		clusterID = strfmt.UUID(uuid.New().String())
 	})
 
-	It("Returns false when hostPrefix is greater than 0", func() {
-		clusterNetworks := []*models.ClusterNetwork{
-			{Cidr: "10.0.2.1/24", ClusterID: clusterID, HostPrefix: 1},
-			{Cidr: "2002::1234:abcd:ffff:c0a8:102/64", ClusterID: clusterID, HostPrefix: 1},
-		}
-
-		preprocessContext.cluster = &common.Cluster{Cluster: models.Cluster{
-			ID:              &clusterID,
-			ClusterNetworks: clusterNetworks,
-		}}
-
-		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
-			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
-		}).([]*models.ClusterNetwork)
-		Expect(len(skipped)).Should(Equal(0))
-	})
-
 	It("Returns false when hostPrefix 0 and networkType OVN", func() {
 		clusterNetworks := []*models.ClusterNetwork{
 			{Cidr: "10.0.2.1/24", ClusterID: clusterID},
@@ -657,10 +640,8 @@ var _ = Describe("skipNetworkHostPrefixCheck", func() {
 			NetworkType:     &networkType,
 		}}
 
-		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
-			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
-		}).([]*models.ClusterNetwork)
-		Expect(len(skipped)).Should(Equal(0))
+		skipped := validator.skipNetworkHostPrefixCheck(preprocessContext)
+		Expect(skipped).Should(Equal(false))
 	})
 
 	It("Returns true when hostPrefix 0 and networkType not OVN or SDN", func() {
@@ -678,9 +659,7 @@ var _ = Describe("skipNetworkHostPrefixCheck", func() {
 			InstallConfigOverrides: installCfgOverrides,
 		}}
 
-		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
-			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
-		}).([]*models.ClusterNetwork)
-		Expect(len(skipped)).Should(Equal(2))
+		skipped := validator.skipNetworkHostPrefixCheck(preprocessContext)
+		Expect(skipped).Should(Equal(true))
 	})
 })

--- a/internal/cluster/validator_test.go
+++ b/internal/cluster/validator_test.go
@@ -612,3 +612,75 @@ var _ = Describe("Platform validations", func() {
 		Expect(message).To(Equal("Platform requirements satisfied"))
 	})
 })
+
+var _ = Describe("skipNetworkHostPrefixCheck", func() {
+
+	var (
+		validator         clusterValidator
+		preprocessContext *clusterPreprocessContext
+		clusterID         strfmt.UUID
+	)
+
+	BeforeEach(func() {
+		validator = clusterValidator{logrus.New(), nil}
+		preprocessContext = &clusterPreprocessContext{}
+		clusterID = strfmt.UUID(uuid.New().String())
+	})
+
+	It("Returns false when hostPrefix is greater than 0", func() {
+		clusterNetworks := []*models.ClusterNetwork{
+			{Cidr: "10.0.2.1/24", ClusterID: clusterID, HostPrefix: 1},
+			{Cidr: "2002::1234:abcd:ffff:c0a8:102/64", ClusterID: clusterID, HostPrefix: 1},
+		}
+
+		preprocessContext.cluster = &common.Cluster{Cluster: models.Cluster{
+			ID:              &clusterID,
+			ClusterNetworks: clusterNetworks,
+		}}
+
+		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
+			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
+		}).([]*models.ClusterNetwork)
+		Expect(len(skipped)).Should(Equal(0))
+	})
+
+	It("Returns false when hostPrefix 0 and networkType OVN", func() {
+		clusterNetworks := []*models.ClusterNetwork{
+			{Cidr: "10.0.2.1/24", ClusterID: clusterID},
+			{Cidr: "2002::1234:abcd:ffff:c0a8:102/64", ClusterID: clusterID},
+		}
+		networkType := models.ClusterNetworkTypeOVNKubernetes
+
+		preprocessContext.cluster = &common.Cluster{Cluster: models.Cluster{
+			ID:              &clusterID,
+			ClusterNetworks: clusterNetworks,
+			NetworkType:     &networkType,
+		}}
+
+		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
+			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
+		}).([]*models.ClusterNetwork)
+		Expect(len(skipped)).Should(Equal(0))
+	})
+
+	It("Returns true when hostPrefix 0 and networkType not OVN or SDN", func() {
+		clusterNetworks := []*models.ClusterNetwork{
+			{Cidr: "10.0.2.1/24", ClusterID: clusterID},
+			{Cidr: "2002::1234:abcd:ffff:c0a8:102/64", ClusterID: clusterID},
+		}
+		networkType := models.ClusterNetworkTypeOVNKubernetes
+		installCfgOverrides := "{\"networking\":{\"networkType\":\"Calico\"}}"
+
+		preprocessContext.cluster = &common.Cluster{Cluster: models.Cluster{
+			ID:                     &clusterID,
+			ClusterNetworks:        clusterNetworks,
+			NetworkType:            &networkType,
+			InstallConfigOverrides: installCfgOverrides,
+		}}
+
+		skipped := funk.Filter(preprocessContext.cluster.ClusterNetworks, func(clusterNetwork *models.ClusterNetwork) bool {
+			return validator.skipNetworkHostPrefixCheck(preprocessContext, clusterNetwork.HostPrefix)
+		}).([]*models.ClusterNetwork)
+		Expect(len(skipped)).Should(Equal(2))
+	})
+})


### PR DESCRIPTION
For plugins other than OVN/SDN (e.g. Calico), the clusterNetwork hostPrefix setting is not used so remove the validation. Since the networkType for plugins other than OVN/SDN can be passed in installconfig-overrides, that must also be checked.

Note that this is similar to the installer change to ignore the hostPrefix for these networkTypes - https://github.com/openshift/installer/pull/3888.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
