### PR TITLE
MGMT-17365: Add support for setting agent labels in BMH as annotations

### DIFF
--- a/docs/hive-integration/README.md
+++ b/docs/hive-integration/README.md
@@ -171,6 +171,8 @@ In case that the Bare Metal Operator is installed, the Baremetal Agent Controlle
       - `bmac.agent-install.openshift.io/installer-args`
     - IgnitionConfigOverrides (optional for user to set)
       - `bmac.agent-install.openshift.io/ignition-config-overrides`
+    - AgentLabels (optional for user to set)
+      -  `bmac.agent-install.openshift.io.agent-label.` (prefix)
 - Reconcile the BareMetalHost hardware details by copying the Agent's inventory data to the BMH's `hardwaredetails` annotation.
 - Disable ironic inspection
 
@@ -335,6 +337,28 @@ kind: BareMetalHost
 metadata:
   annotations:
     bmac.agent-install.openshift.io/ignition-config-overrides: '{"ignition": {"version": "3.1.0"}, "storage": {"files": [{"path": "/tmp/example", "contents": {"source": "data:text/plain;base64,aGVscGltdHJhcHBlZGluYXN3YWdnZXJzcGVj"}}]}}'
+  creationTimestamp: "2021-04-14T10:46:57Z"
+  generation: 1
+  name: openshift-worker-0
+  namespace: mynamespace
+spec:
+```
+### Creating agent labels from BMH
+
+There is an option to add agent labels from BMH.  In order to add agent label, a BMH annotation is added.  The annotation key
+has a prefix __bmac.agent-install.openshift.io.agent-label.__. The suffix of the annotation is regarded as the agent label key.
+The annotation value is the agent label value.
+
+Note: Agent labels are just added from BMH annotations. They are not removed if there is no corresponding BMH annotation.
+
+Here is an example of such BMH annotation representing an agent label:
+
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  annotations:
+    bmac.agent-install.openshift.io.agent-label.agent-label: 'label-value'
   creationTimestamp: "2021-04-14T10:46:57Z"
   generation: 1
   name: openshift-worker-0

--- a/internal/controller/controllers/crd_utils.go
+++ b/internal/controller/controllers/crd_utils.go
@@ -185,3 +185,11 @@ func AddLabel(labels map[string]string, labelKey, labelValue string) map[string]
 	labels[labelKey] = labelValue
 	return labels
 }
+
+func getLabel(labels map[string]string, labelKey string) (value string, exists bool) {
+	if labels == nil {
+		return "", false
+	}
+	value, exists = labels[labelKey]
+	return
+}


### PR DESCRIPTION
BMH is the custom resource that is used to add a new host. Agent on the other hand is created automatically when a host registers. Since there is a need to control agent labels the following agent label support was added:

In order to add an entry that controls agent label, a new BMH annotation needs to be added.
The annotation key is prefixed with the string
'bmac.agent-install.openshift.io.agent-label.'.  The remainder of the annotation is considered the label key.
The value of the annotation is a JSON dictionary with 2 possible keys. The key 'operation' can contain one of the values ["add","delete"] which mean that the label can either added , or deleted. The dictionary key 'value' contains the label value.
The value of the annotation is identical to the agent label value.
    
Note: agent labels cannot be deleted by usage of BMH annotations.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @carbonin 