### PR TITLE
MGMT-16373: KubeAPI - Ensure that ISO type is full-iso when cpuarchitecture is S390x

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -140,6 +140,15 @@ func (r *InfraEnvReconciler) Reconcile(origCtx context.Context, req ctrl.Request
 	return r.ensureISO(ctx, log, infraEnv)
 }
 
+func (r *InfraEnvReconciler) getImageType(ctx context.Context, infraEnv *aiv1beta1.InfraEnv) models.ImageType {
+	// S390X platform does not support minimal ISO, ensure that full ISO is requested instead.
+	imageType := r.Config.ImageType
+	if infraEnv.Spec.CpuArchitecture == models.ClusterCPUArchitectureS390x {
+		imageType = models.ImageTypeFullIso
+	}
+	return imageType
+}
+
 func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv, internalInfraEnv *common.InfraEnv) (*common.InfraEnv, error) {
 	updateParams := installer.UpdateInfraEnvParams{
 		InfraEnvID:           *internalInfraEnv.ID,
@@ -198,7 +207,7 @@ func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.Fiel
 		updateParams.InfraEnvUpdateParams.StaticNetworkConfig = staticNetworkConfig
 	}
 
-	updateParams.InfraEnvUpdateParams.ImageType = r.Config.ImageType
+	updateParams.InfraEnvUpdateParams.ImageType = r.getImageType(ctx, infraEnv)
 
 	existingKargs, err := kubeKernelArgs(internalInfraEnv)
 	if err != nil {
@@ -476,7 +485,7 @@ func (r *InfraEnvReconciler) createInfraEnv(ctx context.Context, log logrus.Fiel
 	if cluster != nil {
 		clusterID = cluster.ID
 	}
-	createParams := CreateInfraEnvParams(infraEnv, r.Config.ImageType, pullSecret, clusterID, osImageVersion)
+	createParams := CreateInfraEnvParams(infraEnv, r.getImageType(ctx, infraEnv), pullSecret, clusterID, osImageVersion)
 
 	staticNetworkConfig, err := r.processNMStateConfig(ctx, log, infraEnv)
 	if err != nil {


### PR DESCRIPTION
Presently when an infraenv is created via KubeAPI for the S390x architecture it is created with the default "minimum-iso" imagetype. This is incompatible with S390x.

This PR makes sure that the imagetype is updated to "full-iso" to maintain compatibility.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
