### PR TITLE
MGMT-17361: Changing the addition of configuration release images to run when the instance becomes leader instead of skipping if it not

### DIFF
--- a/internal/releasesources/release_sources.go
+++ b/internal/releasesources/release_sources.go
@@ -265,11 +265,6 @@ func (h *releaseSourcesHandler) mergeEnrichedReleaseImages(staticReleaseImages, 
 // SyncReleaseImages is an internal function intended to perform synchronization of release images and return any errors encountered.
 // This design is due to SyncReleaseImagesThreadFunc being restricted to thread package functionality and not directly handling errors.
 func (h *releaseSourcesHandler) SyncReleaseImages() error {
-	if !h.lead.IsLeader() {
-		h.log.Debug("Not a leader, exiting SyncReleaseImagesThreadFunc")
-		return nil
-	}
-
 	enrichedDynamicReleaseImages, err := h.getDynamicReleaseImages()
 	if err != nil {
 		return err
@@ -446,6 +441,11 @@ func (h *releaseSourcesHandler) deleteAllReleases(tx *gorm.DB) error {
 }
 
 func (h *releaseSourcesHandler) SyncReleaseImagesThreadFunc() {
+	if !h.lead.IsLeader() {
+		h.log.Debug("Not a leader, exiting SyncReleaseImagesThreadFunc")
+		return
+	}
+
 	err := h.SyncReleaseImages()
 	if err != nil {
 		h.log.WithError(err).Warn("Failed to sync OpenShift ReleaseImages")


### PR DESCRIPTION
Currently, when an assisted-service instance starts, it first checks if it is the leader. If it is, the instance deletes all the release images from the database and adds the configuration ones. If not, it bypasses this procedure. Due to the deployment strategy of the service in SaaS, a scenario arises where none of the instances become the leader when executing this flow. This results in an empty database if the service is run for the first time, leading the `/openshift-versions` endpoint to return an empty list. Consequently, the UI is unable to display the new cluster page. To address this issue, I propose modifying the current flow to operate similarly to how migrations are handled: wait to become the leader, then execute the code, and finally release the lock.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
