### PR TITLE
NO-ISSUE: Fix CI gather script for baremetal operator

### DIFF
--- a/deploy/operator/gather.sh
+++ b/deploy/operator/gather.sh
@@ -43,15 +43,15 @@ function gather_operator_data() {
 }
 
 function gather_agentclusterinstall_data() {
-  readarray -t agentclusterinstall_objects < <(oc get agentclusterinstall -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
+  readarray -t agentclusterinstall_objects < <(oc get agentclusterinstall -A -o json | jq -c '.items[]')
   for agentclusterinstall in "${agentclusterinstall_objects[@]}"; do
     agentclusterinstall_name=$(echo ${agentclusterinstall} | jq -r .metadata.name)
     agentclusterinstall_namespace=$(echo ${agentclusterinstall} | jq -r .metadata.namespace)
 
-    cluster_dir="${LOGS_DEST}/${agentclusterinstall_namespace}_${agentclusterinstall_name}"
+    cluster_dir="${LOGS_DEST}/agentclusterinstall"
     mkdir -p "${cluster_dir}"
 
-    oc get agentclusterinstall -n ${agentclusterinstall_namespace} ${agentclusterinstall_name} -o yaml > "${cluster_dir}/agentclusterinstall.yaml"
+    oc get agentclusterinstall -n ${agentclusterinstall_namespace} ${agentclusterinstall_name} -o yaml > "${cluster_dir}/${agentclusterinstall_namespace}_${agentclusterinstall_name}.yaml"
 
     events_url=$(echo ${agentclusterinstall} | jq -r .status.debugInfo.eventsURL)
     if [ -n "${events_url}" ] && [ "${events_url}" != null ]; then
@@ -104,10 +104,11 @@ function gather_clusterdeployment_data() {
   cd_dir="${LOGS_DEST}/clusterdeployment"
   mkdir -p "${cd_dir}"
 
-  readarray -t cd_objects < <(oc get clusterdeployments.hive.openshift.io -n ${SPOKE_NAMESPACE} -o json | jq -c '.items[]')
+  readarray -t cd_objects < <(oc get clusterdeployments.hive.openshift.io -A -o json | jq -c '.items[]')
   for cd in "${cd_objects[@]}"; do
     cd_name=$(echo ${cd} | jq -r .metadata.name)
-    oc get clusterdeployments.hive.openshift.io -n "${SPOKE_NAMESPACE}" "${cd_name}" -o yaml > "${cd_dir}/${cd_name}.yaml"
+    cd_namespace=$(echo ${cd} | jq -r .metadata.namespace)
+    oc get clusterdeployments.hive.openshift.io -n "${cd_namespace}" "${cd_name}" -o yaml > "${cd_dir}/${cd_namespace}_${cd_name}.yaml"
   done
 }
 


### PR DESCRIPTION
Agentclusterinstall and clusterdeployment queried only for objects in the spoke namespace, which is not applicable in the hypershift/capi space. This modifies it to look for all those CRs in all the namespaces.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
