### PR TITLE
MGMT-16312 fix update host ignition for unbound host

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -5813,60 +5813,56 @@ func (b *bareMetalInventory) V2UpdateHostIgnition(ctx context.Context, params in
 func (b *bareMetalInventory) V2UpdateHostIgnitionInternal(ctx context.Context, params installer.V2UpdateHostIgnitionParams) (*models.Host, error) {
 	log := logutil.FromContext(ctx, b.log)
 
-	txSuccess := false
-	tx := b.db.Begin()
-	defer func() {
-		if !txSuccess {
-			log.Error("UpdateHostIgnition failed")
-			tx.Rollback()
-		}
-		if r := recover(); r != nil {
-			log.Error("UpdateHostIgnition failed")
-			tx.Rollback()
-		}
-	}()
-
-	h, err := common.GetHostFromDB(tx, params.InfraEnvID.String(), params.HostID.String())
-	if err != nil {
-		return nil, err
-	}
-
-	if err = b.checkUpdateAccessToObj(ctx, h, "host", &params.HostID); err != nil {
-		return nil, err
-	}
-
-	if params.HostIgnitionParams.Config != "" {
-		_, err = ignition.ParseToLatest([]byte(params.HostIgnitionParams.Config))
+	err := b.db.Transaction(func(tx *gorm.DB) error {
+		h, err := common.GetHostFromDB(tx, params.InfraEnvID.String(), params.HostID.String())
 		if err != nil {
-			log.WithError(err).Errorf("Failed to parse host ignition config patch %s", params.HostIgnitionParams)
-			return nil, common.NewApiError(http.StatusBadRequest, err)
+			return err
 		}
-	} else {
-		log.Infof("Removing custom ignition override from host %s in infra-env %s", params.HostID, params.InfraEnvID)
-	}
 
-	err = tx.Model(&common.Host{}).Where("id = ? and infra_env_id = ?", params.HostID, params.InfraEnvID).Update("ignition_config_overrides", params.HostIgnitionParams.Config).Error
+		if err = b.checkUpdateAccessToObj(ctx, h, "host", &params.HostID); err != nil {
+			return err
+		}
+
+		if params.HostIgnitionParams.Config != "" {
+			_, err = ignition.ParseToLatest([]byte(params.HostIgnitionParams.Config))
+			if err != nil {
+				log.WithError(err).Errorf("Failed to parse host ignition config patch %s", params.HostIgnitionParams)
+				return common.NewApiError(http.StatusBadRequest, err)
+			}
+		} else {
+			log.Infof("Removing custom ignition override from host %s in infra-env %s", params.HostID, params.InfraEnvID)
+		}
+
+		err = tx.Model(&common.Host{}).Where("id = ? and infra_env_id = ?", params.HostID, params.InfraEnvID).
+			Update("ignition_config_overrides", params.HostIgnitionParams.Config).Error
+		if err != nil {
+			return common.NewApiError(http.StatusInternalServerError, err)
+		}
+
+		log.Infof("Custom discovery ignition config was applied to host %s in infra-env %s", params.HostID, params.InfraEnvID)
+
+		// Set the feature usage for ignition config overrides
+		if h.ClusterID != nil {
+			if err = b.setIgnitionConfigOverrideUsage(*h.ClusterID, params.HostIgnitionParams.Config, "host", tx); err != nil {
+				// Failure to set the feature usage isn't a failure to update the host ignition so we only print the error instead of returning it
+				log.WithError(err).Warnf("failed to set ignition config override usage for cluster %s", h.ClusterID)
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, common.NewApiError(http.StatusInternalServerError, err)
+		return nil, err
 	}
 
-	eventgen.SendHostDiscoveryIgnitionConfigAppliedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID,
-		hostutil.GetHostnameForMsg(&h.Host))
-	log.Infof("Custom discovery ignition config was applied to host %s in infra-env %s", params.HostID, params.InfraEnvID)
-	h, err = common.GetHostFromDB(tx, params.InfraEnvID.String(), params.HostID.String())
+	h, err := common.GetHostFromDB(b.db, params.InfraEnvID.String(), params.HostID.String())
 	if err != nil {
 		log.WithError(err).Errorf("failed to get host %s after update", params.HostID)
 		return nil, common.NewApiError(http.StatusInternalServerError, err)
 	}
 
-	// Set the feature usage for ignition config overrides
-	if err = b.setIgnitionConfigOverrideUsage(*h.ClusterID, params.HostIgnitionParams.Config, "host", tx); err != nil {
-		// Failure to set the feature usage isn't a failure to update the host ignition so we only print the error instead of returning it
-		log.WithError(err).Warnf("failed to set ignition config override usage for cluster %s", h.ClusterID)
-	}
+	eventgen.SendHostDiscoveryIgnitionConfigAppliedEvent(ctx, b.eventsHandler, params.HostID, params.InfraEnvID,
+		hostutil.GetHostnameForMsg(&h.Host))
 
-	tx.Commit()
-	txSuccess = true
 	return &h.Host, nil
 }
 

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -18360,3 +18360,57 @@ var _ = Describe("GetHostByKubeKey", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("V2UpdateHostIgnition unbound blabla", func() {
+	var (
+		bm     *bareMetalInventory
+		cfg    Config
+		db     *gorm.DB
+		dbName string
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		bm = createInventory(db, cfg)
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+		ctrl.Finish()
+	})
+
+	It("unbound host ignition update", func() {
+		infraEnvID := strfmt.UUID(uuid.New().String())
+		infraEnv := &common.InfraEnv{
+			InfraEnv: models.InfraEnv{
+				ID: &infraEnvID,
+			},
+		}
+		Expect(db.Create(infraEnv).Error).ToNot(HaveOccurred())
+
+		hostID := strfmt.UUID(uuid.New().String())
+		host := models.Host{
+			ID:         &hostID,
+			InfraEnvID: infraEnvID,
+			Kind:       swag.String(models.HostKindHost),
+			Status:     swag.String(models.HostStatusKnownUnbound),
+			Role:       models.HostRoleAutoAssign,
+		}
+		Expect(db.Create(&host).Error).ShouldNot(HaveOccurred())
+
+		override := `{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}`
+		params := installer.V2UpdateHostIgnitionParams{
+			InfraEnvID:         infraEnvID,
+			HostID:             hostID,
+			HostIgnitionParams: &models.HostIgnitionParams{Config: override},
+		}
+
+		mockEvents.EXPECT().SendHostEvent(gomock.Any(), eventstest.NewEventMatcher(
+			eventstest.WithNameMatcher(eventgen.HostDiscoveryIgnitionConfigAppliedEventName),
+			eventstest.WithHostIdMatcher(params.HostID.String()),
+			eventstest.WithInfraEnvIdMatcher(params.InfraEnvID.String())))
+
+		response := bm.V2UpdateHostIgnition(context.TODO(), params)
+		Expect(response).To(BeAssignableToTypeOf(&installer.V2UpdateHostIgnitionCreated{}))
+	})
+})


### PR DESCRIPTION
Becuase of a recover function in V2UpdateHostIgnition if a panic occurs
then a controller will get nil as a reply and assume that the call
didn't fail, it casued a hot loop that tried to update the ignition
again and again, because and event was called before the panic and
before the ignition was commited we ended up with 95 million events
before we ran out of space on the disk

This commit will remove the recover in order to return a proper error
and fail the service if tehre is a painc

The pacin was caused by calling setIgnitionConfigOverrideUsage and
assuming that cluster ID exists, added a validation for the cluster id
before using it.

added unit tests to check functionality to unbound host

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
