### PR TITLE
MGMT-17794: Make sure that uploaded manifest files have valid filename before extensions

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -453,7 +453,7 @@ func (m *Manifests) fetchManifestContent(ctx context.Context, clusterID strfmt.U
 func (m *Manifests) validateManifestFileNames(ctx context.Context, clusterID strfmt.UUID, fileNames []string) error {
 	for _, fileName := range fileNames {
 		fileNameWithoutExtension := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-		if len(strings.TrimSpace(fileNameWithoutExtension)) == 0 {
+		if fileName[0] == '.' || len(strings.TrimSpace(fileNameWithoutExtension)) == 0 {
 			return m.prepareAndLogError(
 				ctx,
 				http.StatusUnprocessableEntity,

--- a/internal/manifests/manifests_test.go
+++ b/internal/manifests/manifests_test.go
@@ -269,7 +269,7 @@ var _ = Describe("ClusterManifestTests", func() {
 			It("Does not accept a filename that does not contain a name before the extension", func() {
 				clusterID := registerCluster().ID
 				content := "{}"
-				fileName := ".yaml"
+				fileName := ".yaml.patch"
 				response := manifestsAPI.V2CreateClusterManifest(ctx, operations.V2CreateClusterManifestParams{
 					ClusterID: *clusterID,
 					CreateManifestParams: &models.CreateManifestParams{


### PR DESCRIPTION
The validation of manifest filenames as it stands has a bug

any file without a name before the extension starts is considered to be valid.

`.yaml.patch` is considered valid when it should not be for example

This fix remedies that by ensuring that, in addition to the other checks we already peform, that file filename does not begin with a `.`

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
