### PR TITLE
MGMT-17898: Use the EL8 assisted-service image when requested by annotation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,8 @@ spec:
         env:
           - name: SERVICE_IMAGE
             value: quay.io/edge-infrastructure/assisted-service:latest
+          - name: SERVICE_EL8_IMAGE
+            value: quay.io/edge-infrastructure/assisted-service-el8:latest
           - name: IMAGE_SERVICE_IMAGE
             value: quay.io/edge-infrastructure/assisted-image-service:latest
           - name: DATABASE_IMAGE

--- a/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/manifests/assisted-service-operator.clusterserviceversion.yaml
@@ -990,6 +990,8 @@ spec:
                 env:
                 - name: SERVICE_IMAGE
                   value: quay.io/edge-infrastructure/assisted-service:latest
+                - name: SERVICE_EL8_IMAGE
+                  value: quay.io/edge-infrastructure/assisted-service-el8:latest
                 - name: IMAGE_SERVICE_IMAGE
                   value: quay.io/edge-infrastructure/assisted-image-service:latest
                 - name: DATABASE_IMAGE

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -397,3 +397,13 @@ spec:
 The following endpoints would be exposed via HTTP:
 * `api/assisted-installer/v2/infra-envs/<id>/downloads/files?file_name=ipxe-script` in assisted-service
 * `boot-artifacts/` and `images/<infra-enf id>/pxe-initrd` in assisted-image-service
+
+### Alternate service images for running on FIPS mode clusters
+
+**NOTE**: This only applies when the cluster on which assisted-service is running is FIPS-enabled. The default image will work for all other cases.
+
+The assisted-service container runs the `openshift-baremetal-install` binary as a part of installing a cluster.
+When the cluster on which assisted-service is running is FIPS-enabled, the assisted-service image base must contain the crypto libraries expected by the `openshift-baremetal-install` binary being run.
+
+For installing OpenShift clusters of version > 4.15, the annotation is not required.
+For installing OpenShift clusters of version <= 4.15, set the annotation `agent-install.openshift.io/service-image-base` on the AgentServiceConfig to `el8`.

--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -1080,7 +1080,7 @@ func newAssistedCM(ctx context.Context, log logrus.FieldLogger, asc ASC) (client
 			"AGENT_DOCKER_IMAGE":     AgentImage(),
 			"CONTROLLER_IMAGE":       ControllerImage(),
 			"INSTALLER_IMAGE":        InstallerImage(),
-			"SELF_VERSION":           ServiceImage(),
+			"SELF_VERSION":           ServiceImage(asc.Object),
 			"OS_IMAGES":              getOSImages(log, asc.spec),
 			"MUST_GATHER_IMAGES":     getMustGatherImages(log, asc.spec),
 			"ISO_IMAGE_TYPE":         "minimal-iso",
@@ -1166,7 +1166,7 @@ func getDeploymentData(ctx context.Context, cm *corev1.ConfigMap, asc ASC) {
 	}
 	//  Both ACM and MCE are not deployed so this is a stand-alone operator deployment
 	cm.Data["DEPLOYMENT_TYPE"] = "Operator"
-	cm.Data["DEPLOYMENT_VERSION"] = ServiceImage()
+	cm.Data["DEPLOYMENT_VERSION"] = ServiceImage(asc.Object)
 }
 
 // Extracts the environment variable OPERATOR_VERSION from a k8s deployment
@@ -1602,7 +1602,7 @@ func newAssistedServiceDeployment(ctx context.Context, log logrus.FieldLogger, a
 
 	serviceContainer := corev1.Container{
 		Name:  serviceName,
-		Image: ServiceImage(),
+		Image: ServiceImage(asc.Object),
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: int32(servicePort.IntValue()),
@@ -2366,8 +2366,9 @@ func newWebHookAPIService(ctx context.Context, log logrus.FieldLogger, asc ASC) 
 
 func newWebHookDeployment(ctx context.Context, log logrus.FieldLogger, asc ASC) (client.Object, controllerutil.MutateFn, error) {
 	serviceContainer := corev1.Container{
-		Name:  "agentinstalladmission",
-		Image: ServiceImage(),
+		Name: "agentinstalladmission",
+		// always use the default image for webhooks since this will never need to run the installer binary
+		Image: serviceImageDefault(),
 		Command: []string{
 			"/assisted-service-admission",
 			"--secure-port=9443",

--- a/internal/controller/controllers/images.go
+++ b/internal/controller/controllers/images.go
@@ -18,14 +18,30 @@ package controllers
 
 import (
 	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	OsImagesEnvVar string = "OS_IMAGES"
+	OsImagesEnvVar             string = "OS_IMAGES"
+	serviceImageBaseAnnotation string = "agent-install.openshift.io/service-image-base"
+	serviceImageBaseEL8        string = "el8"
 )
 
-func ServiceImage() string {
+func ServiceImage(asc client.Object) string {
+	val, ok := asc.GetAnnotations()[serviceImageBaseAnnotation]
+	if ok && val == serviceImageBaseEL8 {
+		return serviceImageEL8()
+	}
+	return serviceImageDefault()
+}
+
+func serviceImageDefault() string {
 	return getEnvVar("SERVICE_IMAGE", "quay.io/edge-infrastructure/assisted-service:latest")
+}
+
+func serviceImageEL8() string {
+	return getEnvVar("SERVICE_EL8_IMAGE", "quay.io/edge-infrastructure/assisted-service-el8:latest")
 }
 
 func ImageServiceImage() string {


### PR DESCRIPTION
A user should request the EL8 image when they are running in a FIPS-enabled cluster and intend to only install OCP versions <4.16.

This can be done by setting the
`agent-install.openshift.io/service-image-base` annotation to `el8` on the AgentServiceConfig resource

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-17898

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed the new operator and configured the new image env var.
Set and unset the annotation and observed that the operator changed the image correctly.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [x] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
  - I don't think this is worth documenting upstream
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
