### PR TITLE
MGMT-17811: Do not create local cluster namespace

### DIFF
--- a/internal/controller/controllers/local_cluster_import_controller_test.go
+++ b/internal/controller/controllers/local_cluster_import_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -14,6 +15,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,8 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const localClusterName = "local-cluster"
+
 func newLocalClusterImportTestReconciler(scheme *runtime.Scheme, initObjs ...client.Object) *LocalClusterImportReconciler {
 
 	rtoList := []runtime.Object{}
@@ -39,7 +43,7 @@ func newLocalClusterImportTestReconciler(scheme *runtime.Scheme, initObjs ...cli
 	return &LocalClusterImportReconciler{
 		log:                    logrus.New(),
 		client:                 c,
-		localClusterName:       "local-cluster",
+		localClusterName:       localClusterName,
 		agentServiceConfigName: "agent",
 	}
 }
@@ -129,7 +133,7 @@ var _ = Describe("Reconcile", func() {
 		key = clnt.ObjectKeyFromObject(agentServiceConfig)
 		managedCluster = &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "local-cluster",
+				Name: localClusterName,
 			},
 			Spec: clusterv1.ManagedClusterSpec{
 				HubAcceptsClient:     true,
@@ -219,7 +223,12 @@ var _ = Describe("Reconcile", func() {
 				},
 			},
 		}
-		reconciler = newLocalClusterImportTestReconciler(scheme, managedCluster, agentServiceConfig, node1, node2, node3, proxy, dns, kubeConfigSecret, clusterVersion, machineApiPullSecret)
+		namespace := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: localClusterName,
+			},
+		}
+		reconciler = newLocalClusterImportTestReconciler(scheme, managedCluster, agentServiceConfig, node1, node2, node3, proxy, dns, kubeConfigSecret, clusterVersion, machineApiPullSecret, namespace)
 		client = reconciler.client
 	})
 
@@ -229,8 +238,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedName := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		err = client.Get(ctx, namespacedName, clusterDeployment)
 		Expect(err).ToNot(HaveOccurred())
@@ -242,8 +251,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		err := client.Delete(ctx, agentServiceConfig)
 		Expect(err).ToNot(HaveOccurred())
@@ -259,8 +268,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		err := client.Delete(ctx, managedCluster)
 		Expect(err).ToNot(HaveOccurred())
@@ -275,8 +284,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -297,8 +306,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -318,8 +327,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -350,8 +359,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -379,8 +388,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -429,8 +438,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -451,7 +460,7 @@ var _ = Describe("Reconcile", func() {
 		localClusterPullSecret := corev1.Secret{}
 		err = client.Get(ctx, types.NamespacedName{
 			Name:      "pull-secret",
-			Namespace: "local-cluster",
+			Namespace: localClusterName,
 		}, &localClusterPullSecret)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(localClusterPullSecret.Data[".dockerconfigjson"]).To(Equal(pullSecret.Data[".dockerconfigjson"]))
@@ -468,7 +477,7 @@ var _ = Describe("Reconcile", func() {
 		// Check local cluster pull secret after reconcile.
 		err = client.Get(ctx, types.NamespacedName{
 			Name:      "pull-secret",
-			Namespace: "local-cluster",
+			Namespace: localClusterName,
 		}, &localClusterPullSecret)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(err).ToNot(HaveOccurred())
@@ -479,8 +488,8 @@ var _ = Describe("Reconcile", func() {
 		clusterDeployment := &hivev1.ClusterDeployment{}
 		agentClusterInstall := &hiveext.AgentClusterInstall{}
 		namespacedname := types.NamespacedName{
-			Namespace: "local-cluster",
-			Name:      "local-cluster",
+			Namespace: localClusterName,
+			Name:      localClusterName,
 		}
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err := client.Get(ctx, namespacedname, clusterDeployment)
@@ -497,8 +506,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		localClusterAdminKubeConfigSecret := corev1.Secret{}
 		err = client.Get(ctx, types.NamespacedName{
-			Name:      "local-cluster-admin-kubeconfig",
-			Namespace: "local-cluster",
+			Name:      fmt.Sprintf("%s-admin-kubeconfig", localClusterName),
+			Namespace: localClusterName,
 		}, &localClusterAdminKubeConfigSecret)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(localClusterAdminKubeConfigSecret.Data["kubeconfig"]).To(Equal(nodeKubeConfigsSecret.Data["lb-ext.kubeconfig"]))
@@ -509,8 +518,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		awaitReconcile(aiv1beta1.ConditionLocalClusterManaged, aiv1beta1.ReasonLocalClusterManaged, corev1.ConditionTrue, nil)
 		err = client.Get(ctx, types.NamespacedName{
-			Name:      "local-cluster-admin-kubeconfig",
-			Namespace: "local-cluster",
+			Name:      fmt.Sprintf("%s-admin-kubeconfig", localClusterName),
+			Namespace: localClusterName,
 		}, &localClusterAdminKubeConfigSecret)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(localClusterAdminKubeConfigSecret.Data["kubeconfig"]).To(Equal(nodeKubeConfigsSecret.Data["lb-ext.kubeconfig"]))


### PR DESCRIPTION
The code in master to create the local cluster namespace is not working due to a copy/paste error (it's really creating a clusterImageSet)
While looking into this, I considered that the local-cluster namespace does not need to be managed or updated by us as it is owned by ACM.
So I am removing the code to create/update a namespace in production code.

In tests, we will create a local-cluster namespace for the purpose of testing.


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
