### PR TITLE
MGMT-17901: Ignore mirror registries during pull secret validation 

### DIFF
--- a/pkg/mirrorregistries/generator.go
+++ b/pkg/mirrorregistries/generator.go
@@ -74,10 +74,10 @@ func (m *mirrorRegistriesConfigBuilder) ExtractLocationMirrorDataFromRegistries(
 	if err != nil {
 		return nil, err
 	}
-	return extractLocationMirrorDataFromRegistries(string(contents))
+	return ExtractLocationMirrorDataFromRegistriesFromToml(string(contents))
 }
 
-func extractLocationMirrorDataFromRegistries(registriesConfToml string) ([]RegistriesConf, error) {
+func ExtractLocationMirrorDataFromRegistriesFromToml(registriesConfToml string) ([]RegistriesConf, error) {
 	tomlTree, err := toml.Load(registriesConfToml)
 	if err != nil {
 		return nil, err

--- a/pkg/mirrorregistries/generator_test.go
+++ b/pkg/mirrorregistries/generator_test.go
@@ -47,23 +47,23 @@ location = "mirror_location3"
 
 var _ = Describe("extractLocationMirrorDataFromRegistries", func() {
 	It("extracts data from registry config with mirrors", func() {
-		dataList, err := extractLocationMirrorDataFromRegistries(configWithMirrors)
+		dataList, err := ExtractLocationMirrorDataFromRegistriesFromToml(configWithMirrors)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(dataList).Should(Equal(expectedExtractList))
 	})
 
 	It("fails to extract data from registry config without mirrors", func() {
-		_, err := extractLocationMirrorDataFromRegistries(configWithoutMirrors)
+		_, err := ExtractLocationMirrorDataFromRegistriesFromToml(configWithoutMirrors)
 		Expect(err.Error()).Should(Equal("failed to cast registry key to toml Tree, registriesConfToml: unqualified-search-registries = [\"registry1\", \"registry2\", \"registry3\"]"))
 	})
 
 	It("fails to extract data from registry config with garbage", func() {
-		_, err := extractLocationMirrorDataFromRegistries(configWithGarbage)
+		_, err := ExtractLocationMirrorDataFromRegistriesFromToml(configWithGarbage)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("fails to extract data from empty config", func() {
-		_, err := extractLocationMirrorDataFromRegistries("")
+		_, err := ExtractLocationMirrorDataFromRegistriesFromToml("")
 		Expect(err.Error()).Should(Equal("failed to cast registry key to toml Tree, registriesConfToml: "))
 	})
 


### PR DESCRIPTION
Up until https://github.com/openshift/assisted-service/pull/6158/ was merged, installations flows in kubeAPI mode were not validating the `clusterImageSet` release images as they were added to the cache later in the flow. Therefore, since this PR was merged, a new issue appeared - registries specified by the user as local mirrors are not added to the ignore list, thus causing the flow to fail. The changes in this PR are adding the local registries to the ignore list.

Waiting for QE test
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
