### PR TITLE
MGMT-18010: Use the static installer for 4.16 nightlies when not FIPS-enabled

### DIFF
--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -31,7 +31,7 @@ const (
 	okdRPMSImageName               = "okd-rpms"
 	DefaultTries                   = 5
 	DefaltRetryDelay               = time.Second * 5
-	staticInstallerRequiredVersion = "4.16.0-ec.6"
+	staticInstallerRequiredVersion = "4.16.0-0.alpha"
 )
 
 type Config struct {

--- a/internal/oc/release_test.go
+++ b/internal/oc/release_test.go
@@ -653,6 +653,15 @@ var _ = Describe("GetReleaseBinaryPath", func() {
 			_, bin, _, err = r.GetReleaseBinaryPath("image", "dir", "4.16.0-rc.0")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(bin).To(Equal("openshift-install"))
+			_, bin, _, err = r.GetReleaseBinaryPath("image", "dir", "4.16.0-rc.3")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(bin).To(Equal("openshift-install"))
+		})
+
+		It("returns the openshift-install binary for 4.16 nightlies", func() {
+			_, bin, _, err := r.GetReleaseBinaryPath("image", "dir", "4.16.0-0.nightly-2024-05-30-130713")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(bin).To(Equal("openshift-install"))
 		})
 
 		It("returns the openshift-install binary for versions later than 4.16.0", func() {


### PR DESCRIPTION
Previously this code would use the dynamic binary for 4.16 nighlies this change ensures all 4.16 releases will get the static binary when FIPS is not enabled.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-18010

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Unit tests were sufficient

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported? - **Yes, this should go to 2.10**