### PR TITLE
MGMT-17618: NMStateConfig interfaces presence should be validated

### DIFF
--- a/subsystem/image_test.go
+++ b/subsystem/image_test.go
@@ -62,7 +62,7 @@ var _ = Describe("system-test image tests", func() {
 					},
 				}
 
-				config := common.FormatStaticConfigHostYAML("nic10", "02000048ba38", "192.0.2.155", "192.0.2.156", "192.0.2.1", macInterfaceMap)
+				config := common.FormatStaticConfigHostYAML("eth0", "eth1", "192.0.2.155", "192.0.2.156", "192.0.2.1", macInterfaceMap)
 				getResp, err := userBMClient.Installer.RegisterInfraEnv(ctx, &installer.RegisterInfraEnvParams{
 					InfraenvCreateParams: &models.InfraEnvCreateParams{
 						Name:                swag.String("iso-test-infra-env"),

--- a/subsystem/infra_env_test.go
+++ b/subsystem/infra_env_test.go
@@ -326,6 +326,12 @@ var _ = Describe("Infra_Env", func() {
   type: ethernet`
 		staticNetworkConfig := models.HostStaticNetworkConfig{
 			NetworkYaml: netYaml,
+			MacInterfaceMap: []*models.MacInterfaceMapItems0{
+				{
+					LogicalNicName: "eth0",
+					MacAddress:     "52:54:00:09:de:93",
+				},
+			},
 		}
 		staticNetworkConfigs := []*models.HostStaticNetworkConfig{&staticNetworkConfig}
 		updateParams := &installer.UpdateInfraEnvParams{


### PR DESCRIPTION
In case there is static networking configuration without mac-interface mapping, it is created but the configuration is not applied.

This change validates that for every ethernet interface there is a corresponding mac-interface mapping when the static network configuration is set during infa-env registration or during infra-env update.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [x] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [x] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @gamli75 