### PR TITLE
MGMT-16332: allow lvms on multi node

### DIFF
--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -101,56 +101,6 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		Expect(isArchitectureSupported(feature, "4.30")).To(BeTrue())
 	})
 
-	Context("Test LVM/Nutanix are not supported under 4.11", func() {
-		features := []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM, models.FeatureSupportLevelIDNUTANIXINTEGRATION}
-		for _, f := range features {
-			feature := f
-			It(fmt.Sprintf("%s test", feature), func() {
-				arch := "DoesNotMatter"
-				Expect(IsFeatureAvailable(feature, "4.6", swag.String(arch))).To(BeFalse())
-				Expect(IsFeatureAvailable(feature, "4.7", swag.String(arch))).To(BeFalse())
-				Expect(IsFeatureAvailable(feature, "4.8", swag.String(arch))).To(BeFalse())
-				Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch))).To(BeFalse())
-				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeTrue())
-
-				featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.11", CPUArchitecture: swag.String(arch)}
-				Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelDevPreview))
-				featureSupportParams = SupportLevelFilters{OpenshiftVersion: "4.11.20", CPUArchitecture: swag.String(arch)}
-				Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelDevPreview))
-
-				Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch))).To(BeTrue())
-				Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch))).To(BeTrue())
-
-				// Check for feature release
-				Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch))).To(BeTrue())
-			})
-		}
-	})
-
-	Context("Test LVM feature", func() {
-		feature := models.FeatureSupportLevelIDLVM
-		It("Validate LVM on arch", func() {
-			supportedCpuArch := []string{
-				models.ClusterCPUArchitectureArm64,
-				models.ClusterCPUArchitectureMulti,
-				models.ClusterCPUArchitectureX8664,
-			}
-			notSupportedCpuArch := []string{
-				models.ClusterCPUArchitectureS390x,
-				models.ClusterCPUArchitecturePpc64le,
-			}
-			for _, arch := range supportedCpuArch {
-				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeTrue())
-			}
-			for _, arch := range notSupportedCpuArch {
-				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeFalse())
-			}
-		})
-		// It("validate LVM on version 4.15", func() {
-		// 	featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.15", CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664,ex)}
-		// 	Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelSupported))
-		// })
-	})
 	Context("Test LSO CPU compatibility", func() {
 		feature := models.FeatureSupportLevelIDLSO
 		It("LSO IsFeatureAvailable", func() {

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -127,6 +127,30 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		}
 	})
 
+	Context("Test LVM feature", func() {
+		feature := models.FeatureSupportLevelIDLVM
+		It("Validate LVM on arch", func() {
+			supportedCpuArch := []string{
+				models.ClusterCPUArchitectureArm64,
+				models.ClusterCPUArchitectureMulti,
+				models.ClusterCPUArchitectureX8664,
+			}
+			notSupportedCpuArch := []string{
+				models.ClusterCPUArchitectureS390x,
+				models.ClusterCPUArchitecturePpc64le,
+			}
+			for _, arch := range supportedCpuArch {
+				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeTrue())
+			}
+			for _, arch := range notSupportedCpuArch {
+				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeFalse())
+			}
+		})
+		// It("validate LVM on version 4.15", func() {
+		// 	featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.15", CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664,ex)}
+		// 	Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelSupported))
+		// })
+	})
 	Context("Test LSO CPU compatibility", func() {
 		feature := models.FeatureSupportLevelIDLSO
 		It("LSO IsFeatureAvailable", func() {

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -36,7 +36,6 @@ func (feature *VipAutoAllocFeature) getIncompatibleFeatures(string) *[]models.Fe
 	return &[]models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDSNO,
 		models.FeatureSupportLevelIDEXTERNALPLATFORMOCI,
-		models.FeatureSupportLevelIDLVM,
 		models.FeatureSupportLevelIDNONEPLATFORM,
 		models.FeatureSupportLevelIDEXTERNALPLATFORM,
 	}
@@ -128,7 +127,6 @@ func (feature *ClusterManagedNetworkingFeature) getIncompatibleFeatures(string) 
 		models.FeatureSupportLevelIDSNO,
 		models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDEXTERNALPLATFORMOCI,
-		models.FeatureSupportLevelIDLVM,
 		models.FeatureSupportLevelIDNONEPLATFORM,
 		models.FeatureSupportLevelIDEXTERNALPLATFORM,
 	}

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -81,8 +81,6 @@ func (feature *LvmFeature) getFeatureActiveLevel(cluster *common.Cluster, _ *mod
 
 func (feature *LvmFeature) getIncompatibleFeatures(string) *[]models.FeatureSupportLevelID {
 	return &[]models.FeatureSupportLevelID{
-		models.FeatureSupportLevelIDVIPAUTOALLOC,
-		models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDODF,

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -65,7 +65,11 @@ func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters) models.S
 		return models.SupportLevelUnavailable
 	}
 
-	if isGreaterEqual, _ := common.BaseVersionGreaterOrEqual("4.11", filters.OpenshiftVersion); isGreaterEqual {
+	if isEqual, _ := common.BaseVersionEqual("4.11", filters.OpenshiftVersion); isEqual {
+		return models.SupportLevelDevPreview
+	}
+
+	if isEqual, _ := common.BaseVersionEqual("4.15", filters.OpenshiftVersion); isEqual {
 		return models.SupportLevelDevPreview
 	}
 
@@ -85,7 +89,7 @@ func (feature *LvmFeature) getIncompatibleFeatures(OCPVersion string) *[]models.
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDODF,
 	}
-	if isEqual, _ := common.BaseVersionEqual("4.11", OCPVersion); isEqual {
+	if isEqual, _ := common.BaseVersionLessThan("4.15", OCPVersion); isEqual {
 		incompatibleFeatures = append(incompatibleFeatures,
 			models.FeatureSupportLevelIDVIPAUTOALLOC,
 			models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -69,10 +69,6 @@ func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters) models.S
 		return models.SupportLevelDevPreview
 	}
 
-	if isEqual, _ := common.BaseVersionEqual("4.15", filters.OpenshiftVersion); isEqual {
-		return models.SupportLevelDevPreview
-	}
-
 	return models.SupportLevelSupported
 }
 

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -65,7 +65,7 @@ func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters) models.S
 		return models.SupportLevelUnavailable
 	}
 
-	if isEqual, _ := common.BaseVersionEqual("4.11", filters.OpenshiftVersion); isEqual {
+	if isGreaterEqual, _ := common.BaseVersionGreaterOrEqual("4.11", filters.OpenshiftVersion); isGreaterEqual {
 		return models.SupportLevelDevPreview
 	}
 
@@ -79,12 +79,19 @@ func (feature *LvmFeature) getFeatureActiveLevel(cluster *common.Cluster, _ *mod
 	return activeLevelNotActive
 }
 
-func (feature *LvmFeature) getIncompatibleFeatures(string) *[]models.FeatureSupportLevelID {
-	return &[]models.FeatureSupportLevelID{
+func (feature *LvmFeature) getIncompatibleFeatures(OCPVersion string) *[]models.FeatureSupportLevelID {
+	incompatibleFeatures := []models.FeatureSupportLevelID{
 		models.FeatureSupportLevelIDNUTANIXINTEGRATION,
 		models.FeatureSupportLevelIDVSPHEREINTEGRATION,
 		models.FeatureSupportLevelIDODF,
 	}
+	if isEqual, _ := common.BaseVersionEqual("4.11", OCPVersion); isEqual {
+		incompatibleFeatures = append(incompatibleFeatures,
+			models.FeatureSupportLevelIDVIPAUTOALLOC,
+			models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+		)
+	}
+	return &incompatibleFeatures
 }
 
 func (feature *LvmFeature) getIncompatibleArchitectures(_ *string) *[]models.ArchitectureSupportLevelID {

--- a/internal/featuresupport/features_olm_operators_test.go
+++ b/internal/featuresupport/features_olm_operators_test.go
@@ -93,7 +93,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 					id:       6,
 					version:  "4.15",
 					platform: models.PlatformTypeNone.Pointer(),
-					expected: models.SupportLevelDevPreview,
+					expected: models.SupportLevelSupported,
 				},
 			}
 

--- a/internal/featuresupport/features_olm_operators_test.go
+++ b/internal/featuresupport/features_olm_operators_test.go
@@ -1,0 +1,184 @@
+package featuresupport
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/swag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/assisted-service/models"
+)
+
+var _ = Describe("V2ListFeatureSupportLevels API", func() {
+	lVMavailableVersions := []string{"4.11", "4.12", "4.13", "4.14", "4.15"}
+	unspportedLVMVersions := []string{"4.10", "4.9", "4.8", "4.7", "4.6"}
+
+	Context("Test LVM/Nutanix are not supported under 4.11", func() {
+		features := []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM, models.FeatureSupportLevelIDNUTANIXINTEGRATION}
+		for _, f := range features {
+			feature := f
+			It(fmt.Sprintf("%s test", feature), func() {
+				for _, version := range unspportedLVMVersions {
+					Expect(IsFeatureAvailable(feature, version, nil)).To(BeFalse())
+				}
+				for _, version := range lVMavailableVersions {
+					Expect(IsFeatureAvailable(feature, version, nil)).To(BeTrue())
+				}
+				// feature test
+				Expect(IsFeatureAvailable(feature, "4.30", nil)).To(BeTrue())
+
+			})
+		}
+	})
+
+	Context("Test LVM feature", func() {
+		lvmFeatureList := featuresList[models.FeatureSupportLevelIDLVM]
+		feature := models.FeatureSupportLevelIDLVM
+		It("Validate LVM on CPU arch", func() {
+			supportedCpuArch := []string{
+				models.ClusterCPUArchitectureArm64,
+				models.ClusterCPUArchitectureMulti,
+				models.ClusterCPUArchitectureX8664,
+			}
+			notSupportedCpuArch := []string{
+				models.ClusterCPUArchitectureS390x,
+				models.ClusterCPUArchitecturePpc64le,
+			}
+			for _, arch := range supportedCpuArch {
+				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeTrue())
+			}
+			for _, arch := range notSupportedCpuArch {
+				Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeFalse())
+			}
+		})
+		It("Validate Feature Support for LVM", func() {
+
+			tests := []struct {
+				id       int // used to know which test case failed
+				version  string
+				platform *models.PlatformType
+				expected models.SupportLevel
+			}{
+				{
+					id:       1,
+					version:  "4.11",
+					platform: models.PlatformTypeNone.Pointer(),
+					expected: models.SupportLevelDevPreview,
+				},
+				{
+					id:       2,
+					version:  "4.9",
+					platform: models.PlatformTypeBaremetal.Pointer(),
+					expected: models.SupportLevelUnavailable,
+				},
+				{
+					id:       3,
+					version:  "4.11",
+					platform: models.PlatformTypeVsphere.Pointer(),
+					expected: models.SupportLevelUnavailable,
+				},
+				{
+					id:       4,
+					version:  "4.12",
+					platform: models.PlatformTypeBaremetal.Pointer(),
+					expected: models.SupportLevelSupported,
+				},
+				{
+					id:       5,
+					version:  "4.14",
+					platform: models.PlatformTypeNone.Pointer(),
+					expected: models.SupportLevelSupported,
+				},
+				{
+					id:       6,
+					version:  "4.15",
+					platform: models.PlatformTypeNone.Pointer(),
+					expected: models.SupportLevelDevPreview,
+				},
+			}
+
+			for _, test := range tests {
+
+				featureSupportParams := SupportLevelFilters{OpenshiftVersion: test.version, CPUArchitecture: nil, PlatformType: test.platform}
+				resultSupportLevel := GetSupportLevel(feature, featureSupportParams)
+				Expect(fmt.Sprintf("id: %d, result: %s", test.id, resultSupportLevel)).To(Equal(fmt.Sprintf("id: %d, result: %s", test.id, test.expected)))
+			}
+		})
+		It("Validate Compacompatible Features", func() {
+			incompatibleFeatures := make(map[string]*[]models.FeatureSupportLevelID)
+
+			incompatibleFeatures["4.11"] = &[]models.FeatureSupportLevelID{
+				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDVIPAUTOALLOC,
+				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+			}
+
+			incompatibleFeatures["4.12"] = &[]models.FeatureSupportLevelID{
+				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+				models.FeatureSupportLevelIDODF,
+				models.FeatureSupportLevelIDVIPAUTOALLOC,
+				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+			}
+
+			incompatibleFeatures["4.15"] = &[]models.FeatureSupportLevelID{
+				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+				models.FeatureSupportLevelIDODF,
+			}
+			incompatibleFeatures["4.16.0-rc0"] = &[]models.FeatureSupportLevelID{
+				models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+				models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+				models.FeatureSupportLevelIDODF,
+			}
+
+			testIncompatibleFeatures := []struct {
+				id          int
+				version     string
+				featureList []models.FeatureSupportLevelID
+			}{
+				{
+					id:          1,
+					version:     "4.11",
+					featureList: []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM},
+				},
+				{
+					id:          2,
+					version:     "4.12",
+					featureList: []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM},
+				},
+				{
+					id:          3,
+					version:     "4.15",
+					featureList: []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM},
+				},
+				{
+					id:          4,
+					version:     "4.16.0-rc0", // check pre release version
+					featureList: []models.FeatureSupportLevelID{models.FeatureSupportLevelIDLVM},
+				},
+			}
+
+			for _, test := range testIncompatibleFeatures {
+				for _, featureId := range test.featureList {
+					result := featuresList[featureId].getIncompatibleFeatures(test.version)
+					Expect(fmt.Sprintf("id: %d, result: %s", test.id, result)).To(Equal(fmt.Sprintf("id: %d, result: %s", test.id, incompatibleFeatures[test.version])))
+				}
+			}
+		})
+
+		It("Ensure LVM  multinode is supportted on version 4.15", func() {
+			features := []models.FeatureSupportLevelID{
+				models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+				models.FeatureSupportLevelIDVIPAUTOALLOC,
+				models.FeatureSupportLevelIDSNO,
+			}
+			for _, feature := range features {
+				Expect(isFeatureCompatible("4.15", featuresList[feature], lvmFeatureList)).To(BeNil())
+			}
+
+		})
+	})
+})


### PR DESCRIPTION
## LVMS support for multi node deployment 

- allowing deployment for multi node LVMS on 4.15+ 
- creating separated file for olm feature testing
- full unit testing for all LVM deployments and versions
- fixing feature support levels as follows
    - 4.11 dev preview
    - 4.12 - 4.14  supported  only SNO (GA )
    - 4.15:
        - supported SNO (GA )
        - Multi node (GA )

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
