### PR TITLE
MGMT-17763: Setting Machine network CIDR is forbidden" error is only present on cluster updates

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -2125,6 +2125,7 @@ func (b *bareMetalInventory) updateNonDhcpNetworkParams(cluster *common.Cluster,
 	}
 	if params.ClusterUpdateParams.MachineNetworks != nil &&
 		common.IsSliceNonEmpty(params.ClusterUpdateParams.MachineNetworks) &&
+		interactivity == Interactive &&
 		!reqDualStack {
 		err := errors.New("Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 		log.WithError(err).Warnf("Set Machine Network CIDR")

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -4299,6 +4299,26 @@ var _ = Describe("cluster", func() {
 					verifyApiErrorString(reply, http.StatusBadRequest,
 						"Setting Machine network CIDR is forbidden when cluster is not in vip-dhcp-allocation mode")
 				})
+				It("Machine network CIDR in non dhcp non interactive", func() {
+					mockClusterUpdatability(2)
+					mockHostApi.EXPECT().GetStagesByRole(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+					setAndCheck := func(cidr models.Subnet) {
+						_, err := bm.UpdateClusterNonInteractive(ctx, installer.V2UpdateClusterParams{
+							ClusterID: clusterID,
+							ClusterUpdateParams: &models.V2ClusterUpdateParams{
+								MachineNetworks: []*models.MachineNetwork{{Cidr: cidr}},
+							},
+						})
+						Expect(err).ToNot(HaveOccurred())
+						var machineNetworks []*models.MachineNetwork
+						Expect(db.Where("cluster_id = ?", clusterID).Find(&machineNetworks).Error).ToNot(HaveOccurred())
+						Expect(machineNetworks).To(HaveLen(1))
+						Expect(machineNetworks[0].Cidr).To(Equal(cidr))
+					}
+					setAndCheck("10.11.0.0/16")
+					setAndCheck("1.2.3.0/24")
+				})
 
 				It("Machine network CIDR in non dhcp for dual-stack", func() {
 					mockClusterUpdatability(1)


### PR DESCRIPTION
When a cluster is single stack and DHCP VIP allocation is off, the machine-network is calculated by selecting a host network that the VIPs belong to. So machine network update is forbidden in this case. This is undesirable for KubeAPI where the machine-network is specified in a custom resource.
So this change allows machine-network update if the update arrived from KubeAPI (non interactive).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @gamli75 
/cc @carbonin 
/cc @eranco74 