### PR TITLE
MGMT-17478: Use ICC config secret for converged flow info when available

### DIFF
--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -31,7 +31,7 @@ const (
 type BMOUtils interface {
 	ConvergedFlowAvailable() bool
 	GetIronicIPs() ([]string, []string, error)
-	GetICCConfig() (*ICCConfig, error)
+	GetICCConfig(ctx context.Context) (*ICCConfig, error)
 }
 
 type ICCConfig struct {
@@ -106,12 +106,12 @@ func (r *bmoUtils) GetIronicIPs() ([]string, []string, error) {
 	return ironicIPs, inspectorIPs, nil
 }
 
-func (r *bmoUtils) GetICCConfig() (*ICCConfig, error) {
+func (r *bmoUtils) GetICCConfig(ctx context.Context) (*ICCConfig, error) {
 	const configKeyNotFoundError string = "Failed to get '%s' key from secret %s in namespace %s"
 
 	secret := &corev1.Secret{}
 	namespacedName := types.NamespacedName{Name: iccSecretName, Namespace: iccNamespace}
-	if err := r.c.Get(context.TODO(), namespacedName, secret); err != nil {
+	if err := r.c.Get(ctx, namespacedName, secret); err != nil {
 		return nil, fmt.Errorf("Failed to get secret %s in namespace %s: %w", iccSecretName, iccNamespace, err)
 	}
 

--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -12,17 +12,32 @@ import (
 	"github.com/openshift/cluster-baremetal-operator/provisioning"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const MinimalVersionForConvergedFlow = "4.12.0-0.alpha"
+const (
+	MinimalVersionForConvergedFlow = "4.12.0-0.alpha"
+	iccNamespace                   = "openshift-machine-api"
+	iccSecretName                  = "metal3-image-customization-config" // #nosec G101
+	ironicBaseURLKey               = "IRONIC_BASE_URL"
+	ironicInspectorBaseURLKey      = "IRONIC_INSPECTOR_BASE_URL"
+	ironicAgentImageKey            = "IRONIC_AGENT_IMAGE"
+)
 
 //go:generate mockgen --build_flags=--mod=mod -package=controllers -destination=mock_bmo_utils.go . BMOUtils
 type BMOUtils interface {
 	ConvergedFlowAvailable() bool
 	GetIronicIPs() ([]string, []string, error)
+	GetICCConfig() (*ICCConfig, error)
+}
+
+type ICCConfig struct {
+	IronicBaseURL          string
+	IronicInspectorBaseUrl string
+	IronicAgentImage       string
 }
 
 type bmoUtils struct {
@@ -89,6 +104,37 @@ func (r *bmoUtils) GetIronicIPs() ([]string, []string, error) {
 		return nil, nil, err
 	}
 	return ironicIPs, inspectorIPs, nil
+}
+
+func (r *bmoUtils) GetICCConfig() (*ICCConfig, error) {
+	const configKeyNotFoundError string = "Failed to get '%s' key from secret %s in namespace %s"
+
+	secret := &corev1.Secret{}
+	namespacedName := types.NamespacedName{Name: iccSecretName, Namespace: iccNamespace}
+	if err := r.c.Get(context.TODO(), namespacedName, secret); err != nil {
+		return nil, fmt.Errorf("Failed to get secret %s in namespace %s: %w", iccSecretName, iccNamespace, err)
+	}
+
+	ironicBaseURL, ok := secret.Data[ironicBaseURLKey]
+	if !ok {
+		return nil, fmt.Errorf(configKeyNotFoundError, ironicBaseURLKey, secret.Name, secret.Namespace)
+	}
+
+	ironicInspectorBaseURL, ok := secret.Data[ironicInspectorBaseURLKey]
+	if !ok {
+		return nil, fmt.Errorf(configKeyNotFoundError, ironicInspectorBaseURLKey, secret.Name, secret.Namespace)
+	}
+
+	ironicAgentImage, ok := secret.Data[ironicAgentImageKey]
+	if !ok {
+		return nil, fmt.Errorf(configKeyNotFoundError, ironicAgentImageKey, secret.Name, secret.Namespace)
+	}
+
+	return &ICCConfig{
+		IronicBaseURL:          string(ironicBaseURL),
+		IronicInspectorBaseUrl: string(ironicInspectorBaseURL),
+		IronicAgentImage:       string(ironicAgentImage),
+	}, nil
 }
 
 func (r *bmoUtils) getProvisioningInfo() (*provisioning.ProvisioningInfo, error) {

--- a/internal/controller/controllers/bmo_utils.go
+++ b/internal/controller/controllers/bmo_utils.go
@@ -31,7 +31,7 @@ const (
 type BMOUtils interface {
 	ConvergedFlowAvailable() bool
 	GetIronicIPs() ([]string, []string, error)
-	GetICCConfig(ctx context.Context) (*ICCConfig, error)
+	getICCConfig(ctx context.Context) (*ICCConfig, error)
 }
 
 type ICCConfig struct {
@@ -106,7 +106,7 @@ func (r *bmoUtils) GetIronicIPs() ([]string, []string, error) {
 	return ironicIPs, inspectorIPs, nil
 }
 
-func (r *bmoUtils) GetICCConfig(ctx context.Context) (*ICCConfig, error) {
+func (r *bmoUtils) getICCConfig(ctx context.Context) (*ICCConfig, error) {
 	const configKeyNotFoundError string = "Failed to get '%s' key from secret %s in namespace %s"
 
 	secret := &corev1.Secret{}

--- a/internal/controller/controllers/bmo_utils_test.go
+++ b/internal/controller/controllers/bmo_utils_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/assisted-service/internal/common"
 	metal3iov1alpha1 "github.com/openshift/cluster-baremetal-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -119,6 +120,87 @@ var _ = Describe("bmoUtils", func() {
 			Expect(err.Error()).To(ContainSubstring("unable to determine inspector IP, check if metal3 pod is running"))
 			Expect(serviceIPs).Should(BeNil())
 			Expect(inspectorIPs).Should(BeNil())
+		})
+
+	})
+	Context("GetICCConfig", func() {
+		It("success", func() {
+			bmoUtils := &bmoUtils{
+				c:              c,
+				log:            log,
+				kubeAPIEnabled: true,
+			}
+			ironicURLs := getUrlFromIP("10.10.10.11")
+			inspectorURLs := getUrlFromIP("10.10.10.10")
+			agentImage := "quay.io/some/agent:image"
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      iccSecretName,
+					Namespace: iccNamespace,
+				},
+				Data: map[string][]byte{
+					ironicBaseURLKey:          []byte(ironicURLs),
+					ironicInspectorBaseURLKey: []byte(inspectorURLs),
+					ironicAgentImageKey:       []byte(agentImage),
+				},
+			}
+			Expect(c.Create(context.Background(), secret)).To(BeNil())
+			iccConfig, err := bmoUtils.GetICCConfig()
+			Expect(err).Should(BeNil())
+			Expect(iccConfig.IronicBaseURL).Should(Equal(ironicURLs))
+			Expect(iccConfig.IronicInspectorBaseUrl).Should(Equal(inspectorURLs))
+			Expect(iccConfig.IronicAgentImage).Should(Equal(agentImage))
+		})
+		It("throws an error when secret is missing", func() {
+			bmoUtils := &bmoUtils{
+				c:              c,
+				log:            log,
+				kubeAPIEnabled: true,
+			}
+			_, err := bmoUtils.GetICCConfig()
+			Expect(err).Should(Not(BeNil()))
+		})
+
+		DescribeTable("throws an error when config is incomplete",
+			func(ironicURLs []byte, inspectorURLs []byte, agentImage []byte) {
+				bmoUtils := &bmoUtils{
+					c:              c,
+					log:            log,
+					kubeAPIEnabled: true,
+				}
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      iccSecretName,
+						Namespace: iccNamespace,
+					},
+					Data: map[string][]byte{},
+				}
+				if ironicURLs != nil {
+					secret.Data[ironicBaseURLKey] = ironicURLs
+				}
+				if inspectorURLs != nil {
+					secret.Data[ironicInspectorBaseURLKey] = inspectorURLs
+				}
+				if agentImage != nil {
+					secret.Data[ironicAgentImageKey] = agentImage
+				}
+
+				Expect(c.Create(context.Background(), secret)).To(BeNil())
+				_, err := bmoUtils.GetICCConfig()
+				Expect(err).Should(Not(BeNil()))
+			},
+			Entry("ironicURLs is missing", nil, []byte("some"), []byte("some")),
+			Entry("ironicInspectorURLs is missing", []byte("some"), nil, []byte("some")),
+			Entry("ironicAgentImage is missing", []byte("some"), []byte("some"), nil),
+		)
+		It("throws an error when the configuration is incomplete", func() {
+			bmoUtils := &bmoUtils{
+				c:              c,
+				log:            log,
+				kubeAPIEnabled: true,
+			}
+			_, err := bmoUtils.GetICCConfig()
+			Expect(err).Should(Not(BeNil()))
 		})
 
 	})

--- a/internal/controller/controllers/bmo_utils_test.go
+++ b/internal/controller/controllers/bmo_utils_test.go
@@ -145,7 +145,7 @@ var _ = Describe("bmoUtils", func() {
 				},
 			}
 			Expect(c.Create(context.Background(), secret)).To(BeNil())
-			iccConfig, err := bmoUtils.GetICCConfig()
+			iccConfig, err := bmoUtils.GetICCConfig(context.Background())
 			Expect(err).Should(BeNil())
 			Expect(iccConfig.IronicBaseURL).Should(Equal(ironicURLs))
 			Expect(iccConfig.IronicInspectorBaseUrl).Should(Equal(inspectorURLs))
@@ -157,7 +157,7 @@ var _ = Describe("bmoUtils", func() {
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			_, err := bmoUtils.GetICCConfig()
+			_, err := bmoUtils.GetICCConfig(context.Background())
 			Expect(err).Should(Not(BeNil()))
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("bmoUtils", func() {
 				}
 
 				Expect(c.Create(context.Background(), secret)).To(BeNil())
-				_, err := bmoUtils.GetICCConfig()
+				_, err := bmoUtils.GetICCConfig(context.Background())
 				Expect(err).Should(Not(BeNil()))
 			},
 			Entry("ironicURLs is missing", nil, []byte("some"), []byte("some")),
@@ -199,7 +199,7 @@ var _ = Describe("bmoUtils", func() {
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			_, err := bmoUtils.GetICCConfig()
+			_, err := bmoUtils.GetICCConfig(context.Background())
 			Expect(err).Should(Not(BeNil()))
 		})
 

--- a/internal/controller/controllers/bmo_utils_test.go
+++ b/internal/controller/controllers/bmo_utils_test.go
@@ -123,7 +123,7 @@ var _ = Describe("bmoUtils", func() {
 		})
 
 	})
-	Context("GetICCConfig", func() {
+	Context("getICCConfig", func() {
 		It("success", func() {
 			bmoUtils := &bmoUtils{
 				c:              c,
@@ -145,7 +145,7 @@ var _ = Describe("bmoUtils", func() {
 				},
 			}
 			Expect(c.Create(context.Background(), secret)).To(BeNil())
-			iccConfig, err := bmoUtils.GetICCConfig(context.Background())
+			iccConfig, err := bmoUtils.getICCConfig(context.Background())
 			Expect(err).Should(BeNil())
 			Expect(iccConfig.IronicBaseURL).Should(Equal(ironicURLs))
 			Expect(iccConfig.IronicInspectorBaseUrl).Should(Equal(inspectorURLs))
@@ -157,7 +157,7 @@ var _ = Describe("bmoUtils", func() {
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			_, err := bmoUtils.GetICCConfig(context.Background())
+			_, err := bmoUtils.getICCConfig(context.Background())
 			Expect(err).Should(Not(BeNil()))
 		})
 
@@ -186,7 +186,7 @@ var _ = Describe("bmoUtils", func() {
 				}
 
 				Expect(c.Create(context.Background(), secret)).To(BeNil())
-				_, err := bmoUtils.GetICCConfig(context.Background())
+				_, err := bmoUtils.getICCConfig(context.Background())
 				Expect(err).Should(Not(BeNil()))
 			},
 			Entry("ironicURLs is missing", nil, []byte("some"), []byte("some")),
@@ -199,7 +199,7 @@ var _ = Describe("bmoUtils", func() {
 				log:            log,
 				kubeAPIEnabled: true,
 			}
-			_, err := bmoUtils.GetICCConfig(context.Background())
+			_, err := bmoUtils.getICCConfig(context.Background())
 			Expect(err).Should(Not(BeNil()))
 		})
 

--- a/internal/controller/controllers/mock_bmo_utils.go
+++ b/internal/controller/controllers/mock_bmo_utils.go
@@ -48,21 +48,6 @@ func (mr *MockBMOUtilsMockRecorder) ConvergedFlowAvailable() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvergedFlowAvailable", reflect.TypeOf((*MockBMOUtils)(nil).ConvergedFlowAvailable))
 }
 
-// GetICCConfig mocks base method.
-func (m *MockBMOUtils) GetICCConfig(arg0 context.Context) (*ICCConfig, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetICCConfig", arg0)
-	ret0, _ := ret[0].(*ICCConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetICCConfig indicates an expected call of GetICCConfig.
-func (mr *MockBMOUtilsMockRecorder) GetICCConfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetICCConfig", reflect.TypeOf((*MockBMOUtils)(nil).GetICCConfig), arg0)
-}
-
 // GetIronicIPs mocks base method.
 func (m *MockBMOUtils) GetIronicIPs() ([]string, []string, error) {
 	m.ctrl.T.Helper()
@@ -77,4 +62,19 @@ func (m *MockBMOUtils) GetIronicIPs() ([]string, []string, error) {
 func (mr *MockBMOUtilsMockRecorder) GetIronicIPs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIronicIPs", reflect.TypeOf((*MockBMOUtils)(nil).GetIronicIPs))
+}
+
+// getICCConfig mocks base method.
+func (m *MockBMOUtils) getICCConfig(arg0 context.Context) (*ICCConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getICCConfig", arg0)
+	ret0, _ := ret[0].(*ICCConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getICCConfig indicates an expected call of getICCConfig.
+func (mr *MockBMOUtilsMockRecorder) getICCConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getICCConfig", reflect.TypeOf((*MockBMOUtils)(nil).getICCConfig), arg0)
 }

--- a/internal/controller/controllers/mock_bmo_utils.go
+++ b/internal/controller/controllers/mock_bmo_utils.go
@@ -5,6 +5,7 @@
 package controllers
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -48,18 +49,18 @@ func (mr *MockBMOUtilsMockRecorder) ConvergedFlowAvailable() *gomock.Call {
 }
 
 // GetICCConfig mocks base method.
-func (m *MockBMOUtils) GetICCConfig() (*ICCConfig, error) {
+func (m *MockBMOUtils) GetICCConfig(arg0 context.Context) (*ICCConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetICCConfig")
+	ret := m.ctrl.Call(m, "GetICCConfig", arg0)
 	ret0, _ := ret[0].(*ICCConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetICCConfig indicates an expected call of GetICCConfig.
-func (mr *MockBMOUtilsMockRecorder) GetICCConfig() *gomock.Call {
+func (mr *MockBMOUtilsMockRecorder) GetICCConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetICCConfig", reflect.TypeOf((*MockBMOUtils)(nil).GetICCConfig))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetICCConfig", reflect.TypeOf((*MockBMOUtils)(nil).GetICCConfig), arg0)
 }
 
 // GetIronicIPs mocks base method.

--- a/internal/controller/controllers/mock_bmo_utils.go
+++ b/internal/controller/controllers/mock_bmo_utils.go
@@ -47,6 +47,21 @@ func (mr *MockBMOUtilsMockRecorder) ConvergedFlowAvailable() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvergedFlowAvailable", reflect.TypeOf((*MockBMOUtils)(nil).ConvergedFlowAvailable))
 }
 
+// GetICCConfig mocks base method.
+func (m *MockBMOUtils) GetICCConfig() (*ICCConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetICCConfig")
+	ret0, _ := ret[0].(*ICCConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetICCConfig indicates an expected call of GetICCConfig.
+func (mr *MockBMOUtilsMockRecorder) GetICCConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetICCConfig", reflect.TypeOf((*MockBMOUtils)(nil).GetICCConfig))
+}
+
 // GetIronicIPs mocks base method.
 func (m *MockBMOUtils) GetIronicIPs() ([]string, []string, error) {
 	m.ctrl.T.Helper()

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -511,7 +511,6 @@ func (r *PreprovisioningImageReconciler) getIronicServiceURLs(ctx context.Contex
 
 	// default to the first IP returned
 	// v4 for dualstack hub or whatever family the single stack is
-
 	ironicURL := getUrlFromIP(ironicIPs[0])
 	inspectorURL := getUrlFromIP(inspectorIPs[0])
 

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -417,7 +417,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx contex
 	}
 
 	var architectures []string
-	architectures, err = r.OcRelease.GetReleaseArchitecture(log, iccConfig.IronicAgentImage, r.ReleaseImageMirror, infraEnvInternal.PullSecret)
+	architectures, err = r.OcRelease.GetImageArchitecture(log, iccConfig.IronicAgentImage, infraEnvInternal.PullSecret)
 	if err == nil && funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
 		log.Infof("Setting ironic agent image (%s) for infraEnv %s from ICC config", iccConfig.IronicAgentImage, infraEnvInternal.Name)
 		return iccConfig

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -419,11 +419,11 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx contex
 	var architectures []string
 	architectures, err = r.OcRelease.GetImageArchitecture(log, iccConfig.IronicAgentImage, infraEnvInternal.PullSecret)
 	if err == nil && funk.Contains(architectures, infraEnvInternal.CPUArchitecture) {
-		log.Infof("Setting ironic agent image (%s) for infraEnv %s from ICC config", iccConfig.IronicAgentImage, infraEnvInternal.Name)
+		log.Infof("Setting ironic agent image (%s) for infraEnv %v from ICC config", iccConfig.IronicAgentImage, infraEnvInternal.Name)
 		return iccConfig
 	}
 
-	log.Infof("CPU architecture (%v) of Ironic agent image (%s) from ICC config is not available for infraEnv (%s) with arch (%s)",
+	log.Infof("CPU architecture (%v) of Ironic agent image (%s) from ICC config is not available for infraEnv %v with arch (%s)",
 		architectures,
 		iccConfig.IronicAgentImage,
 		infraEnvInternal.Name,
@@ -438,7 +438,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromHUB(ctx context.Cont
 		return nil
 	}
 
-	log.Infof("Setting ironic agent image (%s) for infraEnv %s from HUB cluster", ironicAgentImage, infraEnvInternal.Name)
+	log.Infof("Setting ironic agent image (%s) for infraEnv %v from HUB cluster", ironicAgentImage, infraEnvInternal.Name)
 	return &ICCConfig{
 		IronicAgentImage: ironicAgentImage,
 	}
@@ -452,7 +452,7 @@ func (r *PreprovisioningImageReconciler) getIronicDefaultConfig(log logrus.Field
 		ironicAgentImage = r.Config.BaremetalIronicAgentImage
 	}
 
-	log.Infof("Setting default ironic agent image (%s) for infraEnv %s", ironicAgentImage, infraEnvInternal.Name)
+	log.Infof("Setting default ironic agent image (%s) for infraEnv %v", ironicAgentImage, infraEnvInternal.Name)
 	return &ICCConfig{
 		IronicAgentImage: ironicAgentImage,
 	}

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -421,7 +421,7 @@ func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Co
 	// 2 - Check if ICC config is available, use agent image if CPU architecture is supported.
 	var iccConfig *ICCConfig
 	if ironicAgentImage == "" {
-		iccConfig, err = r.BMOUtils.GetICCConfig()
+		iccConfig, err = r.BMOUtils.GetICCConfig(ctx)
 		if err != nil {
 			log.WithError(err).Info("ICC configuration is not available, will continue without it")
 		}

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -415,7 +415,7 @@ func (r *PreprovisioningImageReconciler) getIronicConfigFromUserOverride(log log
 }
 
 func (r *PreprovisioningImageReconciler) getIronicConfigFromBMOConfig(ctx context.Context, log logrus.FieldLogger, infraEnvInternal *common.InfraEnv) *ICCConfig {
-	iccConfig, err := r.BMOUtils.GetICCConfig(ctx)
+	iccConfig, err := r.BMOUtils.getICCConfig(ctx)
 	if err != nil {
 		log.WithError(err).Info("ICC configuration is not available")
 		return nil

--- a/internal/controller/controllers/preprovisioningimage_controller.go
+++ b/internal/controller/controllers/preprovisioningimage_controller.go
@@ -126,6 +126,11 @@ func (r *PreprovisioningImageReconciler) Reconcile(origCtx context.Context, req 
 		return ctrl.Result{}, nil
 	}
 
+	log = log.WithFields(logrus.Fields{
+		"infra_env":           infraEnv.Name,
+		"infra_env_namespace": infraEnv.Namespace,
+	})
+
 	imageArch := common.NormalizeCPUArchitecture(image.Spec.Architecture)
 	infraArch := common.NormalizeCPUArchitecture(infraEnv.Spec.CpuArchitecture)
 	if infraArch != imageArch {
@@ -518,11 +523,6 @@ func (r *PreprovisioningImageReconciler) getIronicConfig(ctx context.Context, lo
 // AddIronicAgentToInfraEnv updates the infra-env in the database with the ironic agent ignition config if required
 // returns true when the infra-env was updated, false otherwise
 func (r *PreprovisioningImageReconciler) AddIronicAgentToInfraEnv(ctx context.Context, log logrus.FieldLogger, infraEnv *aiv1beta1.InfraEnv) (bool, error) {
-	log = log.WithFields(logrus.Fields{
-		"infra_env":           infraEnv.Name,
-		"infra_env_namespace": infraEnv.Namespace,
-	})
-
 	// Retrieve infraenv from the database
 	key := types.NamespacedName{
 		Name:      infraEnv.Name,

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -193,7 +193,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -220,7 +220,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Expect(*internalIgnitionConfig).Should(ContainSubstring(url.QueryEscape(ironicInspectorIPs[1])))
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -243,7 +243,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -272,7 +272,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -309,7 +309,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -341,7 +341,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -373,7 +373,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -401,7 +401,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			SetImageUrl(ppi, *infraEnv)
 			Expect(c.Update(ctx, ppi)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -444,7 +444,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(&iccConfig, nil)
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -480,7 +480,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(&iccConfig, nil)
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -511,7 +511,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -541,7 +541,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -573,7 +573,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(2)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(2)
-			mockBMOUtils.EXPECT().GetICCConfig().Times(2).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(2).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -630,7 +630,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Update(ctx, ppi)).To(Succeed())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -652,7 +652,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Update(ctx, ppi)).To(Succeed())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -670,7 +670,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			infraEnv.Status = aiv1beta1.InfraEnvStatus{}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -724,7 +724,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		backendInfraEnv.ClusterID = ""
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 
-		mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+		mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 		mockBMOUtils.EXPECT().GetIronicIPs().Return(nil, nil, fmt.Errorf("failed to get urls"))
 		res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 		Expect(err).To(HaveOccurred())
@@ -739,7 +739,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		backendInfraEnv.ClusterID = ""
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 		Expect(c.Create(ctx, infraEnv)).To(BeNil())
-		mockBMOUtils.EXPECT().GetICCConfig().Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+		mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 		mockBMOUtils.EXPECT().GetIronicIPs().AnyTimes().Return(ironicServiceIPs, ironicInspectorIPs, nil)
 		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to update infraEnvInternal"))
 

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -193,7 +193,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -220,7 +220,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 					Expect(*internalIgnitionConfig).Should(ContainSubstring(url.QueryEscape(ironicInspectorIPs[1])))
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -243,7 +243,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -272,7 +272,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -309,7 +309,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -341,7 +341,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -373,7 +373,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -401,7 +401,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			SetImageUrl(ppi, *infraEnv)
 			Expect(c.Update(ctx, ppi)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -444,7 +444,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -481,7 +481,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(&iccConfig, nil)
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -512,7 +512,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -542,7 +542,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(1)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(1)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
 			Expect(res).To(Equal(ctrl.Result{}))
@@ -574,7 +574,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 				}).Return(
 				&common.InfraEnv{InfraEnv: models.InfraEnv{ClusterID: clusterID, ID: &infraEnvID, DownloadURL: downloadURL, CPUArchitecture: infraEnvArch}, GeneratedAt: strfmt.DateTime(time.Now())}, nil).Times(2)
 			mockCRDEventsHandler.EXPECT().NotifyInfraEnvUpdates(infraEnv.Name, infraEnv.Namespace).Times(2)
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(2).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(2).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -631,7 +631,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Update(ctx, ppi)).To(Succeed())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -653,7 +653,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			Expect(c.Update(ctx, ppi)).To(Succeed())
 
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -671,7 +671,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			infraEnv.Status = aiv1beta1.InfraEnvStatus{}
 			Expect(c.Create(ctx, infraEnv)).To(BeNil())
 			setInfraEnvIronicConfig()
-			mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+			mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 
 			res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 			Expect(err).To(BeNil())
@@ -725,7 +725,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		backendInfraEnv.ClusterID = ""
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 
-		mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+		mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 		mockBMOUtils.EXPECT().GetIronicIPs().Return(nil, nil, fmt.Errorf("failed to get urls"))
 		res, err := pr.Reconcile(ctx, newPreprovisioningImageRequest(ppi))
 		Expect(err).To(HaveOccurred())
@@ -740,7 +740,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 		backendInfraEnv.ClusterID = ""
 		mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 		Expect(c.Create(ctx, infraEnv)).To(BeNil())
-		mockBMOUtils.EXPECT().GetICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
+		mockBMOUtils.EXPECT().getICCConfig(gomock.Any()).Times(1).Return(nil, errors.Errorf("ICC configuration is not available"))
 		mockBMOUtils.EXPECT().GetIronicIPs().AnyTimes().Return(ironicServiceIPs, ironicInspectorIPs, nil)
 		mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Failed to update infraEnvInternal"))
 

--- a/internal/controller/controllers/preprovisioningimage_controller_test.go
+++ b/internal/controller/controllers/preprovisioningimage_controller_test.go
@@ -432,7 +432,7 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			backendInfraEnv.PullSecret = "mypullsecret"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 
-			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), iccConfig.IronicAgentImage, "", backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
+			mockOcRelease.EXPECT().GetImageArchitecture(gomock.Any(), iccConfig.IronicAgentImage, backendInfraEnv.PullSecret).Return([]string{"x86_64"}, nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {
 					Expect(params.InfraEnvID).To(Equal(*backendInfraEnv.ID))
@@ -469,7 +469,8 @@ var _ = Describe("PreprovisioningImage reconcile", func() {
 			backendInfraEnv.PullSecret = "mypullsecret"
 			mockInstallerInternal.EXPECT().GetInfraEnvByKubeKey(gomock.Any()).Return(backendInfraEnv, nil)
 
-			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), gomock.Any(), "", backendInfraEnv.PullSecret).Times(2).Return([]string{"arm64"}, nil)
+			mockOcRelease.EXPECT().GetImageArchitecture(gomock.Any(), iccConfig.IronicAgentImage, backendInfraEnv.PullSecret).Times(1).Return([]string{"arm64"}, nil)
+			mockOcRelease.EXPECT().GetReleaseArchitecture(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Times(1).Return([]string{"arm64"}, nil)
 			mockOcRelease.EXPECT().GetIronicAgentImage(gomock.Any(), hubReleaseImage, "", backendInfraEnv.PullSecret).Return("ironic-image:4.12.0", nil)
 			mockInstallerInternal.EXPECT().UpdateInfraEnvInternal(gomock.Any(), gomock.Any(), gomock.Any()).
 				Do(func(ctx context.Context, params installer.UpdateInfraEnvParams, internalIgnitionConfig *string) {

--- a/internal/oc/mock_release.go
+++ b/internal/oc/mock_release.go
@@ -49,6 +49,21 @@ func (mr *MockReleaseMockRecorder) Extract(log, releaseImage, releaseImageMirror
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extract", reflect.TypeOf((*MockRelease)(nil).Extract), log, releaseImage, releaseImageMirror, cacheDir, pullSecret, ocpVersion)
 }
 
+// GetImageArchitecture mocks base method.
+func (m *MockRelease) GetImageArchitecture(log logrus.FieldLogger, image, pullSecret string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageArchitecture", log, image, pullSecret)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageArchitecture indicates an expected call of GetImageArchitecture.
+func (mr *MockReleaseMockRecorder) GetImageArchitecture(log, image, pullSecret interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageArchitecture", reflect.TypeOf((*MockRelease)(nil).GetImageArchitecture), log, image, pullSecret)
+}
+
 // GetIronicAgentImage mocks base method.
 func (m *MockRelease) GetIronicAgentImage(log logrus.FieldLogger, releaseImage, releaseImageMirror, pullSecret string) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/oc/release.go
+++ b/internal/oc/release.go
@@ -48,6 +48,7 @@ type Release interface {
 	GetOpenshiftVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetMajorMinorVersion(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) (string, error)
 	GetReleaseArchitecture(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, pullSecret string) ([]string, error)
+	GetImageArchitecture(log logrus.FieldLogger, image string, pullSecret string) ([]string, error)
 	GetReleaseBinaryPath(releaseImage string, cacheDir string, ocpVersion string) (workdir string, binary string, path string, err error)
 	Extract(log logrus.FieldLogger, releaseImage string, releaseImageMirror string, cacheDir string, pullSecret string, ocpVersion string) (string, error)
 }
@@ -197,6 +198,10 @@ func (r *release) GetReleaseArchitecture(log logrus.FieldLogger, releaseImage st
 		return nil, errors.New("no releaseImage nor releaseImageMirror provided")
 	}
 
+	return r.GetImageArchitecture(log, image, pullSecret)
+}
+
+func (r *release) GetImageArchitecture(log logrus.FieldLogger, image string, pullSecret string) ([]string, error) {
 	icspFile, err := r.getIcspFileFromRegistriesConfig(log)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create file ICSP file from registries config")


### PR DESCRIPTION
When available, read the ICC secret set by BMO in order to retrieve the
agent image, the agent URL(s), and the inspector URL(s).

This this change, we wil try to:
1/ Get the agent image from the user override
2/ if 1/ is not found, get the image from the ICC configuration
3/ if 2/ is not found, get the image from the HUB cluster
4/ if 3/ is not found, return the default image
