### PR TITLE
NO-ISSUE: Refactor uploader pkg

### DIFF
--- a/internal/uploader/auth_utils.go
+++ b/internal/uploader/auth_utils.go
@@ -1,52 +1,130 @@
 package uploader
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/pkg/k8sclient"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
-	openshiftTokenKey = "cloud.openshift.com"
+	openshiftNamespace  = "openshift-config"
+	openshiftSecretName = "pull-secret"
+	openshiftTokenKey   = "cloud.openshift.com"
 )
 
-func getPullSecret(clusterPullSecret string, k8sclient k8sclient.K8SClient, key string) (*validations.PullSecretCreds, error) {
-	data, exists := getOCMPullSecret(k8sclient)
-	if !exists {
-		data = clusterPullSecret
-	}
-	if data == "" {
-		return nil, errors.Errorf("failed to find pull secret for %s", key)
-	}
-	pullSecret, err := validations.ParsePullSecret(data)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse pull secret")
-	}
-	if auth, ok := pullSecret[key]; ok {
-		return &auth, nil
-	}
-	return nil, errors.Errorf("pull secret doesn't contain authentication information for %s", key)
+type Identity struct {
+	Username    string
+	EmailDomain string
 }
 
-func getOCMPullSecret(k8sclient k8sclient.K8SClient) (string, bool) {
-	if k8sclient != nil {
-		secret, err := k8sclient.GetSecret("openshift-config", "pull-secret")
-		if err != nil {
-			err = client.IgnoreNotFound(err)
-			// A "not found" error (err == nil) should return false
-			// indicating that the secret does not exist
-			return "", err != nil
-		}
-		if pullSecret, ok := secret.Data[corev1.DockerConfigJsonKey]; ok {
-			return string(pullSecret), true
-		}
-		return "", true
+type APIAuth struct {
+	AuthRaw string
+}
+
+type PullSecret struct {
+	Identity Identity
+	APIAuth  APIAuth
+}
+
+func getPullSecret(clusterPullSecret string, k8sclient k8sclient.K8SClient) (PullSecret, error) {
+	ret := PullSecret{}
+
+	managementCreds, managementErr := getManagementCreds(k8sclient)
+	workloadCreds, workloadErr := getCloudOpenshiftCreds(clusterPullSecret)
+
+	if managementErr != nil && workloadErr != nil {
+		return ret, errors.Join(
+			fmt.Errorf("failed to get management creds: %w", managementErr),
+			fmt.Errorf("failed to get workload creds: %w", workloadErr),
+		)
 	}
-	return "", false
+
+	identityCreds := selectPullSecretForDataProcessing(managementCreds, workloadCreds)
+	authCreds := selectPullSecretForAuthent(managementCreds, workloadCreds)
+
+	ret.Identity.Username = identityCreds.Username
+	ret.Identity.EmailDomain = getEmailDomain(identityCreds.Email)
+	ret.APIAuth.AuthRaw = authCreds.AuthRaw
+
+	return ret, nil
+}
+
+// Checks if cloud.openshift.com is present in the OCM pull secret to see if the user
+// is still opted-in to sending data
+func isOCMPullSecretOptIn(k8sclient k8sclient.K8SClient) (bool, error) {
+	creds, err := getManagementCreds(k8sclient)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Indicates the pull secret doesn't exist, so we'll assume they're opted-in
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to get management creds: %w", err)
+	}
+
+	if creds == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func getManagementCreds(k8sclient k8sclient.K8SClient) (*validations.PullSecretCreds, error) {
+	if k8sclient == nil {
+		return nil, errors.New("nil kube client") // Should not happen
+	}
+
+	secret, err := k8sclient.GetSecret(openshiftNamespace, openshiftSecretName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	pullSecret, ok := secret.Data[corev1.DockerConfigJsonKey]
+	if !ok {
+		return nil, errors.New("missing .dockerconfigjson field")
+	}
+
+	ret, err := getCloudOpenshiftCreds(string(pullSecret))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud openshift creds: %w", err)
+	}
+
+	return ret, nil
+}
+
+func getCloudOpenshiftCreds(pullSecretData string) (*validations.PullSecretCreds, error) {
+	pullSecret, err := validations.ParsePullSecret(pullSecretData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pull secret: %w", err)
+	}
+
+	auth, ok := pullSecret[openshiftTokenKey]
+	if !ok {
+		return nil, fmt.Errorf("pull secret doesn't contain authentication information for %s", openshiftTokenKey)
+	}
+
+	return &auth, nil
+}
+
+func selectPullSecretForDataProcessing(managementCreds, workloadCreds *validations.PullSecretCreds) *validations.PullSecretCreds {
+	if workloadCreds != nil {
+		return workloadCreds
+	}
+
+	return managementCreds
+}
+
+func selectPullSecretForAuthent(managementCreds, workloadCreds *validations.PullSecretCreds) *validations.PullSecretCreds {
+	if managementCreds != nil {
+		return managementCreds
+	}
+
+	return workloadCreds
 }
 
 func getEmailDomain(email string) string {
@@ -54,20 +132,6 @@ func getEmailDomain(email string) string {
 	if len(parts) < 2 {
 		return ""
 	}
-	return parts[1]
-}
 
-// Checks if cloud.openshift.com is present in the OCM pull secret to see if the user
-// is still opted-in to sending data
-func isOCMPullSecretOptIn(k8sclient k8sclient.K8SClient) bool {
-	if data, exists := getOCMPullSecret(k8sclient); exists {
-		if pullSecret, err := validations.ParsePullSecret(data); err == nil {
-			if _, ok := pullSecret[openshiftTokenKey]; ok {
-				return ok
-			}
-		}
-		return false
-	}
-	// Indicates the pull secret doesn't exist, so we'll assume they're opted-in
-	return true
+	return parts[1]
 }

--- a/internal/uploader/auth_utils.go
+++ b/internal/uploader/auth_utils.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openshift/assisted-service/internal/cluster/validations"
 	"github.com/openshift/assisted-service/pkg/k8sclient"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -52,26 +51,6 @@ func getPullSecret(clusterPullSecret string, k8sclient k8sclient.K8SClient) (Pul
 	ret.APIAuth.AuthRaw = authCreds.AuthRaw
 
 	return ret, nil
-}
-
-// Checks if cloud.openshift.com is present in the OCM pull secret to see if the user
-// is still opted-in to sending data
-func isOCMPullSecretOptIn(k8sclient k8sclient.K8SClient) (bool, error) {
-	creds, err := getManagementCreds(k8sclient)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Indicates the pull secret doesn't exist, so we'll assume they're opted-in
-			return true, nil
-		}
-
-		return false, fmt.Errorf("failed to get management creds: %w", err)
-	}
-
-	if creds == nil {
-		return false, nil
-	}
-
-	return true, nil
 }
 
 func getManagementCreds(k8sclient k8sclient.K8SClient) (*validations.PullSecretCreds, error) {

--- a/internal/uploader/events_uploader.go
+++ b/internal/uploader/events_uploader.go
@@ -71,13 +71,8 @@ func (e *eventsUploader) UploadEvents(ctx context.Context, cluster *common.Clust
 }
 
 func (e *eventsUploader) IsEnabled() bool {
-	// This is arguable since we could use the workload pull secret creds to upload.
-	isOCMPullSecretOptIn, err := isOCMPullSecretOptIn(e.client)
-	if err != nil {
-		return false
-	}
-
-	return e.EnableDataCollection && isOCMPullSecretOptIn && isURLReachable(e.DataUploadEndpoint)
+	// isURLReachable is arguable: it could have failed because of a transient error.
+	return e.EnableDataCollection && isURLReachable(e.DataUploadEndpoint)
 }
 
 func (e *eventsUploader) setHeaders(req *http.Request, clusterID *strfmt.UUID, token, formDataContentType string) error {

--- a/internal/uploader/extract_test.go
+++ b/internal/uploader/extract_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/versions"
@@ -164,10 +165,10 @@ var _ = Describe("Trying to extract events", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(len(events)).To(Equal(2))
-					Expect(events).To(Equal([]eventModels.Events{
+					Expect(events).To(BeComparableTo([]eventModels.Events{
 						generateExpectedEvents(clusterID1.String(), config1),
 						generateExpectedEvents(clusterID2.String(), config2),
-					}))
+					}, cmpopts.SortSlices(func(a, b eventModels.Events) bool { return a.ClusterID < b.ClusterID })))
 				})
 			})
 		})


### PR DESCRIPTION
* Flatten pyramidal code
* Explicit data modification
* Use different creds for data enrichment & push authent

Currently, the logic to get pull secret is hard to read (and more complex than it seems). While flattening the nested logic, it highlights some shortcuts in the err check. I tried to explicit the different scenario, so there is a change of behavior. Previously the Hub cluster credentials were used by default and if not, the spoke cluster creds were used (if any). I think spoke cluster creds should be used to enrich the data (since it seems to be more accurate to reflect the cluster owner identity. Any insights/opinions about this part are welcome)

Since the code is able to use the spoke cluster credentials to push data, should we disable by default this feature if there is no creds in the hub creds ? I kept the check, but we can discuss it

Otherwise, since the cluster entity is passed by as a pointer, and the code is modifying its values, it can be error prone in the future for the callers. I isolated the part that changes the data. Introducing a deepcopy library would be the way to go IMHO

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
