### PR TITLE
MGMT-16814: Pass both IP family URLs to ironic agent

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -212,8 +212,8 @@ The converged flow is enabled by default, you can disable the converged flow by 
 The ironic agent image will be determined based on the hub release image set in the ClusterVersion resource.
 If the hub cluster architecture does not match that of the InfraEnv or if the release image cannot be retrieved for some reason a default ironic agent image will be used.
 The defaults are:
-- x86_64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446`
-- arm64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43`
+- x86_64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:eca574867cb18fdd4cc3061a57865148030581ddbd6dad4db352bd27d52efca3`
+- arm64: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:27cf2412c22c87fa5daa5302d6b6b4e10d397571677749a4033bbda4b6c4d3ac`
 
 To set a different default ironicAgent image you can override the following env vars:
 The environment var for the ironicAgent image to be used on X86_64 CPU architecture:
@@ -221,8 +221,11 @@ The environment var for the ironicAgent image to be used on X86_64 CPU architect
 The environment var for the ironicAgent image to be used on arm64 CPU architecture:
 `IRONIC_AGENT_IMAGE_ARM`
 
+When changing the default image the environment variable `DEFAULT_IRONIC_AGENT_VERSION` also must be set.
+
 The ironic agent image can also be overridden using the InfraEnv annotation `infraenv.agent-install.openshift.io/ironic-agent-image-override`
-If this field is set this image will be used instead of the hub or default image.
+The version of the referenced image must also be provided in `infraenv.agent-install.openshift.io/ironic-agent-image-override-version`
+If thess fields are set this image will be used instead of the hub or default image.
 
 **NOTE**
 Ensure the correct images are mirrored if installing in a disconnected environment.

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.2
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a
-	github.com/openshift/image-customization-controller v0.0.0-20231018032321-4677f060c4bf
+	github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -1366,8 +1366,8 @@ github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b2
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f/go.mod h1:/CLsleDcQ6AFTGKJe9VL3Y4rB9DqX3fQwQv47q2/ZJc=
 github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a h1:E+XPJs/aVvYsrlJzo2ED38ZTR2RTNUlFMmOaFAAdMZg=
 github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a/go.mod h1:E1bgquRiwfugdArdecPbpYIrAdve5kTzMaJb0+8jMXI=
-github.com/openshift/image-customization-controller v0.0.0-20231018032321-4677f060c4bf h1:Z+LlKXsPGtzMsIQxSWAtebZLlUV/o678wYReGItPSkc=
-github.com/openshift/image-customization-controller v0.0.0-20231018032321-4677f060c4bf/go.mod h1:rTvO75VGcFhEuE2HgQe10OijcR9HBDNC+CnKei8p1HE=
+github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e h1:x1j5gWm4PdTTXTmuX3S7VAmsnazbbMiefQyCLdyjH74=
+github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e/go.mod h1:rTvO75VGcFhEuE2HgQe10OijcR9HBDNC+CnKei8p1HE=
 github.com/openshift/library-go v0.0.0-20191003152030-97c62d8a2901/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/library-go v0.0.0-20200831114015-2ab0c61c15de/go.mod h1:6vwp+YhYOIlj8MpkQKkebTTSn2TuYyvgiAFQ206jIEQ=
 github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b h1:BmunS/b02dKSwQ0H21+3EbXDfDr9t8UDlO54WxKkOts=

--- a/internal/controller/controllers/infraenv_controller.go
+++ b/internal/controller/controllers/infraenv_controller.go
@@ -58,10 +58,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const defaultRequeueAfterPerRecoverableError = 2 * bminventory.WindowBetweenRequestsInSeconds
-const InfraEnvFinalizerName = "infraenv." + aiv1beta1.Group + "/ai-deprovision"
-const EnableIronicAgentAnnotation = "infraenv." + aiv1beta1.Group + "/enable-ironic-agent"
-const ironicAgentImageOverrideAnnotation = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override"
+const (
+	defaultRequeueAfterPerRecoverableError    = 2 * bminventory.WindowBetweenRequestsInSeconds
+	InfraEnvFinalizerName                     = "infraenv." + aiv1beta1.Group + "/ai-deprovision"
+	EnableIronicAgentAnnotation               = "infraenv." + aiv1beta1.Group + "/enable-ironic-agent"
+	ironicAgentImageOverrideAnnotation        = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override"
+	ironicAgentImageOverrideVersionAnnotation = "infraenv." + aiv1beta1.Group + "/ironic-agent-image-override-version"
+)
 
 type InfraEnvConfig struct {
 	ImageType models.ImageType `envconfig:"ISO_IMAGE_TYPE" default:"minimal-iso"`

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -56,11 +56,10 @@ type imageConditionReason string
 const archMismatchReason = "InfraEnvArchMismatch"
 
 type PreprovisioningImageControllerConfig struct {
-	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.11.0-fc.0-x86_64"
-	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446"`
-	// The default ironic agent image for arm architecture was obtained by running "oc adm release info --image-for=ironic-agent quay.io/openshift-release-dev/ocp-release@sha256:1b8e71b9bccc69c732812ebf2bfba62af6de77378f8329c8fec10b63a0dbc33c"
-	// The release image digest for arm architecture was obtained from this link https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp-dev-preview/4.11.0-fc.0/release.txt
-	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43"`
+	// The default ironic agent image was obtained by running "oc adm release info --image-for=ironic-agent  quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64"
+	BaremetalIronicAgentImage string `envconfig:"IRONIC_AGENT_IMAGE" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:eca574867cb18fdd4cc3061a57865148030581ddbd6dad4db352bd27d52efca3"`
+	// The default ironic agent image for arm architecture was obtained from this link https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/4.15.0/release.txt
+	BaremetalIronicAgentImageForArm string `envconfig:"IRONIC_AGENT_IMAGE_ARM" default:"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:27cf2412c22c87fa5daa5302d6b6b4e10d397571677749a4033bbda4b6c4d3ac"`
 }
 
 // PreprovisioningImage reconciles a AgentClusterInstall object

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -420,6 +420,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 
 			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
 			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil)
+			mockOcRelease.EXPECT().GetOpenshiftVersion(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("4.12.0", nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
@@ -449,6 +450,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 
 			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"arm64"}, nil)
 			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("ironic-image:4.12.0", nil)
+			mockOcRelease.EXPECT().GetOpenshiftVersion(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("4.12.0", nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
@@ -481,6 +483,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			// These should only be called once if the cache is working
 			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil).Times(1)
 			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return(ironicAgentImage, nil).Times(1)
+			mockOcRelease.EXPECT().GetOpenshiftVersion(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("4.12.0", nil).Times(1)
 
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
@@ -508,8 +511,9 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		})
 
 		It("uses the override ironic image when supplied", func() {
-			overrideAgentImage := "ironic-agent-override:latest"
+			overrideAgentImage := "ironic-agent-override:4.13.0"
 			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideAnnotation, overrideAgentImage)
+			setAnnotation(&infraEnv.ObjectMeta, ironicAgentImageOverrideVersionAnnotation, "4.13.0")
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			backendInfraEnv.CPUArchitecture = "x86_64"
 			backendInfraEnv.PullSecret = "mypullsecret"

--- a/internal/ignition/ironic.go
+++ b/internal/ignition/ironic.go
@@ -14,11 +14,11 @@ func GenerateIronicConfig(ironicBaseURL string, ironicInspectorURL string, infra
 
 	httpProxy, httpsProxy, noProxy := common.GetProxyConfigs(infraEnv.Proxy)
 	// TODO: this should probably get the pullSecret as well
-	ib, err := iccignition.New([]byte{}, []byte{}, ironicBaseURL, ironicInspectorURL, ironicAgentImage, "", "", "", httpProxy, httpsProxy, noProxy, "")
+	ib, err := iccignition.New([]byte{}, []byte{}, ironicBaseURL, ironicInspectorURL, ironicAgentImage, "", "", "", httpProxy, httpsProxy, noProxy, "", "")
 	if err != nil {
 		return []byte{}, err
 	}
-	config.Storage.Files = []ignition_config_types_32.File{ib.IronicAgentConf()}
+	config.Storage.Files = []ignition_config_types_32.File{ib.IronicAgentConf("")}
 	// TODO: sort out the flags (authfile...) and copy network
 	config.Systemd.Units = []ignition_config_types_32.Unit{ib.IronicAgentService(false)}
 	return json.Marshal(config)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -753,7 +753,7 @@ github.com/openshift/hive/apis/hive/v1/openstack
 github.com/openshift/hive/apis/hive/v1/ovirt
 github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/image-customization-controller v0.0.0-20231018032321-4677f060c4bf
+# github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e
 ## explicit; go 1.19
 github.com/openshift/image-customization-controller/pkg/ignition
 # github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b


### PR DESCRIPTION
When deploying a single stack spoke cluster from a dual-stack hub it's hard for us to determine what callback URLs we should send to the ironic agent. If we get the choice wrong the agent simply never registers and the ironic agent gets stuck trying to send data to ironic on the hub.

As of https://issues.redhat.com/browse/OCPBUGS-24579 the ironic agent can accept a comma-separated list of URLs and will select the correct one based on the host's networking situation at runtime.

This PR provides that comma-separated list of URLs to the ironic agent if the agent is of a version that includes the fix (currently OCP 4.16+).

As a side effect we also need to track the version of the ironic agent we're embedding. This is so that we don't provide a list of URLs to an agent that is only expecting a single one. This is simple enough for now, but may become more complicated as the fix is backported (we may need to track multiple releases for each Y-stream depending on how far back the fix goes). This also means that we need users to provide the version of overrides and the env-configurable defaults.

## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-16814

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

I don't have the environment to test this, but QE is going to run my image through a test.

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc) - **docs updated**
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?