### PR TITLE
MGMT-15902: Trigger reboots for node event when day2 node moves to done

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -610,6 +610,7 @@ func main() {
 				ApproveCsrsRequeueDuration: Options.ApproveCsrsRequeueDuration,
 				AgentContainerImage:        Options.BMConfig.AgentDockerImg,
 				HostFSMountDir:             hostFSMountDir,
+				EventSender:                eventsHandler,
 			}).SetupWithManager(ctrlMgr), "unable to create controller Agent")
 
 			failOnError((&controllers.BMACReconciler{

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/danielerez/go-dns-client v0.0.0-20200630114514-0b60d1703f0b
 	github.com/dustin/go-humanize v1.0.0
 	github.com/filanov/stateswitch v1.0.1-0.20221122134945-bfa198e3a83a
+	github.com/go-errors/errors v1.0.1
 	github.com/go-gormigrate/gormigrate/v2 v2.0.1
 	github.com/go-logr/logr v1.2.4
 	github.com/go-openapi/errors v0.20.3
@@ -102,7 +103,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
-	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
@@ -246,7 +246,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/internal/oc/debug.go
+++ b/internal/oc/debug.go
@@ -1,0 +1,96 @@
+package oc
+
+import (
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-errors/errors"
+	"github.com/openshift/assisted-service/pkg/executer"
+	"golang.org/x/net/context"
+)
+
+type Debug interface {
+	RebootsForNode(nodeName string) (int, error)
+}
+
+type debug struct {
+	kubeconfig []byte
+	exec       executer.Executer
+}
+
+func NewDebug(kubeconfig []byte) Debug {
+	return &debug{
+		kubeconfig: kubeconfig,
+		exec:       &executer.CommonExecuter{},
+	}
+}
+
+func NewDebugWithExecuter(kubeconfig []byte, exec executer.Executer) Debug {
+	return &debug{
+		kubeconfig: kubeconfig,
+		exec:       exec,
+	}
+}
+
+func (d *debug) kubeconfigFile() (string, error) {
+	var n int
+
+	f, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	numWritten := 0
+	for n, err = f.Write(d.kubeconfig[numWritten:]); err == io.ErrShortWrite; n, err = f.Write(d.kubeconfig[numWritten:]) {
+		numWritten += n
+	}
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func (d *debug) runDebug(entity string, args ...string) (string, string, error) {
+	kubeconfigFname, err := d.kubeconfigFile()
+	if err != nil {
+		return "", "", err
+	}
+	defer func() {
+		_ = os.RemoveAll(kubeconfigFname)
+	}()
+	execArgs := append([]string{
+		"debug",
+		"--kubeconfig",
+		kubeconfigFname,
+		entity,
+		"--",
+	}, args...)
+	execCtx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
+	defer cancel()
+	out, errOut, exitCode := d.exec.ExecuteWithContext(execCtx, "oc", execArgs...)
+	if exitCode != 0 {
+		return "", "", errors.Errorf("oc debug failed to execute with code %d: %s", exitCode, errOut)
+	}
+	return out, errOut, nil
+}
+
+func (d *debug) RebootsForNode(nodeName string) (int, error) {
+	out, _, err := d.runDebug("node/"+nodeName,
+		"chroot",
+		"/host",
+		"last",
+		"reboot")
+	if err != nil {
+		return 0, err
+	}
+	lines := strings.Split(out, "\n")
+	numReboots := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "reboot ") {
+			numReboots++
+		}
+	}
+	return numReboots, nil
+}

--- a/internal/oc/debug_test.go
+++ b/internal/oc/debug_test.go
@@ -1,0 +1,68 @@
+package oc
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/pkg/executer"
+)
+
+var _ = Describe("oc debug", func() {
+	const (
+		kubeconfig = "kubeconfig"
+		nodeName   = "node1"
+	)
+	var (
+		ctrl     *gomock.Controller
+		execMock *executer.MockExecuter
+		d        Debug
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		execMock = executer.NewMockExecuter(ctrl)
+		d = NewDebugWithExecuter([]byte(kubeconfig), execMock)
+	})
+	expectOk := func(ret string) {
+		execMock.EXPECT().ExecuteWithContext(gomock.Any(),
+			"oc",
+			"debug",
+			"--kubeconfig",
+			gomock.Any(),
+			fmt.Sprintf("node/%s", nodeName),
+			"--",
+			"chroot",
+			"/host",
+			"last",
+			"reboot").Return(ret, "", 0)
+	}
+	It("1 reboot", func() {
+		expectOk("reboot   system boot  4.18.0-372.9.1.e Tue Mar  7 04:13   still running\n")
+		numReboots, err := d.RebootsForNode(nodeName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(numReboots).To(Equal(1))
+	})
+	It("2 reboot", func() {
+		expectOk("reboot   system boot  4.18.0-372.9.1.e Tue Mar  7 04:13   still running\nreboot   system boot  4.18.0-372.9.1.e Sun Mar  5 07:29 - 09:11 (2+01:41)\n")
+		numReboots, err := d.RebootsForNode(nodeName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(numReboots).To(Equal(2))
+	})
+	It("with error", func() {
+		execMock.EXPECT().ExecuteWithContext(gomock.Any(),
+			"oc",
+			"debug",
+			"--kubeconfig",
+			gomock.Any(),
+			fmt.Sprintf("node/%s", nodeName),
+			"--",
+			"chroot",
+			"/host",
+			"last",
+			"reboot").Return("", "This is an error", -1)
+		_, err := d.RebootsForNode(nodeName)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/spoke_k8s_client/factory.go
+++ b/internal/spoke_k8s_client/factory.go
@@ -41,7 +41,7 @@ func (cf *spokeK8sClientFactory) CreateFromRawKubeconfig(kubeconfig []byte) (Spo
 }
 
 func (cf *spokeK8sClientFactory) CreateFromSecret(secret *corev1.Secret) (SpokeK8sClient, error) {
-	kubeconfigData, err := kubeconfigFromSecret(secret)
+	kubeconfigData, err := KubeconfigFromSecret(secret)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (cf *spokeK8sClientFactory) CreateFromStorageKubeconfig(ctx context.Context
 }
 
 func (cf *spokeK8sClientFactory) ClientAndSetFromSecret(secret *corev1.Secret) (SpokeK8sClient, *kubernetes.Clientset, error) {
-	kubeconfig, err := kubeconfigFromSecret(secret)
+	kubeconfig, err := KubeconfigFromSecret(secret)
 	if err != nil {
 		cf.log.WithError(err).Error("failed to get kubeconfig from secret")
 		return nil, nil, err
@@ -75,7 +75,7 @@ func (cf *spokeK8sClientFactory) ClientAndSetFromSecret(secret *corev1.Secret) (
 	return cf.clientAndSetForKubeconfig(kubeconfig)
 }
 
-func kubeconfigFromSecret(secret *corev1.Secret) ([]byte, error) {
+func KubeconfigFromSecret(secret *corev1.Secret) ([]byte, error) {
 	if secret.Data == nil {
 		return nil, errors.Errorf("Secret %s/%s  does not contain any data", secret.Namespace, secret.Name)
 	}


### PR DESCRIPTION
This is done for kube api client only when spoke kubeconfig is available.
The implementation is done using debug command (as in oc command). The number of reboots are counted by 'last reboot' linux command.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @filanov 