### PR TITLE
MGMT-16588: Adding host with incompatible platform to day2 cluster should fail

### DIFF
--- a/internal/host/validator.go
+++ b/internal/host/validator.go
@@ -361,9 +361,6 @@ func (v *validator) compatibleWithClusterPlatform(c *validationContext) (Validat
 	if c.infraEnv != nil {
 		return ValidationSuccessSuppressOutput, ""
 	}
-	if *c.cluster.Kind == models.ClusterKindAddHostsCluster {
-		return ValidationSuccess, fmt.Sprintf("Host is compatible with cluster platform %s", common.PlatformTypeValue(c.cluster.Platform.Type))
-	}
 	if c.inventory == nil || common.PlatformTypeValue(c.cluster.Platform.Type) == "" {
 		return ValidationPending, "Missing inventory or platform isn't set"
 	}

--- a/subsystem/day2_cluster_test.go
+++ b/subsystem/day2_cluster_test.go
@@ -508,7 +508,6 @@ var _ = Describe("Day2 cluster tests", func() {
 		h = getHostV2(infraEnvID, *host.ID)
 		Expect(*h.Status).Should(Equal("discovering"))
 	})
-
 })
 
 var _ = Describe("Day2 cluster with bind/unbind hosts", func() {


### PR DESCRIPTION
Currently, the `assisted-service` code attempts to validate host compatibility with the cluster at - https://github.com/openshift/assisted-service/blob/99a3b96819cade4b6d7ae142d663cd53dde731fb/internal/host/validator.go#L359C21-L359C50. 
However, this validation seems unjustified because every `day2` cluster is expected to pass it, given their kind is `addHostsCluster`. We want to validate the host's platform against the cluster's platform, so the mentioned line of code should be removed.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
