### PR TITLE
NO-ISSUE: Update okd-configmap.yml 4.14 to latest fcos stable version

### DIFF
--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -27,7 +27,7 @@ data:
   PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
   SERVICE_BASE_URL: http://127.0.0.1:8090
   STORAGE: filesystem
-  OS_IMAGES: '[{"openshift_version":"4.12","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/37.20221225.3.0/x86_64/fedora-coreos-37.20221225.3.0-live.x86_64.iso","version":"37.20221225.3.0"}]'
-  RELEASE_IMAGES: '[{"openshift_version":"4.12","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift/okd:4.12.0-0.okd-2023-03-18-084815","version":"4.12.0-0.okd-2023-03-18-084815","default":true}]'
+  OS_IMAGES: '[{"openshift_version":"4.14","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3/x86_64/fedora-coreos-38.20231027.3-live.x86_64.iso","version":"38.20231027.3"}]'
+  RELEASE_IMAGES: '[{"openshift_version":"4.14","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift/okd:4.14.0-0.okd-2024-01-26-175629","version":"4.14.0-0.okd-2024-01-26-175629","default":true}]'
   ENABLE_UPGRADE_AGENT: "false"
   ENABLE_OKD_SUPPORT: "true"

--- a/deploy/podman/okd-configmap.yml
+++ b/deploy/podman/okd-configmap.yml
@@ -27,7 +27,7 @@ data:
   PUBLIC_CONTAINER_REGISTRIES: 'quay.io'
   SERVICE_BASE_URL: http://127.0.0.1:8090
   STORAGE: filesystem
-  OS_IMAGES: '[{"openshift_version":"4.14","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3/x86_64/fedora-coreos-38.20231027.3-live.x86_64.iso","version":"38.20231027.3"}]'
+  OS_IMAGES: '[{"openshift_version":"4.14","cpu_architecture":"x86_64","url":"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/38.20231027.3.2/x86_64/fedora-coreos-38.20231027.3.2-live.x86_64.iso","version":"38.20231027.3.2"}]'
   RELEASE_IMAGES: '[{"openshift_version":"4.14","cpu_architecture":"x86_64","cpu_architectures":["x86_64"],"url":"quay.io/openshift/okd:4.14.0-0.okd-2024-01-26-175629","version":"4.14.0-0.okd-2024-01-26-175629","default":true}]'
   ENABLE_UPGRADE_AGENT: "false"
   ENABLE_OKD_SUPPORT: "true"


### PR DESCRIPTION
bump fcos version from 4.12 to 4.14 in okd-configmap.yml.
In disconnected environments, or baremetal, one can rely on these parameters to know which ISO to pull to and create the VMs by.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

