### PR TITLE
MGMT-15971: Create ManagedCluster CR so that the hub will show up as "Ready" in MCE

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -164,7 +164,7 @@ var Options struct {
 	PreprovisioningImageControllerConfig controllers.PreprovisioningImageControllerConfig
 	BMACConfig                           controllers.BMACConfig
 	EnableLocalClusterImport             bool   `envconfig:"ENABLE_LOCAL_CLUSTER_IMPORT" default:"true"`
-	LocalClusterImportNamespace          string `envconfig:"LOCAL_CLUSTER_IMPORT_NAMESPACE" default:"local-agent-cluster"`
+	LocalClusterImportNamespace          string `envconfig:"LOCAL_CLUSTER_IMPORT_NAMESPACE" default:"local-cluster"`
 
 	// Directory containing pre-generated TLS certs/keys for the ephemeral installer
 	ClusterTLSCertOverrideDir string `envconfig:"EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR" default:""`

--- a/pkg/localclusterimport/import_local_cluster.go
+++ b/pkg/localclusterimport/import_local_cluster.go
@@ -94,7 +94,7 @@ func (i *LocalClusterImport) createAgentClusterInstall(numberOfControlPlaneNodes
 				UserManagedNetworking: &userManagedNetworkingActive,
 			},
 			ClusterDeploymentRef: v1.LocalObjectReference{
-				Name: i.localClusterNamespace + "-cluster-deployment",
+				Name: i.localClusterNamespace,
 			},
 			ImageSetRef: &hivev1.ClusterImageSetReference{
 				Name: "local-cluster-image-set",
@@ -105,7 +105,7 @@ func (i *LocalClusterImport) createAgentClusterInstall(numberOfControlPlaneNodes
 		},
 	}
 	agentClusterInstall.Namespace = i.localClusterNamespace
-	agentClusterInstall.Name = i.localClusterNamespace + "-cluster-install"
+	agentClusterInstall.Name = i.localClusterNamespace
 	err := i.clusterImportOperations.CreateAgentClusterInstall(agentClusterInstall)
 	if err != nil {
 		i.log.Errorf("could not create AgentClusterInstall due to error %s", err.Error())
@@ -141,7 +141,7 @@ func (i *LocalClusterImport) createClusterDeployment(pullSecret *v1.Secret, dns 
 				AdminKubeconfigSecretRef: v1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", i.localClusterNamespace)},
 			},
 			ClusterInstallRef: &hivev1.ClusterInstallLocalReference{
-				Name:    i.localClusterNamespace + "-cluster-install",
+				Name:    i.localClusterNamespace,
 				Group:   "extensions.hive.openshift.io",
 				Kind:    "AgentClusterInstall",
 				Version: "v1beta1",
@@ -158,9 +158,9 @@ func (i *LocalClusterImport) createClusterDeployment(pullSecret *v1.Secret, dns 
 			},
 		},
 	}
-	clusterDeployment.Name = i.localClusterNamespace + "-cluster-deployment"
+	clusterDeployment.Name = i.localClusterNamespace
 	clusterDeployment.Namespace = i.localClusterNamespace
-	clusterDeployment.Spec.ClusterName = i.localClusterNamespace + "-cluster-deployment"
+	clusterDeployment.Spec.ClusterName = i.localClusterNamespace
 	clusterDeployment.Spec.BaseDomain = dns.Spec.BaseDomain
 	agentClusterInstallOwnerRef := metav1.OwnerReference{
 		Kind:       "AgentServiceConfig",

--- a/pkg/localclusterimport/import_local_cluster_test.go
+++ b/pkg/localclusterimport/import_local_cluster_test.go
@@ -259,7 +259,7 @@ var _ = Describe("ImportLocalCluster", func() {
 					UserManagedNetworking: &userManagedNetworkingActive,
 				},
 				ClusterDeploymentRef: v1.LocalObjectReference{
-					Name: localClusterNamespace + "-cluster-deployment",
+					Name: localClusterNamespace,
 				},
 				ImageSetRef: &hivev1.ClusterImageSetReference{
 					Name: "local-cluster-image-set",
@@ -270,7 +270,7 @@ var _ = Describe("ImportLocalCluster", func() {
 			},
 		}
 		agentClusterInstall.Namespace = localClusterNamespace
-		agentClusterInstall.Name = localClusterNamespace + "-cluster-install"
+		agentClusterInstall.Name = localClusterNamespace
 		return agentClusterInstall
 	}
 
@@ -298,7 +298,7 @@ var _ = Describe("ImportLocalCluster", func() {
 					AdminKubeconfigSecretRef: v1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", localClusterNamespace)},
 				},
 				ClusterInstallRef: &hivev1.ClusterInstallLocalReference{
-					Name:    localClusterNamespace + "-cluster-install",
+					Name:    localClusterNamespace,
 					Group:   "extensions.hive.openshift.io",
 					Kind:    "AgentClusterInstall",
 					Version: "v1beta1",
@@ -315,9 +315,9 @@ var _ = Describe("ImportLocalCluster", func() {
 				},
 			},
 		}
-		clusterDeployment.Name = localClusterNamespace + "-cluster-deployment"
+		clusterDeployment.Name = localClusterNamespace
 		clusterDeployment.Namespace = localClusterNamespace
-		clusterDeployment.Spec.ClusterName = localClusterNamespace + "-cluster-deployment"
+		clusterDeployment.Spec.ClusterName = localClusterNamespace
 		clusterDeployment.Spec.BaseDomain = "foobar.local"
 		//
 		// Adding this ownership reference to ensure we can submit clusterDeployment without ManagedClusterSet/join permission


### PR DESCRIPTION
Presently, the locally imported hub cluster will show up in the UI of MCE as a "Disconnected" cluster.
This means that the end user will be unable to perform actions such as adding nodes to the cluster.

This PR addresses this issue by changing the naming, and namespacing of the AgentClusterInstall and ClusterDeployment CR's so that they reference the already existing ManagedCluster


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Going to run up MCE UI and make sure that the Hosted Cluster shows up as "Connected" once automatically created
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
