### PR TITLE
MGMT-16660: OCI is tech-preview from OCP 4.15

### DIFF
--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -245,6 +245,24 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 	})
 
+	Context("Test OCI platform support", func() {
+		DescribeTable(
+			"Validation pass",
+			func(openshiftVersion string, expectedSupportLevel models.SupportLevel) {
+				filters := SupportLevelFilters{
+					OpenshiftVersion: openshiftVersion,
+					CPUArchitecture:  swag.String(common.DefaultCPUArchitecture),
+				}
+				supportLevel := GetSupportLevel(models.FeatureSupportLevelIDEXTERNALPLATFORMOCI, filters)
+				Expect(supportLevel).To(Equal(expectedSupportLevel))
+			},
+			Entry("OCI unavailable with Openshift 4.13", "4.13", models.SupportLevelUnavailable),
+			Entry("OCI dev-preview with Openshift 4.14", "4.14", models.SupportLevelDevPreview),
+			Entry("OCI tech-preview with Openshidt 4.15", "4.15", models.SupportLevelTechPreview),
+			Entry("OCI tech-preview with Openshift 4.16", "4.16", models.SupportLevelTechPreview),
+		)
+	})
+
 	Context("GetSupportList", func() {
 
 		for _, filters := range getPlatformFilters() {

--- a/internal/featuresupport/features_platforms.go
+++ b/internal/featuresupport/features_platforms.go
@@ -272,11 +272,15 @@ func (feature *OciIntegrationFeature) getSupportLevel(filters SupportLevelFilter
 		return models.SupportLevelUnavailable
 	}
 
-	if isNotSupported, err := common.BaseVersionLessThan("4.14", filters.OpenshiftVersion); isNotSupported || err != nil {
-		return models.SupportLevelUnavailable
+	if isDevPreview, err := common.BaseVersionEqual("4.14", filters.OpenshiftVersion); isDevPreview || err != nil {
+		return models.SupportLevelDevPreview
 	}
 
-	return models.SupportLevelSupported
+	if isTechPreview, err := common.BaseVersionGreaterOrEqual("4.15", filters.OpenshiftVersion); isTechPreview || err != nil {
+		return models.SupportLevelTechPreview
+	}
+
+	return models.SupportLevelUnavailable
 }
 
 func (feature *OciIntegrationFeature) getIncompatibleFeatures(string) *[]models.FeatureSupportLevelID {


### PR DESCRIPTION
Update feature support to return tech-preview for OCI platform feature
from OCP 4.15.

Fixes [MGMT-16661](https://issues.redhat.com//browse/MGMT-16661) that should return dev-preview for OCI platform feature
for OCP 4.14.
