### PR TITLE
MGMT-16753: use ip=on to configure dual stack host

### DIFF
--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -404,7 +404,7 @@ func getDHCPArgPerNIC(network *net.IPNet, nic *models.Interface, ipv6 bool, dual
 	}
 	if found {
 		if dualStack {
-			dhcp = "dhcp,dhcp6"
+			dhcp = "on"
 		}
 		log.Debugf("Host %s: Added kernel argument ip=%s:%s", hostID, nic.Name, dhcp)
 		return append(args, "--append-karg", fmt.Sprintf("ip=%s:%s", nic.Name, dhcp)), nil

--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1013,7 +1013,7 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=eth1:dhcp,dhcp6"]`))
+		Expect(args).To(Equal(`["--append-karg","rd.break=cmdline","--append-karg","ip=eth1:on"]`))
 	})
 	It("existing args updated with ip=<nic>:dhcp when machine CIDR is IPv4", func() {
 		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "192.186.10.0/24"}}

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -116,6 +116,7 @@ type NutanixInstallConfigPlatform struct {
 	PrismCentral         NutanixPrismCentral   `yaml:"prismCentral"`
 	PrismElements        []NutanixPrismElement `yaml:"prismElements"`
 	SubnetUUIDs          []strfmt.UUID         `yaml:"subnetUUIDs"`
+	FailureDomains []NutanixFailureDomain `yaml:"failureDomains,omitempty"`
 }
 
 type NutanixPrismCentral struct {
@@ -140,6 +141,23 @@ type NutanixPrismElement struct {
 	UUID                           strfmt.UUID     `yaml:"uuid"`
 	Name                           string          `yaml:"name"`
 }
+
+// NutanixFailureDomain configures failure domain information for the Nutanix platform.
+type NutanixFailureDomain struct {
+	// Name defines the unique name of a failure domain.
+	Name string `json:"name"`
+
+	// prismElement holds the identification (name, uuid) and the optional endpoint address and port of the Nutanix Prism Element.
+	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
+	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
+	// proxy spec.noProxy list.
+	PrismElement NutanixPrismElement `json:"prismElement"`
+
+	// SubnetUUIDs identifies the network subnets of the Prism Element.
+	// Currently we only support one subnet for a failure domain.
+	SubnetUUIDs []string `json:"subnetUUIDs"`
+}
+
 
 // CloudControllerManager describes the type of cloud controller manager to be enabled.
 type CloudControllerManager string

--- a/internal/installcfg/installcfg.go
+++ b/internal/installcfg/installcfg.go
@@ -116,7 +116,6 @@ type NutanixInstallConfigPlatform struct {
 	PrismCentral         NutanixPrismCentral   `yaml:"prismCentral"`
 	PrismElements        []NutanixPrismElement `yaml:"prismElements"`
 	SubnetUUIDs          []strfmt.UUID         `yaml:"subnetUUIDs"`
-	FailureDomains []NutanixFailureDomain `yaml:"failureDomains,omitempty"`
 }
 
 type NutanixPrismCentral struct {
@@ -141,23 +140,6 @@ type NutanixPrismElement struct {
 	UUID                           strfmt.UUID     `yaml:"uuid"`
 	Name                           string          `yaml:"name"`
 }
-
-// NutanixFailureDomain configures failure domain information for the Nutanix platform.
-type NutanixFailureDomain struct {
-	// Name defines the unique name of a failure domain.
-	Name string `json:"name"`
-
-	// prismElement holds the identification (name, uuid) and the optional endpoint address and port of the Nutanix Prism Element.
-	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
-	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
-	// proxy spec.noProxy list.
-	PrismElement NutanixPrismElement `json:"prismElement"`
-
-	// SubnetUUIDs identifies the network subnets of the Prism Element.
-	// Currently we only support one subnet for a failure domain.
-	SubnetUUIDs []string `json:"subnetUUIDs"`
-}
-
 
 // CloudControllerManager describes the type of cloud controller manager to be enabled.
 type CloudControllerManager string


### PR DESCRIPTION
`ip=<nic>:dhcp,dhcp6` is not valid according to [dracut documentation](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html), and it makes `systemd-network-generator` to complain with:
```
Feb 01 14:45:07 ai-saas-ci-1104-master-2 systemd-network-generator[1803]: Failed to parse kernel command line: Invalid argument
```

Fixing this issue by setting `ip=<nic>:on`.