### PR TITLE
[release-ocm-2.11] NO-ISSUE: Fix subsystem tests in the CI - WireMock stubs script is failing to reach WireMock from time to time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,9 +461,6 @@ enable-kube-api-for-subsystem: $(BUILD_FOLDER)
 
 deploy-wiremock: deploy-namespace
 	python3 ./tools/deploy_wiremock.py --target $(TARGET) --namespace "$(NAMESPACE)"
-	timeout 5m ./hack/wait_for_wiremock.sh
-	OCM_URL=$$(kubectl get service wiremock -n $(NAMESPACE) -ojson | jq --from-file ./hack/k8s_service_host_port.jq --raw-output); \
-	export OCM_URL && go run ./hack/add_wiremock_stubs.go
 
 deploy-olm: deploy-namespace
 	python3 ./tools/deploy_olm.py --target $(TARGET)

--- a/tools/deploy_wiremock.py
+++ b/tools/deploy_wiremock.py
@@ -1,5 +1,14 @@
 import utils
 import deployment_options
+import os
+import requests
+import waiting
+from argparse import Namespace
+
+
+TIMEOUT = 60 * 30
+REQUEST_TIMEOUT = 2
+SLEEP = 10
 
 
 log = utils.get_logger('deploy_wiremock')
@@ -11,9 +20,11 @@ def main():
     deploy_wiremock(deploy_options)
     log.info('Wiremock deployment completed')
 
-def deploy_wiremock(deploy_options):
+
+def deploy_wiremock(deploy_options: Namespace):
     docs = utils.load_yaml_file_docs('deploy/wiremock/wiremock-deployment.yaml')
     utils.set_namespace_in_yaml_docs(docs, deploy_options.namespace)
+        
     dst_file = utils.dump_yaml_file_docs('build/wiremock-deployment.yaml', docs)
 
     log.info('Deploying %s', dst_file)
@@ -22,6 +33,86 @@ def deploy_wiremock(deploy_options):
         namespace=deploy_options.namespace,
         file=dst_file
     )
+
+    # Ensure the Wiremock pod is ready before populating the stubs.
+    # To verify if Wiremock is ready to receive requests,
+    # we need to obtain its hostname and port.
+    log.info("Waiting for Wiremock service to be ready...")
+    wait_for_wiremock_service(namespace=deploy_options.namespace)
+    log.info("Wiremock service is ready")
+    hostname = get_service_external_ip(namespace=deploy_options.namespace)
+    port = get_service_external_port(namespace=deploy_options.namespace)
+
+    url = f"http://{hostname}:{port}/__admin/mappings"
+    log.info(f"Trying to reach Wiremock is on {url}...")
+    wait_for_wiremock_pod(url=url)
+    log.info(f"Wiremock is accessible")
+    populate_stubs(hostname=hostname, port=port)
+    log.info("Wiremock stubs populated")
+
+def get_service_external_ip(namespace: str) -> str:
+    return utils.check_output(f"kubectl get service wiremock -n {namespace} -ojson | jq -r '.status.loadBalancer.ingress[0].ip // .status.loadBalancer.ingress[0].hostname'")
+
+
+def get_service_external_port(namespace: str) -> str:
+    return utils.check_output(f"kubectl get service wiremock -n {namespace} -ojson | jq -r '.spec.ports[0].port'")
+
+
+def deploy_ingress(hostname, deploy_options):
+    src_file = os.path.join(os.getcwd(), 'deploy', "wiremock", "wiremock-ingress.yaml")
+    dst_file = os.path.join(os.getcwd(), 'build', deploy_options.namespace, "wiremock-ingress.yaml")
+    with open(src_file, "r") as src:
+        with open(dst_file, "w+") as dst:
+            data = src.read()
+            data = data.replace('REPLACE_NAMESPACE', deploy_options.namespace)
+            data = data.replace("REPLACE_HOSTNAME", hostname)
+            log.info(f"Deploying {dst_file}")
+            dst.write(data)
+
+    utils.apply(
+        target=deploy_options.target,
+        namespace=deploy_options.namespace,
+        file=dst_file
+    )
+
+
+def populate_stubs(hostname: str, port: str):
+    cmd = f"go run ./hack/add_wiremock_stubs.go"
+    os.environ["OCM_URL"] = f"{hostname}:{port}"
+
+    log.info("Waiting for wiremock stubs population...")
+    
+    waiting.wait(
+        lambda: utils.check_output(cmd),
+        timeout_seconds=120,
+        expected_exceptions=(RuntimeError),
+        sleep_seconds=SLEEP, waiting_for="Stubs to be populated"
+    )
+
+
+def is_wiremock_service_ready(namespace: str) -> bool:
+    return get_service_external_ip(namespace=namespace) != "null"
+
+
+def wait_for_wiremock_service(namespace: str):
+    waiting.wait(
+        lambda: is_wiremock_service_ready(namespace=namespace),
+        timeout_seconds=TIMEOUT,
+        expected_exceptions=(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout),
+        sleep_seconds=SLEEP, waiting_for="Wiremock service to be ready")
+
+
+def wait_for_wiremock_pod(url: str):
+    waiting.wait(
+        lambda: is_wiremock_pod_ready(url=url),
+        timeout_seconds=TIMEOUT,
+        expected_exceptions=(requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout),
+        sleep_seconds=SLEEP, waiting_for="Wiremock pod to be ready")
+
+
+def is_wiremock_pod_ready(url: str) -> bool:
+    res = requests.get(url=url, timeout=REQUEST_TIMEOUT, verify=False)
+    return res.status_code == 200
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tailored backport of - https://github.com/openshift/assisted-service/pull/6569

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

You can refer to [Kubernetes community documentation] on writing good commit messages, which provides good tips and ideas.

Some PRs address specific issues. Please, refer to the [CONTRIBUTING] documentation for more
information on how to link a PR to an existing issue.

It's recommended to take a few extra minutes to provide more information about
how this code was tested. Here are some questions that may be worth answering:

- Should this PR be tested by the reviewer?
- Is this PR relying on CI for an e2e test run?
- Should this PR be tested in a specific environment?
- Any logs, screenshots, etc that can help with the review process?

-->

## List all the issues related to this PR

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [x] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [x] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [ ] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [x] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [ ] No tests needed

## Checklist

- [x] Title and description added to both, commit and PR.
- [x] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [x] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?

[Kubernetes community documentation]: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#commit-message-guidelines
[CONTRIBUTING]: https://github.com/openshift/assisted-service/blob/master/CONTRIBUTING.md
