### PR TITLE
[release-ocm-2.8] MGMT-16370: fix golangci-lint failing to be pulled

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -10,8 +10,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV TOOLS=/tools/
 ENV PATH="$VIRTUAL_ENV/bin:$GOROOT/bin:$GOPATH/bin:$TOOLS:$PATH"
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
-
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.46.0
 # TODO: Replace with version 0.30.4 once it is released.
 #
 # We need version 5d0a00d of go-swagger because it is the first that contains

--- a/ci-images/Dockerfile.lint
+++ b/ci-images/Dockerfile.lint
@@ -1,6 +1,6 @@
 FROM base
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.46.0
 COPY --from=quay.io/coreos/shellcheck-alpine:v0.5.0 /bin/shellcheck /usr/bin/shellcheck
 
 RUN dnf install -y diffutils


### PR DESCRIPTION
app-sre made their repo mirroring golangci-lint for legal reasons, and
now out jobs are failing to install it. Installing it now from the cli.

We could also have pulled golangci-ling from dockerhub, but rate
limitation there is quite aggressive.
