### PR TITLE
MGMT-17414: Changing requirements for LVM on 4.16

### DIFF
--- a/internal/operators/lvm/config.go
+++ b/internal/operators/lvm/config.go
@@ -5,6 +5,7 @@ const (
 	LvmsMinOpenshiftVersion4_12                        string = "4.12.0"
 	LvmsMinOpenshiftVersion_ForNewResourceRequirements string = "4.13.0"
 	LvmMinMultiNodeSupportVersion                      string = "4.15.0"
+	LvmNewResourcesOpenshiftVersion4_16                string = "4.16.0"
 
 	LvmoSubscriptionName string = "odf-lvm-operator"
 	LvmsSubscriptionName string = "lvms-operator"
@@ -14,4 +15,5 @@ type Config struct {
 	LvmCPUPerHost                 int64 `envconfig:"LVM_CPU_PER_HOST" default:"1"`
 	LvmMemoryPerHostMiB           int64 `envconfig:"LVM_MEMORY_PER_HOST_MIB" default:"400"`
 	LvmMemoryPerHostMiBBefore4_13 int64 `envconfig:"LVM_MEMORY_PER_HOST_MIB" default:"1200"`
+	LvmMemoryPerHostMiBFrom4_16   int64 `envconfig:"LVM_MEMORY_PER_HOST_MIB" default:"100"`
 }

--- a/internal/operators/lvm/lvm_operator.go
+++ b/internal/operators/lvm/lvm_operator.go
@@ -184,6 +184,10 @@ func (o *operator) GetPreflightRequirements(context context.Context, cluster *co
 		memoryRequirements = o.Config.LvmMemoryPerHostMiBBefore4_13
 	}
 
+	if ok, _ := common.BaseVersionGreaterOrEqual(LvmNewResourcesOpenshiftVersion4_16, cluster.OpenshiftVersion); ok {
+		memoryRequirements = o.Config.LvmMemoryPerHostMiBFrom4_16
+	}
+
 	return &models.OperatorHardwareRequirements{
 		OperatorName: o.GetName(),
 		Dependencies: dependecies,

--- a/internal/operators/lvm/lvm_operator_test.go
+++ b/internal/operators/lvm/lvm_operator_test.go
@@ -176,6 +176,10 @@ var _ = Describe("Lvm Operator", func() {
 			CPUCores: operator.Config.LvmCPUPerHost,
 			RAMMib:   operator.Config.LvmMemoryPerHostMiBBefore4_13,
 		}
+		successResultAfter4_16 := models.ClusterHostRequirementsDetails{
+			CPUCores: operator.Config.LvmCPUPerHost,
+			RAMMib:   operator.Config.LvmMemoryPerHostMiBFrom4_16,
+		}
 		successResultMasterfull := models.ClusterHostRequirementsDetails{
 			CPUCores: 0,
 			RAMMib:   0,
@@ -266,6 +270,16 @@ var _ = Describe("Lvm Operator", func() {
 				name:                 "SNO 4.11.0, not supported",
 				ocpVersion:           "4.10.0",
 				result:               &successResultBefore4_13,
+				clusterhosts:         []*models.Host{},
+				hostCPU:              12,
+				HighAvailabilityMode: models.ClusterHighAvailabilityModeNone,
+				hostRole:             models.HostRoleMaster,
+				hostMem:              32 * conversions.GiB,
+			},
+			{
+				name:                 "SNO 4.16.0",
+				ocpVersion:           "4.16.0",
+				result:               &successResultAfter4_16,
 				clusterhosts:         []*models.Host{},
 				hostCPU:              12,
 				HighAvailabilityMode: models.ClusterHighAvailabilityModeNone,


### PR DESCRIPTION
As part of the effort to reduce LVM footprint. We have Adjusted new requirement for OCP 4.16.
Memory required:
- Before: 400MiB
- New: 100MiB


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)


## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
