### PR TITLE
MGMT-16235: Ensure that agent controller will watch for changes to ignition endpoint token.

### DIFF
--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1640,6 +1640,14 @@ var _ = Describe("[kube-api]cluster installation", func() {
 			dbHost := GetHostByKubeKey(ctx, db, hostkey, waitForReconcileTimeout)
 			return dbHost != nil && dbHost.IgnitionEndpointToken == ignitionEndpointToken
 		}, "30s", "1s").Should(BeTrue())
+		By("Update to ignition endpoint token to trigger reconciliation", func() {
+			updateSecret(ctx, kubeClient, ignitionTokenSecretName, map[string]string{"ignition-token": "updated-token-data"})
+		})
+		By("Verify ignition token updated in DB after reconciliation")
+		Eventually(func() bool {
+			dbHost := GetHostByKubeKey(ctx, db, hostkey, waitForReconcileTimeout)
+			return dbHost != nil && dbHost.IgnitionEndpointToken == "updated-token-data"
+		}, "30s", "1s").Should(BeTrue())
 	})
 
 	It("deploy CD with ACI and agents with node labels", func() {


### PR DESCRIPTION
Presently when a user updates a secret assosciated with the ignition endpoint token of a host, no agent reconciliation is performed. This means that the host associated with any agents that use that ignition endpoint token will not be updated.

This PR fixes that by adding a watch on secrets that will then map to agents that need to be updated as a result of the change.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
