### PR TITLE
NO-ISSUE: Fix skipper configuration

### DIFF
--- a/skipper.yaml
+++ b/skipper.yaml
@@ -11,7 +11,6 @@ volumes:
   - $MINIKUBE_HOME:$MINIKUBE_HOME
   - $HOME/.minikube:$HOME/.minikube
   - $HOME/.kube/:$HOME/.kube
-  - $HOME/.docker/:$HOME/.docker
   - $KUBECONFIG:$KUBECONFIG
   - /etc/subuid:/etc/subuid
   - /etc/subgid:/etc/subgid


### PR DESCRIPTION
Currently skipper (+ podman at least) fails with the following error:

```
Error: /home/agentil/.docker: duplicate mount destination
```

because skipper already mounts it by default.
