### PR TITLE
MGMT-17354: Update CBO to support dual stack SNO hub deploying an IPv6 spoke

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/openshift/assisted-service/client v0.0.0
 	github.com/openshift/assisted-service/models v0.0.0
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/cluster-baremetal-operator v0.0.0-20231115111127-9178df00c706
+	github.com/openshift/cluster-baremetal-operator v0.0.0-20240207191432-82df158cd2e9
 	github.com/openshift/custom-resource-status v1.1.2
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a

--- a/go.sum
+++ b/go.sum
@@ -1367,8 +1367,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mo
 github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/cluster-baremetal-operator v0.0.0-20231115111127-9178df00c706 h1:4GPO2eNI/GzQ55lj7B0W5uNWaE9ygNhagEdgEm8+7+g=
-github.com/openshift/cluster-baremetal-operator v0.0.0-20231115111127-9178df00c706/go.mod h1:RJShHY6ZNnI4dLZFLJsfSd8gGYHJhWIIgO98ZarSo9Q=
+github.com/openshift/cluster-baremetal-operator v0.0.0-20240207191432-82df158cd2e9 h1:5M8gBJpo3B7BZTnd+hB4mYtgfeWFzSWIWcXyuGHRaw0=
+github.com/openshift/cluster-baremetal-operator v0.0.0-20240207191432-82df158cd2e9/go.mod h1:RJShHY6ZNnI4dLZFLJsfSd8gGYHJhWIIgO98ZarSo9Q=
 github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPfHnSOQoQf/sypqA6A4=
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f h1:LzKRLvLJkWW4+4KsuvMmXJQ81ZZJSm2xxu6jwtn5gN0=

--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -73,7 +73,7 @@ func (r *bmoUtils) GetIronicIPs() ([]string, []string, error) {
 		r.log.WithError(err).Error("unable to get provisioning CR")
 		return nil, nil, err
 	}
-	ironicIPs, inspectorIPs, err := provisioning.GetIronicIPs(*provisioningInfo)
+	ironicIPs, inspectorIPs, err := provisioning.GetIronicIPs(provisioningInfo)
 	if err != nil {
 		r.log.WithError(err).Error("unable to determine Ironic's IP")
 		return nil, nil, err

--- a/vendor/github.com/openshift/cluster-baremetal-operator/provisioning/image_cache.go
+++ b/vendor/github.com/openshift/cluster-baremetal-operator/provisioning/image_cache.go
@@ -93,6 +93,7 @@ func createContainerImageCache(images *Images) corev1.Container {
 		Image:           images.Ironic,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
+			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
 		},
 		Command:      []string{"/bin/runhttpd"},

--- a/vendor/github.com/openshift/cluster-baremetal-operator/provisioning/machine_os_images.go
+++ b/vendor/github.com/openshift/cluster-baremetal-operator/provisioning/machine_os_images.go
@@ -33,6 +33,7 @@ func createInitContainerMachineOSImages(info *ProvisioningInfo, whichImages stri
 			},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			// Needed for hostPath image volume mount
 			Privileged: pointer.BoolPtr(true),
 		},
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -777,7 +777,7 @@ github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1alpha1
-# github.com/openshift/cluster-baremetal-operator v0.0.0-20231115111127-9178df00c706
+# github.com/openshift/cluster-baremetal-operator v0.0.0-20240207191432-82df158cd2e9
 ## explicit; go 1.19
 github.com/openshift/cluster-baremetal-operator/api/v1alpha1
 github.com/openshift/cluster-baremetal-operator/provisioning


### PR DESCRIPTION
Updates CBO to include https://github.com/openshift/cluster-baremetal-operator/pull/380 which is required for a single stack ipv6 cluster to be deployed from a dual-stack hub when the hub is a single node.


## List all the issues related to this PR

https://issues.redhat.com/browse/MGMT-17354

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
