### PR TITLE
MGMT-17194: Ensure releaseImage is not tag based when mirror registry enabled.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -579,20 +579,21 @@ func main() {
 			cluster_client := ctrlMgr.GetClient()
 			cluster_reader := ctrlMgr.GetAPIReader()
 			failOnError((&controllers.ClusterDeploymentsReconciler{
-				Client:                cluster_client,
-				APIReader:             cluster_reader,
-				Log:                   log,
-				Scheme:                ctrlMgr.GetScheme(),
-				Installer:             bm,
-				ClusterApi:            clusterApi,
-				HostApi:               hostApi,
-				CRDEventsHandler:      crdEventsHandler,
-				Manifests:             manifestsApi,
-				ServiceBaseURL:        Options.BMConfig.ServiceBaseURL,
-				PullSecretHandler:     controllers.NewPullSecretHandler(cluster_client, cluster_reader, bm),
-				AuthType:              Options.Auth.AuthType,
-				VersionsHandler:       versionHandler,
-				SpokeK8sClientFactory: spoke_k8s_client.NewSpokeK8sClientFactory(log),
+				Client:                        cluster_client,
+				APIReader:                     cluster_reader,
+				Log:                           log,
+				Scheme:                        ctrlMgr.GetScheme(),
+				Installer:                     bm,
+				ClusterApi:                    clusterApi,
+				HostApi:                       hostApi,
+				CRDEventsHandler:              crdEventsHandler,
+				Manifests:                     manifestsApi,
+				ServiceBaseURL:                Options.BMConfig.ServiceBaseURL,
+				PullSecretHandler:             controllers.NewPullSecretHandler(cluster_client, cluster_reader, bm),
+				AuthType:                      Options.Auth.AuthType,
+				VersionsHandler:               versionHandler,
+				SpokeK8sClientFactory:         spoke_k8s_client.NewSpokeK8sClientFactory(log),
+				MirrorRegistriesConfigBuilder: mirrorregistries.New(),
 			}).SetupWithManager(ctrlMgr), "unable to create controller ClusterDeployment")
 
 			failOnError((&controllers.AgentReconciler{

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0-20220222213051-def9088fdb5a
 	github.com/openshift/image-customization-controller v0.0.0-20240129110832-60a3867d7f9e
+	github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -126,7 +127,6 @@ require (
 	github.com/moby/sys/user v0.1.0 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/openshift/library-go v0.0.0-20231110170715-08d73a9c798b // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/controller/controllers/clusterdeployments_controller_test.go
+++ b/internal/controller/controllers/clusterdeployments_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/assisted-service/internal/spoke_k8s_client"
 	"github.com/openshift/assisted-service/internal/versions"
 	"github.com/openshift/assisted-service/models"
+	"github.com/openshift/assisted-service/pkg/mirrorregistries"
 	"github.com/openshift/assisted-service/restapi/operations/installer"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/apis/hive/v1/aws"
@@ -170,6 +171,7 @@ var _ = Describe("cluster reconcile", func() {
 		mockManifestsApi               *manifestsapi.MockClusterManifestsInternals
 		mockCRDEventsHandler           *MockCRDEventsHandler
 		mockVersions                   *versions.MockHandler
+		mockMirrorRegistries           *mirrorregistries.MockMirrorRegistriesConfigBuilder
 		defaultClusterSpec             hivev1.ClusterDeploymentSpec
 		clusterName                    = "test-cluster"
 		agentClusterInstallName        = "test-cluster-aci"
@@ -231,19 +233,22 @@ var _ = Describe("cluster reconcile", func() {
 		mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 		mockManifestsApi = manifestsapi.NewMockClusterManifestsInternals(mockCtrl)
 		mockVersions = versions.NewMockHandler(mockCtrl)
+		mockMirrorRegistries = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(mockCtrl)
 		cr = &ClusterDeploymentsReconciler{
-			Client:            c,
-			APIReader:         c,
-			Scheme:            scheme.Scheme,
-			Log:               common.GetTestLog(),
-			Installer:         mockInstallerInternal,
-			ClusterApi:        mockClusterApi,
-			HostApi:           mockHostApi,
-			CRDEventsHandler:  mockCRDEventsHandler,
-			Manifests:         mockManifestsApi,
-			PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
-			VersionsHandler:   mockVersions,
+			Client:                        c,
+			APIReader:                     c,
+			Scheme:                        scheme.Scheme,
+			Log:                           common.GetTestLog(),
+			Installer:                     mockInstallerInternal,
+			ClusterApi:                    mockClusterApi,
+			HostApi:                       mockHostApi,
+			CRDEventsHandler:              mockCRDEventsHandler,
+			Manifests:                     mockManifestsApi,
+			PullSecretHandler:             NewPullSecretHandler(c, c, mockInstallerInternal),
+			VersionsHandler:               mockVersions,
+			MirrorRegistriesConfigBuilder: mockMirrorRegistries,
 		}
+
 	})
 
 	AfterEach(func() {
@@ -287,7 +292,47 @@ var _ = Describe("cluster reconcile", func() {
 				Expect(FindStatusCondition(aci.Status.Conditions, hiveext.ClusterRequirementsMetCondition).Status).To(Equal(corev1.ConditionFalse))
 			}
 
+			It("should fail validation if mirror registries enabled and ImageSetRef references a tagged image", func() {
+				cluster := newClusterDeployment(clusterName, testNamespace,
+					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, ""))
+				cluster.Spec.Installed = true
+				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+				aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, getDefaultSNOAgentClusterInstallSpec(clusterName), cluster)
+				imageSet := getDefaultTestImageSet("taggedImageSet-ocp-release:4.15.0-multi", "quay.io/openshift-release-dev/ocp-release:4.15.0-multi")
+				Expect(c.Create(ctx, imageSet)).To(BeNil())
+				aci.Spec.ImageSetRef = &hivev1.ClusterImageSetReference{Name: "taggedImageSet-ocp-release:4.15.0-multi"}
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(true)
+				Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+				request := newClusterDeploymentRequest(cluster)
+				result, err := cr.Reconcile(ctx, request)
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 0}))
+			})
+
+			It("should succeed validation if mirror registries enabled and ImageSetRef references a digest based image", func() {
+				cluster := newClusterDeployment(clusterName, testNamespace,
+					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, ""))
+				cluster.Spec.Installed = true
+				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
+
+				mockInstallerInternal.EXPECT().V2ImportClusterInternal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+				aci := newAgentClusterInstall(agentClusterInstallName, testNamespace, getDefaultSNOAgentClusterInstallSpec(clusterName), cluster)
+				imageSet := getDefaultTestImageSet("taggedImageSet-ocp-release:4.15.0-multi", "quay.io/openshift-release-dev/ocp-release@sha256:b86422e972b9c838dfdb8b481a67ae08308437d6489ea6aaf150242b1d30fa1c")
+				Expect(c.Create(ctx, imageSet)).To(BeNil())
+				aci.Spec.ImageSetRef = &hivev1.ClusterImageSetReference{Name: "taggedImageSet-ocp-release:4.15.0-multi"}
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(true)
+				Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+
+				request := newClusterDeploymentRequest(cluster)
+				result, err := cr.Reconcile(ctx, request)
+				Expect(err).To(BeNil())
+				Expect(result).To(Equal(ctrl.Result{RequeueAfter: 0}))
+			})
+
 			It("create new cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
@@ -303,6 +348,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create new cluster with Proxy parameters", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				httpProxy := "http://proxy.org"
 				httpsProxy := "https://secureproxy.org"
 				noProxy := "acme.com"
@@ -324,6 +370,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create new cluster with IgnitionEndpoint CaCertificate", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(*releaseImage.Version))
@@ -352,6 +399,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create new cluster with arm cpu architecture", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				clusterReply.Cluster.CPUArchitecture = CpuArchitectureArm
 				armReleaseImageUrl := "quay.io/openshift-release-dev/ocp-release:4.9.11-aarch64"
 				armOcpReleaseVersion := "4.9.11"
@@ -378,6 +426,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create new cluster with disk encryption", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				tangServersConfig := `[{"URL":"http://tang.example.com:7500","Thumbprint":"PLjNyRdGw03zlRoGjQYMahSZGu9"}]`
 				id := strfmt.UUID(uuid.New().String())
 				clusterReply = &common.Cluster{
@@ -416,6 +465,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create sno cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(arg1, arg2 interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.OpenshiftVersion)).To(Equal(ocpReleaseVersion))
@@ -435,6 +485,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create single node cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(ctx, kubeKey interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.StringValue(params.NewClusterParams.HighAvailabilityMode)).
@@ -455,6 +506,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("create none platform cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(ctx, kubeKey interface{}, params installer.V2RegisterClusterParams) {
 						Expect(swag.BoolValue(params.NewClusterParams.UserManagedNetworking)).
@@ -477,6 +529,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("no pull secret name when trying to create a cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				cluster := newClusterDeployment(clusterName, testNamespace,
 					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, ""))
 				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -501,6 +554,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("no imagesetref when trying to create a day1 cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				cluster := newClusterDeployment(clusterName, testNamespace,
 					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName))
 				Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -526,6 +580,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("no imagesetref when trying to create a day2 cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				cluster := newClusterDeployment(clusterName, testNamespace,
 					getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, ""))
 				cluster.Spec.Installed = true
@@ -544,6 +599,7 @@ var _ = Describe("cluster reconcile", func() {
 			})
 
 			It("fail to get openshift version when trying to create a cluster", func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 				mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.Errorf("some-error"))
 				mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
@@ -572,6 +628,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("create new cluster backend failure", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			errString := "internal error"
 			mockInstallerInternal.EXPECT().RegisterClusterInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, errors.Errorf(errString))
@@ -623,6 +680,7 @@ var _ = Describe("cluster reconcile", func() {
 			mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil)
 			mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 			mockVersions.EXPECT().GetReleaseImageByURL(gomock.Any(), gomock.Any(), gomock.Any()).Return(releaseImage, nil)
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		setupTestForStatusAndReason := func(status string, reason string) {
@@ -681,6 +739,10 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	Context("CreateClusterParams", func() {
+		BeforeEach(func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
+		})
+
 		It("create new param - success", func() {
 			cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 			Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -707,6 +769,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
 			imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
 			Expect(c.Create(ctx, imageSet)).To(BeNil())
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("Update agentclusterinstall::validationsInfo", func() {
@@ -757,6 +820,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("backend internal error when trying to retrieve cluster details", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, errors.New("internal error"))
 		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 
@@ -781,6 +845,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("not supported platform", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		spec := hivev1.ClusterDeploymentSpec{
 			ClusterName: clusterName,
 			Provisioning: &hivev1.Provisioning{
@@ -805,6 +870,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate owner reference creation", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		sId := strfmt.UUID(uuid.New().String())
 		backEndCluster := &common.Cluster{
 			Cluster: models.Cluster{
@@ -838,6 +904,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate label on Pull Secret", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		sId := strfmt.UUID(uuid.New().String())
 		backEndCluster := &common.Cluster{
 			Cluster: models.Cluster{
@@ -890,6 +957,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate Event URL", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		_, priv, err := gencrypto.ECDSAKeyPairPEM()
 		Expect(err).NotTo(HaveOccurred())
 		os.Setenv("EC_PRIVATE_KEY_PEM", priv)
@@ -927,6 +995,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate ignitionEndpoint override doesn't trigger clusterUpdate unless required", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		mockInstallerInternal.EXPECT().HostWithCollectedLogsExists(gomock.Any()).Return(false, nil).Times(2)
 		mockInstallerInternal.EXPECT().ValidatePullSecret(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 		pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
@@ -1004,6 +1073,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate Logs URL - before and after host log collection", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		serviceBaseURL := "http://acme.com"
 		cr.ServiceBaseURL = serviceBaseURL
 		sId := strfmt.UUID(uuid.New().String())
@@ -1076,6 +1146,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("validate Logs URL - before and after controller log collection", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		serviceBaseURL := "http://acme.com"
 		cr.ServiceBaseURL = serviceBaseURL
 		sId := strfmt.UUID(uuid.New().String())
@@ -1124,6 +1195,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("failed to get cluster from backend", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 		cluster.Status = hivev1.ClusterDeploymentStatus{}
 		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -1146,6 +1218,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("create cluster without pull secret reference", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		cluster := newClusterDeployment(clusterName, testNamespace, defaultClusterSpec)
 		cluster.Spec.PullSecretRef = nil
 		Expect(c.Create(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -1188,18 +1261,20 @@ var _ = Describe("cluster reconcile", func() {
 			mockCRDEventsHandler = NewMockCRDEventsHandler(mockCtrl)
 			mockManifestsApi = manifestsapi.NewMockClusterManifestsInternals(mockCtrl)
 			mockVersions = versions.NewMockHandler(mockCtrl)
+			mockMirrorRegistries = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(mockCtrl)
 			cr = &ClusterDeploymentsReconciler{
-				Client:            c,
-				APIReader:         c,
-				Scheme:            scheme.Scheme,
-				Log:               common.GetTestLog(),
-				Installer:         mockInstallerInternal,
-				ClusterApi:        mockClusterApi,
-				HostApi:           mockHostApi,
-				CRDEventsHandler:  mockCRDEventsHandler,
-				Manifests:         mockManifestsApi,
-				PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
-				VersionsHandler:   mockVersions,
+				Client:                        c,
+				APIReader:                     c,
+				Scheme:                        scheme.Scheme,
+				Log:                           common.GetTestLog(),
+				Installer:                     mockInstallerInternal,
+				ClusterApi:                    mockClusterApi,
+				HostApi:                       mockHostApi,
+				CRDEventsHandler:              mockCRDEventsHandler,
+				Manifests:                     mockManifestsApi,
+				PullSecretHandler:             NewPullSecretHandler(c, c, mockInstallerInternal),
+				VersionsHandler:               mockVersions,
+				MirrorRegistriesConfigBuilder: mockMirrorRegistries,
 			}
 			Expect(c.Create(ctx, cd)).ShouldNot(HaveOccurred())
 			Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
@@ -1207,6 +1282,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
 			imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
 			Expect(c.Create(ctx, imageSet)).To(BeNil())
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("agentClusterInstall resource deleted - verify call to deregister cluster", func() {
@@ -1382,6 +1458,7 @@ var _ = Describe("cluster reconcile", func() {
 				hosts = append(hosts, h)
 			}
 			backEndCluster.Hosts = hosts
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("success", func() {
@@ -2497,6 +2574,7 @@ var _ = Describe("cluster reconcile", func() {
 	})
 
 	It("reconcile on installed sno cluster should not return an error or requeue", func() {
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound).Times(1)
 		cluster := newClusterDeployment(clusterName, testNamespace,
 			getDefaultClusterDeploymentSpec(clusterName, agentClusterInstallName, pullSecretName))
@@ -2550,6 +2628,7 @@ var _ = Describe("cluster reconcile", func() {
 
 			aci = newAgentClusterInstall(agentClusterInstallName, testNamespace, defaultAgentClusterInstallSpec, cluster)
 			Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("update pull-secret network cidr and cluster name", func() {
@@ -2707,6 +2786,10 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		Context("Networks", func() {
+			BeforeEach(func() {
+				mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
+			})
+
 			tests := []struct {
 				name                    string
 				specMachineNetworks     []hiveext.MachineNetworkEntry
@@ -2793,6 +2876,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("only state changed", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:               &sId,
@@ -2830,6 +2914,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("failed getting cluster", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			expectedErr := "some internal error"
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).
 				Return(nil, errors.Errorf(expectedErr))
@@ -2846,6 +2931,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("update internal error", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:               &sId,
@@ -2877,6 +2963,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("add install config overrides annotation", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:               &sId,
@@ -2921,6 +3008,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("Remove existing install config overrides annotation", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:                     &sId,
@@ -2962,6 +3050,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("Update install config overrides annotation", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:                     &sId,
@@ -3007,6 +3096,7 @@ var _ = Describe("cluster reconcile", func() {
 		})
 
 		It("invalid install config overrides annotation", func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			backEndCluster := &common.Cluster{
 				Cluster: models.Cluster{
 					ID:               &sId,
@@ -3056,6 +3146,7 @@ var _ = Describe("cluster reconcile", func() {
 		BeforeEach(func() {
 			id := uuid.New()
 			sId = strfmt.UUID(id.String())
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("SSHPublicKey in ClusterDeployment has spaces in suffix", func() {
@@ -3203,6 +3294,7 @@ var _ = Describe("cluster reconcile", func() {
 			Expect(c.Create(ctx, aci)).ShouldNot(HaveOccurred())
 
 			mockInstallerInternal.EXPECT().GetClusterByKubeKey(gomock.Any()).Return(nil, gorm.ErrRecordNotFound)
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		})
 
 		It("success", func() {
@@ -3277,6 +3369,7 @@ var _ = Describe("cluster reconcile", func() {
 		}
 
 		BeforeEach(func() {
+			mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 			pullSecret := getDefaultTestPullSecret("pull-secret", testNamespace)
 			Expect(c.Create(ctx, pullSecret)).To(BeNil())
 			imageSet := getDefaultTestImageSet(imageSetName, releaseImageUrl)
@@ -3452,22 +3545,26 @@ var _ = Describe("TestConditions", func() {
 		clusterKey             types.NamespacedName
 		agentClusterInstallKey types.NamespacedName
 		mockInstallerInternal  *bminventory.MockInstallerInternals
+		mockMirrorRegistries   *mirrorregistries.MockMirrorRegistriesConfigBuilder
 	)
 
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
 			WithStatusSubresource(&hiveext.AgentClusterInstall{}).Build()
 		mockCtrl = gomock.NewController(GinkgoT())
+		mockMirrorRegistries = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(mockCtrl)
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockClusterApi := cluster.NewMockAPI(mockCtrl)
 		cr = &ClusterDeploymentsReconciler{
-			Client:            c,
-			APIReader:         c,
-			Scheme:            scheme.Scheme,
-			Log:               common.GetTestLog(),
-			Installer:         mockInstallerInternal,
-			ClusterApi:        mockClusterApi,
-			PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
+			Client:                        c,
+			APIReader:                     c,
+			Scheme:                        scheme.Scheme,
+			Log:                           common.GetTestLog(),
+			Installer:                     mockInstallerInternal,
+			ClusterApi:                    mockClusterApi,
+			PullSecretHandler:             NewPullSecretHandler(c, c, mockInstallerInternal),
+			MirrorRegistriesConfigBuilder: mockMirrorRegistries,
 		}
 		backEndCluster = &common.Cluster{
 			Cluster: models.Cluster{
@@ -4099,24 +4196,27 @@ var _ = Describe("day2 cluster", func() {
 		cr                             *ClusterDeploymentsReconciler
 		mockVersions                   *versions.MockHandler
 		dbCluster                      *common.Cluster
+		mockMirrorRegistries           *mirrorregistries.MockMirrorRegistriesConfigBuilder
 	)
 
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockInstallerInternal = bminventory.NewMockInstallerInternals(mockCtrl)
 		mockVersions = versions.NewMockHandler(mockCtrl)
-
+		mockMirrorRegistries = mirrorregistries.NewMockMirrorRegistriesConfigBuilder(mockCtrl)
+		mockMirrorRegistries.EXPECT().IsMirrorRegistriesConfigured().AnyTimes().Return(false)
 		c = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).
 			WithStatusSubresource(&hiveext.AgentClusterInstall{}).Build()
 
 		cr = &ClusterDeploymentsReconciler{
-			Client:            c,
-			APIReader:         c,
-			Scheme:            scheme.Scheme,
-			Log:               common.GetTestLog(),
-			Installer:         mockInstallerInternal,
-			PullSecretHandler: NewPullSecretHandler(c, c, mockInstallerInternal),
-			VersionsHandler:   mockVersions,
+			Client:                        c,
+			APIReader:                     c,
+			Scheme:                        scheme.Scheme,
+			Log:                           common.GetTestLog(),
+			Installer:                     mockInstallerInternal,
+			PullSecretHandler:             NewPullSecretHandler(c, c, mockInstallerInternal),
+			VersionsHandler:               mockVersions,
+			MirrorRegistriesConfigBuilder: mockMirrorRegistries,
 		}
 
 		clusterKey = types.NamespacedName{

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
@@ -1,0 +1,138 @@
+package digest
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Digest allows simple protection of hex formatted digest strings, prefixed
+// by their algorithm. Strings of type Digest have some guarantee of being in
+// the correct format and it provides quick access to the components of a
+// digest string.
+//
+// The following is an example of the contents of Digest types:
+//
+//	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//
+// This allows to abstract the digest behind this type and work only in those
+// terms.
+type Digest string
+
+// NewDigest returns a Digest from alg and a hash.Hash object.
+func NewDigest(alg Algorithm, h hash.Hash) Digest {
+	return NewDigestFromBytes(alg, h.Sum(nil))
+}
+
+// NewDigestFromBytes returns a new digest from the byte contents of p.
+// Typically, this can come from hash.Hash.Sum(...) or xxx.SumXXX(...)
+// functions. This is also useful for rebuilding digests from binary
+// serializations.
+func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
+	return Digest(fmt.Sprintf("%s:%x", alg, p))
+}
+
+// NewDigestFromHex returns a Digest from alg and a the hex encoded digest.
+func NewDigestFromHex(alg, hex string) Digest {
+	return Digest(fmt.Sprintf("%s:%s", alg, hex))
+}
+
+// DigestRegexp matches valid digest types.
+var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
+
+// DigestRegexpAnchored matches valid digest types, anchored to the start and end of the match.
+var DigestRegexpAnchored = regexp.MustCompile(`^` + DigestRegexp.String() + `$`)
+
+var (
+	// ErrDigestInvalidFormat returned when digest format invalid.
+	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
+
+	// ErrDigestInvalidLength returned when digest has invalid length.
+	ErrDigestInvalidLength = fmt.Errorf("invalid checksum digest length")
+
+	// ErrDigestUnsupported returned when the digest algorithm is unsupported.
+	ErrDigestUnsupported = fmt.Errorf("unsupported digest algorithm")
+)
+
+// ParseDigest parses s and returns the validated digest object. An error will
+// be returned if the format is invalid.
+func ParseDigest(s string) (Digest, error) {
+	d := Digest(s)
+
+	return d, d.Validate()
+}
+
+// FromReader returns the most valid digest for the underlying content using
+// the canonical digest algorithm.
+func FromReader(rd io.Reader) (Digest, error) {
+	return Canonical.FromReader(rd)
+}
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) Digest {
+	return Canonical.FromBytes(p)
+}
+
+// Validate checks that the contents of d is a valid digest, returning an
+// error if not.
+func (d Digest) Validate() error {
+	s := string(d)
+
+	if !DigestRegexpAnchored.MatchString(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return ErrDigestInvalidFormat
+	}
+
+	// case: "sha256:" with no hex.
+	if i+1 == len(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	switch algorithm := Algorithm(s[:i]); algorithm {
+	case SHA256, SHA384, SHA512:
+		if algorithm.Size()*2 != len(s[i+1:]) {
+			return ErrDigestInvalidLength
+		}
+	default:
+		return ErrDigestUnsupported
+	}
+
+	return nil
+}
+
+// Algorithm returns the algorithm portion of the digest. This will panic if
+// the underlying digest is not in a valid format.
+func (d Digest) Algorithm() Algorithm {
+	return Algorithm(d[:d.sepIndex()])
+}
+
+// Hex returns the hex digest portion of the digest. This will panic if the
+// underlying digest is not in a valid format.
+func (d Digest) Hex() string {
+	return string(d[d.sepIndex()+1:])
+}
+
+func (d Digest) String() string {
+	return string(d)
+}
+
+func (d Digest) sepIndex() int {
+	i := strings.Index(string(d), ":")
+
+	if i < 0 {
+		panic("could not find ':' in digest: " + d)
+	}
+
+	return i
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
@@ -1,0 +1,155 @@
+package digest
+
+import (
+	"crypto"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// Algorithm identifies and implementation of a digester by an identifier.
+// Note the that this defines both the hash algorithm used and the string
+// encoding.
+type Algorithm string
+
+// supported digest types
+const (
+	SHA256 Algorithm = "sha256" // sha256 with hex encoding
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding
+
+	// Canonical is the primary digest algorithm used with the distribution
+	// project. Other digests may be used but this one is the primary storage
+	// digest.
+	Canonical = SHA256
+)
+
+var (
+	// TODO(stevvooe): Follow the pattern of the standard crypto package for
+	// registration of digests. Effectively, we are a registerable set and
+	// common symbol access.
+
+	// algorithms maps values to hash.Hash implementations. Other algorithms
+	// may be available but they cannot be calculated by the digest package.
+	algorithms = map[Algorithm]crypto.Hash{
+		SHA256: crypto.SHA256,
+		SHA384: crypto.SHA384,
+		SHA512: crypto.SHA512,
+	}
+)
+
+// Available returns true if the digest type is available for use. If this
+// returns false, New and Hash will return nil.
+func (a Algorithm) Available() bool {
+	h, ok := algorithms[a]
+	if !ok {
+		return false
+	}
+
+	// check availability of the hash, as well
+	return h.Available()
+}
+
+func (a Algorithm) String() string {
+	return string(a)
+}
+
+// Size returns number of bytes returned by the hash.
+func (a Algorithm) Size() int {
+	h, ok := algorithms[a]
+	if !ok {
+		return 0
+	}
+	return h.Size()
+}
+
+// Set implemented to allow use of Algorithm as a command line flag.
+func (a *Algorithm) Set(value string) error {
+	if value == "" {
+		*a = Canonical
+	} else {
+		// just do a type conversion, support is queried with Available.
+		*a = Algorithm(value)
+	}
+
+	return nil
+}
+
+// New returns a new digester for the specified algorithm. If the algorithm
+// does not have a digester implementation, nil will be returned. This can be
+// checked by calling Available before calling New.
+func (a Algorithm) New() Digester {
+	return &digester{
+		alg:  a,
+		hash: a.Hash(),
+	}
+}
+
+// Hash returns a new hash as used by the algorithm. If not available, the
+// method will panic. Check Algorithm.Available() before calling.
+func (a Algorithm) Hash() hash.Hash {
+	if !a.Available() {
+		// NOTE(stevvooe): A missing hash is usually a programming error that
+		// must be resolved at compile time. We don't import in the digest
+		// package to allow users to choose their hash implementation (such as
+		// when using stevvooe/resumable or a hardware accelerated package).
+		//
+		// Applications that may want to resolve the hash at runtime should
+		// call Algorithm.Available before call Algorithm.Hash().
+		panic(fmt.Sprintf("%v not available (make sure it is imported)", a))
+	}
+
+	return algorithms[a].New()
+}
+
+// FromReader returns the digest of the reader using the algorithm.
+func (a Algorithm) FromReader(rd io.Reader) (Digest, error) {
+	digester := a.New()
+
+	if _, err := io.Copy(digester.Hash(), rd); err != nil {
+		return "", err
+	}
+
+	return digester.Digest(), nil
+}
+
+// FromBytes digests the input and returns a Digest.
+func (a Algorithm) FromBytes(p []byte) Digest {
+	digester := a.New()
+
+	if _, err := digester.Hash().Write(p); err != nil {
+		// Writes to a Hash should never fail. None of the existing
+		// hash implementations in the stdlib or hashes vendored
+		// here can return errors from Write. Having a panic in this
+		// condition instead of having FromBytes return an error value
+		// avoids unnecessary error handling paths in all callers.
+		panic("write to hash function returned error: " + err.Error())
+	}
+
+	return digester.Digest()
+}
+
+// TODO(stevvooe): Allow resolution of verifiers using the digest type and
+// this registration system.
+
+// Digester calculates the digest of written data. Writes should go directly
+// to the return value of Hash, while calling Digest will return the current
+// value of the digest.
+type Digester interface {
+	Hash() hash.Hash // provides direct access to underlying hash instance.
+	Digest() Digest
+}
+
+// digester provides a simple digester definition that embeds a hasher.
+type digester struct {
+	alg  Algorithm
+	hash hash.Hash
+}
+
+func (d *digester) Hash() hash.Hash {
+	return d.hash
+}
+
+func (d *digester) Digest() Digest {
+	return NewDigest(d.alg, d.hash)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
@@ -1,0 +1,5 @@
+// digest is a copy from "github.com/distribution/distribution/v3/digest" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package digest

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
@@ -1,0 +1,5 @@
+// reference is a copy from "github.com/distribution/distribution/v3/reference" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package reference

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
@@ -1,0 +1,370 @@
+// Package reference provides a general type to represent any way of referencing images within the registry.
+// Its main purpose is to abstract tags and digests (content-addressable hash).
+//
+// Grammar
+//
+//	reference                       := name [ ":" tag ] [ "@" digest ]
+//	name                            := [hostname '/'] component ['/' component]*
+//	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	port-number                     := /[0-9]+/
+//	component                       := alpha-numeric [separator alpha-numeric]*
+//	alpha-numeric                   := /[a-z0-9]+/
+//	separator                       := /[_.]|__|[-]*/
+//
+//	tag                             := /[\w][\w.-]{0,127}/
+//
+//	digest                          := digest-algorithm ":" digest-hex
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm-separator      := /[+.-_]/
+//	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+//	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+package reference
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+)
+
+const (
+	// NameTotalLengthMax is the maximum total number of characters in a repository name.
+	NameTotalLengthMax = 255
+)
+
+var (
+	// ErrReferenceInvalidFormat represents an error while trying to parse a string as a reference.
+	ErrReferenceInvalidFormat = errors.New("invalid reference format")
+
+	// ErrTagInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrTagInvalidFormat = errors.New("invalid tag format")
+
+	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameContainsUppercase is returned for invalid repository names that contain uppercase characters.
+	ErrNameContainsUppercase = errors.New("repository name must be lowercase")
+
+	// ErrNameEmpty is returned for empty, invalid repository names.
+	ErrNameEmpty = errors.New("repository name must have at least one component")
+
+	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Field provides a wrapper type for resolving correct reference types when
+// working with encoding.
+type Field struct {
+	reference Reference
+}
+
+// AsField wraps a reference in a Field for encoding.
+func AsField(reference Reference) Field {
+	return Field{reference}
+}
+
+// Reference unwraps the reference type from the field to
+// return the Reference object. This object should be
+// of the appropriate type to further check for different
+// reference types.
+func (f Field) Reference() Reference {
+	return f.reference
+}
+
+// MarshalText serializes the field to byte text which
+// is the string of the reference.
+func (f Field) MarshalText() (p []byte, err error) {
+	return []byte(f.reference.String()), nil
+}
+
+// UnmarshalText parses text bytes by invoking the
+// reference parser to ensure the appropriately
+// typed reference object is wrapped by field.
+func (f *Field) UnmarshalText(p []byte) error {
+	r, err := Parse(string(p))
+	if err != nil {
+		return err
+	}
+
+	f.reference = r
+	return nil
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// Tagged is an object which has a tag
+type Tagged interface {
+	Reference
+	Tag() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Digested is an object which has a digest
+// in which it can be referenced by
+type Digested interface {
+	Reference
+	Digest() digest.Digest
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with hostname and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// SplitHostname splits a named reference into a
+// hostname and name string. If no valid hostname is
+// found, the hostname is empty and the full value
+// is returned as name
+func SplitHostname(named Named) (string, string) {
+	name := named.Name()
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if len(match) != 3 {
+		return "", name
+	}
+	return match[1], match[2]
+}
+
+// Parse parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: Parse will not handle short digests.
+func Parse(s string) (Reference, error) {
+	matches := ReferenceRegexp.FindStringSubmatch(s)
+	if matches == nil {
+		if s == "" {
+			return nil, ErrNameEmpty
+		}
+		if ReferenceRegexp.FindStringSubmatch(strings.ToLower(s)) != nil {
+			return nil, ErrNameContainsUppercase
+		}
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(matches[1]) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	ref := reference{
+		name: matches[1],
+		tag:  matches[2],
+	}
+	if matches[3] != "" {
+		var err error
+		ref.digest, err = digest.ParseDigest(matches[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	r := getBestReferenceType(ref)
+	if r == nil {
+		return nil, ErrNameEmpty
+	}
+
+	return r, nil
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name, otherwise an error is
+// returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	ref, err := Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	named, isNamed := ref.(Named)
+	if !isNamed {
+		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	}
+	return named, nil
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	if len(name) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+	if !anchoredNameRegexp.MatchString(name) {
+		return nil, ErrReferenceInvalidFormat
+	}
+	return repository(name), nil
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	if !anchoredTagRegexp.MatchString(tag) {
+		return nil, ErrTagInvalidFormat
+	}
+	if canonical, ok := name.(Canonical); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tag,
+			digest: canonical.Digest(),
+		}, nil
+	}
+	return taggedReference{
+		name: name.Name(),
+		tag:  tag,
+	}, nil
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	if !anchoredDigestRegexp.MatchString(digest.String()) {
+		return nil, ErrDigestInvalidFormat
+	}
+	if tagged, ok := name.(Tagged); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tagged.Tag(),
+			digest: digest,
+		}, nil
+	}
+	return canonicalReference{
+		name:   name.Name(),
+		digest: digest,
+	}, nil
+}
+
+// Match reports whether ref matches the specified pattern.
+// See https://godoc.org/path#Match for supported patterns.
+func Match(pattern string, ref Reference) (bool, error) {
+	matched, err := path.Match(pattern, ref.String())
+	if namedRef, isNamed := ref.(Named); isNamed && !matched {
+		matched, _ = path.Match(pattern, namedRef.Name())
+	}
+	return matched, err
+}
+
+// TrimNamed removes any tag or digest from the named reference.
+func TrimNamed(ref Named) Named {
+	return repository(ref.Name())
+}
+
+func getBestReferenceType(ref reference) Reference {
+	if ref.name == "" {
+		// Allow digest only references
+		if ref.digest != "" {
+			return digestReference(ref.digest)
+		}
+		return nil
+	}
+	if ref.tag == "" {
+		if ref.digest != "" {
+			return canonicalReference{
+				name:   ref.name,
+				digest: ref.digest,
+			}
+		}
+		return repository(ref.name)
+	}
+	if ref.digest == "" {
+		return taggedReference{
+			name: ref.name,
+			tag:  ref.tag,
+		}
+	}
+
+	return ref
+}
+
+type reference struct {
+	name   string
+	tag    string
+	digest digest.Digest
+}
+
+func (r reference) String() string {
+	return r.name + ":" + r.tag + "@" + r.digest.String()
+}
+
+func (r reference) Name() string {
+	return r.name
+}
+
+func (r reference) Tag() string {
+	return r.tag
+}
+
+func (r reference) Digest() digest.Digest {
+	return r.digest
+}
+
+type repository string
+
+func (r repository) String() string {
+	return string(r)
+}
+
+func (r repository) Name() string {
+	return string(r)
+}
+
+type digestReference digest.Digest
+
+func (d digestReference) String() string {
+	return string(d)
+}
+
+func (d digestReference) Digest() digest.Digest {
+	return digest.Digest(d)
+}
+
+type taggedReference struct {
+	name string
+	tag  string
+}
+
+func (t taggedReference) String() string {
+	return t.name + ":" + t.tag
+}
+
+func (t taggedReference) Name() string {
+	return t.name
+}
+
+func (t taggedReference) Tag() string {
+	return t.tag
+}
+
+type canonicalReference struct {
+	name   string
+	digest digest.Digest
+}
+
+func (c canonicalReference) String() string {
+	return c.name + "@" + c.digest.String()
+}
+
+func (c canonicalReference) Name() string {
+	return c.name
+}
+
+func (c canonicalReference) Digest() digest.Digest {
+	return c.digest
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
@@ -1,0 +1,124 @@
+package reference
+
+import "regexp"
+
+var (
+	// alphaNumericRegexp defines the alpha numeric atom, typically a
+	// component of names. This only allows lower case characters and digits.
+	alphaNumericRegexp = match(`[a-z0-9]+`)
+
+	// separatorRegexp defines the separators allowed to be embedded in name
+	// components. This allow one period, one or two underscore and multiple
+	// dashes.
+	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+
+	// nameComponentRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponentRegexp = expression(
+		alphaNumericRegexp,
+		optional(repeated(separatorRegexp, alphaNumericRegexp)))
+
+	// hostnameComponentRegexp restricts the registry hostname component of a
+	// repository name to start with a component as defined by hostnameRegexp
+	// and followed by an optional port.
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+
+	// hostnameRegexp defines the structure of potential hostname components
+	// that may be part of image names. This is purposely a subset of what is
+	// allowed by DNS to ensure backwards compatibility with Docker image
+	// names.
+	hostnameRegexp = expression(
+		hostnameComponentRegexp,
+		optional(repeated(literal(`.`), hostnameComponentRegexp)),
+		optional(literal(`:`), match(`[0-9]+`)))
+
+	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
+	TagRegexp = match(`[\w][\w.-]{0,127}`)
+
+	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// end of the matched string.
+	anchoredTagRegexp = anchored(TagRegexp)
+
+	// DigestRegexp matches valid digests.
+	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
+
+	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// end of the matched string.
+	anchoredDigestRegexp = anchored(DigestRegexp)
+
+	// NameRegexp is the format for the name component of references. The
+	// regexp has capturing groups for the hostname and name part omitting
+	// the separating forward slash from either.
+	NameRegexp = expression(
+		optional(hostnameRegexp, literal(`/`)),
+		nameComponentRegexp,
+		optional(repeated(literal(`/`), nameComponentRegexp)))
+
+	// anchoredNameRegexp is used to parse a name value, capturing the
+	// hostname and trailing components.
+	anchoredNameRegexp = anchored(
+		optional(capture(hostnameRegexp), literal(`/`)),
+		capture(nameComponentRegexp,
+			optional(repeated(literal(`/`), nameComponentRegexp))))
+
+	// ReferenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	ReferenceRegexp = anchored(capture(NameRegexp),
+		optional(literal(":"), capture(TagRegexp)),
+		optional(literal("@"), capture(DigestRegexp)))
+)
+
+// match compiles the string to a regular expression.
+var match = regexp.MustCompile
+
+// literal compiles s into a literal regular expression, escaping any regexp
+// reserved characters.
+func literal(s string) *regexp.Regexp {
+	re := match(regexp.QuoteMeta(s))
+
+	if _, complete := re.LiteralPrefix(); !complete {
+		panic("must be a literal")
+	}
+
+	return re
+}
+
+// expression defines a full expression, where each regular expression must
+// follow the previous.
+func expression(res ...*regexp.Regexp) *regexp.Regexp {
+	var s string
+	for _, re := range res {
+		s += re.String()
+	}
+
+	return match(s)
+}
+
+// optional wraps the expression in a non-capturing group and makes the
+// production optional.
+func optional(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `?`)
+}
+
+// repeated wraps the regexp in a non-capturing group to get one or more
+// matches.
+func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `+`)
+}
+
+// group wraps the regexp in a non-capturing group.
+func group(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `)`)
+}
+
+// capture wraps the expression in a capturing group.
+func capture(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(` + expression(res...).String() + `)`)
+}
+
+// anchored anchors the regular expression by adding start and end delimiters.
+func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`^` + expression(res...).String() + `$`)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
@@ -1,0 +1,257 @@
+package reference
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+	"github.com/openshift/library-go/pkg/image/internal/reference"
+)
+
+// DockerImageReference points to a Docker image.
+type DockerImageReference struct {
+	Registry  string
+	Namespace string
+	Name      string
+	Tag       string
+	ID        string
+}
+
+const (
+	// DockerDefaultRegistry is the value for the registry when none was provided.
+	DockerDefaultRegistry = "docker.io"
+	// DockerDefaultV1Registry is the host name of the default v1 registry
+	DockerDefaultV1Registry = "index." + DockerDefaultRegistry
+	// DockerDefaultV2Registry is the host name of the default v2 registry
+	DockerDefaultV2Registry = "registry-1." + DockerDefaultRegistry
+)
+
+// Parse parses a Docker pull spec string into a
+// DockerImageReference.
+func Parse(spec string) (DockerImageReference, error) {
+	var ref DockerImageReference
+
+	namedRef, err := reference.ParseNamed(spec)
+	if err != nil {
+		return ref, err
+	}
+
+	name := namedRef.Name()
+	i := strings.IndexRune(name, '/')
+
+	// if there are no path components, and it looks like a url (contains a .) or localhost, it's a registry
+	isRegistryOnly := i == -1 && (strings.ContainsAny(name, ".") || strings.HasPrefix(name, "localhost"))
+
+	// if there are no path components, and it's not a registry, it's a name
+	isNameOnly := i == -1 && !isRegistryOnly
+
+	// if there are path components, and the first component doesn't look like a url, it's a name
+	isNameOnly = isNameOnly || (i > -1 && (!strings.ContainsAny(name[:i], ":.") && name[:i] != "localhost"))
+
+	if isRegistryOnly {
+		ref.Registry = namedRef.String()
+	} else if isNameOnly {
+		ref.Name = name
+	} else {
+		ref.Registry, ref.Name = name[:i], name[i+1:]
+	}
+
+	if named, ok := namedRef.(reference.NamedTagged); !isRegistryOnly && ok {
+		ref.Tag = named.Tag()
+	}
+
+	if named, ok := namedRef.(reference.Canonical); ok {
+		ref.ID = named.Digest().String()
+	}
+
+	// It's not enough just to use the reference.ParseNamed(). We have to fill
+	// ref.Namespace from ref.Name
+	if i := strings.IndexRune(ref.Name, '/'); i != -1 {
+		ref.Namespace, ref.Name = ref.Name[:i], ref.Name[i+1:]
+	}
+
+	return ref, nil
+}
+
+// Equal returns true if the other DockerImageReference is equivalent to the
+// reference r. The comparison applies defaults to the Docker image reference,
+// so that e.g., "foobar" equals "docker.io/library/foobar:latest".
+func (r DockerImageReference) Equal(other DockerImageReference) bool {
+	defaultedRef := r.DockerClientDefaults()
+	otherDefaultedRef := other.DockerClientDefaults()
+	return defaultedRef == otherDefaultedRef
+}
+
+// DockerClientDefaults sets the default values used by the Docker client.
+func (r DockerImageReference) DockerClientDefaults() DockerImageReference {
+	if len(r.Registry) == 0 {
+		r.Registry = DockerDefaultRegistry
+	}
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	if len(r.Tag) == 0 {
+		r.Tag = "latest"
+	}
+	return r
+}
+
+// Minimal reduces a DockerImageReference to its minimalist form.
+func (r DockerImageReference) Minimal() DockerImageReference {
+	if r.Tag == "latest" {
+		r.Tag = ""
+	}
+	return r
+}
+
+// AsRepository returns the reference without tags or IDs.
+func (r DockerImageReference) AsRepository() DockerImageReference {
+	r.Tag = ""
+	r.ID = ""
+	return r
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RepositoryName() string {
+	r.Tag = ""
+	r.ID = ""
+	r.Registry = ""
+	return r.Exact()
+}
+
+// RegistryHostPort returns the registry hostname and the port.
+// If the port is not specified in the registry hostname we default to 443.
+// This will also default to Docker client defaults if the registry hostname is empty.
+func (r DockerImageReference) RegistryHostPort(insecure bool) (string, string) {
+	registryHost := r.AsV2().DockerClientDefaults().Registry
+	if strings.Contains(registryHost, ":") {
+		hostname, port, _ := net.SplitHostPort(registryHost)
+		return hostname, port
+	}
+	if insecure {
+		return registryHost, "80"
+	}
+	return registryHost, "443"
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RegistryURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   r.AsV2().Registry,
+	}
+}
+
+// DaemonMinimal clears defaults that Docker assumes.
+func (r DockerImageReference) DaemonMinimal() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultV2Registry:
+		r.Registry = DockerDefaultRegistry
+	}
+	if IsRegistryDockerHub(r.Registry) && r.Namespace == "library" {
+		r.Namespace = ""
+	}
+	return r.Minimal()
+}
+
+func (r DockerImageReference) AsV2() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultRegistry:
+		r.Registry = DockerDefaultV2Registry
+	}
+	return r
+}
+
+// MostSpecific returns the most specific image reference that can be constructed from the
+// current ref, preferring an ID over a Tag. Allows client code dealing with both tags and IDs
+// to get the most specific reference easily.
+func (r DockerImageReference) MostSpecific() DockerImageReference {
+	if len(r.ID) == 0 {
+		return r
+	}
+	if _, err := digest.ParseDigest(r.ID); err == nil {
+		r.Tag = ""
+		return r
+	}
+	if len(r.Tag) == 0 {
+		r.Tag, r.ID = r.ID, ""
+		return r
+	}
+	return r
+}
+
+// NameString returns the name of the reference with its tag or ID.
+func (r DockerImageReference) NameString() string {
+	switch {
+	case len(r.Name) == 0:
+		return ""
+	case len(r.ID) > 0:
+		var ref string
+		if _, err := digest.ParseDigest(r.ID); err == nil {
+			// if it parses as a digest, its v2 pull by id
+			ref = "@" + r.ID
+		} else {
+			// if it doesn't parse as a digest, it's presumably a v1 registry by-id tag
+			ref = ":" + r.ID
+		}
+		return r.Name + ref
+	case len(r.Tag) > 0:
+		return r.Name + ":" + r.Tag
+	default:
+		return r.Name
+	}
+}
+
+// Exact returns a string representation of the set fields on the DockerImageReference
+func (r DockerImageReference) Exact() string {
+	name := r.NameString()
+	if len(name) == 0 {
+		return name
+	}
+	s := r.Registry
+	if len(s) > 0 {
+		s += "/"
+	}
+
+	if len(r.Namespace) != 0 {
+		s += r.Namespace + "/"
+	}
+	return s + name
+}
+
+// String converts a DockerImageReference to a Docker pull spec (which implies a default namespace
+// according to V1 Docker registry rules). Use Exact() if you want no defaulting.
+func (r DockerImageReference) String() string {
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	return r.Exact()
+}
+
+// IsRegistryDockerHub returns true if the given registry name belongs to
+// Docker hub.
+func IsRegistryDockerHub(registry string) bool {
+	switch registry {
+	case DockerDefaultRegistry, DockerDefaultV1Registry, DockerDefaultV2Registry:
+		return true
+	default:
+		return false
+	}
+}
+
+// DeepCopyInto writing into out. in must be non-nil.
+func (in *DockerImageReference) DeepCopyInto(out *DockerImageReference) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver, creating a new DockerImageReference.
+func (in *DockerImageReference) DeepCopy() *DockerImageReference {
+	if in == nil {
+		return nil
+	}
+	out := new(DockerImageReference)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -811,6 +811,9 @@ github.com/openshift/image-customization-controller/pkg/ignition
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/crypto
+github.com/openshift/library-go/pkg/image/internal/digest
+github.com/openshift/library-go/pkg/image/internal/reference
+github.com/openshift/library-go/pkg/image/reference
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper


### PR DESCRIPTION
When mirror registries are enabled, it is not possible to use a tag based image (for example quay.io/openshift-release-dev/ocp-release:4.15.0-multi) for the release image of a cluster being deployed by assisted.
The user should use digest a based image (such as quay.io/openshift-release-dev/ocp-release@sha256:b86422e972b9c838dfdb8b481a67ae08308437d6489ea6aaf150242b1d30fa1c)

This PR ensures that we check for this scenario during the validation of the ClusterDeployment.

This will be propagated to the ClusterDeployments_Controller as a validation failure if the image is tag based.
A spec Sync failure will be indicated in the conditions of the controller.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
