### PR TITLE
MGMT-17523: Fail when OS images CPU architecture is missing instead of giving it default value

### DIFF
--- a/internal/versions/osimages.go
+++ b/internal/versions/osimages.go
@@ -51,8 +51,8 @@ func validateOSImage(osImage *models.OsImage) error {
 	if swag.StringValue(osImage.Version) == "" {
 		return errors.Errorf(fmt.Sprintf(missingValueTemplate, "version", *osImage.OpenshiftVersion))
 	}
-	if swag.StringValue(osImage.CPUArchitecture) == "" {
-		osImage.CPUArchitecture = swag.String(common.DefaultCPUArchitecture)
+	if osImage.CPUArchitecture == nil {
+		return errors.Errorf("osImage version '%s' CPU architecture is missing", *osImage.OpenshiftVersion)
 	}
 	if err := osImage.Validate(strfmt.Default); err != nil {
 		return errors.Wrapf(err, "osImage version '%s' CPU architecture is not valid", *osImage.OpenshiftVersion)

--- a/internal/versions/osimages_test.go
+++ b/internal/versions/osimages_test.go
@@ -35,7 +35,7 @@ var _ = Describe("NewOSImages", func() {
 		Expect(err).Should(HaveOccurred())
 	})
 
-	It("should not fail when missing CPU architecture, should set to default", func() {
+	It("should fail when missing CPU architecture", func() {
 		osImages := models.OsImages{
 			{
 				OpenshiftVersion: swag.String("4.14"),
@@ -45,8 +45,7 @@ var _ = Describe("NewOSImages", func() {
 		}
 
 		_, err := NewOSImages(osImages)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(*osImages[0].CPUArchitecture).To(Equal(common.X86CPUArchitecture))
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("should fail when missing URL", func() {
@@ -261,7 +260,7 @@ var _ = Describe("GetCPUArchitectures", func() {
 		images OSImages
 	)
 
-	Context("with default imges", func() {
+	Context("with default images", func() {
 		BeforeEach(func() {
 			var err error
 			images, err = NewOSImages(defaultOsImages)
@@ -281,27 +280,6 @@ var _ = Describe("GetCPUArchitectures", func() {
 			expected := []string{common.TestDefaultConfig.CPUArchitecture, common.ARM64CPUArchitecture}
 			Expect(images.GetCPUArchitectures("4.9.1")).Should(Equal(expected))
 		})
-	})
-
-	It("returns the default architecture", func() {
-		osImages := models.OsImages{
-			&models.OsImage{
-				CPUArchitecture:  swag.String(""),
-				OpenshiftVersion: swag.String("4.9"),
-				URL:              swag.String("rhcos_4.9"),
-				Version:          swag.String("version-49.123-0"),
-			},
-			&models.OsImage{
-				CPUArchitecture:  nil,
-				OpenshiftVersion: swag.String("4.9"),
-				URL:              swag.String("rhcos_4.9"),
-				Version:          swag.String("version-49.123-0"),
-			},
-		}
-		images, err := NewOSImages(osImages)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(images.GetCPUArchitectures("4.9")).Should(Equal([]string{common.TestDefaultConfig.CPUArchitecture}))
 	})
 })
 
@@ -360,5 +338,29 @@ var _ = Describe("NewOSImages", func() {
 			},
 		}
 		Expect(validateImages(osImages)).NotTo(Succeed())
+	})
+
+	It("CPU architecture is not valid", func() {
+		osImages := models.OsImages{
+			&models.OsImage{
+				CPUArchitecture:  swag.String(""),
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9"),
+				Version:          swag.String("version-49.123-0"),
+			},
+		}
+		_, err := NewOSImages(osImages)
+		Expect(err).Should(HaveOccurred())
+
+		osImages = models.OsImages{
+			&models.OsImage{
+				CPUArchitecture:  nil,
+				OpenshiftVersion: swag.String("4.9"),
+				URL:              swag.String("rhcos_4.9"),
+				Version:          swag.String("version-49.123-0"),
+			},
+		}
+		_, err = NewOSImages(osImages)
+		Expect(err).Should(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Fail when OS images CPU architecture is missing instead of giving it default value in order not to generate false infraenv

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
