### PR TITLE
MGMT-17468: Use x86_64 over amd64 and arm64 over aarch64 for CPU architecture of both release and OS images to comply with ABI current behavior

### DIFF
--- a/internal/versions/common_test.go
+++ b/internal/versions/common_test.go
@@ -95,6 +95,42 @@ var _ = Describe("NewHandler", func() {
 		Expect(err).Should(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("version"))
 	})
+
+	It("Normalizes CPU architecture", func() {
+		releaseImages := models.ReleaseImages{
+			&models.ReleaseImage{
+				OpenshiftVersion: swag.String("4.14"),
+				Version:          swag.String("4.14.1"),
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				URL:              swag.String("release_4.14"),
+			},
+			&models.ReleaseImage{
+				OpenshiftVersion: swag.String("4.14"),
+				Version:          swag.String("4.14.1"),
+				CPUArchitecture:  swag.String(common.AARCH64CPUArchitecture),
+				URL:              swag.String("release_4.14"),
+			},
+		}
+
+		_, err := NewHandler(common.GetTestLog(), nil, releaseImages, nil, "", nil, nil, nil, false, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*releaseImages[0].CPUArchitecture).To(Equal(common.X86CPUArchitecture))
+		Expect(*releaseImages[1].CPUArchitecture).To(Equal(common.ARM64CPUArchitecture))
+	})
+
+	It("Validates CPU architecture", func() {
+		releaseImages := models.ReleaseImages{
+			&models.ReleaseImage{
+				OpenshiftVersion: swag.String("4.14"),
+				Version:          swag.String("4.14.1"),
+				CPUArchitecture:  swag.String(common.AMD64CPUArchitecture),
+				URL:              swag.String("release_4.14"),
+			},
+		}
+
+		_, err := NewHandler(common.GetTestLog(), nil, releaseImages, nil, "", nil, nil, nil, false, nil)
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 var _ = Describe("validateReleaseImageForRHCOS", func() {

--- a/internal/versions/kube_api_versions_test.go
+++ b/internal/versions/kube_api_versions_test.go
@@ -267,6 +267,12 @@ var _ = Describe("GetReleaseImage", func() {
 		Expect(*releaseImage.Version).Should(Equal("4.12.999-rc.4"))
 	})
 
+	It("gets successfuly single-arch image with normaliznig CPU architecture", func() {
+		releaseImage, err := h.GetReleaseImage(ctx, "4.9-candidate_arm64", common.AARCH64CPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.OpenshiftVersion).Should(Equal("4.9"))
+	})
+
 	It("returns the matching CPU architecture over multi-arch if it is present", func() {
 		h.releaseImages = models.ReleaseImages{
 			&models.ReleaseImage{

--- a/internal/versions/rest_api_versions.go
+++ b/internal/versions/rest_api_versions.go
@@ -31,6 +31,7 @@ type restAPIVersionsHandler struct {
 // For OpenShift versions specified as major.minor, it fetches the latest matching release image.
 // The function returns an error Returns an error for other formats of OpenShift version or if no matching image can be found.
 func (h *restAPIVersionsHandler) GetReleaseImage(_ context.Context, openshiftVersion, cpuArchitecture, _ string) (*models.ReleaseImage, error) {
+	cpuArchitecture = common.NormalizeCPUArchitecture(cpuArchitecture)
 	// validations
 	if err := validateCPUArchitecture(cpuArchitecture); err != nil {
 		return nil, err

--- a/internal/versions/rest_api_versions_test.go
+++ b/internal/versions/rest_api_versions_test.go
@@ -381,6 +381,27 @@ var _ = Describe("GetReleaseImage", func() {
 		Expect(releaseImage).To(BeNil())
 	})
 
+	It("gets successfully with normalizing CPU architecture", func() {
+		releaseImages := models.ReleaseImages{
+			{
+				OpenshiftVersion: swag.String("4.14"),
+				Version:          swag.String("4.14.1"),
+				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+				CPUArchitectures: []string{common.ARM64CPUArchitecture},
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.1-aarch64"),
+				SupportLevel:     models.ReleaseImageSupportLevelProduction,
+				Default:          false,
+			},
+		}
+
+		err := db.Create(releaseImages).Error
+		Expect(err).ShouldNot(HaveOccurred())
+
+		releaseImage, err := handler.GetReleaseImage(ctx, "4.14.1", common.AARCH64CPUArchitecture, pullSecret)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(*releaseImage.Version).To(Equal("4.14.1"))
+	})
+
 	It("filters ignored release images successfully with major.minor ignored versions", func() {
 		releaseImages := models.ReleaseImages{
 			{


### PR DESCRIPTION
Currently assisted-service `normalizes` only release images in `kubeAPI` flow. we want it to `normalize` in `restAPI` flow as well. This is due to the nature of `ABI` flow currently, which starts the service with a release image with CPU architecture `aarch64`, but registers a cluster with `arm64` release image, and same with OS imags. In order to neatralize these differentials, this PR changes the way release and OS images are created and later fetched by normalizing it in creation and then during fetching.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
