### PR TITLE
MGMT-16420: enable latest lso for 4.15 ztp

### DIFF
--- a/deploy/operator/setup_lso.sh
+++ b/deploy/operator/setup_lso.sh
@@ -22,32 +22,6 @@ function install_lso() {
 
   catalog_source_name="redhat-operators"
 
-  OC_VERSION_MAJOR_MINOR=$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -d'.' -f1-2)
-  if [[ ${OC_VERSION_MAJOR_MINOR} == "4.15" && "${DISCONNECTED}" != true ]]; then
-      # LSO has not been published to the 4.15 redhat-operators catalog, so
-      # it cannot be installed on OpenShift 4.15. Until this is resolved,
-      # we explicitly install the 4.13 catalog as redhat-operators-v4-14
-      # and then subscribe to the LSO version from the 4.14 rather than the 4.15 catalog.
-      # TODO: Bump the versions once LSO is published to the 4.14 catalog.
-      catalog_source_name="redhat-operators-v4-14"
-      tee << EOCR >(oc apply -f -)
-kind: CatalogSource
-apiVersion: operators.coreos.com/v1alpha1
-metadata:
-  name: redhat-operators-v4-14
-  namespace: openshift-marketplace
-spec:
-  displayName: Red Hat Operators v4.14
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.14
-  priority: -100
-  publisher: Red Hat
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 10m0s
-EOCR
-  fi
-
   if [ "${DISCONNECTED}" = true ]; then
     if ! which opm; then
         install_opm


### PR DESCRIPTION
LSO is now avilable on 4.15 catalog 
- Removing workaround for 4.15 ( deploy 4.14 version )
- updating OPM version 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
