### PR TITLE
MGMT-17513: Change the latest release image retrieved in GetReleaseImage using major.minor OpenShift version to latest non-beta release image if exists, or latest beta release image otherwise

### DIFF
--- a/internal/versions/rest_api_versions_test.go
+++ b/internal/versions/rest_api_versions_test.go
@@ -88,19 +88,38 @@ var _ = Describe("GetReleaseImage", func() {
 			{
 				OpenshiftVersion: swag.String("4.14"),
 				Version:          swag.String("4.14.3"),
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.3-x86_64"),
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
+				Default:          false,
+			},
+			{
+				OpenshiftVersion: swag.String("4.14"),
+				Version:          swag.String("4.14.3"),
 				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
 				CPUArchitectures: []string{common.ARM64CPUArchitecture},
 				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.3-aarch64"),
 				SupportLevel:     models.ReleaseImageSupportLevelProduction,
 				Default:          false,
 			},
+
 			{
 				OpenshiftVersion: swag.String("4.15"),
 				Version:          swag.String("4.15.1"),
 				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
 				CPUArchitectures: []string{common.X86CPUArchitecture},
 				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.15.1-x86_64"),
-				SupportLevel:     models.ReleaseImageSupportLevelProduction,
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
+				Default:          false,
+			},
+			{
+				OpenshiftVersion: swag.String("4.15"),
+				Version:          swag.String("4.15.2"),
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.15.2-x86_64"),
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
 				Default:          false,
 			},
 		}
@@ -111,6 +130,10 @@ var _ = Describe("GetReleaseImage", func() {
 		releaseImage, err := handler.GetReleaseImage(ctx, "4.14", common.X86CPUArchitecture, pullSecret)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(*releaseImage.Version).Should(Equal("4.14.2"))
+
+		releaseImage, err = handler.GetReleaseImage(ctx, "4.15", common.X86CPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.Version).Should(Equal("4.15.2"))
 	})
 
 	It("gets the exact matching release image with major.minor.patch / prerelease openshiftVersion", func() {


### PR DESCRIPTION
Currently `GetReleaseImage` function retrieves the latest matching release image found if when the `OpenShift` version specified is in the form of major.minor. This PR Changes the latest release image retrieved in `GetReleaseImage` using major.minor `OpenShift` version to latest non-beta release image if exists, or latest beta release image otherwise.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
