### PR TITLE
MGMT-18127: User name and password in a proxy url should be url encoded

### DIFF
--- a/pkg/validations/validations.go
+++ b/pkg/validations/validations.go
@@ -138,6 +138,20 @@ func ValidateHTTPProxyFormat(proxyURL string) error {
 	if u.Scheme != "http" {
 		return errors.Errorf("The URL scheme must be http and specified in the URL: '%s'", proxyURL)
 	}
+
+	userName := u.User.Username()
+	encodedUserName := url.QueryEscape(userName)
+	if userName != encodedUserName {
+		return errors.Errorf("The URL '%s' user name '%s' has to be encoded: '%s'", proxyURL, userName, encodedUserName)
+	}
+
+	password, hasPassword := u.User.Password()
+	if hasPassword {
+		encodedPassword := url.QueryEscape(password)
+		if password != encodedPassword {
+			return errors.Errorf("The URL '%s' password '%s' has to be encoded: '%s'", proxyURL, password, encodedPassword)
+		}
+	}
 	return nil
 }
 

--- a/pkg/validations/validations_test.go
+++ b/pkg/validations/validations_test.go
@@ -65,6 +65,14 @@ var _ = Describe("URL validations", func() {
 				"http://!@#$!@#$",
 				"Proxy URL format is not valid: 'http://!@#$!@#$'",
 			},
+			{
+				"http://user@name:pswd@proxy.com",
+				"The URL 'http://user@name:pswd@proxy.com' user name 'user@name' has to be encoded: 'user%40name'",
+			},
+			{
+				"http://username:ps$wd@proxy.com",
+				"The URL 'http://username:ps$wd@proxy.com' password 'ps$wd' has to be encoded: 'ps%24wd'",
+			},
 		}
 
 		It("validates proxy URL input", func() {


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

AI doesn't support non-encoded user name and password in the proxy url. Currently if a non-encoded value is passed, the proxy won't work and it will be hard for the user to understand why.
This commit changes the behaviour to return an error message in case a non-encoded value is passed.

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
