### PR TITLE
AGENT-860: Update configure command to handle multiple HostConfigs

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -57,8 +57,9 @@ var RegisterOptions struct {
 }
 
 var ConfigureOptions struct {
-	InfraEnvID    string `envconfig:"INFRA_ENV_ID" default:""`
-	HostConfigDir string `envconfig:"HOST_CONFIG_DIR" default:"/etc/assisted/hostconfig"`
+	InfraEnvID    string                                `envconfig:"INFRA_ENV_ID" default:""`
+	HostConfigDir string                                `envconfig:"HOST_CONFIG_DIR" default:"/etc/assisted/hostconfig"`
+	WorkflowType  agentbasedinstaller.AgentWorkflowType `envconfig:"WORKFLOW_TYPE" default:"install"`
 }
 
 var ImportOptions struct {
@@ -219,7 +220,7 @@ func configure(ctx context.Context, log *log.Logger, bmInventory *client.Assiste
 		log.Fatal("No INFRA_ENV_ID specified")
 	}
 
-	hostConfigs, err := agentbasedinstaller.LoadHostConfigs(ConfigureOptions.HostConfigDir)
+	hostConfigs, err := agentbasedinstaller.LoadHostConfigs(ConfigureOptions.HostConfigDir, ConfigureOptions.WorkflowType)
 	if err != nil {
 		log.Fatal("Failed to load host configuration: ", err)
 	}


### PR DESCRIPTION
for day-2/addnodes workflow.

Updated the LoadHostConfigs function to only load the current host's HostConfig if the workflow is addnodes.

Only the current host's HostConfig is needed because each host in the addnodes workflow has its own assisted-service. Loading other node's HostConfigs would cause the apply-host-config service to continually wait for other hosts to register with assisted-service because each node is added in isolation.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) - Tested using ABI with the addnodes workflow currently being developed.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
