### PR TITLE
[cloud_hotfix_releases] MGMT-18059: Mark OCI as supported integration

### DIFF
--- a/internal/featuresupport/feature_support_test.go
+++ b/internal/featuresupport/feature_support_test.go
@@ -257,8 +257,8 @@ var _ = Describe("V2ListFeatureSupportLevels API", func() {
 				Expect(supportLevel).To(Equal(expectedSupportLevel))
 			},
 			Entry("OCI unavailable with Openshift 4.13", "4.13", models.SupportLevelUnavailable),
-			Entry("OCI tech-preview with Openshift 4.14", "4.14", models.SupportLevelTechPreview),
-			Entry("OCI tech-preview with Openshidt 4.15", "4.15", models.SupportLevelTechPreview),
+			Entry("OCI tech-preview with Openshift 4.14", "4.14", models.SupportLevelSupported),
+			Entry("OCI tech-preview with Openshidt 4.15", "4.15", models.SupportLevelSupported),
 		)
 	})
 

--- a/internal/featuresupport/features_platforms.go
+++ b/internal/featuresupport/features_platforms.go
@@ -274,8 +274,8 @@ func (feature *OciIntegrationFeature) getSupportLevel(filters SupportLevelFilter
 		return models.SupportLevelUnavailable
 	}
 
-	if isTechPreview, err := common.BaseVersionGreaterOrEqual("4.14", filters.OpenshiftVersion); isTechPreview || err != nil {
-		return models.SupportLevelTechPreview
+	if isSupported, err := common.BaseVersionGreaterOrEqual("4.14", filters.OpenshiftVersion); isSupported || err != nil {
+		return models.SupportLevelSupported
 	}
 
 	return models.SupportLevelUnavailable


### PR DESCRIPTION
Remove OCI from technology preview as it is now a supported integration.
