### PR TITLE
MGMT-8356: Fix postgres deployment script in 'kind' target to set static nodePort correctly, Remove static nodePorts for deployment targets other then 'kind'

### DIFF
--- a/deploy/assisted-image-service-service.yaml
+++ b/deploy/assisted-image-service-service.yaml
@@ -13,7 +13,6 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: 8080
-      nodePort: 30001
   selector:
     app: assisted-image-service
   type: LoadBalancer

--- a/deploy/assisted-service-service.yaml
+++ b/deploy/assisted-service-service.yaml
@@ -13,7 +13,6 @@ spec:
       port: 8090
       protocol: TCP
       targetPort: 8090
-      nodePort: 30000
   selector:
     app: assisted-service
   type: LoadBalancer

--- a/deploy/postgres/postgres-deployment.yaml
+++ b/deploy/postgres/postgres-deployment.yaml
@@ -61,7 +61,6 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-      nodePort: 30003
   selector:
     app: postgres
 status:

--- a/deploy/wiremock/wiremock-deployment.yaml
+++ b/deploy/wiremock/wiremock-deployment.yaml
@@ -35,7 +35,6 @@ spec:
         port: 8080
         protocol: TCP
         targetPort: 8080
-        nodePort: 30002
     selector:
       app: wiremock
   status:

--- a/tools/deploy_postgres.py
+++ b/tools/deploy_postgres.py
@@ -31,14 +31,6 @@ def deploy_postgres_secret(deploy_options):
         docs=docs
     )
 
-    if deploy_options.target == "kind":
-        utils.override_service_type_definition_and_node_port(
-            internal_definitions_path=f'build/{deploy_options.namespace}/postgres-secret.yaml',
-            internal_target_definitions_path=f'build/{deploy_options.namespace}/postgres-secret.yaml',
-            service_type="NodePort",
-            node_port=30003
-        )
-
     if not deploy_options.apply_manifest:
         return
     log.info('Deploying %s', dst_file)
@@ -61,6 +53,14 @@ def deploy_postgres(deploy_options):
         basename=f'build/{deploy_options.namespace}/postgres-deployment.yaml',
         docs=docs
     )
+
+    if deploy_options.target == "kind":
+        utils.override_service_type_definition_and_node_port(
+            internal_definitions_path=f'build/{deploy_options.namespace}/postgres-deployment.yaml',
+            internal_target_definitions_path=f'build/{deploy_options.namespace}/postgres-deployment.yaml',
+            service_type="NodePort",
+            node_port=30003
+        )
 
     if not deploy_options.apply_manifest:
         return


### PR DESCRIPTION
- Fix postgres deployment script in 'kind' target to set static nodePort correctly
- Remove static nodePorts for deployment targets other then 'kind'

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
