### PR TITLE
MGMT-16505: Huge amount of "Cluster was updated with api-vip <IP ADDRESS>, ingress-vip <IP ADDRESS>" in cluster events

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -3307,7 +3307,7 @@ func (b *bareMetalInventory) updateFreeAddressesReport(ctx context.Context, host
 func (b *bareMetalInventory) processDhcpAllocationResponse(ctx context.Context, host *models.Host, dhcpAllocationResponseStr string) error {
 	log := logutil.FromContext(ctx, b.log)
 
-	cluster, err := common.GetClusterFromDB(common.LoadTableFromDB(b.db, common.MachineNetworksTable),
+	cluster, err := common.GetClusterFromDB(b.db.Preload(common.MachineNetworksTable).Preload(common.APIVIPsTable).Preload(common.IngressVIPsTable),
 		strfmt.UUID(host.ClusterID.String()), common.SkipEagerLoading)
 	if err != nil {
 		log.WithError(err).Warnf("Get cluster %s", host.ClusterID.String())

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1030,14 +1030,14 @@ func (m *Manager) SetVipsData(ctx context.Context, c *common.Cluster, apiVip, in
 	}
 	log := logutil.FromContext(ctx, m.log)
 	formattedApiLease := network.FormatLease(apiVipLease)
-	formattedIngressVip := network.FormatLease(ingressVipLease)
+	formattedIngressLease := network.FormatLease(ingressVipLease)
 	clusterIngressVip := network.GetIngressVipById(c, 0)
 	clusterApiVip := network.GetApiVipById(c, 0)
 
 	if apiVip == clusterApiVip &&
 		ingressVip == clusterIngressVip &&
 		formattedApiLease == c.ApiVipLease &&
-		formattedIngressVip == c.IngressVipLease {
+		formattedIngressLease == c.IngressVipLease {
 		return nil
 	}
 	switch swag.StringValue(c.Status) {
@@ -1050,7 +1050,7 @@ func (m *Manager) SetVipsData(ctx context.Context, c *common.Cluster, apiVip, in
 		if err = db.Model(&common.Cluster{}).Where("id = ?", c.ID.String()).
 			Updates(map[string]interface{}{
 				"api_vip_lease":     formattedApiLease,
-				"ingress_vip_lease": formattedIngressVip,
+				"ingress_vip_lease": formattedIngressLease,
 			}).Error; err != nil {
 			log.WithError(err).Warnf("Update vips of cluster %s", c.ID.String())
 			return err

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2192,9 +2192,6 @@ var _ = Describe("SetVipsData", func() {
 			Expect(swag.StringValue(c.Status)).To(Equal(t.expectedState))
 		})
 	}
-	AfterEach(func() {
-		common.DeleteTestDB(db, dbName)
-	})
 })
 
 var _ = Describe("Majority groups", func() {


### PR DESCRIPTION


When setting VIPs data for DHCP vips allocation, the VIPs tables are not loaded.  This causes the VIPs to be always be updated when VIPs allocation response arrives from host.

NO-ISSUE: Remove redundant AfterEach in SetVipsData tests

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
