### PR TITLE
MGMT-16199: block unbind host while cluster is progressing

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -440,7 +440,7 @@ func CanUnbindhost(c *Cluster) (err error) {
 	clusterStatus := swag.StringValue(c.Status)
 	NotAllowedStatuses := []string{
 		models.ClusterStatusFinalizing,
-		models.ClusterStatusInstalled,
+		models.ClusterStatusInstalling,
 		models.ClusterStatusInstallingPendingUserAction,
 		models.ClusterStatusPreparingForInstallation,
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	yamlpatch "github.com/krishicks/yaml-patch"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/models"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
@@ -100,8 +101,10 @@ const NMDebugModeConf = `
 domains=ALL:DEBUG
 `
 
-const ValidationTypeHost = "host"
-const ValidationTypeCluster = "cluster"
+const (
+	ValidationTypeHost    = "host"
+	ValidationTypeCluster = "cluster"
+)
 
 func GetIgnoredValidations(validationsJSON string, clusterID string) ([]string, bool) {
 	ignoredValidations := []string{}
@@ -430,6 +433,22 @@ func GetInventoryInterfaces(inventory string) (string, error) {
 
 	endLocation := endIndex + len("}]")
 	return inventory[interfacesLocation : interfacesLocation+endLocation], nil
+}
+
+// blocking host removal while cluster is progressing
+func CanUnbindhost(c *Cluster) (err error) {
+	clusterStatus := swag.StringValue(c.Status)
+	NotAllowedStatuses := []string{
+		models.ClusterStatusFinalizing,
+		models.ClusterStatusInstalled,
+		models.ClusterStatusInstallingPendingUserAction,
+		models.ClusterStatusPreparingForInstallation,
+	}
+	if funk.Contains(NotAllowedStatuses, clusterStatus) {
+		err = fmt.Errorf("cluster %s is in %s state, %s cannot be unbind when status is one of: %s",
+			c.ID, clusterStatus, constants.Kubeconfig, NotAllowedStatuses)
+	}
+	return err
 }
 
 // GetTagFromImageRef returns the tag of the given container image reference. For example, if the

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	yamlpatch "github.com/krishicks/yaml-patch"
-	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/models"
 	"github.com/thoas/go-funk"
 	"gorm.io/gorm"
@@ -438,15 +437,15 @@ func GetInventoryInterfaces(inventory string) (string, error) {
 // blocking host removal while cluster is progressing
 func CanUnbindhost(c *Cluster) (err error) {
 	clusterStatus := swag.StringValue(c.Status)
-	NotAllowedStatuses := []string{
+	NotAllowedStatus := []string{
 		models.ClusterStatusFinalizing,
 		models.ClusterStatusInstalling,
 		models.ClusterStatusInstallingPendingUserAction,
 		models.ClusterStatusPreparingForInstallation,
 	}
-	if funk.Contains(NotAllowedStatuses, clusterStatus) {
-		err = fmt.Errorf("cluster %s is in %s state, %s cannot be unbind when status is one of: %s",
-			c.ID, clusterStatus, constants.Kubeconfig, NotAllowedStatuses)
+	if funk.Contains(NotAllowedStatus, clusterStatus) {
+		err = fmt.Errorf("cluster %s is in %s state, host cannot be unbind when status is one of: %s",
+			c.ID, clusterStatus, NotAllowedStatus)
 	}
 	return err
 }

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -135,8 +135,10 @@ fQEw+cWRxwFPJujSOTSKRHZDo1UwOIQbxqkbznSHlLCICEXxuvQ=
 -----END CERTIFICATE-----
 `
 
-const inventoryWithSingleNIC string = "{\"bmc_address\":\"0.0.0.0\",\"bmc_v6address\":\"::/0\",\"boot\":{\"current_boot_mode\":\"bios\"},\"cpu\":{\"architecture\":\"x86_64\",\"count\":16,\"flags\":[\"fpu\",\"vme\",\"de\",\"pse\",\"tsc\",\"msr\",\"pae\",\"mce\",\"cx8\",\"apic\",\"sep\",\"mtrr\",\"pge\",\"mca\",\"cmov\",\"pat\",\"pse36\",\"clflush\",\"mmx\",\"fxsr\",\"sse\",\"sse2\",\"ss\",\"syscall\",\"nx\",\"pdpe1gb\",\"rdtscp\",\"lm\",\"constant_tsc\",\"arch_perfmon\",\"nopl\",\"xtopology\",\"tsc_reliable\",\"nonstop_tsc\",\"cpuid\",\"pni\",\"pclmulqdq\",\"ssse3\",\"fma\",\"cx16\",\"pcid\",\"sse4_1\",\"sse4_2\",\"x2apic\",\"movbe\",\"popcnt\",\"tsc_deadline_timer\",\"aes\",\"xsave\",\"avx\",\"f16c\",\"rdrand\",\"hypervisor\",\"lahf_lm\",\"abm\",\"3dnowprefetch\",\"cpuid_fault\",\"invpcid_single\",\"pti\",\"ssbd\",\"ibrs\",\"ibpb\",\"stibp\",\"fsgsbase\",\"tsc_adjust\",\"bmi1\",\"avx2\",\"smep\",\"bmi2\",\"invpcid\",\"rdseed\",\"adx\",\"smap\",\"xsaveopt\",\"arat\",\"md_clear\",\"flush_l1d\",\"arch_capabilities\"],\"frequency\":2194.917,\"model_name\":\"Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz\"},\"disks\":[{\"by_id\":\"/dev/disk/by-id/wwn-0x6000c2911a3fb8af754385340083d09c\",\"by_path\":\"/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0\",\"drive_type\":\"HDD\",\"has_uuid\":true,\"hctl\":\"0:0:0:0\",\"id\":\"/dev/disk/by-id/wwn-0x6000c2911a3fb8af754385340083d09c\",\"installation_eligibility\":{\"eligible\":true,\"not_eligible_reasons\":null},\"model\":\"Virtual_disk\",\"name\":\"sda\",\"path\":\"/dev/sda\",\"serial\":\"6000c2911a3fb8af754385340083d09c\",\"size_bytes\":128849018880,\"smart\":\"SMART support is:     Unavailable - device lacks SMART capability.\\n\",\"vendor\":\"VMware\",\"wwn\":\"0x6000c2911a3fb8af754385340083d09c\"},{\"by_path\":\"/dev/disk/by-path/pci-0000:00:07.1-ata-1\",\"drive_type\":\"ODD\",\"hctl\":\"1:0:0:0\",\"id\":\"/dev/disk/by-path/pci-0000:00:07.1-ata-1\",\"installation_eligibility\":{\"not_eligible_reasons\":[\"Disk is removable\",\"Disk is too small (disk only has 106 MB, but 100 GB are required)\",\"Drive type is ODD, it must be one of HDD, SSD, Multipath.\"]},\"is_installation_media\":true,\"model\":\"VMware_IDE_CDR00\",\"name\":\"sr0\",\"path\":\"/dev/sr0\",\"removable\":true,\"serial\":\"00000000000000000001\",\"size_bytes\":106516480,\"smart\":\"SMART support is:     Unavailable - device lacks SMART capability.\\n\",\"vendor\":\"NECVMWar\"}],\"gpus\":[{\"address\":\"0000:00:0f.0\"}],\"hostname\":\"master-2.qe1.e2e.bos.redhat.com\",\"interfaces\":[{\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[\"10.19.114.222/23\"],\"ipv6_addresses\":[\"2620:52:0:1372:b55f:731b:f1dc:d773/64\"],\"mac_address\":\"00:50:56:83:87:09\",\"mtu\":1500,\"name\":\"ens192\",\"product\":\"0x07b0\",\"speed_mbps\":10000,\"type\":\"physical\",\"vendor\":\"0x15ad\"}],\"memory\":{\"physical_bytes\":34359738368,\"physical_bytes_method\":\"dmidecode\",\"usable_bytes\":33711775744},\"routes\":[{\"destination\":\"0.0.0.0\",\"family\":2,\"gateway\":\"10.19.115.254\",\"interface\":\"ens192\"},{\"destination\":\"10.19.114.0\",\"family\":2,\"interface\":\"ens192\"},{\"destination\":\"10.88.0.0\",\"family\":2,\"interface\":\"cni-podman0\"},{\"destination\":\"::1\",\"family\":10,\"interface\":\"lo\"},{\"destination\":\"2620:52:0:1372::\",\"family\":10,\"interface\":\"ens192\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"ens192\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"cni-podman0\"},{\"destination\":\"::\",\"family\":10,\"gateway\":\"fe80::a81:f4ff:fea6:dc01\",\"interface\":\"ens192\"}],\"system_vendor\":{\"manufacturer\":\"VMware, Inc.\",\"product_name\":\"VMware Virtual Platform\",\"serial_number\":\"VMware-42 09 5f ea c8 4e 8c 88-f3 0c 06 65 5a 4d 32 fb\",\"virtual\":true},\"tpm_version\":\"none\"}"
-const inventoryWithMultipleNICs string = "\"hostname\":\"localhost\",\"interfaces\":[{\"biosdevname\":\"em2\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:85\",\"mtu\":1500,\"name\":\"eno2\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em1\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:84\",\"mtu\":1500,\"name\":\"eno1\",\"product\":\"0x1537\",\"speed_mbps\":1000,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em3\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:86\",\"mtu\":1500,\"name\":\"eno3\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em4\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:87\",\"mtu\":1500,\"name\":\"eno4\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em5\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:88\",\"mtu\":1500,\"name\":\"eno5\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"p1p1\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":8000,\"name\":\"ens1f0\",\"product\":\"0x158b\",\"speed_mbps\":25000,\"vendor\":\"0x8086\"},{\"biosdevname\":\"p1p2\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":8000,\"name\":\"ens1f1\",\"product\":\"0x158b\",\"speed_mbps\":25000,\"vendor\":\"0x8086\"},{\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[\"10.195.70.120/24\"],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":1500,\"name\":\"bond0\",\"speed_mbps\":25000}],\"memory\":{\"physical_bytes\":412316860416,\"physical_bytes_method\":\"dmidecode\",\"usable_bytes\":405391712256},\"routes\":[{\"destination\":\"0.0.0.0\",\"family\":2,\"gateway\":\"10.195.70.1\",\"interface\":\"bond0\"},{\"destination\":\"10.88.0.0\",\"family\":2,\"interface\":\"cni-podman0\"},{\"destination\":\"10.195.70.0\",\"family\":2,\"interface\":\"bond0\"},{\"destination\":\"::1\",\"family\":10,\"interface\":\"lo\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"cni-podman0\"}],\"system_vendor\":{\"manufacturer\":\"HPE\",\"product_name\":\"ProLiant e910\",\"serial_number\":\"MXQ1291HP3\"},\"timestamp\":1657725466,\"tpm_version\":\"2.0\"}"
+const (
+	inventoryWithSingleNIC    string = "{\"bmc_address\":\"0.0.0.0\",\"bmc_v6address\":\"::/0\",\"boot\":{\"current_boot_mode\":\"bios\"},\"cpu\":{\"architecture\":\"x86_64\",\"count\":16,\"flags\":[\"fpu\",\"vme\",\"de\",\"pse\",\"tsc\",\"msr\",\"pae\",\"mce\",\"cx8\",\"apic\",\"sep\",\"mtrr\",\"pge\",\"mca\",\"cmov\",\"pat\",\"pse36\",\"clflush\",\"mmx\",\"fxsr\",\"sse\",\"sse2\",\"ss\",\"syscall\",\"nx\",\"pdpe1gb\",\"rdtscp\",\"lm\",\"constant_tsc\",\"arch_perfmon\",\"nopl\",\"xtopology\",\"tsc_reliable\",\"nonstop_tsc\",\"cpuid\",\"pni\",\"pclmulqdq\",\"ssse3\",\"fma\",\"cx16\",\"pcid\",\"sse4_1\",\"sse4_2\",\"x2apic\",\"movbe\",\"popcnt\",\"tsc_deadline_timer\",\"aes\",\"xsave\",\"avx\",\"f16c\",\"rdrand\",\"hypervisor\",\"lahf_lm\",\"abm\",\"3dnowprefetch\",\"cpuid_fault\",\"invpcid_single\",\"pti\",\"ssbd\",\"ibrs\",\"ibpb\",\"stibp\",\"fsgsbase\",\"tsc_adjust\",\"bmi1\",\"avx2\",\"smep\",\"bmi2\",\"invpcid\",\"rdseed\",\"adx\",\"smap\",\"xsaveopt\",\"arat\",\"md_clear\",\"flush_l1d\",\"arch_capabilities\"],\"frequency\":2194.917,\"model_name\":\"Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz\"},\"disks\":[{\"by_id\":\"/dev/disk/by-id/wwn-0x6000c2911a3fb8af754385340083d09c\",\"by_path\":\"/dev/disk/by-path/pci-0000:03:00.0-scsi-0:0:0:0\",\"drive_type\":\"HDD\",\"has_uuid\":true,\"hctl\":\"0:0:0:0\",\"id\":\"/dev/disk/by-id/wwn-0x6000c2911a3fb8af754385340083d09c\",\"installation_eligibility\":{\"eligible\":true,\"not_eligible_reasons\":null},\"model\":\"Virtual_disk\",\"name\":\"sda\",\"path\":\"/dev/sda\",\"serial\":\"6000c2911a3fb8af754385340083d09c\",\"size_bytes\":128849018880,\"smart\":\"SMART support is:     Unavailable - device lacks SMART capability.\\n\",\"vendor\":\"VMware\",\"wwn\":\"0x6000c2911a3fb8af754385340083d09c\"},{\"by_path\":\"/dev/disk/by-path/pci-0000:00:07.1-ata-1\",\"drive_type\":\"ODD\",\"hctl\":\"1:0:0:0\",\"id\":\"/dev/disk/by-path/pci-0000:00:07.1-ata-1\",\"installation_eligibility\":{\"not_eligible_reasons\":[\"Disk is removable\",\"Disk is too small (disk only has 106 MB, but 100 GB are required)\",\"Drive type is ODD, it must be one of HDD, SSD, Multipath.\"]},\"is_installation_media\":true,\"model\":\"VMware_IDE_CDR00\",\"name\":\"sr0\",\"path\":\"/dev/sr0\",\"removable\":true,\"serial\":\"00000000000000000001\",\"size_bytes\":106516480,\"smart\":\"SMART support is:     Unavailable - device lacks SMART capability.\\n\",\"vendor\":\"NECVMWar\"}],\"gpus\":[{\"address\":\"0000:00:0f.0\"}],\"hostname\":\"master-2.qe1.e2e.bos.redhat.com\",\"interfaces\":[{\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[\"10.19.114.222/23\"],\"ipv6_addresses\":[\"2620:52:0:1372:b55f:731b:f1dc:d773/64\"],\"mac_address\":\"00:50:56:83:87:09\",\"mtu\":1500,\"name\":\"ens192\",\"product\":\"0x07b0\",\"speed_mbps\":10000,\"type\":\"physical\",\"vendor\":\"0x15ad\"}],\"memory\":{\"physical_bytes\":34359738368,\"physical_bytes_method\":\"dmidecode\",\"usable_bytes\":33711775744},\"routes\":[{\"destination\":\"0.0.0.0\",\"family\":2,\"gateway\":\"10.19.115.254\",\"interface\":\"ens192\"},{\"destination\":\"10.19.114.0\",\"family\":2,\"interface\":\"ens192\"},{\"destination\":\"10.88.0.0\",\"family\":2,\"interface\":\"cni-podman0\"},{\"destination\":\"::1\",\"family\":10,\"interface\":\"lo\"},{\"destination\":\"2620:52:0:1372::\",\"family\":10,\"interface\":\"ens192\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"ens192\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"cni-podman0\"},{\"destination\":\"::\",\"family\":10,\"gateway\":\"fe80::a81:f4ff:fea6:dc01\",\"interface\":\"ens192\"}],\"system_vendor\":{\"manufacturer\":\"VMware, Inc.\",\"product_name\":\"VMware Virtual Platform\",\"serial_number\":\"VMware-42 09 5f ea c8 4e 8c 88-f3 0c 06 65 5a 4d 32 fb\",\"virtual\":true},\"tpm_version\":\"none\"}"
+	inventoryWithMultipleNICs string = "\"hostname\":\"localhost\",\"interfaces\":[{\"biosdevname\":\"em2\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:85\",\"mtu\":1500,\"name\":\"eno2\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em1\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:84\",\"mtu\":1500,\"name\":\"eno1\",\"product\":\"0x1537\",\"speed_mbps\":1000,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em3\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:86\",\"mtu\":1500,\"name\":\"eno3\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em4\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:87\",\"mtu\":1500,\"name\":\"eno4\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"em5\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"b4:7a:f1:da:fe:88\",\"mtu\":1500,\"name\":\"eno5\",\"product\":\"0x37ce\",\"speed_mbps\":-1,\"vendor\":\"0x8086\"},{\"biosdevname\":\"p1p1\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":8000,\"name\":\"ens1f0\",\"product\":\"0x158b\",\"speed_mbps\":25000,\"vendor\":\"0x8086\"},{\"biosdevname\":\"p1p2\",\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":8000,\"name\":\"ens1f1\",\"product\":\"0x158b\",\"speed_mbps\":25000,\"vendor\":\"0x8086\"},{\"flags\":[\"up\",\"broadcast\",\"multicast\"],\"has_carrier\":true,\"ipv4_addresses\":[\"10.195.70.120/24\"],\"ipv6_addresses\":[],\"mac_address\":\"d4:f5:ef:56:35:64\",\"mtu\":1500,\"name\":\"bond0\",\"speed_mbps\":25000}],\"memory\":{\"physical_bytes\":412316860416,\"physical_bytes_method\":\"dmidecode\",\"usable_bytes\":405391712256},\"routes\":[{\"destination\":\"0.0.0.0\",\"family\":2,\"gateway\":\"10.195.70.1\",\"interface\":\"bond0\"},{\"destination\":\"10.88.0.0\",\"family\":2,\"interface\":\"cni-podman0\"},{\"destination\":\"10.195.70.0\",\"family\":2,\"interface\":\"bond0\"},{\"destination\":\"::1\",\"family\":10,\"interface\":\"lo\"},{\"destination\":\"fe80::\",\"family\":10,\"interface\":\"cni-podman0\"}],\"system_vendor\":{\"manufacturer\":\"HPE\",\"product_name\":\"ProLiant e910\",\"serial_number\":\"MXQ1291HP3\"},\"timestamp\":1657725466,\"tpm_version\":\"2.0\"}"
+)
 
 func TestCommon(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -393,9 +395,7 @@ var _ = Describe("Test GetInventoryInterfaces", func() {
 })
 
 var _ = Describe("db features", func() {
-	var (
-		db *gorm.DB
-	)
+	var db *gorm.DB
 	BeforeEach(func() {
 		db, _ = PrepareTestDB()
 	})
@@ -463,6 +463,55 @@ var _ = Describe("JSON serialization checks", func() {
 		for i := 0; i != 100; i++ {
 			Expect(testMap()).To(Equal(v))
 		}
+	})
+})
+
+var _ = Describe("Test CanUnbindhost", func() {
+	Context("Verify Host cannot be removed while cluster progressing", func() {
+		hosts := make([]*models.Host, 0)
+		var cluster Cluster
+		BeforeEach(func() {
+			for i := 1; i < 5; i++ {
+				// Creating full cluster 3 masters 3 nodes
+				hosts = append(hosts, createHost(models.HostRoleMaster, models.HostStatusKnown))
+				hosts = append(hosts, createHost(models.HostRoleWorker, models.HostStatusKnown))
+			}
+			cluster = Cluster{
+				Cluster: models.Cluster{
+					Hosts: hosts,
+				},
+			}
+		})
+		It("fail while cluster is progressing", func() {
+			notAllowedStatus := []string{
+				models.ClusterStatusFinalizing,
+				models.ClusterStatusInstalling,
+				models.ClusterStatusInstallingPendingUserAction,
+				models.ClusterStatusPreparingForInstallation,
+			}
+			for _, failState := range notAllowedStatus {
+				cluster.Status = swag.String(failState)
+				err := CanUnbindhost(&cluster)
+
+				Expect(err).ToNot(BeNil())
+			}
+		})
+		It("success unbind host", func() {
+			allowedStatus := []string{
+				models.ClusterStatusInstalled,
+				models.ClusterStatusReady,
+				models.ClusterStatusAddingHosts,
+				models.ClusterStatusCancelled,
+				models.ClusterStatusError,
+				models.ClusterStatusInsufficient,
+			}
+			for _, successState := range allowedStatus {
+				cluster.Status = swag.String(successState)
+				err := CanUnbindhost(&cluster)
+
+				Expect(err).To(BeNil())
+			}
+		})
 	})
 })
 

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -493,7 +493,9 @@ var _ = Describe("Test CanUnbindhost", func() {
 				cluster.Status = swag.String(failState)
 				err := CanUnbindhost(&cluster)
 
-				Expect(err).ToNot(BeNil())
+				errMsg := fmt.Errorf("cluster %s is in %s state, host cannot be unbind when status is one of: %s",
+					cluster.ID, failState, notAllowedStatus)
+				Expect(err).To(Equal(errMsg))
 			}
 		})
 		It("success unbind host", func() {


### PR DESCRIPTION
bugfix
-  remove the ability to unbind Host while the cluster is progressing 
- allow removing host's which are not bound to a cluster , for ACM 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
