### PR TITLE
MGMT-16002: Accept *yml.patch* and *yaml.patch* extensions

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
@@ -26,7 +26,7 @@ type CreateManifestParams struct {
 
 	// The name of the manifest to customize the installed OCP cluster.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -71,7 +71,7 @@ func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -22,7 +22,7 @@ type UpdateManifestParams struct {
 
 	// The file name for the manifest to modify.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName string `json:"file_name"`
 
 	// The folder for the manifest to modify.
@@ -74,7 +74,7 @@ func (m *UpdateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/api/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -34,7 +34,7 @@ type UpdateManifestParams struct {
 	UpdatedContent *string `json:"updated_content,omitempty"`
 
 	// The new file name for the manifest.
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	UpdatedFileName *string `json:"updated_file_name,omitempty"`
 
 	// The new folder for the manifest. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -129,7 +129,7 @@ func (m *UpdateManifestParams) validateUpdatedFileName(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/client/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
@@ -26,7 +26,7 @@ type CreateManifestParams struct {
 
 	// The name of the manifest to customize the installed OCP cluster.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -71,7 +71,7 @@ func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/client/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -22,7 +22,7 @@ type UpdateManifestParams struct {
 
 	// The file name for the manifest to modify.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName string `json:"file_name"`
 
 	// The folder for the manifest to modify.
@@ -74,7 +74,7 @@ func (m *UpdateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/client/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -34,7 +34,7 @@ type UpdateManifestParams struct {
 	UpdatedContent *string `json:"updated_content,omitempty"`
 
 	// The new file name for the manifest.
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	UpdatedFileName *string `json:"updated_file_name,omitempty"`
 
 	// The new folder for the manifest. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -129,7 +129,7 @@ func (m *UpdateManifestParams) validateUpdatedFileName(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/docs/user-guide/install-customization.md
+++ b/docs/user-guide/install-customization.md
@@ -9,6 +9,18 @@ These will only take effect after the machine config operator is up and running 
 Formats json, yaml, and multi-document yaml are accepted as manifests.
 Multi-document yaml manifests are split with unique names to avoid any collisions with existing files when they are added to their respective folders (either "manifests" or "openshift").
 
+Yaml patches are also accepted and should be in the yaml-patch format, patches should contain `.yaml.patch.` or `.yml.patch.` as a part of their filename.
+Here is an example of the format of a Yaml patch file, for more information on the format, please see https://github.com/krishicks/yaml-patch
+
+```
+---
+- op: replace
+  path: /status/infrastructureTopology
+  value: HighlyAvailable
+```
+
+
+
 ### Create a cluster manifest
 
 Note: In environments where TLS is enabled (e.g. _api.openshift.com_), you will need to use the `https` scheme in URLs.

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	yamlpatch "github.com/krishicks/yaml-patch"
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/constants"
 	manifestsapi "github.com/openshift/assisted-service/internal/manifests/api"
@@ -541,11 +542,11 @@ func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID 
 			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s has an illegal JSON format", fileName, string(clusterID)))
 		}
 	} else if strings.Contains(fileName, ".yaml.patch") || strings.Contains(fileName, ".yml.patch") {
-		if err := isValidYaml(manifestContent); err != nil {
-			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Patch content of file %s for cluster ID %s has an invalid YAML format: %s", fileName, string(clusterID), err))
+		if _, err := yamlpatch.DecodePatch(manifestContent); err != nil {
+			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Patch content of file %s for cluster ID %s is invalid: %s", fileName, string(clusterID), err))
 		}
 	} else {
-		return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest filename of file %s for cluster ID %s is invalid. Only json, yaml and yml extensions are supported", fileName, string(clusterID)))
+		return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest filename of file %s for cluster ID %s is invalid. Only json, yaml and yml or patch extensions are supported", fileName, string(clusterID)))
 	}
 	return nil
 }

--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -540,7 +540,7 @@ func (m *Manifests) validateUserSuppliedManifest(ctx context.Context, clusterID 
 		if !json.Valid(manifestContent) {
 			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Manifest content of file %s for cluster ID %s has an illegal JSON format", fileName, string(clusterID)))
 		}
-	} else if strings.HasPrefix(extension, ".patch") && (strings.Contains(fileName, ".yaml.patch") || strings.Contains(fileName, ".yml.patch")) {
+	} else if strings.Contains(fileName, ".yaml.patch") || strings.Contains(fileName, ".yml.patch") {
 		if err := isValidYaml(manifestContent); err != nil {
 			return m.prepareAndLogError(ctx, http.StatusBadRequest, errors.Errorf("Patch content of file %s for cluster ID %s has an invalid YAML format: %s", fileName, string(clusterID), err))
 		}

--- a/models/create_manifest_params.go
+++ b/models/create_manifest_params.go
@@ -26,7 +26,7 @@ type CreateManifestParams struct {
 
 	// The name of the manifest to customize the installed OCP cluster.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -71,7 +71,7 @@ func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/models/update_manifest_params.go
+++ b/models/update_manifest_params.go
@@ -22,7 +22,7 @@ type UpdateManifestParams struct {
 
 	// The file name for the manifest to modify.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName string `json:"file_name"`
 
 	// The folder for the manifest to modify.
@@ -74,7 +74,7 @@ func (m *UpdateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/models/update_manifest_params.go
+++ b/models/update_manifest_params.go
@@ -34,7 +34,7 @@ type UpdateManifestParams struct {
 	UpdatedContent *string `json:"updated_content,omitempty"`
 
 	// The new file name for the manifest.
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	UpdatedFileName *string `json:"updated_file_name,omitempty"`
 
 	// The new folder for the manifest. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -129,7 +129,7 @@ func (m *UpdateManifestParams) validateUpdatedFileName(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7165,7 +7165,7 @@ func init() {
         "file_name": {
           "description": "The name of the manifest to customize the installed OCP cluster.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$"
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",
@@ -10217,7 +10217,7 @@ func init() {
         "file_name": {
           "description": "The file name for the manifest to modify.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$",
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$",
           "x-nullable": false
         },
         "folder": {
@@ -17929,7 +17929,7 @@ func init() {
         "file_name": {
           "description": "The name of the manifest to customize the installed OCP cluster.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$"
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$"
         },
         "folder": {
           "description": "The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.",
@@ -20920,7 +20920,7 @@ func init() {
         "file_name": {
           "description": "The file name for the manifest to modify.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$",
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$",
           "x-nullable": false
         },
         "folder": {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -10238,7 +10238,7 @@ func init() {
         "updated_file_name": {
           "description": "The new file name for the manifest.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$",
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$",
           "x-nullable": true
         },
         "updated_folder": {
@@ -20941,7 +20941,7 @@ func init() {
         "updated_file_name": {
           "description": "The new file name for the manifest.",
           "type": "string",
-          "pattern": "^[^/]*\\.(yaml|yml|json)$",
+          "pattern": "^[^/]*\\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$",
           "x-nullable": true
         },
         "updated_folder": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6892,7 +6892,7 @@ definitions:
       file_name:
         description: The name of the manifest to customize the installed OCP cluster.
         type: string
-        pattern: '^[^/]*\.(yaml|yml|json)$'
+        pattern: '^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$'
       content:
         description: base64 encoded manifest content.
         type: string
@@ -6912,7 +6912,7 @@ definitions:
       file_name:
         description: The file name for the manifest to modify.
         type: string
-        pattern: '^[^/]*\.(yaml|yml|json)$'
+        pattern: '^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$'
         x-nullable: false
       updated_folder:
         description: The new folder for the manifest. Manifests can be placed in 'manifests' or 'openshift' directories.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6923,7 +6923,7 @@ definitions:
       updated_file_name:
         description: The new file name for the manifest.
         type: string
-        pattern: '^[^/]*\.(yaml|yml|json)$'
+        pattern: '^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$'
         x-nullable: true
       updated_content:
         description: The new base64 encoded manifest content.

--- a/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/create_manifest_params.go
@@ -26,7 +26,7 @@ type CreateManifestParams struct {
 
 	// The name of the manifest to customize the installed OCP cluster.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName *string `json:"file_name"`
 
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -71,7 +71,7 @@ func (m *CreateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", *m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -22,7 +22,7 @@ type UpdateManifestParams struct {
 
 	// The file name for the manifest to modify.
 	// Required: true
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	FileName string `json:"file_name"`
 
 	// The folder for the manifest to modify.
@@ -74,7 +74,7 @@ func (m *UpdateManifestParams) validateFileName(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("file_name", "body", m.FileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
+++ b/vendor/github.com/openshift/assisted-service/models/update_manifest_params.go
@@ -34,7 +34,7 @@ type UpdateManifestParams struct {
 	UpdatedContent *string `json:"updated_content,omitempty"`
 
 	// The new file name for the manifest.
-	// Pattern: ^[^/]*\.(yaml|yml|json)$
+	// Pattern: ^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$
 	UpdatedFileName *string `json:"updated_file_name,omitempty"`
 
 	// The new folder for the manifest. Manifests can be placed in 'manifests' or 'openshift' directories.
@@ -129,7 +129,7 @@ func (m *UpdateManifestParams) validateUpdatedFileName(formats strfmt.Registry) 
 		return nil
 	}
 
-	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json)$`); err != nil {
+	if err := validate.Pattern("updated_file_name", "body", *m.UpdatedFileName, `^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Presently we do not accept filenames containing *yml.patch* or *yaml.patch*
We should accept these files.
This PR rectifies that.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
Performed curl requests against an assisted-test-infra based cluster that is running this service image. *yml.patch* and *yaml.patch* files were accepted as expected.
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
