### PR TITLE
MGMT-16759: Copy cluster proxy settings to imported local-cluster AgentCluster Install

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -295,6 +295,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -674,6 +674,12 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -201,6 +201,7 @@ type ComponentStatusFn func(context.Context, logrus.FieldLogger, string, appsv1.
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get
 // +kubebuilder:rbac:groups="apiregistration.k8s.io",resources=apiservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 

--- a/pkg/localclusterimport/local_cluster_import_operations.go
+++ b/pkg/localclusterimport/local_cluster_import_operations.go
@@ -24,6 +24,7 @@ type ClusterImportOperations interface {
 	GetNodes() (*v1.NodeList, error)
 	GetNumberOfControlPlaneNodes() (int, error)
 	GetClusterDNS() (*configv1.DNS, error)
+	GetClusterProxy() (*configv1.Proxy, error)
 	GetAgentServiceConfig() (*aiv1beta1.AgentServiceConfig, error)
 	CreateAgentClusterInstall(agentClusterInstall *hiveext.AgentClusterInstall) error
 	CreateNamespace(name string) error
@@ -202,4 +203,17 @@ func (o *LocalClusterImportOperations) GetClusterDNS() (*configv1.DNS, error) {
 		return nil, err
 	}
 	return dns, nil
+}
+
+func (o *LocalClusterImportOperations) GetClusterProxy() (*configv1.Proxy, error) {
+	proxy := &configv1.Proxy{}
+	namespacedName := types.NamespacedName{
+		Namespace: "",
+		Name:      "cluster",
+	}
+	err := o.apiReader.Get(o.context, namespacedName, proxy)
+	if err != nil {
+		return nil, err
+	}
+	return proxy, nil
 }

--- a/pkg/localclusterimport/local_cluster_import_operations_mocks.go
+++ b/pkg/localclusterimport/local_cluster_import_operations_mocks.go
@@ -153,6 +153,21 @@ func (mr *MockClusterImportOperationsMockRecorder) GetClusterImageSet(name inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterImageSet", reflect.TypeOf((*MockClusterImportOperations)(nil).GetClusterImageSet), name)
 }
 
+// GetClusterProxy mocks base method.
+func (m *MockClusterImportOperations) GetClusterProxy() (*v1.Proxy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterProxy")
+	ret0, _ := ret[0].(*v1.Proxy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterProxy indicates an expected call of GetClusterProxy.
+func (mr *MockClusterImportOperationsMockRecorder) GetClusterProxy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterProxy", reflect.TypeOf((*MockClusterImportOperations)(nil).GetClusterProxy))
+}
+
 // GetClusterVersion mocks base method.
 func (m *MockClusterImportOperations) GetClusterVersion(name string) (*v1.ClusterVersion, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
The settings for HTTPProxy and HTTPSProxy should be copied to the AgentClusterInstall that is created during the import of the local cluster.
This PR ensures that this takes place.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
