### PR TITLE
MGMT-15683: Ensure that manifest filename has valid name part

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -451,6 +451,15 @@ func (m *Manifests) fetchManifestContent(ctx context.Context, clusterID strfmt.U
 
 func (m *Manifests) validateManifestFileNames(ctx context.Context, clusterID strfmt.UUID, fileNames []string) error {
 	for _, fileName := range fileNames {
+		fileNameWithoutExtension := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+		if len(strings.TrimSpace(fileNameWithoutExtension)) == 0 {
+			return m.prepareAndLogError(
+				ctx,
+				http.StatusUnprocessableEntity,
+				errors.Errorf("Cluster manifest %s for cluster %s has an invalid filename.",
+					fileName,
+					clusterID))
+		}
 		if strings.Contains(fileName, " ") {
 			return m.prepareAndLogError(
 				ctx,

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -258,6 +258,23 @@ var _ = Describe("ClusterManifestTests", func() {
 				return fmt.Sprintf("{\"data\":\"%s\"}", largeElementBuilder.String())
 			}
 
+			It("Does not accept a filename that does not contain a name before the extension", func() {
+				clusterID := registerCluster().ID
+				content := "{}"
+				fileName := ".yaml"
+				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
+					ClusterID: *clusterID,
+					CreateManifestParams: &models.CreateManifestParams{
+						Content:  &content,
+						FileName: &fileName,
+					},
+				})
+				err := response.(*common.ApiErrorResponse)
+				expectedErrorMessage := fmt.Sprintf("Cluster manifest %s for cluster %s has an invalid filename.", fileName, clusterID)
+				Expect(err.StatusCode()).To(Equal(int32(http.StatusUnprocessableEntity)))
+				Expect(err.Error()).To(Equal(expectedErrorMessage))
+			})
+
 			It("Does not accept a filename that contains spaces", func() {
 				clusterID := registerCluster().ID
 				content := "{}"


### PR DESCRIPTION
Presently when uploading a manifest, it's possible to upload a filename with just an extension, for example a filename '.yaml' is considered to be valid.

Clearly this is incorrect and this PR seeks to rectify this issue.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
