### PR TITLE
MGMT-17697: Change L3 connectivity to use connected addresses instead of majority groups

### DIFF
--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -2260,11 +2260,11 @@ var _ = Describe("Majority groups", func() {
 	}
 	expect := func(networks ...string) {
 		c := getClusterFromDB(*cluster.ID, db)
-		majorityGroups := make(map[string][]strfmt.UUID)
-		Expect(json.Unmarshal([]byte(c.ConnectivityMajorityGroups), &majorityGroups)).ToNot(HaveOccurred())
-		Expect(majorityGroups).ToNot(BeEmpty())
+		var connectivity network.Connectivity
+		Expect(json.Unmarshal([]byte(c.ConnectivityMajorityGroups), &connectivity)).ToNot(HaveOccurred())
+		Expect(connectivity.MajorityGroups).ToNot(BeEmpty())
 		for _, n := range []string{"1.2.3.0/24", "10.0.0.0/24"} {
-			group := majorityGroups[n]
+			group := connectivity.MajorityGroups[n]
 			if funk.ContainsString(networks, n) {
 				for _, h := range cluster.Hosts {
 					Expect(group).To(ContainElement(*h.ID))


### PR DESCRIPTION
Currently when L3 connectivity groups, there must be symmetrical connectivity between all nodes. This poses restriction that nodes cannot have networks that do not participate in cluster networking.

Instead, the L3 connectivity will change to connected addresses. A connected address is in address that can be reached from all other hosts. So if a host has a connected address, then it is regarded as host that belongs to majority group (the validation).

[MGMT-17698](https://issues.redhat.com//browse/MGMT-17698): Add to majority groups connected addresses

n order to use the L3 connected addresses the JSON encoded string in the ConnectivityMajorityGroups field in cluster must be changed. It will become a dictionary. One key will be the "majority_groups". It will contain the old dictionary as before. Another key will be "l3_connected_addresses" which will contain a dictionary with host-id keys. The values will be a list of all the connected addresses for that host.

[MGMT-17699](https://issues.redhat.com//browse/MGMT-17699): Change none platform validation to use the connected addresses

Change the belongs-to-majority-groups validation for none platform to use the "l3_connected_addresses".  This will remove the restriction that all the addresses in a host must be connected.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @tsorya 