### PR TITLE
OCPBUGS-31733: Remove CPMS manifest for vSphere platform

### DIFF
--- a/internal/provider/vsphere/ignition.go
+++ b/internal/provider/vsphere/ignition.go
@@ -35,6 +35,15 @@ func (p vsphereProvider) PostCreateManifestsHook(_ *common.Cluster, _ *[]string,
 		return fmt.Errorf("error deleting machineset: %w", err)
 	}
 
+	// Delete machine-api control plane machine set manifest
+	p.Log.Info("Deleting machine-api control plane machine set manifest")
+	files, _ = filepath.Glob(path.Join(workDir, "openshift", "*_openshift-machine-api_master-control-plane-machine-set.yaml"))
+	err = p.deleteAllFiles(files)
+
+	if err != nil {
+		return fmt.Errorf("error deleting control plane machine set: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The control-plane-machine-set (CPMS) cluster operator fails to deploy on 4.16-ec.5 build for ABI deployments on vSphere. That build removed the CPMS feature gate.

Because ABI and assisted deployments do not create or include machines in the manifests, and the control plane machine operator expects machines to be present for each control plane node, the CO fails to deploy.

The CPMS manifest should be removed for ABI and other UPI-like deployments.

For UPI there is documentation indicating the CPMS manifest must be removed: https://docs.openshift.com/container-platform/4.15/installing/installing_vsphere/upi/installing-vsphere.html#installation-user-infra-generate-k8s-manifest-ignition_installing-vsphere

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested) - Deployed a cluster on vSphere using ABI with this PR included in a custom assisted-service image and checked the control-plane-machine-set cluster operator does not fail.
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
