### PR TITLE
MGMT-18269: Reset finalizing stage in DB while resetting cluster

### DIFF
--- a/internal/cluster/transition.go
+++ b/internal/cluster/transition.go
@@ -31,7 +31,9 @@ import (
 
 var resetLogsField = []interface{}{"logs_info", "", "controller_logs_started_at", strfmt.DateTime(time.Time{}), "controller_logs_collected_at", strfmt.DateTime(time.Time{})}
 var resetProgressFields = []interface{}{"progress_finalizing_stage_percentage", 0, "progress_installing_stage_percentage", 0,
-	"progress_preparing_for_installation_stage_percentage", 0, "progress_total_percentage", 0}
+	"progress_preparing_for_installation_stage_percentage", 0, "progress_total_percentage", 0,
+	"progress_finalizing_stage_timed_out", false,
+	"progress_finalizing_stage", "", "progress_finalizing_stage_started_at", strfmt.DateTime(time.Time{})}
 
 var resetFields = append(append(resetProgressFields, resetLogsField...), "openshift_cluster_id", "")
 


### PR DESCRIPTION
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

FinalizingStage is not reset while resetting a cluster, leading to skipping an update for the progress field (https://github.com/openshift/assisted-service/blob/v2.31.7/internal/cluster/cluster.go#L1811) 
Then the timeout (set from the 1st install try) is more likely to be reached, flagging the installation as failed while it's not

Strictly speaking this value can be updated by this route https://github.com/openshift/assisted-service/blob/v2.31.7/swagger.yaml#L333-L338. While the body is required, the internal param is not https://github.com/openshift/assisted-service/blob/v2.31.7/swagger.yaml#L5713-L5717. That means that this API could be called with something empty (and then break the idea of setting it to empty to be able to reset the start time)
But good news, this check here will do the trick https://github.com/openshift/assisted-service/blob/v2.31.7/internal/cluster/cluster.go#L1793


## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [x] Cloud
- [x] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [x] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
