### PR TITLE
OCPBUGS-27376: Allow domain names starting with a number

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	baseDomainRegex          = `^[a-z]([\-]*[a-z\d]+)+$`
-	dnsNameRegex             = `^([a-z]([\-]*[a-z\d]+)*\.)+[a-z\d]+([\-]*[a-z\d]+)+$`
+	baseDomainRegex          = `^[a-z\d]([\-]*[a-z\d]+)+$`
+	dnsNameRegex             = `^([a-z\d]([\-]*[a-z\d]+)*\.)+[a-z\d]+([\-]*[a-z\d]+)+$`
 	wildCardDomainRegex      = `^(validateNoWildcardDNS\.).+\.?$`
 	hostnameRegex            = `^[a-z0-9][a-z0-9\-\.]{0,61}[a-z0-9]$`
 	installerArgsValuesRegex = `^[A-Za-z0-9@!#$%*()_+-=//.,";':{}\[\]]+$`
@@ -56,15 +56,18 @@ func ValidateDomainNameFormat(dnsDomainName string) (int32, error) {
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "Single DNS base domain validation for %s", dnsDomainName)
 	}
-	if matched && len(domainName) > 1 {
+	if matched && len(domainName) > 1 && len(domainName) < 63 {
 		return 0, nil
 	}
 	matched, err = regexp.MatchString(dnsNameRegex, domainName)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "DNS name validation for %s", dnsDomainName)
 	}
-	if !matched {
-		return http.StatusBadRequest, errors.Errorf("DNS format mismatch: %s domain name is not valid", dnsDomainName)
+
+	if !matched || isDottedDecimalDomain(domainName) || len(domainName) > 255 {
+		return http.StatusBadRequest, errors.Errorf(
+			"DNS format mismatch: %s domain name is not valid. Must match regex [%s], be no more than 255 characters, and not be in dotted decimal format (##.##.##.##)",
+			dnsDomainName, dnsNameRegex)
 	}
 	return 0, nil
 }
@@ -196,4 +199,11 @@ func ValidateCaCertificate(certificate string) error {
 	}
 
 	return nil
+}
+
+// RFC 1123 (https://datatracker.ietf.org/doc/html/rfc1123#page-13)
+// states that domains cannot resemble the format ##.##.##.##
+func isDottedDecimalDomain(domain string) bool {
+	regex := `([\d]+\.){3}[\d]+`
+	return regexp.MustCompile(regex).MatchString(domain)
 }

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -171,115 +171,141 @@ var _ = Describe("URL validations", func() {
 
 var _ = Describe("dns name", func() {
 	hugeDomainName := "DNSnamescancontainonlyalphabeticalcharactersa-znumericcharacters0-9theminussign-andtheperiod"
-	fqnHugeDomain := hugeDomainName + ".com"
+	fqnHugeDomain := hugeDomainName + "." + hugeDomainName + "." + hugeDomainName + ".com"
 	tests := []struct {
 		domainName string
+		reason     string
 		valid      bool
 	}{
 		{
 			domainName: hugeDomainName,
+			reason:     "base domain: should fail - name exceeds max character limit of 63 characters",
 			valid:      false,
 		},
 		{
 			domainName: fqnHugeDomain,
+			reason:     "full domain: should fail - name exceeds max character limit of 255 characters",
 			valid:      false,
 		},
 		{
 			domainName: "a",
+			reason:     "base domain: should fail - name requires at least two characters",
 			valid:      false,
 		},
 		{
 			domainName: "-",
+			reason:     "base domain: should fail - requires alphanumerical characters and not just a dash",
 			valid:      false,
 		},
 		{
 			domainName: "a-",
-			valid:      false,
-		},
-		{
-			domainName: "1c",
-			valid:      false,
-		},
-		{
-			domainName: "1-c",
-			valid:      false,
-		},
-		{
-			domainName: "1--c",
+			reason:     "base domain: should fail - names can only end in alphanumerical characters and not a dash",
 			valid:      false,
 		},
 		{
 			domainName: "a.c",
+			reason:     "full domain: should fail - top level domain must be at least two characters",
 			valid:      false,
-		},
-		{
-			domainName: "aaa.c",
-			valid:      false,
-		},
-		{
-			domainName: "co",
-			valid:      true,
-		},
-		{
-			domainName: "a.com",
-			valid:      true,
-		},
-		{
-			domainName: "abc.def",
-			valid:      true,
 		},
 		{
 			domainName: "-aaa.com",
+			reason:     "full domain: should fail - labels can only start with alphanumerical characters and not a dash",
 			valid:      false,
 		},
 		{
 			domainName: "aaa-.com",
+			reason:     "full domain: should fail - labels can only end in an alphanumerical character and not a dash",
 			valid:      false,
 		},
 		{
-			domainName: "a-aa.com",
-			valid:      true,
-		},
-		{
-			domainName: "a--aa.com",
-			valid:      true,
-		},
-		{
-			domainName: "0-example.com0",
+			domainName: "11.11.11.11",
+			reason:     "full domain: should fail - dotted decimal domains (##.##.##.##) are not allowed",
 			valid:      false,
 		},
 		{
-			domainName: "example-example-example.com",
+			domainName: "1c",
+			reason:     "base domain: should pass - two character domain starting with a number",
 			valid:      true,
 		},
 		{
-			domainName: "example.example-example.com",
+			domainName: "1-c",
+			reason:     "base domain: should pass - minimum of two characters and starts and ends with alphanumerical characters",
 			valid:      true,
 		},
 		{
-			domainName: "exam--ple.example--example.com",
+			domainName: "1--c",
+			reason:     "base domain: should pass - testing multiple consecutive dashes",
 			valid:      true,
 		},
 		{
 			domainName: "exam-ple",
+			reason:     "base domain: should pass - multiple characters on either side of dash",
 			valid:      true,
 		},
 		{
 			domainName: "exam--ple",
+			reason:     "base domain: should pass - multiple characters on either side of multiple consecutive dashes",
+			valid:      true,
+		},
+		{
+			domainName: "co",
+			reason:     "base domain: should pass - regular two character domain",
+			valid:      true,
+		},
+		{
+			domainName: "a.com",
+			reason:     "full domain: should pass - just one character as the first subdomain label",
+			valid:      true,
+		},
+		{
+			domainName: "abc.def",
+			reason:     "full domain: should pass - regular domain",
+			valid:      true,
+		},
+		{
+			domainName: "a-aa.com",
+			reason:     "full domain: should pass - single dash within label",
+			valid:      true,
+		},
+		{
+			domainName: "a--aa.com",
+			reason:     "full domain: should pass - multiple consecutive dashes within label",
+			valid:      true,
+		},
+		{
+			domainName: "0-example.com0",
+			reason:     "full domain: should pass - starting and ending with a number",
+			valid:      true,
+		},
+		{
+			domainName: "example-example-example.com",
+			reason:     "full domain: should pass - multiple dashes present within a label",
+			valid:      true,
+		},
+		{
+			domainName: "example.example-example.com",
+			reason:     "full domain: should pass - dash within a different level subdomain label",
+			valid:      true,
+		},
+		{
+			domainName: "exam--ple.example--example.com",
+			reason:     "full domain: should pass - multiple consecutive dashes within multiple subdomain labels",
 			valid:      true,
 		},
 		{
 			domainName: "validateNoWildcardDNS.test.com",
+			reason:     "full domain: should pass - allows wildcard dns test",
 			valid:      true,
 		},
 		{
 			domainName: "validateNoWildcardDNS.test.com.",
+			reason:     "full domain: should pass - allows wildcard dns test (format with period at the end)",
 			valid:      true,
 		},
 	}
 	for _, t := range tests {
 		t := t
-		It(fmt.Sprintf("Domain name \"%s\"", t.domainName), func() {
+		It(fmt.Sprintf("Domain name \"%s\" - testing: \"%s\"", t.domainName, t.reason), func() {
 			_, err := ValidateDomainNameFormat(t.domainName)
 			if t.valid {
 				Expect(err).ToNot(HaveOccurred())

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -1025,9 +1025,9 @@ var _ = Describe("Validate BaseDNSDomain when creating a cluster", func() {
 			ShouldThrow:   true,
 		},
 		{
-			It:            "V2RegisterCluster should throw an error. BaseDNSDomain='1-example.com', Illegal first character in domain name",
+			It:            "V2RegisterCluster should not throw an error. BaseDNSDomain='1-example.com', valid DNS",
 			BaseDNSDomain: "1-example.com",
-			ShouldThrow:   true,
+			ShouldThrow:   false,
 		},
 		{
 			It:            "V2RegisterCluster should not throw an error. BaseDNSDomain='example.com', valid DNS",


### PR DESCRIPTION
[OCPBUGS-27376](https://issues.redhat.com/browse/OCPBUGS-27376)
[RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034#section-3.5) initially stated domain names should only start with a letter, but that was later revised by [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123#page-13). Updates the domain regex to allow domains to start with a number. Also adds a check to prevent dotted decimal domains. 

Includes changes that also check for the length of domains. [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123#page-13) also states that a label must be no more than 63 characters and a full domain must be no more than 255 characters.

Revision to the previous incorrect PR https://github.com/openshift/assisted-service/pull/5801
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
