### PR TITLE
MGMT-16813: Prioritize finding release image with exact CPU architecture

### DIFF
--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -211,6 +211,13 @@ var _ = Describe("GetReleaseImage", func() {
 		Expect(*releaseImage.Version).Should(Equal("4.9-candidate"))
 	})
 
+	It("fetch release image by major.minor if given X.Y.Z version", func() {
+		releaseImage, err := h.GetReleaseImage(ctx, "4.9.2", common.DefaultCPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
+		Expect(*releaseImage.Version).Should(Equal("4.9-candidate"))
+	})
+
 	It("get from ReleaseImages", func() {
 		for _, key := range osImages.GetOpenshiftVersions() {
 			for _, architecture := range osImages.GetCPUArchitectures(key) {
@@ -269,6 +276,56 @@ var _ = Describe("GetReleaseImage", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.12"))
 		Expect(*releaseImage.Version).Should(Equal("4.12.999-rc.4"))
+	})
+
+	It("returns the matching CPU architecture over multi-arch if it is present", func() {
+		h.releaseImages = models.ReleaseImages{
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
+				OpenshiftVersion: swag.String("4.12-multi"),
+				URL:              swag.String("release_4.12.999-multi"),
+				Version:          swag.String("4.12.999"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				OpenshiftVersion: swag.String("4.12"),
+				URL:              swag.String("release_4.12.999-x86_64"),
+				Version:          swag.String("4.12.999"),
+			},
+		}
+
+		releaseImage, err := h.GetReleaseImage(ctx, "4.12.999", common.X86CPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.12"))
+		Expect(*releaseImage.Version).Should(Equal("4.12.999"))
+		Expect(*releaseImage.CPUArchitecture).Should(Equal(common.X86CPUArchitecture))
+	})
+
+	It("returns the multi-arch image if matching CPU architecture is not present", func() {
+		h.releaseImages = models.ReleaseImages{
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture, common.PowerCPUArchitecture},
+				OpenshiftVersion: swag.String("4.12-multi"),
+				URL:              swag.String("release_4.12.999-multi"),
+				Version:          swag.String("4.12.999"),
+			},
+			&models.ReleaseImage{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				OpenshiftVersion: swag.String("4.13"),
+				URL:              swag.String("release_4.13.999-x86_64"),
+				Version:          swag.String("4.13.999"),
+			},
+		}
+
+		releaseImage, err := h.GetReleaseImage(ctx, "4.12.999", common.X86CPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.12-multi"))
+		Expect(*releaseImage.Version).Should(Equal("4.12.999"))
+		Expect(*releaseImage.CPUArchitecture).Should(Equal(common.MultiCPUArchitecture))
 	})
 
 	Context("with a kube client", func() {

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Operators endpoint tests", func() {
 				swag.String(models.ClusterCPUArchitectureArm64),
 				nil,
 			)
-			Expect(cluster.Payload.CPUArchitecture).To(Equal(models.ClusterCPUArchitectureMulti))
+			Expect(cluster.Payload.CPUArchitecture).To(Equal(models.ClusterCPUArchitectureArm64))
 			Expect(len(cluster.Payload.MonitoredOperators)).To(Equal(1))
 
 			infraEnvParams := installer.RegisterInfraEnvParams{


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->
https://issues.redhat.com/browse/MGMT-16813
Previously, the `getReleaseImageFromCache` would get all release
images that included the CPU architecture and return the first
instance it found that matched the desired Openshift version.

Since multi-arch images include the CPU architecture, it led
to undesireable selection of the multi-arch image over the
exact matching image with the specified CPU architecture.

This fix ensures that the release image will be found with
the following priority:
1. Exact CPU Architecture & OpenShift x.y.z version match
2. Exact CPU Architecture & OpenShift Major Minor (x.y) version match
3. Multi-arch CPU with specified CPU Architecture & OpenShift x.y.z version match
4. Multi-arch CPU with specified CPU Architecture & OpenShift Major Minor (x.y) version match

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

**note**: will push up code gen once it finishes