### PR TITLE
NO-ISSUE: Update OKD images to 4.16

### DIFF
--- a/data/default_okd_os_images.json
+++ b/data/default_okd_os_images.json
@@ -1,8 +1,8 @@
 [
     {
-        "openshift_version": "4.12",
+        "openshift_version": "4.16",
         "cpu_architecture": "x86_64",
-        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso",
-        "version": "37.20221225.3.0"
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso",
+        "version": "39.20240322.3.1"
     }
 ]

--- a/data/default_okd_release_images.json
+++ b/data/default_okd_release_images.json
@@ -1,10 +1,11 @@
 [
     {
-        "openshift_version": "4.12",
+        "openshift_version": "4.16",
         "cpu_architecture": "x86_64",
         "cpu_architectures": ["x86_64"],
-        "url": "quay.io/openshift/okd:4.12.0-0.okd-2023-03-18-084815",
-        "version": "4.12.0-0.okd-2023-03-18-084815",
-        "default": true
+        "url": "registry.ci.openshift.org/origin/release:4.16",
+        "version": "4.16.0-0.okd",
+        "default": true,
+        "support_level": "beta"
     }
 ]

--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -27,7 +27,7 @@ data:
   PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
   SERVICE_BASE_URL: http://127.0.0.1:8090
   STORAGE: filesystem
-  OS_IMAGES: '[{"openshift_version":"4.12","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso","version":"37.20221225.3.0"}]'
-  RELEASE_IMAGES: '[{"openshift_version":"4.12","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift/okd:4.12.0-0.okd-2023-03-18-084815","version":"4.12.0-0.okd-2023-03-18-084815","default":true}]'
+  OS_IMAGES: '[{"openshift_version":"4.16","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/39.20240322.3.1/x86_64/fedora-coreos-39.20240322.3.1-live.x86_64.iso","version":"39.20240322.3.1"}]'
+  RELEASE_IMAGES: '[{"openshift_version":"4.16","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"registry.ci.openshift.org/origin/release:4.16","version":"4.16.0-0.okd","default":true,"support_level":"beta"}]'
   ENABLE_UPGRADE_AGENT: "false"
   ENABLE_OKD_SUPPORT: "true"


### PR DESCRIPTION
The goal is to have an assisted installer job on master that installs
OKD.

x-ref: https://github.com/openshift/release/pull/50983