### PR TITLE
MGMT-16625: Make host connection timeout soft

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/host.go
@@ -37,6 +37,9 @@ type Host struct {
 	// Format: uuid
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty" gorm:"foreignkey:Cluster"`
 
+	// Indicate that connection to assisted service was timed out when soft timeout is enabled.
+	ConnectionTimedOut bool `json:"connection_timed_out,omitempty"`
+
 	// connectivity
 	Connectivity string `json:"connectivity,omitempty" gorm:"type:text"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/host.go
@@ -37,6 +37,9 @@ type Host struct {
 	// Format: uuid
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty" gorm:"foreignkey:Cluster"`
 
+	// Indicate that connection to assisted service was timed out when soft timeout is enabled.
+	ConnectionTimedOut bool `json:"connection_timed_out,omitempty"`
+
 	// connectivity
 	Connectivity string `json:"connectivity,omitempty" gorm:"type:text"`
 

--- a/internal/host/common.go
+++ b/internal/host/common.go
@@ -36,6 +36,8 @@ const (
 	statusInfoAbortingDueClusterErrors                             = "Host is part of a cluster that failed to install"
 	statusInfoInstallationTimedOut                                 = "Host failed to install due to timeout while starting installation"
 	statusInfoConnectionTimedOutInstalling                         = "Host failed to install due to timeout while connecting to host during the installation phase."
+	statusInfoConnectionSoftTimedOutInstalling                     = "Host is failing to perform periodic health check during the installation phase."
+	statusInfoConnectionSoftTimedOutInstallingReconnected          = "Host recovered from failure to perform periodic health check during the installation phase."
 	statusInfoConnectionTimedOutPreparing                          = "Host failed to install due to timeout while connecting to host during the preparation phase."
 	statusInfoInstallationInProgressTimedOut                       = "Host failed to install because its installation stage $STAGE took longer than expected $MAX_TIME"
 	statusInfoInstallationInProgressSoftTimedOut                   = "Host installation stage $STAGE is taking longer than expected $MAX_TIME"

--- a/internal/host/conditions.go
+++ b/internal/host/conditions.go
@@ -25,6 +25,7 @@ const (
 	SuccessfulContainerImageAvailability = conditionId("successful-container-image-availability")
 	HostStageTimedOut                    = conditionId("host-stage-timed-out")
 	SoftTimeoutsEnabled                  = conditionId("soft-timeouts-enabled")
+	ConnectionTimedOut                   = conditionId("connection-timed-out")
 )
 
 func (c conditionId) String() string {
@@ -101,4 +102,8 @@ func (v *validator) isHostStageTimedOut(c *validationContext) bool {
 
 func (v *validator) softTimeoutsEnabled(c *validationContext) bool {
 	return c.softTimeoutsEnabled && (c.cluster != nil && c.cluster.OrgSoftTimeoutsEnabled)
+}
+
+func (v *validator) connectionTimedOut(c *validationContext) bool {
+	return c.host.ConnectionTimedOut
 }

--- a/internal/host/mock_transition.go
+++ b/internal/host/mock_transition.go
@@ -353,6 +353,20 @@ func (mr *MockTransitionHandlerMockRecorder) PostRefreshHost(reason interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRefreshHost", reflect.TypeOf((*MockTransitionHandler)(nil).PostRefreshHost), reason)
 }
 
+// PostRefreshHostDisconnection mocks base method.
+func (m *MockTransitionHandler) PostRefreshHostDisconnection(statusInfo string, connectionTimedOut bool) stateswitch.PostTransition {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostRefreshHostDisconnection", statusInfo, connectionTimedOut)
+	ret0, _ := ret[0].(stateswitch.PostTransition)
+	return ret0
+}
+
+// PostRefreshHostDisconnection indicates an expected call of PostRefreshHostDisconnection.
+func (mr *MockTransitionHandlerMockRecorder) PostRefreshHostDisconnection(statusInfo, connectionTimedOut interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRefreshHostDisconnection", reflect.TypeOf((*MockTransitionHandler)(nil).PostRefreshHostDisconnection), statusInfo, connectionTimedOut)
+}
+
 // PostRefreshHostRefreshStageUpdateTime mocks base method.
 func (m *MockTransitionHandler) PostRefreshHostRefreshStageUpdateTime(sw stateswitch.StateSwitch, args stateswitch.TransitionArgs) error {
 	m.ctrl.T.Helper()

--- a/internal/host/refresh_status_preprocessor.go
+++ b/internal/host/refresh_status_preprocessor.go
@@ -355,6 +355,10 @@ func newConditions(v *validator) []condition {
 			id: SoftTimeoutsEnabled,
 			fn: v.softTimeoutsEnabled,
 		},
+		{
+			id: ConnectionTimedOut,
+			fn: v.connectionTimedOut,
+		},
 	}
 	return ret
 }

--- a/internal/host/transition_test.go
+++ b/internal/host/transition_test.go
@@ -6623,6 +6623,9 @@ var _ = Describe("State machine test - refresh transition", func() {
 		mockTransitionHandler.EXPECT().PostHostStageTimeout(gomock.Any()).Return(
 			func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
 		).AnyTimes()
+		mockTransitionHandler.EXPECT().PostRefreshHostDisconnection(gomock.Any(), gomock.Any()).Return(
+			func(_ stateswitch.StateSwitch, _ stateswitch.TransitionArgs) error { return nil },
+		).AnyTimes()
 	}
 
 	BeforeEach(func() {

--- a/models/host.go
+++ b/models/host.go
@@ -37,6 +37,9 @@ type Host struct {
 	// Format: uuid
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty" gorm:"foreignkey:Cluster"`
 
+	// Indicate that connection to assisted service was timed out when soft timeout is enabled.
+	ConnectionTimedOut bool `json:"connection_timed_out,omitempty"`
+
 	// connectivity
 	Connectivity string `json:"connectivity,omitempty" gorm:"type:text"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7791,6 +7791,10 @@ func init() {
           "x-go-custom-tag": "gorm:\"foreignkey:Cluster\"",
           "x-nullable": true
         },
+        "connection_timed_out": {
+          "description": "Indicate that connection to assisted service was timed out when soft timeout is enabled.",
+          "type": "boolean"
+        },
         "connectivity": {
           "type": "string",
           "x-go-custom-tag": "gorm:\"type:text\""
@@ -18408,6 +18412,10 @@ func init() {
           "format": "uuid",
           "x-go-custom-tag": "gorm:\"foreignkey:Cluster\"",
           "x-nullable": true
+        },
+        "connection_timed_out": {
+          "description": "Indicate that connection to assisted service was timed out when soft timeout is enabled.",
+          "type": "boolean"
         },
         "connectivity": {
           "type": "string",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4537,6 +4537,9 @@ definitions:
         format: date-time
         x-go-custom-tag: gorm:"type:timestamp with time zone"
         description: The last time the host's agent communicated with the service.
+      connection_timed_out:
+        type: boolean
+        description: Indicate that connection to assisted service was timed out when soft timeout is enabled.
       registered_at:
         type: string
         format: date-time

--- a/vendor/github.com/openshift/assisted-service/models/host.go
+++ b/vendor/github.com/openshift/assisted-service/models/host.go
@@ -37,6 +37,9 @@ type Host struct {
 	// Format: uuid
 	ClusterID *strfmt.UUID `json:"cluster_id,omitempty" gorm:"foreignkey:Cluster"`
 
+	// Indicate that connection to assisted service was timed out when soft timeout is enabled.
+	ConnectionTimedOut bool `json:"connection_timed_out,omitempty"`
+
 	// connectivity
 	Connectivity string `json:"connectivity,omitempty" gorm:"type:text"`
 


### PR DESCRIPTION
When soft timeouts are enabled and host is disconnected while installing, send indication that such timeout occured and continue installation.
The indication is special status-info and event generation. When the hosts reconnects, another status-info is emitted indicating that the host is now connected.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @avishayt 
/cc @carbonin 