### PR TITLE
MGMT-17196: Fix none existens of static MAC adr. in case of specific network devices on s390x.

### DIFF
--- a/internal/host/hostcommands/install_cmd_test.go
+++ b/internal/host/hostcommands/install_cmd_test.go
@@ -1163,7 +1163,7 @@ var _ = Describe("construct host install arguments", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(args).To(Equal(`["--append-karg","rd.neednet=1","--append-karg","zfcp.allow_lun_scan=0","--append-karg","rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1","--append-karg","rd.dasd=0.0.5235","--append-karg","rd.dasd=0.0.5236"]`))
 	})
-	It("s390x and LPAR - static ip w/o nmstate, fcp", func() {
+	It("s390x and LPAR - static ip w/o nmstate(ip cfg override set), fcp", func() {
 		host.Inventory = `{
 				"interfaces":[
 					{
@@ -1176,7 +1176,26 @@ var _ = Describe("construct host install arguments", func() {
 		inventory, _ := common.UnmarshalInventory(host.Inventory)
 		inventory.SystemVendor = &models.SystemVendor{Manufacturer: "IBM/S390"}
 		inventory.SystemVendor.ProductName = ""
-		inventory.Boot = &models.Boot{CommandLine: "rd.neednet=1 console=ttysclp0 coreos.live.rootfs_url=http://172.23.236.156:8080/assisted-installer/rootfs.img ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none nameserver=10.14.6.1 ip=[fd00::3]::[fd00::1]:64::encbdd0:none nameserver=[fd00::1] zfcp.allow_lun_scan=0 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000 random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8"}
+		inventory.Boot = &models.Boot{CommandLine: "rd.neednet=1 ai.ip_cfg_override=1 console=ttysclp0 coreos.live.rootfs_url=http://172.23.236.156:8080/assisted-installer/rootfs.img ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none nameserver=10.14.6.1 ip=[fd00::3]::[fd00::1]:64::encbdd0:none nameserver=[fd00::1] zfcp.allow_lun_scan=0 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000 random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8"}
+
+		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(args).To(Equal(`["--append-karg","rd.neednet=1","--append-karg","ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none","--append-karg","nameserver=10.14.6.1","--append-karg","ip=[fd00::3]::[fd00::1]:64::encbdd0:none","--append-karg","nameserver=[fd00::1]","--append-karg","zfcp.allow_lun_scan=0","--append-karg","rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1","--append-karg","rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000"]`))
+	})
+	It("s390x and LPAR - ip cfg override=0, fcp", func() {
+		host.Inventory = `{
+				"interfaces":[
+					{
+						"name": "eth0",
+						"ipv4_addresses":["192.186.10.12/24"]
+					}
+				]
+			}`
+		cluster.MachineNetworks = []*models.MachineNetwork{{Cidr: "2001:db8::/120"}}
+		inventory, _ := common.UnmarshalInventory(host.Inventory)
+		inventory.SystemVendor = &models.SystemVendor{Manufacturer: "IBM/S390"}
+		inventory.SystemVendor.ProductName = ""
+		inventory.Boot = &models.Boot{CommandLine: "rd.neednet=1 ai.ip_cfg_override=0 console=ttysclp0 coreos.live.rootfs_url=http://172.23.236.156:8080/assisted-installer/rootfs.img ip=10.14.6.3::10.14.6.1:255.255.255.0:master-0.boea3e06.lnxero1.boe:encbdd0:none nameserver=10.14.6.1 ip=[fd00::3]::[fd00::1]:64::encbdd0:none nameserver=[fd00::1] zfcp.allow_lun_scan=0 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 rd.zfcp=0.0.8002,0x500507630400d1e3,0x4000404600000000 random.trust_cpu=on rd.luks.options=discard ignition.firstboot ignition.platform.id=metal console=tty1 console=ttyS1,115200n8"}
 
 		args, err := constructHostInstallerArgs(cluster, host, inventory, infraEnv, log)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
On s390x there are some network configurations where MAC addresses are not static and lead to issues using Assisted Installer, Agent based Installer and HCP (see attached net conf).

For AI and HCP there is a possibility to patch kernel arguments but using the UI there is a separate manual step needed using the API. This will be a bad user experience.
In addition patching the kernel arguments for ABI is not possible.

To solve this, a config override parameter need to be added to the parm file by the user and the ip settings will be automatically passed to the coreos installer regardless what the user configure (DHCP or static IP using nmstate).

See matrix in ticket:
https://issues.redhat.com/browse/MGMT-17196

Doc ticket:
https://issues.redhat.com/browse/MULTIARCH-4537

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?
- Simple parse test by running unit tests

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x ] Title and description added to both, commit and PR.
- [ x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
