### PR TITLE
OCPBUGS-25434: handle NMStateConfig deletion

### DIFF
--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -205,6 +205,9 @@ func (r *InfraEnvReconciler) updateInfraEnv(ctx context.Context, log logrus.Fiel
 	if len(staticNetworkConfig) > 0 {
 		log.Infof("the amount of nmStateConfigs included in the image is: %d", len(staticNetworkConfig))
 		updateParams.InfraEnvUpdateParams.StaticNetworkConfig = staticNetworkConfig
+	} else if internalInfraEnv.StaticNetworkConfig != "" {
+		log.Infof("removed all nmStateConfigs from the image")
+		updateParams.InfraEnvUpdateParams.StaticNetworkConfig = []*models.HostStaticNetworkConfig{}
 	}
 
 	updateParams.InfraEnvUpdateParams.ImageType = r.getImageType(ctx, infraEnv)

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -542,6 +542,13 @@ func getSecret(ctx context.Context, client k8sclient.Client, key types.Namespace
 	return secret
 }
 
+func getNMStateConfig(ctx context.Context, client k8sclient.Client, key types.NamespacedName) *v1beta1.NMStateConfig {
+	nmstateConfig := &v1beta1.NMStateConfig{}
+	err := client.Get(ctx, key, nmstateConfig)
+	Expect(err).To(BeNil())
+	return nmstateConfig
+}
+
 // configureLoclAgentClient reassigns the global agentBMClient variable to a client instance using local token auth
 func configureLocalAgentClient(infraEnvID string) {
 	if Options.AuthType != auth.TypeLocal {
@@ -3318,6 +3325,69 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}
 		// InfraEnv Reconcile takes longer, since it needs to generate the image.
 		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, "Unsupported keys found")
+	})
+
+	It("ensure StaticNetworkConfig is empty after NMStateConfig deletion", func() {
+		var (
+			NMStateLabelName  = "someName"
+			NMStateLabelValue = "someValue"
+			nicPrimary        = "eth0"
+			nicSecondary      = "eth1"
+			macPrimary        = "09:23:0f:d8:92:AA"
+			macSecondary      = "09:23:0f:d8:92:AB"
+			ip4Primary        = "192.168.126.30"
+			ip4Secondary      = "192.168.140.30"
+			dnsGW             = "192.168.126.1"
+		)
+		hostStaticNetworkConfig := common.FormatStaticConfigHostYAML(
+			nicPrimary, nicSecondary, ip4Primary, ip4Secondary, dnsGW,
+			models.MacInterfaceMap{
+				{MacAddress: macPrimary, LogicalNicName: nicPrimary},
+				{MacAddress: macSecondary, LogicalNicName: nicSecondary},
+			})
+		nmstateConfigSpec := getDefaultNMStateConfigSpec(nicPrimary, nicSecondary, macPrimary, macSecondary, hostStaticNetworkConfig.NetworkYaml)
+
+		// Deploy MMStateConfig/CD/ACI/InfraEnv
+		deployNMStateConfigCRD(ctx, kubeClient, "nmstate1", NMStateLabelName, NMStateLabelValue, nmstateConfigSpec)
+		deployClusterDeploymentCRD(ctx, kubeClient, clusterDeploymentSpec)
+		deployAgentClusterInstallCRD(ctx, kubeClient, aciSpec, clusterDeploymentSpec.ClusterInstallRef.Name)
+		installkey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      clusterDeploymentSpec.ClusterInstallRef.Name,
+		}
+		checkAgentClusterInstallCondition(ctx, installkey, hiveext.ClusterRequirementsMetCondition, hiveext.ClusterNotReadyReason)
+		infraEnvSpec.NMStateConfigLabelSelector = metav1.LabelSelector{MatchLabels: map[string]string{NMStateLabelName: NMStateLabelValue}}
+		deployInfraEnvCRD(ctx, kubeClient, infraNsName.Name, infraEnvSpec)
+		infraEnvKubeName := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+
+		// InfraEnv Reconcile takes longer, since it needs to generate the image.
+		checkInfraEnvCondition(ctx, infraEnvKubeName, v1beta1.ImageCreatedCondition, v1beta1.ImageStateCreated)
+		infraEnvKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      infraNsName.Name,
+		}
+		infraEnv := getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
+		var staticNetworkConfig []*models.HostStaticNetworkConfig
+		Expect(json.Unmarshal([]byte(infraEnv.StaticNetworkConfig), &staticNetworkConfig)).ToNot(HaveOccurred())
+		Expect(staticNetworkConfig).To(HaveLen(1))
+		Expect(staticNetworkConfig[0].NetworkYaml).To(Equal(hostStaticNetworkConfig.NetworkYaml))
+		Expect(infraEnv.Generated).Should(Equal(true))
+
+		// Delete NMState config
+		nmstateConfigKey := types.NamespacedName{
+			Namespace: Options.Namespace,
+			Name:      "nmstate1",
+		}
+		Expect(kubeClient.Delete(ctx, getNMStateConfig(ctx, kubeClient, nmstateConfigKey))).ShouldNot(HaveOccurred())
+
+		// Ensure StaticNetworkConfig is empty
+		Eventually(func() string {
+			infraEnv = getInfraEnvFromDBByKubeKey(ctx, db, infraEnvKey, waitForReconcileTimeout)
+			return infraEnv.StaticNetworkConfig
+		}, "1m", "20s").Should(Equal(""))
 	})
 
 	It("Unbind", func() {


### PR DESCRIPTION
When deleting an NMStateConfig CR, the discovery ISO and static network config are not updated accordingly. I.e. the previous config remains intact. Hence, ensure that the StaticNetworkConfig is emptied when the CR is deleted (set on InfraEnvUpdateParams).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
