### PR TITLE
MGMT-18092: infraenv cannot be created while deploying vlan spokes with previous configuration

### DIFF
--- a/pkg/staticnetworkconfig/generator.go
+++ b/pkg/staticnetworkconfig/generator.go
@@ -183,11 +183,21 @@ func (s *StaticNetworkConfigGenerator) validateInterfaceNamesExistence(macInterf
 		if err != nil {
 			return errors.Wrapf(err, "failed to get interface type for interface %s", interfaceName.String())
 		}
-		if lo.Contains([]string{"802-3-ethernet", "ethernet"}, interfaceType.String()) {
+		switch interfaceType.String() {
+		case "802-3-ethernet", "ethernet":
 			if !lo.Contains(interfaceNames, interfaceName.String()) {
 				return errors.Errorf("mac-interface mapping for interface %s is missing", interfaceName.String())
 			}
 			matched = true
+		case "vlan":
+			vlanSection := cfg.Section("vlan")
+			parent, err := vlanSection.GetKey("parent")
+			if err != nil {
+				return errors.Wrapf(err, "failed to get parent of vlan %s", interfaceName.Name())
+			}
+			if lo.Contains(interfaceNames, parent.String()) {
+				matched = true
+			}
 		}
 	}
 	if !matched {

--- a/pkg/staticnetworkconfig/generator_test.go
+++ b/pkg/staticnetworkconfig/generator_test.go
@@ -278,6 +278,19 @@ parent=eth1
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("vlan with underlying interface - with mapping without parent", func() {
+			err := staticNetworkGenerator.validateInterfaceNamesExistence(models.MacInterfaceMap{
+				{
+					LogicalNicName: "eth1",
+					MacAddress:     "f8:75:a4:a4:00:fe",
+				},
+			}, []StaticNetworkConfigData{
+				{
+					FileContents: vlanConnection,
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION


Recently a validation was added when adding static network configuration.  During this configuration there was a requirement that there will be at least one physical interface that corresponds to an entry in the mac-interface mapping.
It seems that this requirement is not always correct since with vlan an underlying interface does not have to exist.
So this change also checks for vlan and if it is vlan it will check existance of underlying interface.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
/cc @gamli75 
/cc @paul-maidment 
