### PR TITLE
AGENT-720: Change vSphere credential field tags to json

### DIFF
--- a/internal/installcfg/builder/builder_test.go
+++ b/internal/installcfg/builder/builder_test.go
@@ -207,6 +207,26 @@ aEA8gNEmV+rb7h1v0r3EwDQYJKoZIhvcNAQELBQAwYTELMAkGA1UEBhMCaXMxCzAJBgNVBAgMAmRk
 		Expect(result.Networking.NetworkType).To(Equal(models.ClusterNetworkTypeOpenShiftSDN))
 	})
 
+	It("vSphere credentials in overrides is decoded correctly", func() {
+		var result installcfg.InstallerConfigBaremetal
+		overrides := "{\"platform\":{\"vsphere\":{\"vcenters\":[{\"server\":\"vcenter.openshift.com\",\"user\":\"testUser\",\"password\":\"testPassword\",\"datacenters\":[\"testDatacenter\"]}],\"failureDomains\":[{\"name\":\"testfailureDomain\",\"region\":\"testRegion\",\"zone\":\"testZone\",\"server\":\"vcenter.openshift.com\",\"topology\":{\"datacenter\":\"testDatacenter\",\"computeCluster\":\"/testDatacenter/host/testComputecluster\",\"networks\":[\"testNetwork\"],\"datastore\":\"/testDatacenter/datastore/testDatastore\",\"resourcePool\":\"/testDatacenter/host/testComputecluster//Resources\",\"folder\":\"/testDatacenter/vm/testFolder\"}}]}}}"
+		err := installConfig.applyConfigOverrides(overrides, &result)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(result.Platform.Vsphere.VCenters[0].Server).Should(Equal("vcenter.openshift.com"))
+		Expect(result.Platform.Vsphere.VCenters[0].Username).Should(Equal("testUser"))
+		Expect(result.Platform.Vsphere.VCenters[0].Password.String()).Should(Equal("testPassword"))
+		Expect(len(result.Platform.Vsphere.VCenters[0].Datacenters)).Should(Equal(1))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Name).Should(Equal("testfailureDomain"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Region).Should(Equal("testRegion"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Server).Should(Equal("vcenter.openshift.com"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Topology.Datacenter).Should(Equal("testDatacenter"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Topology.ComputeCluster).Should(Equal("/testDatacenter/host/testComputecluster"))
+		Expect(len(result.Platform.Vsphere.FailureDomains[0].Topology.Networks)).Should(Equal(1))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Topology.Datastore).Should(Equal("/testDatacenter/datastore/testDatastore"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Topology.ResourcePool).Should(Equal("/testDatacenter/host/testComputecluster//Resources"))
+		Expect(result.Platform.Vsphere.FailureDomains[0].Topology.Folder).Should(Equal("/testDatacenter/vm/testFolder"))
+	})
+
 	It("correctly applies cluster overrides", func() {
 		var result installcfg.InstallerConfigBaremetal
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(2)

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -32,66 +32,66 @@ type BareMetalInstallConfigPlatform struct {
 }
 
 type VsphereFailureDomainTopology struct {
-	ComputeCluster string   `yaml:"computeCluster"`
-	Datacenter     string   `yaml:"datacenter"`
-	Datastore      string   `yaml:"datastore"`
-	Folder         string   `yaml:"folder,omitempty"`
-	Networks       []string `yaml:"networks,omitempty"`
-	ResourcePool   string   `yaml:"resourcePool,omitempty"`
+	ComputeCluster string   `json:"computeCluster"`
+	Datacenter     string   `json:"datacenter"`
+	Datastore      string   `json:"datastore"`
+	Folder         string   `json:"folder,omitempty"`
+	Networks       []string `json:"networks,omitempty"`
+	ResourcePool   string   `json:"resourcePool,omitempty"`
 }
 
 // VsphereFailureDomain holds the region and zone failure domain and the vCenter topology of that failure domain.
 type VsphereFailureDomain struct {
 	// Name defines the name of the VsphereFailureDomain. This name is arbitrary but will be used in VSpherePlatformDeploymentZone for association
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 
 	// Region defines a FailureDomainCoordinate which includes the name of the vCenter tag, the failure domain type and the name of the vCenter tag category.
-	Region string `yaml:"region"`
+	Region string `json:"region"`
 
 	// Server is the fully-qualified domain name or the IP address of the vCenter server.
-	Server string `yaml:"server"`
+	Server string `json:"server"`
 
 	// Topology describes a given failure domain using vSphere constructs
-	Topology VsphereFailureDomainTopology `yaml:"topology"`
+	Topology VsphereFailureDomainTopology `json:"topology"`
 
 	// Zone defines a VSpherePlatformFailureDomain which includes the name of the vCenter tag, the failure domain type and the name of the vCenter tag category.
-	Zone string `yaml:"zone"`
+	Zone string `json:"zone"`
 }
 
 // VsphereVCenter stores the vCenter connection fields https://github.com/kubernetes/cloud-provider-vsphere/blob/master/pkg/common/config/types_yaml.go
 type VsphereVCenter struct {
 	// Datacenter in which VMs are located.
-	Datacenters []string `yaml:"datacenters"`
+	Datacenters []string `json:"datacenters"`
 
 	// Password is the password for the user to use
-	Password strfmt.Password `yaml:"password"`
+	Password strfmt.Password `json:"password"`
 
 	// Port is the TCP port that will be used to communicate to the vCenter endpoint. This is typically unchanged
 	// from the default of HTTPS TCP/443.
-	Port int32 `yaml:"port,omitempty"`
+	Port int32 `json:"port,omitempty"`
 
 	// Server is the fully-qualified domain name or the IP address of the vCenter server
-	Server string `yaml:"server"`
+	Server string `json:"server"`
 
 	// Username is the username that will be used to connect to vCenter
-	Username string `yaml:"user"`
+	Username string `json:"user"`
 }
 
 type VsphereInstallConfigPlatform struct {
-	DeprecatedVCenter          string                 `yaml:"vCenter,omitempty"`
-	DeprecatedUsername         string                 `yaml:"username,omitempty"`
-	DeprecatedPassword         strfmt.Password        `yaml:"password,omitempty"`
-	DeprecatedDatacenter       string                 `yaml:"datacenter,omitempty"`
-	DeprecatedDefaultDatastore string                 `yaml:"defaultDatastore,omitempty"`
-	DeprecatedFolder           string                 `yaml:"folder,omitempty"`
-	DeprecatedNetwork          string                 `yaml:"network,omitempty"`
-	DeprecatedCluster          string                 `yaml:"cluster,omitempty"`
-	DeprecatedAPIVIP           string                 `yaml:"apiVIP,omitempty"`
-	DeprecatedIngressVIP       string                 `yaml:"ingressVIP,omitempty"`
-	IngressVIPs                []string               `yaml:"ingressVIPs,omitempty"`
-	APIVIPs                    []string               `yaml:"apiVIPs,omitempty"`
-	FailureDomains             []VsphereFailureDomain `yaml:"failureDomains,omitempty"`
-	VCenters                   []VsphereVCenter       `yaml:"vcenters,omitempty"`
+	DeprecatedVCenter          string                 `json:"vCenter,omitempty"`
+	DeprecatedUsername         string                 `json:"username,omitempty"`
+	DeprecatedPassword         strfmt.Password        `json:"password,omitempty"`
+	DeprecatedDatacenter       string                 `json:"datacenter,omitempty"`
+	DeprecatedDefaultDatastore string                 `json:"defaultDatastore,omitempty"`
+	DeprecatedFolder           string                 `json:"folder,omitempty"`
+	DeprecatedNetwork          string                 `json:"network,omitempty"`
+	DeprecatedCluster          string                 `json:"cluster,omitempty"`
+	DeprecatedAPIVIP           string                 `json:"apiVIP,omitempty"`
+	DeprecatedIngressVIP       string                 `json:"ingressVIP,omitempty"`
+	IngressVIPs                []string               `json:"ingressVIPs,omitempty"`
+	APIVIPs                    []string               `json:"apiVIPs,omitempty"`
+	FailureDomains             []VsphereFailureDomain `json:"failureDomains,omitempty"`
+	VCenters                   []VsphereVCenter       `json:"vcenters,omitempty"`
 }
 
 type NutanixInstallConfigPlatform struct {


### PR DESCRIPTION
The username is currently defined as yaml in the field tag. It should be defined as json because builder.applyConfigOverrides uses json.NewDecoder to decode the overrides string to the InstallerConfigBaremetal struct.

When it is set as yaml in the field tag named "user" in the yaml isn't decoded to "Username" in the struct. It works correctly when the field tag is defined as json.

Other vSphere credential field tags are also updated to json in this patch. The deprecated fields also exhibit the same problem because their field names and struct names are not spelled the same.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None
- [x] Agent-based installations

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
