### PR TITLE
MGMT-16157 move db transactions to new format

### DIFF
--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -193,10 +193,11 @@ var _ = Describe("update_role", func() {
 			Expect(h.Role).Should(Equal(models.HostRoleWorker))
 		})
 		By("commit transaction", func() {
-			tx := db.Begin()
-			Expect(tx.Error).ShouldNot(HaveOccurred())
-			Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, tx)).NotTo(HaveOccurred())
-			Expect(tx.Commit().Error).ShouldNot(HaveOccurred())
+			err := db.Transaction(func(tx *gorm.DB) error {
+				Expect(state.UpdateRole(ctx, &host, models.HostRoleMaster, tx)).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).ShouldNot(HaveOccurred())
 			h := hostutil.GetHostFromDB(id, infraEnvID, db)
 			Expect(h.Role).Should(Equal(models.HostRoleMaster))
 		})


### PR DESCRIPTION
The new format will reduce the need for a defer function to handle db transaction failues and avoid hiding panic in case somone will add a recover function

make the code shorter and cleaner

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
