### PR TITLE
MGMT-18418: Revert "Add certs to ingress when deploying in non-OCP clusters (#6564)"

### DIFF
--- a/internal/controller/controllers/agentserviceconfig_controller_test.go
+++ b/internal/controller/controllers/agentserviceconfig_controller_test.go
@@ -2717,7 +2717,7 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		Expect(cert.Spec.DNSNames).To(ContainElement(fmt.Sprintf("%s.%s.svc.cluster.local", webhookServiceName, testNamespace)))
 	})
 
-	It("creates the assisted configmap without https server config and with ingress https config", func() {
+	It("creates the assisted configmap without https config", func() {
 		res, err := reconciler.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
@@ -2728,11 +2728,11 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		Expect(cm.Data).ToNot(HaveKey("SERVE_HTTPS"))
 		Expect(cm.Data).ToNot(HaveKey("HTTPS_CERT_FILE"))
 		Expect(cm.Data).ToNot(HaveKey("HTTPS_KEY_FILE"))
-
-		Expect(cm.Data["SERVICE_CA_CERT_PATH"]).To(Equal("/etc/assisted-ingress-cert/ca.crt"))
+		Expect(cm.Data).ToNot(HaveKey("SERVICE_CA_CERT_PATH"))
+		Expect(cm.Data).ToNot(HaveKey("SKIP_CERT_VERIFICATION"))
 	})
 
-	It("creates the assisted deployment without serving https, but with ingress https config", func() {
+	It("creates the assisted deployment without https config", func() {
 		res, err := reconciler.Reconcile(ctx, newAgentServiceConfigRequest(asc))
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(ctrl.Result{Requeue: true}))
@@ -2749,18 +2749,11 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		}
 
 		By("ensure no cert volumes are present")
-		Expect(container.VolumeMounts).To(ConsistOf(
-			corev1.VolumeMount{Name: "bucket-filesystem", MountPath: "/data"},
-			corev1.VolumeMount{Name: "ingress-cert", MountPath: "/etc/assisted-ingress-cert"},
-		))
-		foundIngressVol := false
+		Expect(container.VolumeMounts).To(Equal([]corev1.VolumeMount{{Name: "bucket-filesystem", MountPath: "/data"}}))
 		for _, vol := range deploy.Spec.Template.Spec.Volumes {
 			Expect(vol.Name).NotTo(Equal("tls-certs"))
-			if vol.Name == "ingress-cert" {
-				foundIngressVol = true
-			}
+			Expect(vol.Name).NotTo(Equal("ingress-cert"))
 		}
-		Expect(foundIngressVol).To(BeTrue(), "expected ingress volume to be present")
 
 		By("ensure probe scheme is http")
 		Expect(container.ReadinessProbe.ProbeHandler.HTTPGet.Scheme).To(Equal(corev1.URISchemeHTTP))
@@ -2800,7 +2793,6 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 	validateIngress := func(ingress *netv1.Ingress, host string, service string, port int32) {
 		Expect(ingress.Spec.IngressClassName).To(HaveValue(Equal(*asc.Spec.Ingress.ClassName)))
 		Expect(len(ingress.Spec.Rules)).To(Equal(1))
-
 		rule := ingress.Spec.Rules[0]
 		Expect(rule.Host).To(Equal(host))
 		Expect(rule.IngressRuleValue.HTTP).NotTo(BeNil())
@@ -2812,10 +2804,6 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 			Port: netv1.ServiceBackendPort{Number: port},
 		}
 		Expect(rule.IngressRuleValue.HTTP.Paths[0].Backend.Service).To(HaveValue(Equal(serviceBackend)))
-
-		Expect(len(ingress.Spec.TLS)).To(Equal(1))
-		tls := ingress.Spec.TLS[0]
-		Expect(tls.Hosts).To(Equal([]string{host}))
 	}
 
 	It("creates ingress instead of routes", func() {
@@ -2847,8 +2835,8 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		cm := corev1.ConfigMap{}
 		key := types.NamespacedName{Name: serviceName, Namespace: testNamespace}
 		Expect(reconciler.Client.Get(ctx, key, &cm)).To(Succeed())
-		Expect(cm.Data["SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.AssistedServiceHostname)))
-		Expect(cm.Data["IMAGE_SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.ImageServiceHostname)))
+		Expect(cm.Data["SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.AssistedServiceHostname)))
+		Expect(cm.Data["IMAGE_SERVICE_BASE_URL"]).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.ImageServiceHostname)))
 	})
 
 	It("sets the image service base URL env to the ingress host", func() {
@@ -2864,7 +2852,7 @@ var _ = Describe("Reconcile on non-OCP clusters", func() {
 		var found bool
 		for _, env := range ss.Spec.Template.Spec.Containers[0].Env {
 			if env.Name == "IMAGE_SERVICE_BASE_URL" {
-				Expect(env.Value).To(Equal(fmt.Sprintf("https://%s", asc.Spec.Ingress.ImageServiceHostname)))
+				Expect(env.Value).To(Equal(fmt.Sprintf("http://%s", asc.Spec.Ingress.ImageServiceHostname)))
 				found = true
 			}
 		}

--- a/internal/controller/controllers/kube_compat.go
+++ b/internal/controller/controllers/kube_compat.go
@@ -21,7 +21,6 @@ const (
 	caIssuerName                     = "assisted-installer-ca"
 	certificateCRDName               = "certificates.cert-manager.io"
 	certManagerCAInjectionAnnotation = "cert-manager.io/inject-ca-from"
-	certManagerIssuerAnnotation      = "cert-manager.io/issuer"
 	clusterVersionCRDName            = "clusterversions.config.openshift.io"
 	selfSignedIssuerName             = "assisted-installer-selfsigned-ca"
 )
@@ -40,10 +39,6 @@ func crdExists(ctx context.Context, c client.Client, crdName string) (bool, erro
 	return err == nil, client.IgnoreNotFound(err)
 }
 
-func ingressTLSSecretName(ingressName string) string {
-	return fmt.Sprintf("%s-ingress", ingressName)
-}
-
 func newIngress(asc ASC, name string, host string, port int32) (client.Object, controllerutil.MutateFn, error) {
 	if asc.spec.Ingress == nil {
 		return nil, nil, fmt.Errorf("ingress config is required for non-OpenShift deployments")
@@ -60,7 +55,6 @@ func newIngress(asc ASC, name string, host string, port int32) (client.Object, c
 		if err := controllerutil.SetControllerReference(asc.Object, ingress, asc.rec.Scheme); err != nil {
 			return err
 		}
-		setAnnotation(&ingress.ObjectMeta, certManagerIssuerAnnotation, caIssuerName)
 		ingress.Spec = netv1.IngressSpec{
 			IngressClassName: asc.spec.Ingress.ClassName,
 			Rules: []netv1.IngressRule{{
@@ -79,10 +73,6 @@ func newIngress(asc ASC, name string, host string, port int32) (client.Object, c
 						},
 					}},
 				}},
-			}},
-			TLS: []netv1.IngressTLS{{
-				Hosts:      []string{host},
-				SecretName: ingressTLSSecretName(name),
 			}},
 		}
 		return nil


### PR DESCRIPTION
This reverts commit 77219eebd4c4fd4ad4e7486ecd97dc9cdee3b974.

When using BMO to deploy hosts the ironic server didn't trust the certs
used for the ingress. This failed the deployment.

Revert the cert addition while we investigate a different way to handle
this.

## List all the issues related to this PR

Related to https://issues.redhat.com/browse/MGMT-18418

- [ ] New Feature <!-- new functionality -->
- [ ] Enhancement <!-- refactor, code changes, improvement, that won't add new features -->
- [ ] Bug fix
- [ ] Tests
- [ ] Documentation
- [ ] CI/CD <!-- Notice that changes for Dockerfiles/Jenkinsfiles aren't tested in CI due to a known bug. -->

## What environments does this code impact?

- [ ] Automation (CI, tools, etc)
- [ ] Cloud
- [ ] Operator Managed Deployments
- [x] None

## How was this code tested?

<!-- Please, select one or more if needed: -->

- [ ] assisted-test-infra environment
- [ ] dev-scripts environment
- [ ] Reviewer's test appreciated
- [ ] Waiting for CI to do a full test run
- [ ] Manual (Elaborate on how it was tested)
- [x] No tests needed

## Checklist

- [ ] Title and description added to both, commit and PR.
- [ ] Relevant issues have been associated (see [CONTRIBUTING] guide)
- [ ] This change does not require a documentation update (docstring, `docs`, README, etc)
- [ ] Does this change include unit-tests (note that code changes require unit-tests)

## Reviewers Checklist

- Are the title and description (in both PR and commit) meaningful and clear?
- Is there a bug required (and linked) for this change?
- Should this PR be backported?
