### PR TITLE
MGMT-17353: Debug pod left in ImagePullBackOff after install in disconnected environment

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -75,6 +75,9 @@ type InstallCmdRequest struct {
 	// Must-gather images to use
 	MustGatherImage string `json:"must_gather_image,omitempty"`
 
+	// If true, notify number of reboots by assisted controller
+	NotifyNumReboots bool `json:"notify_num_reboots,omitempty"`
+
 	// Version of the OpenShift cluster.
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -75,6 +75,9 @@ type InstallCmdRequest struct {
 	// Must-gather images to use
 	MustGatherImage string `json:"must_gather_image,omitempty"`
 
+	// If true, notify number of reboots by assisted controller
+	NotifyNumReboots bool `json:"notify_num_reboots,omitempty"`
+
 	// Version of the OpenShift cluster.
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/internal/host/hostcommands/install_cmd.go
+++ b/internal/host/hostcommands/install_cmd.go
@@ -47,10 +47,11 @@ type installCmd struct {
 	eventsHandler       eventsapi.Handler
 	versionsHandler     versions.Handler
 	enableSkipMcoReboot bool
+	notifyNumReboots    bool
 }
 
 func NewInstallCmd(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Validator, ocRelease oc.Release,
-	instructionConfig InstructionConfig, eventsHandler eventsapi.Handler, versionsHandler versions.Handler, enableSkipMcoReboot bool) *installCmd {
+	instructionConfig InstructionConfig, eventsHandler eventsapi.Handler, versionsHandler versions.Handler, enableSkipMcoReboot, notifyNumReboots bool) *installCmd {
 	return &installCmd{
 		baseCmd:             baseCmd{log: log},
 		db:                  db,
@@ -60,6 +61,7 @@ func NewInstallCmd(log logrus.FieldLogger, db *gorm.DB, hwValidator hardware.Val
 		eventsHandler:       eventsHandler,
 		versionsHandler:     versionsHandler,
 		enableSkipMcoReboot: enableSkipMcoReboot,
+		notifyNumReboots:    notifyNumReboots,
 	}
 }
 
@@ -133,6 +135,7 @@ func (i *installCmd) getFullInstallerCommand(ctx context.Context, cluster *commo
 		request.EnableSkipMcoReboot = featuresupport.IsFeatureAvailable(models.FeatureSupportLevelIDSKIPMCOREBOOT,
 			cluster.OpenshiftVersion, swag.String(cluster.CPUArchitecture))
 	}
+	request.NotifyNumReboots = i.notifyNumReboots
 
 	// those flags are not used on day2 installation
 	if swag.StringValue(cluster.Kind) != models.ClusterKindAddHostsCluster {

--- a/internal/host/hostcommands/instruction_manager.go
+++ b/internal/host/hostcommands/instruction_manager.go
@@ -79,7 +79,7 @@ func NewInstructionManager(log logrus.FieldLogger, db *gorm.DB, hwValidator hard
 	instructionConfig InstructionConfig, connectivityValidator connectivity.Validator, eventsHandler eventsapi.Handler,
 	versionHandler versions.Handler, osImages versions.OSImages, kubeApiEnabled bool) *InstructionManager {
 	connectivityCmd := NewConnectivityCheckCmd(log, db, connectivityValidator, instructionConfig.AgentImage)
-	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot)
+	installCmd := NewInstallCmd(log, db, hwValidator, ocRelease, instructionConfig, eventsHandler, versionHandler, instructionConfig.EnableSkipMcoReboot, !kubeApiEnabled)
 	inventoryCmd := NewInventoryCmd(log, instructionConfig.AgentImage)
 	freeAddressesCmd := newFreeAddressesCmd(log, kubeApiEnabled)
 	stopCmd := NewStopInstallationCmd(log)

--- a/models/install_cmd_request.go
+++ b/models/install_cmd_request.go
@@ -75,6 +75,9 @@ type InstallCmdRequest struct {
 	// Must-gather images to use
 	MustGatherImage string `json:"must_gather_image,omitempty"`
 
+	// If true, notify number of reboots by assisted controller
+	NotifyNumReboots bool `json:"notify_num_reboots,omitempty"`
+
 	// Version of the OpenShift cluster.
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -8942,6 +8942,10 @@ func init() {
           "description": "Must-gather images to use",
           "type": "string"
         },
+        "notify_num_reboots": {
+          "description": "If true, notify number of reboots by assisted controller",
+          "type": "boolean"
+        },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",
           "type": "string"
@@ -19695,6 +19699,10 @@ func init() {
         "must_gather_image": {
           "description": "Must-gather images to use",
           "type": "string"
+        },
+        "notify_num_reboots": {
+          "description": "If true, notify number of reboots by assisted controller",
+          "type": "boolean"
         },
         "openshift_version": {
           "description": "Version of the OpenShift cluster.",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6669,6 +6669,9 @@ definitions:
       enable_skip_mco_reboot:
         type: boolean
         description: If true, assisted service will attempt to skip MCO reboot
+      notify_num_reboots:
+        type: boolean
+        description: If true, notify number of reboots by assisted controller
 
   ntp_synchronization_request:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
+++ b/vendor/github.com/openshift/assisted-service/models/install_cmd_request.go
@@ -75,6 +75,9 @@ type InstallCmdRequest struct {
 	// Must-gather images to use
 	MustGatherImage string `json:"must_gather_image,omitempty"`
 
+	// If true, notify number of reboots by assisted controller
+	NotifyNumReboots bool `json:"notify_num_reboots,omitempty"`
+
 	// Version of the OpenShift cluster.
 	OpenshiftVersion string `json:"openshift_version,omitempty"`
 


### PR DESCRIPTION


Pass a flag in the installation command instructing the controller if notify reboots functionality is enabled.
The flag is enabled only if kube-api is not enabled in the service

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @tsorya 
/cc @carbonin 