### PR TITLE
MGMT-15271: Add the boot command line to the host inventory

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -17,6 +17,9 @@ import (
 // swagger:model boot
 type Boot struct {
 
+	// command line
+	CommandLine string `json:"command_line,omitempty"`
+
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -17,6 +17,9 @@ import (
 // swagger:model boot
 type Boot struct {
 
+	// command line
+	CommandLine string `json:"command_line,omitempty"`
+
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 

--- a/models/boot.go
+++ b/models/boot.go
@@ -17,6 +17,9 @@ import (
 // swagger:model boot
 type Boot struct {
 
+	// command line
+	CommandLine string `json:"command_line,omitempty"`
+
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5978,6 +5978,9 @@ func init() {
     "boot": {
       "type": "object",
       "properties": {
+        "command_line": {
+          "type": "string"
+        },
         "current_boot_mode": {
           "type": "string"
         },
@@ -16432,6 +16435,9 @@ func init() {
     "boot": {
       "type": "object",
       "properties": {
+        "command_line": {
+          "type": "string"
+        },
         "current_boot_mode": {
           "type": "string"
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5853,6 +5853,8 @@ definitions:
         type: string
       pxe_interface:
         type: string
+      command_line:
+        type: string
 
   system_vendor:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/boot.go
+++ b/vendor/github.com/openshift/assisted-service/models/boot.go
@@ -17,6 +17,9 @@ import (
 // swagger:model boot
 type Boot struct {
 
+	// command line
+	CommandLine string `json:"command_line,omitempty"`
+
 	// current boot mode
 	CurrentBootMode string `json:"current_boot_mode,omitempty"`
 


### PR DESCRIPTION
With the support of zVM in Assisted Installer, the necessary kernel arguments to boot a zVM nodes need to be considered. During the first boot of a zVM node a parm file will be provided to activate the necessary devices or specify a static IP w/o nmstate. This parm file looks like:

rd.neednet=1 console=ttysclp0 coreos.live.rootfs_url=http://172.23.236.156:8080/assisted-installer/rootfs.img ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none nameserver=10.14.6.1 ip=[fd00::3]::[fd00::1]:64::encbdd0:none nameserver=[fd00::1] zfcp.allow_lun_scan=0 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 rd.dasd=0.0.5235 rd.dasd=0.0.5236 random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8

These arguments need to be passed to the coreos installer otherwise the first reboot will end in an emergency shell.
This PR is the first PR of at least three PRs to provide support of automatically discovering the kernel arguments and pass them to the coreos installer.
The RestAPI provide a possibility to set the necessary kernel arguments:

curl https://api.openshift.com/api/assisted-install/v2/infra-envs/${INFRA_ENV_ID}/hosts/$1/installer-args
-X PATCH
-H "Authorization: Bearer ${API_TOKEN}"
-H "Content-Type: application/json"
-d '
{
"args": [
"--append-karg", "rd.neednet=1",
"--append-karg", "ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none",
"--append-karg", "nameserver=10.14.6.1",
"--append-karg", "ip=[fd00::3]::[fd00::1]:64::encbdd0:none",
"--append-karg", "nameserver=[fd00::1]",
"--append-karg", "zfcp.allow_lun_scan=0",
"--append-karg", "rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1",
"--append-karg", "rd.dasd=0.0.5235",
"--append-karg", "rd.dasd=0.0.5236"
]
}
' | jq

but this would break the WebUI flow (bad user experience if an additional step is needed to install a cluster).

## List all the issues related to this PR

- [x ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
