### PR TITLE
NO-ISSUE: Upgrade debug image to latest delve

### DIFF
--- a/Dockerfile.assisted-service-debug
+++ b/Dockerfile.assisted-service-debug
@@ -1,6 +1,6 @@
 ARG SERVICE=quay.io/edge-infrastructure/assisted-service:latest
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS download_dlv
-RUN GOFLAGS=-mod=mod go install github.com/go-delve/delve/cmd/dlv@v1.9.1
+FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS download_dlv
+RUN GOFLAGS=-mod=mod go install github.com/go-delve/delve/cmd/dlv@v1.21.2
 
 FROM $SERVICE
 ARG DEBUG_SERVICE_PORT=40000


### PR DESCRIPTION
The debug image is broken because the version of delve is too old for v1.20 of go. This PR updates the debug image so that debugging may continue to work

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
I made sure that debugging in subsystem tests works after the change when it did not before.
- [] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
