### PR TITLE
MGMT-17802: Ensure that manifest patches may be placed in either `manifests` or `openshift`

### DIFF
--- a/internal/ignition/installmanifests_test.go
+++ b/internal/ignition/installmanifests_test.go
@@ -1219,12 +1219,12 @@ spec:
 		err := os.WriteFile(manifestPatchPath, []byte(schedulableMastersManifestPatch), 0600)
 		Expect(err).NotTo(HaveOccurred())
 
-		manifestPatchCustomTestPath := filepath.Join(manifestsOpenshiftDir, "cluster-scheduler-02-config.yml.patch_custom_test")
-		err = os.WriteFile(manifestPatchCustomTestPath, []byte(schedulerPatchCustomTest), 0600)
-		Expect(err).NotTo(HaveOccurred())
-
 		manifestsDir := filepath.Join(workDir, "/manifests")
 		Expect(os.Mkdir(manifestsDir, 0755)).To(Succeed())
+
+		manifestPatchCustomTestPath := filepath.Join(manifestsDir, "cluster-scheduler-02-config.yml.patch_custom_test")
+		err = os.WriteFile(manifestPatchCustomTestPath, []byte(schedulerPatchCustomTest), 0600)
+		Expect(err).NotTo(HaveOccurred())
 
 		err = os.WriteFile(filepath.Join(manifestsDir, "cluster-scheduler-02-config.yml"), []byte(base), 0600)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Presently, manifest patches will only be processed if they are located within the `openshift` directory This change ensures that we check the `manifests` directory for patch files also.

As we already enforce that files are distinct between these directories it is safe to do this and it seems like a more `user friendly` choice to allow the application of patches when they are uploaded to either directory.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
