### PR TITLE
[release-4.16] OCPBUGS-35932: Allow auth in docker credentials to be empty

### DIFF
--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -1,7 +1,6 @@
 package validations
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -161,13 +160,13 @@ func parseAuthConfig(registry string, authConfig map[string]interface{}) (PullSe
 		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", registry)}
 	}
 
-	res := bytes.SplitN(data, []byte(":"), 2)
+	res := strings.SplitN(string(data), ":", 2)
 	if len(res) != 2 {
 		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", registry)}
 	}
 
-	ret.Username = string(res[0])
-	ret.Password = string(res[1])
+	ret.Username = res[0]
+	ret.Password = res[1]
 
 	return ret, nil
 }

--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -68,7 +68,7 @@ func (e *PullSecretError) Unwrap() error {
 	return e.Cause
 }
 
-// ParsePullSecret validates the format of a pull secret and converts the secret string into individual credentail entries
+// ParsePullSecret validates the format of a pull secret and converts the secret string into individual credential entries
 func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	result := make(map[string]PullSecretCreds)
 	var s imagePullSecret
@@ -83,11 +83,9 @@ func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	}
 
 	for d, a := range s.Auths {
-
 		_, authPresent := a["auth"]
-		_, credsStorePresent := a["credsStore"]
-		if !authPresent && !credsStorePresent {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires either 'auth' or 'credsStore' field", d)}
+		if !authPresent {
+			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires 'auth' field", d)}
 		}
 
 		var authRaw string

--- a/internal/cluster/validations/pull_secret_validation.go
+++ b/internal/cluster/validations/pull_secret_validation.go
@@ -83,41 +83,14 @@ func ParsePullSecret(secret string) (map[string]PullSecretCreds, error) {
 	}
 
 	for d, a := range s.Auths {
-		_, authPresent := a["auth"]
-		if !authPresent {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: %q JSON-object requires 'auth' field", d)}
-		}
-
-		var authRaw string
-		if auth, ok := a["auth"].(string); authPresent && !ok {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is %v but should be a string", d, a["auth"])}
-		} else {
-			authRaw = auth
-		}
-		data, err := base64.StdEncoding.DecodeString(authRaw)
+		pullSecretCreds, err := parseAuthConfig(d, a)
 		if err != nil {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", d)}
+			return nil, err
 		}
 
-		res := bytes.SplitN(data, []byte(":"), 2)
-		if len(res) != 2 {
-			return nil, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", d)}
-		}
-
-		var email string
-		if emailString, ok := a["email"].(string); ok {
-			email = emailString
-		}
-
-		result[d] = PullSecretCreds{
-			Password: string(res[1]),
-			Username: string(res[0]),
-			AuthRaw:  authRaw,
-			Registry: d,
-			Email:    email,
-		}
-
+		result[d] = pullSecretCreds
 	}
+
 	return result, nil
 }
 
@@ -157,6 +130,46 @@ func NewPullSecretValidator(publicRegistries map[string]bool, authHandler auth.A
 		registriesWithAuth: registriesWithAuth,
 		authHandler:        authHandler,
 	}, nil
+}
+
+func parseAuthConfig(registry string, authConfig map[string]interface{}) (PullSecretCreds, error) {
+	email, _ := authConfig["email"].(string)
+
+	ret := PullSecretCreds{
+		Registry: registry,
+		Email:    email,
+	}
+
+	auth, authPresent := authConfig["auth"]
+	if !authPresent {
+		return ret, nil
+	}
+
+	authRaw, ok := auth.(string)
+	if !ok {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is %v but should be a string", registry, authConfig["auth"])}
+	}
+
+	if len(authRaw) == 0 {
+		return ret, nil
+	}
+
+	ret.AuthRaw = authRaw
+
+	data, err := base64.StdEncoding.DecodeString(authRaw)
+	if err != nil {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' field of %q is not base64-encoded", registry)}
+	}
+
+	res := bytes.SplitN(data, []byte(":"), 2)
+	if len(res) != 2 {
+		return ret, &PullSecretError{Msg: fmt.Sprintf("invalid pull secret: 'auth' for %s is not in 'user:password' format", registry)}
+	}
+
+	ret.Username = string(res[0])
+	ret.Password = string(res[1])
+
+	return ret, nil
 }
 
 func validateRegistryWithAuth(registry string, credentials map[string]PullSecretCreds) error {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/assisted-service/pull/6465

I didn't backport the changes in `uploader/` because they required additional changes that wasn't backported
- https://github.com/openshift/assisted-service/pull/6415
- https://github.com/openshift/assisted-service/pull/6435

I feel like it's a bit too much. If you think I should backport those 2 PRs as well, let me know