### PR TITLE
AGENT-860: Add command to import cluster for agent-based-installer

### DIFF
--- a/cmd/agentbasedinstaller/import.go
+++ b/cmd/agentbasedinstaller/import.go
@@ -1,0 +1,34 @@
+package agentbasedinstaller
+
+import (
+	"context"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/openshift/assisted-service/client"
+	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/models"
+	errorutil "github.com/openshift/assisted-service/pkg/error"
+	log "github.com/sirupsen/logrus"
+)
+
+func ImportCluster(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall,
+	clusterID strfmt.UUID, clusterName string, clusterAPIVIPDNSName string) (*models.Cluster, error) {
+
+	importClusterParams := &models.ImportClusterParams{
+		Name:               &clusterName,
+		APIVipDnsname:      &clusterAPIVIPDNSName,
+		OpenshiftClusterID: &clusterID,
+	}
+	importParams := &installer.V2ImportClusterParams{
+		NewImportClusterParams: importClusterParams,
+	}
+	clusterResult, importClusterErr := bmInventory.Installer.V2ImportCluster(ctx, importParams)
+	if importClusterErr != nil {
+		return nil, errorutil.GetAssistedError(importClusterErr)
+	}
+	result := clusterResult.GetPayload()
+
+	log.Infof("Imported cluster with id: %s", clusterResult.Payload.ID)
+
+	return result, nil
+}


### PR DESCRIPTION
This patch adds a CLI command to ABI that will be called by an agent-import-cluster service running on the day2 add-nodes ISO to register an existing cluster to assisted-service as part of the day2 workflow.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) - Manually tested importing a cluster using day2 ABI workflow that is currently in development.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
