### PR TITLE
add annotations 'ironic-agent-image-override'

### DIFF
--- a/deploy/operator/capi/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/capi/assisted-installer-crds-playbook.yaml
@@ -29,6 +29,7 @@
     - assisted_upgrade_operator: "{{ lookup('env', 'ASSISTED_UPGRADE_OPERATOR') }}"
     - assisted_stop_after_agent_discovery: "{{ lookup('env', 'ASSISTED_STOP_AFTER_AGENT_DISCOVERY') }}"
     - user_managed_networking: "{{ lookup('env', 'USER_MANAGED_NETWORKING') }}"
+    - ironic_image: "{{ lookup('env', 'IRONIC_IMAGE') }}"
     - day2: "false"
 
   tasks:

--- a/deploy/operator/capi/deploy_capi_cluster.sh
+++ b/deploy/operator/capi/deploy_capi_cluster.sh
@@ -27,6 +27,7 @@ export CONTROL_PLANE_OPERATOR_IMAGE="${CONTROL_PLANE_OPERATOR_IMAGE:-}"
 export PROVIDER_IMAGE="${PROVIDER_IMAGE:-}"
 export EXTRA_HYPERSHIFT_INSTALL_FLAGS="${EXTRA_HYPERSHIFT_INSTALL_FLAGS:-}"
 export EXTRA_HYPERSHIFT_CREATE_COMMANDS="${EXTRA_HYPERSHIFT_CREATE_COMMANDS:-}"
+export IRONIC_IMAGE=$(oc adm release info --image-for=ironic-agent "$(oc get clusterversion version -ojsonpath='{.status.desired.image}')")
 
 if [[ ${SPOKE_CONTROLPLANE_AGENTS} -eq 1 ]]; then
     export USER_MANAGED_NETWORKING="true"

--- a/deploy/operator/capi/infraEnv.j2
+++ b/deploy/operator/capi/infraEnv.j2
@@ -1,6 +1,8 @@
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
+  annotations:
+    infraenv.agent-install.openshift.io/ironic-agent-image-override: '{{ ironic_image }}'
   name: '{{ infraenv_name }}'
   namespace: '{{ spoke_namespace }}'
 spec:

--- a/deploy/operator/hypershift/deploy_hypershift_cluster.sh
+++ b/deploy/operator/hypershift/deploy_hypershift_cluster.sh
@@ -24,6 +24,7 @@ export EXTERNAL_SUBNET="${EXTERNAL_SUBNET_V4}"
 export SERVICE_SUBNET="${SERVICE_SUBNET_V4}"
 export PUBLIC_CONTAINER_REGISTRIES="${PUBLIC_CONTAINER_REGISTRIES:-quay.io}"
 export EXTRA_HYPERSHIFT_INSTALL_FLAGS="${EXTRA_HYPERSHIFT_INSTALL_FLAGS:-}"
+export IRONIC_IMAGE=$(oc adm release info --image-for=ironic-agent "$(oc get clusterversion version -ojsonpath='{.status.desired.image}')")
 
 set -o nounset
 set -o pipefail

--- a/deploy/operator/hypershift/playbooks/spoke-crs-playbook.yaml
+++ b/deploy/operator/hypershift/playbooks/spoke-crs-playbook.yaml
@@ -29,6 +29,7 @@
     - assisted_upgrade_operator: "{{ lookup('env', 'ASSISTED_UPGRADE_OPERATOR') }}"
     - assisted_stop_after_agent_discovery: "{{ lookup('env', 'ASSISTED_STOP_AFTER_AGENT_DISCOVERY') }}"
     - user_managed_networking: "{{ lookup('env', 'USER_MANAGED_NETWORKING') }}"
+    - ironic_image: "{{ lookup('env', 'IRONIC_IMAGE') }}"
 
   tasks:
   - name: create directory for generated resources

--- a/deploy/operator/ztp/add-worker-nodes-to-local-cluster-playbook.yaml
+++ b/deploy/operator/ztp/add-worker-nodes-to-local-cluster-playbook.yaml
@@ -17,6 +17,7 @@
     - machine_config_pools: "{{ lookup('env', 'MACHINE_CONFIG_POOLS') }}"
     - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
     - infraenv_label: "{{ lookup('env', 'LOCAL_CLUSTER_INFRAENV_LABEL', default='local-cluster') }}"
+    - ironic_image: "{{ lookup('env', 'IRONIC_IMAGE') }}"
 
   tasks:
   - name: generate-crs-and-apply

--- a/deploy/operator/ztp/add_day2_local_cluster_nodes.sh
+++ b/deploy/operator/ztp/add_day2_local_cluster_nodes.sh
@@ -9,6 +9,7 @@ source "${__dir}/../utils.sh"
 
 export REMOTE_BAREMETALHOSTS_FILE="${REMOTE_BAREMETALHOSTS_FILE:-/home/test/dev-scripts/ocp/ostest/remote_baremetalhosts.json}"
 export LOCAL_CLUSTER_NAMESPACE="${LOCAL_CLUSTER_NAMESPACE:-local-agent-cluster}"
+export IRONIC_IMAGE=$(oc adm release info --image-for=ironic-agent "$(oc get clusterversion version -ojsonpath='{.status.desired.image}')")
 
 echo "Adding day2 local cluster nodes"
 ansible-playbook "${__dir}/add-worker-nodes-to-local-cluster-playbook.yaml"

--- a/deploy/operator/ztp/add_day2_remote_nodes.sh
+++ b/deploy/operator/ztp/add_day2_remote_nodes.sh
@@ -11,6 +11,7 @@ export REMOTE_BAREMETALHOSTS_FILE="${REMOTE_BAREMETALHOSTS_FILE:-/home/test/dev-
 
 export DAY2_LATE_BINDING=${DAY2_LATE_BINDING:-}
 export DAY2_MASTERS=${DAY2_MASTERS:-}
+export IRONIC_IMAGE=$(oc adm release info --image-for=ironic-agent "$(oc get clusterversion version -ojsonpath='{.status.desired.image}')")
 
 # If performing late binding then we need to generate an infraenv for this.
 # Generation is handled within "add-remote-nodes-playbook"

--- a/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
+++ b/deploy/operator/ztp/assisted-installer-crds-playbook.yaml
@@ -36,6 +36,7 @@
     - node_labels: "{{ lookup('env', 'NODE_LABELS') }}"
     - manifests: "{{ lookup('env', 'MANIFESTS') }}"
     - infraenv_label: ""
+    - ironic_image: "{{ lookup('env', 'IRONIC_IMAGE') }}"
 
   tasks:
   - name: create directory for generated CRDs

--- a/deploy/operator/ztp/deploy_spoke_cluster.sh
+++ b/deploy/operator/ztp/deploy_spoke_cluster.sh
@@ -23,6 +23,7 @@ export ADD_NONE_PLATFORM_LIBVIRT_DNS="${ADD_NONE_PLATFORM_LIBVIRT_DNS:-false}"
 export LIBVIRT_NONE_PLATFORM_NETWORK="${LIBVIRT_NONE_PLATFORM_NETWORK:-ostestbm}"
 export LOAD_BALANCER_IP="${LOAD_BALANCER_IP:-192.168.111.1}"
 export API_IP=${LOAD_BALANCER_IP}
+export IRONIC_IMAGE=$(oc adm release info --image-for=ironic-agent "$(oc get clusterversion version -ojsonpath='{.status.desired.image}')")
 
 if [[ ${SPOKE_CONTROLPLANE_AGENTS} -eq 1 ]]; then
     export USER_MANAGED_NETWORKING="true"

--- a/deploy/operator/ztp/infraEnv-latebinding.j2
+++ b/deploy/operator/ztp/infraEnv-latebinding.j2
@@ -3,6 +3,8 @@
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
+  annotations:
+    infraenv.agent-install.openshift.io/ironic-agent-image-override: '{{ ironic_image }}'
   name: '{{ infraenv_name }}'
   namespace: '{{ spoke_namespace }}'
 spec:

--- a/deploy/operator/ztp/infraEnv.j2
+++ b/deploy/operator/ztp/infraEnv.j2
@@ -3,6 +3,8 @@
 apiVersion: agent-install.openshift.io/v1beta1
 kind: InfraEnv
 metadata:
+  annotations:
+    infraenv.agent-install.openshift.io/ironic-agent-image-override: '{{ ironic_image }}'
   name: '{{ infraenv_name }}'
   namespace: '{{ spoke_namespace }}'
 spec:


### PR DESCRIPTION
Currently, the default version of the infraenv ironic-agent-image is outdated, so we should ensure consistency between the ironic-agent image and the hub cluster version by setting ironic-agent-image-override.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->
- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] No tests needed
- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
