### PR TITLE
MGMT-18019: Display a message to user advising re-upload if S3 issue occurs with file metadata

### DIFF
--- a/internal/manifests/manifests.go
+++ b/internal/manifests/manifests.go
@@ -124,7 +124,7 @@ func (m *Manifests) unmarkUserSuppliedManifest(ctx context.Context, clusterID st
 func (m *Manifests) markUserSuppliedManifest(ctx context.Context, clusterID strfmt.UUID, path string) error {
 	objectName := GetManifestMetadataObjectName(clusterID, path, constants.ManifestSourceUserSupplied)
 	if err := m.objectHandler.Upload(ctx, []byte{}, objectName); err != nil {
-		return err
+		return errors.Wrap(err, "failed to mark the manifest as user-supplied - please re-upload this file")
 	}
 	return nil
 }


### PR DESCRIPTION
While uploading a manifest, it is possible that assisted may fail to mark the file as "user uploaded" if there is an S3 issue during the operation to mark the file.

This is a rare edge case that is not easily resolved without making major changes to how manifests are stored.

If this occurs, an error is generated.

This PR seeks to clarify this error message and instructs the user to re-uplaod the file.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
