### PR TITLE
MGMT-18130: Allow infra-operator to start in non OCP kubernetes clusters

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller.go
+++ b/internal/controller/controllers/agentserviceconfig_controller.go
@@ -126,6 +126,9 @@ type AgentServiceConfigReconcileContext struct {
 	Tolerations  []corev1.Toleration
 
 	Recorder record.EventRecorder
+
+	// flag to indicate if the operator is running on an OpenShift cluster or some other flavor of Kubernetes
+	IsOpenShift bool
 }
 
 // AgentServiceConfigReconciler reconciles a AgentServiceConfig object
@@ -463,34 +466,38 @@ func cleanHTTPRoute(ctx context.Context, log logrus.FieldLogger, asc ASC) error 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AgentServiceConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	ingressCMPredicates := builder.WithPredicates(predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return checkIngressCMName(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return checkIngressCMName(e.ObjectNew) },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return checkIngressCMName(e.Object) },
-		GenericFunc: func(e event.GenericEvent) bool { return checkIngressCMName(e.Object) },
-	})
-	ingressCMHandler := handler.EnqueueRequestsFromMapFunc(
-		func(_ context.Context, _ client.Object) []reconcile.Request {
-			return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: AgentServiceConfigName}}}
-		},
-	)
-
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&aiv1beta1.AgentServiceConfig{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Secret{}).
-		Owns(&routev1.Route{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
-		Owns(&apiregv1.APIService{}).
-		Watches(&corev1.ConfigMap{}, ingressCMHandler, ingressCMPredicates).
-		Complete(r)
+		Owns(&apiregv1.APIService{})
+
+	if r.IsOpenShift {
+		ingressCMPredicates := builder.WithPredicates(predicate.Funcs{
+			CreateFunc:  func(e event.CreateEvent) bool { return checkIngressCMName(e.Object) },
+			UpdateFunc:  func(e event.UpdateEvent) bool { return checkIngressCMName(e.ObjectNew) },
+			DeleteFunc:  func(e event.DeleteEvent) bool { return checkIngressCMName(e.Object) },
+			GenericFunc: func(e event.GenericEvent) bool { return checkIngressCMName(e.Object) },
+		})
+		ingressCMHandler := handler.EnqueueRequestsFromMapFunc(
+			func(_ context.Context, _ client.Object) []reconcile.Request {
+				return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: AgentServiceConfigName}}}
+			},
+		)
+
+		b = b.Owns(&monitoringv1.ServiceMonitor{}).
+			Owns(&routev1.Route{}).
+			Watches(&corev1.ConfigMap{}, ingressCMHandler, ingressCMPredicates)
+	}
+
+	return b.Complete(r)
 }
 
 func monitorOperands(ctx context.Context, log logrus.FieldLogger, asc ASC) error {

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -494,22 +494,25 @@ func (hr *HypershiftAgentServiceConfigReconciler) ensureSpokeNamespace(ctx conte
 
 // SetupWithManager sets up the controller with the Manager.
 func (hr *HypershiftAgentServiceConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&aiv1beta1.HypershiftAgentServiceConfig{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&monitoringv1.ServiceMonitor{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Secret{}).
-		Owns(&routev1.Route{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&apiregv1.APIService{}).
-		Complete(hr)
+		Owns(&apiregv1.APIService{})
+
+	if hr.IsOpenShift {
+		b = b.Owns(&monitoringv1.ServiceMonitor{}).Owns(&routev1.Route{})
+	}
+
+	return b.Complete(hr)
 }
 
 func parseFile(fileName string, dest interface{}) error {

--- a/internal/controller/controllers/kube_compat.go
+++ b/internal/controller/controllers/kube_compat.go
@@ -1,0 +1,20 @@
+package controllers
+
+import (
+	"context"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const clusterVersionCRDName = "clusterversions.config.openshift.io"
+
+func ServerIsOpenShift(ctx context.Context, c client.Client) (bool, error) {
+	clusterVersionCRD := apiextensionsv1.CustomResourceDefinition{}
+	err := c.Get(ctx, types.NamespacedName{Name: clusterVersionCRDName}, &clusterVersionCRD)
+	if err == nil {
+		return true, nil
+	}
+	return false, client.IgnoreNotFound(err)
+}

--- a/internal/controller/controllers/kube_compat_test.go
+++ b/internal/controller/controllers/kube_compat_test.go
@@ -8,7 +8,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -21,7 +20,7 @@ var _ = Describe("ServerIsOpenShift", func() {
 
 	BeforeEach(func() {
 		scheme := runtime.NewScheme()
-		apiextensionsv1.AddToScheme(scheme)
+		Expect(apiextensionsv1.AddToScheme(scheme)).To(Succeed())
 		client = fake.NewClientBuilder().WithScheme(scheme).Build()
 		ctx = context.Background()
 	})

--- a/internal/controller/controllers/kube_compat_test.go
+++ b/internal/controller/controllers/kube_compat_test.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ServerIsOpenShift", func() {
+	var (
+		client client.Client
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		apiextensionsv1.AddToScheme(scheme)
+		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		ctx = context.Background()
+	})
+
+	It("returns true when the clusterversion CRD is present", func() {
+		cvCRD := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterVersionCRDName,
+			},
+		}
+		Expect(client.Create(ctx, cvCRD)).To(Succeed())
+		isOCP, err := ServerIsOpenShift(ctx, client)
+		Expect(err).To(BeNil())
+		Expect(isOCP).To(BeTrue())
+	})
+
+	It("returns false when the clusterversion CRD is not present", func() {
+		isOCP, err := ServerIsOpenShift(ctx, client)
+		Expect(err).To(BeNil())
+		Expect(isOCP).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Only watch the OCP-specific kinds from our operator when it is running in an OpenShift cluster.

This doesn't address the rest of the runtime issues, but allows the operator to start in non-OCP kubernetes clusters.

## List all the issues related to this PR

Resolves https://issues.redhat.com/browse/MGMT-18130

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

Deployed the operator manually to a kind cluster without error.

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [x] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
