### PR TITLE
test iscsi without ip=ibft

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -308,7 +308,7 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 				installerArgs = append(installerArgs, "--append-karg", "root=/dev/disk/by-label/dm-mpath-root", "--append-karg", "rw", "--append-karg", "rd.multipath=default")
 			} else if disk.DriveType == models.DriveTypeISCSI {
 				// Currently only allowed on the OCI platform
-				installerArgs = append(installerArgs, "--append-karg", "rd.iscsi.firmware=1")
+				installerArgs = append(installerArgs, "--append-karg", "rd.iscsi.firmware=1", "--append-karg", "console=ttyS0")
 			}
 		}
 	}

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -308,7 +308,7 @@ func constructHostInstallerArgs(cluster *common.Cluster, host *models.Host, inve
 				installerArgs = append(installerArgs, "--append-karg", "root=/dev/disk/by-label/dm-mpath-root", "--append-karg", "rw", "--append-karg", "rd.multipath=default")
 			} else if disk.DriveType == models.DriveTypeISCSI {
 				// Currently only allowed on the OCI platform
-				installerArgs = append(installerArgs, "--append-karg", "rd.iscsi.firmware=1", "--append-karg", "ip=ibft")
+				installerArgs = append(installerArgs, "--append-karg", "rd.iscsi.firmware=1")
 			}
 		}
 	}

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -403,7 +403,7 @@ func getDHCPArgPerNIC(network *net.IPNet, nic *models.Interface, ipv6 bool, dual
 			dhcp = "dhcp,dhcp6"
 		}
 		log.Debugf("Host %s: Added kernel argument ip=%s:%s", hostID, nic.Name, dhcp)
-		return append(args, "--append-karg", fmt.Sprintf("ip=%s:%s", nic.Name, dhcp)), nil
+		return append(args, "--append-karg", "x-systemd.device-timeout=0"), nil
 	}
 	return args, nil
 }

--- a/internal/ignition/ignition_test.go
+++ b/internal/ignition/ignition_test.go
@@ -1415,13 +1415,14 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).Should(ContainSubstring("/tmp/example"))
 	})
 
-	It("no multipath for okd - config setting", func() {
+	It("no multipath and iscsistart for okd - config setting", func() {
 		ignitionConfig.OKDRPMsImage = "image"
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, ignitionConfig, false, auth.TypeRHSSO, "")
 
 		Expect(err).Should(BeNil())
 		Expect(text).ShouldNot(ContainSubstring("multipathd"))
+		Expect(text).ShouldNot(ContainSubstring("iscsistart"))
 	})
 
 	It("okd support disabled", func() {
@@ -1433,7 +1434,7 @@ var _ = Describe("IgnitionBuilder", func() {
 		Expect(text).ShouldNot(ContainSubstring("okd-overlay.servicemultipathd"))
 	})
 
-	It("no multipath for okd - okd payload", func() {
+	It("no multipath and iscsistart for okd - okd payload", func() {
 		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
 		okdNewImageVersion := "4.12.0-0.okd-2022-11-20-010424"
 		okdNewImageURL := "registry.ci.openshift.org/origin/release:4.12.0-0.okd-2022-11-20-010424"
@@ -1450,6 +1451,7 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		Expect(err).Should(BeNil())
 		Expect(text).ShouldNot(ContainSubstring("multipathd"))
+		Expect(text).ShouldNot(ContainSubstring("iscsistart"))
 	})
 
 	It("multipath configured for non-okd", func() {
@@ -1460,6 +1462,16 @@ var _ = Describe("IgnitionBuilder", func() {
 
 		Expect(err).Should(BeNil())
 		Expect(text).Should(ContainSubstring("multipathd"))
+	})
+
+	It("iscsistart configured for non-okd", func() {
+		config := ignitionConfig
+		mockMirrorRegistriesConfigBuilder.EXPECT().IsMirrorRegistriesConfigured().Return(false).Times(1)
+		mockVersionHandler.EXPECT().GetReleaseImage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("some error")).Times(1)
+		text, err := builder.FormatDiscoveryIgnitionFile(context.Background(), &infraEnv, config, false, auth.TypeRHSSO, "")
+
+		Expect(err).Should(BeNil())
+		Expect(text).Should(ContainSubstring("iscsistart"))
 	})
 
 	Context("static network config", func() {

--- a/internal/ignition/templates/discovery.ign
+++ b/internal/ignition/templates/discovery.ign
@@ -37,6 +37,11 @@
         "name": "systemd-journal-gatewayd.socket",
         "enabled": true,
         "contents": {{ executeTemplate "systemd-journal-gatewayd.socket" . | toString | toJson }}
+    }{{end}}{{if .OKDBinaries | not}},
+    {
+        "name": "iscsistart.service",
+        "enabled": true,
+        "contents": {{ executeTemplate "iscsistart.service" . | toString | toJson }}
     }{{end}}
     ]
   },

--- a/internal/ignition/templates/iscsistart.service
+++ b/internal/ignition/templates/iscsistart.service
@@ -1,0 +1,8 @@
+[Service]
+Type=oneshot
+ExecStartPre=-/usr/sbin/modprobe iscsi_ibft
+ExecStartPre=-/usr/sbin/iscsistart -f
+ExecStart=-/usr/sbin/iscsistart -b
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- [MGMT-16273](https://issues.redhat.com//browse/MGMT-16273): Allow installing on iSCSI disks on OCI (#5728)
- Update RHTAP references (#5733)
- [HOSTEDCP-999](https://issues.redhat.com//browse/HOSTEDCP-999): Fix incorrect check for CAPI image in ci (#5741)
- [MGMT-15972](https://issues.redhat.com//browse/MGMT-15972): Remove Swagger definition for api_vip and ingress_vip (#5734)
- [MGMT-13461](https://issues.redhat.com//browse/MGMT-13461): Fix Tang validation when day2 host join an imported cluster (#5700)
- [MGMT-16235](https://issues.redhat.com//browse/MGMT-16235): Ensure that agent controller will watch for changes to ignition endpoint token. (#5736)
- [MGMT-16320](https://issues.redhat.com//browse/MGMT-16320): Agent should connect to iBFT iSCSI targets
- don't setup network from ibft
