### PR TITLE
NO-ISSUE: Mount emptyDir for data in image service

### DIFF
--- a/deploy/assisted-image-service.yaml
+++ b/deploy/assisted-image-service.yaml
@@ -56,4 +56,10 @@ items:
                 value: REPLACE_IMAGE_SERVICE_BASE_URL
               - name: ALLOWED_DOMAINS
                 value: "*"
+            volumeMounts:
+              - mountPath: /data
+                name: image-service-data
         serviceAccountName: assisted-service
+        volumes:
+         - emptyDir: {}
+           name: image-service-data


### PR DESCRIPTION
Creating an emptyDir workaround the permission issues with the `/data` directory we are encountering in the susbsystem tests.

```
{"file":"/go/src/github.com/openshift/origin/main.go:132","func":"main.main.func1","level":"fatal","msg":"Failed to populate image store: failed to download https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.14/4.14.15/rhcos-4.14.15-ppc64le-live.ppc64le.iso: unable to create a temp file for /data/rhcos-full-iso-4.14-414.92.202402130420-0-ppc64le.iso: open /data/.rhcos-full-iso-4.14-414.92.202402130420-0-ppc64le.iso2762773689: permission denied\n","time":"2024-07-08T11:07:48Z"}
```
