### PR TITLE
MGMT-15684: Return appropriate HTTP error code for invalid manifest file path

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -454,7 +454,7 @@ func (m *Manifests) validateManifestFileNames(ctx context.Context, clusterID str
 		if strings.Contains(fileName, " ") {
 			return m.prepareAndLogError(
 				ctx,
-				http.StatusBadRequest,
+				http.StatusUnprocessableEntity,
 				errors.Errorf("Cluster manifest %s for cluster %s should not include a space in its name.",
 					fileName,
 					clusterID))
@@ -462,8 +462,8 @@ func (m *Manifests) validateManifestFileNames(ctx context.Context, clusterID str
 		if strings.ContainsRune(fileName, os.PathSeparator) {
 			return m.prepareAndLogError(
 				ctx,
-				http.StatusBadRequest,
-				errors.Errorf("Cluster manifest %s for cluster %s should not include a directory in its name.",
+				http.StatusUnprocessableEntity,
+				errors.Errorf("Cluster manifest %s for cluster %s should not include a directory in it's name.",
 					fileName,
 					clusterID))
 		}

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -271,7 +271,7 @@ var _ = Describe("ClusterManifestTests", func() {
 				})
 				err := response.(*common.ApiErrorResponse)
 				expectedErrorMessage := fmt.Sprintf("Cluster manifest %s for cluster %s should not include a space in its name.", fileName, clusterID)
-				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusUnprocessableEntity)))
 				Expect(err.Error()).To(Equal(expectedErrorMessage))
 			})
 
@@ -443,8 +443,8 @@ spec:
 				})
 				Expect(response).Should(BeAssignableToTypeOf(common.NewApiError(http.StatusBadRequest, errors.New(""))))
 				err := response.(*common.ApiErrorResponse)
-				Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
-				Expect(err.Error()).To(ContainSubstring("Cluster manifest openshift/99-test.yaml for cluster " + clusterID.String() + " should not include a directory in its name."))
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusUnprocessableEntity)))
+				Expect(err.Error()).To(ContainSubstring("Cluster manifest openshift/99-test.yaml for cluster " + clusterID.String() + " should not include a directory in it's name."))
 			})
 
 			It("Creation fails for a manifest file that exceeds the maximum upload size", func() {
@@ -864,7 +864,7 @@ invalid YAML content: {
 			})
 			err := response.(*common.ApiErrorResponse)
 			expectedErrorMessage := fmt.Sprintf("Cluster manifest %s for cluster %s should not include a space in its name.", destFileName, clusterID)
-			Expect(err.StatusCode()).To(Equal(int32(http.StatusBadRequest)))
+			Expect(err.StatusCode()).To(Equal(int32(http.StatusUnprocessableEntity)))
 			Expect(err.Error()).To(Equal(expectedErrorMessage))
 		})
 


### PR DESCRIPTION
When validating the manifest file path, the assisted service presently returns a 400 (Bad Request) HTTP error code in the case of a request that contains invalid manifest file paths.

It has been pointed out that this should be a 422 (Unprocessable Entity) error code instead.

This PR changes the returned error code and updates tests to match.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
