### PR TITLE
NO-ISSUE: Push cluster_installation_failed event each time the state …

### DIFF
--- a/internal/cluster/mock_transition.go
+++ b/internal/cluster/mock_transition.go
@@ -5,6 +5,7 @@
 package cluster
 
 import (
+	context "context"
 	reflect "reflect"
 
 	stateswitch "github.com/filanov/stateswitch"
@@ -341,6 +342,25 @@ func (mr *MockTransitionHandlerMockRecorder) PostUpdateFinalizingAMSConsoleUrl(s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostUpdateFinalizingAMSConsoleUrl", reflect.TypeOf((*MockTransitionHandler)(nil).PostUpdateFinalizingAMSConsoleUrl), sw, args)
 }
 
+// SendClusterInstallationFailedEvent mocks base method.
+func (m *MockTransitionHandler) SendClusterInstallationFailedEvent(template string, formatFuncs ...formatFunction) stateswitch.PostTransition {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{template}
+	for _, a := range formatFuncs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SendClusterInstallationFailedEvent", varargs...)
+	ret0, _ := ret[0].(stateswitch.PostTransition)
+	return ret0
+}
+
+// SendClusterInstallationFailedEvent indicates an expected call of SendClusterInstallationFailedEvent.
+func (mr *MockTransitionHandlerMockRecorder) SendClusterInstallationFailedEvent(template interface{}, formatFuncs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{template}, formatFuncs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendClusterInstallationFailedEvent", reflect.TypeOf((*MockTransitionHandler)(nil).SendClusterInstallationFailedEvent), varargs...)
+}
+
 // SoftTimeoutsEnabled mocks base method.
 func (m *MockTransitionHandler) SoftTimeoutsEnabled(arg0 stateswitch.StateSwitch, arg1 stateswitch.TransitionArgs) (bool, error) {
 	m.ctrl.T.Helper()
@@ -399,4 +419,83 @@ func (m *MockTransitionHandler) hasClusterCompleteInstallation(sw stateswitch.St
 func (mr *MockTransitionHandlerMockRecorder) hasClusterCompleteInstallation(sw, args interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "hasClusterCompleteInstallation", reflect.TypeOf((*MockTransitionHandler)(nil).hasClusterCompleteInstallation), sw, args)
+}
+
+// MockEventHandler is a mock of EventHandler interface.
+type MockEventHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockEventHandlerMockRecorder
+}
+
+// MockEventHandlerMockRecorder is the mock recorder for MockEventHandler.
+type MockEventHandlerMockRecorder struct {
+	mock *MockEventHandler
+}
+
+// NewMockEventHandler creates a new mock instance.
+func NewMockEventHandler(ctrl *gomock.Controller) *MockEventHandler {
+	mock := &MockEventHandler{ctrl: ctrl}
+	mock.recorder = &MockEventHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockEventHandler) EXPECT() *MockEventHandlerMockRecorder {
+	return m.recorder
+}
+
+// SendClusterInstallationFailedEvent mocks base method.
+func (m *MockEventHandler) SendClusterInstallationFailedEvent(template string, formatFuncs ...formatFunction) stateswitch.PostTransition {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{template}
+	for _, a := range formatFuncs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SendClusterInstallationFailedEvent", varargs...)
+	ret0, _ := ret[0].(stateswitch.PostTransition)
+	return ret0
+}
+
+// SendClusterInstallationFailedEvent indicates an expected call of SendClusterInstallationFailedEvent.
+func (mr *MockEventHandlerMockRecorder) SendClusterInstallationFailedEvent(template interface{}, formatFuncs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{template}, formatFuncs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendClusterInstallationFailedEvent", reflect.TypeOf((*MockEventHandler)(nil).SendClusterInstallationFailedEvent), varargs...)
+}
+
+// MockErrorEventArgs is a mock of ErrorEventArgs interface.
+type MockErrorEventArgs struct {
+	ctrl     *gomock.Controller
+	recorder *MockErrorEventArgsMockRecorder
+}
+
+// MockErrorEventArgsMockRecorder is the mock recorder for MockErrorEventArgs.
+type MockErrorEventArgsMockRecorder struct {
+	mock *MockErrorEventArgs
+}
+
+// NewMockErrorEventArgs creates a new mock instance.
+func NewMockErrorEventArgs(ctrl *gomock.Controller) *MockErrorEventArgs {
+	mock := &MockErrorEventArgs{ctrl: ctrl}
+	mock.recorder = &MockErrorEventArgsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockErrorEventArgs) EXPECT() *MockErrorEventArgsMockRecorder {
+	return m.recorder
+}
+
+// GetContext mocks base method.
+func (m *MockErrorEventArgs) GetContext() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetContext")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// GetContext indicates an expected call of GetContext.
+func (mr *MockErrorEventArgsMockRecorder) GetContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContext", reflect.TypeOf((*MockErrorEventArgs)(nil).GetContext))
 }


### PR DESCRIPTION
…machine go to failed state

Leveraging PostTransition functions.

The idea here is to start isolating the events logic aside from the state logic

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
