### PR TITLE
MGMT-17620: Change the way multi-arch release images are handled in RestAPI flow 

### DIFF
--- a/subsystem/cluster_v2_test.go
+++ b/subsystem/cluster_v2_test.go
@@ -540,11 +540,11 @@ var _ = Describe("[V2ClusterTests] multiarch", func() {
 			clusterReq, err := user2BMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{
 				NewClusterParams: &models.ClusterCreateParams{
 					Name:                  swag.String("test-cluster"),
-					OpenshiftVersion:      swag.String("4.12"),
+					OpenshiftVersion:      swag.String("4.12-multi"),
 					PullSecret:            swag.String(fmt.Sprintf(psTemplate, FakePS2)),
 					BaseDNSDomain:         "example.com",
 					UserManagedNetworking: swag.Bool(true),
-					CPUArchitecture:       common.MultiCPUArchitecture,
+					CPUArchitecture:       common.S390xCPUArchitecture,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/subsystem/feature_support_levels_test.go
+++ b/subsystem/feature_support_levels_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Feature support levels API", func() {
 
 		Context("Update cluster", func() {
 			It("Update umn true won't fail on 4.13 with multi release without infra-env", func() {
-				cluster, err := registerNewCluster("4.13", common.MultiCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
+				cluster, err := registerNewCluster("4.13-multi", common.MultiCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cluster.Payload.CPUArchitecture).To(Equal(common.MultiCPUArchitecture))
 
@@ -117,7 +117,7 @@ var _ = Describe("Feature support levels API", func() {
 
 			It("Update umn true fail on 4.13 with s390x with infra-env", func() {
 				expectedError := "cannot use Cluster Managed Networking because it's not compatible with the s390x architecture on version 4.13"
-				cluster, err := registerNewCluster("4.13", common.MultiCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
+				cluster, err := registerNewCluster("4.13-multi", common.S390xCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cluster.Payload.CPUArchitecture).To(Equal(common.MultiCPUArchitecture))
 
@@ -138,7 +138,7 @@ var _ = Describe("Feature support levels API", func() {
 
 			It("Create infra-env after updating OLM operators on s390x architecture ", func() {
 				expectedError := "cannot use OpenShift Virtualization because it's not compatible with the s390x architecture on version 4.13"
-				cluster, err := registerNewCluster("4.13", common.MultiCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
+				cluster, err := registerNewCluster("4.13-multi", common.S390xCPUArchitecture, models.ClusterHighAvailabilityModeFull, swag.Bool(true))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cluster.Payload.CPUArchitecture).To(Equal(common.MultiCPUArchitecture))
 

--- a/subsystem/operators_test.go
+++ b/subsystem/operators_test.go
@@ -317,7 +317,7 @@ var _ = Describe("Operators endpoint tests", func() {
 				swag.String(models.ClusterCPUArchitectureArm64),
 				nil,
 			)
-			Expect(cluster.Payload.CPUArchitecture).To(Equal(models.ClusterCPUArchitectureArm64))
+			Expect(cluster.Payload.CPUArchitecture).To(Equal(common.MultiCPUArchitecture))
 			Expect(len(cluster.Payload.MonitoredOperators)).To(Equal(1))
 
 			infraEnvParams := installer.RegisterInfraEnvParams{


### PR DESCRIPTION
Up until https://issues.redhat.com/browse/MGMT-10088, assisted-service was handling multi-arch release images in a way that basically means if you requested for (in GetReleaseImage) a release image with `openshiftVersion` and `cpuArchitecture` where cpuArchitecture is single-arch, you could get back a multi-arch release if it contains the requested architecture in its manifest. This behavior seems to evolve due to historical reasons where CPU architectures like `s390x` and `ppc64le` where only accessible using multi-arch images. In https://issues.redhat.com/browse/MGMT-10088 PRs, this behavior was changed to require `cpuArchitecture-multi` in case where openshiftVersion=<multi-arch-release>, as the reasoning before no longer true. Nevertheless, the UI still registers cluster with openshiftVersion=<multi-arch-release> and `cpuArchitecture=<single-arch>, which caused failure. This PR changes the service behavior to allow the old flow  along with the new one.
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
