### PR TITLE
MGMT-16001: Sanitize reclaim daemonset name

### DIFF
--- a/internal/controller/controllers/agent_reclaimer.go
+++ b/internal/controller/controllers/agent_reclaimer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kelseyhightower/envconfig"
 	authzv1 "github.com/openshift/api/authorization/v1"
@@ -235,7 +236,7 @@ func (r *agentReclaimer) createNextStepRunnerDaemonSet(ctx context.Context, c cl
 		})
 	}
 
-	name := fmt.Sprintf("%s-reclaim", nodeName)
+	name := fmt.Sprintf("%s-reclaim", strings.ReplaceAll(nodeName, ".", "_"))
 	var privileged bool = true
 	containers := []corev1.Container{{
 		Name:            name,

--- a/internal/controller/controllers/agent_reclaimer_test.go
+++ b/internal/controller/controllers/agent_reclaimer_test.go
@@ -290,10 +290,10 @@ var _ = Context("with a fake client", func() {
 		})
 	})
 
-	Describe("createNextStepRunnerDaemonSet", func() {
+	Describe("CC createNextStepRunnerDaemonSet", func() {
 		var (
 			nodeName      = "node.example.com"
-			daemonSetName = "node.example.com-reclaim"
+			daemonSetName = "node_example_com-reclaim"
 			infraEnvID    string
 			hostID        string
 			nodeUID       string


### PR DESCRIPTION
[MGMT-16001](https://issues.redhat.com/browse/MGMT-16001)
Recently there have been errors running the reclaim agent when unbinding due to the daemonset's
container's name containing dots. This replaces all dot characters `.` with underscore characters `_`.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
