### PR TITLE
MGMT-16273: Allow installing on iSCSI disks on OCI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -331,7 +331,7 @@ func main() {
 
 	manifestsApi := manifests.NewManifestsAPI(db, log.WithField("pkg", "manifests"), objectHandler, usageManager)
 	operatorsManager := operators.NewManager(log, manifestsApi, Options.OperatorsConfig, objectHandler, extracterHandler)
-	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager)
+	hwValidator := hardware.NewValidator(log.WithField("pkg", "validators"), Options.HWValidatorConfig, operatorsManager, providerRegistry)
 	connectivityValidator := connectivity.NewValidator(log.WithField("pkg", "validators"))
 	Options.InstructionConfig.HostFSMountDir = hostFSMountDir
 	instructionApi := hostcommands.NewInstructionManager(log.WithField("pkg", "instructions"), db, hwValidator,

--- a/internal/hardware/mock_validator.go
+++ b/internal/hardware/mock_validator.go
@@ -156,17 +156,17 @@ func (mr *MockValidatorMockRecorder) GetPreflightInfraEnvHardwareRequirements(ct
 }
 
 // IsValidStorageDeviceType mocks base method.
-func (m *MockValidator) IsValidStorageDeviceType(disk *models.Disk, hostArchitecture string) bool {
+func (m *MockValidator) IsValidStorageDeviceType(disk *models.Disk, hostArchitecture, openshiftVersion string, ociPlatformType bool) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValidStorageDeviceType", disk, hostArchitecture)
+	ret := m.ctrl.Call(m, "IsValidStorageDeviceType", disk, hostArchitecture, openshiftVersion, ociPlatformType)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsValidStorageDeviceType indicates an expected call of IsValidStorageDeviceType.
-func (mr *MockValidatorMockRecorder) IsValidStorageDeviceType(disk, hostArchitecture interface{}) *gomock.Call {
+func (mr *MockValidatorMockRecorder) IsValidStorageDeviceType(disk, hostArchitecture, openshiftVersion, ociPlatformType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidStorageDeviceType", reflect.TypeOf((*MockValidator)(nil).IsValidStorageDeviceType), disk, hostArchitecture)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidStorageDeviceType", reflect.TypeOf((*MockValidator)(nil).IsValidStorageDeviceType), disk, hostArchitecture, openshiftVersion, ociPlatformType)
 }
 
 // ListEligibleDisks mocks base method.

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -3027,7 +3027,7 @@ var _ = Describe("IsValidMasterCandidate", func() {
 		hwValidatorCfg := createValidatorCfg()
 		ctrl = gomock.NewController(GinkgoT())
 		mockOperators := operators.NewMockAPI(ctrl)
-		hwValidator := hardware.NewValidator(testLog, *hwValidatorCfg, mockOperators)
+		hwValidator := hardware.NewValidator(testLog, *hwValidatorCfg, mockOperators, nil)
 		mockProviderRegistry := registry.NewMockProviderRegistry(ctrl)
 		mockProviderRegistry.EXPECT().IsHostSupported(models.PlatformTypeBaremetal, gomock.Any()).Return(true, nil).AnyTimes()
 		mockProviderRegistry.EXPECT().IsHostSupported(models.PlatformTypeVsphere, gomock.Any()).Return(false, nil).AnyTimes()

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -303,8 +303,13 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 	}
 
 	for _, disk := range inventory.Disks {
-		if disk.DriveType == models.DriveTypeMultipath && disk.ID == host.InstallationDiskID {
-			installerArgs = append(installerArgs, "--append-karg", "root=/dev/disk/by-label/dm-mpath-root", "--append-karg", "rw", "--append-karg", "rd.multipath=default")
+		if disk.ID == host.InstallationDiskID {
+			if disk.DriveType == models.DriveTypeMultipath {
+				installerArgs = append(installerArgs, "--append-karg", "root=/dev/disk/by-label/dm-mpath-root", "--append-karg", "rw", "--append-karg", "rd.multipath=default")
+			} else if disk.DriveType == models.DriveTypeISCSI {
+				// Currently only allowed on the OCI platform
+				installerArgs = append(installerArgs, "--append-karg", "rd.iscsi.firmware=1", "--append-karg", "ip=ibft")
+			}
 		}
 	}
 

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -1577,7 +1577,7 @@ var _ = Describe("Refresh Host", func() {
 				)).AnyTimes()
 
 				mockDefaultClusterHostRequirements(mockHwValidator)
-				mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+				mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any(), "", false).Return(true).AnyTimes()
 				mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return([]*models.Disk{}).AnyTimes()
 				mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 			}

--- a/internal/host/validations_test.go
+++ b/internal/host/validations_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Validations test", func() {
 
 	mockAndRefreshStatusWithoutEvents := func(h *models.Host) {
 		mockDefaultClusterHostRequirements(mockHwValidator)
-		mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		mockHwValidator.EXPECT().IsValidStorageDeviceType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHwValidator.EXPECT().ListEligibleDisks(gomock.Any()).Return([]*models.Disk{}).AnyTimes()
 		mockHwValidator.EXPECT().GetHostInstallationPath(gomock.Any()).Return("/dev/sda").AnyTimes()
 		mockOperators.EXPECT().ValidateHost(gomock.Any(), gomock.Any(), gomock.Any()).Return([]api.ValidationResult{
@@ -1557,7 +1557,7 @@ var _ = Describe("Validations test", func() {
 			updateClusterPlatform()
 			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
 
-			mockHwValidator.EXPECT().IsValidStorageDeviceType(CDROM, models.ClusterCPUArchitectureX8664).Return(false).Times(1)
+			mockHwValidator.EXPECT().IsValidStorageDeviceType(CDROM, models.ClusterCPUArchitectureX8664, "", false).Return(false).Times(1)
 			mockAndRefreshStatus(&host)
 			host = hostutil.GetHostFromDB(*host.ID, host.InfraEnvID, db).Host
 			status, _, _ := getValidationResult(host.ValidationsInfo, hostUUIDValidation)

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -1703,7 +1703,7 @@ func (v *validator) isVSphereDiskUUIDEnabled(c *validationContext) (ValidationSt
 		// if any of them doesn't have that flag, it's likely because the user has forgotten to
 		// enable `disk.EnableUUID` for this virtual machine
 		// See https://access.redhat.com/solutions/4606201
-		if v.hwValidator.IsValidStorageDeviceType(disk, c.inventory.CPU.Architecture) && !disk.HasUUID {
+		if v.hwValidator.IsValidStorageDeviceType(disk, c.inventory.CPU.Architecture, "", false) && !disk.HasUUID {
 			return ValidationFailure, "VSphere disk.EnableUUID isn't enabled for this virtual machine, it's necessary for disks to be mounted properly"
 		}
 	}


### PR DESCRIPTION
Allow booting from iSCSI for x86_64 OpenShift versions at least 4.15.0 on the OCI platform.

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
