### PR TITLE
OCPBUGS-34925: allow use of the secure port when adding a new node

### DIFF
--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -1029,7 +1030,11 @@ func (b *bareMetalInventory) UpdateIgnitionEndpointIfHasMCSCert(log logrus.Field
 		return ignitionEndpointUrl, err
 	}
 	url.Scheme = "https"
-	url.Host = fmt.Sprintf("%s.%s.%s:%d", constants.InternalAPIClusterSubdomain, cluster.Name, cluster.BaseDNSDomain, constants.SecureMCSPort)
+	urlHost, _, err := net.SplitHostPort(url.Host)
+	if err != nil {
+		return ignitionEndpointUrl, err
+	}
+	url.Host = fmt.Sprintf("%s:%d", urlHost, constants.SecureMCSPort)
 	ignitionEndpointUrl = url.String()
 	log.Infof("Resetting Ignition endpoint URL to %s for %s, host %s", ignitionEndpointUrl, cluster.ID, host.ID)
 	return ignitionEndpointUrl, nil

--- a/internal/bminventory/inventory.go
+++ b/internal/bminventory/inventory.go
@@ -986,6 +986,10 @@ func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context
 	if err != nil {
 		return errors.Wrapf(err, "Failed to build ignition endpoint for host %s in cluster %s", host.ID, cluster.ID)
 	}
+	ignitionEndpointUrl, err = b.UpdateIgnitionEndpointIfHasMCSCert(log, host, cluster, ignitionEndpointUrl)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to build ignition endpoint for host %s in cluster %s", host.ID, cluster.ID)
+	}
 
 	var caCert *string = nil
 	if cluster.IgnitionEndpoint != nil {
@@ -1004,6 +1008,31 @@ func (b *bareMetalInventory) createAndUploadDay2NodeIgnition(ctx context.Context
 		return errors.Errorf("Failed to upload worker ignition for cluster %s", cluster.ID)
 	}
 	return nil
+}
+
+func (b *bareMetalInventory) UpdateIgnitionEndpointIfHasMCSCert(log logrus.FieldLogger, host *models.Host, cluster *common.Cluster, ignitionEndpointUrl string) (string, error) {
+	// No ignition override set by bmh agent controller
+	if host.IgnitionConfigOverrides == "" {
+		return ignitionEndpointUrl, nil
+	}
+	// No CA certs set in ignition override
+	if !ignition.HasCACertInIgnition(host.IgnitionConfigOverrides) {
+		return ignitionEndpointUrl, nil
+	}
+	// Not an operator-backed deployment
+	if b.k8sClient == nil {
+		return ignitionEndpointUrl, nil
+	}
+	log.Infof("Found CA certificate in ignition override for cluster %s, host %s", cluster.ID, host.ID)
+	url, err := url.Parse(ignitionEndpointUrl)
+	if err != nil {
+		return ignitionEndpointUrl, err
+	}
+	url.Scheme = "https"
+	url.Host = fmt.Sprintf("%s.%s.%s:%d", constants.InternalAPIClusterSubdomain, cluster.Name, cluster.BaseDNSDomain, constants.SecureMCSPort)
+	ignitionEndpointUrl = url.String()
+	log.Infof("Resetting Ignition endpoint URL to %s for %s, host %s", ignitionEndpointUrl, cluster.ID, host.ID)
+	return ignitionEndpointUrl, nil
 }
 
 func (b *bareMetalInventory) integrateWithAMSClusterDeregistration(ctx context.Context, cluster *common.Cluster) error {

--- a/internal/bminventory/inventory_test.go
+++ b/internal/bminventory/inventory_test.go
@@ -18903,3 +18903,135 @@ func createClusterWithMonitoredOperator(db *gorm.DB, operator models.MonitoredOp
 	Expect(db.Create(&c).Error).ShouldNot(HaveOccurred())
 	return &c
 }
+
+var _ = Describe("UpdateIgnitionEndpointIfHasMCSCert", func() {
+	var (
+		bm      *bareMetalInventory
+		cfg     Config
+		db      *gorm.DB
+		dbName  string
+		cluster *common.Cluster
+		log     logrus.FieldLogger
+	)
+	const (
+		httpIgnitionEndpointUrl  = "http://api.foo.bar.com:22624/config/custom-pool"
+		httpsIgnitionEndpointUrl = "https://api-int.foo.bar.com:22623/config/custom-pool"
+		masterIgn                = `{
+		  "ignition": {
+		    "config": {
+		      "merge": [
+			{
+			  "source": "https://192.168.126.199:22623/config/master"
+			}
+		      ]
+		    },
+		    "security": {
+		      "tls": {
+			"certificateAuthorities": [
+			  {
+			    "source": "data:text/plain;charset=utf-8;base64,LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURFRENDQWZpZ0F3SUJBZ0lJUk90aUgvOC82ckF3RFFZSktvWklodmNOQVFFTEJRQXdKakVTTUJBR0ExVUUKQ3hNSmIzQmxibk5vYVdaME1SQXdEZ1lEVlFRREV3ZHliMjkwTFdOaE1CNFhEVEl3TURreE9ERTVORFV3TVZvWApEVE13TURreE5qRTVORFV3TVZvd0pqRVNNQkFHQTFVRUN4TUpiM0JsYm5Ob2FXWjBNUkF3RGdZRFZRUURFd2R5CmIyOTBMV05oTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE1c1orVWtaaGsxUWQKeFU3cWI3YXArNFczaS9ZWTFzZktURC8ybDVJTjFJeVhPajlSL1N2VG5SOGYvajNJa1JHMWN5ZXR4bnNlNm1aZwpaOW1IRDJMV0srSEFlTTJSYXpuRkEwVmFwOWxVbVRrd3Vza2Z3QzhnMWJUZUVHUlEyQmFId09KekpvdjF4a0ZICmU2TUZCMlcxek1rTWxLTkwycnlzMzRTeVYwczJpNTFmTTJvTEM2SXRvWU91RVVVa2o0dnVUbThPYm5rV0t4ZnAKR1VGMThmNzVYeHJId0tVUEd0U0lYMGxpVGJNM0tiTDY2V2lzWkFIeStoN1g1dnVaaFYzYXhwTVFMdlczQ2xvcQpTaG9zSXY4SWNZbUJxc210d2t1QkN3cWxibEo2T2gzblFrelorVHhQdGhkdWsrZytzaVBUNi9va0JKU2M2cURjClBaNUNyN3FrR3dJREFRQUJvMEl3UURBT0JnTlZIUThCQWY4RUJBTUNBcVF3RHdZRFZSMFRBUUgvQkFVd0F3RUIKL3pBZEJnTlZIUTRFRmdRVWNSbHFHT1g3MWZUUnNmQ0tXSGFuV3NwMFdmRXdEUVlKS29aSWh2Y05BUUVMQlFBRApnZ0VCQU5Xc0pZMDY2RnNYdzFOdXluMEkwNUtuVVdOMFY4NVJVV2drQk9Wd0J5bHluTVRneGYyM3RaY1FsS0U4CjVHMlp4Vzl5NmpBNkwzMHdSNWhOcnBzM2ZFcUhobjg3UEM3L2tWQWlBOWx6NjBwV2ovTE5GU1hobDkyejBGMEIKcGNUQllFc1JNYU0zTFZOK0tZb3Q2cnJiamlXdmxFMU9hS0Q4dnNBdkk5YXVJREtOdTM0R2pTaUJGWXMrelRjSwphUUlTK3UzRHVYMGpVY001aUgrMmwzNGxNR0hlY2tjS1hnUWNXMGJiT28xNXY1Q2ExenJtQ2hIUHUwQ2NhMU1MCjJaM2MxMHVXZnR2OVZnbC9LcEpzSjM3b0phbTN1Mmp6MXN0K3hHby9iTmVSdHpOMjdXQSttaDZ6bXFwRldYKzUKdWFjZUY1SFRWc0FkbmtJWHpwWXBuek5qb0lFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+			  }
+			]
+		      }
+		    },
+		    "version": "3.2.0"
+		  },
+		  "storage": {}
+		}`
+
+		BeforeEach(func() {
+			db, dbName = common.PrepareTestDB()
+			bm = createInventory(db, cfg)
+			cluster = createClusterWithAvailability(db, models.ClusterStatusReady, models.ClusterCreateParamsHighAvailabilityModeNone)
+			cluster.Name = "foo"
+			cluster.BaseDNSDomain = "bar.com"
+			// this doesn't need to be a VM, but any host works for this test
+			addVMToCluster(cluster, db)
+			log = logrus.New()
+		})
+	
+		AfterEach(func() {
+			common.DeleteTestDB(db, dbName)
+			ctrl.Finish()
+		})
+
+		It("no ignition overrides for host set", func() {
+			h := cluster.Hosts[0]
+			ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+		})
+
+		It("ignition override has no CA set", func() {
+			h := cluster.Hosts[0]
+			h.IgnitionConfigOverrides = "{}"
+			ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+		})
+
+		It("bm has no k8sclient", func() {
+			h := cluster.Hosts[0]
+			h.IgnitionConfigOverrides = masterIgn
+			bm.k8sClient = nil
+			ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionEndpointUrl).To(Equal(httpIgnitionEndpointUrl))
+		})
+
+		It("should use https", func() {
+			h := cluster.Hosts[0]
+			h.IgnitionConfigOverrides = masterIgn
+			ignitionEndpointUrl, err := bm.UpdateIgnitionEndpointIfHasMCSCert(log, h, cluster, httpIgnitionEndpointUrl)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ignitionEndpointUrl).To(Equal(httpsIgnitionEndpointUrl))
+		})
+})
+
+var _ = Describe("Notify stream", func() {
+		var (
+			ctx             = context.Background()
+			bm              *bareMetalInventory
+			cfg             Config
+			db              *gorm.DB
+			dbName          string
+			mockStream      *eventstream.MockEventStreamWriter
+			ctrl            *gomock.Controller
+			infraEnvID      strfmt.UUID
+			clusterID       strfmt.UUID
+			createdInfraEnv *common.InfraEnv
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			db, dbName = common.PrepareTestDB()
+			mockStream = eventstream.NewMockEventStreamWriter(ctrl)
+			infraEnvID = strfmt.UUID(uuid.New().String())
+			clusterID = strfmt.UUID(uuid.New().String())
+			createdInfraEnv = createInfraEnv(db, infraEnvID, clusterID)
+		})
+
+		When("Notifying stream with defined stream", func() {
+			It("Should send an event", func() {
+				bm = createInventoryWithEventStream(db, cfg, mockStream)
+
+				mockStream.EXPECT().Write(ctx, "InfraEnv", []byte(createdInfraEnv.ClusterID.String()), gomock.Any()).Times(1).Return(nil)
+
+				bm.notifyEventStream(ctx, createdInfraEnv)
+			})
+		})
+
+		When("Notifying stream without defined stream", func() {
+			It("should do nothing", func() {
+				bm = createInventory(db, cfg)
+
+				mockStream.EXPECT().Write(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				bm.notifyEventStream(ctx, createdInfraEnv)
+			})
+		})
+
+		AfterEach(func() {
+			common.DeleteTestDB(db, dbName)
+			ctrl.Finish()
+		})
+})

--- a/internal/constants/files.go
+++ b/internal/constants/files.go
@@ -17,5 +17,8 @@ const InternalAPIClusterSubdomain = "api-int"
 // is known to be problematic for OCP
 const DNSWildcardFalseDomainName = "validateNoWildcardDNS"
 
+// HTTPS-backed machine config server port
+const SecureMCSPort = 22623
+
 // Plain http machine config server port
 const InsecureMCSPort = 22624

--- a/internal/host/hostutil/host_utils.go
+++ b/internal/host/hostutil/host_utils.go
@@ -350,6 +350,7 @@ func GetIgnitionEndpoint(cluster *common.Cluster, host *models.Host) (string, er
 		"http://%s/config/%s",
 		net.JoinHostPort(common.GetAPIHostname(cluster), fmt.Sprint(constants.InsecureMCSPort)),
 		poolName)
+
 	if cluster.IgnitionEndpoint != nil && cluster.IgnitionEndpoint.URL != nil {
 		url, err := url.Parse(*cluster.IgnitionEndpoint.URL)
 		if err != nil {

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -125,3 +125,11 @@ func MergeIgnitionConfig(base []byte, overrides []byte) (string, error) {
 
 	return string(res), nil
 }
+
+func HasCACertInIgnition(contents string) bool {
+	config, err := ParseToLatest([]byte(contents))
+	if err != nil {
+		return false
+	}
+	return len(config.Ignition.Security.TLS.CertificateAuthorities) > 0
+}


### PR DESCRIPTION
This patch resumes the originak @vrutkovs's work from PR #4911. This will allow to use the secure port when adding a new node by using the approach implemented in https://issues.redhat.com/browse/AGENT-682.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [X] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [X] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [X] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
