### PR TITLE
MGMT-17984: [soft timeout] operators timeout after 10 hours without events

### DIFF
--- a/internal/cluster/finalizing_stages_test.go
+++ b/internal/cluster/finalizing_stages_test.go
@@ -8,12 +8,13 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/models"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/thoas/go-funk"
 )
 
 var _ = DescribeTable("finalizing stage timeouts",
-	func(stage models.FinalizingStage, operators []*models.MonitoredOperator, envValue string, expected time.Duration) {
+	func(stage models.FinalizingStage, operators []*models.MonitoredOperator, softTimeoutEnabled bool, envValue string, expected time.Duration) {
 		if envValue != "" {
 			envKey := convertStageToEnvVar(stage)
 			_ = os.Setenv(envKey, envValue)
@@ -21,7 +22,7 @@ var _ = DescribeTable("finalizing stage timeouts",
 				_ = os.Unsetenv(envKey)
 			}()
 		}
-		Expect(finalizingStageTimeout(stage, operators, logrus.New())).To(Equal(expected))
+		Expect(finalizingStageTimeout(stage, operators, softTimeoutEnabled, logrus.New())).To(Equal(expected))
 	},
 	func() []TableEntry {
 		// Variables for test setup
@@ -60,38 +61,41 @@ var _ = DescribeTable("finalizing stage timeouts",
 		// End of variables declaration section
 
 		// Test cases for all stages without operators
-		for _, stage := range finalizingStages {
-			defaultTimeout := finalizingStageDefaultTimeout(stage, log)
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and without operators", stage), stage, nil, "", defaultTimeout))
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and without operators", stage), stage, nil, "123m", 123*time.Minute))
-		}
+		for _, softTimeoutEnabled := range []bool{false, true} {
+			timeoutStr := lo.Ternary(softTimeoutEnabled, "with soft timeouts", "with hard timeouts")
+			for _, stage := range finalizingStages {
+				defaultTimeout := finalizingStageDefaultTimeout(stage, softTimeoutEnabled, log)
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and without operators %s", stage, timeoutStr), stage, nil, softTimeoutEnabled, "", defaultTimeout))
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and without operators %s", stage, timeoutStr), stage, nil, softTimeoutEnabled, "123m", 123*time.Minute))
+			}
 
-		// Test cases for non OLM stages with operators.  Should behave the same as if operators were not provided
-		for _, stage := range nonOlmStages {
-			defaultTimeout := finalizingStageDefaultTimeout(stage, log)
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and with operators", stage), stage, operators, "", defaultTimeout))
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and with operators", stage), stage, operators, "123m", 123*time.Minute))
-		}
+			// Test cases for non OLM stages with operators.  Should behave the same as if operators were not provided
+			for _, stage := range nonOlmStages {
+				defaultTimeout := finalizingStageDefaultTimeout(stage, softTimeoutEnabled, log)
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and with operators %s", stage, timeoutStr), stage, operators, softTimeoutEnabled, "", defaultTimeout))
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and with operators %s", stage, timeoutStr), stage, operators, softTimeoutEnabled, "123m", 123*time.Minute))
+			}
 
-		// Test cases for OLM stages with operators.  Should return the maximum of default timeout and the timeout specified in the operators
-		for _, stage := range olmStages {
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the operator timeout in stage '%s' without environment setting and with operators", stage), stage, operators, "", 21*time.Hour))
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the operator timeout  in stage '%s' with environment setting and with operators", stage), stage, operators, "123m", 21*time.Hour))
-		}
+			// Test cases for OLM stages with operators.  Should return the maximum of default timeout and the timeout specified in the operators
+			for _, stage := range olmStages {
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the operator timeout in stage '%s' without environment setting and with operators %s", stage, timeoutStr), stage, operators, softTimeoutEnabled, "", 21*time.Hour))
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the operator timeout  in stage '%s' with environment setting and with operators %s", stage, timeoutStr), stage, operators, softTimeoutEnabled, "123m", 21*time.Hour))
+			}
 
-		// Test cases that use the default timeout because operator timeout is too short
-		for _, stage := range olmStages {
-			defaultTimeout := finalizingStageDefaultTimeout(stage, log)
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and with short timeout operator", stage), stage, shortTimeoutOperator, "", defaultTimeout))
-			ret = append(ret,
-				Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and with short timeout operator", stage), stage, shortTimeoutOperator, "123m", 123*time.Minute))
+			// Test cases that use the default timeout because operator timeout is too short
+			for _, stage := range olmStages {
+				defaultTimeout := finalizingStageDefaultTimeout(stage, softTimeoutEnabled, log)
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the default timeout in stage '%s' without environment setting and with short timeout operator %s", stage, timeoutStr), stage, shortTimeoutOperator, softTimeoutEnabled, "", defaultTimeout))
+				ret = append(ret,
+					Entry(fmt.Sprintf("uses the environment setting in stage '%s' with environment setting and with short timeout operator %s", stage, timeoutStr), stage, shortTimeoutOperator, softTimeoutEnabled, "123m", 123*time.Minute))
+			}
 		}
 		return ret
 	}()...,

--- a/internal/cluster/transition_test.go
+++ b/internal/cluster/transition_test.go
@@ -4840,7 +4840,7 @@ var _ = Describe("finalizing timeouts", func() {
 		})
 		for _, st := range finalizingStages {
 			stage := st
-			timeout := finalizingStageTimeout(stage, nil, logrus.New())
+			timeout := finalizingStageTimeout(stage, nil, false, logrus.New())
 			Context(fmt.Sprintf("finalizing stage '%s' timeout expired", stage), func() {
 				if funk.Contains(nonFailingFinalizingStages, stage) {
 					It("should stay in same status and trigger soft timeout", func() {
@@ -4886,7 +4886,7 @@ var _ = Describe("finalizing timeouts", func() {
 		})
 		for _, st := range finalizingStages {
 			stage := st
-			timeout := finalizingStageTimeout(stage, nil, logrus.New())
+			timeout := finalizingStageTimeout(stage, nil, true, logrus.New())
 			It(fmt.Sprintf("finalizing stage '%s' timeout expired", stage), func() {
 				cls := createCluster(models.ClusterStatusFinalizing, stage, time.Now(), time.Now().Add(-(timeout + time.Second)))
 				mockEvents.EXPECT().SendClusterEvent(gomock.Any(), gomock.Any()).Times(1)


### PR DESCRIPTION


Some default timeouts are very long.  For example 'waiting for cluster operators' is 10 hours.
This change adds ability to have different timeout values for soft-timeouts, and changes the value of 'waiting for cluster operators' to general-wait-timeout (70 minutes).

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @gamli75 