### PR TITLE
MGMT-17412: Change fallbck behavior when error occuring in OpenShift Release Syncer

### DIFF
--- a/internal/releasesources/release_sources_test.go
+++ b/internal/releasesources/release_sources_test.go
@@ -183,7 +183,7 @@ var _ = Describe("SyncReleaseImages", func() {
 	// Testing ReleaseSources with standard ReleaseImages
 
 	It("Should not cause an error with empty release sources", func() {
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			models.ReleaseSources{},
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -217,7 +217,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -242,7 +242,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -267,7 +267,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -292,7 +292,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -317,7 +317,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -346,7 +346,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -378,7 +378,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			},
 		}
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -402,7 +402,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -421,7 +421,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -444,7 +444,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			},
 		}
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -468,7 +468,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),
@@ -482,7 +482,7 @@ var _ = Describe("SyncReleaseImages", func() {
 	// Testing ReleaseImages with standard ReleaseSources
 
 	It("Should not cause an error with empty ReleaseImages", func() {
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			models.ReleaseImages{},
 			common.GetTestLog(),
@@ -503,7 +503,7 @@ var _ = Describe("SyncReleaseImages", func() {
 	})
 
 	It("Should not cause an error with nil ReleaseImages", func() {
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			nil,
 			common.GetTestLog(),
@@ -533,7 +533,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -561,7 +561,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				URL:             swag.String("quay.io/openshift-release-dev/ocp-release:4.11.1-x86_64"),
 			},
 		}
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -579,7 +579,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -597,7 +597,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -615,7 +615,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -636,7 +636,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -666,7 +666,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -692,7 +692,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			releaseImages,
 			common.GetTestLog(),
@@ -758,7 +758,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				releaseImages,
 				common.GetTestLog(),
@@ -856,7 +856,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				releaseImages,
 				common.GetTestLog(),
@@ -954,7 +954,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				releaseImages,
 				common.GetTestLog(),
@@ -1064,7 +1064,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				models.ReleaseSources{},
 				releaseImages,
 				common.GetTestLog(),
@@ -1181,7 +1181,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				models.ReleaseImages{},
 				common.GetTestLog(),
@@ -1311,7 +1311,7 @@ var _ = Describe("SyncReleaseImages", func() {
 			},
 		}
 
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			releaseSources,
 			models.ReleaseImages{},
 			common.GetTestLog(),
@@ -1463,7 +1463,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				releaseImages,
 				common.GetTestLog(),
@@ -1542,7 +1542,7 @@ var _ = Describe("SyncReleaseImages", func() {
 				},
 			}
 
-			handler, err = NewReleaseSourcesHandler(
+			handler, err = newReleaseSourcesHandler(
 				releaseSources,
 				releaseImages,
 				common.GetTestLog(),
@@ -1577,7 +1577,7 @@ var _ = Describe("SyncReleaseImages", func() {
 	})
 
 	It("Should be successfull with valid static and dynamic release images extended scenario", func() {
-		handler, err = NewReleaseSourcesHandler(
+		handler, err = newReleaseSourcesHandler(
 			defaultReleaseSources,
 			staticReleaseImages,
 			common.GetTestLog(),


### PR DESCRIPTION
If release images are already present in the database, the service should continue to use this stale data instead of failing. In addition, currently failure to fetch new release images from the API does not trigger an error, allowing the service to proceed, truncate the table, and insert only static images. Hence, I propose treating failures to fetch release images as errors as well.

## Failure Scenarios of `OpenShift Release Syncer`

| Scenario              | Currently                                                                                   | Target                                                                                       |
|-----------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| **Startup & Empty Table** | Service fails to start.                                                                     | Service should fail to start.                   |
| **Startup & Full Table** | Service fails to start.                                                                     | Service should start successfully with stale data.              |
| **Routine & Empty Table** | Shouldn't happen, though if it does then the service will continue using stale data.                                                                          | Shouldn't happen, though if it does then the service should continue using stale data.                                                                            |
| **Routine & Full Table**  | The service will continue using stale data. | The service should continue using stale data.                                 |
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
