### PR TITLE
NO-ISSUE: Differentiate between monitoring failures and component issues

### DIFF
--- a/api/v1beta1/agentserviceconfig_types.go
+++ b/api/v1beta1/agentserviceconfig_types.go
@@ -204,6 +204,8 @@ const (
 	ReasonKonnectivityAgentFailure string = "KonnectivityAgentFailure"
 	// ReasonOSImageCACertRefFailure when there has been a failure resolving the OS image CA using OSImageCACertRef.
 	ReasonOSImageCACertRefFailure string = "OSImageCACertRefFailure"
+	// ReasonMonitoringFailure indicates there was a failure monitoring operand status
+	ReasonMonitoringFailure string = "MonitoringFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"

--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -595,7 +595,7 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 		ascr = newTestReconciler(asc, ingressCM, route, imageRoute, agentinstalladmissionDeployment, imageServiceStatefulSet, assistedServiceDeployment)
 		result, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 
-		Expect(err).NotTo(Succeed())
+		Expect(err).To(BeNil())
 		Expect(result).NotTo(Equal(ctrl.Result{}))
 
 		instance := &aiv1beta1.AgentServiceConfig{}
@@ -646,7 +646,7 @@ var _ = Describe("agentserviceconfig_controller reconcile", func() {
 		ascr = newTestReconciler(asc, ingressCM, route, imageRoute, agentinstalladmissionDeployment, imageServiceStatefulSet, assistedServiceDeployment)
 		result, err := ascr.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 
-		Expect(err).NotTo(Succeed())
+		Expect(err).To(BeNil())
 		Expect(result).NotTo(Equal(ctrl.Result{}))
 
 		instance := &aiv1beta1.AgentServiceConfig{}

--- a/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
+++ b/internal/controller/controllers/hypershiftagentserviceconfig_controller.go
@@ -234,11 +234,7 @@ func (hr *HypershiftAgentServiceConfigReconciler) Reconcile(origCtx context.Cont
 		return result, err
 	}
 
-	if err = updateConditions(ctx, log, asc); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return updateConditions(ctx, log, asc)
 }
 
 func (hr *HypershiftAgentServiceConfigReconciler) reconcileHubComponents(ctx context.Context, log *logrus.Entry, asc ASC) (ctrl.Result, error) {

--- a/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
+++ b/vendor/github.com/openshift/assisted-service/api/v1beta1/agentserviceconfig_types.go
@@ -204,6 +204,8 @@ const (
 	ReasonKonnectivityAgentFailure string = "KonnectivityAgentFailure"
 	// ReasonOSImageCACertRefFailure when there has been a failure resolving the OS image CA using OSImageCACertRef.
 	ReasonOSImageCACertRefFailure string = "OSImageCACertRefFailure"
+	// ReasonMonitoringFailure indicates there was a failure monitoring operand status
+	ReasonMonitoringFailure string = "MonitoringFailure"
 
 	// IPXEHTTPRouteEnabled is expected value in IPXEHTTPRoute to enable the route
 	IPXEHTTPRouteEnabled string = "enabled"


### PR DESCRIPTION
Currently the function for monitoring the status of components deployed by the agentserviceconfig controller doesn't differentiate between a failure to monitor and a component that is failing.

This means that the reconciliation function actually returns an error when reconcile succeeded, but some component isn't healthy. This isn't correct and causes issues when testing basic success cases.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [x] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

