### PR TITLE
MGMT-16814: Use all cluster networks to determine IP family for ironic

### DIFF
--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -471,7 +471,7 @@ func (r *PreprovisioningImageReconciler) getIPFamilyForInfraEnv(ctx context.Cont
 	if err != nil {
 		return false, false, err
 	}
-	return network.GetAddressFamilies(cluster.MachineNetworks)
+	return network.GetConfiguredAddressFamilies(cluster)
 }
 
 func (r *PreprovisioningImageReconciler) getIronicServiceURLs(ctx context.Context, infraEnv *common.InfraEnv) (string, string, error) {

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -205,9 +205,11 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(infraEnv.ObjectMeta.Annotations[EnableIronicAgentAnnotation]).To(Equal("true"))
 		})
 		It("Adds the ironic IPv6 address to the ignition when the spoke cluster is IPv6 only", func() {
-			backendCluster.MachineNetworks = []*models.MachineNetwork{
+			backendCluster.ClusterNetworks = []*models.ClusterNetwork{
 				{Cidr: "2001:db8::/32"},
 			}
+			backendCluster.MachineNetworks = nil
+			backendCluster.ServiceNetworks = nil
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Before this, when deploying an IPv6 spoke from a dualstack hub only the machine network was being used to determine the address family of the spoke cluster.

This was an issue because the machine network is not generally set until after hosts are discovered.

This change uses all the cluster networks to determine the address family and should allow the preprovisioning image controller to correctly determine the IP family and set the ironic and inspector urls accordingly.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-16814

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

QE will test this fix fully before merge

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

