### PR TITLE
MGMT-17313: Create Machine / BMH resources on spoke cluster also for control-plane nodes

### DIFF
--- a/internal/controller/controllers/bmh_agent_controller.go
+++ b/internal/controller/controllers/bmh_agent_controller.go
@@ -1600,8 +1600,8 @@ func (r *BMACReconciler) formatMCSCertificateIgnition(mcsCert string) (string, e
 
 func (r *BMACReconciler) validateWorkerForDay2(log logrus.FieldLogger, agent *aiv1beta1.Agent) bool {
 	// Only worker role is supported for day2 operation
-	if agent.Status.Role != models.HostRoleWorker || agent.Spec.ClusterDeploymentName == nil {
-		log.Debugf("Skipping spoke BareMetalHost reconcile for agent, role %s and clusterDeployment %s.", agent.Status.Role, agent.Spec.ClusterDeploymentName)
+	if agent.Spec.ClusterDeploymentName == nil {
+		log.Debugf("Skipping spoke BareMetalHost reconcile for agent in clusterDeployment %s.", agent.Spec.ClusterDeploymentName)
 		return false
 	}
 	return true


### PR DESCRIPTION
We've supported installing day-2 control-plane nodes for a while now.
But some old `if` condition was missed which prevents Machine / BMH
resources from being created on the spoke cluster for control-plane
nodes.

This commit fixes that `if` condition to ensure BMH and Machine
resources will also be created for day-2 control-plane nodes

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

!!!!! This code was not tested yet, it's just a draft !!!!!

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md