### PR TITLE
MGMT-15405: Add a URL to infraenv to show download link from static network config

### DIFF
--- a/api/v1beta1/infraenv_types.go
+++ b/api/v1beta1/infraenv_types.go
@@ -172,6 +172,8 @@ type InfraEnvDebugInfo struct {
 	// EventsURL specifies an HTTP/S URL that contains InfraEnv events
 	// +optional
 	EventsURL string `json:"eventsURL"`
+	// StaticNetworkDownloadURL specifies an HTTP/S URL that contains the static network config
+	StaticNetworkDownloadURL string `json:"staticNetworkDownloadURL,omitempty"`
 }
 
 type BootArtifacts struct {

--- a/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
+++ b/config/crd/bases/agent-install.openshift.io_infraenvs.yaml
@@ -315,6 +315,10 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains InfraEnv
                       events
                     type: string
+                  staticNetworkDownloadURL:
+                    description: StaticNetworkDownloadURL specifies an HTTP/S URL
+                      that contains the static network config
+                    type: string
                 type: object
               isoDownloadURL:
                 description: ISODownloadURL specifies an HTTP/S URL that contains

--- a/config/crd/resources.yaml
+++ b/config/crd/resources.yaml
@@ -2744,6 +2744,10 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains InfraEnv
                       events
                     type: string
+                  staticNetworkDownloadURL:
+                    description: StaticNetworkDownloadURL specifies an HTTP/S URL
+                      that contains the static network config
+                    type: string
                 type: object
               isoDownloadURL:
                 description: ISODownloadURL specifies an HTTP/S URL that contains

--- a/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
+++ b/deploy/olm-catalog/manifests/agent-install.openshift.io_infraenvs.yaml
@@ -313,6 +313,10 @@ spec:
                     description: EventsURL specifies an HTTP/S URL that contains InfraEnv
                       events
                     type: string
+                  staticNetworkDownloadURL:
+                    description: StaticNetworkDownloadURL specifies an HTTP/S URL
+                      that contains the static network config
+                    type: string
                 type: object
               isoDownloadURL:
                 description: ISODownloadURL specifies an HTTP/S URL that contains

--- a/internal/controller/controllers/infraenv_controller_test.go
+++ b/internal/controller/controllers/infraenv_controller_test.go
@@ -148,7 +148,7 @@ var _ = Describe("infraEnv reconcile", func() {
 				Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
 				Expect(params.InfraEnvUpdateParams.ImageType).To(Equal(models.ImageTypeMinimalIso))
 			}).Return(
-			&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
+			&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: sId, ID: &sId, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch, StaticNetworkConfig: "foobar"}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 		infraEnvImage := newInfraEnvImage("infraEnvImage", testNamespace, aiv1beta1.InfraEnvSpec{
 			ClusterRef:    &aiv1beta1.ClusterReference{Name: "clusterDeployment", Namespace: testNamespace},
 			PullSecretRef: &corev1.LocalObjectReference{Name: "pull-secret"},
@@ -165,6 +165,7 @@ var _ = Describe("infraEnv reconcile", func() {
 		}
 		Expect(c.Get(ctx, key, infraEnvImage)).To(BeNil())
 		Expect(infraEnvImage.Status.ISODownloadURL).To(Equal(imageInfo.DownloadURL))
+		Expect(infraEnvImage.Status.InfraEnvDebugInfo.StaticNetworkDownloadURL).To(Equal(fmt.Sprintf("https://www.acme.com/api/assisted-install/v2/infra-envs/%s/downloads/files?file_name=static-network-config", &sId)))
 		Expect(infraEnvImage.Status.CreatedTime).ToNot(BeNil())
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Message).To(Equal(aiv1beta1.ImageStateCreated))
 		Expect(conditionsv1.FindStatusCondition(infraEnvImage.Status.Conditions, aiv1beta1.ImageCreatedCondition).Reason).To(Equal(aiv1beta1.ImageCreatedReason))

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/infraenv_types.go
@@ -172,6 +172,8 @@ type InfraEnvDebugInfo struct {
 	// EventsURL specifies an HTTP/S URL that contains InfraEnv events
 	// +optional
 	EventsURL string `json:"eventsURL"`
+	// StaticNetworkDownloadURL specifies an HTTP/S URL that contains the static network config
+	StaticNetworkDownloadURL string `json:"staticNetworkDownloadURL,omitempty"`
 }
 
 type BootArtifacts struct {


### PR DESCRIPTION
In [MGMT-11443](https://issues.redhat.com//browse/MGMT-11443) a download link was created for static network config.

This PR adds the generated URL for the static network to the infraenv if the static network config is defined.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
