### PR TITLE
OCPBUGS-35932: Allow auth in docker credentials to be empty

### DIFF
--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -68,7 +68,7 @@ func (e *PullSecretError) Unwrap() error {
 	return e.Cause
 }
 
-// ParsePullSecret validates the format of a pull secret and converts the secret string into individual credentail entries
+// ParsePullSecret validates the format of a pull secret and converts the secret string into individual credential entries
 func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	result := make(map[string]PullSecretCreds)
 	var s imagePullSecret
@@ -83,11 +83,9 @@ func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	}
 
 	for d, a := range s.Auths {
-
 		_, authPresent := a["auth"]
-		_, credsStorePresent := a["credsStore"]
-		if !authPresent && !credsStorePresent {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires either 'auth' or 'credsStore' field", d)}
+		if !authPresent {
+			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires 'auth' field", d)}
 		}
 
 		var authRaw string

--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -77,47 +77,19 @@ func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	if err != nil {
 		return nil, &PullSecretError{Msg: "pull secret must be a well-formed JSON", Cause: err}
 	}
-
 	if len(s.Auths) == 0 {
 		return nil, &PullSecretError{Msg: "pull secret must contain 'auths' JSON-object field"}
 	}
 
 	for d, a := range s.Auths {
-		_, authPresent := a["auth"]
-		if !authPresent {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires 'auth' field", d)}
-		}
-
-		var authRaw string
-		if auth, ok := a["auth"].(string); authPresent && !ok {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is %v but should be a string", d, a["auth"])}
-		} else {
-			authRaw = auth
-		}
-		data, err := base64.StdEncoding.DecodeString(authRaw)
+		pullSecretCreds, err := parseAuthConfig(d, a)
 		if err != nil {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", d)}
+			return nil, err
 		}
 
-		res := bytes.SplitN(data, []byte(":"), 2)
-		if len(res) != 2 {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", d)}
-		}
-
-		var email string
-		if emailString, ok := a["email"].(string); ok {
-			email = emailString
-		}
-
-		result[d] = PullSecretCreds{
-			Password: string(res[1]),
-			Username: string(res[0]),
-			AuthRaw:  authRaw,
-			Registry: d,
-			Email:    email,
-		}
-
+		result[d] = pullSecretCreds
 	}
+
 	return result, nil
 }
 
@@ -157,6 +129,46 @@ func NewPullSecretValidator(publicRegistries map[string]bool, authHandler auth.A
 		registriesWithAuth: registriesWithAuth,
 		authHandler:        authHandler,
 	}, nil
+}
+
+func parseAuthConfig(registry string, authConfig map[string]interface{}) (PullSecretCreds, error) {
+	email, _ := authConfig["email"].(string)
+
+	ret := PullSecretCreds{
+		Registry: registry,
+		Email:    email,
+	}
+
+	auth, authPresent := authConfig["auth"]
+	if !authPresent {
+		return ret, nil
+	}
+
+	authRaw, ok := auth.(string)
+	if !ok {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is %v but should be a string", registry, authConfig["auth"])}
+	}
+
+	if len(authRaw) == 0 {
+		return ret, nil
+	}
+
+	ret.AuthRaw = authRaw
+
+	data, err := base64.StdEncoding.DecodeString(authRaw)
+	if err != nil {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", registry)}
+	}
+
+	res := bytes.SplitN(data, []byte(":"), 2)
+	if len(res) != 2 {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", registry)}
+	}
+
+	ret.Username = string(res[0])
+	ret.Password = string(res[1])
+
+	return ret, nil
 }
 
 func validateRegistryWithAuth(registry string, credentials map[string]PullSecretCreds) error {

--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -1,7 +1,6 @@
 package validations
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -160,13 +159,13 @@ func parseAuthConfig(registry string, authConfig map[string]interface{}) (PullSe
 		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", registry)}
 	}
 
-	res := bytes.SplitN(data, []byte(":"), 2)
+	res := strings.SplitN(string(data), ":", 2)
 	if len(res) != 2 {
 		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", registry)}
 	}
 
-	ret.Username = string(res[0])
-	ret.Password = string(res[1])
+	ret.Username = res[0]
+	ret.Password = res[1]
 
 	return ret, nil
 }


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

Allow auth field to be empty in docker pull secret

The impacts are limited to 
* uploader/ package (for on-prem usecase)
* Saas. The code being called by https://github.com/openshift/assisted-service/blob/v2.32.0/internal/cluster/auth.go#L45
  * it only looks for "cloud.openshift.com"
  * this func is only called if the authType is `auth.TypeRHSSO`

I will appreciate to have the opinion of Assisted-Installer gurus to be sure I'm not missing something and it's safe to allow such entry without additional checks. For example, should I add some check here https://github.com/openshift/assisted-service/blob/v2.32.0/internal/cluster/auth.go#L32 or somewhere else to ensure that for SaaS the user:password is specified ?

Also 
  * removed Password that wasn't used https://github.com/openshift/assisted-service/blob/v2.32.0/internal/cluster/validations/pull_secret_validation.go#L51
  * removed credsStore logic, that didn't look functional

credsStore didn't seem functional because:
* The wrong field was parsed (it is at the same level of `auths`, the code was looking at it in `auths.*`. See https://github.com/docker/cli/blob/master/cli/config/configfile/file.go#L28
* The logic looked wrong at first sight, so it probably never worked ?
  * check if one of `credsStore` or `auth` is valuated https://github.com/openshift/assisted-service/blob/v2.32.0/internal/cluster/validations/pull_secret_validation.go#L89
  * if auth is not present take the default value of it (empty string)  - why ? https://github.com/openshift/assisted-service/blob/v2.32.0/internal/cluster/validations/pull_secret_validation.go#L97
  * Assume from here, auth is valuated and try to parse it and extract info from it. This should fail all the time if auth is not present

So I think it's safe to assume that credsStore can be removed. Let me know what you think

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
