### PR TITLE
MGMT-15736: Align feature support level to support HighAvailabilityMode

### DIFF
--- a/client/installer/get_supported_features_parameters.go
+++ b/client/installer/get_supported_features_parameters.go
@@ -75,6 +75,12 @@ type GetSupportedFeaturesParams struct {
 	*/
 	ExternalPlatformName *string
 
+	/* HighAvailabilityMode.
+
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	*/
+	HighAvailabilityMode *string
+
 	/* OpenshiftVersion.
 
 	   Version of the OpenShift cluster.
@@ -173,6 +179,17 @@ func (o *GetSupportedFeaturesParams) SetExternalPlatformName(externalPlatformNam
 	o.ExternalPlatformName = externalPlatformName
 }
 
+// WithHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) WithHighAvailabilityMode(highAvailabilityMode *string) *GetSupportedFeaturesParams {
+	o.SetHighAvailabilityMode(highAvailabilityMode)
+	return o
+}
+
+// SetHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) SetHighAvailabilityMode(highAvailabilityMode *string) {
+	o.HighAvailabilityMode = highAvailabilityMode
+}
+
 // WithOpenshiftVersion adds the openshiftVersion to the get supported features params
 func (o *GetSupportedFeaturesParams) WithOpenshiftVersion(openshiftVersion string) *GetSupportedFeaturesParams {
 	o.SetOpenshiftVersion(openshiftVersion)
@@ -232,6 +249,23 @@ func (o *GetSupportedFeaturesParams) WriteToRequest(r runtime.ClientRequest, reg
 		if qExternalPlatformName != "" {
 
 			if err := r.SetQueryParam("external_platform_name", qExternalPlatformName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.HighAvailabilityMode != nil {
+
+		// query param high_availability_mode
+		var qrHighAvailabilityMode string
+
+		if o.HighAvailabilityMode != nil {
+			qrHighAvailabilityMode = *o.HighAvailabilityMode
+		}
+		qHighAvailabilityMode := qrHighAvailabilityMode
+		if qHighAvailabilityMode != "" {
+
+			if err := r.SetQueryParam("high_availability_mode", qHighAvailabilityMode); err != nil {
 				return err
 			}
 		}

--- a/client/installer/get_supported_features_parameters.go
+++ b/client/installer/get_supported_features_parameters.go
@@ -77,7 +77,7 @@ type GetSupportedFeaturesParams struct {
 
 	/* HighAvailabilityMode.
 
-	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.
 	*/
 	HighAvailabilityMode *string
 

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -1598,7 +1598,7 @@ func (b *bareMetalInventory) GetClusterSupportedPlatformsInternal(
 	var supportedPlatforms []models.PlatformType
 	for _, platformType := range hostsSupportedPlatforms {
 		featureId := provider.GetPlatformFeatureID(platformType)
-		if featureId == "" || featuresupport.IsFeatureAvailable(featureId, cluster.OpenshiftVersion, &cluster.CPUArchitecture) {
+		if featureId == "" || featuresupport.IsFeatureAvailable(featureId, cluster.OpenshiftVersion, &cluster.CPUArchitecture, cluster.HighAvailabilityMode) {
 			supportedPlatforms = append(supportedPlatforms, platformType)
 		} else {
 			b.log.Debugf("The platform %s was removed from cluster %s supported-platforms because it is not compatible with "+
@@ -1619,7 +1619,14 @@ func (b *bareMetalInventory) GetClusterSupportedPlatforms(ctx context.Context, p
 }
 
 func (b *bareMetalInventory) GetFeatureSupportLevelListInternal(_ context.Context, params installer.GetSupportedFeaturesParams) (models.SupportLevels, error) {
-	return featuresupport.GetFeatureSupportList(params.OpenshiftVersion, params.CPUArchitecture, (*models.PlatformType)(params.PlatformType), params.ExternalPlatformName), nil
+	featureFilter := featuresupport.SupportLevelFilters{
+		OpenshiftVersion:     params.OpenshiftVersion,
+		CPUArchitecture:      params.CPUArchitecture,
+		PlatformType:         (*models.PlatformType)(params.PlatformType),
+		ExternalPlatformName: params.ExternalPlatformName,
+		HighAvailabilityMode: params.HighAvailabilityMode,
+	}
+	return featuresupport.GetFeatureSupportList(featureFilter), nil
 }
 
 func (b *bareMetalInventory) GetArchitecturesSupportLevelListInternal(_ context.Context, params installer.GetSupportedArchitecturesParams) (models.SupportLevels, error) {
@@ -1740,7 +1747,7 @@ func (b *bareMetalInventory) generateClusterInstallConfig(ctx context.Context, c
 	}
 
 	installerReleaseImageOverride := ""
-	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster.CPUArchitecture, cluster.OpenshiftVersion) {
+	if isBaremetalBinaryFromAnotherReleaseImageRequired(cluster) {
 		defaultArchImage, err := b.versionsHandler.GetReleaseImage(ctx, cluster.OpenshiftVersion, common.DefaultCPUArchitecture, cluster.PullSecret)
 		if err != nil {
 			msg := fmt.Sprintf("failed to get image for installer image override "+
@@ -2582,7 +2589,7 @@ func (b *bareMetalInventory) updateNetworkParams(params installer.V2UpdateCluste
 	if params.ClusterUpdateParams.UserManagedNetworking != nil && swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) != userManagedNetworking {
 		if !swag.BoolValue(params.ClusterUpdateParams.UserManagedNetworking) &&
 			(cluster.CPUArchitecture != common.DefaultCPUArchitecture &&
-				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture))) {
+				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode)) {
 			err = errors.Errorf("disabling User Managed Networking is not allowed for clusters with non-x86_64 CPU architecture")
 			return common.NewApiError(http.StatusBadRequest, err)
 		}
@@ -6366,10 +6373,11 @@ func (b *bareMetalInventory) GetKnownApprovedHosts(clusterId strfmt.UUID) ([]*co
 // This flow does not affect the multiarch release images and is meant purely for using arm64 release image with the x86 hub.
 // Implementation of handling the multiarch images is done directly in the `oc` binary and relies on the fact that `oc adm release extract`
 // will automatically use the image matching the Hub's architecture.
-func isBaremetalBinaryFromAnotherReleaseImageRequired(cpuArchitecture, version string) bool {
-	return cpuArchitecture != common.MultiCPUArchitecture &&
-		cpuArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
-		featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, version, swag.String(models.ClusterCPUArchitectureArm64))
+func isBaremetalBinaryFromAnotherReleaseImageRequired(cluster common.Cluster) bool {
+	return cluster.CPUArchitecture != common.MultiCPUArchitecture &&
+		cluster.CPUArchitecture != common.NormalizeCPUArchitecture(runtime.GOARCH) &&
+		featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion,
+			swag.String(models.ClusterCPUArchitectureArm64), cluster.HighAvailabilityMode)
 }
 
 // updateMonitoredOperators checks the content of the installer configuration and updates the list

--- a/internal/cluster/validations/validations.go
+++ b/internal/cluster/validations/validations.go
@@ -402,7 +402,7 @@ func ValidateClusterCreateIPAddresses(ipV6Supported bool, clusterId strfmt.UUID,
 	targetConfiguration := common.Cluster{}
 
 	if (len(params.APIVips) > 1 || len(params.IngressVips) > 1) &&
-		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, swag.StringValue(params.OpenshiftVersion), swag.String(params.CPUArchitecture)) {
+		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, swag.StringValue(params.OpenshiftVersion), swag.String(params.CPUArchitecture), params.HighAvailabilityMode) {
 
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s %s", "dual-stack VIPs are not supported in OpenShift", *params.OpenshiftVersion))
 	}
@@ -467,7 +467,7 @@ func ValidateClusterUpdateVIPAddresses(ipV6Supported bool, cluster *common.Clust
 	ingressVips = params.IngressVips
 
 	if (len(params.APIVips) > 1 || len(params.IngressVips) > 1) &&
-		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 
 		return common.NewApiError(http.StatusBadRequest, errors.Errorf("%s %s", "dual-stack VIPs are not supported in OpenShift", cluster.OpenshiftVersion))
 	}

--- a/internal/featuresupport/common.go
+++ b/internal/featuresupport/common.go
@@ -11,11 +11,11 @@ import (
 	"github.com/thoas/go-funk"
 )
 
-func GetSupportLevel[T models.FeatureSupportLevelID | models.ArchitectureSupportLevelID](featureId T, filters interface{}) models.SupportLevel {
+func GetSupportLevel[T models.FeatureSupportLevelID | models.ArchitectureSupportLevelID](featureId T, filters SupportLevelFilters) models.SupportLevel {
 	if reflect.TypeOf(featureId).Name() == "FeatureSupportLevelID" {
-		return featuresList[models.FeatureSupportLevelID(featureId)].getSupportLevel(filters.(SupportLevelFilters))
+		return featuresList[models.FeatureSupportLevelID(featureId)].getSupportLevel(filters)
 	}
-	return cpuFeaturesList[models.ArchitectureSupportLevelID(featureId)].getSupportLevel(filters.(string))
+	return cpuFeaturesList[models.ArchitectureSupportLevelID(featureId)].getSupportLevel(filters.OpenshiftVersion)
 }
 
 func ValidateActiveFeatures(log logrus.FieldLogger, cluster *common.Cluster, infraEnv *models.InfraEnv, updateParams interface{}) error {
@@ -48,17 +48,22 @@ func ValidateActiveFeatures(log logrus.FieldLogger, cluster *common.Cluster, inf
 
 func ValidateIncompatibleFeatures(log logrus.FieldLogger, cpuArchitecture string, cluster *common.Cluster, infraEnv *models.InfraEnv, updateParams interface{}) error {
 	var openshiftVersion *string
+	var highAvailabilityMode *string = swag.String("")
 	if cluster != nil {
 		openshiftVersion = &cluster.OpenshiftVersion
+		if cluster.HighAvailabilityMode != nil {
+			highAvailabilityMode = cluster.HighAvailabilityMode
+		}
 	}
 
 	activatedFeatures := getActivatedFeatures(log, cluster, infraEnv, updateParams)
 	if cpuArchitecture != "" && swag.StringValue(openshiftVersion) != "" {
-		if isSupported := isArchitectureSupported(cpuArchitectureFeatureIdMap[cpuArchitecture], swag.StringValue(openshiftVersion)); !isSupported {
+		filters := SupportLevelFilters{OpenshiftVersion: *openshiftVersion, CPUArchitecture: &cpuArchitecture, HighAvailabilityMode: highAvailabilityMode}
+		if isSupported := isArchitectureSupported(filters); !isSupported {
 			return fmt.Errorf("cannot use %s architecture because it's not compatible on version %s of OpenShift", cpuArchitecture, cluster.OpenshiftVersion)
 		}
 
-		if err := isFeaturesCompatible(swag.StringValue(openshiftVersion), cpuArchitecture, activatedFeatures); err != nil {
+		if err := isFeaturesCompatible(swag.StringValue(openshiftVersion), cpuArchitecture, highAvailabilityMode, activatedFeatures); err != nil {
 			return err
 		}
 

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -122,6 +122,90 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		}
 	})
 
+	Context("Test HighAvailabilityMode", func() {
+		var (
+			filters = SupportLevelFilters{
+				OpenshiftVersion:     "4.14",
+				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+			}
+		)
+		supportedHighAvilabilityModeNone := []models.FeatureSupportLevelID{
+			models.FeatureSupportLevelIDBAREMETALPLATFORM,
+			models.FeatureSupportLevelIDCNV,
+			models.FeatureSupportLevelIDCUSTOMMANIFEST,
+			models.FeatureSupportLevelIDDUALSTACK,
+			models.FeatureSupportLevelIDDUALSTACKVIPS,
+			models.FeatureSupportLevelIDEXTERNALPLATFORM,
+			models.FeatureSupportLevelIDFULLISO,
+			models.FeatureSupportLevelIDLSO,
+			models.FeatureSupportLevelIDLVM,
+			models.FeatureSupportLevelIDMCE,
+			models.FeatureSupportLevelIDMINIMALISO,
+			models.FeatureSupportLevelIDNONEPLATFORM,
+			models.FeatureSupportLevelIDOVNNETWORKTYPE,
+			models.FeatureSupportLevelIDSDNNETWORKTYPE,
+			models.FeatureSupportLevelIDSINGLENODEEXPANSION,
+			models.FeatureSupportLevelIDSNO,
+			models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
+		}
+		for i := range supportedHighAvilabilityModeNone {
+			feature := supportedHighAvilabilityModeNone[i]
+			It(fmt.Sprintf("feature %v, should be supported in HighAvailabilityMode None", feature), func() {
+				Expect(GetSupportLevel(feature, filters)).To(Equal(models.SupportLevelSupported))
+			})
+		}
+		unSupportedHighAvilabilityModeNone := []models.FeatureSupportLevelID{
+			models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+			models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+			models.FeatureSupportLevelIDODF,
+			models.FeatureSupportLevelIDSKIPMCOREBOOT,
+			models.FeatureSupportLevelIDVIPAUTOALLOC,
+			models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+		}
+		for i := range unSupportedHighAvilabilityModeNone {
+			feature := unSupportedHighAvilabilityModeNone[i]
+			It(fmt.Sprintf("feature %v, should be unavailable in HighAvailabilityMode None", feature), func() {
+				Expect(GetSupportLevel(feature, filters)).To(Equal(models.SupportLevelUnavailable))
+			})
+		}
+
+		supportedHighAvilabilityModeFull := []models.FeatureSupportLevelID{
+			models.FeatureSupportLevelIDBAREMETALPLATFORM,
+			models.FeatureSupportLevelIDCNV,
+			models.FeatureSupportLevelIDCUSTOMMANIFEST,
+			models.FeatureSupportLevelIDDUALSTACK,
+			models.FeatureSupportLevelIDDUALSTACKVIPS,
+			models.FeatureSupportLevelIDEXTERNALPLATFORM,
+			models.FeatureSupportLevelIDFULLISO,
+			models.FeatureSupportLevelIDLSO,
+			models.FeatureSupportLevelIDMCE,
+			models.FeatureSupportLevelIDMINIMALISO,
+			models.FeatureSupportLevelIDNONEPLATFORM,
+			models.FeatureSupportLevelIDOVNNETWORKTYPE,
+			models.FeatureSupportLevelIDSDNNETWORKTYPE,
+			models.FeatureSupportLevelIDSINGLENODEEXPANSION,
+			models.FeatureSupportLevelIDSNO,
+			models.FeatureSupportLevelIDODF,
+			models.FeatureSupportLevelIDUSERMANAGEDNETWORKING,
+			models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING,
+			models.FeatureSupportLevelIDNUTANIXINTEGRATION,
+			models.FeatureSupportLevelIDVSPHEREINTEGRATION,
+		}
+		for i := range supportedHighAvilabilityModeFull {
+			feature := supportedHighAvilabilityModeFull[i]
+			It(fmt.Sprintf("feature %v, should be supported in HighAvailabilityMode Full", feature), func() {
+				filters.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+				Expect(GetSupportLevel(feature, filters)).To(Equal(models.SupportLevelSupported))
+			})
+		}
+
+		feature := models.FeatureSupportLevelIDSKIPMCOREBOOT
+		It(fmt.Sprintf("feature %v, should be unavailable in HighAvailabilityMode Full", feature), func() {
+			filters.HighAvailabilityMode = swag.String(models.ClusterHighAvailabilityModeFull)
+			Expect(GetSupportLevel(feature, filters)).To(Equal(models.SupportLevelUnavailable))
+		})
+	})
+
 	Context("Test LSO CPU compatibility", func() {
 		feature := models.FeatureSupportLevelIDLSO
 		It("LSO IsFeatureAvailable", func() {
@@ -357,21 +441,21 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 	})
 	Context("GetFeatureSupportList 4.14 with Platform", func() {
-		platforms := []models.PlatformType{
-			models.PlatformTypeNutanix,
-			models.PlatformTypeVsphere,
-			models.PlatformTypeExternal,
-			models.PlatformTypeBaremetal,
-			models.PlatformTypeNone,
+		platforms := []*models.PlatformType{
+			models.PlatformTypeNutanix.Pointer(),
+			models.PlatformTypeVsphere.Pointer(),
+			models.PlatformTypeExternal.Pointer(),
+			models.PlatformTypeBaremetal.Pointer(),
+			models.PlatformTypeNone.Pointer(),
 		}
 		for _, platform := range platforms {
 			list := GetFeatureSupportList(SupportLevelFilters{
 				OpenshiftVersion:     "4.14",
 				CPUArchitecture:      nil,
-				PlatformType:         &platform,
+				PlatformType:         platform,
 				HighAvailabilityMode: nil,
 			})
-			It(fmt.Sprintf("feature %v SupportList should be 19", platform), func() {
+			It(fmt.Sprintf("feature %v SupportList should be 19", *platform), func() {
 				Expect(len(list)).To(Equal(19))
 			})
 		}
@@ -385,25 +469,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 		Expect(len(list)).To(Equal(24))
 	})
-	// This Test is not correct
-	// FContext("overrideInvalidRequest 4.12 vsphere with HighAvailabilityMode None", func() {
-	// 	platform := models.PlatformTypeVsphere
-	// 	list := GetFeatureSupportList(SupportLevelFilters{
-	// 		OpenshiftVersion:     "4.12",
-	// 		CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
-	// 		PlatformType:         &platform,
-	// 		// HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
-	// 	})
-	// 	for featureId, supportLevel := range list {
-	// 		sl := supportLevel
-	// 		It(fmt.Sprintf("Feature %s", featureId), func() {
-	// 			// All features in that case should be unavailable
-	// 			Expect(sl).To(Equal(models.SupportLevelUnavailable))
-	// 		})
-	// 	}
-	// })
-
-  It("GetFeatureSupportList 4.14", func() {
+	It("GetFeatureSupportList 4.14", func() {
 		list := GetFeatureSupportList(SupportLevelFilters{
 			OpenshiftVersion:     "4.14",
 			CPUArchitecture:      nil,

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -356,72 +356,72 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelSupported))
 		})
 	})
-	// =======
-	// 		It("GetFeatureSupportList 4.14 with Platform", func() {
-	// 			platforms := []models.PlatformType{
-	// 				models.PlatformTypeNutanix,
-	// 				models.PlatformTypeVsphere,
-	// 				models.PlatformTypeOci,
-	// 				models.PlatformTypeBaremetal,
-	// 				models.PlatformTypeNone,
-	// 			}
-	// 			for _, platform := range platforms {
-	// 				p := platform
-	// 				list := GetFeatureSupportList(SupportLevelFilters{
-	// 					OpenshiftVersion:     "4.14",
-	// 					CPUArchitecture:      nil,
-	// 					PlatformType:         &p,
-	// 					HighAvailabilityMode: nil,
-	// 				})
-	// 				Expect(len(list)).To(Equal(16))
-	// 			}
+	Context("GetFeatureSupportList 4.14 with Platform", func() {
+		platforms := []models.PlatformType{
+			models.PlatformTypeNutanix,
+			models.PlatformTypeVsphere,
+			models.PlatformTypeExternal,
+			models.PlatformTypeBaremetal,
+			models.PlatformTypeNone,
+		}
+		for _, platform := range platforms {
+			list := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion:     "4.14",
+				CPUArchitecture:      nil,
+				PlatformType:         &platform,
+				HighAvailabilityMode: nil,
+			})
+			It(fmt.Sprintf("feature %v SupportList should be 19", platform), func() {
+				Expect(len(list)).To(Equal(19))
+			})
+		}
+	})
+	It("GetFeatureSupportList 4.14 with HighAvailabilityMode", func() {
+		list := GetFeatureSupportList(SupportLevelFilters{
+			OpenshiftVersion:     "4.14",
+			CPUArchitecture:      nil,
+			PlatformType:         nil,
+			HighAvailabilityMode: swag.String("does_not_matter_what_is_the_value"),
+		})
+		Expect(len(list)).To(Equal(24))
+	})
+	// This Test is not correct
+	// FContext("overrideInvalidRequest 4.12 vsphere with HighAvailabilityMode None", func() {
+	// 	platform := models.PlatformTypeVsphere
+	// 	list := GetFeatureSupportList(SupportLevelFilters{
+	// 		OpenshiftVersion:     "4.12",
+	// 		CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+	// 		PlatformType:         &platform,
+	// 		// HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+	// 	})
+	// 	for featureId, supportLevel := range list {
+	// 		sl := supportLevel
+	// 		It(fmt.Sprintf("Feature %s", featureId), func() {
+	// 			// All features in that case should be unavailable
+	// 			Expect(sl).To(Equal(models.SupportLevelUnavailable))
 	// 		})
-	// 		It("GetFeatureSupportList 4.12 with HighAvailabilityMode", func() {
-	// 			list := GetFeatureSupportList(SupportLevelFilters{
-	// 				OpenshiftVersion:     "4.12",
-	// 				CPUArchitecture:      nil,
-	// 				PlatformType:         nil,
-	// 				HighAvailabilityMode: swag.String("does_not_matter_what_is_the_value"),
-	// 			})
-	// 			Expect(len(list)).To(Equal(19))
-	// 		})
-	// 		It("overrideInvalidRequest 4.12 vsphere with HighAvailabilityMode None", func() {
-	// 			platform := models.PlatformTypeVsphere
-	// 			list := GetFeatureSupportList(SupportLevelFilters{
-	// 				OpenshiftVersion:     "4.10",
-	// 				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
-	// 				PlatformType:         &platform,
-	// 				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
-	// 			})
-	// 			for featureId, supportLevel := range list {
-	// 				sl := supportLevel
-	// 				By(fmt.Sprintf("Feature %s", featureId), func() {
-	// 					// All features in that case should be unavailable
-	// 					Expect(sl).To(Equal(models.SupportLevelUnavailable))
-	// 				})
-	// 			}
-	// 		})
-	//
-	// 		It("GetFeatureSupportList 4.12", func() {
-	// 			list := GetFeatureSupportList(SupportLevelFilters{
-	// 				OpenshiftVersion:     "4.12",
-	// 				CPUArchitecture:      nil,
-	// 				PlatformType:         nil,
-	// 				HighAvailabilityMode: nil,
-	// 			})
-	// 			Expect(len(list)).To(Equal(20))
-	// 		})
-	//
-	// 		It("GetFeatureSupportList 4.13", func() {
-	// 			list := GetFeatureSupportList(SupportLevelFilters{
-	// 				OpenshiftVersion:     "4.13",
-	// 				CPUArchitecture:      nil,
-	// 				PlatformType:         nil,
-	// 				HighAvailabilityMode: nil,
-	// 			})
-	// 			Expect(len(list)).To(Equal(20))
-	// >>>>>>> db440e81b (MGMT-15736: Align feature support level to support HighAvailabilityMode as filterable feature)
-	// 		})
+	// 	}
+	// })
+
+  It("GetFeatureSupportList 4.14", func() {
+		list := GetFeatureSupportList(SupportLevelFilters{
+			OpenshiftVersion:     "4.14",
+			CPUArchitecture:      nil,
+			PlatformType:         nil,
+			HighAvailabilityMode: nil,
+		})
+		Expect(len(list)).To(Equal(24))
+	})
+
+	It("GetFeatureSupportList 4.13", func() {
+		list := GetFeatureSupportList(SupportLevelFilters{
+			OpenshiftVersion:     "4.13",
+			CPUArchitecture:      nil,
+			PlatformType:         nil,
+			HighAvailabilityMode: nil,
+		})
+		Expect(len(list)).To(Equal(24))
+	})
 
 	Context("ValidateIncompatibleFeatures", func() {
 		log := logrus.New()

--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -28,7 +28,16 @@ func getPlatformFilters() []SupportLevelFilters {
 }
 
 var _ = Describe("V2ListFeatureSupportLevels API", func() {
-	availableVersions := []string{"4.9", "4.10", "4.11", "4.12", "4.13"}
+	validateVersions := func() []string {
+		version := make([]string, 12)
+		for i := range version {
+			// check versions 4.9 - 4.20
+			version[i] = fmt.Sprintf("4.%v", 9+i)
+
+		}
+		return version
+	}()
+
 	availableCpuArch := []string{
 		models.ClusterCPUArchitectureX8664,
 		models.ClusterCPUArchitectureArm64,
@@ -40,7 +49,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 
 	Context("Feature compatibility", func() {
 		for _, f := range featuresList {
-			for _, v := range availableVersions {
+			for _, v := range validateVersions {
 				for _, a := range availableCpuArch {
 					feature := f
 					version := v
@@ -56,58 +65,70 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	})
 
 	It("Test ARM64 is not supported under 4.10", func() {
-		feature := models.ArchitectureSupportLevelIDARM64ARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.7")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.8")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.9")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.10")).To(BeTrue())
-		Expect(isArchitectureSupported(feature, "4.11")).To(BeTrue())
-		Expect(isArchitectureSupported(feature, "4.12")).To(BeTrue())
-		Expect(isArchitectureSupported(feature, "4.13")).To(BeTrue())
+		feature := SupportLevelFilters{
+			CPUArchitecture: swag.String(models.ClusterCPUArchitectureArm64),
+		}
+		minimumSupportVersion := "4.10"
 
-		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(BeTrue())
+		for i := range validateVersions {
+
+			feature.OpenshiftVersion = validateVersions[i]
+			if ok, _ := common.BaseVersionGreaterOrEqual(minimumSupportVersion, feature.OpenshiftVersion); ok {
+				Expect(isArchitectureSupported(feature)).To(BeTrue(),
+					fmt.Sprintf("Should be True on verison: %v", feature.OpenshiftVersion))
+			} else {
+
+				Expect(isArchitectureSupported(feature)).To(BeFalse(),
+					fmt.Sprintf("Should be False on verison: %v", feature.OpenshiftVersion))
+			}
+		}
 	})
 
 	It("Test s390x is not supported under 4.12", func() {
-		feature := models.ArchitectureSupportLevelIDS390XARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.7")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.8")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.9")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.10")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.11")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.12")).To(BeTrue())
-		Expect(isArchitectureSupported(feature, "4.13")).To(BeTrue())
+		feature := SupportLevelFilters{
+			CPUArchitecture: swag.String(models.ClusterCPUArchitectureS390x),
+		}
+		minimumSupportVersion := "4.12"
+		for i := range validateVersions {
 
-		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(BeTrue())
-
+			feature.OpenshiftVersion = validateVersions[i]
+			if ok, _ := common.BaseVersionGreaterOrEqual(minimumSupportVersion, feature.OpenshiftVersion); ok {
+				Expect(isArchitectureSupported(feature)).To(BeTrue(),
+					fmt.Sprintf("Should be True on version: %v", feature.OpenshiftVersion))
+			} else {
+				Expect(isArchitectureSupported(feature)).To(BeFalse(),
+					fmt.Sprintf("Should be False on version: %v", feature.OpenshiftVersion))
+			}
+		}
 	})
 
 	It("Test PPC64LE is not supported under 4.12", func() {
-		feature := models.ArchitectureSupportLevelIDPPC64LEARCHITECTURE
-		Expect(isArchitectureSupported(feature, "4.6")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.7")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.8")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.9")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.10")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.11")).To(BeFalse())
-		Expect(isArchitectureSupported(feature, "4.12")).To(BeTrue())
-		Expect(isArchitectureSupported(feature, "4.13")).To(BeTrue())
+		feature := SupportLevelFilters{
+			CPUArchitecture: swag.String(models.ClusterCPUArchitecturePpc64le),
+		}
+		minimumSupportVersion := "4.12"
 
-		// Check for feature release
-		Expect(isArchitectureSupported(feature, "4.30")).To(BeTrue())
+		for i := range validateVersions {
+
+			feature.OpenshiftVersion = validateVersions[i]
+			if ok, _ := common.BaseVersionGreaterOrEqual(minimumSupportVersion, feature.OpenshiftVersion); ok {
+				Expect(isArchitectureSupported(feature)).To(BeTrue(),
+					fmt.Sprintf("Should be True on verison: %v", feature.OpenshiftVersion))
+			} else {
+
+				Expect(isArchitectureSupported(feature)).To(BeFalse(),
+					fmt.Sprintf("Should be False on verison: %v", feature.OpenshiftVersion))
+			}
+		}
 	})
 
 	Context("Test LSO CPU compatibility", func() {
 		feature := models.FeatureSupportLevelIDLSO
 		It("LSO IsFeatureAvailable", func() {
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitecturePpc64le))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureX8664))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureS390x))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureArm64))).To(BeFalse())
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitecturePpc64le), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureX8664), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureS390x), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "Does not matter", swag.String(models.ClusterCPUArchitectureArm64), nil)).To(BeFalse())
 		})
 		It("LSO GetSupportLevel on architecture", func() {
 			featureSupportParams := SupportLevelFilters{OpenshiftVersion: "Any", CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664)}
@@ -127,10 +148,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	Context("Test skip MCO reboot", func() {
 		feature := models.FeatureSupportLevelIDSKIPMCOREBOOT
 		It("IsFeatureAvailable", func() {
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitecturePpc64le))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureX8664))).To(Equal(true))
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureS390x))).To(Equal(false))
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureArm64))).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitecturePpc64le), nil)).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureX8664), nil)).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureS390x), nil)).To(Equal(false))
+			Expect(IsFeatureAvailable(feature, "4.15", swag.String(models.ClusterCPUArchitectureArm64), nil)).To(Equal(true))
 		})
 		It("GetSupportLevel on architecture", func() {
 			featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.15", CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664)}
@@ -181,20 +202,21 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		feature := models.FeatureSupportLevelIDMCE
 		It(fmt.Sprintf("%s test", feature), func() {
 			arch := "DoesNotMatter"
-			Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch))).To(BeFalse())
-			Expect(IsFeatureAvailable(feature, "4.10", swag.String(arch))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch))).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.9", swag.String(arch), nil)).To(BeFalse())
+			Expect(IsFeatureAvailable(feature, "4.10", swag.String(arch), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.11", swag.String(arch), nil)).To(BeTrue())
 
-			featureSupportParams := SupportLevelFilters{OpenshiftVersion: "4.9", CPUArchitecture: swag.String(arch)}
+			featureSupportParams := SupportLevelFilters{
+				OpenshiftVersion: "4.9",
+				CPUArchitecture:  swag.String(arch),
+			}
 			Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelUnavailable))
-			featureSupportParams = SupportLevelFilters{OpenshiftVersion: "4.11.20", CPUArchitecture: swag.String(arch)}
+
+			featureSupportParams.OpenshiftVersion = "4.11.20"
 			Expect(GetSupportLevel(feature, featureSupportParams)).To(Equal(models.SupportLevelSupported))
 
-			Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch))).To(BeTrue())
-
-			// Check for feature release
-			Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch))).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch), nil)).To(BeTrue())
 		})
 	})
 
@@ -202,17 +224,19 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		It("Test SDN not supported over 4.15", func() {
 			feature := models.FeatureSupportLevelIDSDNNETWORKTYPE
 			arch := "DoesNotMatter"
-			Expect(IsFeatureAvailable(feature, "4.14", swag.String(arch))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(arch))).To(BeFalse())
-			Expect(IsFeatureAvailable(feature, "4.16", swag.String(arch))).To(BeFalse())
+			Expect(IsFeatureAvailable(feature, "4.14", swag.String(arch), nil)).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.15", swag.String(arch), nil)).To(BeFalse())
+			Expect(IsFeatureAvailable(feature, "4.16", swag.String(arch), nil)).To(BeFalse())
 		})
 
 		It("Test OVN is supported over 4.15", func() {
 			feature := models.FeatureSupportLevelIDOVNNETWORKTYPE
 			arch := "DoesNotMatter"
-			Expect(IsFeatureAvailable(feature, "4.14", swag.String(arch))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "4.15", swag.String(arch))).To(BeTrue())
-			Expect(IsFeatureAvailable(feature, "4.16", swag.String(arch))).To(BeTrue())
+			Expect(IsFeatureAvailable(feature, "4.12", swag.String(arch), nil)).To(Equal(true))
+			Expect(IsFeatureAvailable(feature, "4.13", swag.String(arch), nil)).To(Equal(true))
+
+			// Check for feature release
+			Expect(IsFeatureAvailable(feature, "4.30", swag.String(arch), nil)).To(Equal(true))
 		})
 	})
 
@@ -263,24 +287,30 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 	})
 
 	Context("GetSupportList", func() {
-
 		for _, filters := range getPlatformFilters() {
 			filters := filters
 			When("GetFeatureSupportList 4.12 with Platform", func() {
 				It(string(*filters.PlatformType)+" "+swag.StringValue(filters.ExternalPlatformName), func() {
-					list := GetFeatureSupportList("dummy", nil, filters.PlatformType, filters.ExternalPlatformName)
+					featureFilter := SupportLevelFilters{
+						CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+						OpenshiftVersion:     "4.12",
+						PlatformType:         filters.PlatformType,
+						ExternalPlatformName: filters.ExternalPlatformName,
+					}
+
+					list := GetFeatureSupportList(featureFilter)
 					Expect(len(list)).To(Equal(19))
 				})
 			})
 		}
 
 		It("GetFeatureSupportList 4.12", func() {
-			list := GetFeatureSupportList("4.12", nil, nil, nil)
+			list := GetFeatureSupportList(SupportLevelFilters{CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664), OpenshiftVersion: "4.12"})
 			Expect(len(list)).To(Equal(24))
 		})
 
 		It("GetFeatureSupportList 4.13", func() {
-			list := GetFeatureSupportList("4.13", nil, nil, nil)
+			list := GetFeatureSupportList(SupportLevelFilters{CPUArchitecture: swag.String(models.ClusterCPUArchitectureX8664), OpenshiftVersion: "4.13"})
 			Expect(len(list)).To(Equal(24))
 		})
 
@@ -295,7 +325,10 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 
 		It("GetFeatureSupportList 4.11 with not supported architecture", func() {
-			featuresList := GetFeatureSupportList("4.11", swag.String(models.ClusterCPUArchitecturePpc64le), nil, nil)
+			featuresList := GetFeatureSupportList(SupportLevelFilters{
+				OpenshiftVersion: "4.11",
+				CPUArchitecture:  swag.String(models.ClusterCPUArchitecturePpc64le),
+			})
 
 			for _, supportLevel := range featuresList {
 				Expect(supportLevel).To(Equal(models.SupportLevelUnavailable))
@@ -303,18 +336,92 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
-			featuresList := GetFeatureSupportList("4.12", swag.String(models.ClusterCPUArchitecturePpc64le), nil, nil)
+			featureFilter := SupportLevelFilters{
+				CPUArchitecture:  swag.String(models.ClusterCPUArchitecturePpc64le),
+				OpenshiftVersion: "4.12",
+			}
+			featuresList := GetFeatureSupportList(featureFilter)
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelUnavailable))
 
-			featuresList = GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitecturePpc64le), nil, nil)
+			featureFilter.OpenshiftVersion = "4.13"
+			featuresList = GetFeatureSupportList(featureFilter)
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelDevPreview))
 		})
 
 		It("GetFeatureSupportList 4.13 with unsupported architecture", func() {
-			featuresList := GetFeatureSupportList("4.13", swag.String(models.ClusterCPUArchitectureX8664), nil, nil)
+			featuresList := GetFeatureSupportList(SupportLevelFilters{
+				CPUArchitecture:  swag.String(models.ClusterCPUArchitectureX8664),
+				OpenshiftVersion: "4.13",
+			})
 			Expect(featuresList[string(models.FeatureSupportLevelIDSNO)]).To(Equal(models.SupportLevelSupported))
 		})
 	})
+	// =======
+	// 		It("GetFeatureSupportList 4.14 with Platform", func() {
+	// 			platforms := []models.PlatformType{
+	// 				models.PlatformTypeNutanix,
+	// 				models.PlatformTypeVsphere,
+	// 				models.PlatformTypeOci,
+	// 				models.PlatformTypeBaremetal,
+	// 				models.PlatformTypeNone,
+	// 			}
+	// 			for _, platform := range platforms {
+	// 				p := platform
+	// 				list := GetFeatureSupportList(SupportLevelFilters{
+	// 					OpenshiftVersion:     "4.14",
+	// 					CPUArchitecture:      nil,
+	// 					PlatformType:         &p,
+	// 					HighAvailabilityMode: nil,
+	// 				})
+	// 				Expect(len(list)).To(Equal(16))
+	// 			}
+	// 		})
+	// 		It("GetFeatureSupportList 4.12 with HighAvailabilityMode", func() {
+	// 			list := GetFeatureSupportList(SupportLevelFilters{
+	// 				OpenshiftVersion:     "4.12",
+	// 				CPUArchitecture:      nil,
+	// 				PlatformType:         nil,
+	// 				HighAvailabilityMode: swag.String("does_not_matter_what_is_the_value"),
+	// 			})
+	// 			Expect(len(list)).To(Equal(19))
+	// 		})
+	// 		It("overrideInvalidRequest 4.12 vsphere with HighAvailabilityMode None", func() {
+	// 			platform := models.PlatformTypeVsphere
+	// 			list := GetFeatureSupportList(SupportLevelFilters{
+	// 				OpenshiftVersion:     "4.10",
+	// 				CPUArchitecture:      swag.String(models.ClusterCPUArchitectureX8664),
+	// 				PlatformType:         &platform,
+	// 				HighAvailabilityMode: swag.String(models.ClusterHighAvailabilityModeNone),
+	// 			})
+	// 			for featureId, supportLevel := range list {
+	// 				sl := supportLevel
+	// 				By(fmt.Sprintf("Feature %s", featureId), func() {
+	// 					// All features in that case should be unavailable
+	// 					Expect(sl).To(Equal(models.SupportLevelUnavailable))
+	// 				})
+	// 			}
+	// 		})
+	//
+	// 		It("GetFeatureSupportList 4.12", func() {
+	// 			list := GetFeatureSupportList(SupportLevelFilters{
+	// 				OpenshiftVersion:     "4.12",
+	// 				CPUArchitecture:      nil,
+	// 				PlatformType:         nil,
+	// 				HighAvailabilityMode: nil,
+	// 			})
+	// 			Expect(len(list)).To(Equal(20))
+	// 		})
+	//
+	// 		It("GetFeatureSupportList 4.13", func() {
+	// 			list := GetFeatureSupportList(SupportLevelFilters{
+	// 				OpenshiftVersion:     "4.13",
+	// 				CPUArchitecture:      nil,
+	// 				PlatformType:         nil,
+	// 				HighAvailabilityMode: nil,
+	// 			})
+	// 			Expect(len(list)).To(Equal(20))
+	// >>>>>>> db440e81b (MGMT-15736: Align feature support level to support HighAvailabilityMode as filterable feature)
+	// 		})
 
 	Context("ValidateIncompatibleFeatures", func() {
 		log := logrus.New()
@@ -638,9 +745,11 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 					feature := feature
 					When("Empty support level - platforms", func() {
 						It(fmt.Sprintf("Feature %s Platform %s ExternalPlatformName %s", feature.GetName(), *filters.PlatformType, swag.StringValue(filters.ExternalPlatformName)), func() {
-							emptyFilters := SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: nil, ExternalPlatformName: nil}
-							Expect(string(feature.getSupportLevel(emptyFilters))).To(Not(Equal("")))
-							Expect(string(feature.getSupportLevel(filters))).To(Equal(""))
+							emptyFilters := SupportLevelFilters{OpenshiftVersion: "", CPUArchitecture: nil, PlatformType: nil, ExternalPlatformName: nil, HighAvailabilityMode: nil}
+							Expect(string(feature.getSupportLevel(emptyFilters))).To(Not(Equal("")),
+								fmt.Sprintf("empty filter on feature: %v", feature))
+							Expect(string(feature.getSupportLevel(filters))).To(Equal(""),
+								fmt.Sprintf("feature: %v, with filter %v", feature, filters))
 						})
 					})
 				}
@@ -657,6 +766,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 					})
 				})
 			}
+
 			It("s390x not supporting minimal-iso", func() {
 				cpuArchitecture := models.ClusterCPUArchitectureS390x
 				cluster := common.Cluster{Cluster: models.Cluster{
@@ -769,7 +879,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			DescribeTable(
 				"Valid VipDhcpAllocation and OpenShift version",
 				func(openshiftVersion string) {
-					Expect(IsFeatureAvailable(models.FeatureSupportLevelIDVIPAUTOALLOC, openshiftVersion, swag.String("anyarch"))).To(BeFalse())
+					Expect(IsFeatureAvailable(models.FeatureSupportLevelIDVIPAUTOALLOC, openshiftVersion, swag.String("anyarch"), nil)).To(BeFalse())
 				},
 				Entry("VipAutoAllocation disabled for 4.15", "4.15.3"),
 				Entry("VipAutoAllocation disabled for 4.16", "4.16.2"),
@@ -778,7 +888,7 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 			DescribeTable(
 				"Valid VipDhcpAllocation and OpenShift version",
 				func(openshiftVersion string) {
-					Expect(IsFeatureAvailable(models.FeatureSupportLevelIDVIPAUTOALLOC, openshiftVersion, swag.String("anyarch"))).To(BeTrue())
+					Expect(IsFeatureAvailable(models.FeatureSupportLevelIDVIPAUTOALLOC, openshiftVersion, swag.String("anyarch"), nil)).To(BeTrue())
 				},
 				Entry("VipAutoAllocation enabled for 4.14", "4.14.3"),
 				Entry("VipAutoAllocation enabled for 4.12", "4.12.24"),

--- a/internal/featuresupport/features_misc.go
+++ b/internal/featuresupport/features_misc.go
@@ -63,8 +63,10 @@ func (feature *SnoFeature) getIncompatibleArchitectures(openshiftVersion *string
 }
 
 func (feature *SnoFeature) getFeatureActiveLevel(cluster *common.Cluster, _ *models.InfraEnv, _ *models.V2ClusterUpdateParams, _ *models.InfraEnvUpdateParams) featureActiveLevel {
-	if cluster != nil && swag.StringValue(cluster.HighAvailabilityMode) == models.ClusterHighAvailabilityModeNone {
-		return activeLevelActive
+	if cluster != nil && cluster.HighAvailabilityMode != nil {
+		if *cluster.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			return activeLevelActive
+		}
 	}
 	return activeLevelNotActive
 }

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/assisted-service/internal/common"
 	"github.com/openshift/assisted-service/internal/network"
 	"github.com/openshift/assisted-service/models"
-	"k8s.io/utils/strings/slices"
+	"github.com/thoas/go-funk"
 )
 
 // VipAutoAllocFeature
@@ -30,7 +30,7 @@ func (feature *VipAutoAllocFeature) getSupportLevel(filters SupportLevelFilters)
 		string(models.PlatformTypeExternal),
 		string(models.PlatformTypeNone),
 	}
-	if filters.PlatformType != nil && slices.Contains(
+	if filters.PlatformType != nil && funk.Contains(
 		unavailablePlatform, string(*filters.PlatformType)) {
 		return models.SupportLevelUnavailable
 	}

--- a/internal/featuresupport/features_networking.go
+++ b/internal/featuresupport/features_networking.go
@@ -95,8 +95,10 @@ func (feature *ClusterManagedNetworkingFeature) getSupportLevel(filters SupportL
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
-	if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
-		return models.SupportLevelUnavailable
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			return models.SupportLevelUnavailable
+		}
 	}
 	if swag.StringValue(filters.CPUArchitecture) == models.ClusterCPUArchitectureArm64 {
 		isNotAvailable, err := common.BaseVersionLessThan("4.11", filters.OpenshiftVersion)

--- a/internal/featuresupport/features_olm_operators.go
+++ b/internal/featuresupport/features_olm_operators.go
@@ -61,6 +61,14 @@ func (feature *LvmFeature) getSupportLevel(filters SupportLevelFilters) models.S
 		return models.SupportLevelUnavailable
 	}
 
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeFull {
+			if isNotSupported, err := common.BaseVersionLessThan("4.15", filters.OpenshiftVersion); isNotSupported || err != nil {
+				return models.SupportLevelUnavailable
+			}
+		}
+	}
+
 	if filters.PlatformType != nil && (*filters.PlatformType == models.PlatformTypeVsphere || *filters.PlatformType == models.PlatformTypeNutanix) {
 		return models.SupportLevelUnavailable
 	}
@@ -119,6 +127,11 @@ func (feature *OdfFeature) GetName() string {
 func (feature *OdfFeature) getSupportLevel(filters SupportLevelFilters) models.SupportLevel {
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
+	}
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			return models.SupportLevelUnavailable
+		}
 	}
 
 	return models.SupportLevelSupported
@@ -260,6 +273,13 @@ func (feature *MceFeature) getSupportLevel(filters SupportLevelFilters) models.S
 
 	if filters.PlatformType != nil && (*filters.PlatformType == models.PlatformTypeNutanix) {
 		return models.SupportLevelUnavailable
+	}
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			if filters.PlatformType != nil && (*filters.PlatformType == models.PlatformTypeVsphere) {
+				return models.SupportLevelUnavailable
+			}
+		}
 	}
 
 	return models.SupportLevelSupported

--- a/internal/featuresupport/features_platforms.go
+++ b/internal/featuresupport/features_platforms.go
@@ -155,6 +155,11 @@ func (feature *NutanixIntegrationFeature) getSupportLevel(filters SupportLevelFi
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
 	}
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			return models.SupportLevelUnavailable
+		}
+	}
 
 	if isNotSupported, err := common.BaseVersionLessThan("4.11", filters.OpenshiftVersion); isNotSupported || err != nil {
 		return models.SupportLevelUnavailable
@@ -215,6 +220,12 @@ func (feature *VsphereIntegrationFeature) getSupportLevel(filters SupportLevelFi
 
 	if !isFeatureCompatibleWithArchitecture(feature, filters.OpenshiftVersion, swag.StringValue(filters.CPUArchitecture)) {
 		return models.SupportLevelUnavailable
+	}
+
+	if filters.HighAvailabilityMode != nil {
+		if *filters.HighAvailabilityMode == models.ClusterHighAvailabilityModeNone {
+			return models.SupportLevelUnavailable
+		}
 	}
 
 	return models.SupportLevelSupported

--- a/internal/featuresupport/support_level_feature.go
+++ b/internal/featuresupport/support_level_feature.go
@@ -16,7 +16,7 @@ type SupportLevelFeature interface {
 	New() SupportLevelFeature
 	// getId - Get SupportLevelFeature unique ID
 	getId() models.FeatureSupportLevelID
-	// GetName - Get SupportLevelFeature user friendly name
+	// GetName - Get SupportLevelFeature user-friendly name
 	GetName() string
 	// getSupportLevel - Get feature support-level value, filtered by given filters (e.g. OpenshiftVersion, CpuArchitecture)
 	getSupportLevel(filters SupportLevelFilters) models.SupportLevel
@@ -33,6 +33,7 @@ type SupportLevelFilters struct {
 	CPUArchitecture      *string
 	PlatformType         *models.PlatformType
 	ExternalPlatformName *string
+	HighAvailabilityMode *string
 }
 
 type featureActiveLevel string

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -131,7 +131,7 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 	}
 	if i.enableSkipMcoReboot {
 		request.EnableSkipMcoReboot = featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDSKIPMCOREBOOT,
-			cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture))
+			cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), swag.String(*cluster.HighAvailabilityMode))
 	}
 
 	// those flags are not used on day2 installation

--- a/internal/provider/baremetal/installConfig.go
+++ b/internal/provider/baremetal/installConfig.go
@@ -90,7 +90,7 @@ func (p baremetalProvider) AddPlatformToInstallConfig(
 	}
 	p.Log.Infof("setting Baremetal.ProvisioningNetwork to %s", provNetwork)
 
-	if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+	if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 		cfg.Platform = installcfg.Platform{
 			Baremetal: &installcfg.BareMetalInstallConfigPlatform{
 				ProvisioningNetwork: provNetwork,

--- a/internal/provider/nutanix/installConfig.go
+++ b/internal/provider/nutanix/installConfig.go
@@ -50,7 +50,7 @@ func (p nutanixProvider) AddPlatformToInstallConfig(
 			return errors.New("invalid cluster parameters, IngressVip must be provided")
 		}
 
-		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 			nPlatform.APIVIPs = network.GetApiVips(cluster)
 			nPlatform.IngressVIPs = network.GetIngressVips(cluster)
 		} else {

--- a/internal/provider/platform.go
+++ b/internal/provider/platform.go
@@ -219,7 +219,7 @@ func getUpdateParamsForPlatformUMNMandatory(platform *models.Platform, userManag
 	if !swag.BoolValue(userManagedNetworking) {
 		if platform == nil || isPlatformBM(platform) {
 			if cluster.CPUArchitecture != common.X86CPUArchitecture &&
-				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+				!featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDCLUSTERMANAGEDNETWORKING, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 				return nil, nil, common.NewApiError(http.StatusBadRequest, errors.New("disabling User Managed Networking or setting Bare-Metal platform is not allowed for clusters with non-x86_64 CPU architecture"))
 			}
 

--- a/internal/provider/vsphere/installConfig.go
+++ b/internal/provider/vsphere/installConfig.go
@@ -64,7 +64,7 @@ func (p vsphereProvider) AddPlatformToInstallConfig(cfg *installcfg.InstallerCon
 			return errors.New("invalid cluster parameters, IngressVip must be provided")
 		}
 
-		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture)) {
+		if featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDDUALSTACKVIPS, cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture), cluster.HighAvailabilityMode) {
 			vsPlatform.APIVIPs = network.GetApiVips(cluster)
 			vsPlatform.IngressVIPs = network.GetIngressVips(cluster)
 		} else {

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5859,6 +5859,16 @@ func init() {
             "description": "External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external.",
             "name": "external_platform_name",
             "in": "query"
+          },
+          {
+            "enum": [
+              "Full",
+              "None"
+            ],
+            "type": "string",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "name": "high_availability_mode",
+            "in": "query"
           }
         ],
         "responses": {
@@ -16525,6 +16535,16 @@ func init() {
             "type": "string",
             "description": "External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external.",
             "name": "external_platform_name",
+            "in": "query"
+          },
+          {
+            "enum": [
+              "Full",
+              "None"
+            ],
+            "type": "string",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "name": "high_availability_mode",
             "in": "query"
           }
         ],

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -5866,7 +5866,7 @@ func init() {
               "None"
             ],
             "type": "string",
-            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.",
             "name": "high_availability_mode",
             "in": "query"
           }
@@ -16543,7 +16543,7 @@ func init() {
               "None"
             ],
             "type": "string",
-            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.",
+            "description": "Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.",
             "name": "high_availability_mode",
             "in": "query"
           }

--- a/restapi/operations/installer/get_supported_features_parameters.go
+++ b/restapi/operations/installer/get_supported_features_parameters.go
@@ -48,6 +48,10 @@ type GetSupportedFeaturesParams struct {
 	  In: query
 	*/
 	ExternalPlatformName *string
+	/*Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	  In: query
+	*/
+	HighAvailabilityMode *string
 	/*Version of the OpenShift cluster.
 	  Required: true
 	  In: query
@@ -77,6 +81,11 @@ func (o *GetSupportedFeaturesParams) BindRequest(r *http.Request, route *middlew
 
 	qExternalPlatformName, qhkExternalPlatformName, _ := qs.GetOK("external_platform_name")
 	if err := o.bindExternalPlatformName(qExternalPlatformName, qhkExternalPlatformName, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qHighAvailabilityMode, qhkHighAvailabilityMode, _ := qs.GetOK("high_availability_mode")
+	if err := o.bindHighAvailabilityMode(qHighAvailabilityMode, qhkHighAvailabilityMode, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -142,6 +151,38 @@ func (o *GetSupportedFeaturesParams) bindExternalPlatformName(rawData []string, 
 		return nil
 	}
 	o.ExternalPlatformName = &raw
+
+	return nil
+}
+
+// bindHighAvailabilityMode binds and validates parameter HighAvailabilityMode from query.
+func (o *GetSupportedFeaturesParams) bindHighAvailabilityMode(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.HighAvailabilityMode = &raw
+
+	if err := o.validateHighAvailabilityMode(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateHighAvailabilityMode carries on validations for parameter HighAvailabilityMode
+func (o *GetSupportedFeaturesParams) validateHighAvailabilityMode(formats strfmt.Registry) error {
+
+	if err := validate.EnumCase("high_availability_mode", "query", *o.HighAvailabilityMode, []interface{}{"Full", "None"}, true); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/restapi/operations/installer/get_supported_features_parameters.go
+++ b/restapi/operations/installer/get_supported_features_parameters.go
@@ -48,7 +48,7 @@ type GetSupportedFeaturesParams struct {
 	  In: query
 	*/
 	ExternalPlatformName *string
-	/*Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	/*Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.
 	  In: query
 	*/
 	HighAvailabilityMode *string

--- a/restapi/operations/installer/get_supported_features_urlbuilder.go
+++ b/restapi/operations/installer/get_supported_features_urlbuilder.go
@@ -15,6 +15,7 @@ import (
 type GetSupportedFeaturesURL struct {
 	CPUArchitecture      *string
 	ExternalPlatformName *string
+	HighAvailabilityMode *string
 	OpenshiftVersion     string
 	PlatformType         *string
 
@@ -66,6 +67,14 @@ func (o *GetSupportedFeaturesURL) Build() (*url.URL, error) {
 	}
 	if externalPlatformNameQ != "" {
 		qs.Set("external_platform_name", externalPlatformNameQ)
+	}
+
+	var highAvailabilityModeQ string
+	if o.HighAvailabilityMode != nil {
+		highAvailabilityModeQ = *o.HighAvailabilityMode
+	}
+	if highAvailabilityModeQ != "" {
+		qs.Set("high_availability_mode", highAvailabilityModeQ)
 	}
 
 	openshiftVersionQ := o.OpenshiftVersion

--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -262,11 +262,7 @@ var _ = Describe("Feature support levels API", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for featureID, supportLevel := range response.Payload.Features {
-						filters := featuresupport.SupportLevelFilters{
-              OpenshiftVersion: version, 
-              CPUArchitecture: swag.String(arch),
-              HighAvailabilityMode: swag.String(""),
-            }
+						filters := featuresupport.SupportLevelFilters{OpenshiftVersion: version, CPUArchitecture: swag.String(arch)}
 						featureSupportLevel := featuresupport.GetSupportLevel(models.FeatureSupportLevelID(featureID), filters)
 						Expect(featureSupportLevel).To(BeEquivalentTo(supportLevel))
 					}

--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -262,7 +262,11 @@ var _ = Describe("Feature support levels API", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for featureID, supportLevel := range response.Payload.Features {
-						filters := featuresupport.SupportLevelFilters{OpenshiftVersion: version, CPUArchitecture: swag.String(arch)}
+						filters := featuresupport.SupportLevelFilters{
+              OpenshiftVersion: version, 
+              CPUArchitecture: swag.String(arch),
+              HighAvailabilityMode: swag.String(""),
+            }
 						featureSupportLevel := featuresupport.GetSupportLevel(models.FeatureSupportLevelID(featureID), filters)
 						Expect(featureSupportLevel).To(BeEquivalentTo(supportLevel))
 					}

--- a/subsystem/kubeapi_test.go
+++ b/subsystem/kubeapi_test.go
@@ -1369,7 +1369,7 @@ var _ = Describe("[kube-api]cluster installation", func() {
 		}, "2m", "2s").Should(Equal(0))
 	})
 
-	It("deploy external platform", func() {
+	FIt("deploy external platform", func() {
 		By("Upload CCM manifests for OCI")
 		name := "cloud-controller-manager"
 		namespace := fmt.Sprintf("oci-%s", name)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3720,6 +3720,11 @@ paths:
           name: external_platform_name
           description: External platform name when platform type is set to external. The value of this parameter will be ignored if platform_type is not external.
           type: string
+        - in: query
+          name: high_availability_mode
+          type: string
+          enum: [ 'Full', 'None' ]
+          description: Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
       responses:
         "200":
           description: Success.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3724,7 +3724,7 @@ paths:
           name: high_availability_mode
           type: string
           enum: [ 'Full', 'None' ]
-          description: Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+          description: Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.
       responses:
         "200":
           description: Success.

--- a/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
@@ -75,6 +75,12 @@ type GetSupportedFeaturesParams struct {
 	*/
 	ExternalPlatformName *string
 
+	/* HighAvailabilityMode.
+
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	*/
+	HighAvailabilityMode *string
+
 	/* OpenshiftVersion.
 
 	   Version of the OpenShift cluster.
@@ -173,6 +179,17 @@ func (o *GetSupportedFeaturesParams) SetExternalPlatformName(externalPlatformNam
 	o.ExternalPlatformName = externalPlatformName
 }
 
+// WithHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) WithHighAvailabilityMode(highAvailabilityMode *string) *GetSupportedFeaturesParams {
+	o.SetHighAvailabilityMode(highAvailabilityMode)
+	return o
+}
+
+// SetHighAvailabilityMode adds the highAvailabilityMode to the get supported features params
+func (o *GetSupportedFeaturesParams) SetHighAvailabilityMode(highAvailabilityMode *string) {
+	o.HighAvailabilityMode = highAvailabilityMode
+}
+
 // WithOpenshiftVersion adds the openshiftVersion to the get supported features params
 func (o *GetSupportedFeaturesParams) WithOpenshiftVersion(openshiftVersion string) *GetSupportedFeaturesParams {
 	o.SetOpenshiftVersion(openshiftVersion)
@@ -232,6 +249,23 @@ func (o *GetSupportedFeaturesParams) WriteToRequest(r runtime.ClientRequest, reg
 		if qExternalPlatformName != "" {
 
 			if err := r.SetQueryParam("external_platform_name", qExternalPlatformName); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.HighAvailabilityMode != nil {
+
+		// query param high_availability_mode
+		var qrHighAvailabilityMode string
+
+		if o.HighAvailabilityMode != nil {
+			qrHighAvailabilityMode = *o.HighAvailabilityMode
+		}
+		qHighAvailabilityMode := qrHighAvailabilityMode
+		if qHighAvailabilityMode != "" {
+
+			if err := r.SetQueryParam("high_availability_mode", qHighAvailabilityMode); err != nil {
 				return err
 			}
 		}

--- a/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
+++ b/vendor/github.com/openshift/assisted-service/client/installer/get_supported_features_parameters.go
@@ -77,7 +77,7 @@ type GetSupportedFeaturesParams struct {
 
 	/* HighAvailabilityMode.
 
-	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a full cluster over one node.
+	   Guaranteed availability of the installed cluster. 'Full' installs a Highly-Available cluster over multiple master nodes whereas 'None' installs a cluster over one node.
 	*/
 	HighAvailabilityMode *string
 


### PR DESCRIPTION
- Add parameter to api/assisted-install/v2/support-levels/features API so that the features could be filtered also by high_availability

## example
Request:
High Availability = None 
```bash
> curl -s \ 
'http://localhost:6000/api/assisted-install/v2/support-levels/features?
openshift_version=4.15&high_availability_mode=None&cpu_architecture=x86_64' | jq .
```
Response
```json
{
  "features": {
    "BAREMETAL_PLATFORM": "supported",
    "CLUSTER_MANAGED_NETWORKING": "unavailable",
    "CNV": "supported",
    "CUSTOM_MANIFEST": "supported",
    "DUAL_STACK": "supported",
    "DUAL_STACK_VIPS": "supported",
    "EXTERNAL_PLATFORM": "supported",
    "EXTERNAL_PLATFORM_OCI": "tech-preview",
    "FULL_ISO": "supported",
    "LSO": "supported",
    "LVM": "supported",
    "MCE": "supported",
    "MINIMAL_ISO": "supported",
    "NONE_PLATFORM": "supported",
    "NUTANIX_INTEGRATION": "unavailable",
    "ODF": "unavailable",
    "OVN_NETWORK_TYPE": "supported",
    "SDN_NETWORK_TYPE": "unavailable",
    "SINGLE_NODE_EXPANSION": "supported",
    "SKIP_MCO_REBOOT": "supported",
    "SNO": "supported",
    "USER_MANAGED_NETWORKING": "supported",
    "VIP_AUTO_ALLOC": "unavailable",
    "VSPHERE_INTEGRATION": "unavailable"
  }
}
```
Request:
High Availability = Full 
```bash
> curl -s \
'http://localhost:6000/api/assisted-install/v2/support-levels/features?
openshift_version=4.15&high_availability_mode=Full&cpu_architecture=x86_64' | jq .
```
Response:
```json

{
  "features": {
    "BAREMETAL_PLATFORM": "supported",
    "CLUSTER_MANAGED_NETWORKING": "supported",
    "CNV": "supported",
    "CUSTOM_MANIFEST": "supported",
    "DUAL_STACK": "supported",
    "DUAL_STACK_VIPS": "supported",
    "EXTERNAL_PLATFORM": "supported",
    "EXTERNAL_PLATFORM_OCI": "tech-preview",
    "FULL_ISO": "supported",
    "LSO": "supported",
    "LVM": "supported",
    "MCE": "supported",
    "MINIMAL_ISO": "supported",
    "NONE_PLATFORM": "supported",
    "NUTANIX_INTEGRATION": "supported",
    "ODF": "supported",
    "OVN_NETWORK_TYPE": "supported",
    "SDN_NETWORK_TYPE": "unavailable",
    "SINGLE_NODE_EXPANSION": "supported",
    "SKIP_MCO_REBOOT": "supported",
    "SNO": "supported",
    "USER_MANAGED_NETWORKING": "supported",
    "VIP_AUTO_ALLOC": "unavailable",
    "VSPHERE_INTEGRATION": "supported"
  }
}
```

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [x] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
