### PR TITLE
MGMT-17866: Assisted service change for F5 DNS load balancer

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
@@ -123,6 +123,9 @@ func (m *DomainResolutionResponse) UnmarshalBinary(b []byte) error {
 // swagger:model DomainResolutionResponseDomain
 type DomainResolutionResponseDomain struct {
 
+	// The cnames that were resolved for the domain, empty if none
+	Cnames []string `json:"cnames"`
+
 	// The domain that was resolved
 	// Required: true
 	DomainName *string `json:"domain_name"`

--- a/client/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
@@ -123,6 +123,9 @@ func (m *DomainResolutionResponse) UnmarshalBinary(b []byte) error {
 // swagger:model DomainResolutionResponseDomain
 type DomainResolutionResponseDomain struct {
 
+	// The cnames that were resolved for the domain, empty if none
+	Cnames []string `json:"cnames"`
+
 	// The domain that was resolved
 	// Required: true
 	DomainName *string `json:"domain_name"`

--- a/internal/common/test_configuration.go
+++ b/internal/common/test_configuration.go
@@ -159,6 +159,31 @@ var DomainResolutions = []*models.DomainResolutionResponseDomain{
 	},
 }
 
+var DomainResolutionsWithCname = []*models.DomainResolutionResponseDomain{
+	{
+		DomainName: &DomainAPI,
+		Cnames:     []string{"api.cname.com"},
+	},
+	{
+		DomainName: &DomainAPIInternal,
+		Cnames:     []string{"api-int.cname.com"},
+	},
+	{
+		DomainName: &DomainApps,
+		Cnames:     []string{"console.apps.cname.com"},
+	},
+	{
+		DomainName: &ReleaseDomain,
+		Cnames:     []string{"release.cname.com"},
+	},
+	{
+		DomainName: &WildcardDomain,
+	},
+	{
+		DomainName: &UndottedWildcardDomain,
+	},
+}
+
 var WildcardResolved = []*models.DomainResolutionResponseDomain{
 	{
 		DomainName:    &WildcardDomain,
@@ -169,6 +194,17 @@ var WildcardResolved = []*models.DomainResolutionResponseDomain{
 		DomainName:    &UndottedWildcardDomain,
 		IPV4Addresses: []strfmt.IPv4{"7.8.9.10/24"},
 		IPV6Addresses: []strfmt.IPv6{"1003:db8::40/120"},
+	},
+}
+
+var WildcardResolvedWithCname = []*models.DomainResolutionResponseDomain{
+	{
+		DomainName: &WildcardDomain,
+		Cnames:     []string{"a.test.com"},
+	},
+	{
+		DomainName: &UndottedWildcardDomain,
+		Cnames:     []string{"a.test.com"},
 	},
 }
 
@@ -237,9 +273,11 @@ var DomainResolutionAllEmpty = []*models.DomainResolutionResponseDomain{
 }
 
 var TestDomainNameResolutionsSuccess = &models.DomainResolutionResponse{Resolutions: DomainResolutions}
+var TestDomainNameResolutionsSuccessWithCname = &models.DomainResolutionResponse{Resolutions: DomainResolutionsWithCname}
 var TestDomainResolutionsNoAPI = &models.DomainResolutionResponse{Resolutions: DomainResolutionNoAPI}
 var TestDomainResolutionsAllEmpty = &models.DomainResolutionResponse{Resolutions: DomainResolutionAllEmpty}
 var TestDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: WildcardResolved}
+var TestDomainNameResolutionsWildcardResolvedWithCname = &models.DomainResolutionResponse{Resolutions: WildcardResolvedWithCname}
 var TestSubDomainNameResolutionsWildcardResolved = &models.DomainResolutionResponse{Resolutions: SubDomainWildcardResolved}
 
 var TestDefaultRouteConfiguration = []*models.Route{{Family: FamilyIPv4, Interface: "eth0", Gateway: "1.2.3.10", Destination: "0.0.0.0", Metric: 600}}

--- a/models/domain_resolution_response.go
+++ b/models/domain_resolution_response.go
@@ -123,6 +123,9 @@ func (m *DomainResolutionResponse) UnmarshalBinary(b []byte) error {
 // swagger:model DomainResolutionResponseDomain
 type DomainResolutionResponseDomain struct {
 
+	// The cnames that were resolved for the domain, empty if none
+	Cnames []string `json:"cnames"`
+
 	// The domain that was resolved
 	// Required: true
 	DomainName *string `json:"domain_name"`

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7508,6 +7508,13 @@ func init() {
               "domain_name"
             ],
             "properties": {
+              "cnames": {
+                "description": "The cnames that were resolved for the domain, empty if none",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "domain_name": {
                 "description": "The domain that was resolved",
                 "type": "string"
@@ -16696,6 +16703,13 @@ func init() {
         "domain_name"
       ],
       "properties": {
+        "cnames": {
+          "description": "The cnames that were resolved for the domain, empty if none",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "domain_name": {
           "description": "The domain that was resolved",
           "type": "string"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6300,6 +6300,11 @@ definitions:
               items:
                 type: string
                 format: ipv6
+            cnames:
+              type: array
+              description: The cnames that were resolved for the domain, empty if none
+              items:
+                type: string
 
   disk_speed:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
+++ b/vendor/github.com/openshift/assisted-service/models/domain_resolution_response.go
@@ -123,6 +123,9 @@ func (m *DomainResolutionResponse) UnmarshalBinary(b []byte) error {
 // swagger:model DomainResolutionResponseDomain
 type DomainResolutionResponseDomain struct {
 
+	// The cnames that were resolved for the domain, empty if none
+	Cnames []string `json:"cnames"`
+
 	// The domain that was resolved
 	// Required: true
 	DomainName *string `json:"domain_name"`


### PR DESCRIPTION
In order to support F5 DNS load balancer, CNAMES resolutions will be added.  If a CNAME record exists for a domain-name, it means that the domain is resolved.
This change includes:
- Swagger changes to include the cnames in the domain resolution response
- Validation changes to refer cnames in the domain resolution response

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @zaneb 
/cc @gamli75 