### PR TITLE
MGMT-16766: Use `client_id` instead of `clientId`

### DIFF
--- a/pkg/auth/auth_handler_test_utils.go
+++ b/pkg/auth/auth_handler_test_utils.go
@@ -34,7 +34,7 @@ func GetTokenAndCert(withLateIat bool) (string, []byte) {
 		"email":          "jdoe123@example.com",
 		"username":       "jdoe123@example.com",
 		"is_org_admin":   false,
-		"clientId":       "1234",
+		"client_id":      "1234",
 	}
 	if withLateIat {
 		mapClaims["iat"] = time.Now().Add(5 * time.Minute).Unix()

--- a/pkg/auth/rhsso_authenticator.go
+++ b/pkg/auth/rhsso_authenticator.go
@@ -133,7 +133,14 @@ func parseOCMPayload(userToken *jwt.Token) (*ocm.AuthPayload, error) {
 	payload.LastName, _ = claims["last_name"].(string)
 	payload.Organization, _ = claims["org_id"].(string)
 	payload.Email, _ = claims["email"].(string)
-	payload.ClientID, _ = claims["clientId"].(string)
+
+	// The `clientId` claim was replaced by `client_id` in order to be compliant with the OAuth2
+	// specification. We will still try to use the old `clientId` claim to support older
+	// environments where the change hasn't been made yet.
+	payload.ClientID, _ = claims["client_id"].(string)
+	if payload.ClientID == "" {
+		payload.ClientID, _ = claims["clientId"].(string)
+	}
 
 	// Check values, if empty, use alternative claims from RHD
 	if payload.Username == "" {


### PR DESCRIPTION
The `clientId` claim will be replaced by `client_id` from the SSO server in order to be compliant with the OAuth2 specification. During a transition period the old `clientId` will be preserved. This patch changes our code so that it first tries to use the newer and more correct `client_id`, and then if it doesn't exist it tries the older `clientId`.

In the future we should check if we are really using the value of this `client_id` claim at all. If we aren't then it would probably be good to remove the code completely.

Related: https://issues.redhat.com/browse/MGMT-16766
Related: https://datatracker.ietf.org/doc/html/rfc9068#section-2.2

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
