### PR TITLE
MGMT-16241: Ensure that LastInstallationPreparationStatus is reset on cluster install.

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
@@ -24,7 +24,7 @@ type LastInstallationPreparation struct {
 	Reason string `json:"reason,omitempty"`
 
 	// The last installation preparation status
-	// Enum: [preparation_never_performed failed success]
+	// Enum: [not_started failed success]
 	Status string `json:"status,omitempty"`
 }
 
@@ -46,7 +46,7 @@ var lastInstallationPreparationTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["preparation_never_performed","failed","success"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["not_started","failed","success"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -56,8 +56,8 @@ func init() {
 
 const (
 
-	// LastInstallationPreparationStatusPreparationNeverPerformed captures enum value "preparation_never_performed"
-	LastInstallationPreparationStatusPreparationNeverPerformed string = "preparation_never_performed"
+	// LastInstallationPreparationStatusNotStarted captures enum value "not_started"
+	LastInstallationPreparationStatusNotStarted string = "not_started"
 
 	// LastInstallationPreparationStatusFailed captures enum value "failed"
 	LastInstallationPreparationStatusFailed string = "failed"

--- a/client/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
@@ -24,7 +24,7 @@ type LastInstallationPreparation struct {
 	Reason string `json:"reason,omitempty"`
 
 	// The last installation preparation status
-	// Enum: [preparation_never_performed failed success]
+	// Enum: [not_started failed success]
 	Status string `json:"status,omitempty"`
 }
 
@@ -46,7 +46,7 @@ var lastInstallationPreparationTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["preparation_never_performed","failed","success"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["not_started","failed","success"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -56,8 +56,8 @@ func init() {
 
 const (
 
-	// LastInstallationPreparationStatusPreparationNeverPerformed captures enum value "preparation_never_performed"
-	LastInstallationPreparationStatusPreparationNeverPerformed string = "preparation_never_performed"
+	// LastInstallationPreparationStatusNotStarted captures enum value "not_started"
+	LastInstallationPreparationStatusNotStarted string = "not_started"
 
 	// LastInstallationPreparationStatusFailed captures enum value "failed"
 	LastInstallationPreparationStatusFailed string = "failed"

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1222,6 +1222,17 @@ func (b *bareMetalInventory) InstallClusterInternal(ctx context.Context, params 
 		return nil, common.NewApiError(http.StatusNotFound, err)
 	}
 
+	err = b.db.Model(&models.Cluster{}).Where("id = ?", cluster.ID.String()).Updates(&models.Cluster{
+		LastInstallationPreparation: models.LastInstallationPreparation{
+			Status: models.LastInstallationPreparationStatusNotStarted,
+			Reason: "Preparation never performed",
+		},
+	}).Error
+	if err != nil {
+		b.log.WithError(err).Errorf("Failed to reset last installation preparation state for cluster %s", cluster.ID.String())
+		return nil, common.NewApiError(http.StatusInternalServerError, err)
+	}
+
 	var autoAssigned bool
 
 	// auto select hosts roles if not selected yet.

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -1701,7 +1701,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 			apiVips:            common.TestIPv4Networking.APIVips,
 			ingressVips:        common.TestIPv4Networking.IngressVips,
 			dstState:           models.ClusterStatusPreparingForInstallation,
-			installationStatus: models.LastInstallationPreparationStatusPreparationNeverPerformed,
+			installationStatus: models.LastInstallationPreparationStatusNotStarted,
 			hosts: []models.Host{
 				{
 					ID:     &hid1,
@@ -1723,7 +1723,7 @@ var _ = Describe("RefreshCluster - preparing for install", func() {
 			apiVips:            common.TestIPv4Networking.APIVips,
 			ingressVips:        common.TestIPv4Networking.IngressVips,
 			dstState:           models.ClusterStatusInsufficient,
-			installationStatus: models.LastInstallationPreparationStatusPreparationNeverPerformed,
+			installationStatus: models.LastInstallationPreparationStatusNotStarted,
 			hosts: []models.Host{
 				{
 					ID:     &hid1,

--- a/models/last_installation_preparation.go
+++ b/models/last_installation_preparation.go
@@ -24,7 +24,7 @@ type LastInstallationPreparation struct {
 	Reason string `json:"reason,omitempty"`
 
 	// The last installation preparation status
-	// Enum: [preparation_never_performed failed success]
+	// Enum: [not_started failed success]
 	Status string `json:"status,omitempty"`
 }
 
@@ -46,7 +46,7 @@ var lastInstallationPreparationTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["preparation_never_performed","failed","success"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["not_started","failed","success"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -56,8 +56,8 @@ func init() {
 
 const (
 
-	// LastInstallationPreparationStatusPreparationNeverPerformed captures enum value "preparation_never_performed"
-	LastInstallationPreparationStatusPreparationNeverPerformed string = "preparation_never_performed"
+	// LastInstallationPreparationStatusNotStarted captures enum value "not_started"
+	LastInstallationPreparationStatusNotStarted string = "not_started"
 
 	// LastInstallationPreparationStatusFailed captures enum value "failed"
 	LastInstallationPreparationStatusFailed string = "failed"

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9106,9 +9106,9 @@ func init() {
         "status": {
           "description": "The last installation preparation status",
           "type": "string",
-          "default": "preparation_never_performed",
+          "default": "not_started",
           "enum": [
-            "preparation_never_performed",
+            "not_started",
             "failed",
             "success"
           ],
@@ -19680,9 +19680,9 @@ func init() {
         "status": {
           "description": "The last installation preparation status",
           "type": "string",
-          "default": "preparation_never_performed",
+          "default": "not_started",
           "enum": [
-            "preparation_never_performed",
+            "not_started",
             "failed",
             "success"
           ],

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5423,9 +5423,9 @@ definitions:
     properties:
       status:
         type: string
-        default: "preparation_never_performed"
+        default: "not_started"
         x-nullable: false
-        enum: [preparation_never_performed, failed, success]
+        enum: [not_started, failed, success]
         description: The last installation preparation status
       reason:
         type: string

--- a/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
+++ b/vendor/github.com/openshift/assisted-service/models/last_installation_preparation.go
@@ -24,7 +24,7 @@ type LastInstallationPreparation struct {
 	Reason string `json:"reason,omitempty"`
 
 	// The last installation preparation status
-	// Enum: [preparation_never_performed failed success]
+	// Enum: [not_started failed success]
 	Status string `json:"status,omitempty"`
 }
 
@@ -46,7 +46,7 @@ var lastInstallationPreparationTypeStatusPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["preparation_never_performed","failed","success"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["not_started","failed","success"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -56,8 +56,8 @@ func init() {
 
 const (
 
-	// LastInstallationPreparationStatusPreparationNeverPerformed captures enum value "preparation_never_performed"
-	LastInstallationPreparationStatusPreparationNeverPerformed string = "preparation_never_performed"
+	// LastInstallationPreparationStatusNotStarted captures enum value "not_started"
+	LastInstallationPreparationStatusNotStarted string = "not_started"
 
 	// LastInstallationPreparationStatusFailed captures enum value "failed"
 	LastInstallationPreparationStatusFailed string = "failed"


### PR DESCRIPTION
A recent change to how cluster installation is presented introduced a bug that caused problems when encountering an
error during installation. On fixing the error, the user would have to start the installation twice in order to move
to the `installing` state.

This issue addresses that by resetting the LastInstallationPreparationStatus when an installation is started.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
