### PR TITLE
NO-ISSUE: Use archived dnf repositories for centos8 as the current ones are no longer valid

### DIFF
--- a/Dockerfile.assisted-service
+++ b/Dockerfile.assisted-service
@@ -18,6 +18,7 @@ RUN cd /assisted-service/build && python3 ../tools/client_package_initializer.py
 FROM quay.io/centos/centos:$BASE_TAG as builder
 
 COPY hack/container_build_scripts/install_build_deps.sh .
+COPY hack/container_build_scripts/utils.sh .
 ARG BASE_TAG
 RUN ./install_build_deps.sh $BASE_TAG
 COPY --from=registry.ci.openshift.org/openshift/release:golang-1.20 /usr/local/go /usr/local/go
@@ -44,6 +45,11 @@ RUN cd ./cmd/agentbasedinstaller/client && CGO_ENABLED=1 GOFLAGS="" GO111MODULE=
 
 # Create final image
 FROM quay.io/centos/centos:$BASE_TAG
+
+COPY hack/container_build_scripts/replace_dnf_repositories_ref_if_needed.sh .
+COPY hack/container_build_scripts/utils.sh .
+ARG BASE_TAG
+RUN ./replace_dnf_repositories_ref_if_needed.sh $BASE_TAG
 
 # multiarch images need it till WRKLDS-222 and https://bugzilla.redhat.com/show_bug.cgi?id=2111537 are fixed
 RUN dnf install -y --setopt=install_weak_deps=False skopeo

--- a/hack/container_build_scripts/install_build_deps.sh
+++ b/hack/container_build_scripts/install_build_deps.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 tag=${1}
-
 repo=crb
+
 if [ "$tag" = "stream8" ]; then
   repo=powertools
+  source ./utils.sh
+  replace_dnf_repositories_ref
 fi
 
 dnf install --enablerepo=$repo -y gcc git nmstate-devel && dnf clean all

--- a/hack/container_build_scripts/replace_dnf_repositories_ref_if_needed.sh
+++ b/hack/container_build_scripts/replace_dnf_repositories_ref_if_needed.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+tag=${1}
+
+if [ "$tag" = "stream8" ]; then
+    source ./utils.sh
+    replace_dnf_repositories_ref
+fi

--- a/hack/container_build_scripts/utils.sh
+++ b/hack/container_build_scripts/utils.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+function replace_dnf_repositories_ref () {
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+}


### PR DESCRIPTION
[CentOS Linux 8 had reached the End Of Life (EOL)](https://www.centos.org/centos-linux-eol/) on December 31st, 2021. It means that CentOS 8 will no longer receive development resources from the official CentOS project. After Dec 31st, 2021, if you need to update your CentOS, you need to change the mirrors to [vault.centos.org](https://vault.centos.org/) where they will be archived permanently. Alternatively, you may want to [upgrade to CentOS Stream](https://techglimpse.com/convert-centos8-linux-centosstream/).

from - https://techglimpse.com/failed-metadata-repo-appstream-centos-8/

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
