### PR TITLE
NO-ISSUE: Exclude vendor directory from snyk code analysis

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+exclude:
+  global:
+    - vendor/**
+


### PR DESCRIPTION
We don't want snyk to open PR against files in the vendor directory.

https://docs.snyk.io/scan-using-snyk/import-project-repository/exclude-directories-and-files-from-project-import#use-the-.snyk-file-to-exclude-directories-and-files-from-import