### PR TITLE
NO-ISSUE: Change only-latest api response to compare versions according to pre-release suffix as well instead of just base version

### DIFF
--- a/internal/common/version.go
+++ b/internal/common/version.go
@@ -69,18 +69,6 @@ func BaseVersionEqual(version1, versionMayEqual string) (bool, error) {
 	return *majorMinorVersion1 == *majorMinorVersionMayEqual, nil
 }
 
-func MajorMinorPatchEqual(firstVersion, secondVersion string) (*bool, error) {
-	if GetVersionFormat(firstVersion) != MajorMinorPatchVersion {
-		return nil, fmt.Errorf("version '%s' is not in the form of major.minor.patch or major.minor.patch-<prerelease>", firstVersion)
-	}
-
-	if GetVersionFormat(secondVersion) != MajorMinorPatchVersion {
-		return nil, fmt.Errorf("version '%s' is not in the form of major.minor.patch or major.minor.patch-<prerelease>", secondVersion)
-	}
-
-	return swag.Bool(strings.Split(firstVersion, "-")[0] == strings.Split(secondVersion, "-")[0]), nil
-}
-
 func GetMajorMinorVersion(version string) (*string, error) {
 	version = strings.Split(version, "-")[0]
 	splittedVersion := strings.Split(version, ".")

--- a/internal/common/version_test.go
+++ b/internal/common/version_test.go
@@ -143,16 +143,3 @@ var _ = DescribeTable("GetVersionFormat", func(input string, expectedVersionForm
 	Entry("empty version", "", NoneVersion),
 	Entry("non-version string", "non-version", NoneVersion),
 )
-
-var _ = DescribeTable("MajorMinorPatchEqual", func(firstVersion string, secondVersion string, ExpectedResult *bool) {
-	isEqual, _ := MajorMinorPatchEqual(firstVersion, secondVersion)
-	Expect(isEqual).To(Equal(ExpectedResult))
-},
-	Entry("two equal x.y.z versions", "4.11.0", "4.11.0", swag.Bool(true)),
-	Entry("two not unequal x.y.z versions", "4.11.0", "4.11.1", swag.Bool(false)),
-	Entry("one x.y.z version and one x.y.z-something version, equal", "4.11.0", "4.11.0-alpha", swag.Bool(true)),
-	Entry("one x.y.z version and one x.y.z-something version, unequal", "4.11.0", "4.12.0-alpha", swag.Bool(false)),
-	Entry("majorMinorVersions", "4.11", "4.11", nil),
-	Entry("majorVersions", "4", "4", nil),
-	Entry("malformed versions", "foobar", "foobar", nil),
-)

--- a/internal/versions/api.go
+++ b/internal/versions/api.go
@@ -98,16 +98,17 @@ func getLatestReleaseImagesForMajorMinor(releaseImages models.ReleaseImages, maj
 		}
 
 		// If it is the same version but different CPU architecture, add the atchitecture to the list.
-		isEqual, err := common.MajorMinorPatchEqual(*releaseImage.Version, *latestReleaseImages[0].Version)
-		if err != nil {
-			return nil, err
-		}
-		if *isEqual && !funk.Contains(latestReleaseImages, releaseImage) {
+		// We omit the "-multi" suffix if it exists so multi will be considered the same version.
+		if strings.TrimSuffix(*releaseImage.Version, "-multi") == strings.TrimSuffix(*latestReleaseImages[0].Version, "-multi") &&
+			!funk.Contains(latestReleaseImages, releaseImage) {
 			latestReleaseImages = append(latestReleaseImages, releaseImage)
 			continue
 		}
 
-		isNewest, err := common.BaseVersionLessThan(*releaseImage.Version, *latestReleaseImages[0].Version)
+		isNewest, err := common.VersionGreaterOrEqual(
+			strings.TrimSuffix(*releaseImage.Version, "-multi"),
+			strings.TrimSuffix(*latestReleaseImages[0].Version, "-multi"),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/versions/api_test.go
+++ b/internal/versions/api_test.go
@@ -570,6 +570,30 @@ var _ = Describe("V2ListSupportedOpenshiftVersions", func() {
 				Version:          swag.String("4.13.2-multi"),
 				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
 			},
+			{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				OpenshiftVersion: swag.String("4.14"),
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.0-ec.2-x86_64"),
+				Version:          swag.String("4.14.0-ec.2"),
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
+			},
+			{
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture},
+				OpenshiftVersion: swag.String("4.14"),
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.0-ec.3-x86_64"),
+				Version:          swag.String("4.14.0-ec.3"),
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
+			},
+			{
+				CPUArchitecture:  swag.String(common.MultiCPUArchitecture),
+				CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+				OpenshiftVersion: swag.String("4.14-multi"),
+				URL:              swag.String("quay.io/openshift-release-dev/ocp-release:4.14.0-ec.3-multi"),
+				Version:          swag.String("4.14.0-ec.3-multi"),
+				SupportLevel:     models.OpenshiftVersionSupportLevelBeta,
+			},
 		}
 
 		osImages := osImageList{
@@ -607,7 +631,19 @@ var _ = Describe("V2ListSupportedOpenshiftVersions", func() {
 				OpenshiftVersion: swag.String("4.13"),
 				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
 				URL:              swag.String("https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.13/4.13.48/rhcos-4.13.48-aarch64-live.aarch64.iso"),
-				Version:          swag.String("411.86.202308081056-0"),
+				Version:          swag.String("413.86.202308081056-0"),
+			},
+			{
+				OpenshiftVersion: swag.String("4.14"),
+				CPUArchitecture:  swag.String(common.X86CPUArchitecture),
+				URL:              swag.String("https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.14/4.14.48/rhcos-4.14.48-x86_64-live.x86_64.iso"),
+				Version:          swag.String("414.86.202308081056-0"),
+			},
+			{
+				OpenshiftVersion: swag.String("4.14"),
+				CPUArchitecture:  swag.String(common.ARM64CPUArchitecture),
+				URL:              swag.String("https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.14/4.14.48/rhcos-4.14.48-aarch64-live.aarch64.iso"),
+				Version:          swag.String("414.86.202308081056-0"),
 			},
 		}
 
@@ -672,6 +708,24 @@ var _ = Describe("V2ListSupportedOpenshiftVersions", func() {
 					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
 					Default:          false,
 				},
+				"4.14.0-ec.2": {
+					DisplayName:      swag.String("4.14.0-ec.2"),
+					CPUArchitectures: []string{common.X86CPUArchitecture},
+					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
+					Default:          false,
+				},
+				"4.14.0-ec.3": {
+					DisplayName:      swag.String("4.14.0-ec.3"),
+					CPUArchitectures: []string{common.X86CPUArchitecture},
+					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
+					Default:          false,
+				},
+				"4.14.0-ec.3-multi": {
+					DisplayName:      swag.String("4.14.0-ec.3-multi"),
+					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
+					Default:          false,
+				},
 			}
 
 			reply := handler.V2ListSupportedOpenshiftVersions(
@@ -710,6 +764,18 @@ var _ = Describe("V2ListSupportedOpenshiftVersions", func() {
 				},
 				"4.13.2-multi": {
 					DisplayName:      swag.String("4.13.2-multi"),
+					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
+					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
+					Default:          false,
+				},
+				"4.14.0-ec.3": {
+					DisplayName:      swag.String("4.14.0-ec.3"),
+					CPUArchitectures: []string{common.X86CPUArchitecture},
+					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
+					Default:          false,
+				},
+				"4.14.0-ec.3-multi": {
+					DisplayName:      swag.String("4.14.0-ec.3-multi"),
 					CPUArchitectures: []string{common.X86CPUArchitecture, common.ARM64CPUArchitecture},
 					SupportLevel:     swag.String(models.OpenshiftVersionSupportLevelBeta),
 					Default:          false,


### PR DESCRIPTION
Currently in `../openshift-versions?only_latest=true` request latest release images are compared with base version only, while this doesn't work for early beta releases. This PR fixed this issue by comparing all version.  

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
