### PR TITLE
MGMT-17300: adding has partition field for disks

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -57,6 +57,9 @@ type Disk struct {
 	// name
 	Name string `json:"name,omitempty"`
 
+	// partition types
+	PartitionTypes string `json:"partitionTypes,omitempty"`
+
 	// path
 	Path string `json:"path,omitempty"`
 

--- a/client/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -57,6 +57,9 @@ type Disk struct {
 	// name
 	Name string `json:"name,omitempty"`
 
+	// partition types
+	PartitionTypes string `json:"partitionTypes,omitempty"`
+
 	// path
 	Path string `json:"path,omitempty"`
 

--- a/models/disk.go
+++ b/models/disk.go
@@ -57,6 +57,9 @@ type Disk struct {
 	// name
 	Name string `json:"name,omitempty"`
 
+	// partition types
+	PartitionTypes string `json:"partitionTypes,omitempty"`
+
 	// path
 	Path string `json:"path,omitempty"`
 

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -7326,6 +7326,9 @@ func init() {
         "name": {
           "type": "string"
         },
+        "partitionTypes": {
+          "type": "string"
+        },
         "path": {
           "type": "string"
         },
@@ -18116,6 +18119,9 @@ func init() {
           "type": "string"
         },
         "name": {
+          "type": "string"
+        },
+        "partitionTypes": {
           "type": "string"
         },
         "path": {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -5909,6 +5909,8 @@ definitions:
         type: boolean
       removable:
         type: boolean
+      partitionTypes:
+        type: string
       is_installation_media:
         type: boolean
         description: Whether the disk appears to be an installation media or not

--- a/vendor/github.com/openshift/assisted-service/models/disk.go
+++ b/vendor/github.com/openshift/assisted-service/models/disk.go
@@ -57,6 +57,9 @@ type Disk struct {
 	// name
 	Name string `json:"name,omitempty"`
 
+	// partition types
+	PartitionTypes string `json:"partitionTypes,omitempty"`
+
 	// path
 	Path string `json:"path,omitempty"`
 


### PR DESCRIPTION
- Adding new field for disks
- `HasPartition` field will be used for new validation if disk not empty 

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
