### PR TITLE
NO-ISSUE: fix for subsystem HTTP registry

### DIFF
--- a/docs/dev/running-test.md
+++ b/docs/dev/running-test.md
@@ -33,14 +33,14 @@ First we must prepare the minikube cluster -
 podman network rm minikube || true
 
 # Start minikube
-minikube start --driver=podman --addons dashboard --force
+minikube start --insecure-registry=$(hostname --ip):5000 --driver=podman --addons dashboard --force
 
 # enable the registry addon using quay.io images (to overcome docker-hub's rate-limiter)
 minikube addons enable registry --images="Registry=quay.io/libpod/registry:2.8"
 
 # Make the registry addon accessible locally:
-nohup kubectl port-forward svc/registry 5000:80 -n kube-system &>/dev/null &
-export LOCAL_SUBSYSTEM_REGISTRY=localhost:5000
+nohup kubectl port-forward svc/registry --address 0.0.0.0 5000:80 -n kube-system &>/dev/null &
+export LOCAL_SUBSYSTEM_REGISTRY=$(hostname --ip):5000
 
 echo "Waiting for registry to become ready..."
 while ! curl --location $LOCAL_SUBSYSTEM_REGISTRY; do


### PR DESCRIPTION
when running subsystem test the default pull is HTTPS with cert verification
overwriting local registry to HTTP when Minikube starts

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [x] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
