### PR TITLE
MGMT-16721: handle hosts with no luks

### DIFF
--- a/internal/host/hostcommands/tang_connectivity_check_cmd.go
+++ b/internal/host/hostcommands/tang_connectivity_check_cmd.go
@@ -38,6 +38,14 @@ func (c *tangConnectivityCheckCmd) getTangServersFromHostIgnition(host *models.H
 		if err != nil {
 			return nil, err
 		}
+		if luks == nil {
+			return nil, nil
+		}
+		if luks.Clevis == nil {
+			// This cluster does not use tang, so we shouldn't perform a tang connectivity check
+			c.log.Warn("luks clevis configuration is missing or incomplete in the host ignition, disk encryption will be assumed to be disabled. (MGMT-16721)")
+			return nil, nil
+		}
 		if len(luks.Clevis.Tang) != 0 {
 			if tangServers, err = json.Marshal(luks.Clevis.Tang); err != nil {
 				return nil, err

--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -420,7 +420,7 @@ func (v *validator) diskEncryptionRequirementsSatisfied(c *validationContext) (V
 			return ValidationPending, "Missing ignition information"
 		}
 		if luks == nil || luks.Clevis == nil {
-			// Disk encryption is disabled for workers on day1 cluster
+			// No tang servers to validate for the target cluster
 			return ValidationSuccessSuppressOutput, ""
 		}
 		c.cluster.DiskEncryption = &models.DiskEncryption{}


### PR DESCRIPTION
In line 41 of internal/host/hostcommands/tang_connectivity_check_cmd.go
Both `luks` and `luks.Clevis` are pointers which can be nil, there was no checking in place to ensure that we avoid a nil pointer dereference

This PR fixes that by making appropriate checks to ensure that neither of these pointers are nil.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
