### PR TITLE
MGMT-4458: Remove status change from old CompleteInstallation API

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -30,9 +30,6 @@ func (m FinalizingStage) Pointer() *FinalizingStage {
 
 const (
 
-	// FinalizingStageWaitingForFinalizing captures enum value "Waiting for finalizing"
-	FinalizingStageWaitingForFinalizing FinalizingStage = "Waiting for finalizing"
-
 	// FinalizingStageWaitingForClusterOperators captures enum value "Waiting for cluster operators"
 	FinalizingStageWaitingForClusterOperators FinalizingStage = "Waiting for cluster operators"
 
@@ -57,7 +54,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for finalizing","Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/client/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -30,9 +30,6 @@ func (m FinalizingStage) Pointer() *FinalizingStage {
 
 const (
 
-	// FinalizingStageWaitingForFinalizing captures enum value "Waiting for finalizing"
-	FinalizingStageWaitingForFinalizing FinalizingStage = "Waiting for finalizing"
-
 	// FinalizingStageWaitingForClusterOperators captures enum value "Waiting for cluster operators"
 	FinalizingStageWaitingForClusterOperators FinalizingStage = "Waiting for cluster operators"
 
@@ -57,7 +54,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for finalizing","Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -5763,7 +5763,6 @@ var _ = Describe("cluster", func() {
 			})
 			It("complete failure", func() {
 				success := false
-				mockClusterApi.EXPECT().CompleteInstallation(ctx, gomock.Any(), gomock.Any(), success, errorInfo).Return(nil, nil).Times(1)
 
 				reply := bm.V2CompleteInstallation(ctx, installer.V2CompleteInstallationParams{
 					ClusterID:        clusterID,
@@ -5771,20 +5770,8 @@ var _ = Describe("cluster", func() {
 				})
 				Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2CompleteInstallationAccepted()))
 			})
-			It("complete failure bad request", func() {
-				success := false
-				mockClusterApi.EXPECT().CompleteInstallation(ctx, gomock.Any(), gomock.Any(), success, errorInfo).Return(nil, errors.New("error")).Times(1)
-
-				reply := bm.V2CompleteInstallation(ctx, installer.V2CompleteInstallationParams{
-					ClusterID:        clusterID,
-					CompletionParams: &models.CompletionParams{ErrorInfo: errorInfo, IsSuccess: &success},
-				})
-
-				verifyApiError(reply, http.StatusInternalServerError)
-			})
 			It("complete with failing operator report", func() {
 				success := false
-				mockClusterApi.EXPECT().CompleteInstallation(ctx, gomock.Any(), gomock.Any(), success, errorInfo).Return(nil, nil).Times(1)
 				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), eventstest.NewEventMatcher(
 					eventstest.WithNameMatcher(eventgen.ClusterOperatorReportEventName),
 					eventstest.WithMessageContainsMatcher("authentication, csi-snapshot-controller"))).Times(1)
@@ -5819,9 +5806,6 @@ var _ = Describe("cluster", func() {
 					},
 				})
 				Expect(reply).Should(BeAssignableToTypeOf(installer.NewV2CompleteInstallationAccepted()))
-			})
-			It("complete with bad format operator report", func() {
-
 			})
 		})
 

--- a/internal/bminventory/inventory_v2_handlers.go
+++ b/internal/bminventory/inventory_v2_handlers.go
@@ -355,15 +355,8 @@ func (b *bareMetalInventory) V2CompleteInstallation(ctx context.Context, params 
 				log.Errorf("Bad format of cluster operator report %s", err.Error())
 			}
 		}
-
-		if _, err := b.clusterApi.CompleteInstallation(ctx, b.db, cluster, false, params.CompletionParams.ErrorInfo); err != nil {
-			log.WithError(err).Errorf("Failed to set complete cluster state on %s ", params.ClusterID.String())
-			return common.GenerateErrorResponder(err)
-		}
-	} else {
-		log.Warnf("Cluster %s tried to complete its installation using deprecated CompleteInstallation API. The service decides whether the cluster completed", params.ClusterID)
 	}
-
+	log.Warnf("Cluster %s tried to complete its installation using deprecated CompleteInstallation API. The service decides whether the cluster completed", params.ClusterID)
 	return installer.NewV2CompleteInstallationAccepted().WithPayload(&cluster.Cluster)
 }
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -4116,13 +4116,13 @@ var _ = Describe("update finalizing stage", func() {
 		ctrl.Finish()
 	})
 	It("cluster doesn't exist", func() {
-		err := capi.UpdateFinalizingStage(ctx, clusterID, models.FinalizingStageWaitingForFinalizing)
+		err := capi.UpdateFinalizingStage(ctx, clusterID, models.FinalizingStageWaitingForOlmOperatorsCsvInitialization)
 		Expect(err).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
 		Expect(err.(*common.ApiErrorResponse).Code()).To(BeEquivalentTo(http.StatusNotFound))
 	})
 	It("cluster in wrong status", func() {
 		createCluster(models.ClusterStatusReady)
-		err := capi.UpdateFinalizingStage(ctx, clusterID, models.FinalizingStageWaitingForFinalizing)
+		err := capi.UpdateFinalizingStage(ctx, clusterID, models.FinalizingStageWaitingForOlmOperatorsCsvInitialization)
 		Expect(err).To(BeAssignableToTypeOf(&common.ApiErrorResponse{}))
 		Expect(err.(*common.ApiErrorResponse).Code()).To(BeEquivalentTo(http.StatusBadRequest))
 	})

--- a/internal/cluster/finalizing_stages.go
+++ b/internal/cluster/finalizing_stages.go
@@ -19,7 +19,6 @@ const (
 )
 
 var finalizingStagesTimeoutsDefaults = map[models.FinalizingStage]time.Duration{
-	models.FinalizingStageWaitingForFinalizing:                    longWaitTimeout,
 	models.FinalizingStageWaitingForClusterOperators:              longWaitTimeout,
 	models.FinalizingStageAddingRouterCa:                          generalWaitTimeout,
 	models.FinalizingStageApplyingOlmManifests:                    shortWaitTimeout,
@@ -29,7 +28,6 @@ var finalizingStagesTimeoutsDefaults = map[models.FinalizingStage]time.Duration{
 }
 
 var finalizingStages = []models.FinalizingStage{
-	models.FinalizingStageWaitingForFinalizing,
 	models.FinalizingStageWaitingForClusterOperators,
 	models.FinalizingStageAddingRouterCa,
 	models.FinalizingStageApplyingOlmManifests,

--- a/internal/cluster/mock_cluster_api.go
+++ b/internal/cluster/mock_cluster_api.go
@@ -249,18 +249,18 @@ func (mr *MockAPIMockRecorder) ClusterMonitoring() *gomock.Call {
 }
 
 // CompleteInstallation mocks base method.
-func (m *MockAPI) CompleteInstallation(ctx context.Context, db *gorm.DB, cluster *common.Cluster, successfullyFinished bool, reason string) (*common.Cluster, error) {
+func (m *MockAPI) CompleteInstallation(ctx context.Context, db *gorm.DB, cluster *common.Cluster, reason string) (*common.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, db, cluster, successfullyFinished, reason)
+	ret := m.ctrl.Call(m, "CompleteInstallation", ctx, db, cluster, reason)
 	ret0, _ := ret[0].(*common.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CompleteInstallation indicates an expected call of CompleteInstallation.
-func (mr *MockAPIMockRecorder) CompleteInstallation(ctx, db, cluster, successfullyFinished, reason interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) CompleteInstallation(ctx, db, cluster, reason interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockAPI)(nil).CompleteInstallation), ctx, db, cluster, successfullyFinished, reason)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteInstallation", reflect.TypeOf((*MockAPI)(nil).CompleteInstallation), ctx, db, cluster, reason)
 }
 
 // DeleteClusterLogs mocks base method.

--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -186,7 +186,7 @@ func (th *transitionHandler) PostCompleteInstallation(sw stateswitch.StateSwitch
 
 	log := logutil.FromContext(params.ctx, th.log)
 	if cluster, err := params.clusterAPI.CompleteInstallation(params.ctx, params.db, sCluster.cluster,
-		true, th.createClusterCompletionStatusInfo(params.ctx, log, sCluster.cluster, th.eventsHandler)); err != nil {
+		th.createClusterCompletionStatusInfo(params.ctx, log, sCluster.cluster, th.eventsHandler)); err != nil {
 		return err
 	} else {
 		sCluster.cluster = cluster

--- a/models/finalizing_stage.go
+++ b/models/finalizing_stage.go
@@ -30,9 +30,6 @@ func (m FinalizingStage) Pointer() *FinalizingStage {
 
 const (
 
-	// FinalizingStageWaitingForFinalizing captures enum value "Waiting for finalizing"
-	FinalizingStageWaitingForFinalizing FinalizingStage = "Waiting for finalizing"
-
 	// FinalizingStageWaitingForClusterOperators captures enum value "Waiting for cluster operators"
 	FinalizingStageWaitingForClusterOperators FinalizingStage = "Waiting for cluster operators"
 
@@ -57,7 +54,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for finalizing","Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7690,7 +7690,6 @@ func init() {
       "description": "Cluster finalizing stage managed by controller",
       "type": "string",
       "enum": [
-        "Waiting for finalizing",
         "Waiting for cluster operators",
         "Adding router ca",
         "Applying olm manifests",
@@ -18312,7 +18311,6 @@ func init() {
       "description": "Cluster finalizing stage managed by controller",
       "type": "string",
       "enum": [
-        "Waiting for finalizing",
         "Waiting for cluster operators",
         "Adding router ca",
         "Applying olm manifests",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5076,7 +5076,6 @@ definitions:
     description: Cluster finalizing stage managed by controller
     type: string
     enum:
-    - Waiting for finalizing
     - Waiting for cluster operators
     - Adding router ca
     - Applying olm manifests

--- a/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
+++ b/vendor/github.com/openshift/assisted-service/models/finalizing_stage.go
@@ -30,9 +30,6 @@ func (m FinalizingStage) Pointer() *FinalizingStage {
 
 const (
 
-	// FinalizingStageWaitingForFinalizing captures enum value "Waiting for finalizing"
-	FinalizingStageWaitingForFinalizing FinalizingStage = "Waiting for finalizing"
-
 	// FinalizingStageWaitingForClusterOperators captures enum value "Waiting for cluster operators"
 	FinalizingStageWaitingForClusterOperators FinalizingStage = "Waiting for cluster operators"
 
@@ -57,7 +54,7 @@ var finalizingStageEnum []interface{}
 
 func init() {
 	var res []FinalizingStage
-	if err := json.Unmarshal([]byte(`["Waiting for finalizing","Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Waiting for cluster operators","Adding router ca","Applying olm manifests","Waiting for olm operators csv initialization","Waiting for olm operators csv","Done"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {


### PR DESCRIPTION
Since all status changes are now handled by the assisted service, complete installation will only report operator status in case of failure in the controller.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @tsorya 