### PR TITLE
[release-ocm-2.7] MGMT-16370: fix golangci-lint failing to be pulled

### DIFF
--- a/Dockerfile.assisted-service-build
+++ b/Dockerfile.assisted-service-build
@@ -10,7 +10,7 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV TOOLS=/tools/
 ENV PATH="$VIRTUAL_ENV/bin:$GOROOT/bin:$GOPATH/bin:$TOOLS:$PATH"
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.46.0
 COPY --from=quay.io/goswagger/swagger:v0.28.0 /usr/bin/swagger /usr/bin/goswagger
 COPY --from=quay.io/edge-infrastructure/swagger-codegen-cli:2.4.18 /opt/swagger-codegen-cli /opt/swagger-codegen-cli
 COPY --from=golang /usr/bin/gotestsum /usr/bin/make /usr/bin/

--- a/ci-images/Dockerfile.lint
+++ b/ci-images/Dockerfile.lint
@@ -1,5 +1,5 @@
 FROM base
 
-COPY --from=quay.io/app-sre/golangci-lint:v1.46.0 /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.46.0
 
 RUN dnf install -y diffutils


### PR DESCRIPTION
app-sre made their repo mirroring golangci-lint for legal reasons, and
now out jobs are failing to install it. Installing it now from the cli.

We could also have pulled golangci-ling from dockerhub, but rate
limitation there is quite aggressive.
