### PR TITLE
OCPBUGS-27787: Use multi payload with ABI

### DIFF
--- a/cmd/agentbasedinstaller/register.go
+++ b/cmd/agentbasedinstaller/register.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/client/manifests"
 	"github.com/openshift/assisted-service/internal/cluster/validations"
+	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/controller/controllers"
 	"github.com/openshift/assisted-service/internal/oc"
 	"github.com/openshift/assisted-service/models"
@@ -292,6 +293,10 @@ func getReleaseVersionAndCpuArch(log *log.Logger, releaseImage string, releaseMi
 	// but given the caller of this function here does not check that, we want to explicitly handle this scenario.
 	if len(cpuArchs) == 0 {
 		return "", "", errors.New("could not get release architecture")
+	}
+	if len(cpuArchs) > 1 {
+		log.Info("multi arch release payload detected")
+		return version, common.MultiCPUArchitecture, nil
 	}
 	return version, cpuArchs[0], nil
 }


### PR DESCRIPTION
Fixes OCPBUGS-27787, requires https://github.com/openshift/installer/pull/7349 as well.

## List all the issues related to this PR

- [x] Bug fix

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] ABI with multi payload

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] Manual - Deployed single arch power/x86/aarch64 clusters with multi payload.
