### PR TITLE
NO-ISSUE: Fix for subsystem test that fails locally.

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1138,7 +1138,7 @@ func (m *Manager) createClusterDataFiles(ctx context.Context, c *common.Cluster,
 		if isUserManifest {
 			manifest_prefix = "user-supplied"
 		}
-		fileName := fmt.Sprintf("%s/logs/manifest_%s_%s/%s", c.ID, manifest_prefix, manifestEntry.Folder, manifestEntry.FileName)
+		fileName := fmt.Sprintf("%s/logs/cluster/manifest_%s_%s_%s", c.ID, manifest_prefix, manifestEntry.Folder, manifestEntry.FileName)
 		err = m.uploadDataAsFile(ctx, log, string(fileContent), fileName, objectHandler)
 		if err != nil {
 			log.WithError(err).Errorf("Unable to upload %s to logs for cluster id %s", fileName, *c.ID)

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -2450,7 +2450,7 @@ name: exampleNamespace2`
 			Expect(err).NotTo(HaveOccurred())
 			tarReader := tar.NewReader(file)
 			numOfarchivedFiles := 0
-			expectedFiles := []string{"manifest_user-supplied_openshift_manifest1.yaml", "manifest_user-supplied_openshift_manifest2.yaml", "cluster_events.json", "cluster_metadata.json", "controller_logs.tar.gz", "test-cluster_auto-assign_h1.tar", "test-cluster_auto-assign_h2.tar", "test-cluster_auto-assign_h3.tar"}
+			expectedFiles := []string{"cluster_manifest_user-supplied_openshift_manifest1.yaml", "cluster_manifest_user-supplied_openshift_manifest2.yaml", "cluster_events.json", "cluster_metadata.json", "controller_logs.tar.gz", "test-cluster_auto-assign_h1.tar", "test-cluster_auto-assign_h2.tar", "test-cluster_auto-assign_h3.tar"}
 			for {
 				header, err := tarReader.Next()
 				if err == io.EOF {


### PR DESCRIPTION
It seems there is a small variation between the Object Store and S3 implementations. This means that the "Download Cluster Logs" test fails locally while passing on AWS.

I have updated the test so that it passes locally by generating a filename in a way that is consistent in both environments.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
