### PR TITLE
OCPBUGS-34181: Revert "Use openshift-install binary for releases >= 4.16"

### DIFF
--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -331,7 +331,7 @@ func (g *installerGenerator) Generate(ctx context.Context, installConfig []byte,
 		MaxTries: oc.DefaultTries, RetryDelay: oc.DefaltRetryDelay}, mirrorRegistriesBuilder)
 
 	release, err := g.installerCache.Get(g.installerReleaseImageOverride, g.releaseImageMirror,
-		g.cluster.PullSecret, ocRelease, g.cluster.OpenshiftVersion)
+		g.cluster.PullSecret, ocRelease)
 	if err != nil {
 		return errors.Wrap(err, "failed to get installer path")
 	}

--- a/internal/installercache/installercache.go
+++ b/internal/installercache/installercache.go
@@ -63,7 +63,7 @@ func New(cacheDir string, storageCapacity int64, log logrus.FieldLogger) *Instal
 // Get returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image. Tries the mirror release image first if it's set. It is safe for concurrent use. A cache of
 // binaries is maintained to reduce re-downloading of the same release.
-func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocRelease oc.Release, ocpVersion string) (*Release, error) {
+func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocRelease oc.Release) (*Release, error) {
 	i.Lock()
 	defer i.Unlock()
 
@@ -74,16 +74,13 @@ func (i *Installers) Get(releaseID, releaseIDMirror, pullSecret string, ocReleas
 	if releaseIDMirror != "" {
 		releaseImageLocation = releaseIDMirror
 	}
-	workdir, binary, path, err = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir, ocpVersion)
-	if err != nil {
-		return nil, err
-	}
+	workdir, binary, path = ocRelease.GetReleaseBinaryPath(releaseImageLocation, i.cacheDir)
 	if _, err = os.Stat(path); os.IsNotExist(err) {
 		//evict older files if necessary
 		i.evict()
 
 		//extract the binary
-		_, err = ocRelease.Extract(i.log, releaseID, releaseIDMirror, i.cacheDir, pullSecret, ocpVersion)
+		_, err = ocRelease.Extract(i.log, releaseID, releaseIDMirror, i.cacheDir, pullSecret)
 		if err != nil {
 			return &Release{}, err
 		}

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -35,18 +35,18 @@ func (m *MockRelease) EXPECT() *MockReleaseMockRecorder {
 }
 
 // Extract mocks base method.
-func (m *MockRelease) Extract(log logrus.FieldLogger, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion string) (string, error) {
+func (m *MockRelease) Extract(log logrus.FieldLogger, releaseImage, releaseImageMirror, cacheDir, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Extract", log, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion)
+	ret := m.ctrl.Call(m, "Extract", log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Extract indicates an expected call of Extract.
-func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion interface{}) *gomock.Call {
+func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 }
 
 // GetIronicAgentImage mocks base method.
@@ -155,18 +155,17 @@ func (mr *MockReleaseMockRecorder) GetReleaseArchitecture(log, releaseImage, rel
 }
 
 // GetReleaseBinaryPath mocks base method.
-func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir, ocpVersion string) (string, string, string, error) {
+func (m *MockRelease) GetReleaseBinaryPath(releaseImage, cacheDir string) (string, string, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReleaseBinaryPath", releaseImage, cacheDir, ocpVersion)
+	ret := m.ctrl.Call(m, "GetReleaseBinaryPath", releaseImage, cacheDir)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	return ret0, ret1, ret2
 }
 
 // GetReleaseBinaryPath indicates an expected call of GetReleaseBinaryPath.
-func (mr *MockReleaseMockRecorder) GetReleaseBinaryPath(releaseImage, cacheDir, ocpVersion interface{}) *gomock.Call {
+func (mr *MockReleaseMockRecorder) GetReleaseBinaryPath(releaseImage, cacheDir interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseBinaryPath", reflect.TypeOf((*MockRelease)(nil).GetReleaseBinaryPath), releaseImage, cacheDir, ocpVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReleaseBinaryPath", reflect.TypeOf((*MockRelease)(nil).GetReleaseBinaryPath), releaseImage, cacheDir)
 }

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -24,13 +24,12 @@ import (
 )
 
 const (
-	mcoImageName                   = "machine-config-operator"
-	ironicAgentImageName           = "ironic-agent"
-	mustGatherImageName            = "must-gather"
-	okdRPMSImageName               = "okd-rpms"
-	DefaultTries                   = 5
-	DefaltRetryDelay               = time.Second * 5
-	staticInstallerRequiredVersion = "4.16.0-ec.6"
+	mcoImageName         = "machine-config-operator"
+	ironicAgentImageName = "ironic-agent"
+	mustGatherImageName  = "must-gather"
+	okdRPMSImageName     = "okd-rpms"
+	DefaultTries         = 5
+	DefaltRetryDelay     = time.Second * 5
 )
 
 type Config struct {
@@ -47,8 +46,8 @@ type Release interface {
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetReleaseArchitecture(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) ([]string, error)
-	GetReleaseBinaryPath(releaseImage string, cacheDir string, ocpVersion string) (workdir string, binary string, path string, err error)
-	Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, ocpVersion string) (string, error)
+	GetReleaseBinaryPath(releaseImage string, cacheDir string) (workdir string, binary string, path string)
+	Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error)
 }
 
 type imageValue struct {
@@ -312,9 +311,9 @@ func (r *release) getOpenshiftVersionFromRelease(log logrus.FieldLogger, release
 	return strings.Trim(version, "'"), nil
 }
 
-// Extract installer binary from releaseImageMirror if provided.
+// Extract openshift-baremetal-install binary from releaseImageMirror if provided.
 // Else extract from the source releaseImage
-func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, ocpVersion string) (string, error) {
+func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string) (string, error) {
 	var path string
 	var err error
 	if releaseImage == "" && releaseImageMirror == "" {
@@ -329,13 +328,13 @@ func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseIm
 
 	if releaseImageMirror != "" {
 		//TODO: Get mirror registry certificate from install-config
-		path, err = r.extractFromRelease(log, releaseImageMirror, cacheDir, pullSecret, true, icspFile, ocpVersion)
+		path, err = r.extractFromRelease(log, releaseImageMirror, cacheDir, pullSecret, true, icspFile)
 		if err != nil {
 			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from mirror release image %s", releaseImageMirror)
 			return "", err
 		}
 	} else {
-		path, err = r.extractFromRelease(log, releaseImage, cacheDir, pullSecret, false, icspFile, ocpVersion)
+		path, err = r.extractFromRelease(log, releaseImage, cacheDir, pullSecret, false, icspFile)
 		if err != nil {
 			log.WithError(err).Errorf("failed to extract openshift-baremetal-install from release image %s", releaseImage)
 			return "", err
@@ -344,35 +343,19 @@ func (r *release) Extract(log logrus.FieldLogger, releaseImage string, releaseIm
 	return path, err
 }
 
-func (r *release) GetReleaseBinaryPath(releaseImage string, cacheDir string, ocpVersion string) (workdir string, binary string, path string, err error) {
-	binary = "openshift-baremetal-install"
-
-	// use the statically linked binary for 4.16 and up since our container is el8
-	// based and the baremetal binary for those versions is dynamically linked
-	// against el9 libaries
-	staticLinkingRequiredVersion := version.Must(version.NewVersion(staticInstallerRequiredVersion))
-	v, err := version.NewVersion(ocpVersion)
-	if err != nil {
-		return "", "", "", err
-	}
-	if v.GreaterThanOrEqual(staticLinkingRequiredVersion) {
-		binary = "openshift-install"
-	}
-
+func (r *release) GetReleaseBinaryPath(releaseImage string, cacheDir string) (workdir string, binary string, path string) {
 	workdir = filepath.Join(cacheDir, releaseImage)
+	binary = "openshift-baremetal-install"
 	path = filepath.Join(workdir, binary)
 	return
 }
 
 // extractFromRelease returns the path to an openshift-baremetal-install binary extracted from
 // the referenced release image.
-func (r *release) extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool, icspFile string, ocpVersion string) (string, error) {
-	workdir, binary, path, err := r.GetReleaseBinaryPath(releaseImage, cacheDir, ocpVersion)
-	if err != nil {
-		return "", err
-	}
+func (r *release) extractFromRelease(log logrus.FieldLogger, releaseImage, cacheDir, pullSecret string, insecure bool, icspFile string) (string, error) {
+	workdir, binary, path := r.GetReleaseBinaryPath(releaseImage, cacheDir)
 	log.Infof("extracting %s binary to %s", binary, workdir)
-	err = os.MkdirAll(workdir, 0755)
+	err := os.MkdirAll(workdir, 0755)
 	if err != nil {
 		return "", err
 	}

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -374,7 +374,7 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, "4.15.0")
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImage, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
@@ -386,14 +386,14 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret, "4.15.0")
+			path, err := oc.Extract(log, releaseImage, releaseImageMirror, cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImageMirror, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
 		It("extract baremetal-install with no release image or mirror", func() {
-			path, err := oc.Extract(log, "", "", cacheDir, pullSecret, "4.15.0")
+			path, err := oc.Extract(log, "", "", cacheDir, pullSecret)
 			Expect(path).Should(BeEmpty())
 			Expect(err).Should(HaveOccurred())
 		})
@@ -404,7 +404,7 @@ var _ = Describe("oc", func() {
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "Failed to extract the installer", 1).Times(1)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "", 0).Times(1)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, "4.15.0")
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			filePath := filepath.Join(cacheDir+"/"+releaseImage, baremetalInstallBinary)
 			Expect(path).To(Equal(filePath))
 			Expect(err).ShouldNot(HaveOccurred())
@@ -416,7 +416,7 @@ var _ = Describe("oc", func() {
 			args := splitStringToInterfacesArray(command)
 			mockExecuter.EXPECT().Execute(args[0], args[1:]...).Return("", "Failed to extract the installer", 1).Times(5)
 
-			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret, "4.15.0")
+			path, err := oc.Extract(log, releaseImage, "", cacheDir, pullSecret)
 			Expect(path).To(Equal(""))
 			Expect(err).Should(HaveOccurred())
 		})
@@ -602,43 +602,6 @@ var _ = Describe("getIcspFileFromRegistriesConfig", func() {
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(MatchError("extract failed"))
 		Expect(icspFile).Should(Equal(""))
-	})
-})
-
-var _ = Describe("GetReleaseBinaryPath", func() {
-	var r Release
-	BeforeEach(func() {
-		r = NewRelease(nil, Config{}, nil)
-	})
-
-	It("returns the openshift-baremetal-install binary for versions earlier than 4.16", func() {
-		_, bin, _, err := r.GetReleaseBinaryPath("image", "dir", "4.15.0")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-baremetal-install"))
-	})
-
-	It("returns the openshift-install binary for 4.16.0", func() {
-		_, bin, _, err := r.GetReleaseBinaryPath("image", "dir", "4.16.0")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-install"))
-	})
-
-	It("returns the openshift-install binary for 4.16 pre release", func() {
-		_, bin, _, err := r.GetReleaseBinaryPath("image", "dir", "4.16.0-ec.6")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-install"))
-		_, bin, _, err = r.GetReleaseBinaryPath("image", "dir", "4.16.0-rc.0")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-install"))
-	})
-
-	It("returns the openshift-install binary for versions later than 4.16.0", func() {
-		_, bin, _, err := r.GetReleaseBinaryPath("image", "dir", "4.17.0")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-install"))
-		_, bin, _, err = r.GetReleaseBinaryPath("image", "dir", "4.18.0")
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(bin).To(Equal("openshift-install"))
 	})
 })
 


### PR DESCRIPTION
We must always use the openshift-baremetal-install binary because otherwise enabling FIPS is not possible. The agent-based installer depends on this.

This reverts commit fdf233a7439008dec8ee9215f7da05b794d7ea82 (#6304), which broke FIPS for 4.16 and later.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] ABI
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
