### PR TITLE
MGMT-18165: Make manifest metadata storage more transactional in nature

### DIFF
--- a/api/vendor/github.com/openshift/assisted-service/models/manifest.go
+++ b/api/vendor/github.com/openshift/assisted-service/models/manifest.go
@@ -26,6 +26,10 @@ type Manifest struct {
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
 	// Enum: [manifests openshift]
 	Folder string `json:"folder,omitempty"`
+
+	// Describes whether manifest is sourced from a user or created by the system.
+	// Enum: [user system]
+	ManifestSource string `json:"manifest_source,omitempty"`
 }
 
 // Validate validates this manifest
@@ -33,6 +37,10 @@ func (m *Manifest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateFolder(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateManifestSource(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +86,48 @@ func (m *Manifest) validateFolder(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateFolderEnum("folder", "body", m.Folder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var manifestTypeManifestSourcePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["user","system"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		manifestTypeManifestSourcePropEnum = append(manifestTypeManifestSourcePropEnum, v)
+	}
+}
+
+const (
+
+	// ManifestManifestSourceUser captures enum value "user"
+	ManifestManifestSourceUser string = "user"
+
+	// ManifestManifestSourceSystem captures enum value "system"
+	ManifestManifestSourceSystem string = "system"
+)
+
+// prop value enum
+func (m *Manifest) validateManifestSourceEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, manifestTypeManifestSourcePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manifest) validateManifestSource(formats strfmt.Registry) error {
+	if swag.IsZero(m.ManifestSource) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateManifestSourceEnum("manifest_source", "body", m.ManifestSource); err != nil {
 		return err
 	}
 

--- a/client/vendor/github.com/openshift/assisted-service/models/manifest.go
+++ b/client/vendor/github.com/openshift/assisted-service/models/manifest.go
@@ -26,6 +26,10 @@ type Manifest struct {
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
 	// Enum: [manifests openshift]
 	Folder string `json:"folder,omitempty"`
+
+	// Describes whether manifest is sourced from a user or created by the system.
+	// Enum: [user system]
+	ManifestSource string `json:"manifest_source,omitempty"`
 }
 
 // Validate validates this manifest
@@ -33,6 +37,10 @@ func (m *Manifest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateFolder(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateManifestSource(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +86,48 @@ func (m *Manifest) validateFolder(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateFolderEnum("folder", "body", m.Folder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var manifestTypeManifestSourcePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["user","system"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		manifestTypeManifestSourcePropEnum = append(manifestTypeManifestSourcePropEnum, v)
+	}
+}
+
+const (
+
+	// ManifestManifestSourceUser captures enum value "user"
+	ManifestManifestSourceUser string = "user"
+
+	// ManifestManifestSourceSystem captures enum value "system"
+	ManifestManifestSourceSystem string = "system"
+)
+
+// prop value enum
+func (m *Manifest) validateManifestSourceEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, manifestTypeManifestSourcePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manifest) validateManifestSource(formats strfmt.Registry) error {
+	if swag.IsZero(m.ManifestSource) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateManifestSourceEnum("manifest_source", "body", m.ManifestSource); err != nil {
 		return err
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -436,7 +436,7 @@ func main() {
 	failOnError(err, "failed to create valid bm config S3 endpoint URL from %s", Options.BMConfig.S3EndpointURL)
 	Options.BMConfig.S3EndpointURL = newUrl
 
-	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry)
+	generator := generator.New(log, objectHandler, Options.GeneratorConfig, Options.WorkDir, providerRegistry, manifestsApi)
 	var crdUtils bminventory.CRDUtils
 	if ctrlMgr != nil {
 		crdUtils = controllers.NewCRDUtils(ctrlMgr.GetClient(), hostApi)

--- a/go.mod
+++ b/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/openshift/machine-config-operator v0.0.1-0.20201023110058-6c8bd9b2915c
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
-	github.com/pkg/xattr v0.4.9 // indirect
+	github.com/pkg/xattr v0.4.9
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/internal/constants/manifests.go
+++ b/internal/constants/manifests.go
@@ -1,6 +1,8 @@
 package constants
 
-// ManifestFolder represents the manifests folder on s3 per cluster
 const ManifestFolder = "manifests"
 const ManifestMetadataFolder = "manifest-attributes"
-const ManifestSourceUserSupplied = "user-supplied"
+const ManifestSourceAttribute = "assisted-installer-manifest-source"
+const ManifestSourceSystemGenerated = "system"
+const ManifestSourceUserSupplied = "user"
+const LegacyManifestSourceUserSupplied = "user-supplied"

--- a/internal/manifests/api/interface.go
+++ b/internal/manifests/api/interface.go
@@ -17,8 +17,8 @@ type ManifestsAPI interface {
 
 //go:generate mockgen --build_flags=--mod=mod -package api -destination mock_manifests_internal.go . ClusterManifestsInternals
 type ClusterManifestsInternals interface {
-	IsUserManifest(ctx context.Context, clusterID strfmt.UUID, folder string, fileName string) (bool, error)
 	CreateClusterManifestInternal(ctx context.Context, params operations.V2CreateClusterManifestParams, isCustomManifest bool) (*models.Manifest, error)
 	ListClusterManifestsInternal(ctx context.Context, params operations.V2ListClusterManifestsParams) (models.ListManifests, error)
 	DeleteClusterManifestInternal(ctx context.Context, params operations.V2DeleteClusterManifestParams) error
+	FindUserManifestPathsByLegacyMetadata(ctx context.Context, clusterID strfmt.UUID) ([]string, error)
 }

--- a/internal/manifests/api/mock_manifests_api.go
+++ b/internal/manifests/api/mock_manifests_api.go
@@ -67,19 +67,19 @@ func (mr *MockManifestsAPIMockRecorder) DeleteClusterManifestInternal(arg0, arg1
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterManifestInternal", reflect.TypeOf((*MockManifestsAPI)(nil).DeleteClusterManifestInternal), arg0, arg1)
 }
 
-// IsUserManifest mocks base method.
-func (m *MockManifestsAPI) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (bool, error) {
+// FindUserManifestPathsByLegacyMetadata mocks base method.
+func (m *MockManifestsAPI) FindUserManifestPathsByLegacyMetadata(arg0 context.Context, arg1 strfmt.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "FindUserManifestPathsByLegacyMetadata", arg0, arg1)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsUserManifest indicates an expected call of IsUserManifest.
-func (mr *MockManifestsAPIMockRecorder) IsUserManifest(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// FindUserManifestPathsByLegacyMetadata indicates an expected call of FindUserManifestPathsByLegacyMetadata.
+func (mr *MockManifestsAPIMockRecorder) FindUserManifestPathsByLegacyMetadata(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUserManifest", reflect.TypeOf((*MockManifestsAPI)(nil).IsUserManifest), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUserManifestPathsByLegacyMetadata", reflect.TypeOf((*MockManifestsAPI)(nil).FindUserManifestPathsByLegacyMetadata), arg0, arg1)
 }
 
 // ListClusterManifestsInternal mocks base method.

--- a/internal/manifests/api/mock_manifests_internal.go
+++ b/internal/manifests/api/mock_manifests_internal.go
@@ -66,19 +66,19 @@ func (mr *MockClusterManifestsInternalsMockRecorder) DeleteClusterManifestIntern
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterManifestInternal", reflect.TypeOf((*MockClusterManifestsInternals)(nil).DeleteClusterManifestInternal), arg0, arg1)
 }
 
-// IsUserManifest mocks base method.
-func (m *MockClusterManifestsInternals) IsUserManifest(arg0 context.Context, arg1 strfmt.UUID, arg2, arg3 string) (bool, error) {
+// FindUserManifestPathsByLegacyMetadata mocks base method.
+func (m *MockClusterManifestsInternals) FindUserManifestPathsByLegacyMetadata(arg0 context.Context, arg1 strfmt.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsUserManifest", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "FindUserManifestPathsByLegacyMetadata", arg0, arg1)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IsUserManifest indicates an expected call of IsUserManifest.
-func (mr *MockClusterManifestsInternalsMockRecorder) IsUserManifest(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// FindUserManifestPathsByLegacyMetadata indicates an expected call of FindUserManifestPathsByLegacyMetadata.
+func (mr *MockClusterManifestsInternalsMockRecorder) FindUserManifestPathsByLegacyMetadata(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUserManifest", reflect.TypeOf((*MockClusterManifestsInternals)(nil).IsUserManifest), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUserManifestPathsByLegacyMetadata", reflect.TypeOf((*MockClusterManifestsInternals)(nil).FindUserManifestPathsByLegacyMetadata), arg0, arg1)
 }
 
 // ListClusterManifestsInternal mocks base method.

--- a/models/manifest.go
+++ b/models/manifest.go
@@ -26,6 +26,10 @@ type Manifest struct {
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
 	// Enum: [manifests openshift]
 	Folder string `json:"folder,omitempty"`
+
+	// Describes whether manifest is sourced from a user or created by the system.
+	// Enum: [user system]
+	ManifestSource string `json:"manifest_source,omitempty"`
 }
 
 // Validate validates this manifest
@@ -33,6 +37,10 @@ func (m *Manifest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateFolder(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateManifestSource(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +86,48 @@ func (m *Manifest) validateFolder(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateFolderEnum("folder", "body", m.Folder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var manifestTypeManifestSourcePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["user","system"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		manifestTypeManifestSourcePropEnum = append(manifestTypeManifestSourcePropEnum, v)
+	}
+}
+
+const (
+
+	// ManifestManifestSourceUser captures enum value "user"
+	ManifestManifestSourceUser string = "user"
+
+	// ManifestManifestSourceSystem captures enum value "system"
+	ManifestManifestSourceSystem string = "system"
+)
+
+// prop value enum
+func (m *Manifest) validateManifestSourceEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, manifestTypeManifestSourcePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manifest) validateManifestSource(formats strfmt.Registry) error {
+	if swag.IsZero(m.ManifestSource) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateManifestSourceEnum("manifest_source", "body", m.ManifestSource); err != nil {
 		return err
 	}
 

--- a/pkg/s3wrapper/client.go
+++ b/pkg/s3wrapper/client.go
@@ -33,6 +33,11 @@ const (
 	awsEndpointSuffix = ".amazonaws.com"
 )
 
+type ObjectInfo struct {
+	Path     string
+	Metadata map[string]string
+}
+
 //go:generate mockgen --build_flags=--mod=mod -package=s3wrapper -destination=mock_s3wrapper.go . API
 //go:generate mockgen --build_flags=--mod=mod -package s3wrapper -destination mock_s3iface.go github.com/aws/aws-sdk-go/service/s3/s3iface S3API
 //go:generate mockgen --build_flags=--mod=mod -package s3wrapper -destination mock_s3manageriface.go github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface UploaderAPI
@@ -42,6 +47,9 @@ type API interface {
 	Upload(ctx context.Context, data []byte, objectName string) error
 	UploadStream(ctx context.Context, reader io.Reader, objectName string) error
 	UploadFile(ctx context.Context, filePath, objectName string) error
+	UploadWithMetadata(ctx context.Context, data []byte, objectName string, metadata map[string]string) error
+	UploadStreamWithMetadata(ctx context.Context, reader io.Reader, objectName string, metadata map[string]string) error
+	UploadFileWithMetadata(ctx context.Context, filePath, objectName string, metadata map[string]string) error
 	Download(ctx context.Context, objectName string) (io.ReadCloser, int64, error)
 	DoesObjectExist(ctx context.Context, objectName string) (bool, error)
 	DeleteObject(ctx context.Context, objectName string) (bool, error)
@@ -50,6 +58,7 @@ type API interface {
 	UpdateObjectTimestamp(ctx context.Context, objectName string) (bool, error)
 	ExpireObjects(ctx context.Context, prefix string, deleteTime time.Duration, callback func(ctx context.Context, log logrus.FieldLogger, objectName string))
 	ListObjectsByPrefix(ctx context.Context, prefix string) ([]string, error)
+	ListObjectsByPrefixWithMetadata(ctx context.Context, prefix string) ([]ObjectInfo, error)
 }
 
 var _ API = &S3Client{}
@@ -111,6 +120,7 @@ func newS3Session(accessKeyID, secretAccessKey, region, endpointURL string) (*se
 		S3ForcePathStyle:     aws.Bool(true),
 		S3Disable100Continue: aws.Bool(true),
 		HTTPClient:           &http.Client{Transport: HTTPTransport},
+		LowerCaseHeaderMaps:  aws.Bool(true),
 	}
 	awsSession, err := session.NewSession(awsConfig)
 	if err != nil {
@@ -148,7 +158,7 @@ func (c *S3Client) CreateBucket() error {
 	return c.createBucket(c.client, c.cfg.S3Bucket)
 }
 
-func (c *S3Client) uploadStream(ctx context.Context, reader io.Reader, objectName, bucket string, uploader s3manageriface.UploaderAPI) error {
+func (c *S3Client) uploadStream(ctx context.Context, reader io.Reader, objectName, bucket string, uploader s3manageriface.UploaderAPI, metadata map[string]string) error {
 	log := logutil.FromContext(ctx, c.log)
 	if reader == nil {
 		err := errors.Errorf("Upfile log may not be nil. Cannot upload %s to bucket %s", objectName, bucket)
@@ -163,6 +173,7 @@ func (c *S3Client) uploadStream(ctx context.Context, reader io.Reader, objectNam
 		Key:          aws.String(objectName),
 		Body:         reader,
 		CacheControl: &cacheControl,
+		Metadata:     swag.StringMap(metadata),
 	})
 	if err != nil {
 		err = errors.Wrapf(err, "Unable to upload %s to bucket %s", objectName, bucket)
@@ -174,10 +185,14 @@ func (c *S3Client) uploadStream(ctx context.Context, reader io.Reader, objectNam
 }
 
 func (c *S3Client) UploadStream(ctx context.Context, reader io.Reader, objectName string) error {
-	return c.uploadStream(ctx, reader, objectName, c.cfg.S3Bucket, c.uploader)
+	return c.uploadStream(ctx, reader, objectName, c.cfg.S3Bucket, c.uploader, nil)
 }
 
-func (c *S3Client) uploadFile(ctx context.Context, filePath, objectName, bucket string, uploader s3manageriface.UploaderAPI) error {
+func (c *S3Client) UploadStreamWithMetadata(ctx context.Context, reader io.Reader, objectName string, metadata map[string]string) error {
+	return c.uploadStream(ctx, reader, objectName, c.cfg.S3Bucket, c.uploader, metadata)
+}
+
+func (c *S3Client) uploadFile(ctx context.Context, filePath, objectName, bucket string, uploader s3manageriface.UploaderAPI, metadata map[string]string) error {
 	log := logutil.FromContext(ctx, c.log)
 	log.Infof("Uploading file %s as object %s to bucket %s", filePath, objectName, bucket)
 	file, err := os.Open(filePath)
@@ -189,16 +204,25 @@ func (c *S3Client) uploadFile(ctx context.Context, filePath, objectName, bucket 
 	defer file.Close()
 
 	reader := bufio.NewReader(file)
-	return c.uploadStream(ctx, reader, objectName, bucket, uploader)
+	return c.uploadStream(ctx, reader, objectName, bucket, uploader, metadata)
 }
 
 func (c *S3Client) UploadFile(ctx context.Context, filePath, objectName string) error {
-	return c.uploadFile(ctx, filePath, objectName, c.cfg.S3Bucket, c.uploader)
+	return c.uploadFile(ctx, filePath, objectName, c.cfg.S3Bucket, c.uploader, nil)
+}
+
+func (c *S3Client) UploadFileWithMetadata(ctx context.Context, filePath, objectName string, metadata map[string]string) error {
+	return c.uploadFile(ctx, filePath, objectName, c.cfg.S3Bucket, c.uploader, metadata)
 }
 
 func (c *S3Client) Upload(ctx context.Context, data []byte, objectName string) error {
 	reader := bytes.NewReader(data)
 	return c.UploadStream(ctx, reader, objectName)
+}
+
+func (c *S3Client) UploadWithMetadata(ctx context.Context, data []byte, objectName string, metadata map[string]string) error {
+	reader := bytes.NewReader(data)
+	return c.UploadStreamWithMetadata(ctx, reader, objectName, metadata)
 }
 
 func (c *S3Client) download(ctx context.Context, objectName, bucket string, client s3iface.S3API) (io.ReadCloser, int64, error) {
@@ -415,6 +439,32 @@ func (c *S3Client) ListObjectsByPrefix(ctx context.Context, prefix string) ([]st
 	}
 	for _, key := range resp.Contents {
 		objects = append(objects, *key.Key)
+	}
+	return objects, nil
+}
+
+func (c *S3Client) ListObjectsByPrefixWithMetadata(ctx context.Context, prefix string) ([]ObjectInfo, error) {
+	log := logutil.FromContext(ctx, c.log)
+	objects := []ObjectInfo{}
+	log.Infof("Listing objects by with prefix %s", prefix)
+	resp, err := c.client.ListObjects(&s3.ListObjectsInput{
+		Bucket: aws.String(c.cfg.S3Bucket),
+		Prefix: aws.String(prefix),
+	})
+	if err != nil {
+		err = errors.Wrapf(err, "Error listing objects for prefix %s", prefix)
+		log.Error(err)
+		return nil, err
+	}
+	for _, key := range resp.Contents {
+		// We need to find the metadata for each object
+		headObjectOutput, err := c.client.HeadObject(&s3.HeadObjectInput{Bucket: aws.String(c.cfg.S3Bucket), Key: key.Key})
+		if err != nil {
+			err = errors.Wrapf(err, "Failed to retrieve metadata for %s", *key.Key)
+			log.Error(err)
+			return nil, err
+		}
+		objects = append(objects, ObjectInfo{Path: *key.Key, Metadata: swag.StringValueMap(headObjectOutput.Metadata)})
 	}
 	return objects, nil
 }

--- a/pkg/s3wrapper/filesystem_test.go
+++ b/pkg/s3wrapper/filesystem_test.go
@@ -2,16 +2,20 @@ package s3wrapper
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/assisted-service/internal/metrics"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 var _ = Describe("s3filesystem", func() {
@@ -65,7 +69,7 @@ var _ = Describe("s3filesystem", func() {
 	It("uploadfile_download", func() {
 		mockMetricsAPI.EXPECT().FileSystemUsage(gomock.Any()).Times(1)
 		expLen := len(dataStr)
-		filePath, _ := createFileObject(client.basedir, objKey, now)
+		filePath, _ := createFileObject(client.basedir, objKey, now, nil)
 		err := client.UploadFile(ctx, filePath, objKey)
 		Expect(err).Should(BeNil())
 
@@ -84,7 +88,7 @@ var _ = Describe("s3filesystem", func() {
 	It("uploadstream_download", func() {
 		mockMetricsAPI.EXPECT().FileSystemUsage(gomock.Any()).Times(1)
 		expLen := len(dataStr)
-		filePath, _ := createFileObject(client.basedir, "foo", now)
+		filePath, _ := createFileObject(client.basedir, "foo", now, nil)
 		fileReader, err := os.Open(filePath)
 		Expect(err).Should(BeNil())
 		err = client.UploadStream(ctx, fileReader, objKey)
@@ -122,8 +126,8 @@ var _ = Describe("s3filesystem", func() {
 	})
 	It("expiration", func() {
 		imgCreatedAt, _ := time.Parse(time.RFC3339, "2020-01-01T09:30:00+00:00") // Long ago
-		createFileObject(client.basedir, objKey, imgCreatedAt)
-		createFileObject(client.basedir, objKey2, imgCreatedAt)
+		createFileObject(client.basedir, objKey, imgCreatedAt, nil)
+		createFileObject(client.basedir, objKey2, imgCreatedAt, nil)
 
 		called := 0
 		mockMetricsAPI.EXPECT().FileSystemUsage(gomock.Any()).Times(2)
@@ -140,7 +144,7 @@ var _ = Describe("s3filesystem", func() {
 	})
 	It("expire_not_expired_image", func() {
 		imgCreatedAt, _ := time.Parse(time.RFC3339, "2020-01-01T09:30:00+00:00") // 30 minutes ago
-		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt)
+		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt, nil)
 		called := false
 		mockMetricsAPI.EXPECT().FileSystemUsage(gomock.Any()).Times(1)
 		client.handleFile(ctx, log, filePath, info, now, deleteTime, func(ctx context.Context, log logrus.FieldLogger, objectName string) { called = true })
@@ -148,7 +152,7 @@ var _ = Describe("s3filesystem", func() {
 	})
 	It("expire_expired_image", func() {
 		imgCreatedAt, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00+00:00") // Two hours ago
-		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt)
+		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt, nil)
 		called := false
 		mockMetricsAPI.EXPECT().FileSystemUsage(gomock.Any()).Times(1)
 		client.handleFile(ctx, log, filePath, info, now, deleteTime, func(ctx context.Context, log logrus.FieldLogger, objectName string) { called = true })
@@ -156,7 +160,7 @@ var _ = Describe("s3filesystem", func() {
 	})
 	It("expire_delete_error", func() {
 		imgCreatedAt, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00+00:00") // Two hours ago
-		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt)
+		filePath, info := createFileObject(client.basedir, objKey, imgCreatedAt, nil)
 		os.Remove(filePath)
 		called := false
 		client.handleFile(ctx, log, filePath, info, now, deleteTime, func(ctx context.Context, log logrus.FieldLogger, objectName string) { called = true })
@@ -164,15 +168,15 @@ var _ = Describe("s3filesystem", func() {
 	})
 
 	It("ListObjectByPrefix lists the correct object without a leading slash", func() {
-		_, _ = createFileObject(client.basedir, "dir/other/file", now)
-		_, _ = createFileObject(client.basedir, "dir/other/file2", now)
-		_, _ = createFileObject(client.basedir, "dir/file", now)
-		_, _ = createFileObject(client.basedir, "dir2/file", now)
+		_, _ = createFileObject(client.basedir, "dir/other/file", now, nil)
+		_, _ = createFileObject(client.basedir, "dir/other/file2", now, nil)
+		_, _ = createFileObject(client.basedir, "dir/file", now, nil)
+		_, _ = createFileObject(client.basedir, "dir2/file", now, nil)
 
-		var objects []string
+		var paths []string
 		var err error
 		containsObj := func(obj string) bool {
-			for _, o := range objects {
+			for _, o := range paths {
 				if obj == o {
 					return true
 				}
@@ -180,24 +184,148 @@ var _ = Describe("s3filesystem", func() {
 			return false
 		}
 
-		objects, err = client.ListObjectsByPrefix(ctx, "dir/other")
+		paths, err = client.ListObjectsByPrefix(ctx, "dir/other")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(objects)).To(Equal(2))
-		Expect(containsObj("dir/other/file")).To(BeTrue(), "file list %v does not contain \"dir/other/file\"", objects)
-		Expect(containsObj("dir/other/file2")).To(BeTrue(), "file list %v does not contain \"dir/other/file2\"", objects)
+		Expect(len(paths)).To(Equal(2))
+		Expect(containsObj("dir/other/file")).To(BeTrue(), "file list %v does not contain \"dir/other/file\"", paths)
+		Expect(containsObj("dir/other/file2")).To(BeTrue(), "file list %v does not contain \"dir/other/file2\"", paths)
 
-		objects, err = client.ListObjectsByPrefix(ctx, "dir2")
+		paths, err = client.ListObjectsByPrefix(ctx, "dir2")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(objects)).To(Equal(1))
-		Expect(objects[0]).To(Equal("dir2/file"))
+		Expect(len(paths)).To(Equal(1))
+		Expect(paths[0]).To(Equal("dir2/file"))
 
-		objects, err = client.ListObjectsByPrefix(ctx, "")
+		paths, err = client.ListObjectsByPrefix(ctx, "")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(objects)).To(Equal(4))
-		Expect(containsObj("dir/other/file")).To(BeTrue(), "file list %v does not contain \"dir/other/file\"", objects)
-		Expect(containsObj("dir/other/file2")).To(BeTrue(), "file list %v does not contain \"dir/other/file2\"", objects)
-		Expect(containsObj("dir/file")).To(BeTrue(), "file list %v does not contain \"dir/file\"", objects)
-		Expect(containsObj("dir2/file")).To(BeTrue(), "file list %v does not contain \"dir2/file\"", objects)
+		Expect(len(paths)).To(Equal(4))
+
+		Expect(containsObj("dir/other/file")).To(BeTrue(), "file list %v does not contain \"dir/other/file\"", paths)
+		Expect(containsObj("dir/other/file2")).To(BeTrue(), "file list %v does not contain \"dir/other/file2\"", paths)
+		Expect(containsObj("dir/file")).To(BeTrue(), "file list %v does not contain \"dir/file\"", paths)
+		Expect(containsObj("dir2/file")).To(BeTrue(), "file list %v does not contain \"dir2/file\"", paths)
+	})
+
+	Context("Metadata", func() {
+
+		containsMetadataEntry := func(objects []ObjectInfo, metadata map[string]string) bool {
+			for _, object := range objects {
+				if len(object.Metadata) != len(metadata) {
+					return false
+				}
+				for key, value := range object.Metadata {
+					if val, ok := metadata[key]; ok && val == value {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		validateListObjectsByPrefix := func() {
+			objects, err := client.ListObjectsByPrefixWithMetadata(ctx, "dir/other")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(objects)).To(Equal(2))
+			Expect(containsMetadataEntry(objects, map[string]string{
+				"key1": "bar",
+				"key2": "foo",
+			})).To(BeTrue())
+			Expect(containsMetadataEntry(objects, map[string]string{
+				"key3": "bar2",
+				"key4": "foo2",
+			})).To(BeTrue())
+			Expect(containsMetadataEntry(objects, map[string]string{
+				"key5": "fake",
+				"key6": "fabricated",
+			})).To(BeFalse())
+			Expect(containsMetadataEntry(objects, map[string]string{
+				"key3": "bar",
+				"key5": "foo",
+			})).To(BeFalse())
+		}
+
+		It("ListObjectsByPrefix returns metadata about objects", func() {
+			createFileObject(client.basedir, fmt.Sprintf("dir/other/%s", uuid.New().String()), now, map[string]string{
+				"Key1": "bar",
+				"key2": "foo",
+			})
+			createFileObject(client.basedir, fmt.Sprintf("dir/other/%s", uuid.New().String()), now, map[string]string{
+				"key3": "bar2",
+				"Key4": "foo2",
+			})
+			validateListObjectsByPrefix()
+		})
+
+		Context("Upload", func() {
+
+			var (
+				file1Path         string
+				file2Path         string
+				tempFileDirectory string
+			)
+
+			BeforeEach(func() {
+				var err error
+				tempFileDirectory, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("manifest-test-%s", uuid.NewString()))
+				Expect(err).ToNot(HaveOccurred())
+				file1Path, _ = createFileObject(tempFileDirectory, uuid.NewString(), now, nil)
+				file2Path, _ = createFileObject(tempFileDirectory, uuid.NewString(), now, nil)
+			})
+
+			AfterEach(func() {
+				Expect(os.Remove(file1Path)).To(BeNil())
+				Expect(os.Remove(file2Path)).To(BeNil())
+				Expect(os.Remove(tempFileDirectory)).To(BeNil())
+			})
+
+			It("Upload stores metadata about objects", func() {
+				dataStr := "hello world"
+				err := client.UploadWithMetadata(ctx, []byte(dataStr), "dir/other/file1", map[string]string{
+					"Key1": "bar",
+					"key2": "foo",
+				})
+				Expect(err).Should(BeNil())
+				err = client.UploadWithMetadata(ctx, []byte(dataStr), "dir/other/file2", map[string]string{
+					"key3": "bar2",
+					"Key4": "foo2",
+				})
+				Expect(err).Should(BeNil())
+				validateListObjectsByPrefix()
+			})
+
+			It("UploadFile stores metadata about objects", func() {
+				Expect(client.UploadFileWithMetadata(ctx, file1Path, "dir/other/file1", map[string]string{
+					"Key1": "bar",
+					"key2": "foo",
+				})).To(BeNil())
+				Expect(client.UploadFileWithMetadata(ctx, file2Path, "dir/other/file2", map[string]string{
+					"key3": "bar2",
+					"Key4": "foo2",
+				})).To(BeNil())
+				validateListObjectsByPrefix()
+			})
+
+			It("UploadStream stores metadata about objects", func() {
+				fileReader, err := os.Open(file1Path)
+				Expect(err).Should(BeNil())
+				err = client.UploadStreamWithMetadata(ctx, fileReader, "dir/other/file1", map[string]string{
+					"Key1": "bar",
+					"key2": "foo",
+				})
+				Expect(err).Should(BeNil())
+				fileReader.Close()
+
+				fileReader, err = os.Open(file2Path)
+				Expect(err).Should(BeNil())
+				err = client.UploadStreamWithMetadata(ctx, fileReader, "dir/other/file2", map[string]string{
+					"key3": "bar2",
+					"Key4": "foo2",
+				})
+				Expect(err).Should(BeNil())
+				fileReader.Close()
+
+				validateListObjectsByPrefix()
+			})
+		})
 	})
 
 	AfterEach(func() {
@@ -205,7 +333,12 @@ var _ = Describe("s3filesystem", func() {
 	})
 })
 
-func createFileObject(baseDir, objKey string, imgCreatedAt time.Time) (string, os.FileInfo) {
+func setxattr(path string, name string, data []byte, flags int) error {
+	key := strings.ToLower(fmt.Sprintf("user.%s", name))
+	return unix.Setxattr(path, key, data, flags)
+}
+
+func createFileObject(baseDir, objKey string, imgCreatedAt time.Time, metadata map[string]string) (string, os.FileInfo) {
 	filePath := filepath.Join(baseDir, objKey)
 	Expect(os.MkdirAll(filepath.Dir(filePath), 0755)).To(Succeed())
 	err := os.WriteFile(filePath, []byte("Hello world"), 0600)
@@ -214,5 +347,9 @@ func createFileObject(baseDir, objKey string, imgCreatedAt time.Time) (string, o
 	Expect(err).Should(BeNil())
 	info, err := os.Stat(filePath)
 	Expect(err).Should(BeNil())
+	for k, v := range metadata {
+		err := setxattr(filePath, k, []byte(v), 0)
+		Expect(err).Should(BeNil())
+	}
 	return filePath, info
 }

--- a/pkg/s3wrapper/mock_s3wrapper.go
+++ b/pkg/s3wrapper/mock_s3wrapper.go
@@ -168,6 +168,21 @@ func (mr *MockAPIMockRecorder) ListObjectsByPrefix(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsByPrefix", reflect.TypeOf((*MockAPI)(nil).ListObjectsByPrefix), arg0, arg1)
 }
 
+// ListObjectsByPrefixWithMetadata mocks base method.
+func (m *MockAPI) ListObjectsByPrefixWithMetadata(arg0 context.Context, arg1 string) ([]ObjectInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListObjectsByPrefixWithMetadata", arg0, arg1)
+	ret0, _ := ret[0].([]ObjectInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjectsByPrefixWithMetadata indicates an expected call of ListObjectsByPrefixWithMetadata.
+func (mr *MockAPIMockRecorder) ListObjectsByPrefixWithMetadata(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectsByPrefixWithMetadata", reflect.TypeOf((*MockAPI)(nil).ListObjectsByPrefixWithMetadata), arg0, arg1)
+}
+
 // UpdateObjectTimestamp mocks base method.
 func (m *MockAPI) UpdateObjectTimestamp(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -211,6 +226,20 @@ func (mr *MockAPIMockRecorder) UploadFile(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadFile", reflect.TypeOf((*MockAPI)(nil).UploadFile), arg0, arg1, arg2)
 }
 
+// UploadFileWithMetadata mocks base method.
+func (m *MockAPI) UploadFileWithMetadata(arg0 context.Context, arg1, arg2 string, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadFileWithMetadata", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadFileWithMetadata indicates an expected call of UploadFileWithMetadata.
+func (mr *MockAPIMockRecorder) UploadFileWithMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadFileWithMetadata", reflect.TypeOf((*MockAPI)(nil).UploadFileWithMetadata), arg0, arg1, arg2, arg3)
+}
+
 // UploadStream mocks base method.
 func (m *MockAPI) UploadStream(arg0 context.Context, arg1 io.Reader, arg2 string) error {
 	m.ctrl.T.Helper()
@@ -223,4 +252,32 @@ func (m *MockAPI) UploadStream(arg0 context.Context, arg1 io.Reader, arg2 string
 func (mr *MockAPIMockRecorder) UploadStream(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadStream", reflect.TypeOf((*MockAPI)(nil).UploadStream), arg0, arg1, arg2)
+}
+
+// UploadStreamWithMetadata mocks base method.
+func (m *MockAPI) UploadStreamWithMetadata(arg0 context.Context, arg1 io.Reader, arg2 string, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadStreamWithMetadata", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadStreamWithMetadata indicates an expected call of UploadStreamWithMetadata.
+func (mr *MockAPIMockRecorder) UploadStreamWithMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadStreamWithMetadata", reflect.TypeOf((*MockAPI)(nil).UploadStreamWithMetadata), arg0, arg1, arg2, arg3)
+}
+
+// UploadWithMetadata mocks base method.
+func (m *MockAPI) UploadWithMetadata(arg0 context.Context, arg1 []byte, arg2 string, arg3 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadWithMetadata", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadWithMetadata indicates an expected call of UploadWithMetadata.
+func (mr *MockAPIMockRecorder) UploadWithMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadWithMetadata", reflect.TypeOf((*MockAPI)(nil).UploadWithMetadata), arg0, arg1, arg2, arg3)
 }

--- a/restapi/embedded_spec.go
+++ b/restapi/embedded_spec.go
@@ -9382,6 +9382,14 @@ func init() {
             "manifests",
             "openshift"
           ]
+        },
+        "manifest_source": {
+          "description": "Describes whether manifest is sourced from a user or created by the system.",
+          "type": "string",
+          "enum": [
+            "user",
+            "system"
+          ]
         }
       }
     },
@@ -20138,6 +20146,14 @@ func init() {
           "enum": [
             "manifests",
             "openshift"
+          ]
+        },
+        "manifest_source": {
+          "description": "Describes whether manifest is sourced from a user or created by the system.",
+          "type": "string",
+          "enum": [
+            "user",
+            "system"
           ]
         }
       }

--- a/subsystem/cluster_test.go
+++ b/subsystem/cluster_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/assisted-service/client/manifests"
 	"github.com/openshift/assisted-service/internal/bminventory"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/host"
 	"github.com/openshift/assisted-service/internal/host/hostutil"
 	"github.com/openshift/assisted-service/internal/network"
@@ -2435,7 +2436,7 @@ name: exampleNamespace2`
 			Expect(err).NotTo(HaveOccurred())
 			tarReader := tar.NewReader(file)
 			numOfarchivedFiles := 0
-			expectedFiles := []string{"cluster_manifest_user-supplied_openshift_manifest1.yaml", "cluster_manifest_user-supplied_openshift_manifest2.yaml", "cluster_events.json", "cluster_metadata.json", "controller_logs.tar.gz", "test-cluster_auto-assign_h1.tar", "test-cluster_auto-assign_h2.tar", "test-cluster_auto-assign_h3.tar"}
+			expectedFiles := []string{"cluster_manifest_user_openshift_manifest1.yaml", "cluster_manifest_user_openshift_manifest2.yaml", "cluster_events.json", "cluster_metadata.json", "controller_logs.tar.gz", "test-cluster_auto-assign_h1.tar", "test-cluster_auto-assign_h2.tar", "test-cluster_auto-assign_h3.tar"}
 			for {
 				header, err := tarReader.Next()
 				if err == io.EOF {
@@ -2835,8 +2836,9 @@ spec:
   - 'loglevel=7'`
 				base64Content := base64.StdEncoding.EncodeToString([]byte(content))
 				manifest := models.Manifest{
-					FileName: "01-user-generated-manifest.yaml",
-					Folder:   "openshift",
+					FileName:       "01-user-generated-manifest.yaml",
+					Folder:         "openshift",
+					ManifestSource: constants.ManifestSourceUserSupplied,
 				}
 				// All manifests created via the API are considered to be "user generated"
 				response, err := userBMClient.Manifests.V2CreateClusterManifest(ctx, &manifests.V2CreateClusterManifestParams{

--- a/subsystem/manifests_test.go
+++ b/subsystem/manifests_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/assisted-service/client/installer"
 	"github.com/openshift/assisted-service/client/manifests"
 	"github.com/openshift/assisted-service/internal/common"
+	"github.com/openshift/assisted-service/internal/constants"
 	"github.com/openshift/assisted-service/internal/usage"
 	"github.com/openshift/assisted-service/models"
 )
@@ -50,13 +51,15 @@ spec:
 
 	BeforeEach(func() {
 		manifestFile = models.Manifest{
-			FileName: "99-openshift-machineconfig-master-kargs.yaml",
-			Folder:   "openshift",
+			FileName:       "99-openshift-machineconfig-master-kargs.yaml",
+			Folder:         "openshift",
+			ManifestSource: constants.ManifestSourceUserSupplied,
 		}
 
 		renamedManifestFile = models.Manifest{
-			FileName: "99-openshift-machineconfig-master-renamed-kargs.yaml",
-			Folder:   "openshift",
+			FileName:       "99-openshift-machineconfig-master-renamed-kargs.yaml",
+			Folder:         "openshift",
+			ManifestSource: constants.ManifestSourceUserSupplied,
 		}
 
 		registerClusterReply, err := userBMClient.Installer.V2RegisterCluster(ctx, &installer.V2RegisterClusterParams{

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -6899,6 +6899,10 @@ definitions:
       file_name:
         type: string
         description: The file name prefaced by the folder that contains it.
+      manifest_source:
+        type: string
+        enum: [user,system]
+        description: Describes whether manifest is sourced from a user or created by the system.
 
   create-manifest-params:
     type: object

--- a/vendor/github.com/openshift/assisted-service/models/manifest.go
+++ b/vendor/github.com/openshift/assisted-service/models/manifest.go
@@ -26,6 +26,10 @@ type Manifest struct {
 	// The folder that contains the files. Manifests can be placed in 'manifests' or 'openshift' directories.
 	// Enum: [manifests openshift]
 	Folder string `json:"folder,omitempty"`
+
+	// Describes whether manifest is sourced from a user or created by the system.
+	// Enum: [user system]
+	ManifestSource string `json:"manifest_source,omitempty"`
 }
 
 // Validate validates this manifest
@@ -33,6 +37,10 @@ func (m *Manifest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateFolder(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateManifestSource(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -78,6 +86,48 @@ func (m *Manifest) validateFolder(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateFolderEnum("folder", "body", m.Folder); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var manifestTypeManifestSourcePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["user","system"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		manifestTypeManifestSourcePropEnum = append(manifestTypeManifestSourcePropEnum, v)
+	}
+}
+
+const (
+
+	// ManifestManifestSourceUser captures enum value "user"
+	ManifestManifestSourceUser string = "user"
+
+	// ManifestManifestSourceSystem captures enum value "system"
+	ManifestManifestSourceSystem string = "system"
+)
+
+// prop value enum
+func (m *Manifest) validateManifestSourceEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, manifestTypeManifestSourcePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manifest) validateManifestSource(formats strfmt.Registry) error {
+	if swag.IsZero(m.ManifestSource) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateManifestSourceEnum("manifest_source", "body", m.ManifestSource); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
As detailed in the epic [MGMT-18165](https://issues.redhat.com//browse/MGMT-18165) and the corresponding enhancement doc, there is a need to make transaction storage work in a more transactional way.

This PR addresses that by storing manifest metadata with the file being stored

In S3 this will be performed in a single write and will store user defined attributes alongside the file itself.
In the filesystem implementation, this will be performed using xattr, whereas we cannot make this completely atomic, we can effectively do so by applying all changes to a temporary file and then moving it to the correct location.

This PR includes `read only` support for the legacy method (at the time of writing,
the current method) of marking a file as `user-supplied`;

When generating a list of manifests, we have to determine the correct metadata for
each file. If the metadata was found in S3/Xattr then we accept this as
the source of truth.

If we found no metadata and there is a corresponding `user-supplied`
entry in the manifest metadata files, we will consider the manifest to
be `user supplied`.

This is to allow clean upgrade to the new manifest handling without the
need to run any migration.

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
