### PR TITLE
MGMT-16428: create migration from oci to external platform type

### DIFF
--- a/internal/migrations/20231219105000_update_oci_to_external_platform_type.go
+++ b/internal/migrations/20231219105000_update_oci_to_external_platform_type.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func updateOciToExternalPlatformType() *gormigrate.Migration {
+	migrate := func(tx *gorm.DB) error {
+		err := tx.Exec("UPDATE clusters SET platform_type=?, platform_external_platform_name=?, platform_external_cloud_controller_manager=? WHERE platform_type=?", "external", "oci", "External", "oci").Error
+		return err
+	}
+
+	rollback := func(tx *gorm.DB) error {
+		err := tx.Exec("UPDATE clusters SET platform_type=?, platform_external_platform_name=NULL, platform_external_cloud_controller_manager=NULL WHERE platform_type=? AND platform_external_platform_name=? AND platform_external_cloud_controller_manager=?", "oci", "external", "oci", "External").Error
+		return err
+	}
+
+	return &gormigrate.Migration{
+		ID:       "20231219105000",
+		Migrate:  gormigrate.MigrateFunc(migrate),
+		Rollback: gormigrate.RollbackFunc(rollback),
+	}
+}

--- a/internal/migrations/20231219105000_update_oci_to_external_platform_type_test.go
+++ b/internal/migrations/20231219105000_update_oci_to_external_platform_type_test.go
@@ -1,0 +1,93 @@
+package migrations
+
+import (
+	gormigrate "github.com/go-gormigrate/gormigrate/v2"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/models"
+	"gorm.io/gorm"
+)
+
+type platformResults struct {
+	PlatformType                           *string
+	PlatformExternalCloudControllerManager *string
+	PlatformExternalPlatformName           *string
+}
+
+var _ = Describe("updateOciToExternalPlatformType", func() {
+	var (
+		db        *gorm.DB
+		dbName    string
+		clusterID = strfmt.UUID("46a8d745-dfce-4fd8-9df0-549ee8eabb3d")
+		gm        *gormigrate.Gormigrate
+	)
+
+	BeforeEach(func() {
+		db, dbName = common.PrepareTestDB()
+		gm = gormigrate.New(db, gormigrate.DefaultOptions, post())
+	})
+
+	AfterEach(func() {
+		common.DeleteTestDB(db, dbName)
+	})
+
+	It("Migrates up", func() {
+		var err error
+
+		err = migrateToBefore(db, "20231219105000")
+		Expect(err).NotTo(HaveOccurred())
+
+		// create cluster with platform_type = oci
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID,
+			},
+		}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+		err = db.Exec("UPDATE clusters SET platform_type=? WHERE id=?", "oci", clusterID).Error
+		Expect(err).NotTo(HaveOccurred())
+
+		err = migrateTo(db, "20231219105000")
+		Expect(err).NotTo(HaveOccurred())
+
+		// test
+		var res platformResults
+		db.Raw("SELECT platform_type, platform_external_platform_name, platform_external_cloud_controller_manager FROM clusters WHERE id=?", clusterID).Scan(&res)
+		Expect(*res.PlatformType).To(Equal("external"))
+		Expect(*res.PlatformExternalPlatformName).To(Equal("oci"))
+		Expect(*res.PlatformExternalCloudControllerManager).To(Equal("External"))
+	})
+
+	It("Migrates down", func() {
+		err := migrateTo(db, "20231219105000")
+		Expect(err).NotTo(HaveOccurred())
+
+		// create cluster with platform_type = oci
+		cluster := common.Cluster{
+			Cluster: models.Cluster{
+				ID: &clusterID,
+				Platform: &models.Platform{
+					Type: common.PlatformTypePtr(models.PlatformTypeExternal),
+					External: &models.PlatformExternal{
+						PlatformName:           swag.String("oci"),
+						CloudControllerManager: swag.String(models.PlatformExternalCloudControllerManagerExternal),
+					},
+				},
+			},
+		}
+		Expect(db.Create(&cluster).Error).ShouldNot(HaveOccurred())
+
+		Expect(gm.RollbackMigration(updateOciToExternalPlatformType())).ToNot(HaveOccurred())
+
+		// test
+		var res platformResults
+		db.Raw("SELECT platform_type, platform_external_platform_name, platform_external_cloud_controller_manager FROM clusters WHERE id=?", clusterID).Scan(&res)
+		Expect(*res.PlatformType).To(Equal("oci"))
+		Expect(res.PlatformExternalPlatformName).To(BeNil())
+		Expect(res.PlatformExternalCloudControllerManager).To(BeNil())
+	})
+})

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -43,6 +43,7 @@ func post() []*gormigrate.Migration {
 		renameKernelArguments(),
 		deleteEventsWithUnboundCluster(),
 		dropClusterApiVipAndIngressVip(),
+		updateOciToExternalPlatformType(),
 	}
 
 	sort.SliceStable(postMigrations, func(i, j int) bool { return postMigrations[i].ID < postMigrations[j].ID })


### PR DESCRIPTION
Update existing clusters with platform type oci to use the external platform type