### PR TITLE
OCPBUGS-30233: Filter IPs in majority group validation

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1400,7 +1400,7 @@ func (m *Manager) setConnectivityMajorityGroupsForClusterInternal(cluster *commo
 	}
 
 	for _, family := range []network.AddressFamily{network.IPv4, network.IPv6} {
-		majorityGroup, err := network.CreateL3MajorityGroup(hosts, family)
+		majorityGroup, err := network.CreateL3MajorityGroup(hosts, family, network.GetMachineNetworkCidrs(cluster))
 		if err != nil {
 			m.log.WithError(err).Warnf("Create L3 majority group for cluster %s failed", cluster.ID.String())
 		} else {

--- a/internal/network/connectivity_groups_test.go
+++ b/internal/network/connectivity_groups_test.go
@@ -530,6 +530,8 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 	} else {
 		family = IPv6
 	}
+	cidrs := []string{net1CIDR, net2CIDR}
+
 	Describe(fmt.Sprintf("connectivity groups %s", ipVersion), func() {
 		BeforeEach(func() {
 			if ipV4 {
@@ -560,7 +562,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 						Inventory:    makeInventory(nodes[2]),
 					},
 				}
-				ret, err := CreateL3MajorityGroup(hosts, family)
+				ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ret).To(Equal([]strfmt.UUID{}))
 			})
@@ -579,7 +581,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 						Inventory: makeInventory(nodes[2]),
 					},
 				}
-				ret, err := CreateL3MajorityGroup(hosts, family)
+				ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ret).To(Equal([]strfmt.UUID{}))
 			})
@@ -604,7 +606,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory:    makeInventory(nodes[2]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(Equal([]strfmt.UUID{}))
 		})
@@ -632,7 +634,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[2]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(0))
 		})
@@ -660,7 +662,38 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[2]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(HaveLen(3))
+			Expect(ret).To(ContainElement(*nodes[0].id))
+			Expect(ret).To(ContainElement(*nodes[1].id))
+			Expect(ret).To(ContainElement(*nodes[2].id))
+		})
+		It("3 with data - two networks - no machine network CIDRs", func() {
+			hosts := []*models.Host{
+				{
+					ID: nodes[0].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[0]),
+				},
+				{
+					ID: nodes[1].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[2], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[1]),
+				},
+				{
+					ID: nodes[2].id,
+					Connectivity: createConnectivityReport(
+						createL3Remote(nodes[0], l3LinkNet1, l3LinkNet2),
+						createL3Remote(nodes[1], l3LinkNet1, l3LinkNet2)),
+					Inventory: makeInventory(nodes[2]),
+				},
+			}
+			ret, err := CreateL3MajorityGroup(hosts, family, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -691,7 +724,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[2]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(0))
 		})
@@ -730,7 +763,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[3]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(4))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -774,7 +807,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[3]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(4))
 			Expect(ret).To(ContainElement(*nodes[0].id))
@@ -815,7 +848,7 @@ func GenerateL3ConnectivityGroupTests(ipV4 bool, net1CIDR, net2CIDR string) {
 					Inventory: makeInventory(nodes[3]),
 				},
 			}
-			ret, err := CreateL3MajorityGroup(hosts, family)
+			ret, err := CreateL3MajorityGroup(hosts, family, cidrs)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ret).To(HaveLen(3))
 			Expect(ret).To(ContainElement(*nodes[0].id))

--- a/internal/network/machine_network_cidr.go
+++ b/internal/network/machine_network_cidr.go
@@ -281,6 +281,15 @@ func IpInCidr(ipAddr, cidr string) (bool, error) {
 	return ipNet.Contains(ip), nil
 }
 
+func IpInCidrs(ipAddr string, cidrs []string) bool {
+	for _, cidr := range cidrs {
+		if isInCidr, _ := IpInCidr(ipAddr, cidr); isInCidr {
+			return true
+		}
+	}
+	return false
+}
+
 func belongsToNetwork(log logrus.FieldLogger, h *models.Host, machineIpnet *net.IPNet) bool {
 	var inventory models.Inventory
 	err := json.Unmarshal([]byte(h.Inventory), &inventory)


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-30233
Filter the IP addresses when creating connectivity groups to
hosts that belong within the machine network CIDRs
(if they exist) to prevent failing "belongs-to-majority"
validation. Previously, if the IPs were not filtered,
the validation would fail if hosts had IPs on different
NICs that couldn't connect to other hosts. These IPs
were not used and caused the "belongs-to-majority"
validation to fail.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [x] Reviewer's test appreciated: My test environment isn't capable of installing more than a SNO 
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md

/cc @zaneb 