### PR TITLE
AGENT-925: Allow agent-installer-client to use a secure port when adding a new node in day2

### DIFF
--- a/cmd/agentbasedinstaller/client/main.go
+++ b/cmd/agentbasedinstaller/client/main.go
@@ -68,6 +68,7 @@ var ImportOptions struct {
 	ClusterID            string `envconfig:"CLUSTER_ID" default:""`
 	ClusterName          string `envconfig:"CLUSTER_NAME" default:""`
 	ClusterAPIVIPDNSName string `envconfig:"CLUSTER_API_VIP_DNS_NAME" default:""`
+	ClusterConfigDir     string `envconfig:"CLUSTER_CONFIG_DIR" default:"/clusterconfig"`
 }
 
 func main() {
@@ -271,7 +272,7 @@ func importCluster(ctx context.Context, log *log.Logger, bmInventory *client.Ass
 	}
 
 	clusterID := strfmt.UUID(ImportOptions.ClusterID)
-	_, err = agentbasedinstaller.ImportCluster(ctx, log, bmInventory, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName)
+	_, err = agentbasedinstaller.ImportCluster(ctx, log, bmInventory, clusterID, ImportOptions.ClusterName, ImportOptions.ClusterAPIVIPDNSName, ImportOptions.ClusterConfigDir)
 	if err != nil {
 		log.Fatal("Failed to import cluster with assisted-service: ", err)
 	}

--- a/cmd/agentbasedinstaller/import.go
+++ b/cmd/agentbasedinstaller/import.go
@@ -2,6 +2,9 @@ package agentbasedinstaller
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/openshift/assisted-service/client"
@@ -12,7 +15,7 @@ import (
 )
 
 func ImportCluster(ctx context.Context, log *log.Logger, bmInventory *client.AssistedInstall,
-	clusterID strfmt.UUID, clusterName string, clusterAPIVIPDNSName string) (*models.Cluster, error) {
+	clusterID strfmt.UUID, clusterName string, clusterAPIVIPDNSName string, clusterConfigDir string) (*models.Cluster, error) {
 
 	importClusterParams := &models.ImportClusterParams{
 		Name:               &clusterName,
@@ -26,9 +29,43 @@ func ImportCluster(ctx context.Context, log *log.Logger, bmInventory *client.Ass
 	if importClusterErr != nil {
 		return nil, errorutil.GetAssistedError(importClusterErr)
 	}
-	result := clusterResult.GetPayload()
-
 	log.Infof("Imported cluster with id: %s", clusterResult.Payload.ID)
 
-	return result, nil
+	if err := configureClusterIgnitionEndpoint(ctx, bmInventory, clusterConfigDir, clusterResult.Payload.ID); err != nil {
+		return nil, err
+	}
+
+	return clusterResult.GetPayload(), nil
+}
+
+func configureClusterIgnitionEndpoint(ctx context.Context, bmInventory *client.AssistedInstall, clusterConfigDir string, clusterID *strfmt.UUID) error {
+	workerIgnitionRaw, err := os.ReadFile(path.Join(clusterConfigDir, "worker-ignition-endpoint.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read ignition endpoint file: %w", err)
+	}
+
+	ignitionEndpoint := &models.IgnitionEndpoint{}
+	err = ignitionEndpoint.UnmarshalBinary(workerIgnitionRaw)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal worker ignition endpoint: %w", err)
+	}
+	log.Info("Read worker ignition endpoint file")
+
+	updateClusterParams := &models.V2ClusterUpdateParams{
+		IgnitionEndpoint: ignitionEndpoint,
+	}
+	updateParams := &installer.V2UpdateClusterParams{
+		ClusterID:           *clusterID,
+		ClusterUpdateParams: updateClusterParams,
+	}
+	_, updateClusterErr := bmInventory.Installer.V2UpdateCluster(ctx, updateParams)
+	if updateClusterErr != nil {
+		return errorutil.GetAssistedError(updateClusterErr)
+	}
+	log.Infof("Configured ignition endpoint for cluster %s", *clusterID)
+
+	return nil
 }


### PR DESCRIPTION
This patch enhances the agent-installer-client to use, when possible, the information provided by ABI to configure the imported cluster ignition endpoint. This approach is required to allow using the secure port (22623) when adding a new node during day2

## List all the issues related to this PR

- [X] New Feature <!-- new functionality -->
- [] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [X] dev-scripts environment
- [ ] Reviewer's test appreciated
- [X] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [] No tests needed

## Checklist

- [X] Title and description added to both, commit and PR.
- [X] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [X] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
